### PR TITLE
Require FFmpeg patch to build with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ addons:
     packages:
       - yasm
 
-matrix:
-  allow_failures:
-  - name: "FFmpeg patch"  # See issue #15
-
 jobs:
   include:
    # General Linux build job


### PR DESCRIPTION
Since issue #15 is fixed with PR #57, the allow_failures for the FFmpeg patch can be removed.