### PR TITLE
Preset Optimization and Code Cleanup

### DIFF
--- a/Source/API/EbApi.h
+++ b/Source/API/EbApi.h
@@ -21,6 +21,8 @@ extern "C" {
 #define EB_HME_SEARCH_AREA_COLUMN_MAX_COUNT         2
 #define EB_HME_SEARCH_AREA_ROW_MAX_COUNT            2
 
+#define MAX_ENC_PRESET                              3
+
 #ifdef _WIN32
 #define EB_API __declspec(dllexport)
 #else
@@ -132,7 +134,7 @@ typedef struct EbSvtAv1EncConfiguration
      * is to be performed at. 0 is the highest quality mode, 3 is the highest
      * density mode.
      *
-     * Default is 3. */
+     * Default is defined as MAX_ENC_PRESET. */
     uint8_t                  enc_mode;
 
     // GOP Structure

--- a/Source/App/EbAppConfig.c
+++ b/Source/App/EbAppConfig.c
@@ -415,7 +415,7 @@ void EbConfigCtor(EbConfig_t *config_ptr)
     config_ptr->max_qp_allowed                       = 63;
     config_ptr->min_qp_allowed                       = 0;
     config_ptr->base_layer_switch_mode               = 0;
-    config_ptr->encMode                              = 3;
+    config_ptr->encMode                              = MAX_ENC_PRESET;
     config_ptr->intraPeriod                          = -2;
     config_ptr->intraRefreshType                     = 1;
     config_ptr->hierarchicalLevels                   = 3;

--- a/Source/Lib/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
+++ b/Source/Lib/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
@@ -2055,779 +2055,779 @@ void FullDistortionKernelCbfZero32Bits_AVX2(
 }
 
 static INLINE void _mm_storeh_epi64(__m128i *const d, const __m128i s) {
-	_mm_storeh_pi((__m64 *)d, _mm_castsi128_ps(s));
+    _mm_storeh_pi((__m64 *)d, _mm_castsi128_ps(s));
 }
 
 void ResidualKernel4x4_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	const __m256i zero = _mm256_setzero_si256();
-	const __m256i in = load8bit_4x4_avx2(input, inputStride);
-	const __m256i pr = load8bit_4x4_avx2(pred, predStride);
-	const __m256i in_lo = _mm256_unpacklo_epi8(in, zero);
-	const __m256i pr_lo = _mm256_unpacklo_epi8(pr, zero);
-	const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
-	const __m128i re_01 = _mm256_extracti128_si256(re_lo, 0);
-	const __m128i re_23 = _mm256_extracti128_si256(re_lo, 1);
-	(void)areaWidth;
-	(void)areaHeight;
+    const __m256i zero = _mm256_setzero_si256();
+    const __m256i in = load8bit_4x4_avx2(input, inputStride);
+    const __m256i pr = load8bit_4x4_avx2(pred, predStride);
+    const __m256i in_lo = _mm256_unpacklo_epi8(in, zero);
+    const __m256i pr_lo = _mm256_unpacklo_epi8(pr, zero);
+    const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
+    const __m128i re_01 = _mm256_extracti128_si256(re_lo, 0);
+    const __m128i re_23 = _mm256_extracti128_si256(re_lo, 1);
+    (void)areaWidth;
+    (void)areaHeight;
 
-	_mm_storel_epi64((__m128i*)(residual + 0 * residualStride), re_01);
-	_mm_storeh_epi64((__m128i*)(residual + 1 * residualStride), re_01);
-	_mm_storel_epi64((__m128i*)(residual + 2 * residualStride), re_23);
-	_mm_storeh_epi64((__m128i*)(residual + 3 * residualStride), re_23);
+    _mm_storel_epi64((__m128i*)(residual + 0 * residualStride), re_01);
+    _mm_storeh_epi64((__m128i*)(residual + 1 * residualStride), re_01);
+    _mm_storel_epi64((__m128i*)(residual + 2 * residualStride), re_23);
+    _mm_storeh_epi64((__m128i*)(residual + 3 * residualStride), re_23);
 }
 void ResidualKernel4x8_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	const __m256i zero = _mm256_setzero_si256();
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    const __m256i zero = _mm256_setzero_si256();
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 8; y += 4) {
-		const __m256i in = load8bit_4x4_avx2(input, inputStride);
-		const __m256i pr = load8bit_4x4_avx2(pred, predStride);
-		const __m256i in_lo = _mm256_unpacklo_epi8(in, zero);
-		const __m256i pr_lo = _mm256_unpacklo_epi8(pr, zero);
-		const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
-		const __m128i re_01 = _mm256_extracti128_si256(re_lo, 0);
-		const __m128i re_23 = _mm256_extracti128_si256(re_lo, 1);
+    for (y = 0; y < 8; y += 4) {
+        const __m256i in = load8bit_4x4_avx2(input, inputStride);
+        const __m256i pr = load8bit_4x4_avx2(pred, predStride);
+        const __m256i in_lo = _mm256_unpacklo_epi8(in, zero);
+        const __m256i pr_lo = _mm256_unpacklo_epi8(pr, zero);
+        const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
+        const __m128i re_01 = _mm256_extracti128_si256(re_lo, 0);
+        const __m128i re_23 = _mm256_extracti128_si256(re_lo, 1);
 
-		_mm_storel_epi64((__m128i*)(residual + 0 * residualStride), re_01);
-		_mm_storeh_epi64((__m128i*)(residual + 1 * residualStride), re_01);
-		_mm_storel_epi64((__m128i*)(residual + 2 * residualStride), re_23);
-		_mm_storeh_epi64((__m128i*)(residual + 3 * residualStride), re_23);
-		input += 4 * inputStride;
-		pred += 4 * predStride;
-		residual += 4 * residualStride;
-	}
+        _mm_storel_epi64((__m128i*)(residual + 0 * residualStride), re_01);
+        _mm_storeh_epi64((__m128i*)(residual + 1 * residualStride), re_01);
+        _mm_storel_epi64((__m128i*)(residual + 2 * residualStride), re_23);
+        _mm_storeh_epi64((__m128i*)(residual + 3 * residualStride), re_23);
+        input += 4 * inputStride;
+        pred += 4 * predStride;
+        residual += 4 * residualStride;
+    }
 }
 void ResidualKernel4x16_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	const __m256i zero = _mm256_setzero_si256();
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    const __m256i zero = _mm256_setzero_si256();
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 16; y += 4) {
-		const __m256i in = load8bit_4x4_avx2(input, inputStride);
-		const __m256i pr = load8bit_4x4_avx2(pred, predStride);
-		const __m256i in_lo = _mm256_unpacklo_epi8(in, zero);
-		const __m256i pr_lo = _mm256_unpacklo_epi8(pr, zero);
-		const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
-		const __m128i re_01 = _mm256_extracti128_si256(re_lo, 0);
-		const __m128i re_23 = _mm256_extracti128_si256(re_lo, 1);
+    for (y = 0; y < 16; y += 4) {
+        const __m256i in = load8bit_4x4_avx2(input, inputStride);
+        const __m256i pr = load8bit_4x4_avx2(pred, predStride);
+        const __m256i in_lo = _mm256_unpacklo_epi8(in, zero);
+        const __m256i pr_lo = _mm256_unpacklo_epi8(pr, zero);
+        const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
+        const __m128i re_01 = _mm256_extracti128_si256(re_lo, 0);
+        const __m128i re_23 = _mm256_extracti128_si256(re_lo, 1);
 
-		_mm_storel_epi64((__m128i*)(residual + 0 * residualStride), re_01);
-		_mm_storeh_epi64((__m128i*)(residual + 1 * residualStride), re_01);
-		_mm_storel_epi64((__m128i*)(residual + 2 * residualStride), re_23);
-		_mm_storeh_epi64((__m128i*)(residual + 3 * residualStride), re_23);
-		input += 4 * inputStride;
-		pred += 4 * predStride;
-		residual += 4 * residualStride;
-	}
+        _mm_storel_epi64((__m128i*)(residual + 0 * residualStride), re_01);
+        _mm_storeh_epi64((__m128i*)(residual + 1 * residualStride), re_01);
+        _mm_storel_epi64((__m128i*)(residual + 2 * residualStride), re_23);
+        _mm_storeh_epi64((__m128i*)(residual + 3 * residualStride), re_23);
+        input += 4 * inputStride;
+        pred += 4 * predStride;
+        residual += 4 * residualStride;
+    }
 }
 void ResidualKernel8x32_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	const __m256i zero = _mm256_setzero_si256();
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    const __m256i zero = _mm256_setzero_si256();
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 32; y += 4) {
-		const __m256i in = load8bit_8x4_avx2(input, inputStride);
-		const __m256i pr = load8bit_8x4_avx2(pred, predStride);
-		const __m256i in_lo = _mm256_unpacklo_epi8(in, zero);
-		const __m256i in_hi = _mm256_unpackhi_epi8(in, zero);
-		const __m256i pr_lo = _mm256_unpacklo_epi8(pr, zero);
-		const __m256i pr_hi = _mm256_unpackhi_epi8(pr, zero);
-		const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
-		const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
-		const __m128i re_0 = _mm256_extracti128_si256(re_lo, 0);
-		const __m128i re_1 = _mm256_extracti128_si256(re_hi, 0);
-		const __m128i re_2 = _mm256_extracti128_si256(re_lo, 1);
-		const __m128i re_3 = _mm256_extracti128_si256(re_hi, 1);
+    for (y = 0; y < 32; y += 4) {
+        const __m256i in = load8bit_8x4_avx2(input, inputStride);
+        const __m256i pr = load8bit_8x4_avx2(pred, predStride);
+        const __m256i in_lo = _mm256_unpacklo_epi8(in, zero);
+        const __m256i in_hi = _mm256_unpackhi_epi8(in, zero);
+        const __m256i pr_lo = _mm256_unpacklo_epi8(pr, zero);
+        const __m256i pr_hi = _mm256_unpackhi_epi8(pr, zero);
+        const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
+        const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
+        const __m128i re_0 = _mm256_extracti128_si256(re_lo, 0);
+        const __m128i re_1 = _mm256_extracti128_si256(re_hi, 0);
+        const __m128i re_2 = _mm256_extracti128_si256(re_lo, 1);
+        const __m128i re_3 = _mm256_extracti128_si256(re_hi, 1);
 
-		_mm_storeu_si128((__m128i*)(residual + 0 * residualStride), re_0);
-		_mm_storeu_si128((__m128i*)(residual + 1 * residualStride), re_1);
-		_mm_storeu_si128((__m128i*)(residual + 2 * residualStride), re_2);
-		_mm_storeu_si128((__m128i*)(residual + 3 * residualStride), re_3);
-		input += 4 * inputStride;
-		pred += 4 * predStride;
-		residual += 4 * residualStride;
-	}
+        _mm_storeu_si128((__m128i*)(residual + 0 * residualStride), re_0);
+        _mm_storeu_si128((__m128i*)(residual + 1 * residualStride), re_1);
+        _mm_storeu_si128((__m128i*)(residual + 2 * residualStride), re_2);
+        _mm_storeu_si128((__m128i*)(residual + 3 * residualStride), re_3);
+        input += 4 * inputStride;
+        pred += 4 * predStride;
+        residual += 4 * residualStride;
+    }
 }
 void ResidualKernel8x16_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	const __m256i zero = _mm256_setzero_si256();
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    const __m256i zero = _mm256_setzero_si256();
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 16; y += 4) {
-		const __m256i in = load8bit_8x4_avx2(input, inputStride);
-		const __m256i pr = load8bit_8x4_avx2(pred, predStride);
-		const __m256i in_lo = _mm256_unpacklo_epi8(in, zero);
-		const __m256i in_hi = _mm256_unpackhi_epi8(in, zero);
-		const __m256i pr_lo = _mm256_unpacklo_epi8(pr, zero);
-		const __m256i pr_hi = _mm256_unpackhi_epi8(pr, zero);
-		const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
-		const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
-		const __m128i re_0 = _mm256_extracti128_si256(re_lo, 0);
-		const __m128i re_1 = _mm256_extracti128_si256(re_hi, 0);
-		const __m128i re_2 = _mm256_extracti128_si256(re_lo, 1);
-		const __m128i re_3 = _mm256_extracti128_si256(re_hi, 1);
+    for (y = 0; y < 16; y += 4) {
+        const __m256i in = load8bit_8x4_avx2(input, inputStride);
+        const __m256i pr = load8bit_8x4_avx2(pred, predStride);
+        const __m256i in_lo = _mm256_unpacklo_epi8(in, zero);
+        const __m256i in_hi = _mm256_unpackhi_epi8(in, zero);
+        const __m256i pr_lo = _mm256_unpacklo_epi8(pr, zero);
+        const __m256i pr_hi = _mm256_unpackhi_epi8(pr, zero);
+        const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
+        const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
+        const __m128i re_0 = _mm256_extracti128_si256(re_lo, 0);
+        const __m128i re_1 = _mm256_extracti128_si256(re_hi, 0);
+        const __m128i re_2 = _mm256_extracti128_si256(re_lo, 1);
+        const __m128i re_3 = _mm256_extracti128_si256(re_hi, 1);
 
-		_mm_storeu_si128((__m128i*)(residual + 0 * residualStride), re_0);
-		_mm_storeu_si128((__m128i*)(residual + 1 * residualStride), re_1);
-		_mm_storeu_si128((__m128i*)(residual + 2 * residualStride), re_2);
-		_mm_storeu_si128((__m128i*)(residual + 3 * residualStride), re_3);
-		input += 4 * inputStride;
-		pred += 4 * predStride;
-		residual += 4 * residualStride;
-	}
+        _mm_storeu_si128((__m128i*)(residual + 0 * residualStride), re_0);
+        _mm_storeu_si128((__m128i*)(residual + 1 * residualStride), re_1);
+        _mm_storeu_si128((__m128i*)(residual + 2 * residualStride), re_2);
+        _mm_storeu_si128((__m128i*)(residual + 3 * residualStride), re_3);
+        input += 4 * inputStride;
+        pred += 4 * predStride;
+        residual += 4 * residualStride;
+    }
 }
 
 void ResidualKernel8x8_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	const __m256i zero = _mm256_setzero_si256();
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    const __m256i zero = _mm256_setzero_si256();
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 8; y += 4) {
-		const __m256i in = load8bit_8x4_avx2(input, inputStride);
-		const __m256i pr = load8bit_8x4_avx2(pred, predStride);
-		const __m256i in_lo = _mm256_unpacklo_epi8(in, zero);
-		const __m256i in_hi = _mm256_unpackhi_epi8(in, zero);
-		const __m256i pr_lo = _mm256_unpacklo_epi8(pr, zero);
-		const __m256i pr_hi = _mm256_unpackhi_epi8(pr, zero);
-		const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
-		const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
-		const __m128i re_0 = _mm256_extracti128_si256(re_lo, 0);
-		const __m128i re_1 = _mm256_extracti128_si256(re_hi, 0);
-		const __m128i re_2 = _mm256_extracti128_si256(re_lo, 1);
-		const __m128i re_3 = _mm256_extracti128_si256(re_hi, 1);
+    for (y = 0; y < 8; y += 4) {
+        const __m256i in = load8bit_8x4_avx2(input, inputStride);
+        const __m256i pr = load8bit_8x4_avx2(pred, predStride);
+        const __m256i in_lo = _mm256_unpacklo_epi8(in, zero);
+        const __m256i in_hi = _mm256_unpackhi_epi8(in, zero);
+        const __m256i pr_lo = _mm256_unpacklo_epi8(pr, zero);
+        const __m256i pr_hi = _mm256_unpackhi_epi8(pr, zero);
+        const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
+        const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
+        const __m128i re_0 = _mm256_extracti128_si256(re_lo, 0);
+        const __m128i re_1 = _mm256_extracti128_si256(re_hi, 0);
+        const __m128i re_2 = _mm256_extracti128_si256(re_lo, 1);
+        const __m128i re_3 = _mm256_extracti128_si256(re_hi, 1);
 
-		_mm_storeu_si128((__m128i*)(residual + 0 * residualStride), re_0);
-		_mm_storeu_si128((__m128i*)(residual + 1 * residualStride), re_1);
-		_mm_storeu_si128((__m128i*)(residual + 2 * residualStride), re_2);
-		_mm_storeu_si128((__m128i*)(residual + 3 * residualStride), re_3);
-		input += 4 * inputStride;
-		pred += 4 * predStride;
-		residual += 4 * residualStride;
-	}
+        _mm_storeu_si128((__m128i*)(residual + 0 * residualStride), re_0);
+        _mm_storeu_si128((__m128i*)(residual + 1 * residualStride), re_1);
+        _mm_storeu_si128((__m128i*)(residual + 2 * residualStride), re_2);
+        _mm_storeu_si128((__m128i*)(residual + 3 * residualStride), re_3);
+        input += 4 * inputStride;
+        pred += 4 * predStride;
+        residual += 4 * residualStride;
+    }
 }
 
 void ResidualKernel8x4_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	const __m256i zero = _mm256_setzero_si256();
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    const __m256i zero = _mm256_setzero_si256();
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	//for (y = 0; y < 8; y += 4) {
-		const __m256i in = load8bit_8x4_avx2(input, inputStride);
-		const __m256i pr = load8bit_8x4_avx2(pred, predStride);
-		const __m256i in_lo = _mm256_unpacklo_epi8(in, zero);
-		const __m256i in_hi = _mm256_unpackhi_epi8(in, zero);
-		const __m256i pr_lo = _mm256_unpacklo_epi8(pr, zero);
-		const __m256i pr_hi = _mm256_unpackhi_epi8(pr, zero);
-		const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
-		const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
-		const __m128i re_0 = _mm256_extracti128_si256(re_lo, 0);
-		const __m128i re_1 = _mm256_extracti128_si256(re_hi, 0);
-		const __m128i re_2 = _mm256_extracti128_si256(re_lo, 1);
-		const __m128i re_3 = _mm256_extracti128_si256(re_hi, 1);
+    //for (y = 0; y < 8; y += 4) {
+        const __m256i in = load8bit_8x4_avx2(input, inputStride);
+        const __m256i pr = load8bit_8x4_avx2(pred, predStride);
+        const __m256i in_lo = _mm256_unpacklo_epi8(in, zero);
+        const __m256i in_hi = _mm256_unpackhi_epi8(in, zero);
+        const __m256i pr_lo = _mm256_unpacklo_epi8(pr, zero);
+        const __m256i pr_hi = _mm256_unpackhi_epi8(pr, zero);
+        const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
+        const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
+        const __m128i re_0 = _mm256_extracti128_si256(re_lo, 0);
+        const __m128i re_1 = _mm256_extracti128_si256(re_hi, 0);
+        const __m128i re_2 = _mm256_extracti128_si256(re_lo, 1);
+        const __m128i re_3 = _mm256_extracti128_si256(re_hi, 1);
 
-		_mm_storeu_si128((__m128i*)(residual + 0 * residualStride), re_0);
-		_mm_storeu_si128((__m128i*)(residual + 1 * residualStride), re_1);
-		_mm_storeu_si128((__m128i*)(residual + 2 * residualStride), re_2);
-		_mm_storeu_si128((__m128i*)(residual + 3 * residualStride), re_3);
-		//input += 4 * inputStride;
-		//pred += 4 * predStride;
-		//residual += 4 * residualStride;
-	//}
+        _mm_storeu_si128((__m128i*)(residual + 0 * residualStride), re_0);
+        _mm_storeu_si128((__m128i*)(residual + 1 * residualStride), re_1);
+        _mm_storeu_si128((__m128i*)(residual + 2 * residualStride), re_2);
+        _mm_storeu_si128((__m128i*)(residual + 3 * residualStride), re_3);
+        //input += 4 * inputStride;
+        //pred += 4 * predStride;
+        //residual += 4 * residualStride;
+    //}
 }
 
 void ResidualKernel16x16_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	const __m256i zero = _mm256_setzero_si256();
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    const __m256i zero = _mm256_setzero_si256();
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 16; y += 2) {
-		const __m256i in0 = load8bit_16x2_unaligned_avx2(input, inputStride);
-		const __m256i pr0 = load8bit_16x2_unaligned_avx2(pred, predStride);
-		const __m256i in1 = _mm256_permute4x64_epi64(in0, 0xD8);
-		const __m256i pr1 = _mm256_permute4x64_epi64(pr0, 0xD8);
-		const __m256i in_lo = _mm256_unpacklo_epi8(in1, zero);
-		const __m256i in_hi = _mm256_unpackhi_epi8(in1, zero);
-		const __m256i pr_lo = _mm256_unpacklo_epi8(pr1, zero);
-		const __m256i pr_hi = _mm256_unpackhi_epi8(pr1, zero);
-		const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
-		const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
+    for (y = 0; y < 16; y += 2) {
+        const __m256i in0 = load8bit_16x2_unaligned_avx2(input, inputStride);
+        const __m256i pr0 = load8bit_16x2_unaligned_avx2(pred, predStride);
+        const __m256i in1 = _mm256_permute4x64_epi64(in0, 0xD8);
+        const __m256i pr1 = _mm256_permute4x64_epi64(pr0, 0xD8);
+        const __m256i in_lo = _mm256_unpacklo_epi8(in1, zero);
+        const __m256i in_hi = _mm256_unpackhi_epi8(in1, zero);
+        const __m256i pr_lo = _mm256_unpacklo_epi8(pr1, zero);
+        const __m256i pr_hi = _mm256_unpackhi_epi8(pr1, zero);
+        const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
+        const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
 
-		_mm256_storeu_si256((__m256i*)(residual + 0 * residualStride), re_lo);
-		_mm256_storeu_si256((__m256i*)(residual + 1 * residualStride), re_hi);
-		input += 2 * inputStride;
-		pred += 2 * predStride;
-		residual += 2 * residualStride;
-	}
+        _mm256_storeu_si256((__m256i*)(residual + 0 * residualStride), re_lo);
+        _mm256_storeu_si256((__m256i*)(residual + 1 * residualStride), re_hi);
+        input += 2 * inputStride;
+        pred += 2 * predStride;
+        residual += 2 * residualStride;
+    }
 }
 
 void ResidualKernel16x4_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	const __m256i zero = _mm256_setzero_si256();
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    const __m256i zero = _mm256_setzero_si256();
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 4; y += 2) {
-		const __m256i in0 = load8bit_16x2_unaligned_avx2(input, inputStride);
-		const __m256i pr0 = load8bit_16x2_unaligned_avx2(pred, predStride);
-		const __m256i in1 = _mm256_permute4x64_epi64(in0, 0xD8);
-		const __m256i pr1 = _mm256_permute4x64_epi64(pr0, 0xD8);
-		const __m256i in_lo = _mm256_unpacklo_epi8(in1, zero);
-		const __m256i in_hi = _mm256_unpackhi_epi8(in1, zero);
-		const __m256i pr_lo = _mm256_unpacklo_epi8(pr1, zero);
-		const __m256i pr_hi = _mm256_unpackhi_epi8(pr1, zero);
-		const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
-		const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
+    for (y = 0; y < 4; y += 2) {
+        const __m256i in0 = load8bit_16x2_unaligned_avx2(input, inputStride);
+        const __m256i pr0 = load8bit_16x2_unaligned_avx2(pred, predStride);
+        const __m256i in1 = _mm256_permute4x64_epi64(in0, 0xD8);
+        const __m256i pr1 = _mm256_permute4x64_epi64(pr0, 0xD8);
+        const __m256i in_lo = _mm256_unpacklo_epi8(in1, zero);
+        const __m256i in_hi = _mm256_unpackhi_epi8(in1, zero);
+        const __m256i pr_lo = _mm256_unpacklo_epi8(pr1, zero);
+        const __m256i pr_hi = _mm256_unpackhi_epi8(pr1, zero);
+        const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
+        const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
 
-		_mm256_storeu_si256((__m256i*)(residual + 0 * residualStride), re_lo);
-		_mm256_storeu_si256((__m256i*)(residual + 1 * residualStride), re_hi);
-		input += 2 * inputStride;
-		pred += 2 * predStride;
-		residual += 2 * residualStride;
-	}
+        _mm256_storeu_si256((__m256i*)(residual + 0 * residualStride), re_lo);
+        _mm256_storeu_si256((__m256i*)(residual + 1 * residualStride), re_hi);
+        input += 2 * inputStride;
+        pred += 2 * predStride;
+        residual += 2 * residualStride;
+    }
 }
 
 void ResidualKernel16x8_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	const __m256i zero = _mm256_setzero_si256();
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    const __m256i zero = _mm256_setzero_si256();
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 8; y += 2) {
-		const __m256i in0 = load8bit_16x2_unaligned_avx2(input, inputStride);
-		const __m256i pr0 = load8bit_16x2_unaligned_avx2(pred, predStride);
-		const __m256i in1 = _mm256_permute4x64_epi64(in0, 0xD8);
-		const __m256i pr1 = _mm256_permute4x64_epi64(pr0, 0xD8);
-		const __m256i in_lo = _mm256_unpacklo_epi8(in1, zero);
-		const __m256i in_hi = _mm256_unpackhi_epi8(in1, zero);
-		const __m256i pr_lo = _mm256_unpacklo_epi8(pr1, zero);
-		const __m256i pr_hi = _mm256_unpackhi_epi8(pr1, zero);
-		const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
-		const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
+    for (y = 0; y < 8; y += 2) {
+        const __m256i in0 = load8bit_16x2_unaligned_avx2(input, inputStride);
+        const __m256i pr0 = load8bit_16x2_unaligned_avx2(pred, predStride);
+        const __m256i in1 = _mm256_permute4x64_epi64(in0, 0xD8);
+        const __m256i pr1 = _mm256_permute4x64_epi64(pr0, 0xD8);
+        const __m256i in_lo = _mm256_unpacklo_epi8(in1, zero);
+        const __m256i in_hi = _mm256_unpackhi_epi8(in1, zero);
+        const __m256i pr_lo = _mm256_unpacklo_epi8(pr1, zero);
+        const __m256i pr_hi = _mm256_unpackhi_epi8(pr1, zero);
+        const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
+        const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
 
-		_mm256_storeu_si256((__m256i*)(residual + 0 * residualStride), re_lo);
-		_mm256_storeu_si256((__m256i*)(residual + 1 * residualStride), re_hi);
-		input += 2 * inputStride;
-		pred += 2 * predStride;
-		residual += 2 * residualStride;
-	}
+        _mm256_storeu_si256((__m256i*)(residual + 0 * residualStride), re_lo);
+        _mm256_storeu_si256((__m256i*)(residual + 1 * residualStride), re_hi);
+        input += 2 * inputStride;
+        pred += 2 * predStride;
+        residual += 2 * residualStride;
+    }
 }
 
 void ResidualKernel16x32_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	const __m256i zero = _mm256_setzero_si256();
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    const __m256i zero = _mm256_setzero_si256();
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 32; y += 2) {
-		const __m256i in0 = load8bit_16x2_unaligned_avx2(input, inputStride);
-		const __m256i pr0 = load8bit_16x2_unaligned_avx2(pred, predStride);
-		const __m256i in1 = _mm256_permute4x64_epi64(in0, 0xD8);
-		const __m256i pr1 = _mm256_permute4x64_epi64(pr0, 0xD8);
-		const __m256i in_lo = _mm256_unpacklo_epi8(in1, zero);
-		const __m256i in_hi = _mm256_unpackhi_epi8(in1, zero);
-		const __m256i pr_lo = _mm256_unpacklo_epi8(pr1, zero);
-		const __m256i pr_hi = _mm256_unpackhi_epi8(pr1, zero);
-		const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
-		const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
+    for (y = 0; y < 32; y += 2) {
+        const __m256i in0 = load8bit_16x2_unaligned_avx2(input, inputStride);
+        const __m256i pr0 = load8bit_16x2_unaligned_avx2(pred, predStride);
+        const __m256i in1 = _mm256_permute4x64_epi64(in0, 0xD8);
+        const __m256i pr1 = _mm256_permute4x64_epi64(pr0, 0xD8);
+        const __m256i in_lo = _mm256_unpacklo_epi8(in1, zero);
+        const __m256i in_hi = _mm256_unpackhi_epi8(in1, zero);
+        const __m256i pr_lo = _mm256_unpacklo_epi8(pr1, zero);
+        const __m256i pr_hi = _mm256_unpackhi_epi8(pr1, zero);
+        const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
+        const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
 
-		_mm256_storeu_si256((__m256i*)(residual + 0 * residualStride), re_lo);
-		_mm256_storeu_si256((__m256i*)(residual + 1 * residualStride), re_hi);
-		input += 2 * inputStride;
-		pred += 2 * predStride;
-		residual += 2 * residualStride;
-	}
+        _mm256_storeu_si256((__m256i*)(residual + 0 * residualStride), re_lo);
+        _mm256_storeu_si256((__m256i*)(residual + 1 * residualStride), re_hi);
+        input += 2 * inputStride;
+        pred += 2 * predStride;
+        residual += 2 * residualStride;
+    }
 }
 
 void ResidualKernel16x64_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	const __m256i zero = _mm256_setzero_si256();
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    const __m256i zero = _mm256_setzero_si256();
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 64; y += 2) {
-		const __m256i in0 = load8bit_16x2_unaligned_avx2(input, inputStride);
-		const __m256i pr0 = load8bit_16x2_unaligned_avx2(pred, predStride);
-		const __m256i in1 = _mm256_permute4x64_epi64(in0, 0xD8);
-		const __m256i pr1 = _mm256_permute4x64_epi64(pr0, 0xD8);
-		const __m256i in_lo = _mm256_unpacklo_epi8(in1, zero);
-		const __m256i in_hi = _mm256_unpackhi_epi8(in1, zero);
-		const __m256i pr_lo = _mm256_unpacklo_epi8(pr1, zero);
-		const __m256i pr_hi = _mm256_unpackhi_epi8(pr1, zero);
-		const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
-		const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
+    for (y = 0; y < 64; y += 2) {
+        const __m256i in0 = load8bit_16x2_unaligned_avx2(input, inputStride);
+        const __m256i pr0 = load8bit_16x2_unaligned_avx2(pred, predStride);
+        const __m256i in1 = _mm256_permute4x64_epi64(in0, 0xD8);
+        const __m256i pr1 = _mm256_permute4x64_epi64(pr0, 0xD8);
+        const __m256i in_lo = _mm256_unpacklo_epi8(in1, zero);
+        const __m256i in_hi = _mm256_unpackhi_epi8(in1, zero);
+        const __m256i pr_lo = _mm256_unpacklo_epi8(pr1, zero);
+        const __m256i pr_hi = _mm256_unpackhi_epi8(pr1, zero);
+        const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
+        const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
 
-		_mm256_storeu_si256((__m256i*)(residual + 0 * residualStride), re_lo);
-		_mm256_storeu_si256((__m256i*)(residual + 1 * residualStride), re_hi);
-		input += 2 * inputStride;
-		pred += 2 * predStride;
-		residual += 2 * residualStride;
-	}
+        _mm256_storeu_si256((__m256i*)(residual + 0 * residualStride), re_lo);
+        _mm256_storeu_si256((__m256i*)(residual + 1 * residualStride), re_hi);
+        input += 2 * inputStride;
+        pred += 2 * predStride;
+        residual += 2 * residualStride;
+    }
 }
 static INLINE void ResidualKernel32_AVX2(const uint8_t *const input,
-	const uint8_t *const pred, int16_t *const residual)
+    const uint8_t *const pred, int16_t *const residual)
 {
-	const __m256i zero = _mm256_setzero_si256();
-	const __m256i in0 = _mm256_loadu_si256((__m256i *)input);
-	const __m256i pr0 = _mm256_loadu_si256((__m256i *)pred);
-	const __m256i in1 = _mm256_permute4x64_epi64(in0, 0xD8);
-	const __m256i pr1 = _mm256_permute4x64_epi64(pr0, 0xD8);
-	const __m256i in_lo = _mm256_unpacklo_epi8(in1, zero);
-	const __m256i in_hi = _mm256_unpackhi_epi8(in1, zero);
-	const __m256i pr_lo = _mm256_unpacklo_epi8(pr1, zero);
-	const __m256i pr_hi = _mm256_unpackhi_epi8(pr1, zero);
-	const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
-	const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
-	_mm256_storeu_si256((__m256i*)(residual + 0x00), re_lo);
-	_mm256_storeu_si256((__m256i*)(residual + 0x10), re_hi);
+    const __m256i zero = _mm256_setzero_si256();
+    const __m256i in0 = _mm256_loadu_si256((__m256i *)input);
+    const __m256i pr0 = _mm256_loadu_si256((__m256i *)pred);
+    const __m256i in1 = _mm256_permute4x64_epi64(in0, 0xD8);
+    const __m256i pr1 = _mm256_permute4x64_epi64(pr0, 0xD8);
+    const __m256i in_lo = _mm256_unpacklo_epi8(in1, zero);
+    const __m256i in_hi = _mm256_unpackhi_epi8(in1, zero);
+    const __m256i pr_lo = _mm256_unpacklo_epi8(pr1, zero);
+    const __m256i pr_hi = _mm256_unpackhi_epi8(pr1, zero);
+    const __m256i re_lo = _mm256_sub_epi16(in_lo, pr_lo);
+    const __m256i re_hi = _mm256_sub_epi16(in_hi, pr_hi);
+    _mm256_storeu_si256((__m256i*)(residual + 0x00), re_lo);
+    _mm256_storeu_si256((__m256i*)(residual + 0x10), re_hi);
 }
 
 void ResidualKernel32x8_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 8; ++y) {
-		ResidualKernel32_AVX2(input, pred, residual);
-		input += inputStride;
-		pred += predStride;
-		residual += residualStride;
-	}
+    for (y = 0; y < 8; ++y) {
+        ResidualKernel32_AVX2(input, pred, residual);
+        input += inputStride;
+        pred += predStride;
+        residual += residualStride;
+    }
 }
 
 void ResidualKernel32x16_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 16; ++y) {
-		ResidualKernel32_AVX2(input, pred, residual);
-		input += inputStride;
-		pred += predStride;
-		residual += residualStride;
-	}
+    for (y = 0; y < 16; ++y) {
+        ResidualKernel32_AVX2(input, pred, residual);
+        input += inputStride;
+        pred += predStride;
+        residual += residualStride;
+    }
 }
 
 void ResidualKernel32x32_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 32; ++y) {
-		ResidualKernel32_AVX2(input, pred, residual);
-		input += inputStride;
-		pred += predStride;
-		residual += residualStride;
-	}
+    for (y = 0; y < 32; ++y) {
+        ResidualKernel32_AVX2(input, pred, residual);
+        input += inputStride;
+        pred += predStride;
+        residual += residualStride;
+    }
 }
 
 
 void ResidualKernel32x64_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 64; ++y) {
-		ResidualKernel32_AVX2(input, pred, residual);
-		input += inputStride;
-		pred += predStride;
-		residual += residualStride;
-	}
+    for (y = 0; y < 64; ++y) {
+        ResidualKernel32_AVX2(input, pred, residual);
+        input += inputStride;
+        pred += predStride;
+        residual += residualStride;
+    }
 }
 
 void ResidualKernel64x16_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 16; ++y) {
-		ResidualKernel32_AVX2(input + 0x00, pred + 0x00, residual + 0x00);
-		ResidualKernel32_AVX2(input + 0x20, pred + 0x20, residual + 0x20);
-		input += inputStride;
-		pred += predStride;
-		residual += residualStride;
-	}
+    for (y = 0; y < 16; ++y) {
+        ResidualKernel32_AVX2(input + 0x00, pred + 0x00, residual + 0x00);
+        ResidualKernel32_AVX2(input + 0x20, pred + 0x20, residual + 0x20);
+        input += inputStride;
+        pred += predStride;
+        residual += residualStride;
+    }
 }
 
 void ResidualKernel64x32_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 32; ++y) {
-		ResidualKernel32_AVX2(input + 0x00, pred + 0x00, residual + 0x00);
-		ResidualKernel32_AVX2(input + 0x20, pred + 0x20, residual + 0x20);
-		input += inputStride;
-		pred += predStride;
-		residual += residualStride;
-	}
+    for (y = 0; y < 32; ++y) {
+        ResidualKernel32_AVX2(input + 0x00, pred + 0x00, residual + 0x00);
+        ResidualKernel32_AVX2(input + 0x20, pred + 0x20, residual + 0x20);
+        input += inputStride;
+        pred += predStride;
+        residual += residualStride;
+    }
 }
 
 void ResidualKernel64x64_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 64; ++y) {
-		ResidualKernel32_AVX2(input + 0x00, pred + 0x00, residual + 0x00);
-		ResidualKernel32_AVX2(input + 0x20, pred + 0x20, residual + 0x20);
-		input += inputStride;
-		pred += predStride;
-		residual += residualStride;
-	}
+    for (y = 0; y < 64; ++y) {
+        ResidualKernel32_AVX2(input + 0x00, pred + 0x00, residual + 0x00);
+        ResidualKernel32_AVX2(input + 0x20, pred + 0x20, residual + 0x20);
+        input += inputStride;
+        pred += predStride;
+        residual += residualStride;
+    }
 }
 
 void ResidualKernel64x128_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 128; ++y) {
-		ResidualKernel32_AVX2(input + 0x00, pred + 0x00, residual + 0x00);
-		ResidualKernel32_AVX2(input + 0x20, pred + 0x20, residual + 0x20);
-		input += inputStride;
-		pred += predStride;
-		residual += residualStride;
-	}
+    for (y = 0; y < 128; ++y) {
+        ResidualKernel32_AVX2(input + 0x00, pred + 0x00, residual + 0x00);
+        ResidualKernel32_AVX2(input + 0x20, pred + 0x20, residual + 0x20);
+        input += inputStride;
+        pred += predStride;
+        residual += residualStride;
+    }
 }
 
 
 void ResidualKernel128x128_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 128; ++y) {
-		ResidualKernel32_AVX2(input + 0x00, pred + 0x00, residual + 0x00);
-		ResidualKernel32_AVX2(input + 0x20, pred + 0x20, residual + 0x20);
-		ResidualKernel32_AVX2(input + 0x40, pred + 0x40, residual + 0x40);
-		ResidualKernel32_AVX2(input + 0x60, pred + 0x60, residual + 0x60);
-		input += inputStride;
-		pred += predStride;
-		residual += residualStride;
-	}
+    for (y = 0; y < 128; ++y) {
+        ResidualKernel32_AVX2(input + 0x00, pred + 0x00, residual + 0x00);
+        ResidualKernel32_AVX2(input + 0x20, pred + 0x20, residual + 0x20);
+        ResidualKernel32_AVX2(input + 0x40, pred + 0x40, residual + 0x40);
+        ResidualKernel32_AVX2(input + 0x60, pred + 0x60, residual + 0x60);
+        input += inputStride;
+        pred += predStride;
+        residual += residualStride;
+    }
 }
 
 void ResidualKernel128x64_AVX2_INTRIN(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	uint32_t y;
-	(void)areaWidth;
-	(void)areaHeight;
+    uint32_t y;
+    (void)areaWidth;
+    (void)areaHeight;
 
-	for (y = 0; y < 64; ++y) {
-		ResidualKernel32_AVX2(input + 0x00, pred + 0x00, residual + 0x00);
-		ResidualKernel32_AVX2(input + 0x20, pred + 0x20, residual + 0x20);
-		ResidualKernel32_AVX2(input + 0x40, pred + 0x40, residual + 0x40);
-		ResidualKernel32_AVX2(input + 0x60, pred + 0x60, residual + 0x60);
-		input += inputStride;
-		pred += predStride;
-		residual += residualStride;
-	}
+    for (y = 0; y < 64; ++y) {
+        ResidualKernel32_AVX2(input + 0x00, pred + 0x00, residual + 0x00);
+        ResidualKernel32_AVX2(input + 0x20, pred + 0x20, residual + 0x20);
+        ResidualKernel32_AVX2(input + 0x40, pred + 0x40, residual + 0x40);
+        ResidualKernel32_AVX2(input + 0x60, pred + 0x60, residual + 0x60);
+        input += inputStride;
+        pred += predStride;
+        residual += residualStride;
+    }
 }
 void ResidualKernel_avx2(
-	uint8_t   *input,
-	uint32_t   inputStride,
-	uint8_t   *pred,
-	uint32_t   predStride,
-	int16_t  *residual,
-	uint32_t   residualStride,
-	uint32_t   areaWidth,
-	uint32_t   areaHeight)
+    uint8_t   *input,
+    uint32_t   inputStride,
+    uint8_t   *pred,
+    uint32_t   predStride,
+    int16_t  *residual,
+    uint32_t   residualStride,
+    uint32_t   areaWidth,
+    uint32_t   areaHeight)
 {
-	if (areaWidth == areaHeight) {
-		switch (areaWidth) {
-		case 4:
-			ResidualKernel4x4_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-			break;
-		case 8:
-			ResidualKernel8x8_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-			break;
-		case 16:
-			ResidualKernel16x16_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-			break;
-		case 32:
-			ResidualKernel32x32_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-			break;
-		case 64:
-			ResidualKernel64x64_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-			break;
-		case 128:
-			ResidualKernel128x128_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-			break;
-		}
-	}
-	else {
-		if (areaWidth < areaHeight) {
-			if (areaWidth + areaWidth == areaHeight) {
-				switch (areaWidth) {
-				case 4:
-					ResidualKernel4x8_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-					break;
-				case 8:
-					ResidualKernel8x16_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-					break;
-				case 16:
-					ResidualKernel16x32_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-					break;
-				case 32:
-					ResidualKernel32x64_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-					break;
-				case 64:
-					ResidualKernel64x128_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-					break;
-				}
-			}
-			else {
-				switch (areaWidth) {
-				case 4:
-					ResidualKernel4x16_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-					break;
-				case 8:
-					ResidualKernel8x32_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-					break;
-				case 16:
-					ResidualKernel16x64_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-					break;
-				}
-			}
-		}
-		else {
-			if (areaHeight + areaHeight == areaWidth) {
-				switch (areaHeight) {
-				case 4:
-					ResidualKernel8x4_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-					break;
-				case 8:
-					ResidualKernel16x8_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-					break;
-				case 16:
-					ResidualKernel32x16_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-					break;
-				case 32:
-					ResidualKernel64x32_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-					break;
-				case 64:
-					ResidualKernel128x64_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-					break;
-				}
-			}
-			else {
-				switch (areaHeight) {
-				case 4:
-					ResidualKernel16x4_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-					break;
-				case 8:
-					ResidualKernel32x8_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-					break;
-				case 16:
-					ResidualKernel64x16_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
-					break;
-				}
-			}
-		}
-	}
+    if (areaWidth == areaHeight) {
+        switch (areaWidth) {
+        case 4:
+            ResidualKernel4x4_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+            break;
+        case 8:
+            ResidualKernel8x8_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+            break;
+        case 16:
+            ResidualKernel16x16_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+            break;
+        case 32:
+            ResidualKernel32x32_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+            break;
+        case 64:
+            ResidualKernel64x64_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+            break;
+        case 128:
+            ResidualKernel128x128_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+            break;
+        }
+    }
+    else {
+        if (areaWidth < areaHeight) {
+            if (areaWidth + areaWidth == areaHeight) {
+                switch (areaWidth) {
+                case 4:
+                    ResidualKernel4x8_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+                    break;
+                case 8:
+                    ResidualKernel8x16_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+                    break;
+                case 16:
+                    ResidualKernel16x32_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+                    break;
+                case 32:
+                    ResidualKernel32x64_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+                    break;
+                case 64:
+                    ResidualKernel64x128_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+                    break;
+                }
+            }
+            else {
+                switch (areaWidth) {
+                case 4:
+                    ResidualKernel4x16_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+                    break;
+                case 8:
+                    ResidualKernel8x32_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+                    break;
+                case 16:
+                    ResidualKernel16x64_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+                    break;
+                }
+            }
+        }
+        else {
+            if (areaHeight + areaHeight == areaWidth) {
+                switch (areaHeight) {
+                case 4:
+                    ResidualKernel8x4_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+                    break;
+                case 8:
+                    ResidualKernel16x8_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+                    break;
+                case 16:
+                    ResidualKernel32x16_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+                    break;
+                case 32:
+                    ResidualKernel64x32_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+                    break;
+                case 64:
+                    ResidualKernel128x64_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+                    break;
+                }
+            }
+            else {
+                switch (areaHeight) {
+                case 4:
+                    ResidualKernel16x4_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+                    break;
+                case 8:
+                    ResidualKernel32x8_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+                    break;
+                case 16:
+                    ResidualKernel64x16_AVX2_INTRIN(input, inputStride, pred, predStride, residual, residualStride, areaWidth, areaHeight);
+                    break;
+                }
+            }
+        }
+    }
 }

--- a/Source/Lib/ASM_AVX2/encodetxb_avx2.c
+++ b/Source/Lib/ASM_AVX2/encodetxb_avx2.c
@@ -25,8 +25,8 @@
 typedef int32_t tran_low_t;
 
 void av1_txb_init_levels_avx2(const tran_low_t *const coeff, const int32_t width,
-	const int32_t height, uint8_t *const levels) {
-	const int32_t stride = width + TX_PAD_HOR;
+    const int32_t height, uint8_t *const levels) {
+    const int32_t stride = width + TX_PAD_HOR;
   const __m256i y_zeros = _mm256_setzero_si256();
 
   const int32_t pre_len = sizeof(*levels) * TX_PAD_TOP * stride;

--- a/Source/Lib/ASM_AVX2/highbd_inv_txfm_avx2.c
+++ b/Source/Lib/ASM_AVX2/highbd_inv_txfm_avx2.c
@@ -6543,8 +6543,8 @@ void av1_highbd_inv_txfm2d_add_universe_avx2(const int32_t *input,
     }
 }
 void av1_highbd_inv_txfm_add_avx2(const int32_t *input, uint16_t *dest,
-	int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd) {
-	//assert(av1_ext_tx_used[txfm_param->tx_set_type][txfm_param->tx_type]);
+    int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd) {
+    //assert(av1_ext_tx_used[txfm_param->tx_set_type][txfm_param->tx_type]);
 
     av1_highbd_inv_txfm2d_add_universe_avx2(
         input, dest, stride, tx_type, tx_size,

--- a/Source/Lib/ASM_SSE2/CMakeLists.txt
+++ b/Source/Lib/ASM_SSE2/CMakeLists.txt
@@ -20,7 +20,7 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Intel")
-	SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -static-intel -w")
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -static-intel -w")
 endif()
 
 file(GLOB all_files

--- a/Source/Lib/ASM_SSSE3/CMakeLists.txt
+++ b/Source/Lib/ASM_SSSE3/CMakeLists.txt
@@ -23,7 +23,7 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Intel")
-	SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -static-intel -w")
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC -static-intel -w")
 endif()
 
 file(GLOB all_files

--- a/Source/Lib/Codec/EbAdaptiveMotionVectorPrediction.c
+++ b/Source/Lib/Codec/EbAdaptiveMotionVectorPrediction.c
@@ -18,7 +18,6 @@
 
 #include "EbDefinitions.h"
 #include "EbUtility.h"
-
 #include "EbAdaptiveMotionVectorPrediction.h"
 #include "EbSequenceControlSet.h"
 #include "EbReferenceObject.h"
@@ -60,7 +59,7 @@ static inline void scale_mv(
         td = CLIP3(-128, 127, td);
         temp = (int16_t)((0x4000 + ABS(td >> 1)) / td);
         scale_factor = CLIP3(-4096, 4095, (tb * temp + 32) >> 6);
-        
+
         *mvx = CLIP3(-32768, 32767, (scale_factor * (*mvx) + 127 + (scale_factor * (*mvx) < 0)) >> 8);
         *mvy = CLIP3(-32768, 32767, (scale_factor * (*mvy) + 127 + (scale_factor * (*mvy) < 0)) >> 8);
     }
@@ -280,7 +279,7 @@ static inline EbBool get_scaling_spatial_amvp_v2(
     EbReferenceObject_t      *reference_object;
     uint64_t                  ref_pic_poc;
     EbReflist                ref_pic_list;
-    
+
     cur_pic_poc = picture_control_set_ptr->picture_number;
 
     if (mv_unit->predDirection == BI_PRED)
@@ -508,9 +507,9 @@ static MvReferenceFrame ref_frame_map[TOTAL_COMP_REFS][2] = {
 };
 
 static void clamp_mv(
-    MV *mv, 
-    int32_t min_col, 
-    int32_t max_col, 
+    MV *mv,
+    int32_t min_col,
+    int32_t max_col,
     int32_t min_row,
     int32_t max_row) {
     mv->col = (int16_t)clamp(mv->col, min_col, max_col);
@@ -836,7 +835,7 @@ static void scan_blk_mbmi(const Av1Common *cm, const MacroBlockD *xd,
 
 static int32_t has_top_right(const Av1Common *cm, const MacroBlockD *xd,
     int32_t mi_row, int32_t mi_col, int32_t bs) {
-    
+
     (void)xd;
     (void)cm;
     const int32_t sb_mi_size = mi_size_wide[cm->p_pcs_ptr->sequence_control_set_ptr->sb_size];
@@ -1001,9 +1000,9 @@ void setup_ref_mv_list(
 
 
     //-------------------------- TMVP --------------------------
-    //CHKN  TMVP - get canididates from reference frames- orderHint has to be on, 
+    //CHKN  TMVP - get canididates from reference frames- orderHint has to be on,
     // in order to scale the vectors.
-    //CHKN this checks all colocated block(s) + extra 3 positions. this changes 
+    //CHKN this checks all colocated block(s) + extra 3 positions. this changes
     // the mode context too.
 
     //-------------------------- TMVP --------------------------
@@ -1192,11 +1191,11 @@ void setup_ref_mv_list(
 
             for (int32_t idx = 0; idx < 2; ++idx) {
                 int32_t comp_idx = 0;
-                for (int32_t list_idx = 0; list_idx < ref_id_count[idx] 
+                for (int32_t list_idx = 0; list_idx < ref_id_count[idx]
                     && comp_idx < 3; ++list_idx, ++comp_idx)
                     comp_list[comp_idx][idx] = ref_id[idx][list_idx];
 
-                for (int32_t list_idx = 0; list_idx < ref_diff_count[idx] 
+                for (int32_t list_idx = 0; list_idx < ref_diff_count[idx]
                     && comp_idx < 3; ++list_idx, ++comp_idx)
                     comp_list[comp_idx][idx] = ref_diff[idx][list_idx];
 
@@ -1207,7 +1206,7 @@ void setup_ref_mv_list(
             //CHKN fill the stack, increment the counter
             if (refmv_count[ref_frame]) { //CHKN RefMvCount=1
                 assert(refmv_count[ref_frame] == 1);
-                if (comp_list[0][0].as_int == ref_mv_stack[ref_frame][0].this_mv.as_int 
+                if (comp_list[0][0].as_int == ref_mv_stack[ref_frame][0].this_mv.as_int
                     &&  comp_list[0][1].as_int == ref_mv_stack[ref_frame][0].comp_mv.as_int) {
                     ref_mv_stack[ref_frame][refmv_count[ref_frame]].this_mv = comp_list[1][0];
                     ref_mv_stack[ref_frame][refmv_count[ref_frame]].comp_mv = comp_list[1][1];
@@ -1324,7 +1323,7 @@ void setup_ref_mv_list(
 
         //CHKN  THIS IS a Single Reference case
 
-        //CHKN if the stack has at least 2 cand, then copy the top 2 to the final mvp Table, 
+        //CHKN if the stack has at least 2 cand, then copy the top 2 to the final mvp Table,
         // if the stack has less than 2, use Gm to fill the mvpTable.
         //     the stack counter remains 0 or 1 in this case.
 
@@ -1418,9 +1417,7 @@ static INLINE IntMv gm_get_motion_vector(
 }
 
 void generate_av1_mvp_table(
-#if MEM_RED2
     ModeDecisionContext_t            *context_ptr,
-#endif
     CodingUnit_t                     *cu_ptr,
     const BlockGeom                  *blk_geom,
     uint16_t                          cu_origin_x,
@@ -1447,11 +1444,7 @@ void generate_av1_mvp_table(
     xd->mb_to_right_edge = ((cm->mi_cols - bw - mi_col) * MI_SIZE) * 8;
 
     memset(xd->ref_mv_count, 0, sizeof(xd->ref_mv_count));
-#if MEM_RED2   
     memset(context_ptr->md_local_cu_unit[blk_geom->blkidx_mds].ed_ref_mv_stack, 0, sizeof(context_ptr->md_local_cu_unit[blk_geom->blkidx_mds].ed_ref_mv_stack));
-#else
-    memset(xd->ref_mv_stack, 0, sizeof(xd->ref_mv_stack));
-#endif
 
     xd->up_available = (mi_row > 0);
     xd->left_available = (mi_col > 0);
@@ -1512,11 +1505,7 @@ void generate_av1_mvp_table(
             xd,
             ref_frame,
             xd->ref_mv_count,
-#if MEM_RED2   
             context_ptr->md_local_cu_unit[blk_geom->blkidx_mds].ed_ref_mv_stack,
-#else
-            xd->ref_mv_stack,
-#endif
             cu_ptr->ref_mvs,
             zeromv,
             mi_row,
@@ -1527,9 +1516,7 @@ void generate_av1_mvp_table(
 
 }
 void get_av1_mv_pred_drl(
-#if MEM_RED2
     ModeDecisionContext_t            *context_ptr,
-#endif
     CodingUnit_t      *cu_ptr,
     MvReferenceFrame   ref_frame,
     uint8_t            is_compound,
@@ -1551,27 +1538,14 @@ void get_av1_mv_pred_drl(
 
     if (is_compound && mode != GLOBAL_GLOBALMV) {
         int32_t ref_mv_idx = drl_index + 1;
-#if MEM_RED2   
-       
         nearestmv[0] = context_ptr->md_local_cu_unit[cu_ptr->mds_idx].ed_ref_mv_stack[ref_frame][0].this_mv;
         nearestmv[1] = context_ptr->md_local_cu_unit[cu_ptr->mds_idx].ed_ref_mv_stack[ref_frame][0].comp_mv;
         nearmv[0]    = context_ptr->md_local_cu_unit[cu_ptr->mds_idx].ed_ref_mv_stack[ref_frame][ref_mv_idx].this_mv;
         nearmv[1]    = context_ptr->md_local_cu_unit[cu_ptr->mds_idx].ed_ref_mv_stack[ref_frame][ref_mv_idx].comp_mv;
-
-#else
-        nearestmv[0] = xd->ref_mv_stack[ref_frame][0].this_mv;
-        nearestmv[1] = xd->ref_mv_stack[ref_frame][0].comp_mv;
-        nearmv[0] = xd->ref_mv_stack[ref_frame][ref_mv_idx].this_mv;
-        nearmv[1] = xd->ref_mv_stack[ref_frame][ref_mv_idx].comp_mv;
-#endif
     }
     else if (drl_index > 0 && mode == NEARMV) {
         ASSERT((1 + drl_index) < MAX_REF_MV_STACK_SIZE);
-#if MEM_RED2   
         IntMv cur_mv = context_ptr->md_local_cu_unit[cu_ptr->mds_idx].ed_ref_mv_stack[ref_frame][1 + drl_index].this_mv;
-#else
-        IntMv cur_mv = xd->ref_mv_stack[ref_frame][1 + drl_index].this_mv;
-#endif
         nearmv[0] = cur_mv;
     }
 
@@ -1589,29 +1563,16 @@ void get_av1_mv_pred_drl(
 
         // TODO(jingning, yunqing): Do we need a lower_mv_precision() call here?
         if (compound_ref0_mode(mode) == NEWMV)
-#if MEM_RED2               
             ref_mv[0] = context_ptr->md_local_cu_unit[cu_ptr->mds_idx].ed_ref_mv_stack[ref_frame][ref_mv_idx].this_mv;
-#else
-            ref_mv[0] = xd->ref_mv_stack[ref_frame][ref_mv_idx].this_mv;
-#endif
 
         if (compound_ref1_mode(mode) == NEWMV)
-#if MEM_RED2               
             ref_mv[1] = context_ptr->md_local_cu_unit[cu_ptr->mds_idx].ed_ref_mv_stack[ref_frame][ref_mv_idx].comp_mv;
-#else
-            ref_mv[1] = xd->ref_mv_stack[ref_frame][ref_mv_idx].comp_mv;
-#endif
-
 
     }
     else {
         if (mode == NEWMV) {
             if (xd->ref_mv_count[ref_frame] > 1)
-#if MEM_RED2               
                 ref_mv[0] = context_ptr->md_local_cu_unit[cu_ptr->mds_idx].ed_ref_mv_stack[ref_frame][drl_index].this_mv;
-#else
-                ref_mv[0] = xd->ref_mv_stack[ref_frame][drl_index].this_mv;
-#endif
         }
     }
 
@@ -1619,9 +1580,7 @@ void get_av1_mv_pred_drl(
 }
 
 void enc_pass_av1_mv_pred(
-#if MEM_RED2
     ModeDecisionContext_t            *md_context_ptr,
-#endif
     CodingUnit_t                     *cu_ptr,
     const BlockGeom                  *blk_geom,
     uint16_t                          cu_origin_x,
@@ -1636,9 +1595,7 @@ void enc_pass_av1_mv_pred(
     IntMv    nearestmv[2], nearmv[2];
 
     generate_av1_mvp_table(
-#if MEM_RED2
         md_context_ptr,
-#endif
         cu_ptr,
         blk_geom,
         cu_origin_x,
@@ -1648,9 +1605,7 @@ void enc_pass_av1_mv_pred(
         picture_control_set_ptr);
 
     get_av1_mv_pred_drl(
-#if MEM_RED2
         md_context_ptr,
-#endif
         cu_ptr,
         ref_frame,
         is_compound,
@@ -1745,7 +1700,7 @@ void update_mi_map(
     ModeInfo *miPtr = *(picture_control_set_ptr->mi_grid_base + offset);
     MvReferenceFrame rf[2];
     av1_set_ref_frame(rf, cu_ptr->prediction_unit_array->ref_frame_type);
-    
+
     uint8_t  miX, miY;
     for (miY = 0; miY < (blk_geom->bheight >> MI_SIZE_LOG2); miY++) {
 
@@ -1883,7 +1838,7 @@ int av1_find_samples(
     int mi_row,
     int mi_col,
     int *pts,
-    int *pts_inref) 
+    int *pts_inref)
 {
   MbModeInfo *const mbmi0 = &xd->mi[0]->mbmi;
   int ref_frame = mbmi0->ref_frame[0];

--- a/Source/Lib/Codec/EbAdaptiveMotionVectorPrediction.h
+++ b/Source/Lib/Codec/EbAdaptiveMotionVectorPrediction.h
@@ -47,9 +47,7 @@ extern "C" {
         uint32_t                   tbSize);
 
     void generate_av1_mvp_table(
-#if MEM_RED2
         struct ModeDecisionContext_s            *context_ptr,
-#endif
         CodingUnit_t                     *cu_ptr,
         const BlockGeom                   * blk_geom,
         uint16_t                            cu_origin_x,
@@ -59,9 +57,7 @@ extern "C" {
         PictureControlSet_t              *picture_control_set_ptr);
 
     void get_av1_mv_pred_drl(
-#if MEM_RED2
         struct ModeDecisionContext_s            *context_ptr,
-#endif
         CodingUnit_t      *cu_ptr,
         MvReferenceFrame ref_frame,
         uint8_t              is_compound,
@@ -72,9 +68,7 @@ extern "C" {
         IntMv             ref_mv[2]);
 
     void enc_pass_av1_mv_pred(
-#if MEM_RED2
         struct ModeDecisionContext_s            *md_context_ptr,
-#endif
         CodingUnit_t                     *cu_ptr,
         const BlockGeom                   * blk_geom,
         uint16_t                            cu_origin_x,

--- a/Source/Lib/Codec/EbBitstreamUnit.c
+++ b/Source/Lib/Codec/EbBitstreamUnit.c
@@ -76,21 +76,9 @@ EbErrorType output_bitstream_rbsp_to_payload(
     uint32_t  read_location = start_location;
     EbByte read_byte_ptr;
     EbByte write_byte_ptr;
-#if IVF_FRAME_HEADER_IN_LIB
-    static uint64_t frame_count = 0;
-#endif
     // IVF data
     read_byte_ptr = (EbByte)bitstream_ptr->bufferBeginAv1;
     write_byte_ptr = &output_buffer[*output_buffer_index];
-#if IVF_FRAME_HEADER_IN_LIB
-    mem_put_le32(&write_byte_ptr[write_location], (int32_t)buffer_written_bytes_count);
-    write_location = write_location + 4;
-    mem_put_le32(&write_byte_ptr[write_location], (int32_t)(frame_count & 0xFFFFFFFF));
-    write_location = write_location + 4;
-    mem_put_le32(&write_byte_ptr[write_location], (int32_t)(frame_count >> 32));
-    write_location = write_location + 4;
-    *output_buffer_index += 12;
-#endif
     //frame_count++;
     while ((read_location < buffer_written_bytes_count)) {
         if ((*output_buffer_index) < (*output_buffer_size)) {

--- a/Source/Lib/Codec/EbCodingUnit.c
+++ b/Source/Lib/Codec/EbCodingUnit.c
@@ -31,9 +31,6 @@ EbErrorType largest_coding_unit_ctor(
 {
     EbErrorType return_error = EB_ErrorNone;
     uint32_t borderLargestCuSize;
-#if !MEM_RED
-    uint8_t codedLeafIndex;
-#endif
     uint32_t tu_index;
     EbPictureBufferDescInitData_t coeffInitData;
 
@@ -88,21 +85,6 @@ EbErrorType largest_coding_unit_ctor(
 
     EB_MALLOC(PartitionType*, largestCodingUnitPtr->cu_partition_array, sizeof(PartitionType) * BLOCK_MAX_COUNT, EB_N_PTR);
 
-#if !MEM_RED
-    EB_MALLOC(CodingUnit_t**, largestCodingUnitPtr->coded_leaf_array_ptr, sizeof(CodingUnit_t*) * CU_MAX_COUNT, EB_N_PTR);
-    for (codedLeafIndex = 0; codedLeafIndex < CU_MAX_COUNT; ++codedLeafIndex) {
-        EB_MALLOC(CodingUnit_t*, largestCodingUnitPtr->coded_leaf_array_ptr[codedLeafIndex], sizeof(CodingUnit_t), EB_N_PTR);
-        for (tu_index = 0; tu_index < TRANSFORM_UNIT_MAX_COUNT; ++tu_index) {
-            largestCodingUnitPtr->coded_leaf_array_ptr[codedLeafIndex]->transform_unit_array[tu_index].tu_index = tu_index;
-        }
-
-        largestCodingUnitPtr->coded_leaf_array_ptr[codedLeafIndex]->leaf_index = codedLeafIndex;
-
-        EB_MALLOC(MacroBlockD*, largestCodingUnitPtr->coded_leaf_array_ptr[codedLeafIndex]->av1xd, sizeof(MacroBlockD), EB_N_PTR);
-
-
-    }
-#endif
     coeffInitData.bufferEnableMask = PICTURE_BUFFER_DESC_FULL_MASK;
     coeffInitData.maxWidth = SB_STRIDE_Y;
     coeffInitData.maxHeight = SB_STRIDE_Y;
@@ -112,7 +94,6 @@ EbErrorType largest_coding_unit_ctor(
     coeffInitData.top_padding = 0;
     coeffInitData.bot_padding = 0;
     coeffInitData.splitMode = EB_FALSE;
-
 
     return_error = EbPictureBufferDescCtor(
         (EbPtr*) &(largestCodingUnitPtr->quantized_coeff),

--- a/Source/Lib/Codec/EbCodingUnit.h
+++ b/Source/Lib/Codec/EbCodingUnit.h
@@ -218,11 +218,7 @@ extern "C" {
         uint8_t n8_w, n8_h;
         uint8_t n4_w, n4_h;  // TODO: this is for warped motion, for now
         uint8_t ref_mv_count[MODE_CTX_REF_FRAMES];
-#if MEM_RED2
         CandidateMv final_ref_mv_stack[MAX_REF_MV_STACK_SIZE];       
-#else
-        CandidateMv ref_mv_stack[MODE_CTX_REF_FRAMES][MAX_REF_MV_STACK_SIZE];
-#endif
         uint8_t is_sec_rect;
         int32_t up_available;
         int32_t left_available;
@@ -343,9 +339,6 @@ extern "C" {
     } EdgeLcuResults_t;
     typedef struct LargestCodingUnit_s {
         struct PictureControlSet_s     *picture_control_set_ptr;
-#if !MEM_RED
-        CodingUnit_t                  **coded_leaf_array_ptr;
-#endif
         CodingUnit_t                   *final_cu_arr;
         uint32_t                        tot_final_cu;
         PartitionType                  *cu_partition_array;

--- a/Source/Lib/Codec/EbDefinitions.h
+++ b/Source/Lib/Codec/EbDefinitions.h
@@ -35,121 +35,106 @@
 extern "C" {
 #endif
      //Mode definition : Only one mode should be ON at a time
-#define MM                                    0
-#define NEW_M0                                0
-#define NEW_M1                              0
-#define NEWW_M2                                0
-#define MR_MODE                                0
-#define SHUT_FILTERING                      0 // CDEF RESTORATION DLF
+#define MR_MODE                                         0
+#define SHUT_FILTERING                                  0 // CDEF RESTORATION DLF
     ////
-#define MEM_RED                                1
-#define MEM_RED2                            1
-#define MEM_RED3                            1
-#define MEM_RED4                            0 //  Reduce mem allocation when DISABLE_128X128_SB is ON
+#define MEM_RED4                                        0 //  Reduce mem allocation when DISABLE_128X128_SB is ON
 
-#define INTRA_CORE_OPT                        1
-#define INTRA_LOSSY_OPT                        1
+#define    DLF_TEST2                                       1
+#define    DLF_TEST3                                       0
+#define    DLF_TEST4                                       0
 
-#define ENCODER_MODE_CLEANUP                1                                          
-#define IVF_FRAME_HEADER_IN_LIB                     0
+#define INTRA_CORE_OPT                                  1
 
-#define ENABLE_INTRA_4x4                            1 //
-#define DISABLE_NSQ                                 1 //
-#define DISABLE_128X128_SB                          0
-#define ENABLE_INTER_4x4                            0 // optional
+#define ENCODER_MODE_CLEANUP                            1                                          
 
-#define DISABLE_4xN_Nx4                               1 //
-#define DISABLE_128x128                                  0 //
-#define VCI_CANDIDATE_II                              1
+#define ENABLE_INTRA_4x4                                1 //
+#define DISABLE_NSQ                                     1 //
+#define DISABLE_128X128_SB                              0
+#define ENABLE_INTER_4x4                                0 // optional
+#define DISABLE_4xN_Nx4                                 1 //
+#define DISABLE_128x128                                 0 //
+#define VCI_CANDIDATE_II                                1
 
 #if VCI_CANDIDATE_II
-#define INTRA_ASM                                     1
-#define CBF_ZERO_OFF                                  1 // Remove CBF zero feature due to VQ problems
-#define TX_TYPE_FIX                                   1 // Fix the Tx Type search for Inter blocks
-#define INC_NFL                                       1 // Set NFL to 4 for all sizes and temporal layers
-#define REMOVE_INTRA_CONST                            1 // Remove the constraints for INTRA injection
+#define INTRA_ASM                                       1
+#define CBF_ZERO_OFF                                    1 // Remove CBF zero feature due to VQ problems
+#define TX_TYPE_FIX                                     1 // Fix the Tx Type search for Inter blocks
+#define INC_NFL                                         1 // Set NFL to 4 for all sizes and temporal layers
+#define REMOVE_INTRA_CONST                              1 // Remove the constraints for INTRA injection
 
 // ADOPTED HEVC-M0 FEATURES (Active in M0 and M1)
-#define M0_ME_QUARTER_PEL_SEARCH                      1 // F1
-#define SHUT_CBF_FL_SKIP                              1 // F2 Lossless
-#define V2_HME_ME_SR                                  1 // F3
-#define ME_64x64                                      1 // F4
-#define V2_QP_SCALING                                 1 // F5 to keep for vmaff only
-#define NEW_QP_SCALING                                1 // F6
-#define M0_SSD_HALF_QUARTER_PEL_BIPRED_SEARCH         1 // F7
-#define M0_64x64_32x32_HALF_QUARTER_PEL               1 // F8
-
-#define IMPROVED_UNIPRED_INJECTION                    1 // F11
-#define IMPROVED_BIPRED_INJECTION                     1 // F10
-
-
-#define M0_ME_SEARCH_BASE                             1 // F13
-#define INC_NFL12                                     1 // F14
-
-#define AV1_UPGRADE                                   1 // Upgrade to V1.0.0
-
-#define INTRAD_ASM                                    1 //asm for intra directionnal modes - Z1
-#define SUPPORT_10BIT                                 1 // Support for 10 Bit encodings
-#define NEW_QPS                                       1 // New QPS based on AOM 1Pass
-#define ME_HME_OQ                                     1 // Ported ME HME from EB32 OQ
+#define M0_ME_QUARTER_PEL_SEARCH                        1 // F1
+#define SHUT_CBF_FL_SKIP                                1 // F2 Lossless
+#define V2_HME_ME_SR                                    1 // F3
+#define ME_64x64                                        1 // F4
+#define V2_QP_SCALING                                   1 // F5 to keep for vmaff only
+#define NEW_QP_SCALING                                  1 // F6
+#define M0_SSD_HALF_QUARTER_PEL_BIPRED_SEARCH           1 // F7
+#define M0_64x64_32x32_HALF_QUARTER_PEL                 1 // F8
+#define IMPROVED_UNIPRED_INJECTION                      1 // F11
+#define IMPROVED_BIPRED_INJECTION                       1 // F10
+#define M0_ME_SEARCH_BASE                               1 // F13
+#define INC_NFL12                                       1 // F14
+#define AV1_UPGRADE                                     1 // Upgrade to V1.0.0
+#define INTRAD_ASM                                      1 // asm for intra directionnal modes - Z1
+#define SUPPORT_10BIT                                   1 // Support for 10 Bit encodings
+#define NEW_QPS                                         1 // New QPS based on AOM 1Pass
+#define ME_HME_OQ                                       1 // Ported ME HME from EB32 OQ
 
 #if SUPPORT_10BIT
-
-#define INTRA_10BIT_SUPPORT                         1
-#define QT_10BIT_SUPPORT                            1
-#define CDEF_10BIT_FIX                              1
-#define RS_10BIT_FIX                                1
-#define MD_10BIT_FIX                                1
-#define LF_10BIT_FIX                                1
-#define INTERPOL_FILTER_SEARCH_10BIT_SUPPORT        1
+#define INTRA_10BIT_SUPPORT                             1
+#define QT_10BIT_SUPPORT                                1
+#define CDEF_10BIT_FIX                                  1
+#define RS_10BIT_FIX                                    1
+#define MD_10BIT_FIX                                    1
+#define LF_10BIT_FIX                                    1
+#define INTERPOL_FILTER_SEARCH_10BIT_SUPPORT            1
 #endif
 
-#define BUG_FIX                                     1 // BUG fix related to transform type
-#define LIMIT_INTRA_INJ                                1
-#define TURN_OFF_INTERPOL_FILTER_SEARCH                1
-#define TURN_OFF_TX_TYPE_SEARCH                        1
-#define TURN_OFF_NFL8                                1 // Uses 8->4 NFL
+#define BUG_FIX                                         1 // BUG fix related to transform type
+#define LIMIT_INTRA_INJ                                 1
+#define TURN_OFF_INTERPOL_FILTER_SEARCH                 1
+#define TURN_OFF_TX_TYPE_SEARCH                         1
+#define TURN_OFF_NFL8                                   1 // Uses 8->4 NFL
 
-
-#define TURN_OFF_CFL                               0 // turning CFL off is broken
+#define TURN_OFF_CFL                                    0 // turning CFL off is broken
 #if M0_SSD_HALF_QUARTER_PEL_BIPRED_SEARCH
-#define M0_SAD_HALF_QUARTER_PEL_BIPRED_SEARCH       1
+#define M0_SAD_HALF_QUARTER_PEL_BIPRED_SEARCH           1
 #endif
 #endif
 
 // NEW MACOS
-#define INTRINSIC_OPT_2                             1 // Intrinsics opt work phase 2
-#define DIS_EDGE_FIL                                1 // disable intra edge filter - to be removed after fixing the neigbor array for intra 4xN and Nx4
-#define DISABLE_INTRA_PRED_INTRINSIC                0 // To be used to switch between intrinsic and C code for intra-pred
-#define USE_INLOOP_ME_FULL_SAD                      0 // To switch between full SAD and subsampled-SAD for in-loop-me subpel.
-#define NO_SUBPEL_FOR_128X128                       1 // Intrinsic is not available for 128x128 Subpel
+#define INTRINSIC_OPT_2                                 1 // Intrinsics opt work phase 2
+#define DIS_EDGE_FIL                                    1 // disable intra edge filter - to be removed after fixing the neigbor array for intra 4xN and Nx4
+#define DISABLE_INTRA_PRED_INTRINSIC                    0 // To be used to switch between intrinsic and C code for intra-pred
+#define USE_INLOOP_ME_FULL_SAD                          0 // To switch between full SAD and subsampled-SAD for in-loop-me subpel.
+#define NO_SUBPEL_FOR_128X128                           1 // Intrinsic is not available for 128x128 Subpel
 //FOR DEBUGGING - Do not remove
-#define NO_ENCDEC                                   0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch
+#define NO_ENCDEC                                       0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch
 
-#define    FIX_DEBUG_CRASH                             1
-#define FIX_47                                      1 // interdepth decision to be tedted block aware
-#define HME_ENHANCED_CENTER_SEARCH                  1
-#define TUNE_CHROMA_OFFSET                          1
-#define FAST_TX_SEARCH                                1
-#define MACRO_BLOCK_CLEANUP                            1
-#define DISABLE_NSQ_FOR_NON_REF                     1
-#define FIX_INTER_DEPTH                             1  // Fix interdepth depth cost when MDC cuts depths
-
-#define DISABLE_IN_LOOP_ME                          1
-#define EXTRA_ALLOCATION                            1
-#define USE_FAST_INTERP_SEARCH                      0
-#define SCS_CP_FIX                                  0 
-#define ENCDEC_TX_SEARCH                            1
-#define DISABLE_ANGULAR_MODE                        0
-#define FIX_ME_SR_10BIT                             1
-#define TEST5_DISABLE_NSQ_ME                        0
-#define DISABLE_ANGULAR_MODE_FOR_NON_REF            0
-#define INJECT_ONLY_SQ                                1
-#define OPT_MEMCPY                                    1
-#define DISABLE_DR_REFIN                            0
-#define CDEF_REF_ONLY                               0 //CDEF for ref frame only
-#define REST_REF_ONLY                               0 //REST for ref frame only
-#define REDUCE_COPY_CDEF                            1
+#define FIX_DEBUG_CRASH                                 1
+#define FIX_47                                          1 // interdepth decision to be tedted block aware
+#define HME_ENHANCED_CENTER_SEARCH                      1
+#define TUNE_CHROMA_OFFSET                              1
+#define FAST_TX_SEARCH                                  1
+#define MACRO_BLOCK_CLEANUP                             1
+#define DISABLE_NSQ_FOR_NON_REF                         1
+#define FIX_INTER_DEPTH                                 1  // Fix interdepth depth cost when MDC cuts depths
+#define DISABLE_IN_LOOP_ME                              1
+#define EXTRA_ALLOCATION                                1
+#define SCS_CP_FIX                                      0 
+#define ENCDEC_TX_SEARCH                                1
+#define DISABLE_ANGULAR_MODE                            0
+#define FIX_ME_SR_10BIT                                 1
+#define TEST5_DISABLE_NSQ_ME                            0
+#define DISABLE_ANGULAR_MODE_FOR_NON_REF                0
+#define INJECT_ONLY_SQ                                  1
+#define OPT_MEMCPY                                      1
+#define DISABLE_DR_REFIN                                0
+#define CDEF_REF_ONLY                                   0 //CDEF for ref frame only
+#define REST_REF_ONLY                                   0 //REST for ref frame only
+#define REDUCE_COPY_CDEF                                1
 
 
 /********************************************************/
@@ -182,77 +167,13 @@ extern "C" {
 #define CFL_BUF_SQUARE (CFL_BUF_LINE * CFL_BUF_LINE)
 /***********************************    AV1_OBU     ********************************/
 #define INVALID_NEIGHBOR_DATA 0xFFu
-#define AOM_CONFIG_H_
-#define ARCH_ARM 0
-#define ARCH_MIPS 0
-#define ARCH_PPC 0
-#define ARCH_X86 0
-#define ARCH_X86_64 1
-#define CONFIG_ACCOUNTING 0
-#define CONFIG_ANALYZER 0
-#define CONFIG_AV1 1
-#define CONFIG_AV1_DECODER 1
-#define CONFIG_AV1_ENCODER 1
-#define CONFIG_BIG_ENDIAN 0
 #define CONFIG_BITSTREAM_DEBUG 0
 #define CONFIG_BUFFER_MODEL 1
 #define CONFIG_COEFFICIENT_RANGE_CHECKING 0
-#if AV1_UPGRADE
-#define CONFIG_COLLECT_INTER_MODE_RD_STATS 1
-#else
-#define CONFIG_COLLECT_INTER_MODE_RD_STATS 0
-#endif
-#define CONFIG_COLLECT_RD_STATS 0
-#define CONFIG_DEBUG 0
-#define CONFIG_DECODE_PERF_TESTS 0
-#define CONFIG_DIST_8X8 1
-#define CONFIG_ENCODE_PERF_TESTS 0
 #define CONFIG_ENTROPY_STATS 0
-#define CONFIG_FILEOPTIONS 1
 #define CONFIG_FP_MB_STATS 0
-#define CONFIG_GCC 0
-#define CONFIG_GCOV 0
-#define CONFIG_GPROF 0
-#define CONFIG_INSPECTION 0
 #define CONFIG_INTERNAL_STATS 0
-#define CONFIG_INTER_STATS_ONLY 0
-#define CONFIG_LIBYUV 1
-#define CONFIG_LOWBITDEPTH 0
-#define CONFIG_MISMATCH_DEBUG 0
-#define CONFIG_MSVS 1
-#define CONFIG_MULTITHREAD 1
-#define CONFIG_OS_SUPPORT 1
-#define CONFIG_PIC 0
 #define CONFIG_RD_DEBUG 0
-#define CONFIG_RUNTIME_CPU_DETECT 1
-#define CONFIG_SHARED 0
-#define CONFIG_SIZE_LIMIT 0
-#define CONFIG_SPATIAL_RESAMPLING 1
-#define CONFIG_STATIC 1
-#define CONFIG_UNIT_TESTS 1
-#define CONFIG_WEBM_IO 1
-#define DECODE_HEIGHT_LIMIT 0
-#define DECODE_WIDTH_LIMIT 0
-#define HAVE_AVX 1
-#define HAVE_AVX2 1
-#define HAVE_DSPR2 0
-#define HAVE_FEXCEPT 0
-#define HAVE_MIPS32 0
-#define HAVE_MIPS64 0
-#define HAVE_MMX 1
-#define HAVE_MSA 0
-#define HAVE_NEON 0
-#define HAVE_NEON_ASM 0
-#define HAVE_PTHREAD_H 0
-#define HAVE_SSE 1
-#define HAVE_SSE2 1
-#define HAVE_SSE3 1
-#define HAVE_SSE4_1 1
-#define HAVE_SSE4_2 1
-#define HAVE_SSSE3 1
-#define HAVE_UNISTD_H 0
-#define HAVE_VSX 0
-#define HAVE_WXWIDGETS 0
 
 // Max superblock size
 #define MAX_SB_SIZE_LOG2 7
@@ -350,8 +271,12 @@ one more than the minimum. */
 
 // AV1 Loop Filter
 #define AV1_LF                                    1  // AV1 Loop Filter
-#if AV1_LF
+#if AV1_LF 
+#if DLF_TEST2
+#define AV1_LF_FULL_IMAGE_SELECTION               0
+#else
 #define AV1_LF_FULL_IMAGE_SELECTION               1  // 0 uses LPF_PICK_FROM_Q, 1 uses LPF_PICK_FROM_FULL_IMAGE
+#endif
 #define LF_SHARPNESS 0
 #endif
 
@@ -446,8 +371,7 @@ extern void RunEmms();
 #undef MEM_VALUE_T_SZ_BITS
 #define MEM_VALUE_T_SZ_BITS (sizeof(MEM_VALUE_T) << 3)
 
-
-    static __inline void mem_put_le16(void *vmem, MEM_VALUE_T val) {
+static __inline void mem_put_le16(void *vmem, MEM_VALUE_T val) {
     MAU_T *mem = (MAU_T *)vmem;
 
     mem[0] = (MAU_T)((val >> 0) & 0xff);
@@ -1885,11 +1809,11 @@ typedef enum EB_BITFIELD_MASKS {
 
 #define    Log2f                              Log2f_SSE2
 
-#define INPUT_SIZE_576p_TH                0x90000        // 0.58 Million
-#define INPUT_SIZE_1080i_TH                0xB71B0        // 0.75 Million
-#define INPUT_SIZE_1080p_TH                0x1AB3F0    // 1.75 Million
-#define INPUT_SIZE_4K_TH                0x29F630    // 2.75 Million
-#define INPUT_SIZE_8K_TH                0xA7D8C0    // 11 Million
+#define INPUT_SIZE_576p_TH                  0x90000        // 0.58 Million
+#define INPUT_SIZE_1080i_TH                 0xB71B0        // 0.75 Million
+#define INPUT_SIZE_1080p_TH                 0x1AB3F0    // 1.75 Million
+#define INPUT_SIZE_4K_TH                    0x29F630    // 2.75 Million
+#define INPUT_SIZE_8K_TH                    0xA7D8C0    // 11 Million
 
 /** Redefine ASSERT() to avoid warnings
 */
@@ -3003,12 +2927,14 @@ typedef enum EbCu8x8Mode {
 
 typedef enum EbPictureDepthMode {
 
-    PICT_SB_SWITCH_DEPTH_MODE = 0,
-    PICT_FULL85_DEPTH_MODE = 1,
-    PICT_FULL84_DEPTH_MODE = 2,
-    PICT_BDP_DEPTH_MODE = 3,
-    PICT_LIGHT_BDP_DEPTH_MODE = 4,
-    PICT_OPEN_LOOP_DEPTH_MODE = 5
+    PIC_ALL_DEPTH_MODE          = 0, // ALL sq and nsq:  SB size -> 4x4 
+    PIC_ALL_C_DEPTH_MODE        = 1, // ALL sq and nsq with control :  SB size -> 4x4 
+    PIC_SQ_DEPTH_MODE           = 2, // ALL sq:  SB size -> 4x4 
+    PIC_SQ_NON4_DEPTH_MODE      = 3, // SQ:  SB size -> 8x8 
+    PIC_BDP_DEPTH_MODE          = 4,
+    PIC_LIGHT_BDP_DEPTH_MODE    = 5,
+    PIC_SB_SWITCH_DEPTH_MODE    = 6,
+    PIC_OPEN_LOOP_DEPTH_MODE    = 7
 } EbPictureDepthMode;
 
 typedef enum EbLcuDepthMode {
@@ -3436,7 +3362,7 @@ static const uint16_t HmeLevel0SearchAreaInHeightArrayBottom[5][MAX_SUPPORTED_MO
 };
 
 // HME LEVEL 1
-//     M0    M1    M2    M3    M4    M5    M6    M7
+//      M0    M1    M2    M3    M4    M5    M6    M7
 static const uint8_t EnableHmeLevel1Flag[5][MAX_SUPPORTED_MODES] = {
     {   1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_576p_RANGE_OR_LOWER
     {   1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_720P_RANGE
@@ -3473,7 +3399,7 @@ static const uint16_t HmeLevel1SearchAreaInHeightArrayBottom[5][MAX_SUPPORTED_MO
     {  16,    8,    4,    4,    4,    4,    4,    4 }
 };
 // HME LEVEL 2
-//     M0    M1    M2    M3    M4    M5    M6    M7    M8    M9    M10   M11
+//     M0    M1    M2    M3    M4    M5    M6    M7
 static const uint8_t EnableHmeLevel2Flag[5][MAX_SUPPORTED_MODES] = {
     {   1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_576p_RANGE_OR_LOWER
     {   1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_720P_RANGE

--- a/Source/Lib/Codec/EbEncHandle.c
+++ b/Source/Lib/Codec/EbEncHandle.c
@@ -823,9 +823,7 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         inputData.bot_padding = encHandlePtr->sequenceControlSetInstanceArray[instanceIndex]->sequence_control_set_ptr->bot_padding;
         inputData.bit_depth = EB_8BIT;
         inputData.sb_sz = encHandlePtr->sequenceControlSetInstanceArray[instanceIndex]->sequence_control_set_ptr->sb_sz;
-#if MEM_RED
         inputData.sb_size_pix = scs_init.sb_size;
-#endif
         inputData.max_depth = encHandlePtr->sequenceControlSetInstanceArray[instanceIndex]->sequence_control_set_ptr->max_sb_depth;
         inputData.is16bit = is16bit;
         return_error = EbSystemResourceCtor(
@@ -1579,7 +1577,7 @@ EB_API EbErrorType eb_deinit_encoder(EbComponentType *svt_enc_component)
     return return_error;
 }
 
-EbErrorType EbH265EncInitParameter(
+EbErrorType eb_svt_enc_init_parameter(
     EbSvtAv1EncConfiguration * config_ptr);
 
 EbErrorType init_svt_av1_encoder_handle(
@@ -1621,7 +1619,7 @@ EB_API EbErrorType eb_init_handle(
         //SVT_LOG("Error: Component Struct Malloc Failed\n");
         return_error = EB_ErrorInsufficientResources;
     }
-    return_error = EbH265EncInitParameter(config_ptr);
+    return_error = eb_svt_enc_init_parameter(config_ptr);
 
     return return_error;
 }
@@ -2002,8 +2000,8 @@ static EbErrorType VerifySettings(
     EbSvtAv1EncConfiguration *config = &sequence_control_set_ptr->static_config;
     unsigned int channelNumber = config->channel_id;
 #if ENCODER_MODE_CLEANUP
-    if (config->enc_mode > 3) {
-        SVT_LOG("Error instance %u: EncoderMode must be in the range of [0-3]\n", channelNumber + 1);
+    if (config->enc_mode > MAX_ENC_PRESET) {
+        SVT_LOG("Error instance %u: EncoderMode must be in the range of [0-%d]\n", channelNumber + 1, MAX_ENC_PRESET);
 #else
     if (config->enc_mode != 1) {
         SVT_LOG("Error instance %u: EncoderMode must be [1]\n", channelNumber + 1);
@@ -2301,7 +2299,7 @@ static EbErrorType VerifySettings(
 /**********************************
 Set Default Library Params
 **********************************/
-EbErrorType EbH265EncInitParameter(
+EbErrorType eb_svt_enc_init_parameter(
     EbSvtAv1EncConfiguration * config_ptr)
 {
     EbErrorType                  return_error = EB_ErrorNone;

--- a/Source/Lib/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Codec/EbEntropyCoding.c
@@ -1771,11 +1771,7 @@ void WriteDrlIdx(
         for (idx = 0; idx < 2; ++idx) {
             if (xd->ref_mv_count[ref_frame_type] > idx + 1) {
                 uint8_t drl_ctx =
-#if MEM_RED2
                     av1_drl_ctx(xd->final_ref_mv_stack, idx);
-#else
-                    av1_drl_ctx(xd->ref_mv_stack[ref_frame_type], idx);
-#endif
 
                 aom_write_symbol(ecWriter, cu_ptr->drl_index != idx, frameContext->drl_cdf[drl_ctx],
                     2);
@@ -1792,11 +1788,8 @@ void WriteDrlIdx(
         for (idx = 1; idx < 3; ++idx) {
             if (xd->ref_mv_count[ref_frame_type] > idx + 1) {
                 uint8_t drl_ctx =
-#if MEM_RED2
                     av1_drl_ctx(xd->final_ref_mv_stack, idx);
-#else
-                    av1_drl_ctx(xd->ref_mv_stack[ref_frame_type], idx);
-#endif
+    
                 aom_write_symbol(ecWriter, cu_ptr->drl_index != (idx - 1),
                     frameContext->drl_cdf[drl_ctx], 2);
 

--- a/Source/Lib/Codec/EbInterPrediction.c
+++ b/Source/Lib/Codec/EbInterPrediction.c
@@ -3621,7 +3621,7 @@ static const int32_t filter_sets[DUAL_FILTER_SET_SIZE][2] = {
             uint32_t best_filters = 0;// mbmi->interp_filters;
 
 
-            if (picture_control_set_ptr->parent_pcs_ptr->use_fast_interpolation_filter_search &&
+            if (picture_control_set_ptr->parent_pcs_ptr->interpolation_filter_search_mode == 1 &&
                 picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->enable_dual_filter) {
                 int32_t tmp_skip_sb = 0;
                 int64_t tmp_skip_sse = INT64_MAX;
@@ -3953,7 +3953,7 @@ static const int32_t filter_sets[DUAL_FILTER_SET_SIZE][2] = {
             uint32_t best_filters = 0;// mbmi->interp_filters;
 
 
-            if (picture_control_set_ptr->parent_pcs_ptr->use_fast_interpolation_filter_search &&
+            if (picture_control_set_ptr->parent_pcs_ptr->interpolation_filter_search_mode == 1 &&
                 picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->enable_dual_filter) {
                 int32_t tmp_skip_sb = 0;
                 int64_t tmp_skip_sse = INT64_MAX;
@@ -4289,31 +4289,25 @@ EbErrorType inter_pu_prediction_av1(
         int32_t rs = 0;
         int64_t rd = INT64_MAX;
         candidate_buffer_ptr->candidate_ptr->interp_filters = 0;
-        if (md_context_ptr->blk_geom->bwidth > 4 && md_context_ptr->blk_geom->bheight > 4)
-            interpolation_filter_search_HBD(
-                picture_control_set_ptr,
-                candidate_buffer_ptr->predictionPtrTemp,
-                md_context_ptr,
-                candidate_buffer_ptr,
-                mv_unit,
-                ref_pic_list0,
-                ref_pic_list1,
-                asm_type,
-                &rd,
-                &rs,
-                &skip_txfm_sb,
-                &skip_sse_sb);
 
+        if (picture_control_set_ptr->parent_pcs_ptr->interpolation_filter_search_mode > 0) {
+            if (md_context_ptr->blk_geom->bwidth > 4 && md_context_ptr->blk_geom->bheight > 4)
+                interpolation_filter_search_HBD(
+                    picture_control_set_ptr,
+                    candidate_buffer_ptr->predictionPtrTemp,
+                    md_context_ptr,
+                    candidate_buffer_ptr,
+                    mv_unit,
+                    ref_pic_list0,
+                    ref_pic_list1,
+                    asm_type,
+                    &rd,
+                    &rs,
+                    &skip_txfm_sb,
+                    &skip_sse_sb);
+        }
 
         //candidate_buffer_ptr->candidate_ptr->interp_filters = 1;//SWITCHABLE_FILTERS;
-
-#if TURN_OFF_INTERPOL_FILTER_SEARCH
-#if ENCODER_MODE_CLEANUP && !MR_MODE
-        if (picture_control_set_ptr->parent_pcs_ptr->enc_mode > ENC_M0)
-
-            candidate_buffer_ptr->candidate_ptr->interp_filters = 0;
-#endif
-#endif
 #endif
 #if INTERPOL_FILTER_SEARCH_10BIT_SUPPORT
         AV1InterPrediction10BitMD(
@@ -4344,30 +4338,25 @@ EbErrorType inter_pu_prediction_av1(
         int32_t rs = 0;
         int64_t rd = INT64_MAX;
         candidate_buffer_ptr->candidate_ptr->interp_filters = 0;
-        if (md_context_ptr->blk_geom->bwidth > 4 && md_context_ptr->blk_geom->bheight > 4)
 
-            interpolation_filter_search(
-                picture_control_set_ptr,
-                candidate_buffer_ptr->predictionPtrTemp,
-                md_context_ptr,
-                candidate_buffer_ptr,
-                mv_unit,
-                ref_pic_list0,
-                ref_pic_list1,
-                asm_type,
-                &rd,
-                &rs,
-                &skip_txfm_sb,
-                &skip_sse_sb);
-
-
+        if (picture_control_set_ptr->parent_pcs_ptr->interpolation_filter_search_mode > 0) {
+            if (md_context_ptr->blk_geom->bwidth > 4 && md_context_ptr->blk_geom->bheight > 4)
+                interpolation_filter_search(
+                    picture_control_set_ptr,
+                    candidate_buffer_ptr->predictionPtrTemp,
+                    md_context_ptr,
+                    candidate_buffer_ptr,
+                    mv_unit,
+                    ref_pic_list0,
+                    ref_pic_list1,
+                    asm_type,
+                    &rd,
+                    &rs,
+                    &skip_txfm_sb,
+                    &skip_sse_sb);
+        }
         //candidate_buffer_ptr->candidate_ptr->interp_filters = 1;//SWITCHABLE_FILTERS;
-#if TURN_OFF_INTERPOL_FILTER_SEARCH
-#if ENCODER_MODE_CLEANUP && !MR_MODE
-        if (picture_control_set_ptr->parent_pcs_ptr->enc_mode > ENC_M0)
-            candidate_buffer_ptr->candidate_ptr->interp_filters = 0;
-#endif
-#endif
+
         av1_inter_prediction(
             picture_control_set_ptr,
             candidate_buffer_ptr->candidate_ptr->interp_filters,

--- a/Source/Lib/Codec/EbIntraPrediction.c
+++ b/Source/Lib/Codec/EbIntraPrediction.c
@@ -5373,8 +5373,8 @@ EbErrorType IntraPredictionOpenLoop(
         IntraPlanar_funcPtrArray[asm_type](
             cu_size,
             context_ptr->intra_ref_ptr->y_intra_reference_array_reverse,
-            (&(context_ptr->meContextPtr->sb_buffer[0])),
-            context_ptr->meContextPtr->sb_buffer_stride,
+            (&(context_ptr->me_context_ptr->sb_buffer[0])),
+            context_ptr->me_context_ptr->sb_buffer_stride,
             EB_FALSE);
 
         break;
@@ -5384,8 +5384,8 @@ EbErrorType IntraPredictionOpenLoop(
         IntraDCLuma_funcPtrArray[asm_type](
             cu_size,
             context_ptr->intra_ref_ptr->y_intra_reference_array_reverse,
-            (&(context_ptr->meContextPtr->sb_buffer[0])),
-            context_ptr->meContextPtr->sb_buffer_stride,
+            (&(context_ptr->me_context_ptr->sb_buffer[0])),
+            context_ptr->me_context_ptr->sb_buffer_stride,
             EB_FALSE);
 
         break;
@@ -5395,8 +5395,8 @@ EbErrorType IntraPredictionOpenLoop(
         IntraVerticalLuma_funcPtrArray[asm_type](
             cu_size,
             context_ptr->intra_ref_ptr->y_intra_reference_array_reverse,
-            (&(context_ptr->meContextPtr->sb_buffer[0])),
-            context_ptr->meContextPtr->sb_buffer_stride,
+            (&(context_ptr->me_context_ptr->sb_buffer[0])),
+            context_ptr->me_context_ptr->sb_buffer_stride,
             EB_FALSE);
 
         break;
@@ -5406,8 +5406,8 @@ EbErrorType IntraPredictionOpenLoop(
         IntraHorzLuma_funcPtrArray[asm_type](
             cu_size,
             context_ptr->intra_ref_ptr->y_intra_reference_array_reverse,
-            (&(context_ptr->meContextPtr->sb_buffer[0])),
-            context_ptr->meContextPtr->sb_buffer_stride,
+            (&(context_ptr->me_context_ptr->sb_buffer[0])),
+            context_ptr->me_context_ptr->sb_buffer_stride,
             EB_FALSE);
 
         break;
@@ -5419,8 +5419,8 @@ EbErrorType IntraPredictionOpenLoop(
             cu_size,
             context_ptr->intra_ref_ptr->y_intra_reference_array,
             context_ptr->intra_ref_ptr->y_intra_reference_array_reverse,
-            (&(context_ptr->meContextPtr->sb_buffer[0])),
-            context_ptr->meContextPtr->sb_buffer_stride,
+            (&(context_ptr->me_context_ptr->sb_buffer[0])),
+            context_ptr->me_context_ptr->sb_buffer_stride,
             context_ptr->intra_ref_ptr->reference_above_line_y,
             &context_ptr->intra_ref_ptr->above_ready_flag_y,
             context_ptr->intra_ref_ptr->reference_left_line_y,

--- a/Source/Lib/Codec/EbModeDecision.c
+++ b/Source/Lib/Codec/EbModeDecision.c
@@ -53,9 +53,7 @@ int32_t av1_mv_bit_cost(const MV *mv, const MV *ref, const int32_t *mvjcost,
 #define MV_COST_WEIGHT 108
 
 void ChooseBestAv1MvPred(
-#if MEM_RED2
     ModeDecisionContext_t            *context_ptr,
-#endif
     struct MdRateEstimationContext_s      *md_rate_estimation_ptr,
     CodingUnit_t      *cu_ptr,
     MvReferenceFrame ref_frame,
@@ -82,9 +80,7 @@ void ChooseBestAv1MvPred(
     for (drli = 0; drli < maxDrlIndex; drli++) {
 
         get_av1_mv_pred_drl(
-#if MEM_RED2
             context_ptr,
-#endif
             cu_ptr,
             ref_frame,
             is_compound,
@@ -503,7 +499,7 @@ void Me2Nx2NCandidatesInjectionSwResults(
 
 
         const uint32_t interDirection = mePuResult->distortionDirection[meCandidateIndex].direction;
-        if (interDirection == BI_PRED && picture_control_set_ptr->parent_pcs_ptr->depth_mode == PICT_SB_SWITCH_DEPTH_MODE && picture_control_set_ptr->parent_pcs_ptr->sb_md_mode_array[sb_ptr->index] == LCU_PRED_OPEN_LOOP_1_NFL_DEPTH_MODE)
+        if (interDirection == BI_PRED && picture_control_set_ptr->parent_pcs_ptr->pic_depth_mode == PIC_SB_SWITCH_DEPTH_MODE && picture_control_set_ptr->parent_pcs_ptr->sb_md_mode_array[sb_ptr->index] == LCU_PRED_OPEN_LOOP_1_NFL_DEPTH_MODE)
             continue;
         candidateArray[canTotalCnt].motionVector_x_L0 = mePuResult->xMvL0;
         candidateArray[canTotalCnt].motionVector_y_L0 = mePuResult->yMvL0;
@@ -664,9 +660,7 @@ void Unipred3x3CandidatesInjection(
         candidateArray[canTotalCnt].transform_type[PLANE_TYPE_UV] = DCT_DCT;
 
         ChooseBestAv1MvPred(
-#if MEM_RED2
             context_ptr,
-#endif
             candidateArray[canTotalCnt].md_rate_estimation_ptr,
             context_ptr->cu_ptr,
             candidateArray[canTotalCnt].ref_frame_type,
@@ -722,9 +716,7 @@ void Unipred3x3CandidatesInjection(
             candidateArray[canTotalCnt].transform_type[PLANE_TYPE_UV] = DCT_DCT;
 
             ChooseBestAv1MvPred(
-#if MEM_RED2
                 context_ptr,
-#endif
                 candidateArray[canTotalCnt].md_rate_estimation_ptr,
                 context_ptr->cu_ptr,
                 candidateArray[canTotalCnt].ref_frame_type,
@@ -811,9 +803,7 @@ void Bipred3x3CandidatesInjection(
             candidateArray[canTotalCnt].transform_type[PLANE_TYPE_UV] = DCT_DCT;
 
             ChooseBestAv1MvPred(
-#if MEM_RED2
                 context_ptr,
-#endif
                 candidateArray[canTotalCnt].md_rate_estimation_ptr,
                 context_ptr->cu_ptr,
                 candidateArray[canTotalCnt].ref_frame_type,
@@ -873,9 +863,7 @@ void Bipred3x3CandidatesInjection(
             candidateArray[canTotalCnt].transform_type[PLANE_TYPE_UV] = DCT_DCT;
 
             ChooseBestAv1MvPred(
-#if MEM_RED2
                 context_ptr,
-#endif
                 candidateArray[canTotalCnt].md_rate_estimation_ptr,
                 context_ptr->cu_ptr,
                 candidateArray[canTotalCnt].ref_frame_type,
@@ -992,9 +980,7 @@ void InjectAv1MvpCandidates(
     for (drli = 0; drli < maxDrlIndex; drli++) {
 
         get_av1_mv_pred_drl(
-#if MEM_RED2
             context_ptr,
-#endif
             cu_ptr,
             LAST_FRAME,
             0,
@@ -1062,9 +1048,7 @@ void InjectAv1MvpCandidates(
         for (drli = 0; drli < maxDrlIndex; drli++) {
 
             get_av1_mv_pred_drl(
-#if MEM_RED2
                 context_ptr,
-#endif
                 cu_ptr,
                 BWDREF_FRAME,
                 0,
@@ -1112,17 +1096,10 @@ void InjectAv1MvpCandidates(
         candidateArray[canIdx].is_skip_mode_flag = 0;
         candidateArray[canIdx].is_new_mv = 0;
         candidateArray[canIdx].is_zero_mv = 0;
-#if MEM_RED2
         candidateArray[canIdx].motionVector_x_L0 = context_ptr->md_local_cu_unit[context_ptr->blk_geom->blkidx_mds].ed_ref_mv_stack[LAST_BWD_FRAME][0].this_mv.as_mv.col;
         candidateArray[canIdx].motionVector_y_L0 = context_ptr->md_local_cu_unit[context_ptr->blk_geom->blkidx_mds].ed_ref_mv_stack[LAST_BWD_FRAME][0].this_mv.as_mv.row;
         candidateArray[canIdx].motionVector_x_L1 = context_ptr->md_local_cu_unit[context_ptr->blk_geom->blkidx_mds].ed_ref_mv_stack[LAST_BWD_FRAME][0].comp_mv.as_mv.col;
         candidateArray[canIdx].motionVector_y_L1 = context_ptr->md_local_cu_unit[context_ptr->blk_geom->blkidx_mds].ed_ref_mv_stack[LAST_BWD_FRAME][0].comp_mv.as_mv.row;
-#else
-        candidateArray[canIdx].motionVector_x_L0 = context_ptr->cu_ptr->av1xd->ref_mv_stack[LAST_BWD_FRAME][0].this_mv.as_mv.col;
-        candidateArray[canIdx].motionVector_y_L0 = context_ptr->cu_ptr->av1xd->ref_mv_stack[LAST_BWD_FRAME][0].this_mv.as_mv.row;
-        candidateArray[canIdx].motionVector_x_L1 = context_ptr->cu_ptr->av1xd->ref_mv_stack[LAST_BWD_FRAME][0].comp_mv.as_mv.col;
-        candidateArray[canIdx].motionVector_y_L1 = context_ptr->cu_ptr->av1xd->ref_mv_stack[LAST_BWD_FRAME][0].comp_mv.as_mv.row;
-#endif
         candidateArray[canIdx].drl_index = 0;
         candidateArray[canIdx].ref_mv_index = 0;
         candidateArray[canIdx].pred_mv_weight = 0;
@@ -1138,9 +1115,7 @@ void InjectAv1MvpCandidates(
             for (drli = 0; drli < maxDrlIndex; drli++) {
 
                 get_av1_mv_pred_drl(
-#if MEM_RED2
                     context_ptr,
-#endif
                     cu_ptr,
                     LAST_BWD_FRAME,
                     1,
@@ -1182,7 +1157,7 @@ void InjectAv1MvpCandidates(
 }
 
 // END of Function Declarations
-void  ProductInterCandidateInjectionSwResults(
+void  inject_inter_candidates(
     PictureControlSet_t            *picture_control_set_ptr,
     ModeDecisionContext_t          *context_ptr,
     SsMeContext_t                  *ss_mecontext,
@@ -1220,13 +1195,8 @@ void  ProductInterCandidateInjectionSwResults(
 
     uint32_t max_number_of_pus_per_sb;
 #if DISABLE_NSQ_FOR_NON_REF || DISABLE_NSQ
-#if ENCODER_MODE_CLEANUP
-    if (picture_control_set_ptr->enc_mode > ENC_M0) {
-#endif
-        max_number_of_pus_per_sb = (picture_control_set_ptr->parent_pcs_ptr->non_square_block_flag) ? picture_control_set_ptr->parent_pcs_ptr->max_number_of_pus_per_sb : SQUARE_PU_COUNT;
-#if ENCODER_MODE_CLEANUP
-    }
-#endif
+
+    max_number_of_pus_per_sb = picture_control_set_ptr->parent_pcs_ptr->max_number_of_pus_per_sb;
     
 #if DISABLE_IN_LOOP_ME
 #if TEST5_DISABLE_NSQ_ME
@@ -1235,18 +1205,9 @@ void  ProductInterCandidateInjectionSwResults(
 
 #else
     uint32_t me2Nx2NTableOffset;
-#if ENCODER_MODE_CLEANUP
-    if (picture_control_set_ptr->enc_mode > ENC_M0) {
-#endif
+
         me2Nx2NTableOffset = (context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4 || context_ptr->blk_geom->bwidth == 128 || context_ptr->blk_geom->bheight == 128) ? 0 :
             get_me_info_index(max_number_of_pus_per_sb, context_ptr->blk_geom, geom_offset_x, geom_offset_y);
-#if ENCODER_MODE_CLEANUP
-    }
-    else {
-        me2Nx2NTableOffset = (context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4 || context_ptr->blk_geom->bwidth == 128 || context_ptr->blk_geom->bheight == 128) ? 0 :
-            get_me_info_index(picture_control_set_ptr->parent_pcs_ptr->max_number_of_pus_per_sb, context_ptr->blk_geom, geom_offset_x, geom_offset_y);
-    }
-#endif
 #endif
 #else
     const uint32_t me2Nx2NTableOffset = (context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4) ? 0 :
@@ -1276,9 +1237,7 @@ void  ProductInterCandidateInjectionSwResults(
     IntMv  bestPredmv[2] = { 0 };
 
     generate_av1_mvp_table(
-#if MEM_RED2
         context_ptr,
-#endif
         context_ptr->cu_ptr,
         context_ptr->blk_geom,
         context_ptr->cu_origin_x,
@@ -1335,9 +1294,7 @@ void  ProductInterCandidateInjectionSwResults(
     candidateArray[canTotalCnt].transform_type[PLANE_TYPE_UV] = DCT_DCT;
 
     ChooseBestAv1MvPred(
-#if MEM_RED2
         context_ptr,
-#endif
         candidateArray[canTotalCnt].md_rate_estimation_ptr,
         context_ptr->cu_ptr,
         candidateArray[canTotalCnt].ref_frame_type,
@@ -1389,9 +1346,7 @@ void  ProductInterCandidateInjectionSwResults(
         candidateArray[canTotalCnt].transform_type[PLANE_TYPE_UV] = DCT_DCT;
 
         ChooseBestAv1MvPred(
-#if MEM_RED2
             context_ptr,
-#endif
             candidateArray[canTotalCnt].md_rate_estimation_ptr,
             context_ptr->cu_ptr,
             candidateArray[canTotalCnt].ref_frame_type,
@@ -1447,9 +1402,7 @@ void  ProductInterCandidateInjectionSwResults(
             candidateArray[canTotalCnt].transform_type[PLANE_TYPE_UV] = DCT_DCT;
 
             ChooseBestAv1MvPred(
-#if MEM_RED2
                 context_ptr,
-#endif
                 candidateArray[canTotalCnt].md_rate_estimation_ptr,
                 context_ptr->cu_ptr,
                 candidateArray[canTotalCnt].ref_frame_type,
@@ -1509,9 +1462,7 @@ void  ProductInterCandidateInjectionSwResults(
         candidateArray[canTotalCnt].transform_type[PLANE_TYPE_UV] = DCT_DCT;
 
         ChooseBestAv1MvPred(
-#if MEM_RED2
             context_ptr,
-#endif
             candidateArray[canTotalCnt].md_rate_estimation_ptr,
             context_ptr->cu_ptr,
             candidateArray[canTotalCnt].ref_frame_type,
@@ -1798,7 +1749,7 @@ static INLINE TxType av1_get_tx_type(
 
 
 // END of Function Declarations
-void  ProductIntraCandidateInjectionSwResults(
+void  inject_intra_candidates(
     PictureControlSet_t            *picture_control_set_ptr,
     ModeDecisionContext_t          *context_ptr,
     const SequenceControlSet_t     *sequence_control_set_ptr,
@@ -1808,131 +1759,74 @@ void  ProductIntraCandidateInjectionSwResults(
 
     (void)leaf_index;
     (void)sequence_control_set_ptr;
-    (void)picture_control_set_ptr;
     (void)sb_ptr;
-    uint8_t                   openLoopIntraCandidate;
-    uint32_t                   canTotalCnt = 0;
-    uint8_t                   angleDeltaCounter = 0;
-    EbBool use_angle_delta = (context_ptr->blk_geom->bsize >= BLOCK_8X8);
-#if REMOVE_INTRA_CONST
-    uint8_t                   angleDeltaCandidateCount = use_angle_delta ? 7 : 1;
-#else
-    const uint32_t            cu_size = context_ptr->cu_stats->size;
-    uint8_t                   angleDeltaCandidateCount = cu_size >= 32 ? 1 : 7;
-#endif
-
-#if !MR_MODE && INTRA_LOSSY_OPT
-    angleDeltaCandidateCount = (picture_control_set_ptr->temporal_layer_index == 0) ? angleDeltaCandidateCount : 1;
-#endif
-#if !INTRA_LOSSY_OPT
-#if LIMIT_INTRA_INJ
-    const uint32_t            bwidth = context_ptr->blk_geom->bwidth;
-    const uint32_t            bheight = context_ptr->blk_geom->bheight;
-#if ENCODER_MODE_CLEANUP && !MR_MODE
-
-        angleDeltaCandidateCount = ((bwidth >= 32 && bheight >= 32) || picture_control_set_ptr->temporal_layer_index == 3) && (picture_control_set_ptr->temporal_layer_index > 0) ? 1 : 7;
-#endif
-#endif
-#if DISABLE_DR_REFIN
-    angleDeltaCandidateCount = 1;
-#endif
-#if DISABLE_ANGULAR_MODE
-    angleDeltaCandidateCount = 0;
-#endif
-#if    DISABLE_ANGULAR_MODE_FOR_NON_REF
-    angleDeltaCandidateCount =  picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag == 0 ? 0 : angleDeltaCandidateCount;
-#endif
-#endif
+    uint8_t                     intra_mode_start = DC_PRED;
+    uint8_t                     intra_mode_end   = SMOOTH_H_PRED;
+    uint8_t                     openLoopIntraCandidate;
+    uint32_t                    canTotalCnt = 0;
+    uint8_t                     angleDeltaCounter = 0;
+    EbBool                      use_angle_delta = (context_ptr->blk_geom->bsize >= BLOCK_8X8);
+    uint8_t                     angleDeltaCandidateCount = use_angle_delta ? 7 : 1;
     ModeDecisionCandidate_t    *candidateArray = context_ptr->fast_candidate_array;
-    EbBool disable_cfl_flag = (context_ptr->blk_geom->sq_size > 32 || context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4) ? EB_TRUE : EB_FALSE;
-#if !INTRA_LOSSY_OPT
-    EbBool is_4xN_block = (context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4) ? EB_TRUE : EB_FALSE;
-
-    UNUSED(is_4xN_block);
+    EbBool                      disable_cfl_flag = (context_ptr->blk_geom->sq_size > 32 || 
+                                                    context_ptr->blk_geom->bwidth == 4  ||   
+                                                    context_ptr->blk_geom->bheight == 4)    ? EB_TRUE : EB_FALSE;
+    uint8_t                     disable_z2_prediction    = (picture_control_set_ptr->parent_pcs_ptr->intra_pred_mode == 0) ? 1 : 0;
+    uint8_t                     disable_angle_refinement = (picture_control_set_ptr->parent_pcs_ptr->intra_pred_mode == 0) ? 1 : 0;  
+#if MR_MODE
+    disable_z2_prediction       = 0;
+    disable_angle_refinement    = 0;
 #endif
-    uint8_t intra_mode_start = DC_PRED;
-
-    uint8_t intra_mode_end = SMOOTH_H_PRED;
-#if !INTRA_LOSSY_OPT
-#if LIMIT_INTRA_INJ
-#if ENCODER_MODE_CLEANUP && !MR_MODE
-
-        angleDeltaCandidateCount = is_4xN_block ? 0 : angleDeltaCandidateCount;
-#endif
-#endif
-#endif
+    angleDeltaCandidateCount = disable_angle_refinement ? 1: angleDeltaCandidateCount;
+    
     for (openLoopIntraCandidate = intra_mode_start; openLoopIntraCandidate < intra_mode_end + 1; ++openLoopIntraCandidate) {
 
         if (av1_is_directional_mode((PredictionMode)openLoopIntraCandidate)) {
             for (angleDeltaCounter = 0; angleDeltaCounter < angleDeltaCandidateCount; ++angleDeltaCounter) {
-#if !MR_MODE && INTRA_LOSSY_OPT
                 int32_t angle_delta = angleDeltaCandidateCount == 1 ? 0 : angleDeltaCounter - (angleDeltaCandidateCount >> 1);
                 int32_t  p_angle = mode_to_angle_map[(PredictionMode)openLoopIntraCandidate] + angle_delta * ANGLE_STEP;
+                if (!disable_z2_prediction || (p_angle <= 90 || p_angle >= 180)) {
+                    candidateArray[canTotalCnt].type = INTRA_MODE;
+                    candidateArray[canTotalCnt].intra_luma_mode = openLoopIntraCandidate;
+                    candidateArray[canTotalCnt].distortion_ready = 0;
+                    candidateArray[canTotalCnt].is_directional_mode_flag = (uint8_t)av1_is_directional_mode((PredictionMode)openLoopIntraCandidate);
+                    candidateArray[canTotalCnt].use_angle_delta = use_angle_delta ? candidateArray[canTotalCnt].is_directional_mode_flag : 0;
+                    candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_Y] = angle_delta;
+                    candidateArray[canTotalCnt].intra_chroma_mode = disable_cfl_flag ? intra_luma_to_chroma[openLoopIntraCandidate] : UV_CFL_PRED;
+                    candidateArray[canTotalCnt].cfl_alpha_signs = 0;
+                    candidateArray[canTotalCnt].cfl_alpha_idx = 0;
+                    candidateArray[canTotalCnt].is_directional_chroma_mode_flag = (uint8_t)av1_is_directional_mode((PredictionMode)candidateArray[canTotalCnt].intra_chroma_mode);
+                    candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_UV] = 0;
+                    candidateArray[canTotalCnt].transform_type[PLANE_TYPE_Y] = DCT_DCT;
 
-                if ((picture_control_set_ptr->temporal_layer_index == 0) || (p_angle <= 90 || p_angle >= 180)) {
-#endif
-                candidateArray[canTotalCnt].type = INTRA_MODE;
-                candidateArray[canTotalCnt].intra_luma_mode = openLoopIntraCandidate;
-                candidateArray[canTotalCnt].distortion_ready = 0;
-
-                candidateArray[canTotalCnt].is_directional_mode_flag = (uint8_t)av1_is_directional_mode((PredictionMode)openLoopIntraCandidate);
-
-                candidateArray[canTotalCnt].use_angle_delta = use_angle_delta ? candidateArray[canTotalCnt].is_directional_mode_flag : 0;
-
-#if INTRA_LOSSY_OPT
-                candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_Y] = angle_delta;
-#else
-                candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_Y] = angleDeltaCandidateCount == 1 ? 0 : angleDeltaCounter - (angleDeltaCandidateCount >> 1);
-#endif
-#if TURN_OFF_CFL
-                candidateArray[canTotalCnt].intra_chroma_mode = intra_luma_to_chroma[openLoopIntraCandidate];
-#else
-                candidateArray[canTotalCnt].intra_chroma_mode = disable_cfl_flag ? intra_luma_to_chroma[openLoopIntraCandidate] : UV_CFL_PRED;
-#endif
-                candidateArray[canTotalCnt].cfl_alpha_signs = 0;
-                candidateArray[canTotalCnt].cfl_alpha_idx = 0;
-
-                candidateArray[canTotalCnt].is_directional_chroma_mode_flag = (uint8_t)av1_is_directional_mode((PredictionMode)candidateArray[canTotalCnt].intra_chroma_mode);
-                candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_UV] = 0;
-                candidateArray[canTotalCnt].transform_type[PLANE_TYPE_Y] = DCT_DCT;
-
-
-                if (candidateArray[canTotalCnt].intra_chroma_mode == UV_CFL_PRED)
-                    candidateArray[canTotalCnt].transform_type[PLANE_TYPE_UV] = DCT_DCT;
-                else
-                    candidateArray[canTotalCnt].transform_type[PLANE_TYPE_UV] =
-                    av1_get_tx_type(
-                        context_ptr->blk_geom->bsize,
-                        0,
-                        (PredictionMode)candidateArray[canTotalCnt].intra_luma_mode,
-                        (UV_PredictionMode)candidateArray[canTotalCnt].intra_chroma_mode,
-                        PLANE_TYPE_UV,
-                        0,
-                        0,
-                        0,
-                        context_ptr->blk_geom->txsize_uv[0],
-                        picture_control_set_ptr->parent_pcs_ptr->reduced_tx_set_used);
-
-                // candidateArray[canTotalCnt].transform_type[PLANE_TYPE_UV]            = context_ptr->blk_geom->bwidth_uv >= 32 || context_ptr->blk_geom->bheight_uv >= 32  ? DCT_DCT : chroma_transform_type[candidateArray[canTotalCnt].intra_chroma_mode];
-
-
-                candidateArray[canTotalCnt].mpm_flag = EB_FALSE;
-
-                candidateArray[canTotalCnt].ref_frame_type = INTRA_FRAME;
-                candidateArray[canTotalCnt].pred_mode = (PredictionMode)openLoopIntraCandidate;
-                candidateArray[canTotalCnt].motion_mode = SIMPLE_TRANSLATION;
-
-                ++canTotalCnt;
-#if !MR_MODE  && INTRA_LOSSY_OPT
-            }
-#endif
+                    if (candidateArray[canTotalCnt].intra_chroma_mode == UV_CFL_PRED)
+                        candidateArray[canTotalCnt].transform_type[PLANE_TYPE_UV] = DCT_DCT;
+                    else
+                        candidateArray[canTotalCnt].transform_type[PLANE_TYPE_UV] =
+                        av1_get_tx_type(
+                            context_ptr->blk_geom->bsize,
+                            0,
+                            (PredictionMode)candidateArray[canTotalCnt].intra_luma_mode,
+                            (UV_PredictionMode)candidateArray[canTotalCnt].intra_chroma_mode,
+                            PLANE_TYPE_UV,
+                            0,
+                            0,
+                            0,
+                            context_ptr->blk_geom->txsize_uv[0],
+                            picture_control_set_ptr->parent_pcs_ptr->reduced_tx_set_used);
+                    // candidateArray[canTotalCnt].transform_type[PLANE_TYPE_UV]            = context_ptr->blk_geom->bwidth_uv >= 32 || context_ptr->blk_geom->bheight_uv >= 32  ? DCT_DCT : chroma_transform_type[candidateArray[canTotalCnt].intra_chroma_mode];
+                    candidateArray[canTotalCnt].mpm_flag = EB_FALSE;
+                    candidateArray[canTotalCnt].ref_frame_type = INTRA_FRAME;
+                    candidateArray[canTotalCnt].pred_mode = (PredictionMode)openLoopIntraCandidate;
+                    candidateArray[canTotalCnt].motion_mode = SIMPLE_TRANSLATION;
+                    ++canTotalCnt;
+                }
             }
         }
         else {
             candidateArray[canTotalCnt].type = INTRA_MODE;
             candidateArray[canTotalCnt].intra_luma_mode = openLoopIntraCandidate;
             candidateArray[canTotalCnt].distortion_ready = 0;
-
             candidateArray[canTotalCnt].is_directional_mode_flag = (uint8_t)av1_is_directional_mode((PredictionMode)openLoopIntraCandidate);
             candidateArray[canTotalCnt].use_angle_delta = candidateArray[canTotalCnt].is_directional_mode_flag;
             candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_Y] = 0;
@@ -1943,11 +1837,9 @@ void  ProductIntraCandidateInjectionSwResults(
 #endif
             candidateArray[canTotalCnt].cfl_alpha_signs = 0;
             candidateArray[canTotalCnt].cfl_alpha_idx = 0;
-
             candidateArray[canTotalCnt].is_directional_chroma_mode_flag = (uint8_t)av1_is_directional_mode((PredictionMode)candidateArray[canTotalCnt].intra_chroma_mode);
             candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_UV] = 0;
             candidateArray[canTotalCnt].transform_type[PLANE_TYPE_Y] = DCT_DCT;
-
 
             if (candidateArray[canTotalCnt].intra_chroma_mode == UV_CFL_PRED)
                 candidateArray[canTotalCnt].transform_type[PLANE_TYPE_UV] = DCT_DCT;
@@ -1965,13 +1857,10 @@ void  ProductIntraCandidateInjectionSwResults(
                     context_ptr->blk_geom->txsize_uv[0],
                     picture_control_set_ptr->parent_pcs_ptr->reduced_tx_set_used);
 
-
             candidateArray[canTotalCnt].mpm_flag = EB_FALSE;
-
             candidateArray[canTotalCnt].ref_frame_type = INTRA_FRAME;
             candidateArray[canTotalCnt].pred_mode = (PredictionMode)openLoopIntraCandidate;
             candidateArray[canTotalCnt].motion_mode = SIMPLE_TRANSLATION;
-
             ++canTotalCnt;
         }
     }
@@ -2035,7 +1924,7 @@ EbErrorType ProductGenerateMdCandidatesCu(
 #if    ENABLE_INTER_4x4
         if (context_ptr->blk_geom->bwidth != 4 && context_ptr->blk_geom->bheight != 4)
 #endif
-            ProductIntraCandidateInjectionSwResults(
+            inject_intra_candidates(
                 picture_control_set_ptr,
                 context_ptr,
                 sequence_control_set_ptr,
@@ -2052,7 +1941,7 @@ EbErrorType ProductGenerateMdCandidatesCu(
         if (context_ptr->blk_geom->bwidth != 4 && context_ptr->blk_geom->bheight != 4)
 #endif
 #endif
-            ProductInterCandidateInjectionSwResults(
+            inject_inter_candidates(
                 picture_control_set_ptr,
                 context_ptr,
                 ss_mecontext,

--- a/Source/Lib/Codec/EbModeDecisionConfiguration.c
+++ b/Source/Lib/Codec/EbModeDecisionConfiguration.c
@@ -481,14 +481,14 @@ void RefinementPredictionLoop(
                 }
             }
             else {
-                if (picture_control_set_ptr->parent_pcs_ptr->depth_mode == PICT_SB_SWITCH_DEPTH_MODE && (picture_control_set_ptr->parent_pcs_ptr->sb_md_mode_array[sb_index] == LCU_PRED_OPEN_LOOP_DEPTH_MODE || picture_control_set_ptr->parent_pcs_ptr->sb_md_mode_array[sb_index] == LCU_PRED_OPEN_LOOP_1_NFL_DEPTH_MODE)) {
+                if (picture_control_set_ptr->parent_pcs_ptr->pic_depth_mode == PIC_SB_SWITCH_DEPTH_MODE && (picture_control_set_ptr->parent_pcs_ptr->sb_md_mode_array[sb_index] == LCU_PRED_OPEN_LOOP_DEPTH_MODE || picture_control_set_ptr->parent_pcs_ptr->sb_md_mode_array[sb_index] == LCU_PRED_OPEN_LOOP_1_NFL_DEPTH_MODE)) {
                     refinementLevel = Pred;
                 }
                 else
 
 
-                    if (picture_control_set_ptr->parent_pcs_ptr->depth_mode == PICT_OPEN_LOOP_DEPTH_MODE ||
-                        (picture_control_set_ptr->parent_pcs_ptr->depth_mode == PICT_SB_SWITCH_DEPTH_MODE && (picture_control_set_ptr->parent_pcs_ptr->sb_md_mode_array[sb_index] == LCU_OPEN_LOOP_DEPTH_MODE || picture_control_set_ptr->parent_pcs_ptr->sb_md_mode_array[sb_index] == LCU_AVC_DEPTH_MODE)))
+                    if (picture_control_set_ptr->parent_pcs_ptr->pic_depth_mode == PIC_OPEN_LOOP_DEPTH_MODE ||
+                        (picture_control_set_ptr->parent_pcs_ptr->pic_depth_mode == PIC_SB_SWITCH_DEPTH_MODE && (picture_control_set_ptr->parent_pcs_ptr->sb_md_mode_array[sb_index] == LCU_OPEN_LOOP_DEPTH_MODE || picture_control_set_ptr->parent_pcs_ptr->sb_md_mode_array[sb_index] == LCU_AVC_DEPTH_MODE)))
 
                         refinementLevel = NdpRefinementControlNREF[temporal_layer_index][depth];
                     else
@@ -1081,7 +1081,7 @@ EbErrorType EarlyModeDecisionLcu(
     uint32_t          tbOriginY = sb_ptr->origin_y;
     EB_SLICE        slice_type = picture_control_set_ptr->slice_type;
 
-    uint32_t      startDepth = (picture_control_set_ptr->parent_pcs_ptr->depth_mode == PICT_SB_SWITCH_DEPTH_MODE && picture_control_set_ptr->parent_pcs_ptr->sb_md_mode_array[sb_index] == LCU_AVC_DEPTH_MODE) ?
+    uint32_t      startDepth = (picture_control_set_ptr->parent_pcs_ptr->pic_depth_mode == PIC_SB_SWITCH_DEPTH_MODE && picture_control_set_ptr->parent_pcs_ptr->sb_md_mode_array[sb_index] == LCU_AVC_DEPTH_MODE) ?
         DEPTH_16 :
         DEPTH_64;
 
@@ -1093,7 +1093,7 @@ EbErrorType EarlyModeDecisionLcu(
 
 
     // The MDC refinements had been taken into account at the budgeting algorithm & therefore could be skipped for the ADP case
-    if (picture_control_set_ptr->parent_pcs_ptr->depth_mode != PICT_SB_SWITCH_DEPTH_MODE) {
+    if (picture_control_set_ptr->parent_pcs_ptr->pic_depth_mode != PIC_SB_SWITCH_DEPTH_MODE) {
         PrePredictionRefinement(
             sequence_control_set_ptr,
             picture_control_set_ptr,

--- a/Source/Lib/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Codec/EbModeDecisionProcess.h
@@ -81,9 +81,7 @@ extern "C" {
         PARTITION_CONTEXT           above_neighbor_partition;
         uint64_t                    cost;
         uint64_t                    cost_luma;
-#if MEM_RED2
         CandidateMv ed_ref_mv_stack[MODE_CTX_REF_FRAMES][MAX_REF_MV_STACK_SIZE];//to be used in MD and EncDec
-#endif
 
     } MdCodingUnit_t;
 
@@ -207,6 +205,11 @@ extern "C" {
         DECLARE_ALIGNED(16, uint8_t, above_data[MAX_MB_PLANE][MAX_TX_SIZE * 2 + 32]);
         BlockSize  scaled_chroma_bsize;
 #endif
+
+
+        // Multi-modes signal(s) 
+        uint8_t                           nfl_level;
+
 
     } ModeDecisionContext_t;
 

--- a/Source/Lib/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Codec/EbMotionEstimation.c
@@ -2415,7 +2415,7 @@ void HalfPelSearch_LCU(
     }
 #if DISABLE_NSQ_FOR_NON_REF || DISABLE_NSQ
 #if ENCODER_MODE_CLEANUP
-    if ((picture_control_set_ptr->enc_mode > ENC_M0)?picture_control_set_ptr->non_square_block_flag: sequence_control_set_ptr->static_config.ext_block_flag) {
+    if (picture_control_set_ptr->pic_depth_mode <= PIC_ALL_C_DEPTH_MODE) {
 #else
     if (picture_control_set_ptr->non_square_block_flag) {
 #endif
@@ -6202,21 +6202,9 @@ EbErrorType MotionEstimateLcu(
     uint64_t                  hmeMvSad = 0;
 
     uint32_t                  pu_index;
-#if DISABLE_NSQ_FOR_NON_REF || DISABLE_NSQ
-#if ENCODER_MODE_CLEANUP
-    uint32_t max_number_of_pus_per_sb;
-    if (picture_control_set_ptr->enc_mode > ENC_M0) {
-#endif
-        max_number_of_pus_per_sb = (picture_control_set_ptr->non_square_block_flag) ? picture_control_set_ptr->max_number_of_pus_per_sb : SQUARE_PU_COUNT;
-#if ENCODER_MODE_CLEANUP
-    }
-    else {
-        max_number_of_pus_per_sb = picture_control_set_ptr->max_number_of_pus_per_sb;
-    }
-#endif
-#else
+
     uint32_t                  max_number_of_pus_per_sb = picture_control_set_ptr->max_number_of_pus_per_sb;
-#endif
+
     uint32_t                  numOfListToSearch;
     uint32_t                  listIndex;
     uint8_t                   candidateIndex = 0;
@@ -6754,7 +6742,7 @@ EbErrorType MotionEstimateLcu(
 
 #if DISABLE_NSQ_FOR_NON_REF || DISABLE_NSQ
 #if ENCODER_MODE_CLEANUP
-                    if ((picture_control_set_ptr->enc_mode > ENC_M0)?picture_control_set_ptr->non_square_block_flag: sequence_control_set_ptr->static_config.ext_block_flag) {
+                    if (picture_control_set_ptr->pic_depth_mode <= PIC_ALL_C_DEPTH_MODE) {
 #else
                     if (picture_control_set_ptr->non_square_block_flag) {
 #endif
@@ -6966,7 +6954,7 @@ EbErrorType MotionEstimateLcu(
                             enableQuarterPel,
 #if DISABLE_NSQ_FOR_NON_REF || DISABLE_NSQ
 #if ENCODER_MODE_CLEANUP
-                            (picture_control_set_ptr->enc_mode > ENC_M0)? picture_control_set_ptr->non_square_block_flag:sequence_control_set_ptr->static_config.ext_block_flag);
+                            picture_control_set_ptr->pic_depth_mode <= PIC_ALL_C_DEPTH_MODE);
 #else
                             picture_control_set_ptr->non_square_block_flag);
 #endif
@@ -7037,7 +7025,7 @@ EbErrorType MotionEstimateLcu(
         if (numOfListToSearch) {
 #if DISABLE_NSQ_FOR_NON_REF || DISABLE_NSQ
 #if ENCODER_MODE_CLEANUP
-            if (picture_control_set_ptr->cu8x8_mode == CU_8x8_MODE_0 || pu_index < 21 || ((picture_control_set_ptr->enc_mode > ENC_M0) ? picture_control_set_ptr->non_square_block_flag: sequence_control_set_ptr->static_config.ext_block_flag)) {
+            if (picture_control_set_ptr->cu8x8_mode == CU_8x8_MODE_0 || pu_index < 21 || (picture_control_set_ptr->pic_depth_mode <= PIC_ALL_C_DEPTH_MODE)) {
 #else
             if (picture_control_set_ptr->cu8x8_mode == CU_8x8_MODE_0 || pu_index < 21 || picture_control_set_ptr->non_square_block_flag) {
 #endif
@@ -7459,7 +7447,7 @@ void IntraOpenLoopSearchTheseModesOutputBest(
         sadArray[candidateIndex] = (uint32_t)NxMSadKernel_funcPtrArray[asm_type][cu_size >> 3]( // Always SAD without weighting
             src,
             src_stride,
-            &(context_ptr->meContextPtr->sb_buffer[0]),
+            &(context_ptr->me_context_ptr->sb_buffer[0]),
             BLOCK_SIZE_64,
             cu_size,
             cu_size);
@@ -7783,7 +7771,7 @@ int32_t GetInterIntraSadDistance(
     stage1SadArray[0] = (uint32_t)NxMSadKernel_funcPtrArray[asm_type][cu_size >> 3]( // Always SAD without weighting
         src,
         input_ptr->strideY,
-        &(context_ptr->meContextPtr->sb_buffer[0]),
+        &(context_ptr->me_context_ptr->sb_buffer[0]),
         BLOCK_SIZE_64,
         cu_size,
         cu_size);
@@ -7953,7 +7941,7 @@ uint32_t UpdateNeighborDcIntraPred(
     distortion = (uint32_t)NxMSadKernel_funcPtrArray[asm_type][cu_size >> 3]( // Always SAD without weighting
         &(input_ptr->bufferY[(input_ptr->origin_y + cu_origin_y) * input_ptr->strideY + (input_ptr->origin_x + cu_origin_x)]),
         input_ptr->strideY,
-        &(context_ptr->meContextPtr->sb_buffer[0]),
+        &(context_ptr->me_context_ptr->sb_buffer[0]),
         BLOCK_SIZE_64,
         cu_size,
         cu_size);
@@ -8125,7 +8113,7 @@ EbErrorType OpenLoopIntraSearchLcu(
                     OisCuPtr[0].distortion = (uint32_t)NxMSadKernel_funcPtrArray[asm_type][cu_size >> 3]( // Always SAD without weighting
                         &(input_ptr->bufferY[(input_ptr->origin_y + cu_origin_y) * input_ptr->strideY + (input_ptr->origin_x + cu_origin_x)]),
                         input_ptr->strideY,
-                        &(context_ptr->meContextPtr->sb_buffer[0]),
+                        &(context_ptr->me_context_ptr->sb_buffer[0]),
                         BLOCK_SIZE_64,
                         cu_size,
                         cu_size);
@@ -8253,7 +8241,7 @@ EbErrorType OpenLoopIntraSearchLcu(
                         sadDistortion = (uint32_t)NxMSadKernel_funcPtrArray[asm_type][cu_size >> 3](
                             &(input_ptr->bufferY[(input_ptr->origin_y + cu_origin_y) * input_ptr->strideY + (input_ptr->origin_x + cu_origin_x)]),
                             input_ptr->strideY,
-                            &(context_ptr->meContextPtr->sb_buffer[0]),
+                            &(context_ptr->me_context_ptr->sb_buffer[0]),
                             BLOCK_SIZE_64,
                             cu_size,
                             cu_size);

--- a/Source/Lib/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Codec/EbMotionEstimationProcess.c
@@ -56,32 +56,32 @@ EbErrorType CheckZeroZeroCenter(
 /************************************************
  * Set ME/HME Params from Config
  ************************************************/
-void* SetMeHmeParamsFromConfig(
+void* set_me_hme_params_from_config(
     SequenceControlSet_t        *sequence_control_set_ptr,
-    MeContext_t                 *meContextPtr)
+    MeContext_t                 *me_context_ptr)
 {
 
     uint16_t hmeRegionIndex = 0;
 
-    meContextPtr->search_area_width = (uint8_t)sequence_control_set_ptr->static_config.search_area_width;
-    meContextPtr->search_area_height = (uint8_t)sequence_control_set_ptr->static_config.search_area_height;
+    me_context_ptr->search_area_width = (uint8_t)sequence_control_set_ptr->static_config.search_area_width;
+    me_context_ptr->search_area_height = (uint8_t)sequence_control_set_ptr->static_config.search_area_height;
 
-    meContextPtr->number_hme_search_region_in_width = (uint16_t)sequence_control_set_ptr->static_config.number_hme_search_region_in_width;
-    meContextPtr->number_hme_search_region_in_height = (uint16_t)sequence_control_set_ptr->static_config.number_hme_search_region_in_height;
+    me_context_ptr->number_hme_search_region_in_width = (uint16_t)sequence_control_set_ptr->static_config.number_hme_search_region_in_width;
+    me_context_ptr->number_hme_search_region_in_height = (uint16_t)sequence_control_set_ptr->static_config.number_hme_search_region_in_height;
 
-    meContextPtr->hme_level0_total_search_area_width = (uint16_t)sequence_control_set_ptr->static_config.hme_level0_total_search_area_width;
-    meContextPtr->hme_level0_total_search_area_height = (uint16_t)sequence_control_set_ptr->static_config.hme_level0_total_search_area_height;
+    me_context_ptr->hme_level0_total_search_area_width = (uint16_t)sequence_control_set_ptr->static_config.hme_level0_total_search_area_width;
+    me_context_ptr->hme_level0_total_search_area_height = (uint16_t)sequence_control_set_ptr->static_config.hme_level0_total_search_area_height;
 
-    for (hmeRegionIndex = 0; hmeRegionIndex < meContextPtr->number_hme_search_region_in_width; ++hmeRegionIndex) {
-        meContextPtr->hme_level0_search_area_in_width_array[hmeRegionIndex] = (uint16_t)sequence_control_set_ptr->static_config.hme_level0_search_area_in_width_array[hmeRegionIndex];
-        meContextPtr->hme_level1_search_area_in_width_array[hmeRegionIndex] = (uint16_t)sequence_control_set_ptr->static_config.hme_level1_search_area_in_width_array[hmeRegionIndex];
-        meContextPtr->hme_level2_search_area_in_width_array[hmeRegionIndex] = (uint16_t)sequence_control_set_ptr->static_config.hme_level2_search_area_in_width_array[hmeRegionIndex];
+    for (hmeRegionIndex = 0; hmeRegionIndex < me_context_ptr->number_hme_search_region_in_width; ++hmeRegionIndex) {
+        me_context_ptr->hme_level0_search_area_in_width_array[hmeRegionIndex] = (uint16_t)sequence_control_set_ptr->static_config.hme_level0_search_area_in_width_array[hmeRegionIndex];
+        me_context_ptr->hme_level1_search_area_in_width_array[hmeRegionIndex] = (uint16_t)sequence_control_set_ptr->static_config.hme_level1_search_area_in_width_array[hmeRegionIndex];
+        me_context_ptr->hme_level2_search_area_in_width_array[hmeRegionIndex] = (uint16_t)sequence_control_set_ptr->static_config.hme_level2_search_area_in_width_array[hmeRegionIndex];
     }
 
-    for (hmeRegionIndex = 0; hmeRegionIndex < meContextPtr->number_hme_search_region_in_height; ++hmeRegionIndex) {
-        meContextPtr->hme_level0_search_area_in_height_array[hmeRegionIndex] = (uint16_t)sequence_control_set_ptr->static_config.hme_level0_search_area_in_height_array[hmeRegionIndex];
-        meContextPtr->hme_level1_search_area_in_height_array[hmeRegionIndex] = (uint16_t)sequence_control_set_ptr->static_config.hme_level1_search_area_in_height_array[hmeRegionIndex];
-        meContextPtr->hme_level2_search_area_in_height_array[hmeRegionIndex] = (uint16_t)sequence_control_set_ptr->static_config.hme_level2_search_area_in_height_array[hmeRegionIndex];
+    for (hmeRegionIndex = 0; hmeRegionIndex < me_context_ptr->number_hme_search_region_in_height; ++hmeRegionIndex) {
+        me_context_ptr->hme_level0_search_area_in_height_array[hmeRegionIndex] = (uint16_t)sequence_control_set_ptr->static_config.hme_level0_search_area_in_height_array[hmeRegionIndex];
+        me_context_ptr->hme_level1_search_area_in_height_array[hmeRegionIndex] = (uint16_t)sequence_control_set_ptr->static_config.hme_level1_search_area_in_height_array[hmeRegionIndex];
+        me_context_ptr->hme_level2_search_area_in_height_array[hmeRegionIndex] = (uint16_t)sequence_control_set_ptr->static_config.hme_level2_search_area_in_height_array[hmeRegionIndex];
     }
 
     return EB_NULL;
@@ -91,15 +91,15 @@ void* SetMeHmeParamsFromConfig(
 /************************************************
  * Set ME/HME Params
  ************************************************/
-void* SetMeHmeParamsOq(
-    MeContext_t                     *meContextPtr,
+void* set_me_hme_params_oq(
+    MeContext_t                     *me_context_ptr,
     PictureParentControlSet_t       *picture_control_set_ptr,
     SequenceControlSet_t            *sequence_control_set_ptr,
     EbInputResolution                 input_resolution)
 {
     (void)*picture_control_set_ptr;
     //uint8_t  hmeMeLevel = picture_control_set_ptr->enc_mode;
-    uint8_t  hmeMeLevel = 0; // OMK to be revised after new presets
+    uint8_t  hmeMeLevel = picture_control_set_ptr->enc_mode <= ENC_M3 ? 0: picture_control_set_ptr->enc_mode; // OMK to be revised after new presets
 
     uint32_t inputRatio = sequence_control_set_ptr->luma_width / sequence_control_set_ptr->luma_height;
 
@@ -110,30 +110,30 @@ void* SetMeHmeParamsOq(
         4;  // 4K
 
 // HME/ME default settings
-    meContextPtr->number_hme_search_region_in_width = 2;
-    meContextPtr->number_hme_search_region_in_height = 2;
+    me_context_ptr->number_hme_search_region_in_width = 2;
+    me_context_ptr->number_hme_search_region_in_height = 2;
 
     // HME Level0
-    meContextPtr->hme_level0_total_search_area_width = HmeLevel0TotalSearchAreaWidth[resolutionIndex][hmeMeLevel];
-    meContextPtr->hme_level0_total_search_area_height = HmeLevel0TotalSearchAreaHeight[resolutionIndex][hmeMeLevel];
-    meContextPtr->hme_level0_search_area_in_width_array[0] = HmeLevel0SearchAreaInWidthArrayRight[resolutionIndex][hmeMeLevel];
-    meContextPtr->hme_level0_search_area_in_width_array[1] = HmeLevel0SearchAreaInWidthArrayLeft[resolutionIndex][hmeMeLevel];
-    meContextPtr->hme_level0_search_area_in_height_array[0] = HmeLevel0SearchAreaInHeightArrayTop[resolutionIndex][hmeMeLevel];
-    meContextPtr->hme_level0_search_area_in_height_array[1] = HmeLevel0SearchAreaInHeightArrayBottom[resolutionIndex][hmeMeLevel];
+    me_context_ptr->hme_level0_total_search_area_width = HmeLevel0TotalSearchAreaWidth[resolutionIndex][hmeMeLevel];
+    me_context_ptr->hme_level0_total_search_area_height = HmeLevel0TotalSearchAreaHeight[resolutionIndex][hmeMeLevel];
+    me_context_ptr->hme_level0_search_area_in_width_array[0] = HmeLevel0SearchAreaInWidthArrayRight[resolutionIndex][hmeMeLevel];
+    me_context_ptr->hme_level0_search_area_in_width_array[1] = HmeLevel0SearchAreaInWidthArrayLeft[resolutionIndex][hmeMeLevel];
+    me_context_ptr->hme_level0_search_area_in_height_array[0] = HmeLevel0SearchAreaInHeightArrayTop[resolutionIndex][hmeMeLevel];
+    me_context_ptr->hme_level0_search_area_in_height_array[1] = HmeLevel0SearchAreaInHeightArrayBottom[resolutionIndex][hmeMeLevel];
     // HME Level1
-    meContextPtr->hme_level1_search_area_in_width_array[0] = HmeLevel1SearchAreaInWidthArrayRight[resolutionIndex][hmeMeLevel];
-    meContextPtr->hme_level1_search_area_in_width_array[1] = HmeLevel1SearchAreaInWidthArrayLeft[resolutionIndex][hmeMeLevel];
-    meContextPtr->hme_level1_search_area_in_height_array[0] = HmeLevel1SearchAreaInHeightArrayTop[resolutionIndex][hmeMeLevel];
-    meContextPtr->hme_level1_search_area_in_height_array[1] = HmeLevel1SearchAreaInHeightArrayBottom[resolutionIndex][hmeMeLevel];
+    me_context_ptr->hme_level1_search_area_in_width_array[0] = HmeLevel1SearchAreaInWidthArrayRight[resolutionIndex][hmeMeLevel];
+    me_context_ptr->hme_level1_search_area_in_width_array[1] = HmeLevel1SearchAreaInWidthArrayLeft[resolutionIndex][hmeMeLevel];
+    me_context_ptr->hme_level1_search_area_in_height_array[0] = HmeLevel1SearchAreaInHeightArrayTop[resolutionIndex][hmeMeLevel];
+    me_context_ptr->hme_level1_search_area_in_height_array[1] = HmeLevel1SearchAreaInHeightArrayBottom[resolutionIndex][hmeMeLevel];
     // HME Level2
-    meContextPtr->hme_level2_search_area_in_width_array[0] = HmeLevel2SearchAreaInWidthArrayRight[resolutionIndex][hmeMeLevel];
-    meContextPtr->hme_level2_search_area_in_width_array[1] = HmeLevel2SearchAreaInWidthArrayLeft[resolutionIndex][hmeMeLevel];
-    meContextPtr->hme_level2_search_area_in_height_array[0] = HmeLevel2SearchAreaInHeightArrayTop[resolutionIndex][hmeMeLevel];
-    meContextPtr->hme_level2_search_area_in_height_array[1] = HmeLevel2SearchAreaInHeightArrayBottom[resolutionIndex][hmeMeLevel];
+    me_context_ptr->hme_level2_search_area_in_width_array[0] = HmeLevel2SearchAreaInWidthArrayRight[resolutionIndex][hmeMeLevel];
+    me_context_ptr->hme_level2_search_area_in_width_array[1] = HmeLevel2SearchAreaInWidthArrayLeft[resolutionIndex][hmeMeLevel];
+    me_context_ptr->hme_level2_search_area_in_height_array[0] = HmeLevel2SearchAreaInHeightArrayTop[resolutionIndex][hmeMeLevel];
+    me_context_ptr->hme_level2_search_area_in_height_array[1] = HmeLevel2SearchAreaInHeightArrayBottom[resolutionIndex][hmeMeLevel];
 
     // ME
-    meContextPtr->search_area_width = SearchAreaWidth[resolutionIndex][hmeMeLevel];
-    meContextPtr->search_area_height = SearchAreaHeight[resolutionIndex][hmeMeLevel];
+    me_context_ptr->search_area_width = SearchAreaWidth[resolutionIndex][hmeMeLevel];
+    me_context_ptr->search_area_height = SearchAreaHeight[resolutionIndex][hmeMeLevel];
 
 
     // HME Level0 adjustment for low frame rate contents (frame rate <= 30)
@@ -141,12 +141,12 @@ void* SetMeHmeParamsOq(
         if ((sequence_control_set_ptr->static_config.frame_rate >> 16) <= 30) {
 
             if (hmeMeLevel == ENC_M6) {
-                meContextPtr->hme_level0_total_search_area_width = MAX(96, meContextPtr->hme_level0_total_search_area_width);
-                meContextPtr->hme_level0_total_search_area_height = MAX(64, meContextPtr->hme_level0_total_search_area_height);
-                meContextPtr->hme_level0_search_area_in_width_array[0] = MAX(48, meContextPtr->hme_level0_search_area_in_width_array[0]);
-                meContextPtr->hme_level0_search_area_in_width_array[1] = MAX(48, meContextPtr->hme_level0_search_area_in_width_array[1]);
-                meContextPtr->hme_level0_search_area_in_height_array[0] = MAX(32, meContextPtr->hme_level0_search_area_in_height_array[0]);
-                meContextPtr->hme_level0_search_area_in_height_array[1] = MAX(32, meContextPtr->hme_level0_search_area_in_height_array[1]);
+                me_context_ptr->hme_level0_total_search_area_width = MAX(96, me_context_ptr->hme_level0_total_search_area_width);
+                me_context_ptr->hme_level0_total_search_area_height = MAX(64, me_context_ptr->hme_level0_total_search_area_height);
+                me_context_ptr->hme_level0_search_area_in_width_array[0] = MAX(48, me_context_ptr->hme_level0_search_area_in_width_array[0]);
+                me_context_ptr->hme_level0_search_area_in_width_array[1] = MAX(48, me_context_ptr->hme_level0_search_area_in_width_array[1]);
+                me_context_ptr->hme_level0_search_area_in_height_array[0] = MAX(32, me_context_ptr->hme_level0_search_area_in_height_array[0]);
+                me_context_ptr->hme_level0_search_area_in_height_array[1] = MAX(32, me_context_ptr->hme_level0_search_area_in_height_array[1]);
 
             }
         }
@@ -159,7 +159,7 @@ void* SetMeHmeParamsOq(
   Input   : encoder mode and tune
   Output  : ME Kernel signal(s)
 ******************************************************/
-EbErrorType SignalDerivationMeKernelOq(
+EbErrorType signal_derivation_me_kernel_oq(
     SequenceControlSet_t        *sequence_control_set_ptr,
     PictureParentControlSet_t   *picture_control_set_ptr,
     MotionEstimationContext_t   *context_ptr) {
@@ -168,16 +168,16 @@ EbErrorType SignalDerivationMeKernelOq(
 
     // Set ME/HME search regions
     if (sequence_control_set_ptr->static_config.use_default_me_hme) {
-        SetMeHmeParamsOq(
-            context_ptr->meContextPtr,
+        set_me_hme_params_oq(
+            context_ptr->me_context_ptr,
             picture_control_set_ptr,
             sequence_control_set_ptr,
             sequence_control_set_ptr->input_resolution);
     }
     else {
-        SetMeHmeParamsFromConfig(
+        set_me_hme_params_from_config(
             sequence_control_set_ptr,
-            context_ptr->meContextPtr);
+            context_ptr->me_context_ptr);
     }
 
     return return_error;
@@ -204,7 +204,7 @@ EbErrorType MotionEstimationContextCtor(
     if (return_error == EB_ErrorInsufficientResources) {
         return EB_ErrorInsufficientResources;
     }
-    return_error = MeContextCtor(&(context_ptr->meContextPtr));
+    return_error = MeContextCtor(&(context_ptr->me_context_ptr));
     if (return_error == EB_ErrorInsufficientResources) {
         return EB_ErrorInsufficientResources;
     }
@@ -286,8 +286,8 @@ EbErrorType ComputeDecimatedZzSad(
                     previousInputPictureFull->strideY,
                     BLOCK_SIZE_64,
                     BLOCK_SIZE_64,
-                    context_ptr->meContextPtr->sixteenth_sb_buffer,
-                    context_ptr->meContextPtr->sixteenth_sb_buffer_stride,
+                    context_ptr->me_context_ptr->sixteenth_sb_buffer,
+                    context_ptr->me_context_ptr->sixteenth_sb_buffer_stride,
                     4);
 
                 if (asm_type >= ASM_NON_AVX2 && asm_type < ASM_TYPE_TOTAL)
@@ -295,8 +295,8 @@ EbErrorType ComputeDecimatedZzSad(
                     decimatedLcuCollocatedSad = NxMSadKernel_funcPtrArray[asm_type][2](
                         &(sixteenthDecimatedPicturePtr->bufferY[blkDisplacementDecimated]),
                         sixteenthDecimatedPicturePtr->strideY,
-                        context_ptr->meContextPtr->sixteenth_sb_buffer,
-                        context_ptr->meContextPtr->sixteenth_sb_buffer_stride,
+                        context_ptr->me_context_ptr->sixteenth_sb_buffer,
+                        context_ptr->me_context_ptr->sixteenth_sb_buffer_stride,
                         16, 16);
 
                 // Background Enhancement Algorithm
@@ -442,12 +442,12 @@ void* MotionEstimationKernel(void *input_ptr)
         md_rate_estimation_array = (MdRateEstimationContext_t*)sequence_control_set_ptr->encode_context_ptr->md_rate_estimation_array;
         md_rate_estimation_array += picture_control_set_ptr->slice_type * TOTAL_NUMBER_OF_QP_VALUES + picture_control_set_ptr->picture_qp;
         // Reset MD rate Estimation table to initial values by copying from md_rate_estimation_array
-        EB_MEMCPY(&(context_ptr->meContextPtr->mvd_bits_array[0]), &(md_rate_estimation_array->mvdBits[0]), sizeof(EB_BitFraction)*NUMBER_OF_MVD_CASES);
-        ///context_ptr->meContextPtr->lambda = lambdaModeDecisionLdSadQpScaling[picture_control_set_ptr->picture_qp];
+        EB_MEMCPY(&(context_ptr->me_context_ptr->mvd_bits_array[0]), &(md_rate_estimation_array->mvdBits[0]), sizeof(EB_BitFraction)*NUMBER_OF_MVD_CASES);
+        ///context_ptr->me_context_ptr->lambda = lambdaModeDecisionLdSadQpScaling[picture_control_set_ptr->picture_qp];
 #if ME_HME_OQ
    // ME Kernel Signal(s) derivation
 
-        SignalDerivationMeKernelOq(
+        signal_derivation_me_kernel_oq(
             sequence_control_set_ptr,
             picture_control_set_ptr,
             context_ptr);
@@ -456,21 +456,21 @@ void* MotionEstimationKernel(void *input_ptr)
         if (sequence_control_set_ptr->static_config.pred_structure == EB_PRED_RANDOM_ACCESS) {
 
             if (picture_control_set_ptr->temporal_layer_index == 0) {
-                context_ptr->meContextPtr->lambda = lambdaModeDecisionRaSad[picture_control_set_ptr->picture_qp];
+                context_ptr->me_context_ptr->lambda = lambdaModeDecisionRaSad[picture_control_set_ptr->picture_qp];
             }
             else if (picture_control_set_ptr->temporal_layer_index < 3) {
-                context_ptr->meContextPtr->lambda = lambdaModeDecisionRaSadQpScalingL1[picture_control_set_ptr->picture_qp];
+                context_ptr->me_context_ptr->lambda = lambdaModeDecisionRaSadQpScalingL1[picture_control_set_ptr->picture_qp];
             }
             else {
-                context_ptr->meContextPtr->lambda = lambdaModeDecisionRaSadQpScalingL3[picture_control_set_ptr->picture_qp];
+                context_ptr->me_context_ptr->lambda = lambdaModeDecisionRaSadQpScalingL3[picture_control_set_ptr->picture_qp];
             }
         }
         else {
             if (picture_control_set_ptr->temporal_layer_index == 0) {
-                context_ptr->meContextPtr->lambda = lambdaModeDecisionLdSad[picture_control_set_ptr->picture_qp];
+                context_ptr->me_context_ptr->lambda = lambdaModeDecisionLdSad[picture_control_set_ptr->picture_qp];
             }
             else {
-                context_ptr->meContextPtr->lambda = lambdaModeDecisionLdSadQpScaling[picture_control_set_ptr->picture_qp];
+                context_ptr->me_context_ptr->lambda = lambdaModeDecisionLdSadQpScaling[picture_control_set_ptr->picture_qp];
             }
         }
 
@@ -491,10 +491,10 @@ void* MotionEstimationKernel(void *input_ptr)
                     // Load the SB from the input to the intermediate SB buffer
                     bufferIndex = (inputPicturePtr->origin_y + sb_origin_y) * inputPicturePtr->strideY + inputPicturePtr->origin_x + sb_origin_x;
 
-                    context_ptr->meContextPtr->hme_search_type = HME_RECTANGULAR;
+                    context_ptr->me_context_ptr->hme_search_type = HME_RECTANGULAR;
 
                     for (lcuRow = 0; lcuRow < BLOCK_SIZE_64; lcuRow++) {
-                        EB_MEMCPY((&(context_ptr->meContextPtr->sb_buffer[lcuRow * BLOCK_SIZE_64])), (&(inputPicturePtr->bufferY[bufferIndex + lcuRow * inputPicturePtr->strideY])), BLOCK_SIZE_64 * sizeof(uint8_t));
+                        EB_MEMCPY((&(context_ptr->me_context_ptr->sb_buffer[lcuRow * BLOCK_SIZE_64])), (&(inputPicturePtr->bufferY[bufferIndex + lcuRow * inputPicturePtr->strideY])), BLOCK_SIZE_64 * sizeof(uint8_t));
 
                     }
 
@@ -511,8 +511,8 @@ void* MotionEstimationKernel(void *input_ptr)
                     }
 
 
-                    context_ptr->meContextPtr->sb_src_ptr = &inputPaddedPicturePtr->bufferY[bufferIndex];
-                    context_ptr->meContextPtr->sb_src_stride = inputPaddedPicturePtr->strideY;
+                    context_ptr->me_context_ptr->sb_src_ptr = &inputPaddedPicturePtr->bufferY[bufferIndex];
+                    context_ptr->me_context_ptr->sb_src_stride = inputPaddedPicturePtr->strideY;
 
 
                     // Load the 1/4 decimated SB from the 1/4 decimated input to the 1/4 intermediate SB buffer
@@ -521,7 +521,7 @@ void* MotionEstimationKernel(void *input_ptr)
                         bufferIndex = (quarterDecimatedPicturePtr->origin_y + (sb_origin_y >> 1)) * quarterDecimatedPicturePtr->strideY + quarterDecimatedPicturePtr->origin_x + (sb_origin_x >> 1);
 
                         for (lcuRow = 0; lcuRow < (sb_height >> 1); lcuRow++) {
-                            EB_MEMCPY((&(context_ptr->meContextPtr->quarter_sb_buffer[lcuRow * context_ptr->meContextPtr->quarter_sb_buffer_stride])), (&(quarterDecimatedPicturePtr->bufferY[bufferIndex + lcuRow * quarterDecimatedPicturePtr->strideY])), (sb_width >> 1) * sizeof(uint8_t));
+                            EB_MEMCPY((&(context_ptr->me_context_ptr->quarter_sb_buffer[lcuRow * context_ptr->me_context_ptr->quarter_sb_buffer_stride])), (&(quarterDecimatedPicturePtr->bufferY[bufferIndex + lcuRow * quarterDecimatedPicturePtr->strideY])), (sb_width >> 1) * sizeof(uint8_t));
 
                         }
                     }
@@ -533,7 +533,7 @@ void* MotionEstimationKernel(void *input_ptr)
 
                         {
                             uint8_t  *framePtr = &sixteenthDecimatedPicturePtr->bufferY[bufferIndex];
-                            uint8_t  *localPtr = context_ptr->meContextPtr->sixteenth_sb_buffer;
+                            uint8_t  *localPtr = context_ptr->me_context_ptr->sixteenth_sb_buffer;
 
                             for (lcuRow = 0; lcuRow < (sb_height >> 2); lcuRow += 2) {
                                 EB_MEMCPY(localPtr, framePtr, (sb_width >> 2) * sizeof(uint8_t));
@@ -548,7 +548,7 @@ void* MotionEstimationKernel(void *input_ptr)
                         sb_index,
                         sb_origin_x,
                         sb_origin_y,
-                        context_ptr->meContextPtr,
+                        context_ptr->me_context_ptr,
                         inputPicturePtr);
 
                 }

--- a/Source/Lib/Codec/EbMotionEstimationProcess.h
+++ b/Source/Lib/Codec/EbMotionEstimationProcess.h
@@ -20,7 +20,7 @@ typedef struct MotionEstimationContext_s
     EbFifo_t                        *pictureDecisionResultsInputFifoPtr;
     EbFifo_t                        *motionEstimationResultsOutputFifoPtr;
     IntraReferenceSamplesOpenLoop_t *intra_ref_ptr;
-    MeContext_t                     *meContextPtr;
+    MeContext_t                     *me_context_ptr;
 
     uint8_t                       *indexTable0;
     uint8_t                       *indexTable1;

--- a/Source/Lib/Codec/EbPictureBufferDesc.c
+++ b/Source/Lib/Codec/EbPictureBufferDesc.c
@@ -32,14 +32,10 @@ EbErrorType EbPictureBufferDescCtor(
     EbPictureBufferDesc_t          *pictureBufferDescPtr;
     EbPictureBufferDescInitData_t  *pictureBufferDescInitDataPtr = (EbPictureBufferDescInitData_t*)object_init_data_ptr;
 
-#if MEM_RED3
     uint32_t bytesPerPixel = (pictureBufferDescInitDataPtr->bit_depth == EB_8BIT) ? 1 : (pictureBufferDescInitDataPtr->bit_depth <= EB_16BIT) ? 2 : 4;
 
     if (pictureBufferDescInitDataPtr->bit_depth > EB_8BIT && pictureBufferDescInitDataPtr->bit_depth <= EB_16BIT && pictureBufferDescInitDataPtr->splitMode == EB_TRUE)
         bytesPerPixel = 1;
-#else
-    uint32_t bytesPerPixel = (pictureBufferDescInitDataPtr->bit_depth == EB_8BIT) ? 1 : (pictureBufferDescInitDataPtr->bit_depth == EB_16BIT) ? 2 : 4;
-#endif
 
     EB_MALLOC(EbPictureBufferDesc_t*, pictureBufferDescPtr, sizeof(EbPictureBufferDesc_t), EB_N_PTR);
 

--- a/Source/Lib/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Codec/EbPictureControlSet.c
@@ -202,16 +202,12 @@ EbErrorType PictureControlSetCtor(
     sb_origin_x = 0;
     sb_origin_y = 0;
 
-#if MEM_RED
     const uint16_t picture_sb_w   = (uint16_t)((initDataPtr->picture_width  + initDataPtr->sb_size_pix - 1) / initDataPtr->sb_size_pix); 
     const uint16_t picture_sb_h   = (uint16_t)((initDataPtr->picture_height + initDataPtr->sb_size_pix - 1) / initDataPtr->sb_size_pix);
     const uint16_t all_sb = picture_sb_w * picture_sb_h;
 
     for (sb_index = 0; sb_index < all_sb; ++sb_index) {
 
-#else
-    for (sb_index = 0; sb_index < objectPtr->sb_total_count; ++sb_index) {
-#endif
         return_error = largest_coding_unit_ctor(
             &(objectPtr->sb_ptr_array[sb_index]),
             (uint8_t)initDataPtr->sb_sz,
@@ -225,13 +221,8 @@ EbErrorType PictureControlSetCtor(
             return EB_ErrorInsufficientResources;
         }
         // Increment the Order in coding order (Raster Scan Order)
-#if MEM_RED
         sb_origin_y = (sb_origin_x == picture_sb_w - 1) ? sb_origin_y + 1 : sb_origin_y;
         sb_origin_x = (sb_origin_x == picture_sb_w - 1) ? 0 : sb_origin_x + 1;
-#else
-        sb_origin_y = (sb_origin_x == pictureLcuWidth - 1) ? sb_origin_y + 1 : sb_origin_y;
-        sb_origin_x = (sb_origin_x == pictureLcuWidth - 1) ? 0 : sb_origin_x + 1;
-#endif
 
     }
 

--- a/Source/Lib/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Codec/EbPictureControlSet.h
@@ -14079,14 +14079,19 @@ extern "C" {
 #endif
         // MD
         EbEncMode                             enc_mode;
-        EbPictureDepthMode                    depth_mode;
+
         EbLcuDepthMode                       *sb_md_mode_array;
         EbChromaMode                          chroma_mode;
-        EbSbComplexityStatus                *complex_sb_array;
+        EbSbComplexityStatus                 *complex_sb_array;
         EbCu8x8Mode                           cu8x8_mode;
         EbBool                                use_src_ref;
         EbBool                                limit_ois_to_dc_mode_flag;
 
+        // Multi-modes signal(s) 
+        EbPictureDepthMode                    pic_depth_mode;
+        uint8_t                               interpolation_filter_search_mode;
+        uint8_t                               loop_filter_mode;
+        uint8_t                               intra_pred_mode;
         //**********************************************************************************************************//
         FRAME_TYPE                            av1FrameType;
         Av1RpsNode_t                          av1RefSignal;
@@ -14227,16 +14232,11 @@ extern "C" {
         int16_t                               tiltMvy;
         EbWarpedMotionParams                  global_motion[TOTAL_REFS_PER_FRAME];
         PictureControlSet_t                  *childPcs;
-        int32_t                               use_fast_interpolation_filter_search;
         Macroblock                           *av1x;
         int32_t                               film_grain_params_present; //todo (AN): Do we need this flag at picture level?
         aom_film_grain_t                      film_grain_params;
         struct aom_denoise_and_model_t       *denoise_and_model;
         EbBool                                enable_in_loop_motion_estimation_flag;
-#if DISABLE_NSQ_FOR_NON_REF || DISABLE_NSQ
-        uint8_t                               non_square_block_flag;
-        uint8_t                               small_block_flag;
-#endif
 
     } PictureParentControlSet_t;
 
@@ -14251,10 +14251,8 @@ extern "C" {
         uint16_t                           bot_padding;
         EB_BITDEPTH                        bit_depth;
         uint32_t                           sb_sz;
-#if MEM_RED
         uint32_t                           sb_size_pix;   //since we still have lot of code assuming 64x64 LCU, we add a new paramter supporting both128x128 and 64x64, 
                                                           //ultimately the fixed code supporting 64x64 should be upgraded to use 128x128 and the above could be removed.
-#endif
         uint32_t                           max_depth;
         EbBool                             is16bit;
         uint32_t                           ten_bit_format;

--- a/Source/Lib/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Codec/EbPictureManagerProcess.c
@@ -34,13 +34,8 @@ static void ConfigurePictureEdges(
     PictureControlSet_t  *ppsPtr)
 {
     // Tiles Initialisation
-#if MEM_RED
     const uint16_t picture_width_in_sb = (scsPtr->luma_width + scsPtr->sb_size_pix - 1) / scsPtr->sb_size_pix;
     const uint16_t picture_height_in_sb = (scsPtr->luma_height + scsPtr->sb_size_pix - 1) / scsPtr->sb_size_pix;
-#else
-    const uint16_t picture_width_in_sb = (scsPtr->luma_width + scsPtr->sb_sz - 1) / scsPtr->sb_sz;
-    const uint16_t picture_height_in_sb = (scsPtr->luma_height + scsPtr->sb_sz - 1) / scsPtr->sb_sz;
-#endif
     unsigned xLcuIndex, yLcuIndex, sb_index;
 
     // LCU-loops

--- a/Source/Lib/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Codec/EbRateControlProcess.c
@@ -997,9 +997,6 @@ void* RateControlKernel(void *input_ptr)
     RateControlResults_t        *rateControlResultsPtr;
 
     // SB Loop variables
-#if !MEM_RED
-    uint32_t                       sb_total_count;
-#endif
     LargestCodingUnit_t         *sb_ptr;
     uint32_t                       lcuCodingOrder;
     uint64_t                       totalNumberOfFbFrames = 0;
@@ -1116,10 +1113,6 @@ void* RateControlKernel(void *input_ptr)
                     context_ptr->rateControlParamQueue[0] :
                     context_ptr->rateControlParamQueue[intervalIndexTemp + 1];
             }
-
-#if !MEM_RED
-            sb_total_count = picture_control_set_ptr->sb_total_count;
-#endif
 
             if (sequence_control_set_ptr->static_config.rate_control_mode == 0) {
                 // if RC mode is 0,  fixed QP is used
@@ -1320,12 +1313,7 @@ void* RateControlKernel(void *input_ptr)
                 }
             }
             picture_control_set_ptr->parent_pcs_ptr->average_qp = 0;
-#if MEM_RED
             for (lcuCodingOrder = 0; lcuCodingOrder < sequence_control_set_ptr->sb_tot_cnt; ++lcuCodingOrder) {
-#else
-
-            for (lcuCodingOrder = 0; lcuCodingOrder < sb_total_count; ++lcuCodingOrder) {
-#endif
 
                 sb_ptr = picture_control_set_ptr->sb_ptr_array[lcuCodingOrder];
 #if ADD_DELTA_QP_SUPPORT

--- a/Source/Lib/Codec/EbRateDistortionCost.c
+++ b/Source/Lib/Codec/EbRateDistortionCost.c
@@ -1119,11 +1119,7 @@ EbErrorType Av1InterFastCost(
             for (idx = 0; idx < 2; ++idx) {
                 if (cu_ptr->av1xd->ref_mv_count[candidate_ptr->ref_frame_type] > idx + 1) {
                     uint8_t drl1Ctx =
-#if MEM_RED2
                         av1_drl_ctx(context_ptr->md_local_cu_unit[context_ptr->blk_geom->blkidx_mds].ed_ref_mv_stack[candidate_ptr->ref_frame_type], idx);
-#else
-                        av1_drl_ctx(cu_ptr->av1xd->ref_mv_stack[candidate_ptr->ref_frame_type], idx);
-#endif
 
                     interModeBitsNum += candidate_buffer_ptr->candidate_ptr->md_rate_estimation_ptr->drlModeFacBits[drl1Ctx][candidate_ptr->drl_index != idx];
                     if (candidate_ptr->drl_index == idx) break;
@@ -1137,11 +1133,7 @@ EbErrorType Av1InterFastCost(
             for (idx = 1; idx < 3; ++idx) {
                 if (cu_ptr->av1xd->ref_mv_count[candidate_ptr->ref_frame_type] > idx + 1) {
                     uint8_t drl_ctx =
-#if MEM_RED2
                         av1_drl_ctx(context_ptr->md_local_cu_unit[context_ptr->blk_geom->blkidx_mds].ed_ref_mv_stack[candidate_ptr->ref_frame_type], idx);
-#else
-                        av1_drl_ctx(cu_ptr->av1xd->ref_mv_stack[candidate_ptr->ref_frame_type], idx);
-#endif
 
                     interModeBitsNum += candidate_buffer_ptr->candidate_ptr->md_rate_estimation_ptr->drlModeFacBits[drl_ctx][candidate_ptr->drl_index != (idx - 1)];
 

--- a/Source/Lib/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Codec/EbResourceCoordinationProcess.c
@@ -356,31 +356,28 @@ void* SetMeHmeParams(
 Input   : encoder mode and tune
 Output  : Pre-Analysis signal(s)
 ******************************************************/
-EbErrorType SignalDerivationPreAnalysisOq(
+EbErrorType signal_derivation_pre_analysis_oq(
     SequenceControlSet_t       *sequence_control_set_ptr,
     PictureParentControlSet_t  *picture_control_set_ptr) {
 
     EbErrorType return_error = EB_ErrorNone;
-
     uint8_t input_resolution = sequence_control_set_ptr->input_resolution;
 
-
     // Derive HME Flag
-
     if (sequence_control_set_ptr->static_config.use_default_me_hme) {
-        uint8_t  hmeMeLevel = picture_control_set_ptr->enc_mode;
+        uint8_t  hme_me_level = picture_control_set_ptr->enc_mode;
 
         uint32_t inputRatio = sequence_control_set_ptr->luma_width / sequence_control_set_ptr->luma_height;
-        uint8_t resolutionIndex = input_resolution <= INPUT_SIZE_576p_RANGE_OR_LOWER ? 0 : // 480P
+        uint8_t resolution_index = input_resolution <= INPUT_SIZE_576p_RANGE_OR_LOWER ? 0 : // 480P
             (input_resolution <= INPUT_SIZE_1080i_RANGE && inputRatio < 2) ? 1 : // 720P
             (input_resolution <= INPUT_SIZE_1080i_RANGE && inputRatio > 3) ? 2 : // 1080I
             (input_resolution <= INPUT_SIZE_1080p_RANGE) ? 3 : // 1080I
             4;    // 4K
 
         picture_control_set_ptr->enable_hme_flag = EB_TRUE;
-        picture_control_set_ptr->enable_hme_level0_flag = EnableHmeLevel0Flag[resolutionIndex][hmeMeLevel];
-        picture_control_set_ptr->enable_hme_level1_flag = EnableHmeLevel1Flag[resolutionIndex][hmeMeLevel];
-        picture_control_set_ptr->enable_hme_level2_flag = EnableHmeLevel2Flag[resolutionIndex][hmeMeLevel];
+        picture_control_set_ptr->enable_hme_level0_flag = EnableHmeLevel0Flag[resolution_index][hme_me_level];
+        picture_control_set_ptr->enable_hme_level1_flag = EnableHmeLevel1Flag[resolution_index][hme_me_level];
+        picture_control_set_ptr->enable_hme_level2_flag = EnableHmeLevel2Flag[resolution_index][hme_me_level];
     }
     else {
         picture_control_set_ptr->enable_hme_flag = sequence_control_set_ptr->static_config.enable_hme_flag;
@@ -883,7 +880,7 @@ void* ResourceCoordinationKernel(void *input_ptr)
 #endif
 #if ME_HME_OQ
         // Pre-Analysis Signal(s) derivation
-        SignalDerivationPreAnalysisOq(
+        signal_derivation_pre_analysis_oq(
             sequence_control_set_ptr,
             picture_control_set_ptr);
 #else

--- a/Source/Lib/Codec/EbTransforms.c
+++ b/Source/Lib/Codec/EbTransforms.c
@@ -8318,6 +8318,28 @@ static void highbd_inv_txfm_add(const tran_low_t *input, uint8_t *dest,
     }
 }
 
+void av1_inv_txfm_add_c(const tran_low_t *dqcoeff, uint8_t *dst, int32_t stride,
+    const TxfmParam *txfm_param) {
+    const TxType tx_size = txfm_param->tx_size;
+    DECLARE_ALIGNED(32, uint16_t, tmp[MAX_TX_SQUARE]);
+    int32_t tmp_stride = MAX_TX_SIZE;
+    int32_t w = tx_size_wide[tx_size];
+    int32_t h = tx_size_high[tx_size];
+    for (int32_t r = 0; r < h; ++r) {
+        for (int32_t c = 0; c < w; ++c) {
+            tmp[r * tmp_stride + c] = dst[r * stride + c];
+        }
+    }
+
+    highbd_inv_txfm_add(dqcoeff, CONVERT_TO_BYTEPTR(tmp), tmp_stride,
+        txfm_param);
+
+    for (int32_t r = 0; r < h; ++r) {
+        for (int32_t c = 0; c < w; ++c) {
+            dst[r * stride + c] = (uint8_t)tmp[r * tmp_stride + c];
+        }
+    }
+}
 
 EbErrorType Av1InvTransformRecon(
     int32_t      *coeffBuffer,//1D buffer

--- a/Source/Lib/Codec/RateControlModel.c
+++ b/Source/Lib/Codec/RateControlModel.c
@@ -17,7 +17,7 @@
  * @param {uint32_t} desired_size.
  * @return {uint32_t}.
  */
-static uint32_t	get_inter_qp_for_size(EbRateControlModel *model_ptr, uint32_t desired_size);
+static uint32_t    get_inter_qp_for_size(EbRateControlModel *model_ptr, uint32_t desired_size);
 
 /*
  * @private
@@ -58,7 +58,7 @@ static const size_t DEFAULT_REF_INTER_PICTURE_COMPRESSION_RATIO[64] = {
      20385, 17752, 15465, 13178, 10891
 };
 
-EbErrorType	rate_control_model_ctor(EbRateControlModel **object_doubble_ptr) {
+EbErrorType    rate_control_model_ctor(EbRateControlModel **object_doubble_ptr) {
     EbRateControlModel  *model_ptr;
 
     EB_MALLOC(EbRateControlModel*, model_ptr, sizeof(EbRateControlModel), EB_N_PTR);
@@ -89,7 +89,7 @@ EbErrorType rate_control_model_init(EbRateControlModel *model_ptr, SequenceContr
     return EB_ErrorNone;
 }
 
-EbErrorType	rate_control_update_model(EbRateControlModel *model_ptr, PictureParentControlSet_t *picture_ptr) {
+EbErrorType    rate_control_update_model(EbRateControlModel *model_ptr, PictureParentControlSet_t *picture_ptr) {
     uint64_t                size = picture_ptr->total_num_bits;
     EbRateControlGopInfo    *gop = get_gop_infos(model_ptr->gop_infos, picture_ptr->picture_number);
 
@@ -105,7 +105,7 @@ EbErrorType	rate_control_update_model(EbRateControlModel *model_ptr, PicturePare
       if (gop->actual_size > gop->desired_size) {
         variation = -((int64_t)gop->actual_size / (int64_t)gop->desired_size);
       } else if (gop->desired_size > gop->actual_size) {
-	    variation = ((int64_t)(gop->desired_size / (int64_t)gop->actual_size));
+        variation = ((int64_t)(gop->desired_size / (int64_t)gop->actual_size));
       }
       variation = CLIP3(-100, 100, variation);
       variation -= gop->model_variation;
@@ -116,7 +116,7 @@ EbErrorType	rate_control_update_model(EbRateControlModel *model_ptr, PicturePare
     return EB_ErrorNone;
 }
 
-uint8_t	rate_control_get_quantizer(EbRateControlModel *model_ptr, PictureParentControlSet_t *picture_ptr) {
+uint8_t    rate_control_get_quantizer(EbRateControlModel *model_ptr, PictureParentControlSet_t *picture_ptr) {
     FRAME_TYPE  type = picture_ptr->av1FrameType;
 
     if (type == INTRA_ONLY_FRAME || type == KEY_FRAME) {
@@ -132,9 +132,9 @@ uint32_t get_inter_qp_for_size(EbRateControlModel *model_ptr, uint32_t desired_s
     uint8_t     qp;
     
     for (qp = 0; qp < MAX_QP_VALUE; qp++) {
-        float	size = model_ptr->inter_size_predictions[qp];
+        float    size = model_ptr->inter_size_predictions[qp];
 
-	    size = (size / (1920 * 1080)) * model_ptr->pixels;
+        size = (size / (1920 * 1080)) * model_ptr->pixels;
         // Scale size for current resolution
         if (desired_size > size) {
             break;

--- a/Source/Lib/Codec/RateControlModel.h
+++ b/Source/Lib/Codec/RateControlModel.h
@@ -100,7 +100,7 @@ EbErrorType rate_control_model_ctor(EbRateControlModel **object_double_ptr);
  * @param {SequenceControlSet_t*} sequence_control_set_ptr. First frame used to initialize the model
  * @return {EbErrorType}.
  */
-EbErrorType	rate_control_model_init(EbRateControlModel *model_ptr,
+EbErrorType    rate_control_model_init(EbRateControlModel *model_ptr,
                                     SequenceControlSet_t *sequence_control_set_ptr);
 
 /*
@@ -109,7 +109,7 @@ EbErrorType	rate_control_model_init(EbRateControlModel *model_ptr,
  * @param {PictureParentControlSet_t*} picture_ptr. Encoded frame.
  * @return {EbErrorType}.
  */
-EbErrorType	rate_control_update_model(EbRateControlModel *model_ptr,
+EbErrorType    rate_control_update_model(EbRateControlModel *model_ptr,
                                       PictureParentControlSet_t *picture_ptr);
 
 /*
@@ -119,7 +119,7 @@ EbErrorType	rate_control_update_model(EbRateControlModel *model_ptr,
  * @param {PictureParentControlSet_t*} picture_ptr. Frame to be encoded.
  * @return {uint8_t}. Suggested QP for the given frame
  */
-uint8_t	rate_control_get_quantizer(EbRateControlModel *model_ptr,
+uint8_t    rate_control_get_quantizer(EbRateControlModel *model_ptr,
                                    PictureParentControlSet_t *picture_ptr);
 
 /*

--- a/Source/Lib/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Codec/aom_dsp_rtcd.h
@@ -407,7 +407,7 @@ extern "C" {
 
 
 
-    //void av1_inv_txfm_add_c(const tran_low_t *dqcoeff, uint8_t *dst, int32_t stride, const TxfmParam *txfm_param);
+    void av1_inv_txfm_add_c(const tran_low_t *dqcoeff, uint8_t *dst, int32_t stride, const TxfmParam *txfm_param);
     void av1_inv_txfm_add_ssse3(const tran_low_t *dqcoeff, uint8_t *dst, int32_t stride, const TxfmParam *txfm_param);
     RTCD_EXTERN void(*av1_inv_txfm_add)(const tran_low_t *dqcoeff, uint8_t *dst, int32_t stride, const TxfmParam *txfm_param);
 
@@ -1307,7 +1307,7 @@ extern "C" {
     RTCD_EXTERN void(*aom_highbd_dc_left_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_left_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_left_predictor_2x2 aom_highbd_dc_left_predictor_2x2_c
+    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_left_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_left_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1331,11 +1331,11 @@ extern "C" {
 
     void aom_highbd_dc_left_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_left_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_left_predictor_4x4 aom_highbd_dc_left_predictor_4x4_sse2
+    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_left_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_left_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_left_predictor_4x8 aom_highbd_dc_left_predictor_4x8_sse2
+    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_left_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_left_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1351,7 +1351,7 @@ extern "C" {
 
     void aom_highbd_dc_left_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_left_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_left_predictor_8x16 aom_highbd_dc_left_predictor_8x16_sse2
+    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_left_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_left_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1359,11 +1359,11 @@ extern "C" {
 
     void aom_highbd_dc_left_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_left_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_left_predictor_8x4 aom_highbd_dc_left_predictor_8x4_sse2
+    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_left_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_left_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_left_predictor_8x8 aom_highbd_dc_left_predictor_8x8_sse2
+    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1386,7 +1386,7 @@ extern "C" {
     RTCD_EXTERN void(*aom_highbd_dc_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_predictor_2x2 aom_highbd_dc_predictor_2x2_c
+    RTCD_EXTERN void(*aom_highbd_dc_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1410,11 +1410,11 @@ extern "C" {
 
     void aom_highbd_dc_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_predictor_4x4 aom_highbd_dc_predictor_4x4_sse2
+    RTCD_EXTERN void(*aom_highbd_dc_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_predictor_4x8 aom_highbd_dc_predictor_4x8_sse2
+    RTCD_EXTERN void(*aom_highbd_dc_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1430,7 +1430,7 @@ extern "C" {
 
     void aom_highbd_dc_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_predictor_8x16 aom_highbd_dc_predictor_8x16_sse2
+    RTCD_EXTERN void(*aom_highbd_dc_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1438,11 +1438,11 @@ extern "C" {
 
     void aom_highbd_dc_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_predictor_8x4 aom_highbd_dc_predictor_8x4_sse2
+    RTCD_EXTERN void(*aom_highbd_dc_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_predictor_8x8 aom_highbd_dc_predictor_8x8_sse2
+    RTCD_EXTERN void(*aom_highbd_dc_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_top_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_top_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1465,7 +1465,7 @@ extern "C" {
     RTCD_EXTERN void(*aom_highbd_dc_top_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_top_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_top_predictor_2x2 aom_highbd_dc_top_predictor_2x2_c
+    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_top_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_top_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1489,11 +1489,11 @@ extern "C" {
 
     void aom_highbd_dc_top_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_top_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_top_predictor_4x4 aom_highbd_dc_top_predictor_4x4_sse2
+    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_top_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_top_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_top_predictor_4x8 aom_highbd_dc_top_predictor_4x8_sse2
+    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_top_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_top_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1509,30 +1509,27 @@ extern "C" {
 
     void aom_highbd_dc_top_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_top_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_top_predictor_8x16 aom_highbd_dc_top_predictor_8x16_sse2
+    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_top_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_top_predictor_8x32 aom_highbd_dc_top_predictor_8x32_c
+    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_top_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_top_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_top_predictor_8x4 aom_highbd_dc_top_predictor_8x4_sse2
+    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_dc_top_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_dc_top_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_dc_top_predictor_8x8 aom_highbd_dc_top_predictor_8x8_sse2
+    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_fdct8x8_c(const int16_t *input, tran_low_t *output, int32_t stride);
-    void aom_highbd_fdct8x8_sse2(const int16_t *input, tran_low_t *output, int32_t stride);
-#define aom_highbd_fdct8x8 aom_highbd_fdct8x8_sse2
 
     void aom_highbd_h_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_h_predictor_16x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_h_predictor_16x16 aom_highbd_h_predictor_16x16_sse2
+    RTCD_EXTERN void(*aom_highbd_h_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_h_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_h_predictor_16x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_h_predictor_16x32 aom_highbd_h_predictor_16x32_sse2
+    RTCD_EXTERN void(*aom_highbd_h_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_h_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_h_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1544,18 +1541,18 @@ extern "C" {
 
     void aom_highbd_h_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_h_predictor_16x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_h_predictor_16x8 aom_highbd_h_predictor_16x8_sse2
+    RTCD_EXTERN void(*aom_highbd_h_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_h_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_h_predictor_2x2 aom_highbd_h_predictor_2x2_c
+    RTCD_EXTERN void(*aom_highbd_h_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_h_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_h_predictor_32x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_h_predictor_32x16 aom_highbd_h_predictor_32x16_sse2
+    RTCD_EXTERN void(*aom_highbd_h_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_h_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_h_predictor_32x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_h_predictor_32x32 aom_highbd_h_predictor_32x32_sse2
+    RTCD_EXTERN void(*aom_highbd_h_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_h_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_h_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1571,11 +1568,11 @@ extern "C" {
 
     void aom_highbd_h_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_h_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_h_predictor_4x4 aom_highbd_h_predictor_4x4_sse2
+    RTCD_EXTERN void(*aom_highbd_h_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_h_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_h_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_h_predictor_4x8 aom_highbd_h_predictor_4x8_sse2
+    RTCD_EXTERN void(*aom_highbd_h_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_h_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_h_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1591,7 +1588,7 @@ extern "C" {
 
     void aom_highbd_h_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_h_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_h_predictor_8x16 aom_highbd_h_predictor_8x16_sse2
+    RTCD_EXTERN void(*aom_highbd_h_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_h_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_h_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1599,11 +1596,11 @@ extern "C" {
 
     void aom_highbd_h_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_h_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_h_predictor_8x4 aom_highbd_h_predictor_8x4_sse2
+    RTCD_EXTERN void(*aom_highbd_h_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_h_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_h_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_h_predictor_8x8 aom_highbd_h_predictor_8x8_sse2
+    RTCD_EXTERN void(*aom_highbd_h_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_smooth_h_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_smooth_h_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1626,7 +1623,7 @@ extern "C" {
     RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_smooth_h_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_smooth_h_predictor_2x2 aom_highbd_smooth_h_predictor_2x2_c
+    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_smooth_h_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_smooth_h_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1705,7 +1702,7 @@ extern "C" {
     RTCD_EXTERN void(*aom_highbd_smooth_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_smooth_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_smooth_predictor_2x2 aom_highbd_smooth_predictor_2x2_c
+    RTCD_EXTERN void(*aom_highbd_smooth_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_smooth_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_smooth_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1785,7 +1782,7 @@ extern "C" {
     RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_smooth_v_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_smooth_v_predictor_2x2 aom_highbd_smooth_v_predictor_2x2_c
+    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_smooth_v_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_smooth_v_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1843,25 +1840,14 @@ extern "C" {
     void aom_highbd_smooth_v_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_subtract_block_c(int32_t rows, int32_t cols, int16_t *diff_ptr, ptrdiff_t diff_stride, const uint8_t *src_ptr, ptrdiff_t src_stride, const uint8_t *pred_ptr, ptrdiff_t pred_stride, int32_t bd);
-    void aom_highbd_subtract_block_sse2(int32_t rows, int32_t cols, int16_t *diff_ptr, ptrdiff_t diff_stride, const uint8_t *src_ptr, ptrdiff_t src_stride, const uint8_t *pred_ptr, ptrdiff_t pred_stride, int32_t bd);
-#define aom_highbd_subtract_block aom_highbd_subtract_block_sse2
-
-    //void aom_highbd_upsampled_pred_c(MacroBlockD *xd, const struct AV1Common *const cm, int32_t mi_row, int32_t mi_col,
-    //    const MV *const mv, uint16_t *comp_pred, int32_t width, int32_t height, int32_t subpel_x_q3,
-    //    int32_t subpel_y_q3, const uint8_t *ref8, int32_t ref_stride, int32_t bd);
-    //void aom_highbd_upsampled_pred_sse2(MacroBlockD *xd, const struct AV1Common *const cm, int32_t mi_row, int32_t mi_col,
-    //    const MV *const mv, uint16_t *comp_pred, int32_t width, int32_t height, int32_t subpel_x_q3,
-    //    int32_t subpel_y_q3, const uint8_t *ref8, int32_t ref_stride, int32_t bd);
-    //#define aom_highbd_upsampled_pred aom_highbd_upsampled_pred_sse2
-
+ 
     void aom_highbd_v_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_v_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_v_predictor_16x16 aom_highbd_v_predictor_16x16_avx2
+    RTCD_EXTERN void(*aom_highbd_v_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_v_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_v_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_v_predictor_16x32 aom_highbd_v_predictor_16x32_avx2
+    RTCD_EXTERN void(*aom_highbd_v_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_v_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_v_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1874,18 +1860,18 @@ extern "C" {
 
     void aom_highbd_v_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_v_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_v_predictor_16x8 aom_highbd_v_predictor_16x8_avx2
+    RTCD_EXTERN void(*aom_highbd_v_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_v_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_v_predictor_2x2 aom_highbd_v_predictor_2x2_c
+    RTCD_EXTERN void(*aom_highbd_v_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_v_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_v_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_v_predictor_32x16 aom_highbd_v_predictor_32x16_avx2
+    RTCD_EXTERN void(*aom_highbd_v_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_v_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_v_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_v_predictor_32x32 aom_highbd_v_predictor_32x32_avx2
+    RTCD_EXTERN void(*aom_highbd_v_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_v_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_v_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1901,11 +1887,11 @@ extern "C" {
 
     void aom_highbd_v_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_v_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_v_predictor_4x4 aom_highbd_v_predictor_4x4_sse2
+    RTCD_EXTERN void(*aom_highbd_v_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_v_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_v_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_v_predictor_4x8 aom_highbd_v_predictor_4x8_sse2
+    RTCD_EXTERN void(*aom_highbd_v_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_v_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_v_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1921,7 +1907,7 @@ extern "C" {
 
     void aom_highbd_v_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_v_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_v_predictor_8x16 aom_highbd_v_predictor_8x16_sse2
+    RTCD_EXTERN void(*aom_highbd_v_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_v_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_v_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1929,51 +1915,51 @@ extern "C" {
 
     void aom_highbd_v_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_v_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_v_predictor_8x4 aom_highbd_v_predictor_8x4_sse2
+    RTCD_EXTERN void(*aom_highbd_v_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void aom_highbd_v_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void aom_highbd_v_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-#define aom_highbd_v_predictor_8x8 aom_highbd_v_predictor_8x8_sse2
+    RTCD_EXTERN void(*aom_highbd_v_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-void av1_dr_prediction_z1_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t dx, int32_t dy);
-void av1_dr_prediction_z1_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t dx, int32_t dy);
-RTCD_EXTERN void(*av1_dr_prediction_z1)(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t dx, int32_t dy);
-
-void av1_dr_prediction_z2_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy);
-void av1_dr_prediction_z2_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy);
-RTCD_EXTERN void(*av1_dr_prediction_z2)(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy);
-
-void av1_dr_prediction_z3_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_left, int32_t dx, int32_t dy);
-void av1_dr_prediction_z3_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_left, int32_t dx, int32_t dy);
-RTCD_EXTERN void(*av1_dr_prediction_z3)(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_left, int32_t dx, int32_t dy);
-
-void av1_highbd_dr_prediction_z1_c(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t dx, int32_t dy, int32_t bd);
-void av1_highbd_dr_prediction_z1_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t dx, int32_t dy, int32_t bd);
-RTCD_EXTERN void(*av1_highbd_dr_prediction_z1)(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t dx, int32_t dy, int32_t bd);
-
-void av1_highbd_dr_prediction_z2_c(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
-void av1_highbd_dr_prediction_z2_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
-RTCD_EXTERN void(*av1_highbd_dr_prediction_z2)(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
-
-void av1_highbd_dr_prediction_z3_c(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
-void av1_highbd_dr_prediction_z3_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
-RTCD_EXTERN void(*av1_highbd_dr_prediction_z3)(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
-
-void av1_get_nz_map_contexts_c(const uint8_t *const levels, const int16_t *const scan, const uint16_t eob, const TxSize tx_size, const TX_CLASS tx_class, int8_t *const coeff_contexts);
-void av1_get_nz_map_contexts_sse2(const uint8_t *const levels, const int16_t *const scan, const uint16_t eob, const TxSize tx_size, const TX_CLASS tx_class, int8_t *const coeff_contexts);
-#define av1_get_nz_map_contexts av1_get_nz_map_contexts_sse2
-
-void highbd_variance64_c(const uint8_t *a8, int32_t a_stride, const uint8_t *b8, int32_t b_stride, int32_t w, int32_t h, uint64_t *sse, int64_t *sum);
-void highbd_variance64_avx2(const uint8_t *a8, int32_t a_stride, const uint8_t *b8, int32_t b_stride, int32_t w, int32_t h, uint64_t *sse, int64_t *sum);
-RTCD_EXTERN void (*highbd_variance64)(const uint8_t *a8, int32_t a_stride, const uint8_t *b8, int32_t b_stride, int32_t w, int32_t h, uint64_t *sse, int64_t *sum);
-
-void ResidualKernel_c(uint8_t *input, uint32_t inputStride, uint8_t *pred, uint32_t predStride, int16_t *residual, uint32_t residualStride, uint32_t areaWidth, uint32_t areaHeight);
-void ResidualKernel_avx2(uint8_t *input, uint32_t inputStride, uint8_t *pred, uint32_t predStride, int16_t *residual, uint32_t residualStride, uint32_t areaWidth, uint32_t areaHeight);
-RTCD_EXTERN void(*ResidualKernel)(uint8_t *input, uint32_t inputStride, uint8_t *pred, uint32_t predStride, int16_t *residual, uint32_t residualStride, uint32_t areaWidth, uint32_t areaHeight);
-
-void av1_txb_init_levels_c(const tran_low_t *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
-void av1_txb_init_levels_avx2(const tran_low_t *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
-RTCD_EXTERN void(*av1_txb_init_levels)(const tran_low_t *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
+    void av1_dr_prediction_z1_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t dx, int32_t dy);
+    void av1_dr_prediction_z1_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t dx, int32_t dy);
+    RTCD_EXTERN void(*av1_dr_prediction_z1)(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t dx, int32_t dy);
+    
+    void av1_dr_prediction_z2_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy);
+    void av1_dr_prediction_z2_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy);
+    RTCD_EXTERN void(*av1_dr_prediction_z2)(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy);
+    
+    void av1_dr_prediction_z3_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_left, int32_t dx, int32_t dy);
+    void av1_dr_prediction_z3_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_left, int32_t dx, int32_t dy);
+    RTCD_EXTERN void(*av1_dr_prediction_z3)(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_left, int32_t dx, int32_t dy);
+    
+    void av1_highbd_dr_prediction_z1_c(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t dx, int32_t dy, int32_t bd);
+    void av1_highbd_dr_prediction_z1_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t dx, int32_t dy, int32_t bd);
+    RTCD_EXTERN void(*av1_highbd_dr_prediction_z1)(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t dx, int32_t dy, int32_t bd);
+    
+    void av1_highbd_dr_prediction_z2_c(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
+    void av1_highbd_dr_prediction_z2_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
+    RTCD_EXTERN void(*av1_highbd_dr_prediction_z2)(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
+    
+    void av1_highbd_dr_prediction_z3_c(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
+    void av1_highbd_dr_prediction_z3_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
+    RTCD_EXTERN void(*av1_highbd_dr_prediction_z3)(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
+    
+    //void av1_get_nz_map_contexts_c(const uint8_t *const levels, const int16_t *const scan, const uint16_t eob, const TxSize tx_size, const TX_CLASS tx_class, int8_t *const coeff_contexts);
+    void av1_get_nz_map_contexts_sse2(const uint8_t *const levels, const int16_t *const scan, const uint16_t eob, const TxSize tx_size, const TX_CLASS tx_class, int8_t *const coeff_contexts);
+    RTCD_EXTERN void(*av1_get_nz_map_contexts)(const uint8_t *const levels, const int16_t *const scan, const uint16_t eob, const TxSize tx_size, const TX_CLASS tx_class, int8_t *const coeff_contexts);
+    
+    void highbd_variance64_c(const uint8_t *a8, int32_t a_stride, const uint8_t *b8, int32_t b_stride, int32_t w, int32_t h, uint64_t *sse, int64_t *sum);
+    void highbd_variance64_avx2(const uint8_t *a8, int32_t a_stride, const uint8_t *b8, int32_t b_stride, int32_t w, int32_t h, uint64_t *sse, int64_t *sum);
+    RTCD_EXTERN void (*highbd_variance64)(const uint8_t *a8, int32_t a_stride, const uint8_t *b8, int32_t b_stride, int32_t w, int32_t h, uint64_t *sse, int64_t *sum);
+    
+    void ResidualKernel_c(uint8_t *input, uint32_t inputStride, uint8_t *pred, uint32_t predStride, int16_t *residual, uint32_t residualStride, uint32_t areaWidth, uint32_t areaHeight);
+    void ResidualKernel_avx2(uint8_t *input, uint32_t inputStride, uint8_t *pred, uint32_t predStride, int16_t *residual, uint32_t residualStride, uint32_t areaWidth, uint32_t areaHeight);
+    RTCD_EXTERN void(*ResidualKernel)(uint8_t *input, uint32_t inputStride, uint8_t *pred, uint32_t predStride, int16_t *residual, uint32_t residualStride, uint32_t areaWidth, uint32_t areaHeight);
+    
+    void av1_txb_init_levels_c(const tran_low_t *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
+    void av1_txb_init_levels_avx2(const tran_low_t *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
+    RTCD_EXTERN void(*av1_txb_init_levels)(const tran_low_t *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
 
 #endif
 
@@ -2149,7 +2135,7 @@ RTCD_EXTERN void(*av1_txb_init_levels)(const tran_low_t *const coeff, const int3
         av1_inv_txfm2d_add_16x4 = av1_inv_txfm2d_add_16x4_c;
         if (flags & HAS_SSE4_1) av1_inv_txfm2d_add_16x4 = av1_inv_txfm2d_add_16x4_sse4_1;
 
-        //toDO add C
+        av1_inv_txfm_add = av1_inv_txfm_add_c;
         if (flags & HAS_SSSE3) av1_inv_txfm_add = av1_inv_txfm_add_ssse3;
 
         highbd_variance64 = highbd_variance64_c;
@@ -2165,232 +2151,65 @@ RTCD_EXTERN void(*av1_txb_init_levels)(const tran_low_t *const coeff, const int3
     
 #if INTRINSIC_OPT_2
 
-        aom_highbd_dc_128_predictor_16x16 = aom_highbd_dc_128_predictor_16x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_16x16 = aom_highbd_dc_128_predictor_16x16_avx2;
-
-        aom_highbd_dc_128_predictor_16x32 = aom_highbd_dc_128_predictor_16x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_16x32 = aom_highbd_dc_128_predictor_16x32_avx2;
-
-        aom_highbd_dc_128_predictor_16x4 = aom_highbd_dc_128_predictor_16x4_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_16x4 = aom_highbd_dc_128_predictor_16x4_avx2;
-
-        aom_highbd_dc_128_predictor_16x64 = aom_highbd_dc_128_predictor_16x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_16x64 = aom_highbd_dc_128_predictor_16x64_avx2;
-
-        aom_highbd_dc_128_predictor_16x8 = aom_highbd_dc_128_predictor_16x8_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_16x8 = aom_highbd_dc_128_predictor_16x8_avx2;
-
-        aom_highbd_dc_128_predictor_2x2 = aom_highbd_dc_128_predictor_2x2_c;
-
-        aom_highbd_dc_128_predictor_32x16 = aom_highbd_dc_128_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_32x16 = aom_highbd_dc_128_predictor_32x16_avx2;
-
-        aom_highbd_dc_128_predictor_32x32 = aom_highbd_dc_128_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_32x32 = aom_highbd_dc_128_predictor_32x32_avx2;
-
-        aom_highbd_dc_128_predictor_32x64 = aom_highbd_dc_128_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_32x64 = aom_highbd_dc_128_predictor_32x64_avx2;
-
-        aom_highbd_dc_128_predictor_32x8 = aom_highbd_dc_128_predictor_32x8_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_32x8 = aom_highbd_dc_128_predictor_32x8_avx2;
-
-        aom_highbd_dc_128_predictor_4x16 = aom_highbd_dc_128_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_128_predictor_4x16 = aom_highbd_dc_128_predictor_4x16_sse2;
-        aom_highbd_dc_128_predictor_4x4 = aom_highbd_dc_128_predictor_4x4_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_128_predictor_4x4 = aom_highbd_dc_128_predictor_4x4_sse2;
-        aom_highbd_dc_128_predictor_4x8 = aom_highbd_dc_128_predictor_4x8_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_128_predictor_4x8 = aom_highbd_dc_128_predictor_4x8_sse2;
-        aom_highbd_dc_128_predictor_8x32 = aom_highbd_dc_128_predictor_8x32_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_128_predictor_8x32 = aom_highbd_dc_128_predictor_8x32_sse2;
-
-
-        aom_highbd_dc_left_predictor_16x16 = aom_highbd_dc_left_predictor_16x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_16x16 = aom_highbd_dc_left_predictor_16x16_avx2;
-
-        aom_highbd_dc_left_predictor_16x32 = aom_highbd_dc_left_predictor_16x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_16x32 = aom_highbd_dc_left_predictor_16x32_avx2;
-
-        aom_highbd_dc_left_predictor_16x4 = aom_highbd_dc_left_predictor_16x4_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_16x4 = aom_highbd_dc_left_predictor_16x4_avx2;
-
-        aom_highbd_dc_left_predictor_16x64 = aom_highbd_dc_left_predictor_16x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_16x64 = aom_highbd_dc_left_predictor_16x64_avx2;
-
-        aom_highbd_dc_left_predictor_16x8 = aom_highbd_dc_left_predictor_16x8_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_16x8 = aom_highbd_dc_left_predictor_16x8_avx2;
-
-        aom_highbd_dc_left_predictor_32x16 = aom_highbd_dc_left_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_32x16 = aom_highbd_dc_left_predictor_32x16_avx2;
-
-        aom_highbd_dc_left_predictor_32x32 = aom_highbd_dc_left_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_32x32 = aom_highbd_dc_left_predictor_32x32_avx2;
-
-        aom_highbd_dc_left_predictor_32x64 = aom_highbd_dc_left_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_32x64 = aom_highbd_dc_left_predictor_32x64_avx2;
-
-        aom_highbd_dc_left_predictor_32x8 = aom_highbd_dc_left_predictor_32x8_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_32x8 = aom_highbd_dc_left_predictor_32x8_avx2;
-
-        aom_highbd_dc_left_predictor_4x16 = aom_highbd_dc_left_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_left_predictor_4x16 = aom_highbd_dc_left_predictor_4x16_sse2;
-
-        aom_highbd_dc_left_predictor_8x32 = aom_highbd_dc_left_predictor_8x32_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_left_predictor_8x32 = aom_highbd_dc_left_predictor_8x32_sse2;
-
-        aom_highbd_dc_predictor_16x16 = aom_highbd_dc_predictor_16x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_16x16 = aom_highbd_dc_predictor_16x16_avx2;
-
-        aom_highbd_dc_predictor_16x32 = aom_highbd_dc_predictor_16x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_16x32 = aom_highbd_dc_predictor_16x32_avx2;
-
-        aom_highbd_dc_predictor_16x4 = aom_highbd_dc_predictor_16x4_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_16x4 = aom_highbd_dc_predictor_16x4_avx2;
-
-        aom_highbd_dc_predictor_16x64 = aom_highbd_dc_predictor_16x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_16x64 = aom_highbd_dc_predictor_16x64_avx2;
-
-        aom_highbd_dc_predictor_16x8 = aom_highbd_dc_predictor_16x8_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_16x8 = aom_highbd_dc_predictor_16x8_avx2;
-
-        aom_highbd_dc_predictor_32x16 = aom_highbd_dc_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_32x16 = aom_highbd_dc_predictor_32x16_avx2;
-
-        aom_highbd_dc_predictor_32x32 = aom_highbd_dc_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_32x32 = aom_highbd_dc_predictor_32x32_avx2;
-
-        aom_highbd_dc_predictor_32x64 = aom_highbd_dc_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_32x64 = aom_highbd_dc_predictor_32x64_avx2;
-
-        aom_highbd_dc_predictor_32x8 = aom_highbd_dc_predictor_32x8_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_32x8 = aom_highbd_dc_predictor_32x8_avx2;
-
-        aom_highbd_dc_predictor_4x16 = aom_highbd_dc_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_predictor_4x16 = aom_highbd_dc_predictor_4x16_sse2;
-
-        aom_highbd_dc_predictor_64x16 = aom_highbd_dc_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_64x16 = aom_highbd_dc_predictor_64x16_avx2;
-
-        aom_highbd_dc_predictor_64x32 = aom_highbd_dc_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_64x32 = aom_highbd_dc_predictor_64x32_avx2;
-
-        aom_highbd_dc_predictor_64x64 = aom_highbd_dc_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_64x64 = aom_highbd_dc_predictor_64x64_avx2;
-
-        aom_highbd_dc_predictor_8x32 = aom_highbd_dc_predictor_8x32_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_predictor_8x32 = aom_highbd_dc_predictor_8x32_sse2;
-
-
-        aom_highbd_dc_top_predictor_16x16 = aom_highbd_dc_top_predictor_16x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_16x16 = aom_highbd_dc_top_predictor_16x16_avx2;
-
-        aom_highbd_dc_top_predictor_16x32 = aom_highbd_dc_top_predictor_16x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_16x32 = aom_highbd_dc_top_predictor_16x32_avx2;
-
-        aom_highbd_dc_top_predictor_16x4 = aom_highbd_dc_top_predictor_16x4_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_16x4 = aom_highbd_dc_top_predictor_16x4_avx2;
-
-        aom_highbd_dc_top_predictor_16x64 = aom_highbd_dc_top_predictor_16x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_16x64 = aom_highbd_dc_top_predictor_16x64_avx2;
-
-        aom_highbd_dc_top_predictor_16x8 = aom_highbd_dc_top_predictor_16x8_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_16x8 = aom_highbd_dc_top_predictor_16x8_avx2;
-
-        aom_highbd_dc_top_predictor_32x16 = aom_highbd_dc_top_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_32x16 = aom_highbd_dc_top_predictor_32x16_avx2;
-
-        aom_highbd_dc_top_predictor_32x32 = aom_highbd_dc_top_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_32x32 = aom_highbd_dc_top_predictor_32x32_avx2;
-
-        aom_highbd_dc_top_predictor_32x64 = aom_highbd_dc_top_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_32x64 = aom_highbd_dc_top_predictor_32x64_avx2;
-
-        aom_highbd_dc_top_predictor_32x8 = aom_highbd_dc_top_predictor_32x8_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_32x8 = aom_highbd_dc_top_predictor_32x8_avx2;
-
-        aom_highbd_dc_top_predictor_4x16 = aom_highbd_dc_top_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_top_predictor_4x16 = aom_highbd_dc_top_predictor_4x16_sse2;
-
-
         aom_highbd_smooth_v_predictor_16x16 = aom_highbd_smooth_v_predictor_16x16_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_16x16 = aom_highbd_smooth_v_predictor_16x16_avx2;
-
         aom_highbd_smooth_v_predictor_16x32 = aom_highbd_smooth_v_predictor_16x32_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_16x32 = aom_highbd_smooth_v_predictor_16x32_avx2;
-
         aom_highbd_smooth_v_predictor_16x4 = aom_highbd_smooth_v_predictor_16x4_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_16x4 = aom_highbd_smooth_v_predictor_16x4_avx2;
-
         aom_highbd_smooth_v_predictor_16x64 = aom_highbd_smooth_v_predictor_16x64_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_16x64 = aom_highbd_smooth_v_predictor_16x64_avx2;
-
         aom_highbd_smooth_v_predictor_16x8 = aom_highbd_smooth_v_predictor_16x8_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_16x8 = aom_highbd_smooth_v_predictor_16x8_avx2;
-
+        aom_highbd_smooth_v_predictor_2x2 = aom_highbd_smooth_v_predictor_2x2_c;
         aom_highbd_smooth_v_predictor_32x16 = aom_highbd_smooth_v_predictor_32x16_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_32x16 = aom_highbd_smooth_v_predictor_32x16_avx2;
-
         aom_highbd_smooth_v_predictor_32x32 = aom_highbd_smooth_v_predictor_32x32_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_32x32 = aom_highbd_smooth_v_predictor_32x32_avx2;
-
         aom_highbd_smooth_v_predictor_32x64 = aom_highbd_smooth_v_predictor_32x64_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_32x64 = aom_highbd_smooth_v_predictor_32x64_avx2;
-
         aom_highbd_smooth_v_predictor_32x8 = aom_highbd_smooth_v_predictor_32x8_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_32x8 = aom_highbd_smooth_v_predictor_32x8_avx2;
-
         aom_highbd_smooth_v_predictor_4x16 = aom_highbd_smooth_v_predictor_4x16_c;
         if (flags & HAS_SSSE3) aom_highbd_smooth_v_predictor_4x16 = aom_highbd_smooth_v_predictor_4x16_ssse3;
-
         aom_highbd_smooth_v_predictor_4x4 = aom_highbd_smooth_v_predictor_4x4_c;
         if (flags & HAS_SSSE3) aom_highbd_smooth_v_predictor_4x4 = aom_highbd_smooth_v_predictor_4x4_ssse3;
-
         aom_highbd_smooth_v_predictor_4x8 = aom_highbd_smooth_v_predictor_4x8_c;
         if (flags & HAS_SSSE3) aom_highbd_smooth_v_predictor_4x8 = aom_highbd_smooth_v_predictor_4x8_ssse3;
-
         aom_highbd_smooth_v_predictor_64x16 = aom_highbd_smooth_v_predictor_64x16_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_64x16 = aom_highbd_smooth_v_predictor_64x16_avx2;
-
         aom_highbd_smooth_v_predictor_64x32 = aom_highbd_smooth_v_predictor_64x32_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_64x32 = aom_highbd_smooth_v_predictor_64x32_avx2;
-
         aom_highbd_smooth_v_predictor_64x64 = aom_highbd_smooth_v_predictor_64x64_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_64x64 = aom_highbd_smooth_v_predictor_64x64_avx2;
-
         aom_highbd_smooth_v_predictor_8x16 = aom_highbd_smooth_v_predictor_8x16_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_8x16 = aom_highbd_smooth_v_predictor_8x16_avx2;
-
         aom_highbd_smooth_v_predictor_8x32 = aom_highbd_smooth_v_predictor_8x32_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_8x32 = aom_highbd_smooth_v_predictor_8x32_avx2;
-
         aom_highbd_smooth_v_predictor_8x4 = aom_highbd_smooth_v_predictor_8x4_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_8x4 = aom_highbd_smooth_v_predictor_8x4_avx2;
-
         aom_highbd_smooth_v_predictor_8x8 = aom_highbd_smooth_v_predictor_8x8_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_8x8 = aom_highbd_smooth_v_predictor_8x8_avx2;
 
         cfl_predict_lbd = cfl_predict_lbd_c;
         if (flags & HAS_AVX2) cfl_predict_lbd = cfl_predict_lbd_avx2;
-
         cfl_predict_hbd = cfl_predict_hbd_c;
         if (flags & HAS_AVX2) cfl_predict_hbd = cfl_predict_hbd_avx2;
 
         av1_dr_prediction_z1 = av1_dr_prediction_z1_c;
         if (flags & HAS_AVX2) av1_dr_prediction_z1 = av1_dr_prediction_z1_avx2;
-
         av1_dr_prediction_z2 = av1_dr_prediction_z2_c;
         if (flags & HAS_AVX2) av1_dr_prediction_z2 = av1_dr_prediction_z2_avx2;
-
         av1_dr_prediction_z3 = av1_dr_prediction_z3_c;
         if (flags & HAS_AVX2) av1_dr_prediction_z3 = av1_dr_prediction_z3_avx2;
-
         av1_highbd_dr_prediction_z1 = av1_highbd_dr_prediction_z1_c;
         if (flags & HAS_AVX2) av1_highbd_dr_prediction_z1 = av1_highbd_dr_prediction_z1_avx2;
-
         av1_highbd_dr_prediction_z2 = av1_highbd_dr_prediction_z2_c;
         if (flags & HAS_AVX2) av1_highbd_dr_prediction_z2 = av1_highbd_dr_prediction_z2_avx2;
-
         av1_highbd_dr_prediction_z3 = av1_highbd_dr_prediction_z3_c;
         if (flags & HAS_AVX2) av1_highbd_dr_prediction_z3 = av1_highbd_dr_prediction_z3_avx2;
+        //av1_get_nz_map_contexts = av1_get_nz_map_contexts_c;
+        if (flags & HAS_SSE2) av1_get_nz_map_contexts = av1_get_nz_map_contexts_sse2;
 
         ResidualKernel = ResidualKernel_c;
         if (flags & HAS_AVX2) ResidualKernel = ResidualKernel_avx2;
@@ -2672,6 +2491,17 @@ RTCD_EXTERN void(*av1_txb_init_levels)(const tran_low_t *const coeff, const int3
         if (flags & HAS_SSSE3) aom_smooth_h_predictor_8x32 = aom_smooth_h_predictor_8x32_ssse3;
         aom_smooth_h_predictor_8x4 = aom_smooth_h_predictor_8x4_c;
         if (flags & HAS_SSSE3) aom_smooth_h_predictor_8x4 = aom_smooth_h_predictor_8x4_ssse3;
+        aom_smooth_h_predictor_64x64 = aom_smooth_h_predictor_64x64_c;
+        if (flags & HAS_SSSE3) aom_smooth_h_predictor_64x64 = aom_smooth_h_predictor_64x64_ssse3;
+        aom_smooth_h_predictor_32x32 = aom_smooth_h_predictor_32x32_c;
+        if (flags & HAS_SSSE3) aom_smooth_h_predictor_32x32 = aom_smooth_h_predictor_32x32_ssse3;
+        aom_smooth_h_predictor_16x16 = aom_smooth_h_predictor_16x16_c;
+        if (flags & HAS_SSSE3) aom_smooth_h_predictor_16x16 = aom_smooth_h_predictor_16x16_ssse3;
+        aom_smooth_h_predictor_8x8 = aom_smooth_h_predictor_8x8_c;
+        if (flags & HAS_SSSE3) aom_smooth_h_predictor_8x8 = aom_smooth_h_predictor_8x8_ssse3;
+        aom_smooth_h_predictor_4x4 = aom_smooth_h_predictor_4x4_c;
+        if (flags & HAS_SSSE3) aom_smooth_h_predictor_4x4 = aom_smooth_h_predictor_4x4_ssse3;
+
 
         if (flags & HAS_SSSE3) aom_smooth_v_predictor_16x32 = aom_smooth_v_predictor_16x32_ssse3;
         aom_smooth_v_predictor_16x4 = aom_smooth_v_predictor_16x4_c;
@@ -2700,6 +2530,16 @@ RTCD_EXTERN void(*av1_txb_init_levels)(const tran_low_t *const coeff, const int3
         if (flags & HAS_SSSE3) aom_smooth_v_predictor_8x32 = aom_smooth_v_predictor_8x32_ssse3;
         aom_smooth_v_predictor_8x4 = aom_smooth_v_predictor_8x4_c;
         if (flags & HAS_SSSE3) aom_smooth_v_predictor_8x4 = aom_smooth_v_predictor_8x4_ssse3;
+        aom_smooth_v_predictor_64x64 = aom_smooth_v_predictor_64x64_c;
+        if (flags & HAS_SSSE3) aom_smooth_v_predictor_64x64 = aom_smooth_v_predictor_64x64_ssse3;
+        aom_smooth_v_predictor_32x32 = aom_smooth_v_predictor_32x32_c;
+        if (flags & HAS_SSSE3) aom_smooth_v_predictor_32x32 = aom_smooth_v_predictor_32x32_ssse3;
+        aom_smooth_v_predictor_16x16 = aom_smooth_v_predictor_16x16_c;
+        if (flags & HAS_SSSE3) aom_smooth_v_predictor_16x16 = aom_smooth_v_predictor_16x16_ssse3;
+        aom_smooth_v_predictor_8x8 = aom_smooth_v_predictor_8x8_c;
+        if (flags & HAS_SSSE3) aom_smooth_v_predictor_8x8 = aom_smooth_v_predictor_8x8_ssse3;
+        aom_smooth_v_predictor_4x4 = aom_smooth_v_predictor_4x4_c;
+        if (flags & HAS_SSSE3) aom_smooth_v_predictor_4x4 = aom_smooth_v_predictor_4x4_ssse3;
 
         aom_smooth_predictor_16x32 = aom_smooth_predictor_16x32_c;
         if (flags & HAS_SSSE3) aom_smooth_predictor_16x32 = aom_smooth_predictor_16x32_ssse3;
@@ -2729,29 +2569,6 @@ RTCD_EXTERN void(*av1_txb_init_levels)(const tran_low_t *const coeff, const int3
         if (flags & HAS_SSSE3) aom_smooth_predictor_8x32 = aom_smooth_predictor_8x32_ssse3;
         aom_smooth_predictor_8x4 = aom_smooth_predictor_8x4_c;
         if (flags & HAS_SSSE3) aom_smooth_predictor_8x4 = aom_smooth_predictor_8x4_ssse3;
-
-        aom_smooth_h_predictor_64x64 = aom_smooth_h_predictor_64x64_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_64x64 = aom_smooth_h_predictor_64x64_ssse3;
-        aom_smooth_h_predictor_32x32 = aom_smooth_h_predictor_32x32_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_32x32 = aom_smooth_h_predictor_32x32_ssse3;
-        aom_smooth_h_predictor_16x16 = aom_smooth_h_predictor_16x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_16x16 = aom_smooth_h_predictor_16x16_ssse3;
-        aom_smooth_h_predictor_8x8 = aom_smooth_h_predictor_8x8_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_8x8 = aom_smooth_h_predictor_8x8_ssse3;
-        aom_smooth_h_predictor_4x4 = aom_smooth_h_predictor_4x4_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_4x4 = aom_smooth_h_predictor_4x4_ssse3;
-
-        aom_smooth_v_predictor_64x64 = aom_smooth_v_predictor_64x64_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_64x64 = aom_smooth_v_predictor_64x64_ssse3;
-        aom_smooth_v_predictor_32x32 = aom_smooth_v_predictor_32x32_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_32x32 = aom_smooth_v_predictor_32x32_ssse3;
-        aom_smooth_v_predictor_16x16 = aom_smooth_v_predictor_16x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_16x16 = aom_smooth_v_predictor_16x16_ssse3;
-        aom_smooth_v_predictor_8x8 = aom_smooth_v_predictor_8x8_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_8x8 = aom_smooth_v_predictor_8x8_ssse3;
-        aom_smooth_v_predictor_4x4 = aom_smooth_v_predictor_4x4_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_4x4 = aom_smooth_v_predictor_4x4_ssse3;
-
         aom_smooth_predictor_64x64 = aom_smooth_predictor_64x64_c;
         if (flags & HAS_SSSE3) aom_smooth_predictor_64x64 = aom_smooth_predictor_64x64_ssse3;
         aom_smooth_predictor_32x32 = aom_smooth_predictor_32x32_c;
@@ -2762,6 +2579,45 @@ RTCD_EXTERN void(*av1_txb_init_levels)(const tran_low_t *const coeff, const int3
         if (flags & HAS_SSSE3) aom_smooth_predictor_8x8 = aom_smooth_predictor_8x8_ssse3;
         aom_smooth_predictor_4x4 = aom_smooth_predictor_4x4_c;
         if (flags & HAS_SSSE3) aom_smooth_predictor_4x4 = aom_smooth_predictor_4x4_ssse3;
+
+        aom_v_predictor_4x4 = aom_v_predictor_4x4_c;
+        if (flags & HAS_SSE2) aom_v_predictor_4x4 = aom_v_predictor_4x4_sse2;
+        aom_v_predictor_8x8 = aom_v_predictor_8x8_c;
+        if (flags & HAS_SSE2) aom_v_predictor_8x8 = aom_v_predictor_8x8_sse2;
+        aom_v_predictor_16x16 = aom_v_predictor_16x16_c;
+        if (flags & HAS_SSE2) aom_v_predictor_16x16 = aom_v_predictor_16x16_sse2;
+        aom_v_predictor_32x32 = aom_v_predictor_32x32_c;
+        if (flags & HAS_AVX2) aom_v_predictor_32x32 = aom_v_predictor_32x32_avx2;
+        aom_v_predictor_64x64 = aom_v_predictor_64x64_c;
+        if (flags & HAS_AVX2) aom_v_predictor_64x64 = aom_v_predictor_64x64_avx2;
+        aom_v_predictor_16x32 = aom_v_predictor_16x32_c;
+        if (flags & HAS_SSE2) aom_v_predictor_16x32 = aom_v_predictor_16x32_sse2;
+        aom_v_predictor_16x4 = aom_v_predictor_16x4_c;
+        if (flags & HAS_SSE2) aom_v_predictor_16x4 = aom_v_predictor_16x4_sse2;
+        aom_v_predictor_16x64 = aom_v_predictor_16x64_c;
+        if (flags & HAS_SSE2) aom_v_predictor_16x64 = aom_v_predictor_16x64_sse2;
+        aom_v_predictor_16x8 = aom_v_predictor_16x8_c;
+        if (flags & HAS_SSE2) aom_v_predictor_16x8 = aom_v_predictor_16x8_sse2;
+        aom_v_predictor_32x16 = aom_v_predictor_32x16_c;
+        if (flags & HAS_AVX2) aom_v_predictor_32x16 = aom_v_predictor_32x16_avx2;
+        aom_v_predictor_32x64 = aom_v_predictor_32x64_c;
+        if (flags & HAS_AVX2) aom_v_predictor_32x64 = aom_v_predictor_32x64_avx2;
+        aom_v_predictor_32x8 = aom_v_predictor_32x8_c;
+        if (flags & HAS_SSE2) aom_v_predictor_32x8 = aom_v_predictor_32x8_sse2;
+        aom_v_predictor_4x16 = aom_v_predictor_4x16_c;
+        if (flags & HAS_SSE2) aom_v_predictor_4x16 = aom_v_predictor_4x16_sse2;
+        aom_v_predictor_4x8 = aom_v_predictor_4x8_c;
+        if (flags & HAS_SSE2) aom_v_predictor_4x8 = aom_v_predictor_4x8_sse2;
+        aom_v_predictor_64x16 = aom_v_predictor_64x16_c;
+        if (flags & HAS_AVX2) aom_v_predictor_64x16 = aom_v_predictor_64x16_avx2;
+        aom_v_predictor_64x32 = aom_v_predictor_64x32_c;
+        if (flags & HAS_AVX2) aom_v_predictor_64x32 = aom_v_predictor_64x32_avx2;
+        aom_v_predictor_8x16 = aom_v_predictor_8x16_c;
+        if (flags & HAS_SSE2) aom_v_predictor_8x16 = aom_v_predictor_8x16_sse2;
+        aom_v_predictor_8x32 = aom_v_predictor_8x32_c;
+        if (flags & HAS_SSE2) aom_v_predictor_8x32 = aom_v_predictor_8x32_sse2;
+        aom_v_predictor_8x4 = aom_v_predictor_8x4_c;
+        if (flags & HAS_SSE2) aom_v_predictor_8x4 = aom_v_predictor_8x4_sse2;
 
         aom_h_predictor_4x4 = aom_h_predictor_4x4_c;
         if (flags & HAS_SSE2) aom_h_predictor_4x4 = aom_h_predictor_4x4_sse2;
@@ -2802,44 +2658,7 @@ RTCD_EXTERN void(*av1_txb_init_levels)(const tran_low_t *const coeff, const int3
         aom_h_predictor_8x4 = aom_h_predictor_8x4_c;
         if (flags & HAS_SSE2) aom_h_predictor_8x4 = aom_h_predictor_8x4_sse2;
 
-        aom_v_predictor_4x4 = aom_v_predictor_4x4_c;
-        if (flags & HAS_SSE2) aom_v_predictor_4x4 = aom_v_predictor_4x4_sse2;
-        aom_v_predictor_8x8 = aom_v_predictor_8x8_c;
-        if (flags & HAS_SSE2) aom_v_predictor_8x8 = aom_v_predictor_8x8_sse2;
-        aom_v_predictor_16x16 = aom_v_predictor_16x16_c;
-        if (flags & HAS_SSE2) aom_v_predictor_16x16 = aom_v_predictor_16x16_sse2;
-        aom_v_predictor_32x32 = aom_v_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_v_predictor_32x32 = aom_v_predictor_32x32_avx2;        
-        aom_v_predictor_64x64 = aom_v_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_v_predictor_64x64 = aom_v_predictor_64x64_avx2;
-        aom_v_predictor_16x32 = aom_v_predictor_16x32_c;
-        if (flags & HAS_SSE2) aom_v_predictor_16x32 = aom_v_predictor_16x32_sse2;
-        aom_v_predictor_16x4 = aom_v_predictor_16x4_c;
-        if (flags & HAS_SSE2) aom_v_predictor_16x4 = aom_v_predictor_16x4_sse2;
-        aom_v_predictor_16x64 = aom_v_predictor_16x64_c;
-        if (flags & HAS_SSE2) aom_v_predictor_16x64 = aom_v_predictor_16x64_sse2;
-        aom_v_predictor_16x8 = aom_v_predictor_16x8_c;
-        if (flags & HAS_SSE2) aom_v_predictor_16x8 = aom_v_predictor_16x8_sse2;
-        aom_v_predictor_32x16 = aom_v_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_v_predictor_32x16 = aom_v_predictor_32x16_avx2;
-        aom_v_predictor_32x64 = aom_v_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_v_predictor_32x64 = aom_v_predictor_32x64_avx2;
-        aom_v_predictor_32x8 = aom_v_predictor_32x8_c;
-        if (flags & HAS_SSE2) aom_v_predictor_32x8 = aom_v_predictor_32x8_sse2;
-        aom_v_predictor_4x16 = aom_v_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_v_predictor_4x16 = aom_v_predictor_4x16_sse2;
-        aom_v_predictor_4x8 = aom_v_predictor_4x8_c;
-        if (flags & HAS_SSE2) aom_v_predictor_4x8 = aom_v_predictor_4x8_sse2;
-        aom_v_predictor_64x16 = aom_v_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_v_predictor_64x16 = aom_v_predictor_64x16_avx2;
-        aom_v_predictor_64x32 = aom_v_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_v_predictor_64x32 = aom_v_predictor_64x32_avx2;
-        aom_v_predictor_8x16 = aom_v_predictor_8x16_c;
-        if (flags & HAS_SSE2) aom_v_predictor_8x16 = aom_v_predictor_8x16_sse2;
-        aom_v_predictor_8x32 = aom_v_predictor_8x32_c;
-        if (flags & HAS_SSE2) aom_v_predictor_8x32 = aom_v_predictor_8x32_sse2;
-        aom_v_predictor_8x4 = aom_v_predictor_8x4_c;
-        if (flags & HAS_SSE2) aom_v_predictor_8x4 = aom_v_predictor_8x4_sse2;
+ 
         //QIQ
 #if INTRINSIC_OPT_2
         aom_quantize_b_64x64 = aom_quantize_b_64x64_c_II;
@@ -2906,37 +2725,33 @@ RTCD_EXTERN void(*av1_txb_init_levels)(const tran_low_t *const coeff, const int3
         av1_fwd_txfm2d_4x4 = Av1TransformTwoD_4x4_c;
         if (flags & HAS_SSE4_1) av1_fwd_txfm2d_4x4 = av1_fwd_txfm2d_4x4_sse4_1;
 
-        // aom_highbd_h_predictor
-        aom_highbd_h_predictor_16x4 = aom_highbd_h_predictor_16x4_c;
-        if (flags & HAS_AVX2) aom_highbd_h_predictor_16x4 = aom_highbd_h_predictor_16x4_avx2;
-        aom_highbd_h_predictor_16x64 = aom_highbd_h_predictor_16x64_c;
-        if (flags & HAS_AVX2) aom_highbd_h_predictor_16x64 = aom_highbd_h_predictor_16x64_avx2;
-        aom_highbd_h_predictor_32x64 = aom_highbd_h_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_highbd_h_predictor_32x64 = aom_highbd_h_predictor_32x64_avx2;
-        aom_highbd_h_predictor_32x8 = aom_highbd_h_predictor_32x8_c;
-        if (flags & HAS_AVX2) aom_highbd_h_predictor_32x8 = aom_highbd_h_predictor_32x8_avx2;
-        aom_highbd_h_predictor_4x16 = aom_highbd_h_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_highbd_h_predictor_4x16 = aom_highbd_h_predictor_4x16_sse2;
-        aom_highbd_h_predictor_64x16 = aom_highbd_h_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_highbd_h_predictor_64x16 = aom_highbd_h_predictor_64x16_avx2;
-        aom_highbd_h_predictor_64x32 = aom_highbd_h_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_highbd_h_predictor_64x32 = aom_highbd_h_predictor_64x32_avx2;
-        aom_highbd_h_predictor_8x32 = aom_highbd_h_predictor_8x32_c;
-        if (flags & HAS_SSE2) aom_highbd_h_predictor_8x32 = aom_highbd_h_predictor_8x32_sse2;
-        aom_highbd_h_predictor_64x64 = aom_highbd_h_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_highbd_h_predictor_64x64 = aom_highbd_h_predictor_64x64_avx2;
 
         // aom_highbd_v_predictor
+        aom_highbd_v_predictor_16x16 = aom_highbd_v_predictor_16x16_c;
+        if (flags & HAS_AVX2) aom_highbd_v_predictor_16x16 = aom_highbd_v_predictor_16x16_avx2;
+        aom_highbd_v_predictor_16x32 = aom_highbd_v_predictor_16x32_c;
+        if (flags & HAS_AVX2) aom_highbd_v_predictor_16x32 = aom_highbd_v_predictor_16x32_avx2;
         aom_highbd_v_predictor_16x4 = aom_highbd_v_predictor_16x4_c;
         if (flags & HAS_AVX2) aom_highbd_v_predictor_16x4 = aom_highbd_v_predictor_16x4_avx2;
         aom_highbd_v_predictor_16x64 = aom_highbd_v_predictor_16x64_c;
         if (flags & HAS_AVX2) aom_highbd_v_predictor_16x64 = aom_highbd_v_predictor_16x64_avx2;
+        aom_highbd_v_predictor_16x8 = aom_highbd_v_predictor_16x8_c;
+        if (flags & HAS_AVX2) aom_highbd_v_predictor_16x8 = aom_highbd_v_predictor_16x8_avx2;
+        aom_highbd_v_predictor_2x2 = aom_highbd_v_predictor_2x2_c;
+        aom_highbd_v_predictor_32x16 = aom_highbd_v_predictor_32x16_c;
+        if (flags & HAS_AVX2) aom_highbd_v_predictor_32x16 = aom_highbd_v_predictor_32x16_avx2;
+        aom_highbd_v_predictor_32x32 = aom_highbd_v_predictor_32x32_c;
+        if (flags & HAS_AVX2) aom_highbd_v_predictor_32x32 = aom_highbd_v_predictor_32x32_avx2;
         aom_highbd_v_predictor_32x64 = aom_highbd_v_predictor_32x64_c;
         if (flags & HAS_AVX2) aom_highbd_v_predictor_32x64 = aom_highbd_v_predictor_32x64_avx2;
         aom_highbd_v_predictor_32x8 = aom_highbd_v_predictor_32x8_c;
         if (flags & HAS_AVX2) aom_highbd_v_predictor_32x8 = aom_highbd_v_predictor_32x8_avx2;
         aom_highbd_v_predictor_4x16 = aom_highbd_v_predictor_4x16_c;
         if (flags & HAS_SSE2) aom_highbd_v_predictor_4x16 = aom_highbd_v_predictor_4x16_sse2;
+        aom_highbd_v_predictor_4x4 = aom_highbd_v_predictor_4x4_c;
+        if (flags & HAS_SSE2) aom_highbd_v_predictor_4x4 = aom_highbd_v_predictor_4x4_sse2;
+        aom_highbd_v_predictor_4x8 = aom_highbd_v_predictor_4x8_c;
+        if (flags & HAS_SSE2) aom_highbd_v_predictor_4x8 = aom_highbd_v_predictor_4x8_sse2;
         aom_highbd_v_predictor_64x16 = aom_highbd_v_predictor_64x16_c;
         if (flags & HAS_AVX2) aom_highbd_v_predictor_64x16 = aom_highbd_v_predictor_64x16_avx2;
         aom_highbd_v_predictor_64x32 = aom_highbd_v_predictor_64x32_c;
@@ -2945,6 +2760,12 @@ RTCD_EXTERN void(*av1_txb_init_levels)(const tran_low_t *const coeff, const int3
         if (flags & HAS_SSE2) aom_highbd_v_predictor_8x32 = aom_highbd_v_predictor_8x32_sse2;
         aom_highbd_v_predictor_64x64 = aom_highbd_v_predictor_64x64_c;
         if (flags & HAS_AVX2) aom_highbd_v_predictor_64x64 = aom_highbd_v_predictor_64x64_avx2;
+        aom_highbd_v_predictor_8x16 = aom_highbd_v_predictor_8x16_c;
+        if (flags & HAS_SSE2) aom_highbd_v_predictor_8x16 = aom_highbd_v_predictor_8x16_sse2;
+        aom_highbd_v_predictor_8x4 = aom_highbd_v_predictor_8x4_c;
+        if (flags & HAS_SSE2) aom_highbd_v_predictor_8x4 = aom_highbd_v_predictor_8x4_sse2;
+        aom_highbd_v_predictor_8x8 = aom_highbd_v_predictor_8x8_c;
+        if (flags & HAS_SSE2) aom_highbd_v_predictor_8x8 = aom_highbd_v_predictor_8x8_sse2;
 
         //aom_highbd_smooth_predictor
         aom_highbd_smooth_predictor_16x16 = aom_highbd_smooth_predictor_16x16_c;
@@ -2957,6 +2778,7 @@ RTCD_EXTERN void(*av1_txb_init_levels)(const tran_low_t *const coeff, const int3
         if (flags & HAS_AVX2) aom_highbd_smooth_predictor_16x64 = aom_highbd_smooth_predictor_16x64_avx2;
         aom_highbd_smooth_predictor_16x8 = aom_highbd_smooth_predictor_16x8_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_predictor_16x8 = aom_highbd_smooth_predictor_16x8_avx2;
+        aom_highbd_smooth_predictor_2x2 = aom_highbd_smooth_predictor_2x2_c;
         aom_highbd_smooth_predictor_32x16 = aom_highbd_smooth_predictor_32x16_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_predictor_32x16 = aom_highbd_smooth_predictor_32x16_avx2;
         aom_highbd_smooth_predictor_32x32 = aom_highbd_smooth_predictor_32x32_c;
@@ -2997,6 +2819,7 @@ RTCD_EXTERN void(*av1_txb_init_levels)(const tran_low_t *const coeff, const int3
         if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_16x64 = aom_highbd_smooth_h_predictor_16x64_avx2;
         aom_highbd_smooth_h_predictor_16x8 = aom_highbd_smooth_h_predictor_16x8_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_16x8 = aom_highbd_smooth_h_predictor_16x8_avx2;
+        aom_highbd_smooth_h_predictor_2x2 = aom_highbd_smooth_h_predictor_2x2_c;
         aom_highbd_smooth_h_predictor_32x16 = aom_highbd_smooth_h_predictor_32x16_c;
         if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_32x16 = aom_highbd_smooth_h_predictor_32x16_avx2;
         aom_highbd_smooth_h_predictor_32x32 = aom_highbd_smooth_h_predictor_32x32_c;
@@ -3027,6 +2850,33 @@ RTCD_EXTERN void(*av1_txb_init_levels)(const tran_low_t *const coeff, const int3
         if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_8x8 = aom_highbd_smooth_h_predictor_8x8_avx2;
 
         //aom_highbd_dc_128_predictor
+        aom_highbd_dc_128_predictor_16x16 = aom_highbd_dc_128_predictor_16x16_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_16x16 = aom_highbd_dc_128_predictor_16x16_avx2;
+        aom_highbd_dc_128_predictor_16x32 = aom_highbd_dc_128_predictor_16x32_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_16x32 = aom_highbd_dc_128_predictor_16x32_avx2;
+        aom_highbd_dc_128_predictor_16x4 = aom_highbd_dc_128_predictor_16x4_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_16x4 = aom_highbd_dc_128_predictor_16x4_avx2;
+        aom_highbd_dc_128_predictor_16x64 = aom_highbd_dc_128_predictor_16x64_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_16x64 = aom_highbd_dc_128_predictor_16x64_avx2;
+        aom_highbd_dc_128_predictor_16x8 = aom_highbd_dc_128_predictor_16x8_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_16x8 = aom_highbd_dc_128_predictor_16x8_avx2;
+        aom_highbd_dc_128_predictor_2x2 = aom_highbd_dc_128_predictor_2x2_c;
+        aom_highbd_dc_128_predictor_32x16 = aom_highbd_dc_128_predictor_32x16_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_32x16 = aom_highbd_dc_128_predictor_32x16_avx2;
+        aom_highbd_dc_128_predictor_32x32 = aom_highbd_dc_128_predictor_32x32_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_32x32 = aom_highbd_dc_128_predictor_32x32_avx2;
+        aom_highbd_dc_128_predictor_32x64 = aom_highbd_dc_128_predictor_32x64_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_32x64 = aom_highbd_dc_128_predictor_32x64_avx2;
+        aom_highbd_dc_128_predictor_32x8 = aom_highbd_dc_128_predictor_32x8_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_32x8 = aom_highbd_dc_128_predictor_32x8_avx2;
+        aom_highbd_dc_128_predictor_4x16 = aom_highbd_dc_128_predictor_4x16_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_128_predictor_4x16 = aom_highbd_dc_128_predictor_4x16_sse2;
+        aom_highbd_dc_128_predictor_4x4 = aom_highbd_dc_128_predictor_4x4_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_128_predictor_4x4 = aom_highbd_dc_128_predictor_4x4_sse2;
+        aom_highbd_dc_128_predictor_4x8 = aom_highbd_dc_128_predictor_4x8_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_128_predictor_4x8 = aom_highbd_dc_128_predictor_4x8_sse2;
+        aom_highbd_dc_128_predictor_8x32 = aom_highbd_dc_128_predictor_8x32_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_128_predictor_8x32 = aom_highbd_dc_128_predictor_8x32_sse2;
         aom_highbd_dc_128_predictor_64x16 = aom_highbd_dc_128_predictor_64x16_c;
         if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_64x16 = aom_highbd_dc_128_predictor_64x16_avx2;
         aom_highbd_dc_128_predictor_64x32 = aom_highbd_dc_128_predictor_64x32_c;
@@ -3041,20 +2891,168 @@ RTCD_EXTERN void(*av1_txb_init_levels)(const tran_low_t *const coeff, const int3
         if (flags & HAS_SSE2) aom_highbd_dc_128_predictor_8x8 = aom_highbd_dc_128_predictor_8x8_sse2;
 
         //aom_highbd_dc_left_predictor
+        aom_highbd_dc_left_predictor_16x16 = aom_highbd_dc_left_predictor_16x16_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_16x16 = aom_highbd_dc_left_predictor_16x16_avx2;
+        aom_highbd_dc_left_predictor_16x32 = aom_highbd_dc_left_predictor_16x32_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_16x32 = aom_highbd_dc_left_predictor_16x32_avx2;
+        aom_highbd_dc_left_predictor_16x4 = aom_highbd_dc_left_predictor_16x4_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_16x4 = aom_highbd_dc_left_predictor_16x4_avx2;
+        aom_highbd_dc_left_predictor_16x64 = aom_highbd_dc_left_predictor_16x64_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_16x64 = aom_highbd_dc_left_predictor_16x64_avx2;
+        aom_highbd_dc_left_predictor_16x8 = aom_highbd_dc_left_predictor_16x8_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_16x8 = aom_highbd_dc_left_predictor_16x8_avx2;
+        aom_highbd_dc_left_predictor_2x2 = aom_highbd_dc_left_predictor_2x2_c;
+        aom_highbd_dc_left_predictor_32x16 = aom_highbd_dc_left_predictor_32x16_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_32x16 = aom_highbd_dc_left_predictor_32x16_avx2;
+        aom_highbd_dc_left_predictor_32x32 = aom_highbd_dc_left_predictor_32x32_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_32x32 = aom_highbd_dc_left_predictor_32x32_avx2;
+        aom_highbd_dc_left_predictor_32x64 = aom_highbd_dc_left_predictor_32x64_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_32x64 = aom_highbd_dc_left_predictor_32x64_avx2;
+        aom_highbd_dc_left_predictor_32x8 = aom_highbd_dc_left_predictor_32x8_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_32x8 = aom_highbd_dc_left_predictor_32x8_avx2;
+        aom_highbd_dc_left_predictor_4x16 = aom_highbd_dc_left_predictor_4x16_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_left_predictor_4x16 = aom_highbd_dc_left_predictor_4x16_sse2;
+        aom_highbd_dc_left_predictor_4x4 = aom_highbd_dc_left_predictor_4x4_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_left_predictor_4x4 = aom_highbd_dc_left_predictor_4x4_sse2;
+        aom_highbd_dc_left_predictor_4x8 = aom_highbd_dc_left_predictor_4x8_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_left_predictor_4x8 = aom_highbd_dc_left_predictor_4x8_sse2;
+        aom_highbd_dc_left_predictor_8x32 = aom_highbd_dc_left_predictor_8x32_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_left_predictor_8x32 = aom_highbd_dc_left_predictor_8x32_sse2;
         aom_highbd_dc_left_predictor_64x16 = aom_highbd_dc_left_predictor_64x16_c;
         if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_64x16 = aom_highbd_dc_left_predictor_64x16_avx2;
         aom_highbd_dc_left_predictor_64x32 = aom_highbd_dc_left_predictor_64x32_c;
         if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_64x32 = aom_highbd_dc_left_predictor_64x32_avx2;
         aom_highbd_dc_left_predictor_64x64 = aom_highbd_dc_left_predictor_64x64_c;
         if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_64x64 = aom_highbd_dc_left_predictor_64x64_avx2;
+        aom_highbd_dc_left_predictor_8x16 = aom_highbd_dc_left_predictor_8x16_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_left_predictor_8x16 = aom_highbd_dc_left_predictor_8x16_sse2;
+        aom_highbd_dc_left_predictor_8x4 = aom_highbd_dc_left_predictor_8x4_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_left_predictor_8x4 = aom_highbd_dc_left_predictor_8x4_sse2;
+        aom_highbd_dc_left_predictor_8x8 = aom_highbd_dc_left_predictor_8x8_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_left_predictor_8x8 = aom_highbd_dc_left_predictor_8x8_sse2;
+
+
+        aom_highbd_dc_predictor_16x16 = aom_highbd_dc_predictor_16x16_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_predictor_16x16 = aom_highbd_dc_predictor_16x16_avx2;
+        aom_highbd_dc_predictor_16x32 = aom_highbd_dc_predictor_16x32_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_predictor_16x32 = aom_highbd_dc_predictor_16x32_avx2;
+        aom_highbd_dc_predictor_16x4 = aom_highbd_dc_predictor_16x4_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_predictor_16x4 = aom_highbd_dc_predictor_16x4_avx2;
+        aom_highbd_dc_predictor_16x64 = aom_highbd_dc_predictor_16x64_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_predictor_16x64 = aom_highbd_dc_predictor_16x64_avx2;
+        aom_highbd_dc_predictor_16x8 = aom_highbd_dc_predictor_16x8_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_predictor_16x8 = aom_highbd_dc_predictor_16x8_avx2;
+        aom_highbd_dc_predictor_2x2 = aom_highbd_dc_predictor_2x2_c;
+        aom_highbd_dc_predictor_32x16 = aom_highbd_dc_predictor_32x16_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_predictor_32x16 = aom_highbd_dc_predictor_32x16_avx2;
+        aom_highbd_dc_predictor_32x32 = aom_highbd_dc_predictor_32x32_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_predictor_32x32 = aom_highbd_dc_predictor_32x32_avx2;
+        aom_highbd_dc_predictor_32x64 = aom_highbd_dc_predictor_32x64_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_predictor_32x64 = aom_highbd_dc_predictor_32x64_avx2;
+        aom_highbd_dc_predictor_32x8 = aom_highbd_dc_predictor_32x8_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_predictor_32x8 = aom_highbd_dc_predictor_32x8_avx2;
+        aom_highbd_dc_predictor_4x16 = aom_highbd_dc_predictor_4x16_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_predictor_4x16 = aom_highbd_dc_predictor_4x16_sse2;
+        aom_highbd_dc_predictor_4x4 = aom_highbd_dc_predictor_4x4_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_predictor_4x4 = aom_highbd_dc_predictor_4x4_sse2;
+        aom_highbd_dc_predictor_4x8 = aom_highbd_dc_predictor_4x8_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_predictor_4x8 = aom_highbd_dc_predictor_4x8_sse2;
+        aom_highbd_dc_predictor_64x16 = aom_highbd_dc_predictor_64x16_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_predictor_64x16 = aom_highbd_dc_predictor_64x16_avx2;
+        aom_highbd_dc_predictor_64x32 = aom_highbd_dc_predictor_64x32_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_predictor_64x32 = aom_highbd_dc_predictor_64x32_avx2;
+        aom_highbd_dc_predictor_64x64 = aom_highbd_dc_predictor_64x64_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_predictor_64x64 = aom_highbd_dc_predictor_64x64_avx2;
+        aom_highbd_dc_predictor_8x16 = aom_highbd_dc_predictor_8x16_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_predictor_8x16 = aom_highbd_dc_predictor_8x16_sse2;
+        aom_highbd_dc_predictor_8x4 = aom_highbd_dc_predictor_8x4_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_predictor_8x4 = aom_highbd_dc_predictor_8x4_sse2;
+        aom_highbd_dc_predictor_8x8 = aom_highbd_dc_predictor_8x8_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_predictor_8x8 = aom_highbd_dc_predictor_8x8_sse2;
+        aom_highbd_dc_predictor_8x32 = aom_highbd_dc_predictor_8x32_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_predictor_8x32 = aom_highbd_dc_predictor_8x32_sse2;
 
         //aom_highbd_dc_top_predictor
+        aom_highbd_dc_top_predictor_16x16 = aom_highbd_dc_top_predictor_16x16_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_16x16 = aom_highbd_dc_top_predictor_16x16_avx2;
+        aom_highbd_dc_top_predictor_16x32 = aom_highbd_dc_top_predictor_16x32_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_16x32 = aom_highbd_dc_top_predictor_16x32_avx2;
+        aom_highbd_dc_top_predictor_16x4 = aom_highbd_dc_top_predictor_16x4_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_16x4 = aom_highbd_dc_top_predictor_16x4_avx2;
+        aom_highbd_dc_top_predictor_16x64 = aom_highbd_dc_top_predictor_16x64_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_16x64 = aom_highbd_dc_top_predictor_16x64_avx2;
+        aom_highbd_dc_top_predictor_16x8 = aom_highbd_dc_top_predictor_16x8_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_16x8 = aom_highbd_dc_top_predictor_16x8_avx2;
+        aom_highbd_dc_top_predictor_2x2 = aom_highbd_dc_top_predictor_2x2_c;
+        aom_highbd_dc_top_predictor_32x16 = aom_highbd_dc_top_predictor_32x16_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_32x16 = aom_highbd_dc_top_predictor_32x16_avx2;
+        aom_highbd_dc_top_predictor_32x32 = aom_highbd_dc_top_predictor_32x32_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_32x32 = aom_highbd_dc_top_predictor_32x32_avx2;
+        aom_highbd_dc_top_predictor_32x64 = aom_highbd_dc_top_predictor_32x64_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_32x64 = aom_highbd_dc_top_predictor_32x64_avx2;
+        aom_highbd_dc_top_predictor_32x8 = aom_highbd_dc_top_predictor_32x8_c;
+        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_32x8 = aom_highbd_dc_top_predictor_32x8_avx2;
+        aom_highbd_dc_top_predictor_4x16 = aom_highbd_dc_top_predictor_4x16_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_top_predictor_4x16 = aom_highbd_dc_top_predictor_4x16_sse2;
+        aom_highbd_dc_top_predictor_4x4 = aom_highbd_dc_top_predictor_4x4_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_top_predictor_4x4 = aom_highbd_dc_top_predictor_4x4_sse2;
+        aom_highbd_dc_top_predictor_4x8 = aom_highbd_dc_top_predictor_4x8_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_top_predictor_4x8 = aom_highbd_dc_top_predictor_4x8_sse2;
         aom_highbd_dc_top_predictor_64x16 = aom_highbd_dc_top_predictor_64x16_c;
         if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_64x16 = aom_highbd_dc_top_predictor_64x16_avx2;
         aom_highbd_dc_top_predictor_64x32 = aom_highbd_dc_top_predictor_64x32_c;
         if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_64x32 = aom_highbd_dc_top_predictor_64x32_avx2;
         aom_highbd_dc_top_predictor_64x64 = aom_highbd_dc_top_predictor_64x64_c;
         if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_64x64 = aom_highbd_dc_top_predictor_64x64_avx2;
+        aom_highbd_dc_top_predictor_8x16 = aom_highbd_dc_top_predictor_8x16_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_top_predictor_8x16 = aom_highbd_dc_top_predictor_8x16_sse2;
+        if (flags & HAS_SSE2) aom_highbd_dc_top_predictor_8x32 = aom_highbd_dc_top_predictor_8x32_c;
+        aom_highbd_dc_top_predictor_8x4 = aom_highbd_dc_top_predictor_8x4_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_top_predictor_8x4 = aom_highbd_dc_top_predictor_8x4_sse2;
+        aom_highbd_dc_top_predictor_8x8 = aom_highbd_dc_top_predictor_8x8_c;
+        if (flags & HAS_SSE2) aom_highbd_dc_top_predictor_8x8 = aom_highbd_dc_top_predictor_8x8_sse2;
+
+
+        // aom_highbd_h_predictor
+        aom_highbd_h_predictor_16x4 = aom_highbd_h_predictor_16x4_c;
+        if (flags & HAS_AVX2) aom_highbd_h_predictor_16x4 = aom_highbd_h_predictor_16x4_avx2;
+        aom_highbd_h_predictor_16x64 = aom_highbd_h_predictor_16x64_c;
+        if (flags & HAS_AVX2) aom_highbd_h_predictor_16x64 = aom_highbd_h_predictor_16x64_avx2;
+        aom_highbd_h_predictor_16x8 = aom_highbd_h_predictor_16x8_c;
+        if (flags & HAS_SSE2) aom_highbd_h_predictor_16x8 = aom_highbd_h_predictor_16x8_sse2;
+        aom_highbd_h_predictor_2x2 = aom_highbd_h_predictor_2x2_c;
+        aom_highbd_h_predictor_32x16 = aom_highbd_h_predictor_32x16_c;
+        if (flags & HAS_SSE2) aom_highbd_h_predictor_32x16 = aom_highbd_h_predictor_32x16_sse2;
+        aom_highbd_h_predictor_32x32 = aom_highbd_h_predictor_32x32_c;
+        if (flags & HAS_SSE2) aom_highbd_h_predictor_32x32 = aom_highbd_h_predictor_32x32_sse2;
+        aom_highbd_h_predictor_32x64 = aom_highbd_h_predictor_32x64_c;
+        if (flags & HAS_AVX2) aom_highbd_h_predictor_32x64 = aom_highbd_h_predictor_32x64_avx2;
+        aom_highbd_h_predictor_32x8 = aom_highbd_h_predictor_32x8_c;
+        if (flags & HAS_AVX2) aom_highbd_h_predictor_32x8 = aom_highbd_h_predictor_32x8_avx2;
+        aom_highbd_h_predictor_4x16 = aom_highbd_h_predictor_4x16_c;
+        if (flags & HAS_SSE2) aom_highbd_h_predictor_4x16 = aom_highbd_h_predictor_4x16_sse2;
+        aom_highbd_h_predictor_4x4 = aom_highbd_h_predictor_4x4_c;
+        if (flags & HAS_SSE2) aom_highbd_h_predictor_4x4 = aom_highbd_h_predictor_4x4_sse2;
+        aom_highbd_h_predictor_4x8 = aom_highbd_h_predictor_4x8_c;
+        if (flags & HAS_SSE2) aom_highbd_h_predictor_4x8 = aom_highbd_h_predictor_4x8_sse2;
+        aom_highbd_h_predictor_64x16 = aom_highbd_h_predictor_64x16_c;
+        if (flags & HAS_AVX2) aom_highbd_h_predictor_64x16 = aom_highbd_h_predictor_64x16_avx2;
+        aom_highbd_h_predictor_64x32 = aom_highbd_h_predictor_64x32_c;
+        if (flags & HAS_AVX2) aom_highbd_h_predictor_64x32 = aom_highbd_h_predictor_64x32_avx2;
+        aom_highbd_h_predictor_8x32 = aom_highbd_h_predictor_8x32_c;
+        if (flags & HAS_SSE2) aom_highbd_h_predictor_8x32 = aom_highbd_h_predictor_8x32_sse2;
+        aom_highbd_h_predictor_64x64 = aom_highbd_h_predictor_64x64_c;
+        if (flags & HAS_AVX2) aom_highbd_h_predictor_64x64 = aom_highbd_h_predictor_64x64_avx2;
+        aom_highbd_h_predictor_8x16 = aom_highbd_h_predictor_8x16_c;
+        if (flags & HAS_SSE2) aom_highbd_h_predictor_8x16 = aom_highbd_h_predictor_8x16_sse2;
+        aom_highbd_h_predictor_8x4 = aom_highbd_h_predictor_8x4_c;
+        if (flags & HAS_SSE2) aom_highbd_h_predictor_8x4 = aom_highbd_h_predictor_8x4_sse2;
+        aom_highbd_h_predictor_8x8 = aom_highbd_h_predictor_8x8_c;
+        if (flags & HAS_SSE2) aom_highbd_h_predictor_8x8 = aom_highbd_h_predictor_8x8_sse2;
+        aom_highbd_h_predictor_16x16 = aom_highbd_h_predictor_16x16_c;
+        if (flags & HAS_SSE2) aom_highbd_h_predictor_16x16 = aom_highbd_h_predictor_16x16_sse2;
+        aom_highbd_h_predictor_16x32 = aom_highbd_h_predictor_16x32_c;
+        if (flags & HAS_SSE2) aom_highbd_h_predictor_16x32 = aom_highbd_h_predictor_16x32_sse2;
 
 #endif
         aom_fft2x2_float = aom_fft2x2_float_c;


### PR DESCRIPTION
**Description of changes**
+ update preset trade-offs 1,2,3 increased speed by 2x
  + optimize interpolation filter use
  + optimize dlf
+ add infra-structure for features to be turned on/off localized per kernel depending on the processing stage (block based / picture based)  
+ cleanup extra compile macros
+ some snake_case cleanup
+ cleanup tabs / trailing spaces

**Authors:**
@NaderMahdi
@okhlif