### PR TITLE
Add macOS & Coveralls to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ addons:
     packages:
       - yasm
 
+matrix:
+  allow_failures:
+  - name: "FFmpeg patch"  # See issue #15
+
 jobs:
   include:
    # General Linux build job
@@ -35,7 +39,6 @@ jobs:
      
    # FFmpeg interation build
    - name: FFmpeg patch
-     allow_failures: true
      script:
      # Build and install SVT-AV1
      - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,49 @@ addons:
     packages:
      - cmake
      - yasm
+  homebrew:
+    packages:
+      - yasm
 
 jobs:
   include:
-   - name: SVT-AV1
+   # General Linux build job
+   - name: Build
      script:
      - cd Build/linux
      - ./build.sh release
+   # General macOS build job
+   - name: macOS build
+     os: osx
+     script:
+     - cd Build/linux
+     - ./build.sh release     
+   # Coveralls test job
+   - name: Coveralls
+     before_install:
+     - pip install --user cpp-coveralls
+     script:
+     - cd Build/linux
+     - ./build.sh release
+     after_success:
+     - coveralls
+     
+   # FFmpeg interation build
+   - name: FFmpeg patch
+     allow_failures: true
+     script:
+     # Build and install SVT-AV1
+     - cd $TRAVIS_BUILD_DIR
+     - cd Build
+     - cmake ..
+     - make -j$(nproc)
+     - sudo make install
+     # Apply SVT-AV1 plugin and enable libsvtav1 to FFmpeg
+     - git clone https://github.com/FFmpeg/FFmpeg ffmpeg
+     - cd ffmpeg
+     - git checkout release/4.1
+     - git apply $TRAVIS_BUILD_DIR/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+     - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
+     - export PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig
+     - ./configure --enable-libsvtav1
+     - make --quiet -j$(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,12 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     set(CMAKE_ASM_NASM_FLAGS_DEBUG "")
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 
+# Prepare for Coveralls
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMakeModules)
+if(CMAKE_COMPILER_IS_GNUCXX)
+    include(CodeCoverage)
+    setup_target_for_coverage(${PROJECT_NAME}_coverage ${PROJECT_TEST_NAME} coverage)
+endif()
 
 # Add Subdirectories
 add_subdirectory (Source/Lib)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/OpenVisualCloud/SVT-AV1?branch=master&svg=true)](https://ci.appveyor.com/project/OpenVisualCloud/SVT-AV1)
 [![Travis Build Status](https://travis-ci.org/OpenVisualCloud/SVT-AV1.svg?branch=master)](https://travis-ci.org/OpenVisualCloud/SVT-AV1)
+[![Coverage Status](https://coveralls.io/repos/github/OpenVisualCloud/SVT-AV1/badge.svg?branch=master)](https://coveralls.io/github/OpenVisualCloud/SVT-AV1?branch=master)
 
 The Scalable Video Technology for AV1 Encoder (SVT-AV1 Encoder) is an AV1-compliant encoder library core. The SVT-AV1 development is a work-in-progress targeting performance levels applicable to both VOD and Live encoding / transcoding video applications.
 


### PR DESCRIPTION
I combined the recent Travis proposals in one PR, #22 and #23 where conflicting with each other.

- Adds macOS build (replaces PR #23)
- Adds Coveralls for code coverage (replaces PR #22)
- Allow FFmpeg patch job to fail (see issue #15)