### PR TITLE
Set up basic Coveralls framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,23 @@ addons:
 
 jobs:
   include:
+   # General build job
    - name: SVT-AV1
      script:
      - cd Build/linux
      - ./build.sh release
+     
+   # Coveralls test job
+   - name: Coveralls
+     before_install:
+     - pip install --user cpp-coveralls
+     script:
+     - cd Build/linux
+     - ./build.sh release
+     after_success:
+     - coveralls
+     
+   # FFmpeg interation build
    - name: FFmpeg patch
      script:
      # Build and install SVT-AV1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,12 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     set(CMAKE_ASM_NASM_FLAGS_DEBUG "")
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 
+# Prepare for Coveralls
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMakeModules)
+if(CMAKE_COMPILER_IS_GNUCXX)
+    include(CodeCoverage)
+    setup_target_for_coverage(${PROJECT_NAME}_coverage ${PROJECT_TEST_NAME} coverage)
+endif()
 
 # Add Subdirectories
 add_subdirectory (Source/Lib)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Scalable Video Technology for AV1 Encoder (SVT-AV1 Encoder)
 [![Travis Build Status](https://travis-ci.org/OpenVisualCloud/SVT-AV1.svg?branch=master)](https://travis-ci.org/OpenVisualCloud/SVT-AV1)
+[![Coverage Status](https://coveralls.io/repos/github/OpenVisualCloud/SVT-AV1/badge.svg?branch=master)](https://coveralls.io/github/OpenVisualCloud/SVT-AV1?branch=master)
 
 The Scalable Video Technology for AV1 Encoder (SVT-AV1 Encoder) is an AV1-compliant encoder library core. The SVT-AV1 development is a work-in-progress targeting performance levels applicable to both VOD and Live encoding / transcoding video applications.
 


### PR DESCRIPTION
Sets up basic Coveralls framework for automatic code coverage checking. Of course actual tests need to be added before coverage can be tested. Directories that doesn't need to be tested (and thus don't need to be included in coverage calculations) can be added with a ` --exclude ` parameter on line 26 of the .travis.yml.

Coveralls need to be enabled on the [GitHub Marketplace](https://github.com/marketplace/coveralls) and on [coveralls.io](https://coveralls.io/github/OpenVisualCloud/SVT-AV1).