### PR TITLE
Fix AppVeyor after image update

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ install:
     - git submodule update --init
     - appveyor DownloadFile http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe -FileName yasm.exe
     - set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%
-    - cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_ASM_NASM_COMPILER="yasm.exe"
+    - cmake . -G "Visual Studio 15 2017 Win64" -DCMAKE_ASM_NASM_COMPILER="yasm.exe"
 
 build:
   project: svt-av1.sln


### PR DESCRIPTION
Resolves #48 (@kylophone).

AppVeyor had an [image update](https://www.appveyor.com/updates/2019/02/11/) yesterday which updated CMake to 3.13.3. This broke our AppVeyor config, this PR fixes that.