### PR TITLE
Move the bash shebang to the top of build.sh so that it is executable.

### DIFF
--- a/Build/linux/build.sh
+++ b/Build/linux/build.sh
@@ -1,9 +1,9 @@
-# 
+#!/bin/bash
+
+#
 # Copyright(c) 2019 Intel Corporation
 # SPDX - License - Identifier: BSD - 2 - Clause - Patent
-# 
-
-#!/bin/bash
+#
 
 function clean {
 	rm -R -f debug


### PR DESCRIPTION
The `#!` needs to be on the first line for the script to be executable.