### PR TITLE
Add AppVeyor CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Scalable Video Technology for AV1 Encoder (SVT-AV1 Encoder)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/OpenVisualCloud/SVT-AV1?branch=master&svg=true)](https://ci.appveyor.com/project/OpenVisualCloud/SVT-AV1)
 
 The Scalable Video Technology for AV1 Encoder (SVT-AV1 Encoder) is an AV1-compliant encoder library core. The SVT-AV1 development is a work-in-progress targeting performance levels applicable to both VOD and Live encoding / transcoding video applications.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ install:
     - git submodule update --init
     - appveyor DownloadFile http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe -FileName yasm.exe
     - set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%
-    - Build/windows/generate_vs17.bat
+    - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_ASM_NASM_COMPILER="yasm.exe"
 
 build:
   project: svt-av1.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,11 +13,12 @@ build:
 artifacts:
     - path: bin\Release\*.*
       name: $(APPVEYOR_PROJECT_NAME)
-    - path: bin\Release\**\*.exe
-      name: $(APPVEYOR_PROJECT_NAME)-exe
-    - path: bin\Release\**\*.lib
-      name: $(APPVEYOR_PROJECT_NAME)-lib
-    - path: \**\*svt-av1*.exe
-      name: $(APPVEYOR_PROJECT_NAME)-exe
-    - path: \**\*svt-av1*.lib
-      name: $(APPVEYOR_PROJECT_NAME)-lib
+
+deploy:
+  - provider: GitHub
+    artifact: $(APPVEYOR_PROJECT_NAME)
+    auth_token:
+      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
+    prerelease: true
+    on:
+      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,14 @@ install:
 build:
   project: svt-av1.sln
 
-artifacts:                          
-    - path: bin\Release\*svt-av1*.*
+artifacts:
+    - path: bin\Release\*.*
       name: $(APPVEYOR_PROJECT_NAME)
+    - path: bin\Release\**\*.exe
+      name: $(APPVEYOR_PROJECT_NAME)-exe
+    - path: bin\Release\**\*.lib
+      name: $(APPVEYOR_PROJECT_NAME)-lib
+    - path: \**\*svt-av1*.exe
+      name: $(APPVEYOR_PROJECT_NAME)-exe
+    - path: \**\*svt-av1*.lib
+      name: $(APPVEYOR_PROJECT_NAME)-lib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+image: Visual Studio 2017
+configuration: Release
+
+install:
+    - git submodule update --init
+    - appveyor DownloadFile http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe -FileName yasm.exe
+    - set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%
+    - Build/windows/generate_vs17.bat
+
+build:
+  project: svt-av1.sln
+
+artifacts:                          
+    - path: bin\Release\*svt-av1*.*
+      name: $(APPVEYOR_PROJECT_NAME)


### PR DESCRIPTION
Part of #4.

This PR adds continuous integration & delivery with AppVeyor. SVT-AV1 gets build with Microsoft Visual Studio 2017 and Yasm 1.3.0. AppVeyor publishes `SvtAv1Enc.dll`, `SvtAv1Enc.exp`, `SvtAv1Enc.lib`, `SvtAv1EncApp.exe` and `SvtAv1EncSimpleApp.exe` in the Artifacts tab ([example](https://ci.appveyor.com/project/EwoutH/svt-av1/build/artifacts)).

AppVeyor needs to be enabled on the [GitHub Marketplace](https://github.com/marketplace/appveyor) or on [ci.AppVeyor.com](https://ci.appveyor.com/project/OpenVisualCloud/SVT-AV1).

When enabled, AppVeyor publishes the artifacts with each build. When tagging a new (pre)release, AppVeyor will also upload these files to GitHub, creating a release page [like this](https://github.com/EwoutH/SVT-AV1/releases/tag/0.0.1-test1).

To enable uploading to GitHub Releases, a maintainer needs to update this patch with his personal authentication token. You can generate one on https://github.com/settings/tokens/new (select `public_repo` as scope), and then encrypt it with https://ci.appveyor.com/tools/encrypt. Replace the current token on line 21 (after `secure:`) in the `appveyor.yml` file. 