### PR TITLE
Add basic Travis CI implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: c
+
+addons:
+  apt:
+    update: true
+    packages:
+     - cmake
+     - yasm
+
+script:
+ - cd Build/linux
+ - ./build.sh release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: c
 dist: xenial
 
+compiler
+ - gcc
+ - clang
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: c
-dist: xenial
 
 matrix:
   include:
-    - dist: trusty
+    - dist: xenial
       compiler: gcc
-    - dist: trusty
+    - dist: xenial
       compiler: clang
     - os: osx
       osx_image: xcode10.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ jobs:
      - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
      - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig
      - ./configure --enable-libsvtav1
-     - make -j `nproc`
+     - make --quiet -j `nproc`

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: c
+dist: xenial
 
 addons:
   apt:
-    update: true
     packages:
      - cmake
      - yasm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,5 @@
 language: c
-
-matrix:
-  include:
-    - dist: xenial
-      compiler: gcc
-    - dist: xenial
-      compiler: clang
-    - os: osx
-      osx_image: xcode10.1
+dist: xenial
 
 addons:
   apt:
@@ -15,6 +7,22 @@ addons:
      - cmake
      - yasm
 
-script:
- - cd Build/linux
- - ./build.sh release
+jobs:
+  include:
+   - script:
+     - cd Build/linux
+     - ./build.sh release
+   - script:
+     - cd Build
+     - cmake ..
+     - make -j nproc
+     - sudo make install
+     - cd $TRAVIS_BUILD_DIR
+     - git clone https://github.com/FFmpeg/FFmpeg ffmpeg
+     - cd ffmpeg
+     - git checkout release/4.1
+     - git apply $TRAVIS_BUILD_DIR/SVT-AV1/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+     - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
+     - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig
+     - ./configure --enable-libsvtav1
+     - make -j nproc

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
      - cd $TRAVIS_BUILD_DIR
      - cd Build
      - cmake ..
-     - make -j `nproc`
+     - make -j $(nproc)
      - sudo make install
      # Apply SVT-AV1 plugin and enable libsvtav1 to FFmpeg
      - git clone https://github.com/FFmpeg/FFmpeg ffmpeg
@@ -29,4 +29,4 @@ jobs:
      - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
      - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig
      - ./configure --enable-libsvtav1
-     - make --quiet -j `nproc`
+     - make --quiet -j $(nproc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
      - cd $TRAVIS_BUILD_DIR
      - cd Build
      - cmake ..
-     - make -j $(nproc)
+     - make -j$(nproc)
      - sudo make install
      # Apply SVT-AV1 plugin and enable libsvtav1 to FFmpeg
      - git clone https://github.com/FFmpeg/FFmpeg ffmpeg
@@ -29,4 +29,4 @@ jobs:
      - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
      - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig
      - ./configure --enable-libsvtav1
-     - make --quiet -j $(nproc)
+     - make --quiet -j$(nproc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: c
 dist: xenial
 
-compiler:
- - gcc
- - clang
+matrix:
+  include:
+    - dist: trusty
+      compiler: gcc
+    - dist: trusty
+      compiler: clang
+    - os: osx
+      osx_image: xcode10.1
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
     packages:
      - cmake
      - yasm
-     - nproc
 
 jobs:
   include:
@@ -20,7 +19,7 @@ jobs:
      - cd $TRAVIS_BUILD_DIR
      - cd Build
      - cmake ..
-     - make -j nproc
+     - make -j `nproc`
      - sudo make install
      # Apply SVT-AV1 plugin and enable libsvtav1 to FFmpeg
      - git clone https://github.com/FFmpeg/FFmpeg ffmpeg
@@ -30,4 +29,4 @@ jobs:
      - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
      - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig
      - ./configure --enable-libsvtav1
-     - make -j nproc
+     - make -j `nproc`

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ addons:
      - yasm
 
 script:
- - Build/linux/build.sh release
+ - cd Build/linux
+ - ./build.sh release

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,4 @@ addons:
      - yasm
 
 script:
- - cd Build/linux
- - ./build.sh release
+ - Build/linux/build.sh release

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,17 @@ jobs:
      - ./build.sh release
    - name: FFmpeg patch
      script:
+     # Build and install SVT-AV1
+     - cd $TRAVIS_BUILD_DIR
      - cd Build
      - cmake ..
      - make -j nproc
      - sudo make install
+     # Apply SVT-AV1 plugin and enable libsvtav1 to FFmpeg
      - git clone https://github.com/FFmpeg/FFmpeg ffmpeg
      - cd ffmpeg
      - git checkout release/4.1
-     - git apply ../ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+     - git apply ../SVT-AV1/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
      - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
      - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig
      - ./configure --enable-libsvtav1

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
      - git clone https://github.com/FFmpeg/FFmpeg ffmpeg
      - cd ffmpeg
      - git checkout release/4.1
-     - git apply ../SVT-AV1/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+     - git apply $TRAVIS_BUILD_DIR/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
      - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
      - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig
      - ./configure --enable-libsvtav1

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,10 @@ jobs:
      - cmake ..
      - make -j nproc
      - sudo make install
-     - cd $TRAVIS_BUILD_DIR
      - git clone https://github.com/FFmpeg/FFmpeg ffmpeg
      - cd ffmpeg
      - git checkout release/4.1
-     - git apply $TRAVIS_BUILD_DIR/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+     - git apply ../ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
      - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
      - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig
      - ./configure --enable-libsvtav1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 dist: xenial
 
-compiler
+compiler:
  - gcc
  - clang
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
     packages:
      - cmake
      - yasm
+     - nproc
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,12 @@ addons:
 
 jobs:
   include:
-   - script:
+   - name: SVT-AV1
+     script:
      - cd Build/linux
      - ./build.sh release
-   - script:
+   - name: FFmpeg patch
+     script:
      - cd Build
      - cmake ..
      - make -j nproc
@@ -21,7 +23,7 @@ jobs:
      - git clone https://github.com/FFmpeg/FFmpeg ffmpeg
      - cd ffmpeg
      - git checkout release/4.1
-     - git apply $TRAVIS_BUILD_DIR/SVT-AV1/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+     - git apply $TRAVIS_BUILD_DIR/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
      - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
      - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig
      - ./configure --enable-libsvtav1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Scalable Video Technology for AV1 Encoder (SVT-AV1 Encoder)
+[![Travis Build Status](https://travis-ci.org/OpenVisualCloud/SVT-AV1.svg?branch=master)](https://travis-ci.org/OpenVisualCloud/SVT-AV1)
 
 The Scalable Video Technology for AV1 Encoder (SVT-AV1 Encoder) is an AV1-compliant encoder library core. The SVT-AV1 development is a work-in-progress targeting performance levels applicable to both VOD and Live encoding / transcoding video applications.
 


### PR DESCRIPTION
Partly resolves #4.

First Travis implementation. It compiles SVT-AV1 on Ubuntu 16.04 and also applies the FFmpeg patch, that currently fails (see #15).

For optimal integration, Travis CI needs to be enabled on the [GitHub Marketplace](https://github.com/marketplace/travis-ci).