### PR TITLE
Fix crash with 720x480 yuv420p input

### DIFF
--- a/Source/Lib/Codec/EbDefinitions.h
+++ b/Source/Lib/Codec/EbDefinitions.h
@@ -150,6 +150,8 @@ extern "C" {
 #else
 #define PAD_VALUE                                (128+32)
 #endif
+#define BUFFER_ALIGN                              64
+#define BUFFER_ALIGN_MASK                        (~(BUFFER_ALIGN-1))
 
 //  Delta QP support
 #define ADD_DELTA_QP_SUPPORT                      0  // Add delta QP support - Please enable this flag and iproveSharpness (config) to test the QPM

--- a/Source/Lib/Codec/EbPictureBufferDesc.c
+++ b/Source/Lib/Codec/EbPictureBufferDesc.c
@@ -48,14 +48,15 @@ EbErrorType EbPictureBufferDescCtor(
     pictureBufferDescPtr->width = pictureBufferDescInitDataPtr->maxWidth;
     pictureBufferDescPtr->height = pictureBufferDescInitDataPtr->maxHeight;
     pictureBufferDescPtr->bit_depth = pictureBufferDescInitDataPtr->bit_depth;
-    pictureBufferDescPtr->strideY = pictureBufferDescInitDataPtr->maxWidth + pictureBufferDescInitDataPtr->left_padding + pictureBufferDescInitDataPtr->right_padding;
-    pictureBufferDescPtr->strideCb = pictureBufferDescPtr->strideCr = pictureBufferDescPtr->strideY >> 1;
+    pictureBufferDescPtr->strideY = (pictureBufferDescInitDataPtr->maxWidth + pictureBufferDescInitDataPtr->left_padding + pictureBufferDescInitDataPtr->right_padding + BUFFER_ALIGN - 1) & BUFFER_ALIGN_MASK;
+    pictureBufferDescPtr->strideCb = pictureBufferDescPtr->strideCr = ((pictureBufferDescPtr->strideY >> 1) + BUFFER_ALIGN - 1) & BUFFER_ALIGN_MASK;
     pictureBufferDescPtr->origin_x = pictureBufferDescInitDataPtr->left_padding;
     pictureBufferDescPtr->origin_y = pictureBufferDescInitDataPtr->top_padding;
 
-    pictureBufferDescPtr->lumaSize = (pictureBufferDescInitDataPtr->maxWidth + pictureBufferDescInitDataPtr->left_padding + pictureBufferDescInitDataPtr->right_padding) *
+    pictureBufferDescPtr->lumaSize = pictureBufferDescPtr->strideY *
         (pictureBufferDescInitDataPtr->maxHeight + pictureBufferDescInitDataPtr->top_padding + pictureBufferDescInitDataPtr->bot_padding);
-    pictureBufferDescPtr->chromaSize = pictureBufferDescPtr->lumaSize >> 2;
+    pictureBufferDescPtr->chromaSize = pictureBufferDescPtr->strideCb *
+        (pictureBufferDescInitDataPtr->maxHeight + pictureBufferDescInitDataPtr->top_padding + pictureBufferDescInitDataPtr->bot_padding) >> 1;
     pictureBufferDescPtr->packedFlag = EB_FALSE;
 
     if (pictureBufferDescInitDataPtr->splitMode == EB_TRUE) {


### PR DESCRIPTION
Align strideY, strideCb, and strideCr to 64 bytes (512 bits)

Fixes https://github.com/OpenVisualCloud/SVT-AV1/issues/84