### PR TITLE
Initial support for YUV4MPEG2 (.y4m) input files

### DIFF
--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -127,9 +127,9 @@ static void SetCfgInputFile                     (const char *value, EbConfig_t *
         FOPEN(cfg->inputFile, value, "rb");
     }
 
-    /* if input is a y4m file, read header and parse parameters */
+    /* if input is a YUV4MPEG2 (y4m) file, read header and parse parameters */
     if(cfg->inputFile!=NULL){
-        if(checkIfY4m(value) == EB_TRUE) {
+        if(checkIfY4m(cfg->inputFile) == EB_TRUE) {
             cfg->y4mInput = EB_TRUE;
         }
     }else{

--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "EbAppConfig.h"
+#include "EbAppInputy4m.h"
 
 #ifdef _WIN32
 #else
@@ -115,6 +116,7 @@
  **********************************/
 static void SetCfgInputFile                     (const char *value, EbConfig_t *cfg)
 {
+
     if (cfg->inputFile && cfg->inputFile != stdin) {
         fclose(cfg->inputFile);
     }
@@ -124,6 +126,16 @@ static void SetCfgInputFile                     (const char *value, EbConfig_t *
     else {
         FOPEN(cfg->inputFile, value, "rb");
     }
+
+    /* if input is a y4m file, read header and parse parameters */
+    if(cfg->inputFile!=NULL){
+        if(checkIfY4m(value) == EB_TRUE) {
+            cfg->y4mInput = EB_TRUE;
+        }
+    }else{
+        cfg->y4mInput = EB_FALSE;
+    }
+
 };
 static void SetCfgStreamFile                    (const char *value, EbConfig_t *cfg)
 {
@@ -982,6 +994,7 @@ EbErrorType ReadCommandLine(
     uint32_t    index           = 0;
     int32_t             cmd_token_cnt   = 0;                        // total number of tokens
     int32_t             token_index     = -1;
+    int32_t ret_y4m;
 
     for (index = 0; index < MAX_CHANNEL_NUMBER; ++index){
         config_strings[index] = (char*)malloc(sizeof(char)*COMMAND_LINE_MAX_SIZE);
@@ -1042,6 +1055,21 @@ EbErrorType ReadCommandLine(
                         break;
                     }
                 }
+            }
+        }
+    }
+
+    /***************************************************************************************************/
+    /********************** Parse parameters from input file if in y4m format **************************/
+    /********************** overriding config file and command line inputs    **************************/
+    /***************************************************************************************************/
+
+    for (index = 0; index < numChannels; ++index) {
+        if ((configs[index])->y4mInput == EB_TRUE){
+            ret_y4m = readY4mHeader(configs[index]);
+            if(ret_y4m == EB_ErrorBadParameter){
+                printf("Error found when reading the y4m file parameters.\n");
+                return EB_ErrorBadParameter;
             }
         }
     }

--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -129,7 +129,7 @@ static void SetCfgInputFile                     (const char *value, EbConfig_t *
 
     /* if input is a YUV4MPEG2 (y4m) file, read header and parse parameters */
     if(cfg->inputFile!=NULL){
-        if(checkIfY4m(cfg->inputFile) == EB_TRUE) {
+        if(checkIfY4m(cfg) == EB_TRUE) {
             cfg->y4mInput = EB_TRUE;
         }
     }else{

--- a/Source/App/EbAppConfig.h
+++ b/Source/App/EbAppConfig.h
@@ -217,6 +217,8 @@ typedef struct EbConfig_s
 
     FILE                    *qpFile;
 
+    EbBool                  y4mInput;
+
     EbBool                  use_qp_file;
 
     uint32_t                 frameRate;

--- a/Source/App/EbAppConfig.h
+++ b/Source/App/EbAppConfig.h
@@ -218,6 +218,7 @@ typedef struct EbConfig_s
     FILE                    *qpFile;
 
     EbBool                  y4mInput;
+    unsigned char           y4mBuf[9];
 
     EbBool                  use_qp_file;
 

--- a/Source/App/EbAppInputy4m.c
+++ b/Source/App/EbAppInputy4m.c
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2018 Intel Corporation
+* Copyright(c) 2019 Intel Corporation
 * SPDX - License - Identifier: BSD - 2 - Clause - Patent
 */
 
@@ -226,15 +226,20 @@ int32_t readY4mFrameDelimiter(EbConfig_t *cfg){
 }
 
 /* check if filename contains y4m extension */
-EbBool checkIfY4m(const char* inputFileName){
+EbBool checkIfY4m(FILE* inputFile){
 
-    size_t len;
+    unsigned char buffer[YFM_HEADER_MAX+1];
 
-    len = strlen(inputFileName);
-    if(strncmp(&inputFileName[len-4], ".y4m", 4)==0){
-        return EB_TRUE; /* .y4m file extension */
+    /* find out if this is actually a .y4m file*/
+    fread(buffer, YUV4MPEG2_IND_SIZE, 1, inputFile);
+    buffer[YUV4MPEG2_IND_SIZE] = 0;
+
+    fseek(inputFile, 0, SEEK_SET);
+
+    if (strcmp((const char*)buffer, "YUV4MPEG2") == 0) {
+        return EB_TRUE; /* YUV4MPEG2 file */
     }else{
-        return EB_FALSE; /* not .y4m file extension */
+        return EB_FALSE; /* Not a YUV4MPEG2 file */
     }
 
 }

--- a/Source/App/EbAppInputy4m.c
+++ b/Source/App/EbAppInputy4m.c
@@ -218,18 +218,22 @@ int32_t readY4mFrameDelimiter(EbConfig_t *cfg){
 }
 
 /* check if the input file is in YUV4MPEG2 (y4m) format */
-EbBool checkIfY4m(FILE* inputFile){
+EbBool checkIfY4m(EbConfig_t *cfg){
 
-    unsigned char buffer[YFM_HEADER_MAX+1];
+    unsigned char buffer[YUV4MPEG2_IND_SIZE+1];
 
     /* Parse the header for the "YUV4MPEG2" string */
-    fread(buffer, YUV4MPEG2_IND_SIZE, 1, inputFile);
+    fread(buffer, YUV4MPEG2_IND_SIZE, 1, cfg->inputFile);
     buffer[YUV4MPEG2_IND_SIZE] = 0;
 
     if (strcmp((const char*)buffer, "YUV4MPEG2") == 0) {
         return EB_TRUE; /* YUV4MPEG2 file */
     }else{
-        fseek(inputFile, 0, SEEK_SET);
+        if(cfg->inputFile != stdin) {
+            fseek(cfg->inputFile, 0, SEEK_SET);
+        }else{
+            memcpy(cfg->y4mBuf, buffer, YUV4MPEG2_IND_SIZE); /* TODO copy 9 bytes read to cfg->y4mBuf*/
+        }
         return EB_FALSE; /* Not a YUV4MPEG2 file */
     }
 

--- a/Source/App/EbAppInputy4m.c
+++ b/Source/App/EbAppInputy4m.c
@@ -1,0 +1,240 @@
+/*
+* Copyright(c) 2018 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#include "EbAppInputy4m.h"
+#define YFM_HEADER_MAX 80
+#define YUV4MPEG2_IND_SIZE 9
+#define PRINT_HEADER 0
+
+/* reads the y4m header and parses the input parameters */
+int32_t readY4mHeader(EbConfig_t *cfg){
+
+    FILE *ptr_in;
+    unsigned char buffer[YFM_HEADER_MAX];
+    unsigned char *tokstart, *tokend;
+    uint32_t bitdepth = 8, width = 0, height = 0, fr_n = 0,
+        fr_d = 0, aspect_n, aspect_d;
+    char chroma[4] = "420", scan_type = 'p';
+
+    /* pointer to the input file */
+    ptr_in = cfg->inputFile;
+
+    /* find out if this is actually a .y4m file*/
+    fread(buffer, YUV4MPEG2_IND_SIZE, 1, ptr_in);
+    buffer[YUV4MPEG2_IND_SIZE] = 0;
+    if (strcmp((const char*)buffer, "YUV4MPEG2") != 0) {
+        fprintf(cfg->errorLogFile, "The file provided is not in .y4m format\n");
+        return EB_ErrorBadParameter;
+    }
+
+    /* get first line after YUV4MPEG2 */
+    fgets((char*)buffer, sizeof(buffer), ptr_in);
+
+    /* print header */
+    if(PRINT_HEADER) {
+        printf("y4m header:");
+        fputs((const char *) buffer, stdout);
+    }
+
+    /* read header parameters */
+    for (tokstart = &(buffer[0]); *tokstart != '\0'; tokstart++) {
+        if (*tokstart == 0x20)
+            continue;
+        switch (*tokstart++) {
+        case 'W': /* width, required. */
+            width = strtol(tokstart, &tokend, 10);
+            if(PRINT_HEADER)
+                printf("width = %d\n", width);
+            tokstart = tokend;
+            break;
+        case 'H': /* height, required. */
+            height = strtol(tokstart, &tokend, 10);
+            if(PRINT_HEADER)
+                printf("height = %d\n", height);
+            tokstart = tokend;
+            break;
+        case 'I': /* scan type, not required, default: 'p' */
+            switch (*tokstart++) {
+            case '?':
+                scan_type = '?';
+                break;
+            case 'p':
+                scan_type = 'p';
+                break;
+            case 't':
+                scan_type = 't';
+                break;
+            case 'b':
+                scan_type = 'b';
+                break;
+            default:
+                fprintf(cfg->errorLogFile, "Interlace type not supported\n");
+                return EB_ErrorBadParameter;
+            }
+            if(PRINT_HEADER)
+                printf("scan_type = %c\n", scan_type);
+            break;
+        case 'C': /* color space, not required: default "420" */
+            if (strncmp("420p16", (const char*)tokstart, 6) == 0) {
+                strcpy(chroma, "420");
+                bitdepth = 16;
+            } else if (strncmp("422p16", (const char*)tokstart, 6) == 0) {
+                 strcpy(chroma, "422");
+                 bitdepth = 16;
+            } else if (strncmp("444p16", (const char*)tokstart, 6) == 0) {
+                strcpy(chroma, "444");
+                bitdepth = 16;
+            } else if (strncmp("420p14", (const char*)tokstart, 6) == 0) {
+                strcpy(chroma, "420");
+                bitdepth = 14;
+            } else if (strncmp("422p14", (const char*)tokstart, 6) == 0) {
+                strcpy(chroma, "422");
+                bitdepth = 14;
+            } else if (strncmp("444p14", (const char*)tokstart, 6) == 0) {
+                strcpy(chroma, "444");
+                bitdepth = 14;
+            } else if (strncmp("420p12", (const char*)tokstart, 6) == 0) {
+                strcpy(chroma, "420");
+                bitdepth = 12;
+            } else if (strncmp("422p12", (const char*)tokstart, 6) == 0) {
+                strcpy(chroma, "422");
+                bitdepth = 12;
+            } else if (strncmp("444p12", (const char*)tokstart, 6) == 0) {
+                strcpy(chroma, "444");
+                bitdepth = 12;
+            } else if (strncmp("420p10", (const char*)tokstart, 6) == 0) {
+                strcpy(chroma, "420");
+                bitdepth = 10;
+            } else if (strncmp("422p10", (const char*)tokstart, 6) == 0) {
+                strcpy(chroma, "422");
+                bitdepth = 10;
+            } else if (strncmp("444p10", (const char*)tokstart, 6) == 0) {
+                strcpy(chroma, "444");
+                bitdepth = 10;
+            } else if (strncmp("420p9", (const char*)tokstart, 5) == 0) {
+                strcpy(chroma, "420");
+                bitdepth = 9;
+            } else if (strncmp("422p9", (const char*)tokstart, 5) == 0) {
+                strcpy(chroma, "422");
+                bitdepth = 9;
+            } else if (strncmp("444p9", (const char*)tokstart, 5) == 0) {
+                strcpy(chroma, "444");
+                bitdepth = 9;
+            } else if (strncmp("420", (const char*)tokstart, 3) == 0) {
+                strcpy(chroma, "420");
+                bitdepth = 8;
+            } else if (strncmp("411", (const char*)tokstart, 3) == 0) {
+                strcpy(chroma, "411");
+                bitdepth = 8;
+            } else if (strncmp("422", (const char*)tokstart, 3) == 0) {
+                strcpy(chroma, "422");
+                bitdepth = 8;
+            } else if (strncmp("mono16", (const char*)tokstart, 6) == 0) {
+                strcpy(chroma, "400");
+                bitdepth = 16;
+            } else if (strncmp("mono12", (const char*)tokstart, 6) == 0) {
+                strcpy(chroma, "400");
+                bitdepth = 12;
+            } else if (strncmp("mono10", (const char*)tokstart, 6) == 0) {
+                strcpy(chroma, "400");
+                bitdepth = 10;
+            } else if (strncmp("mono9", (const char*)tokstart, 5) == 0) {
+                strcpy(chroma, "400");
+                bitdepth = 9;
+            } else if (strncmp("mono", (const char*)tokstart, 4) == 0) {
+                strcpy(chroma, "400");
+                bitdepth = 8;
+            } else {
+                fprintf(cfg->errorLogFile, "chroma format not supported\n");
+                return EB_ErrorBadParameter;
+            }
+            while (*tokstart != '\n' && *tokstart != 0x20)
+                tokstart++;
+            if(PRINT_HEADER)
+                printf("chroma = %s, bitdepth = %d\n", chroma, bitdepth);
+            break;
+        case 'F': /* frame rate, required */
+            sscanf((const char*)tokstart, "%d:%d", &fr_n, &fr_d); // 0:0 if unknown
+            if(PRINT_HEADER) {
+                printf("framerate_n = %d\n", fr_n);
+                printf("framerate_d = %d\n", fr_d);
+            }
+            while (*tokstart != '\n' && *tokstart != 0x20) {
+                tokstart++;
+            }
+            break;
+        case 'A': /* aspect ratio, not required */
+            sscanf((const char*)tokstart, "%d:%d", &aspect_n, &aspect_d); // 0:0 if unknown
+            if(PRINT_HEADER) {
+                printf("aspect_n = %d\n", aspect_n);
+                printf("aspect_d = %d\n", aspect_d);
+            }
+            while (*tokstart != '\n' && *tokstart != 0x20) {
+                tokstart++;
+            }
+            break;
+        }
+    }
+
+    /*check if required parameters were read*/
+    if(width == 0) {
+        fprintf(cfg->errorLogFile, "width not found in y4m header\n");
+        return EB_ErrorBadParameter;
+    }
+    if(height == 0) {
+        fprintf(cfg->errorLogFile, "height not found in y4m header\n");
+        return EB_ErrorBadParameter;
+    }
+    if(fr_n == 0 || fr_d == 0) {
+        fprintf(cfg->errorLogFile, "frame rate not found in y4m header\n");
+        return EB_ErrorBadParameter;
+    }
+
+    /* read next line with contains "FRAME" */
+    fgets((char*)buffer, sizeof(buffer), ptr_in);
+
+    /* Assign parameters to cfg */
+    cfg->sourceWidth = width;
+    cfg->sourceHeight = height;
+    cfg->frameRateNumerator = fr_n;
+    cfg->frameRateDenominator = fr_d;
+    cfg->frameRate = fr_n/fr_d;
+    cfg->encoderBitDepth = bitdepth;
+    /* TODO: when implemented, need to set input bit depth
+        (instead of the encoder bit depth) and chroma format */
+
+    return EB_ErrorNone;
+
+}
+
+/* read next line which contains the "FRAME" delimiter */
+int32_t readY4mFrameDelimiter(EbConfig_t *cfg){
+
+    unsigned char bufferY4Mheader[10];
+
+    fgets((char *)bufferY4Mheader, sizeof(bufferY4Mheader), cfg->inputFile);
+
+    if (strcmp((const char*)bufferY4Mheader, "FRAME\n") != 0) {
+        fprintf(cfg->errorLogFile, "Failed to read propor y4m frame delimeter. Read broken.\n");
+        return EB_ErrorBadParameter;
+    }
+
+    return EB_ErrorNone;
+
+}
+
+/* check if filename contains y4m extension */
+EbBool checkIfY4m(const char* inputFileName){
+
+    size_t len;
+
+    len = strlen(inputFileName);
+    if(strncmp(&inputFileName[len-4], ".y4m", 4)==0){
+        return EB_TRUE; /* .y4m file extension */
+    }else{
+        return EB_FALSE; /* not .y4m file extension */
+    }
+
+}

--- a/Source/App/EbAppInputy4m.c
+++ b/Source/App/EbAppInputy4m.c
@@ -21,14 +21,6 @@ int32_t readY4mHeader(EbConfig_t *cfg){
     /* pointer to the input file */
     ptr_in = cfg->inputFile;
 
-    /* find out if this is actually a .y4m file*/
-    fread(buffer, YUV4MPEG2_IND_SIZE, 1, ptr_in);
-    buffer[YUV4MPEG2_IND_SIZE] = 0;
-    if (strcmp((const char*)buffer, "YUV4MPEG2") != 0) {
-        fprintf(cfg->errorLogFile, "The file provided is not in .y4m format\n");
-        return EB_ErrorBadParameter;
-    }
-
     /* get first line after YUV4MPEG2 */
     fgets((char*)buffer, sizeof(buffer), ptr_in);
 
@@ -225,20 +217,19 @@ int32_t readY4mFrameDelimiter(EbConfig_t *cfg){
 
 }
 
-/* check if filename contains y4m extension */
+/* check if the input file is in YUV4MPEG2 (y4m) format */
 EbBool checkIfY4m(FILE* inputFile){
 
     unsigned char buffer[YFM_HEADER_MAX+1];
 
-    /* find out if this is actually a .y4m file*/
+    /* Parse the header for the "YUV4MPEG2" string */
     fread(buffer, YUV4MPEG2_IND_SIZE, 1, inputFile);
     buffer[YUV4MPEG2_IND_SIZE] = 0;
-
-    fseek(inputFile, 0, SEEK_SET);
 
     if (strcmp((const char*)buffer, "YUV4MPEG2") == 0) {
         return EB_TRUE; /* YUV4MPEG2 file */
     }else{
+        fseek(inputFile, 0, SEEK_SET);
         return EB_FALSE; /* Not a YUV4MPEG2 file */
     }
 

--- a/Source/App/EbAppInputy4m.h
+++ b/Source/App/EbAppInputy4m.h
@@ -1,5 +1,5 @@
 /*
-* Copyright(c) 2018 Intel Corporation
+* Copyright(c) 2019 Intel Corporation
 * SPDX - License - Identifier: BSD - 2 - Clause - Patent
 */
 
@@ -13,4 +13,4 @@ int32_t readY4mHeader(EbConfig_t *cfg);
 
 int32_t readY4mFrameDelimiter(EbConfig_t *cfg);
 
-EbBool checkIfY4m(const char* inputFileName);
+EbBool checkIfY4m(FILE* inputFile);

--- a/Source/App/EbAppInputy4m.h
+++ b/Source/App/EbAppInputy4m.h
@@ -13,4 +13,4 @@ int32_t readY4mHeader(EbConfig_t *cfg);
 
 int32_t readY4mFrameDelimiter(EbConfig_t *cfg);
 
-EbBool checkIfY4m(FILE* inputFile);
+EbBool checkIfY4m(EbConfig_t *cfg);

--- a/Source/App/EbAppInputy4m.h
+++ b/Source/App/EbAppInputy4m.h
@@ -1,0 +1,16 @@
+/*
+* Copyright(c) 2018 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "EbAppConfig.h"
+
+int32_t readY4mHeader(EbConfig_t *cfg);
+
+int32_t readY4mFrameDelimiter(EbConfig_t *cfg);
+
+EbBool checkIfY4m(const char* inputFileName);

--- a/Source/App/EbAppProcessCmd.c
+++ b/Source/App/EbAppProcessCmd.c
@@ -22,6 +22,7 @@
 #define CLIP3(MinVal, MaxVal, a)        (((a)<(MinVal)) ? (MinVal) : (((a)>(MaxVal)) ? (MaxVal) :(a)))
 #define FUTURE_WINDOW_WIDTH                 4
 #define SIZE_OF_ONE_FRAME_IN_BYTES(width, height,is16bit) ( ( ((width)*(height)*3)>>1 )<<is16bit)
+#define YUV4MPEG2_IND_SIZE 9
 extern volatile int32_t keepRunning;
 
 /***************************************
@@ -810,7 +811,16 @@ void ReadInputFrames(
             else {
                 uint64_t lumaReadSize = (uint64_t)inputPaddedWidth*inputPaddedHeight << is16bit;
                 ebInputPtr = inputPtr->luma;
-                headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize, inputFile);
+                if(config->y4mInput==EB_FALSE && config->processedFrameCount == 0 && config->inputFile == stdin) {
+                    /* if not a y4m file and input is read from stdin, 9 bytes were already read when checking
+                        or the YUV4MPEG2 string in the stream, so copy those bytes over */
+                    memcpy(ebInputPtr,config->y4mBuf,YUV4MPEG2_IND_SIZE);
+                    headerPtr->n_filled_len += YUV4MPEG2_IND_SIZE;
+                    ebInputPtr += YUV4MPEG2_IND_SIZE;
+                    headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize-YUV4MPEG2_IND_SIZE, inputFile);
+                }else {
+                    headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize, inputFile);
+                }
                 ebInputPtr = inputPtr->cb;
                 headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, inputFile);
                 ebInputPtr = inputPtr->cr;

--- a/Source/App/EbAppProcessCmd.c
+++ b/Source/App/EbAppProcessCmd.c
@@ -13,6 +13,7 @@
 #include "EbAppContext.h"
 #include "EbAppConfig.h"
 #include "EbErrorCodes.h"
+#include "EbAppInputy4m.h"
 
 #include "EbTime.h"
 /***************************************
@@ -814,6 +815,12 @@ void ReadInputFrames(
                 headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, inputFile);
                 ebInputPtr = inputPtr->cr;
                 headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, inputFile);
+
+                /* if input is a y4m file, read next line with contains "FRAME" */
+                if(config->y4mInput==EB_TRUE) {
+                    readY4mFrameDelimiter(config);
+                }
+
                 inputPtr->luma = inputPtr->luma + ((config->inputPaddedWidth*TOP_INPUT_PADDING + LEFT_INPUT_PADDING) << is16bit);
                 inputPtr->cb   = inputPtr->cb + (((config->inputPaddedWidth >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)) << is16bit);
                 inputPtr->cr   = inputPtr->cr + (((config->inputPaddedWidth >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)) << is16bit);


### PR DESCRIPTION
Support for YUV4MPEG2 (.y4m) input files, all bit depths, standard input mode.

Reads the y4m header and saves the video's parameters (width, height, bitdepth, etc) to the config structure, so there is not need to specify them explicitly. 

In addition, when reading each frame, a delimited "FRAME\n" is removed.

More info about the YUV4MPEG2 format can be found here: https://wiki.multimedia.cx/index.php/YUV4MPEG2




