### PR TITLE
Add 422/444 support at API level

### DIFF
--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -128,7 +128,15 @@ typedef struct EbSvtAv1EncConfiguration
      *
      * Default is 8. */
     uint32_t                 encoder_bit_depth;
-
+    /* Specifies the chroma subsampleing format of input video.
+     *
+     * 0 = mono.
+     * 1 = 420.
+     * 2 = 422.
+     * 3 = 444.
+     *
+     * Default is 1. */
+    EbColorFormat            encoder_color_format;
     /* Offline packing of the 2bits: requires two bits packed input.
      *
      * Default is 0. */

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -38,6 +38,7 @@
 #define FRAME_RATE_NUMERATOR_TOKEN      "-fps-num"
 #define FRAME_RATE_DENOMINATOR_TOKEN    "-fps-denom"
 #define ENCODER_BIT_DEPTH               "-bit-depth"
+#define ENCODER_COLOR_FORMAT            "-color-format"
 #define INPUT_COMPRESSED_TEN_BIT_FORMAT "-compressed-ten-bit-format"
 #define ENCMODE_TOKEN                   "-enc-mode"
 #define HIERARCHICAL_LEVELS_TOKEN       "-hierarchical-levels" // no Eval
@@ -173,6 +174,7 @@ static void SetFrameRate                        (const char *value, EbConfig *cf
 static void SetFrameRateNumerator               (const char *value, EbConfig *cfg) { cfg->frame_rate_numerator = strtoul(value, NULL, 0);};
 static void SetFrameRateDenominator             (const char *value, EbConfig *cfg) { cfg->frame_rate_denominator = strtoul(value, NULL, 0);};
 static void SetEncoderBitDepth                  (const char *value, EbConfig *cfg) {cfg->encoder_bit_depth = strtoul(value, NULL, 0);}
+static void SetEncoderColorFormat               (const char *value, EbConfig *cfg) {cfg->encoder_color_format = strtoul(value, NULL, 0);}
 static void SetcompressedTenBitFormat            (const char *value, EbConfig *cfg) {cfg->compressed_ten_bit_format = strtoul(value, NULL, 0);}
 static void SetBaseLayerSwitchMode              (const char *value, EbConfig *cfg) {cfg->base_layer_switch_mode = (EbBool) strtoul(value, NULL, 0);};
 static void SetencMode                          (const char *value, EbConfig *cfg) {cfg->enc_mode = (uint8_t)strtoul(value, NULL, 0);};
@@ -286,6 +288,7 @@ config_entry_t config_entry[] = {
     { SINGLE_INPUT, FRAME_RATE_NUMERATOR_TOKEN, "FrameRateNumerator", SetFrameRateNumerator },
     { SINGLE_INPUT, FRAME_RATE_DENOMINATOR_TOKEN, "FrameRateDenominator", SetFrameRateDenominator },
     { SINGLE_INPUT, ENCODER_BIT_DEPTH, "EncoderBitDepth", SetEncoderBitDepth },
+    { SINGLE_INPUT, ENCODER_COLOR_FORMAT, "EncoderColorFormat", SetEncoderColorFormat},
     { SINGLE_INPUT, INPUT_COMPRESSED_TEN_BIT_FORMAT, "CompressedTenBitFormat", SetcompressedTenBitFormat },
     { SINGLE_INPUT, HIERARCHICAL_LEVELS_TOKEN, "HierarchicalLevels", SetHierarchicalLevels },
     { SINGLE_INPUT, PRED_STRUCT_TOKEN, "PredStructure", SetCfgPredStructure },
@@ -378,11 +381,11 @@ void eb_config_ctor(EbConfig *config_ptr)
     config_ptr->error_log_file                         = stderr;
     config_ptr->qp_file                               = NULL;
 
-
     config_ptr->frame_rate                            = 30 << 16;
     config_ptr->frame_rate_numerator                   = 0;
     config_ptr->frame_rate_denominator                 = 0;
     config_ptr->encoder_bit_depth                      = 8;
+    config_ptr->encoder_color_format                   = 1; //EB_YUV420
     config_ptr->compressed_ten_bit_format               = 0;
     config_ptr->source_width                          = 0;
     config_ptr->source_height                         = 0;
@@ -796,6 +799,10 @@ static EbErrorType VerifySettings(EbConfig *config, uint32_t channelNumber)
         return_error = EB_ErrorBadParameter;
     }
 
+    if (config->encoder_color_format != 1) {
+        fprintf(config->errorLogFile, "Error instance %u: Only support 420 now \n", channelNumber + 1);
+        return_error = EB_ErrorBadParameter;
+    }
     if (config->injector > 1 ){
         fprintf(config->error_log_file, "Error Instance %u: Invalid injector [0 - 1]\n",channelNumber+1);
         return_error = EB_ErrorBadParameter;
@@ -938,7 +945,6 @@ EbBool is_negative_number(
     return EB_TRUE;
 }
 
-#define SIZE_OF_ONE_FRAME_IN_BYTES(width, height,is16bit) ( ( ((width)*(height)*3)>>1 )<<is16bit)
 // Computes the number of frames in the input file
 int32_t ComputeFramesToBeEncoded(
     EbConfig   *config)
@@ -956,7 +962,9 @@ int32_t ComputeFramesToBeEncoded(
         fseeko64(config->input_file, currLoc, SEEK_SET); // seek back to that location
     }
 
-    frameSize = SIZE_OF_ONE_FRAME_IN_BYTES(config->input_padded_width, config->input_padded_height, (uint8_t)((config->encoder_bit_depth == 10) ? 1 : 0));
+    frameSize = config->input_padded_width * config->input_padded_height; // Luma
+    frameSize += 2 * (frameSize >> (3 - config->encoder_color_format)); // Add Chroma
+    frameSize = frameSize << ((config->encoder_bit_depth == 10) ? 1 : 0);
 
     if (frameSize == 0)
         return -1;
@@ -1218,8 +1226,8 @@ EbErrorType read_command_line(
 
                 // Assuming no errors, add padding to width and height
                 if (return_errors[index] == EB_ErrorNone) {
-                    configs[index]->input_padded_width  = configs[index]->source_width + LEFT_INPUT_PADDING + RIGHT_INPUT_PADDING;
-                    configs[index]->input_padded_height = configs[index]->source_height + TOP_INPUT_PADDING + BOTTOM_INPUT_PADDING;
+                    configs[index]->input_padded_width  = configs[index]->sourceWidth;
+                    configs[index]->input_padded_height = configs[index]->sourceHeight;
                 }
 
 

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -800,7 +800,7 @@ static EbErrorType VerifySettings(EbConfig *config, uint32_t channelNumber)
     }
 
     if (config->encoder_color_format != 1) {
-        fprintf(config->errorLogFile, "Error instance %u: Only support 420 now \n", channelNumber + 1);
+        fprintf(config->error_log_file, "Error instance %u: Only support 420 now \n", channelNumber + 1);
         return_error = EB_ErrorBadParameter;
     }
     if (config->injector > 1 ){
@@ -1226,8 +1226,8 @@ EbErrorType read_command_line(
 
                 // Assuming no errors, add padding to width and height
                 if (return_errors[index] == EB_ErrorNone) {
-                    configs[index]->input_padded_width  = configs[index]->sourceWidth;
-                    configs[index]->input_padded_height = configs[index]->sourceHeight;
+                    configs[index]->input_padded_width  = configs[index]->source_width;
+                    configs[index]->input_padded_height = configs[index]->source_height;
                 }
 
 

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -169,14 +169,6 @@ extern rsize_t strnlen_ss(const char *s, rsize_t smax);
 #define FOPEN(f,s,m) f=fopen(s,m)
 #endif
 
-/****************************************
-* Padding
-****************************************/
-#define LEFT_INPUT_PADDING 0
-#define RIGHT_INPUT_PADDING 0
-#define TOP_INPUT_PADDING 0
-#define BOTTOM_INPUT_PADDING 0
-
 
 typedef struct EbPerformanceContext {
 
@@ -229,6 +221,7 @@ typedef struct EbConfig
     uint32_t                 injector;
     uint32_t                 speed_control_flag;
     uint32_t                 encoder_bit_depth;
+    uint32_t                 encoder_color_format;
     uint32_t                 compressed_ten_bit_format;
     uint32_t                 source_width;
     uint32_t                 source_height;

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -204,7 +204,7 @@ EbErrorType CopyConfigurationParameters(
     callback_data->eb_enc_parameters.improve_sharpness = (uint8_t)config->improve_sharpness;
     callback_data->eb_enc_parameters.high_dynamic_range_input = config->high_dynamic_range_input;
     callback_data->eb_enc_parameters.encoder_bit_depth = config->encoder_bit_depth;
-    callbackData->ebEncParameters.encoder_color_format = config->encoder_color_format;
+    callback_data->eb_enc_parameters.encoder_color_format = config->encoder_color_format;
     callback_data->eb_enc_parameters.compressed_ten_bit_format = config->compressed_ten_bit_format;
     callback_data->eb_enc_parameters.profile = config->profile;
     callback_data->eb_enc_parameters.tier = config->tier;
@@ -255,9 +255,9 @@ static EbErrorType AllocateFrameBuffer(
 
     // Determine
     EbSvtIOFormat* inputPtr = (EbSvtIOFormat*)p_buffer;
-    inputPtr->yStride = config->input_padded_width;
-    inputPtr->crStride = config->input_padded_width >> subsampling_x;
-    inputPtr->cbStride = config->input_padded_width >> subsampling_x;
+    inputPtr->y_stride = config->input_padded_width;
+    inputPtr->cr_stride = config->input_padded_width >> subsampling_x;
+    inputPtr->cb_stride = config->input_padded_width >> subsampling_x;
     if (luma8bitSize) {
         EB_APP_MALLOC(uint8_t*, inputPtr->luma, luma8bitSize, EB_N_PTR, EB_ErrorInsufficientResources);
     }
@@ -394,9 +394,9 @@ EbErrorType PreloadFramesIntoRam(
 
     FILE *input_file = config->input_file;
 
-    readSize = inputPaddedWidth * inputPaddedHeight; //Luma
+    readSize = input_padded_width * input_padded_height; //Luma
     readSize += 2 * (readSize >> (3 - color_format)); // Add Chroma
-    if (config->encoder_bit_depth == 10 && config->compressedTenBitFormat == 1) {
+    if (config->encoder_bit_depth == 10 && config->compressed_ten_bit_format == 1) {
         readSize += readSize / 4;
     } else {
         readSize *= (config->encoder_bit_depth > 8 ? 2 : 1); //10 bit
@@ -535,14 +535,14 @@ EbErrorType PreloadFramesIntoRam(
         } else {
             // Fill the buffer with a complete frame
             filledLen = 0;
-            filledLen += (uint32_t)fread(config->sequence_buffer[processed_frame_count], 1, readSize, inputFile);
+            filledLen += (uint32_t)fread(config->sequence_buffer[processed_frame_count], 1, readSize, input_file);
 
             if (readSize != filledLen) {
                 fseek(config->input_file, 0, SEEK_SET);
 
                 // Fill the buffer with a complete frame
                 filledLen = 0;
-                filledLen += (uint32_t)fread(config->sequence_buffer[processed_frame_count], 1, readSize, inputFile);
+                filledLen += (uint32_t)fread(config->sequence_buffer[processed_frame_count], 1, readSize, input_file);
             }
         }
     }

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -18,7 +18,6 @@
 #define INPUT_SIZE_1080p_TH                0x1AB3F0    // 1.75 Million
 #define INPUT_SIZE_4K_TH                0x29F630    // 2.75 Million
 
-#define SIZE_OF_ONE_FRAME_IN_BYTES(width, height,is16bit) ( ( ((width)*(height)*3)>>1 )<<is16bit)
 #define IS_16_BIT(bit_depth) (bit_depth==10?1:0)
 #define EB_OUTPUTSTREAMBUFFERSIZE_MACRO(ResolutionSize)                ((ResolutionSize) < (INPUT_SIZE_1080i_TH) ? 0x1E8480 : (ResolutionSize) < (INPUT_SIZE_1080p_TH) ? 0x2DC6C0 : (ResolutionSize) < (INPUT_SIZE_4K_TH) ? 0x2DC6C0 : 0x2DC6C0  )
 
@@ -205,6 +204,7 @@ EbErrorType CopyConfigurationParameters(
     callback_data->eb_enc_parameters.improve_sharpness = (uint8_t)config->improve_sharpness;
     callback_data->eb_enc_parameters.high_dynamic_range_input = config->high_dynamic_range_input;
     callback_data->eb_enc_parameters.encoder_bit_depth = config->encoder_bit_depth;
+    callbackData->ebEncParameters.encoder_color_format = config->encoder_color_format;
     callback_data->eb_enc_parameters.compressed_ten_bit_format = config->compressed_ten_bit_format;
     callback_data->eb_enc_parameters.profile = config->profile;
     callback_data->eb_enc_parameters.tier = config->tier;
@@ -238,6 +238,8 @@ static EbErrorType AllocateFrameBuffer(
 
     EbErrorType   return_error = EB_ErrorNone;
     const int32_t tenBitPackedMode = (config->encoder_bit_depth > 8) && (config->compressed_ten_bit_format == 0) ? 1 : 0;
+    const EbColorFormat color_format = config->encoder_color_format;    // Chroma subsampling
+    const uint8_t subsampling_x = (color_format == EB_YUV444 ? 1 : 2) - 1;
 
     // Determine size of each plane
     const size_t luma8bitSize =
@@ -247,15 +249,15 @@ static EbErrorType AllocateFrameBuffer(
 
         (1 << tenBitPackedMode);
 
-    const size_t chroma8bitSize = luma8bitSize >> 2;
+    const size_t chroma8bitSize = luma8bitSize >> (3 - color_format);
     const size_t luma10bitSize = (config->encoder_bit_depth > 8 && tenBitPackedMode == 0) ? luma8bitSize : 0;
     const size_t chroma10bitSize = (config->encoder_bit_depth > 8 && tenBitPackedMode == 0) ? chroma8bitSize : 0;
 
     // Determine
     EbSvtIOFormat* inputPtr = (EbSvtIOFormat*)p_buffer;
-    inputPtr->y_stride = config->input_padded_width;
-    inputPtr->cr_stride = config->input_padded_width >> 1;
-    inputPtr->cb_stride = config->input_padded_width >> 1;
+    inputPtr->yStride = config->input_padded_width;
+    inputPtr->crStride = config->input_padded_width >> subsampling_x;
+    inputPtr->cbStride = config->input_padded_width >> subsampling_x;
     if (luma8bitSize) {
         EB_APP_MALLOC(uint8_t*, inputPtr->luma, luma8bitSize, EB_N_PTR, EB_ErrorInsufficientResources);
     }
@@ -340,9 +342,9 @@ EbErrorType AllocateOutputReconBuffers(
         config->input_padded_width    *
         config->input_padded_height;
     // both u and v
-    const size_t chromaSize = lumaSize >> 1;
+    const size_t chromaSize = lumaSize >> (3 - config->encoder_color_format);
     const size_t tenBit = (config->encoder_bit_depth > 8);
-    const size_t frameSize = (lumaSize + chromaSize) << tenBit;
+    const size_t frameSize = (lumaSize + 2 * chromaSize) << tenBit;
 
 // ... Recon Port
     EB_APP_MALLOC(EbBufferHeaderType*, callback_data->recon_buffer, sizeof(EbBufferHeaderType), EB_N_PTR, EB_ErrorInsufficientResources);
@@ -388,21 +390,16 @@ EbErrorType PreloadFramesIntoRam(
     int32_t             input_padded_width = config->input_padded_width;
     int32_t             input_padded_height = config->input_padded_height;
     int32_t             readSize;
-    uint8_t  *ebInputPtr;
+    const EbColorFormat color_format = config->encoder_color_format;    // Chroma subsampling
 
     FILE *input_file = config->input_file;
 
-    if (config->encoder_bit_depth == 10 && config->compressed_ten_bit_format == 1)
-    {
-
-        readSize = (input_padded_width*input_padded_height * 3) / 2 + (input_padded_width / 4 * input_padded_height * 3) / 2;
-
-    }
-    else
-    {
-
-        readSize = input_padded_width * input_padded_height * 3 * (config->encoder_bit_depth > 8 ? 2 : 1) / 2;
-
+    readSize = inputPaddedWidth * inputPaddedHeight; //Luma
+    readSize += 2 * (readSize >> (3 - color_format)); // Add Chroma
+    if (config->encoder_bit_depth == 10 && config->compressedTenBitFormat == 1) {
+        readSize += readSize / 4;
+    } else {
+        readSize *= (config->encoder_bit_depth > 8 ? 2 : 1); //10 bit
     }
     EB_APP_MALLOC(uint8_t **, config->sequence_buffer, sizeof(uint8_t*) * config->buffered_input, EB_N_PTR, EB_ErrorInsufficientResources);
 
@@ -535,22 +532,17 @@ EbErrorType PreloadFramesIntoRam(
                     fseek(input_file, -(long)(readSize << 1), SEEK_CUR);
                 }
             }
-        }
-        else {
-
+        } else {
             // Fill the buffer with a complete frame
             filledLen = 0;
-            ebInputPtr = config->sequence_buffer[processed_frame_count];
-            filledLen += (uint32_t)fread(ebInputPtr, 1, readSize, input_file);
+            filledLen += (uint32_t)fread(config->sequence_buffer[processed_frame_count], 1, readSize, inputFile);
 
             if (readSize != filledLen) {
-
                 fseek(config->input_file, 0, SEEK_SET);
 
                 // Fill the buffer with a complete frame
                 filledLen = 0;
-                ebInputPtr = config->sequence_buffer[processed_frame_count];
-                filledLen += (uint32_t)fread(ebInputPtr, 1, readSize, input_file);
+                filledLen += (uint32_t)fread(config->sequence_buffer[processed_frame_count], 1, readSize, inputFile);
             }
         }
     }

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -765,7 +765,7 @@ void ReadInputFrames(
     uint64_t  readSize;
     const uint32_t  input_padded_width = config->input_padded_width;
     const uint32_t  input_padded_height = config->input_padded_height;
-    FILE   *inputFile = config->inputFile;
+    FILE   *input_file = config->input_file;
     uint8_t  *ebInputPtr;
     EbSvtIOFormat* inputPtr = (EbSvtIOFormat*)headerPtr->p_buffer;
 
@@ -776,7 +776,7 @@ void ReadInputFrames(
     inputPtr->cr_stride = input_padded_width >> subsampling_x;
     inputPtr->cb_stride = input_padded_width >> subsampling_x;
 
-    if (config->bufferedInput == -1) {
+    if (config->buffered_input == -1) {
         if (is16bit == 0 || (is16bit == 1 && config->compressed_ten_bit_format == 0)) {
             readSize = (uint64_t)SIZE_OF_ONE_FRAME_IN_BYTES(input_padded_width, input_padded_height, color_format, is16bit);
 
@@ -831,16 +831,16 @@ void ReadInputFrames(
                     ebInputPtr += YUV4MPEG2_IND_SIZE;
                     headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize-YUV4MPEG2_IND_SIZE, input_file);
                 }else {
-                    headerPtr->n_filled_len += (uint32_t)fread(inputPtr->luma, 1, lumaReadSize, inputFile);
+                    headerPtr->n_filled_len += (uint32_t)fread(inputPtr->luma, 1, lumaReadSize, input_file);
                 }
-                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb, 1, lumaReadSize >> (3 - color_format), inputFile);
-                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr, 1, lumaReadSize >> (3 - color_format), inputFile);
+                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb, 1, lumaReadSize >> (3 - color_format), input_file);
+                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr, 1, lumaReadSize >> (3 - color_format), input_file);
 
                 if (readSize != headerPtr->n_filled_len) {
-                    fseek(inputFile, 0, SEEK_SET);
-                    headerPtr->n_filled_len = (uint32_t)fread(inputPtr->luma, 1, lumaReadSize, inputFile);
-                    headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb, 1, lumaReadSize >> (3 - color_format), inputFile);
-                    headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr, 1, lumaReadSize >> (3 - color_format), inputFile);
+                    fseek(input_file, 0, SEEK_SET);
+                    headerPtr->n_filled_len = (uint32_t)fread(inputPtr->luma, 1, lumaReadSize, input_file);
+                    headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb, 1, lumaReadSize >> (3 - color_format), input_file);
+                    headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr, 1, lumaReadSize >> (3 - color_format), input_file);
                 }
             }
         } else if (is16bit == 1 && config->compressed_ten_bit_format == 1) {
@@ -853,24 +853,24 @@ void ReadInputFrames(
             // Fill the buffer with a complete frame
             headerPtr->n_filled_len = 0;
 
-            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->luma, 1, lumaReadSize, inputFile);
-            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb, 1, chromaReadSize, inputFile);
-            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr, 1, chromaReadSize, inputFile);
+            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->luma, 1, lumaReadSize, input_file);
+            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb, 1, chromaReadSize, input_file);
+            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr, 1, chromaReadSize, input_file);
 
-            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->luma_ext, 1, nbitLumaReadSize, inputFile);
-            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb_ext, 1, nbitChromaReadSize, inputFile);
-            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr_ext, 1, nbitChromaReadSize, inputFile);
+            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->luma_ext, 1, nbitLumaReadSize, input_file);
+            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb_ext, 1, nbitChromaReadSize, input_file);
+            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr_ext, 1, nbitChromaReadSize, input_file);
 
             readSize = lumaReadSize + nbitLumaReadSize + 2 * (chromaReadSize + nbitChromaReadSize);
 
             if (readSize != headerPtr->n_filled_len) {
-                fseek(inputFile, 0, SEEK_SET);
-                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->luma, 1, lumaReadSize, inputFile);
-                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb, 1, chromaReadSize, inputFile);
-                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr, 1, chromaReadSize, inputFile);
-                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->luma_ext, 1, nbitLumaReadSize, inputFile);
-                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb_ext, 1, nbitChromaReadSize, inputFile);
-                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr_ext, 1, nbitChromaReadSize, inputFile);
+                fseek(input_file, 0, SEEK_SET);
+                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->luma, 1, lumaReadSize, input_file);
+                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb, 1, chromaReadSize, input_file);
+                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr, 1, chromaReadSize, input_file);
+                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->luma_ext, 1, nbitLumaReadSize, input_file);
+                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb_ext, 1, nbitChromaReadSize, input_file);
+                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr_ext, 1, nbitChromaReadSize, input_file);
             }
         }
     } else {
@@ -890,9 +890,9 @@ void ReadInputFrames(
             inputPtr->cb = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + luma8bitSize;
             inputPtr->cr = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + luma8bitSize + chroma8bitSize;
 
-            inputPtr->luma_ext = config->sequenceBuffer[config->processedFrameCount % config->bufferedInput] + luma8bitSize + 2 * chroma8bitSize;
-            inputPtr->cb_ext = config->sequenceBuffer[config->processedFrameCount % config->bufferedInput] + luma8bitSize + 2 * chroma8bitSize + luma2bitSize;
-            inputPtr->cr_ext = config->sequenceBuffer[config->processedFrameCount % config->bufferedInput] + luma8bitSize + 2 * chroma8bitSize + luma2bitSize + chroma2bitSize;
+            inputPtr->luma_ext = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + luma8bitSize + 2 * chroma8bitSize;
+            inputPtr->cb_ext = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + luma8bitSize + 2 * chroma8bitSize + luma2bitSize;
+            inputPtr->cr_ext = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + luma8bitSize + 2 * chroma8bitSize + luma2bitSize + chroma2bitSize;
 
             headerPtr->n_filled_len = luma8bitSize + luma2bitSize + 2 * (chroma8bitSize + chroma2bitSize);
         } else {
@@ -906,9 +906,9 @@ void ReadInputFrames(
             inputPtr->cr_stride = input_padded_width >> subsampling_x;
             inputPtr->cb_stride = input_padded_width >> subsampling_x;
 
-            inputPtr->luma = config->sequenceBuffer[config->processedFrameCount % config->bufferedInput];
-            inputPtr->cb = config->sequenceBuffer[config->processedFrameCount % config->bufferedInput] + lumaSize;
-            inputPtr->cr = config->sequenceBuffer[config->processedFrameCount % config->bufferedInput] + lumaSize+ chromaSize;
+            inputPtr->luma = config->sequence_buffer[config->processed_frame_count % config->buffered_input];
+            inputPtr->cb = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + lumaSize;
+            inputPtr->cr = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + lumaSize+ chromaSize;
 
             headerPtr->n_filled_len = lumaSize + 2 * chromaSize;
         }

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -25,7 +25,8 @@
  ***************************************/
 #define CLIP3(min_val, max_val, a)        (((a)<(min_val)) ? (min_val) : (((a)>(max_val)) ? (max_val) :(a)))
 #define FUTURE_WINDOW_WIDTH                 4
-#define SIZE_OF_ONE_FRAME_IN_BYTES(width, height,is16bit) ( ( ((width)*(height)*3)>>1 )<<is16bit)
+#define SIZE_OF_ONE_FRAME_IN_BYTES(width, height, csp, is16bit) \
+    ( (((width)*(height)) + 2*(((width)*(height))>>(3-csp)))<<is16bit)
 #define YUV4MPEG2_IND_SIZE 9
 extern volatile int32_t keepRunning;
 
@@ -628,11 +629,13 @@ void ProcessInputFieldStandardMode(
     uint8_t                    *crInputPtr,
     uint8_t                   is16bit) {
 
-
-    int64_t  input_padded_width  = config->input_padded_width;
-    int64_t  input_padded_height = config->input_padded_height;
-    uint64_t  sourceLumaRowSize = (uint64_t)(input_padded_width << is16bit);
-    uint64_t  sourceChromaRowSize = sourceLumaRowSize >> 1;
+    const int64_t input_padded_width  = config->input_padded_width;
+    const int64_t input_padded_height = config->input_padded_height;
+    const uint8_t color_format = config->encoder_color_format;
+    const uint8_t subsampling_x = (color_format == EB_YUV444 ? 1 : 2) - 1;
+    const uint8_t subsampling_y = (color_format >= EB_YUV422 ? 1 : 2) - 1;
+    const uint64_t source_luma_row_size = (uint64_t)(input_padded_width << is16bit);
+    const uint64_t source_chroma_row_size = source_luma_row_size >> subsampling_x;
     uint8_t  *ebInputPtr;
     uint32_t  inputRowIndex;
 
@@ -640,30 +643,29 @@ void ProcessInputFieldStandardMode(
     ebInputPtr = lumaInputPtr;
     // Skip 1 luma row if bottom field (point to the bottom field)
     if (config->processed_frame_count % 2 != 0)
-        fseeko64(input_file, (long)sourceLumaRowSize, SEEK_CUR);
+        fseeko64(input_file, (long)source_luma_row_size, SEEK_CUR);
 
     for (inputRowIndex = 0; inputRowIndex < input_padded_height; inputRowIndex++) {
 
-        headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, sourceLumaRowSize, input_file);
+        headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, source_luma_row_size, input_file);
         // Skip 1 luma row (only fields)
-        fseeko64(input_file, (long)sourceLumaRowSize, SEEK_CUR);
-        ebInputPtr += sourceLumaRowSize;
+        fseeko64(input_file, (long)source_luma_row_size, SEEK_CUR);
+        ebInputPtr += source_luma_row_size;
     }
 
     // U
     ebInputPtr = cbInputPtr;
     // Step back 1 luma row if bottom field (undo the previous jump), and skip 1 chroma row if bottom field (point to the bottom field)
     if (config->processed_frame_count % 2 != 0) {
-        fseeko64(input_file, -(long)sourceLumaRowSize, SEEK_CUR);
-        fseeko64(input_file, (long)sourceChromaRowSize, SEEK_CUR);
+        fseeko64(input_file, -(long)source_luma_row_size, SEEK_CUR);
+        fseeko64(input_file, (long)source_chroma_row_size, SEEK_CUR);
     }
 
-    for (inputRowIndex = 0; inputRowIndex < input_padded_height >> 1; inputRowIndex++) {
-
-        headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, sourceChromaRowSize, input_file);
+    for (inputRowIndex = 0; inputRowIndex < input_padded_height >> subsampling_y; inputRowIndex++) {
+        headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, source_chroma_row_size, input_file);
         // Skip 1 chroma row (only fields)
-        fseeko64(input_file, (long)sourceChromaRowSize, SEEK_CUR);
-        ebInputPtr += sourceChromaRowSize;
+        fseeko64(input_file, (long)source_chroma_row_size, SEEK_CUR);
+        ebInputPtr += source_chroma_row_size;
     }
 
     // V
@@ -672,17 +674,16 @@ void ProcessInputFieldStandardMode(
     // => no action
 
 
-    for (inputRowIndex = 0; inputRowIndex < input_padded_height >> 1; inputRowIndex++) {
-
-        headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, sourceChromaRowSize, input_file);
+    for (inputRowIndex = 0; inputRowIndex < input_padded_height >> subsampling_y; inputRowIndex++) {
+        headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, source_chroma_row_size, input_file);
         // Skip 1 chroma row (only fields)
-        fseeko64(input_file, (long)sourceChromaRowSize, SEEK_CUR);
-        ebInputPtr += sourceChromaRowSize;
+        fseeko64(input_file, (long)source_chroma_row_size, SEEK_CUR);
+        ebInputPtr += source_chroma_row_size;
     }
 
     // Step back 1 chroma row if bottom field (undo the previous jump)
     if (config->processed_frame_count % 2 != 0) {
-        fseeko64(input_file, -(long)sourceChromaRowSize, SEEK_CUR);
+        fseeko64(input_file, -(long)source_chroma_row_size, SEEK_CUR);
     }
 }
 
@@ -758,25 +759,26 @@ int32_t GetNextQpFromQpFile(
 void ReadInputFrames(
     EbConfig                  *config,
     uint8_t                      is16bit,
-    EbBufferHeaderType         *headerPtr){
+    EbBufferHeaderType         *headerPtr)
+{
 
     uint64_t  readSize;
-    uint32_t  input_padded_width = config->input_padded_width;
-    uint32_t  input_padded_height = config->input_padded_height;
-    FILE   *input_file = config->input_file;
+    const uint32_t  input_padded_width = config->input_padded_width;
+    const uint32_t  input_padded_height = config->input_padded_height;
+    FILE   *inputFile = config->inputFile;
     uint8_t  *ebInputPtr;
     EbSvtIOFormat* inputPtr = (EbSvtIOFormat*)headerPtr->p_buffer;
 
-    uint64_t frameSize = (uint64_t)((input_padded_width*input_padded_height * 3) / 2 + (input_padded_width / 4 * input_padded_height * 3) / 2);
+    const uint8_t color_format = config->encoder_color_format;
+    const uint8_t subsampling_x = (color_format == EB_YUV444 ? 1 : 2) - 1;
+
     inputPtr->y_stride  = input_padded_width;
-    inputPtr->cr_stride = input_padded_width >> 1;
-    inputPtr->cb_stride = input_padded_width >> 1;
+    inputPtr->cr_stride = input_padded_width >> subsampling_x;
+    inputPtr->cb_stride = input_padded_width >> subsampling_x;
 
-    if (config->buffered_input == -1) {
-
+    if (config->bufferedInput == -1) {
         if (is16bit == 0 || (is16bit == 1 && config->compressed_ten_bit_format == 0)) {
-
-            readSize = (uint64_t)SIZE_OF_ONE_FRAME_IN_BYTES(input_padded_width, input_padded_height, is16bit);
+            readSize = (uint64_t)SIZE_OF_ONE_FRAME_IN_BYTES(input_padded_width, input_padded_height, color_format, is16bit);
 
             headerPtr->n_filled_len = 0;
 
@@ -829,300 +831,87 @@ void ReadInputFrames(
                     ebInputPtr += YUV4MPEG2_IND_SIZE;
                     headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize-YUV4MPEG2_IND_SIZE, input_file);
                 }else {
-                    headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize, input_file);
+                    headerPtr->n_filled_len += (uint32_t)fread(inputPtr->luma, 1, lumaReadSize, inputFile);
                 }
-                ebInputPtr = inputPtr->cb;
-                headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, input_file);
-                ebInputPtr = inputPtr->cr;
-                headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, input_file);
-
-                inputPtr->luma = inputPtr->luma + ((config->input_padded_width*TOP_INPUT_PADDING + LEFT_INPUT_PADDING) << is16bit);
-                inputPtr->cb   = inputPtr->cb + (((config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)) << is16bit);
-                inputPtr->cr   = inputPtr->cr + (((config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)) << is16bit);
-
+                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb, 1, lumaReadSize >> (3 - color_format), inputFile);
+                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr, 1, lumaReadSize >> (3 - color_format), inputFile);
 
                 if (readSize != headerPtr->n_filled_len) {
-
-                    fseek(input_file, 0, SEEK_SET);
-                    ebInputPtr = inputPtr->luma;
-                    headerPtr->n_filled_len = (uint32_t)fread(ebInputPtr, 1, lumaReadSize, input_file);
-                    ebInputPtr = inputPtr->cb;
-                    headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, input_file);
-                    ebInputPtr = inputPtr->cr;
-                    headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, input_file);
-
-                    inputPtr->luma = inputPtr->luma + ((config->input_padded_width*TOP_INPUT_PADDING + LEFT_INPUT_PADDING));
-                    inputPtr->cb = inputPtr->cb + (((config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)));
-                    inputPtr->cr = inputPtr->cr + (((config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)));
-
+                    fseek(inputFile, 0, SEEK_SET);
+                    headerPtr->n_filled_len = (uint32_t)fread(inputPtr->luma, 1, lumaReadSize, inputFile);
+                    headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb, 1, lumaReadSize >> (3 - color_format), inputFile);
+                    headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr, 1, lumaReadSize >> (3 - color_format), inputFile);
                 }
             }
-        }
-        // 10-bit Compressed Unpacked Mode
-        else if (is16bit == 1 && config->compressed_ten_bit_format == 1) {
+        } else if (is16bit == 1 && config->compressed_ten_bit_format == 1) {
+            // 10-bit Compressed Unpacked Mode
+            const uint32_t lumaReadSize = input_padded_width * input_padded_height;
+            const uint32_t chromaReadSize = lumaReadSize >> (3 - color_format);
+            const uint32_t nbitLumaReadSize = (input_padded_width / 4) * input_padded_height;
+            const uint32_t nbitChromaReadSize = nbitLumaReadSize >> (3 - color_format);
 
             // Fill the buffer with a complete frame
             headerPtr->n_filled_len = 0;
 
+            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->luma, 1, lumaReadSize, inputFile);
+            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb, 1, chromaReadSize, inputFile);
+            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr, 1, chromaReadSize, inputFile);
 
-            uint64_t lumaReadSize = (uint64_t)input_padded_width*input_padded_height;
-            uint64_t nbitlumaReadSize = (uint64_t)(input_padded_width / 4)*input_padded_height;
+            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->luma_ext, 1, nbitLumaReadSize, inputFile);
+            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb_ext, 1, nbitChromaReadSize, inputFile);
+            headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr_ext, 1, nbitChromaReadSize, inputFile);
 
-            ebInputPtr = inputPtr->luma;
-            headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize, input_file);
-            ebInputPtr = inputPtr->cb;
-            headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, input_file);
-            ebInputPtr = inputPtr->cr;
-            headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, input_file);
-
-            inputPtr->luma = inputPtr->luma + config->input_padded_width*TOP_INPUT_PADDING + LEFT_INPUT_PADDING;
-            inputPtr->cb = inputPtr->cb + (config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1);
-            inputPtr->cr = inputPtr->cr + (config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1);
-
-
-            ebInputPtr = inputPtr->luma_ext;
-            headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, nbitlumaReadSize, input_file);
-            ebInputPtr = inputPtr->cb_ext;
-            headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, nbitlumaReadSize >> 2, input_file);
-            ebInputPtr = inputPtr->cr_ext;
-            headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, nbitlumaReadSize >> 2, input_file);
-
-            inputPtr->luma_ext = inputPtr->luma_ext + ((config->input_padded_width >> 2)*TOP_INPUT_PADDING + (LEFT_INPUT_PADDING >> 2));
-            inputPtr->cb_ext = inputPtr->cb_ext + (((config->input_padded_width >> 1) >> 2)*(TOP_INPUT_PADDING >> 1) + ((LEFT_INPUT_PADDING >> 1) >> 2));
-            inputPtr->cr_ext = inputPtr->cr_ext + (((config->input_padded_width >> 1) >> 2)*(TOP_INPUT_PADDING >> 1) + ((LEFT_INPUT_PADDING >> 1) >> 2));
-
-            readSize = ((lumaReadSize * 3) >> 1) + ((nbitlumaReadSize * 3) >> 1);
+            readSize = lumaReadSize + nbitLumaReadSize + 2 * (chromaReadSize + nbitChromaReadSize);
 
             if (readSize != headerPtr->n_filled_len) {
-
-                fseek(input_file, 0, SEEK_SET);
-                ebInputPtr = inputPtr->luma;
-                headerPtr->n_filled_len = (uint32_t)fread(ebInputPtr, 1, lumaReadSize, input_file);
-                ebInputPtr = inputPtr->cb;
-                headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, input_file);
-                ebInputPtr = inputPtr->cr;
-                headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, input_file);
-
-                inputPtr->luma = inputPtr->luma + config->input_padded_width*TOP_INPUT_PADDING + LEFT_INPUT_PADDING;
-                inputPtr->cb = inputPtr->cb + (config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1);
-                inputPtr->cr = inputPtr->cr + (config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1);
-
-                ebInputPtr = inputPtr->luma_ext;
-                headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, nbitlumaReadSize, input_file);
-                ebInputPtr = inputPtr->cb_ext;
-                headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, nbitlumaReadSize >> 2, input_file);
-                ebInputPtr = inputPtr->cr_ext;
-                headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, nbitlumaReadSize >> 2, input_file);
-
-                inputPtr->luma_ext = inputPtr->luma_ext + ((config->input_padded_width >> 2)*TOP_INPUT_PADDING + (LEFT_INPUT_PADDING >> 2));
-                inputPtr->cb_ext = inputPtr->cb_ext + (((config->input_padded_width >> 1) >> 2)*(TOP_INPUT_PADDING >> 1) + ((LEFT_INPUT_PADDING >> 1) >> 2));
-                inputPtr->cr_ext = inputPtr->cr_ext + (((config->input_padded_width >> 1) >> 2)*(TOP_INPUT_PADDING >> 1) + ((LEFT_INPUT_PADDING >> 1) >> 2));
-
+                fseek(inputFile, 0, SEEK_SET);
+                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->luma, 1, lumaReadSize, inputFile);
+                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb, 1, chromaReadSize, inputFile);
+                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr, 1, chromaReadSize, inputFile);
+                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->luma_ext, 1, nbitLumaReadSize, inputFile);
+                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cb_ext, 1, nbitChromaReadSize, inputFile);
+                headerPtr->n_filled_len += (uint32_t)fread(inputPtr->cr_ext, 1, nbitChromaReadSize, inputFile);
             }
-
         }
-
-        // 10-bit Unpacked Mode
-        else {
-
-            readSize = (uint64_t)SIZE_OF_ONE_FRAME_IN_BYTES(input_padded_width, input_padded_height, 1);
-
-            headerPtr->n_filled_len = 0;
-
-            // Interlaced Video
-            if (config->separate_fields) {
-
-                ProcessInputFieldStandardMode(
-                    config,
-                    headerPtr,
-                    input_file,
-                    inputPtr->luma,
-                    inputPtr->cb,
-                    inputPtr->cr,
-                    0);
-
-                ProcessInputFieldStandardMode(
-                    config,
-                    headerPtr,
-                    input_file,
-                    inputPtr->luma_ext,
-                    inputPtr->cb_ext,
-                    inputPtr->cr_ext,
-                    0);
-
-                if (readSize != headerPtr->n_filled_len) {
-
-                    fseek(input_file, 0, SEEK_SET);
-                    headerPtr->n_filled_len = 0;
-
-                    ProcessInputFieldStandardMode(
-                        config,
-                        headerPtr,
-                        input_file,
-                        inputPtr->luma,
-                        inputPtr->cb,
-                        inputPtr->cr,
-                        0);
-
-                    ProcessInputFieldStandardMode(
-                        config,
-                        headerPtr,
-                        input_file,
-                        inputPtr->luma_ext,
-                        inputPtr->cb_ext,
-                        inputPtr->cr_ext,
-                        0);
-                }
-
-                // Reset the pointer position after a top field
-                if (config->processed_frame_count % 2 == 0) {
-                    fseek(input_file, -(long)(readSize << 1), SEEK_CUR);
-                }
-
-            }
-            else {
-
-
-                uint64_t lumaReadSize = (uint64_t)input_padded_width*input_padded_height;
-
-                ebInputPtr = inputPtr->luma;
-                headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize, input_file);
-                ebInputPtr = inputPtr->cb;
-                headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, input_file);
-                ebInputPtr = inputPtr->cr;
-                headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, input_file);
-
-                inputPtr->luma = inputPtr->luma + ((config->input_padded_width*TOP_INPUT_PADDING + LEFT_INPUT_PADDING));
-                inputPtr->cb = inputPtr->cb + (((config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)));
-                inputPtr->cr = inputPtr->cr + (((config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)));
-
-                ebInputPtr = inputPtr->luma_ext;
-                headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize, input_file);
-                ebInputPtr = inputPtr->cb_ext;
-                headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, input_file);
-                ebInputPtr = inputPtr->cr_ext;
-                headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, input_file);
-
-                inputPtr->luma_ext = inputPtr->luma_ext + ((config->input_padded_width*TOP_INPUT_PADDING + LEFT_INPUT_PADDING));
-                inputPtr->cb_ext = inputPtr->cb_ext + (((config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)));
-                inputPtr->cr_ext = inputPtr->cr_ext + (((config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)));
-
-                if (readSize != headerPtr->n_filled_len) {
-
-                    fseek(input_file, 0, SEEK_SET);
-                    ebInputPtr = inputPtr->luma;
-                    headerPtr->n_filled_len = (uint32_t)fread(ebInputPtr, 1, lumaReadSize, input_file);
-                    ebInputPtr = inputPtr->cb;
-                    headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, input_file);
-                    ebInputPtr = inputPtr->cr;
-                    headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, input_file);
-
-                    inputPtr->luma = inputPtr->luma + ((config->input_padded_width*TOP_INPUT_PADDING + LEFT_INPUT_PADDING));
-                    inputPtr->cb = inputPtr->cb + (((config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)));
-                    inputPtr->cr = inputPtr->cr + (((config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)));
-
-                    ebInputPtr = inputPtr->luma_ext;
-                    headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize, input_file);
-                    ebInputPtr = inputPtr->cb_ext;
-                    headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, input_file);
-                    ebInputPtr = inputPtr->cr_ext;
-                    headerPtr->n_filled_len += (uint32_t)fread(ebInputPtr, 1, lumaReadSize >> 2, input_file);
-
-                    inputPtr->luma_ext = inputPtr->luma_ext + ((config->input_padded_width*TOP_INPUT_PADDING + LEFT_INPUT_PADDING));
-                    inputPtr->cb_ext = inputPtr->cb_ext + (((config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)));
-                    inputPtr->cr_ext = inputPtr->cr_ext + (((config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)));
-
-                }
-
-            }
-
-
-
-
-        }
-
-    }
-    else {
-        if (config->encoder_bit_depth == 10 && config->compressed_ten_bit_format == 1)
-        {
+    } else {
+        if (is16bit && config->compressed_ten_bit_format == 1) {
             // Determine size of each plane
-
-            const size_t luma8bitSize = config->input_padded_width * config->input_padded_height;
-            const size_t chroma8bitSize = luma8bitSize >> 2;
-
+            const size_t luma8bitSize = input_padded_width * input_padded_height;
+            const size_t chroma8bitSize = luma8bitSize >> (3 - color_format);
             const size_t luma2bitSize = luma8bitSize / 4; //4-2bit pixels into 1 byte
-            const size_t chroma2bitSize = luma2bitSize >> 2;
+            const size_t chroma2bitSize = luma2bitSize >> (3 - color_format);
 
             EbSvtIOFormat* inputPtr = (EbSvtIOFormat*)headerPtr->p_buffer;
-            inputPtr->y_stride = config->input_padded_width;
-            inputPtr->cr_stride = config->input_padded_width >> 1;
-            inputPtr->cb_stride = config->input_padded_width >> 1;
+            inputPtr->y_stride = input_padded_width;
+            inputPtr->cr_stride = input_padded_width >> subsampling_x;
+            inputPtr->cb_stride = input_padded_width >> subsampling_x;
 
             inputPtr->luma = config->sequence_buffer[config->processed_frame_count % config->buffered_input];
             inputPtr->cb = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + luma8bitSize;
             inputPtr->cr = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + luma8bitSize + chroma8bitSize;
 
-            inputPtr->luma = inputPtr->luma + ((config->input_padded_width*TOP_INPUT_PADDING + LEFT_INPUT_PADDING));
-            inputPtr->cb = inputPtr->cb + (((config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)));
-            inputPtr->cr = inputPtr->cr + (((config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)));
+            inputPtr->luma_ext = config->sequenceBuffer[config->processedFrameCount % config->bufferedInput] + luma8bitSize + 2 * chroma8bitSize;
+            inputPtr->cb_ext = config->sequenceBuffer[config->processedFrameCount % config->bufferedInput] + luma8bitSize + 2 * chroma8bitSize + luma2bitSize;
+            inputPtr->cr_ext = config->sequenceBuffer[config->processedFrameCount % config->bufferedInput] + luma8bitSize + 2 * chroma8bitSize + luma2bitSize + chroma2bitSize;
 
-            if (is16bit) {
-                inputPtr->luma_ext = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + luma8bitSize + 2 * chroma8bitSize;
-                inputPtr->cb_ext = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + luma8bitSize + 2 * chroma8bitSize + luma2bitSize;
-                inputPtr->cr_ext = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + luma8bitSize + 2 * chroma8bitSize + luma2bitSize + chroma2bitSize;
-
-                inputPtr->luma_ext = inputPtr->luma_ext + config->input_padded_width*TOP_INPUT_PADDING + LEFT_INPUT_PADDING;
-                inputPtr->cb_ext = inputPtr->cb_ext + (config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1);
-                inputPtr->cr_ext = inputPtr->cr_ext + (config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1);
-
-            }
-
-            headerPtr->n_filled_len = (uint32_t)frameSize;
-        }
-        else
-        {
-            const int32_t tenBitPackedMode = (config->encoder_bit_depth > 8) && (config->compressed_ten_bit_format == 0) ? 1 : 0;
-
-            // Determine size of each plane
-            const size_t luma8bitSize =
-                (config->input_padded_width) *
-                (config->input_padded_height) *
-                (1 << tenBitPackedMode);
-
-            const size_t chroma8bitSize = luma8bitSize >> 2;
-
-            const size_t luma10bitSize = (config->encoder_bit_depth > 8 && tenBitPackedMode == 0) ? luma8bitSize : 0;
-            const size_t chroma10bitSize = (config->encoder_bit_depth > 8 && tenBitPackedMode == 0) ? chroma8bitSize : 0;
+            headerPtr->n_filled_len = luma8bitSize + luma2bitSize + 2 * (chroma8bitSize + chroma2bitSize);
+        } else {
+            //Normal unpacked mode:yuv420p10le yuv422p10le yuv444p10le
+            const size_t lumaSize = (input_padded_width * input_padded_height) << is16bit;
+            const size_t chromaSize = lumaSize >> (3 - color_format);
 
             EbSvtIOFormat* inputPtr = (EbSvtIOFormat*)headerPtr->p_buffer;
 
-            inputPtr->y_stride = config->input_padded_width;
-            inputPtr->cr_stride = config->input_padded_width >> 1;
-            inputPtr->cb_stride = config->input_padded_width >> 1;
+            inputPtr->y_stride = input_padded_width;
+            inputPtr->cr_stride = input_padded_width >> subsampling_x;
+            inputPtr->cb_stride = input_padded_width >> subsampling_x;
 
-            inputPtr->luma = config->sequence_buffer[config->processed_frame_count % config->buffered_input];
-            inputPtr->cb = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + luma8bitSize;
-            inputPtr->cr = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + luma8bitSize + chroma8bitSize;
-            inputPtr->luma = inputPtr->luma + ((config->input_padded_width*TOP_INPUT_PADDING + LEFT_INPUT_PADDING) << tenBitPackedMode);
-            inputPtr->cb = inputPtr->cb + (((config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)) << tenBitPackedMode);
-            inputPtr->cr = inputPtr->cr + (((config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1)) << tenBitPackedMode);
+            inputPtr->luma = config->sequenceBuffer[config->processedFrameCount % config->bufferedInput];
+            inputPtr->cb = config->sequenceBuffer[config->processedFrameCount % config->bufferedInput] + lumaSize;
+            inputPtr->cr = config->sequenceBuffer[config->processedFrameCount % config->bufferedInput] + lumaSize+ chromaSize;
 
-
-            if (is16bit) {
-                inputPtr->luma_ext = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + luma8bitSize + 2 * chroma8bitSize;
-                inputPtr->cb_ext = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + luma8bitSize + 2 * chroma8bitSize + luma10bitSize;
-                inputPtr->cr_ext = config->sequence_buffer[config->processed_frame_count % config->buffered_input] + luma8bitSize + 2 * chroma8bitSize + luma10bitSize + chroma10bitSize;
-                inputPtr->luma_ext = inputPtr->luma_ext + config->input_padded_width*TOP_INPUT_PADDING + LEFT_INPUT_PADDING;
-                inputPtr->cb_ext = inputPtr->cb_ext + (config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1);
-                inputPtr->cr_ext = inputPtr->cr_ext + (config->input_padded_width >> 1)*(TOP_INPUT_PADDING >> 1) + (LEFT_INPUT_PADDING >> 1);
-
-            }
-
-            headerPtr->n_filled_len = (uint32_t)(uint64_t)SIZE_OF_ONE_FRAME_IN_BYTES(input_padded_width, input_padded_height, is16bit);
-
+            headerPtr->n_filled_len = lumaSize + 2 * chromaSize;
         }
-
-
     }
 
     // If we reached the end of file, loop over again
@@ -1186,12 +975,14 @@ AppExitConditionType ProcessInputBuffer(
 
     AppExitConditionType    return_value = APP_ExitConditionNone;
 
-    int64_t                  input_padded_width           = config->input_padded_width;
-    int64_t                  input_padded_height          = config->input_padded_height;
-    int64_t                  frames_to_be_encoded          = config->frames_to_be_encoded;
-    uint64_t                 frameSize                  = (uint64_t)((input_padded_width*input_padded_height * 3) / 2 + (input_padded_width / 4 * input_padded_height * 3) / 2);
-    int64_t                  totalBytesToProcessCount;
-    int64_t                  remainingByteCount;
+    const uint8_t color_format = config->encoder_color_format;
+    const int64_t input_padded_width = config->input_padded_width;
+    const int64_t input_padded_height = config->input_padded_height;
+    const int64_t frames_to_be_encoded = config->frames_to_be_encoded;
+    int64_t totalBytesToProcessCount;
+    int64_t remainingByteCount;
+    uint32_t compressed10bitFrameSize = (input_padded_width*input_padded_height) + 2 * ((input_padded_width*input_padded_width) >> (3 - color_format));
+    compressed10bitFrameSize += compressed10bitFrameSize / 4;
 
     if (config->injector && config->processed_frame_count)
     {
@@ -1199,9 +990,8 @@ AppExitConditionType ProcessInputBuffer(
     }
 
     totalBytesToProcessCount = (frames_to_be_encoded < 0) ? -1 : (config->encoder_bit_depth == 10 && config->compressed_ten_bit_format == 1) ?
-            frames_to_be_encoded * (int64_t)frameSize :
-            frames_to_be_encoded * SIZE_OF_ONE_FRAME_IN_BYTES(input_padded_width, input_padded_height, is16bit);
-
+        frames_to_be_encoded * (int64_t)compressed10bitFrameSize:
+        frames_to_be_encoded * SIZE_OF_ONE_FRAME_IN_BYTES(input_padded_width, input_padded_height, color_format, is16bit);
 
     remainingByteCount       = (totalBytesToProcessCount < 0) ?   -1 :  totalBytesToProcessCount - (int64_t)config->processed_byte_count;
 

--- a/Source/Lib/Common/Codec/EbCodingUnit.c
+++ b/Source/Lib/Common/Codec/EbCodingUnit.c
@@ -8,6 +8,7 @@
 #include "EbCodingUnit.h"
 #include "EbUtility.h"
 #include "EbTransformUnit.h"
+#include "EbPictureControlSet.h"
 
 /*
 Tasks & Questions
@@ -72,6 +73,7 @@ EbErrorType largest_coding_unit_ctor(
     coeffInitData.maxWidth = SB_STRIDE_Y;
     coeffInitData.maxHeight = SB_STRIDE_Y;
     coeffInitData.bit_depth = EB_32BIT;
+    coeffInitData.color_format = picture_control_set->color_format;
     coeffInitData.left_padding = 0;
     coeffInitData.right_padding = 0;
     coeffInitData.top_padding = 0;

--- a/Source/Lib/Common/Codec/EbDlfProcess.c
+++ b/Source/Lib/Common/Codec/EbDlfProcess.c
@@ -34,6 +34,7 @@ EbErrorType dlf_context_ctor(
     EbFifo                *dlf_input_fifo_ptr,
     EbFifo                *dlf_output_fifo_ptr ,
     EbBool                  is16bit,
+    EbColorFormat           color_format,
     uint32_t                max_input_luma_width,
     uint32_t                max_input_luma_height
    )
@@ -62,6 +63,7 @@ EbErrorType dlf_context_ctor(
     temp_lf_recon_desc_init_data.bot_padding = PAD_VALUE;
 
     temp_lf_recon_desc_init_data.splitMode = EB_FALSE;
+    temp_lf_recon_desc_init_data.color_format = color_format;
 
     if (is16bit) {
         temp_lf_recon_desc_init_data.bit_depth = EB_16BIT;

--- a/Source/Lib/Common/Codec/EbDlfProcess.h
+++ b/Source/Lib/Common/Codec/EbDlfProcess.h
@@ -38,6 +38,7 @@ extern EbErrorType dlf_context_ctor(
     EbFifo                       *dlf_input_fifo_ptr,
     EbFifo                       *dlf_output_fifo_ptr,
     EbBool                  is16bit,
+    EbColorFormat           color_format,
     uint32_t                max_input_luma_width,
     uint32_t                max_input_luma_height
    );

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -84,6 +84,7 @@ EbErrorType enc_dec_context_ctor(
     EbFifo                *feedback_fifo_ptr,
     EbFifo                *picture_demux_fifo_ptr,
     EbBool                  is16bit,
+    EbColorFormat           color_format,
     uint32_t                max_input_luma_width,
     uint32_t                max_input_luma_height){
 
@@ -95,6 +96,7 @@ EbErrorType enc_dec_context_ctor(
     *context_dbl_ptr = context_ptr;
 
     context_ptr->is16bit = is16bit;
+    context_ptr->color_format = color_format;
 
     // Input/Output System Resource Manager FIFOs
     context_ptr->mode_decision_input_fifo_ptr = mode_decision_configuration_input_fifo_ptr;
@@ -121,6 +123,7 @@ EbErrorType enc_dec_context_ctor(
         initData.top_padding = 0;
         initData.bot_padding = 0;
         initData.splitMode = EB_FALSE;
+        initData.color_format = color_format;
 
         context_ptr->input_sample16bit_buffer = (EbPictureBufferDesc_t *)EB_NULL;
         if (is16bit) {
@@ -144,12 +147,12 @@ EbErrorType enc_dec_context_ctor(
         initData.maxWidth = SB_STRIDE_Y;
         initData.maxHeight = SB_STRIDE_Y;
         initData.bit_depth = EB_16BIT;
+        initData.color_format = color_format;
         initData.left_padding = 0;
         initData.right_padding = 0;
         initData.top_padding = 0;
         initData.bot_padding = 0;
         initData.splitMode = EB_FALSE;
-
 
         EbPictureBufferDescInitData_t init32BitData;
 
@@ -157,6 +160,7 @@ EbErrorType enc_dec_context_ctor(
         init32BitData.maxWidth = SB_STRIDE_Y;
         init32BitData.maxHeight = SB_STRIDE_Y;
         init32BitData.bit_depth = EB_32BIT;
+        init32BitData.color_format = color_format;
         init32BitData.left_padding = 0;
         init32BitData.right_padding = 0;
         init32BitData.top_padding = 0;
@@ -198,7 +202,7 @@ EbErrorType enc_dec_context_ctor(
         }
     }
     // Mode Decision Context
-    return_error = mode_decision_context_ctor(&context_ptr->md_context, 0, 0);
+    return_error = mode_decision_context_ctor(&context_ptr->md_context, color_format, 0, 0);
 
     if (return_error == EB_ErrorInsufficientResources) {
         return EB_ErrorInsufficientResources;
@@ -211,7 +215,6 @@ EbErrorType enc_dec_context_ctor(
 
 
     context_ptr->md_context->enc_dec_context_ptr = context_ptr;
-
 
     return EB_ErrorNone;
 }

--- a/Source/Lib/Common/Codec/EbEncDecProcess.h
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.h
@@ -92,6 +92,7 @@ extern "C" {
         int16_t                                x_mv_amvp_candidate_array_list0[MAX_NUM_OF_AMVP_CANDIDATES];
         uint8_t                                txb_itr;
         EbBool                                 is16bit; //enable 10 bit encode in CL
+        EbColorFormat                          color_format;
         uint64_t                               tot_intra_coded_area;
         uint8_t                                intra_coded_area_sb[MAX_NUMBER_OF_TREEBLOCKS_PER_PICTURE];//percentage of intra coded area 0-100%
         uint8_t                                pmp_masking_level_enc_dec;
@@ -144,6 +145,7 @@ extern "C" {
         EbFifo                *feedback_fifo_ptr,
         EbFifo                *picture_demux_fifo_ptr,
         EbBool                   is16bit,
+        EbColorFormat            color_format,
         uint32_t                 max_input_luma_width,
         uint32_t                 max_input_luma_height);
 

--- a/Source/Lib/Common/Codec/EbInterPrediction.c
+++ b/Source/Lib/Common/Codec/EbInterPrediction.c
@@ -4494,8 +4494,9 @@ EbErrorType inter_pu_prediction_av1(
 
 EbErrorType inter_prediction_context_ctor(
     InterPredictionContext_t **inter_prediction_context,
-    uint16_t                     max_cu_width,
-    uint16_t                     max_cu_height)
+    EbColorFormat              color_format,
+    uint16_t                   max_cu_width,
+    uint16_t                   max_cu_height)
 
 {
     EbErrorType              return_error = EB_ErrorNone;
@@ -4506,6 +4507,7 @@ EbErrorType inter_prediction_context_ctor(
 
     return_error = motion_compensation_prediction_context_ctor(
         &context_ptr->mcp_context,
+        color_format,
         max_cu_width,
         max_cu_height);
 

--- a/Source/Lib/Common/Codec/EbInterPrediction.h
+++ b/Source/Lib/Common/Codec/EbInterPrediction.h
@@ -26,6 +26,7 @@ extern "C" {
 
     extern EbErrorType inter_prediction_context_ctor(
         InterPredictionContext_t   **inter_prediction_context,
+        EbColorFormat                color_format,
         uint16_t                     max_cu_width,
         uint16_t                     max_cu_height);
     EbErrorType av1_inter_prediction(

--- a/Source/Lib/Common/Codec/EbMcp.c
+++ b/Source/Lib/Common/Codec/EbMcp.c
@@ -25,6 +25,7 @@
 
 EbErrorType motion_compensation_prediction_context_ctor(
     MotionCompensationPredictionContext_t **context_dbl_ptr,
+    EbColorFormat                             color_format,
     uint16_t                                  max_cu_width,
     uint16_t                                  max_cu_height)
 
@@ -33,10 +34,11 @@ EbErrorType motion_compensation_prediction_context_ctor(
     MotionCompensationPredictionContext_t *context_ptr;
     EB_MALLOC(MotionCompensationPredictionContext_t *, context_ptr, sizeof(MotionCompensationPredictionContext_t), EB_N_PTR);
     *(context_dbl_ptr) = context_ptr;
+    UNUSED(color_format);
 #if !EXTRA_ALLOCATION
-    EB_MALLOC(EbByte, context_ptr->avc_style_mcp_intermediate_result_buf0, sizeof(uint8_t)*max_cu_width*max_cu_height * 6 * 3 / 2 + 16, EB_N_PTR);        //Y + U + V;
-
-    EB_MALLOC(EbByte, context_ptr->avc_style_mcp_intermediate_result_buf1, sizeof(uint8_t)*max_cu_width*max_cu_height * 6 * 3 / 2 + 16, EB_N_PTR);        //Y + U + V;
+    uint32_t frame_size = (max_cu_width * max_cu_height) + 2 * ((max_cu_width * max_cu_height) >> (3 - color_format));
+    EB_MALLOC(EbByte, context_ptr->avc_style_mcp_intermediate_result_buf0, sizeof(uint8_t) * frame_size * 6 + 16, EB_N_PTR);//Y + U + V;
+    EB_MALLOC(EbByte, context_ptr->avc_style_mcp_intermediate_result_buf1, sizeof(uint8_t) * frame_size * 6 + 16, EB_N_PTR);//Y + U + V;
 
 #if !USE_PRE_COMPUTE
     EB_MALLOC(EbByte, context_ptr->avc_style_mcp_two_d_interpolation_first_pass_filter_result_buf, sizeof(uint8_t)*(6 * max_cu_width + MaxHorizontalLumaFliterTag - 1)*(max_cu_height + MaxVerticalLumaFliterTag - 1), EB_N_PTR);
@@ -56,6 +58,7 @@ EbErrorType motion_compensation_prediction_context_ctor(
         initData.maxHeight = max_cu_height + 16;
 
         initData.bit_depth = EB_16BIT;
+        initData.color_format = EB_YUV420; //always use 420 for MD
         initData.left_padding = 0;
         initData.right_padding = 0;
         initData.top_padding = 0;

--- a/Source/Lib/Common/Codec/EbMcp.h
+++ b/Source/Lib/Common/Codec/EbMcp.h
@@ -101,6 +101,7 @@ extern "C" {
 
     extern EbErrorType motion_compensation_prediction_context_ctor(
         MotionCompensationPredictionContext_t **context_dbl_ptr,
+        EbColorFormat                           color_format,
         uint16_t                                max_cu_width,
         uint16_t                                max_cu_height);
 

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -150,6 +150,7 @@ EbErrorType mode_decision_candidate_buffer_ctor(
     pictureBufferDescInitData.maxWidth = MAX_SB_SIZE;
     pictureBufferDescInitData.maxHeight = MAX_SB_SIZE;
     pictureBufferDescInitData.bit_depth = EB_8BIT;
+    pictureBufferDescInitData.color_format = EB_YUV420;
     pictureBufferDescInitData.bufferEnableMask = PICTURE_BUFFER_DESC_FULL_MASK;
     pictureBufferDescInitData.left_padding = 0;
     pictureBufferDescInitData.right_padding = 0;
@@ -159,6 +160,7 @@ EbErrorType mode_decision_candidate_buffer_ctor(
     doubleWidthPictureBufferDescInitData.maxWidth = MAX_SB_SIZE;
     doubleWidthPictureBufferDescInitData.maxHeight = MAX_SB_SIZE;
     doubleWidthPictureBufferDescInitData.bit_depth = EB_16BIT;
+    doubleWidthPictureBufferDescInitData.color_format = EB_YUV420;
     doubleWidthPictureBufferDescInitData.bufferEnableMask = PICTURE_BUFFER_DESC_FULL_MASK;
     doubleWidthPictureBufferDescInitData.left_padding = 0;
     doubleWidthPictureBufferDescInitData.right_padding = 0;
@@ -169,6 +171,7 @@ EbErrorType mode_decision_candidate_buffer_ctor(
     ThirtyTwoWidthPictureBufferDescInitData.maxWidth = MAX_SB_SIZE;
     ThirtyTwoWidthPictureBufferDescInitData.maxHeight = MAX_SB_SIZE;
     ThirtyTwoWidthPictureBufferDescInitData.bit_depth = EB_32BIT;
+    ThirtyTwoWidthPictureBufferDescInitData.color_format = EB_YUV420;
     ThirtyTwoWidthPictureBufferDescInitData.bufferEnableMask = PICTURE_BUFFER_DESC_FULL_MASK;
     ThirtyTwoWidthPictureBufferDescInitData.left_padding = 0;
     ThirtyTwoWidthPictureBufferDescInitData.right_padding = 0;

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.c
@@ -15,6 +15,7 @@
  ******************************************************/
 EbErrorType mode_decision_context_ctor(
     ModeDecisionContext_t  **context_dbl_ptr,
+    EbColorFormat         color_format,
     EbFifo                *mode_decision_configuration_input_fifo_ptr,
     EbFifo                *mode_decision_output_fifo_ptr){
 
@@ -82,6 +83,7 @@ EbErrorType mode_decision_context_ctor(
     // Inter Prediction Context
     return_error = inter_prediction_context_ctor(
         &context_ptr->inter_prediction_context,
+        color_format,
         SB_STRIDE_Y,
         SB_STRIDE_Y);
     if (return_error == EB_ErrorInsufficientResources) {
@@ -120,6 +122,7 @@ EbErrorType mode_decision_context_ctor(
             initData.maxWidth = SB_STRIDE_Y;
             initData.maxHeight = SB_STRIDE_Y;
             initData.bit_depth = EB_32BIT;
+            initData.color_format = EB_YUV420;
             initData.left_padding = 0;
             initData.right_padding = 0;
             initData.top_padding = 0;
@@ -138,6 +141,7 @@ EbErrorType mode_decision_context_ctor(
             initData.maxWidth = SB_STRIDE_Y;
             initData.maxHeight = SB_STRIDE_Y;
             initData.bit_depth = EB_8BIT;
+            initData.color_format = EB_YUV420;
             initData.left_padding = 0;
             initData.right_padding = 0;
             initData.top_padding = 0;

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -246,6 +246,7 @@ extern "C" {
      **************************************/
     extern EbErrorType mode_decision_context_ctor(
         ModeDecisionContext_t      **context_dbl_ptr,
+        EbColorFormat              color_format,
         EbFifo                    *mode_decision_configuration_input_fifo_ptr,
         EbFifo                    *mode_decision_output_fifo_ptr);
 

--- a/Source/Lib/Common/Codec/EbPictureBufferDesc.c
+++ b/Source/Lib/Common/Codec/EbPictureBufferDesc.c
@@ -33,6 +33,11 @@ EbErrorType eb_picture_buffer_desc_ctor(
     EbPictureBufferDescInitData_t  *pictureBufferDescInitDataPtr = (EbPictureBufferDescInitData_t*)object_init_data_ptr;
 
     uint32_t bytesPerPixel = (pictureBufferDescInitDataPtr->bit_depth == EB_8BIT) ? 1 : (pictureBufferDescInitDataPtr->bit_depth <= EB_16BIT) ? 2 : 4;
+    const uint16_t subsampling_x = (pictureBufferDescInitDataPtr->color_format == EB_YUV444 ? 1 : 2) - 1;
+
+    //if (pictureBufferDescInitDataPtr->color_format != 1 && pictureBufferDescInitDataPtr->bit_depth != 8) {
+    //    assert(0);
+    //}
 
     if (pictureBufferDescInitDataPtr->bit_depth > EB_8BIT && pictureBufferDescInitDataPtr->bit_depth <= EB_16BIT && pictureBufferDescInitDataPtr->splitMode == EB_TRUE)
         bytesPerPixel = 1;
@@ -48,14 +53,15 @@ EbErrorType eb_picture_buffer_desc_ctor(
     pictureBufferDescPtr->width = pictureBufferDescInitDataPtr->maxWidth;
     pictureBufferDescPtr->height = pictureBufferDescInitDataPtr->maxHeight;
     pictureBufferDescPtr->bit_depth = pictureBufferDescInitDataPtr->bit_depth;
+    pictureBufferDescPtr->color_format = pictureBufferDescInitDataPtr->color_format;
     pictureBufferDescPtr->stride_y = pictureBufferDescInitDataPtr->maxWidth + pictureBufferDescInitDataPtr->left_padding + pictureBufferDescInitDataPtr->right_padding;
-    pictureBufferDescPtr->strideCb = pictureBufferDescPtr->strideCr = pictureBufferDescPtr->stride_y >> 1;
+    pictureBufferDescPtr->strideCb = pictureBufferDescPtr->strideCr = pictureBufferDescPtr->stride_y >> subsampling_x;
     pictureBufferDescPtr->origin_x = pictureBufferDescInitDataPtr->left_padding;
     pictureBufferDescPtr->origin_y = pictureBufferDescInitDataPtr->top_padding;
 
     pictureBufferDescPtr->lumaSize = (pictureBufferDescInitDataPtr->maxWidth + pictureBufferDescInitDataPtr->left_padding + pictureBufferDescInitDataPtr->right_padding) *
         (pictureBufferDescInitDataPtr->maxHeight + pictureBufferDescInitDataPtr->top_padding + pictureBufferDescInitDataPtr->bot_padding);
-    pictureBufferDescPtr->chromaSize = pictureBufferDescPtr->lumaSize >> 2;
+    pictureBufferDescPtr->chromaSize = pictureBufferDescPtr->lumaSize >> (3 - pictureBufferDescInitDataPtr->color_format);
     pictureBufferDescPtr->packedFlag = EB_FALSE;
 
     if (pictureBufferDescInitDataPtr->splitMode == EB_TRUE) {
@@ -137,6 +143,7 @@ EbErrorType eb_recon_picture_buffer_desc_ctor(
 {
     EbPictureBufferDesc_t          *pictureBufferDescPtr;
     EbPictureBufferDescInitData_t  *pictureBufferDescInitDataPtr = (EbPictureBufferDescInitData_t*)object_init_data_ptr;
+    const uint16_t subsampling_x = (pictureBufferDescInitDataPtr->color_format == EB_YUV444 ? 1 : 2) - 1;
 
     uint32_t bytesPerPixel = (pictureBufferDescInitDataPtr->bit_depth == EB_8BIT) ? 1 : 2;
 
@@ -151,14 +158,15 @@ EbErrorType eb_recon_picture_buffer_desc_ctor(
     pictureBufferDescPtr->width = pictureBufferDescInitDataPtr->maxWidth;
     pictureBufferDescPtr->height = pictureBufferDescInitDataPtr->maxHeight;
     pictureBufferDescPtr->bit_depth = pictureBufferDescInitDataPtr->bit_depth;
+    pictureBufferDescPtr->color_format = pictureBufferDescInitDataPtr->color_format;
     pictureBufferDescPtr->stride_y = pictureBufferDescInitDataPtr->maxWidth + pictureBufferDescInitDataPtr->left_padding + pictureBufferDescInitDataPtr->right_padding;
-    pictureBufferDescPtr->strideCb = pictureBufferDescPtr->strideCr = pictureBufferDescPtr->stride_y >> 1;
+    pictureBufferDescPtr->strideCb = pictureBufferDescPtr->strideCr = pictureBufferDescPtr->stride_y >> subsampling_x;
     pictureBufferDescPtr->origin_x = pictureBufferDescInitDataPtr->left_padding;
     pictureBufferDescPtr->origin_y = pictureBufferDescInitDataPtr->top_padding;
 
     pictureBufferDescPtr->lumaSize = (pictureBufferDescInitDataPtr->maxWidth + pictureBufferDescInitDataPtr->left_padding + pictureBufferDescInitDataPtr->right_padding) *
         (pictureBufferDescInitDataPtr->maxHeight + pictureBufferDescInitDataPtr->top_padding + pictureBufferDescInitDataPtr->bot_padding);
-    pictureBufferDescPtr->chromaSize = pictureBufferDescPtr->lumaSize >> 2;
+    pictureBufferDescPtr->chromaSize = pictureBufferDescPtr->lumaSize >> (3 - pictureBufferDescInitDataPtr->color_format);
     pictureBufferDescPtr->packedFlag = EB_FALSE;
 
     pictureBufferDescPtr->strideBitIncY = 0;
@@ -233,6 +241,8 @@ void link_Eb_to_aom_buffer_desc_8bit(
     }
 }
 
+//Jing: TODO
+//Change here later
 void LinkEbToAomBufferDesc(
     EbPictureBufferDesc_t          *picBuffDsc,
     Yv12BufferConfig             *aomBuffDsc

--- a/Source/Lib/Common/Codec/EbPictureBufferDesc.c
+++ b/Source/Lib/Common/Codec/EbPictureBufferDesc.c
@@ -35,10 +35,6 @@ EbErrorType eb_picture_buffer_desc_ctor(
     uint32_t bytesPerPixel = (pictureBufferDescInitDataPtr->bit_depth == EB_8BIT) ? 1 : (pictureBufferDescInitDataPtr->bit_depth <= EB_16BIT) ? 2 : 4;
     const uint16_t subsampling_x = (pictureBufferDescInitDataPtr->color_format == EB_YUV444 ? 1 : 2) - 1;
 
-    //if (pictureBufferDescInitDataPtr->color_format != 1 && pictureBufferDescInitDataPtr->bit_depth != 8) {
-    //    assert(0);
-    //}
-
     if (pictureBufferDescInitDataPtr->bit_depth > EB_8BIT && pictureBufferDescInitDataPtr->bit_depth <= EB_16BIT && pictureBufferDescInitDataPtr->splitMode == EB_TRUE)
         bytesPerPixel = 1;
 

--- a/Source/Lib/Common/Codec/EbPictureBufferDesc.h
+++ b/Source/Lib/Common/Codec/EbPictureBufferDesc.h
@@ -53,6 +53,7 @@ extern "C" {
         uint16_t          maxWidth;         // input Luma picture width
         uint16_t          maxHeight;        // input Luma picture height
         EB_BITDEPTH       bit_depth;        // Pixel Bit Depth
+        EbColorFormat     color_format;     // Chroma Subsumpling
 
         // Buffer Parameters
         uint32_t          lumaSize;         // Size of the luma buffer
@@ -286,6 +287,7 @@ extern "C" {
         uint16_t          maxWidth;
         uint16_t          maxHeight;
         EB_BITDEPTH       bit_depth;
+        EbColorFormat     color_format;
         uint32_t          bufferEnableMask;
         uint16_t          left_padding;
         uint16_t          right_padding;

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -13579,6 +13579,7 @@ extern "C" {
         // Marks if we need to use 16bit frame buffers (1: yes, 0: no).
         int32_t use_highbitdepth;
         int32_t bit_depth;
+        int32_t color_format;
         int32_t subsampling_x;
         int32_t subsampling_y;
         int32_t width;
@@ -13721,6 +13722,7 @@ extern "C" {
         uint64_t                              picture_number;
         uint8_t                               temporal_layer_index;
         
+        EbColorFormat                         color_format;
         
         EncDecSegments_t                     *enc_dec_segment_ctrl;
 
@@ -13943,6 +13945,7 @@ extern "C" {
         EbObjectWrapper                    *reference_picture_wrapper_ptr;
         EbObjectWrapper                    *pa_reference_picture_wrapper_ptr;
         EbPictureBufferDesc_t                *enhanced_picture_ptr;
+        EbPictureBufferDesc_t                *chroma_downsampled_picture_ptr; //if 422/444 input, down sample to 420 for MD
         PredictionStructure_t                *pred_struct_ptr;          // need to check
         struct SequenceControlSet          *sequence_control_set_ptr;
         struct PictureParentControlSet_s     *ref_pa_pcs_array[MAX_NUM_OF_REF_PIC_LIST];
@@ -14305,11 +14308,12 @@ extern "C" {
         uint16_t                           top_padding;
         uint16_t                           bot_padding;
         EB_BITDEPTH                        bit_depth;
+        EbColorFormat                      color_format;
         uint32_t                           sb_sz;
         uint32_t                           sb_size_pix;   //since we still have lot of code assuming 64x64 LCU, we add a new paramter supporting both128x128 and 64x64, 
                                                           //ultimately the fixed code supporting 64x64 should be upgraded to use 128x128 and the above could be removed.
         uint32_t                           max_depth;
-        EbBool                             is16bit;
+        //EbBool                             is16bit;
         uint32_t                           ten_bit_format;
         uint32_t                           compressed_ten_bit_format;
         uint16_t                           enc_dec_segment_col;
@@ -14317,7 +14321,7 @@ extern "C" {
         EbEncMode                          enc_mode;
         uint8_t                            speed_control;
         uint16_t                           film_grain_noise_level;
-        uint32_t                           encoder_bit_depth;
+        //uint32_t                           encoder_bit_depth;
         EbBool                             ext_block_flag;
         EbBool                             in_loop_me_flag;
 

--- a/Source/Lib/Common/Codec/EbReferenceObject.c
+++ b/Source/Lib/Common/Codec/EbReferenceObject.c
@@ -153,6 +153,7 @@ EbErrorType eb_reference_object_ctor(
     *object_dbl_ptr = (EbPtr)referenceObject;
 
 
+    //TODO:12bit
     if (pictureBufferDescInitData16BitPtr.bit_depth == EB_10BIT) {
 
         return_error = eb_picture_buffer_desc_ctor(
@@ -198,7 +199,7 @@ EbErrorType eb_reference_object_ctor(
         bufDesc.top_padding = pictureBufferDescInitDataPtr->top_padding;
         bufDesc.bot_padding = pictureBufferDescInitDataPtr->bot_padding;
         bufDesc.splitMode = 0;
-
+        bufDesc.color_format = pictureBufferDescInitDataPtr->color_format;
 
         return_error = eb_picture_buffer_desc_ctor((EbPtr*)&(referenceObject->ref_den_src_picture),
             (EbPtr)&bufDesc);

--- a/Source/Lib/Common/Codec/EbRestProcess.c
+++ b/Source/Lib/Common/Codec/EbRestProcess.c
@@ -63,6 +63,7 @@ EbErrorType rest_context_ctor(
     EbFifo                *rest_output_fifo_ptr ,
     EbFifo                *picture_demux_fifo_ptr,
     EbBool                  is16bit,
+    EbColorFormat           color_format,
     uint32_t                max_input_luma_width,
     uint32_t                max_input_luma_height
    )
@@ -85,6 +86,7 @@ EbErrorType rest_context_ctor(
         initData.maxWidth = (uint16_t)max_input_luma_width;
         initData.maxHeight = (uint16_t)max_input_luma_height;
         initData.bit_depth = is16bit ? EB_16BIT : EB_8BIT;
+        initData.color_format = color_format;
         initData.left_padding = AOM_BORDER_IN_PIXELS;
         initData.right_padding = AOM_BORDER_IN_PIXELS;
         initData.top_padding = AOM_BORDER_IN_PIXELS;
@@ -121,6 +123,7 @@ EbErrorType rest_context_ctor(
     tempLfReconDescInitData.bot_padding = PAD_VALUE;
 
     tempLfReconDescInitData.splitMode = EB_FALSE;
+    tempLfReconDescInitData.color_format = color_format;
 
     if (is16bit) {
         tempLfReconDescInitData.bit_depth = EB_16BIT;

--- a/Source/Lib/Common/Codec/EbRestProcess.h
+++ b/Source/Lib/Common/Codec/EbRestProcess.h
@@ -47,6 +47,7 @@ extern EbErrorType rest_context_ctor(
     EbFifo                       *rest_output_fifo_ptr,
     EbFifo                      *picture_demux_fifo_ptr,
     EbBool                  is16bit,
+    EbColorFormat           color_format,
     uint32_t                max_input_luma_width,
     uint32_t                max_input_luma_height
    );

--- a/Source/Lib/Common/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Common/Codec/EbSequenceControlSet.c
@@ -73,7 +73,7 @@ EbErrorType eb_sequence_control_set_ctor(
     sequence_control_set_ptr->profile_idc = 0;
     sequence_control_set_ptr->level_idc = 0;
     sequence_control_set_ptr->tier_idc = 0;
-    sequence_control_set_ptr->chroma_format_idc = 1; // EB_YUV420
+    sequence_control_set_ptr->chroma_format_idc = EB_YUV420;
     sequence_control_set_ptr->max_temporal_layers = 1;
 
     sequence_control_set_ptr->bits_for_picture_order_count = 16;
@@ -90,8 +90,8 @@ EbErrorType eb_sequence_control_set_ctor(
     sequence_control_set_ptr->encoder_bit_depth = 8;
 
     // Bitdepth
-    sequence_control_set_ptr->input_bitdepth = EB_8BIT;
-    sequence_control_set_ptr->output_bitdepth = EB_8BIT;
+    //sequence_control_set_ptr->input_bitdepth = EB_8BIT;
+    //sequence_control_set_ptr->output_bitdepth = EB_8BIT;
 
     // GOP Structure
     sequence_control_set_ptr->max_ref_count = 1;
@@ -273,8 +273,11 @@ EbErrorType copy_sequence_control_set(
     dst->cropping_bottom_offset = src->cropping_bottom_offset;                    writeCount += sizeof(int32_t);
     dst->conformance_window_flag = src->conformance_window_flag;                   writeCount += sizeof(uint32_t);
     dst->frame_rate = src->frame_rate;                               writeCount += sizeof(uint32_t);
-    dst->input_bitdepth = src->input_bitdepth;                           writeCount += sizeof(EB_BITDEPTH);
-    dst->output_bitdepth = src->output_bitdepth;                          writeCount += sizeof(EB_BITDEPTH);
+    //dst->input_bitdepth = src->input_bitdepth;                           writeCount += sizeof(EB_BITDEPTH);
+    //dst->output_bitdepth = src->output_bitdepth;                          writeCount += sizeof(EB_BITDEPTH);
+    dst->encoder_bit_depth = src->encoder_bit_depth;                      writeCount += sizeof(uint32_t);
+    dst->subsampling_x = src->subsampling_x;                writeCount += sizeof(uint16_t);
+    dst->subsampling_y = src->subsampling_y;                writeCount += sizeof(uint16_t);
     dst->pred_struct_ptr = src->pred_struct_ptr;                           writeCount += sizeof(PredictionStructure_t*);
     dst->intra_period_length = src->intra_period_length;                       writeCount += sizeof(int32_t);
     dst->intra_refresh_type = src->intra_refresh_type;                        writeCount += sizeof(uint32_t);

--- a/Source/Lib/Common/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Common/Codec/EbSequenceControlSet.h
@@ -48,8 +48,8 @@ extern "C" {
         uint32_t                                chroma_format_idc;
         uint32_t                                max_temporal_layers;
         uint32_t                                bits_for_picture_order_count;
-        int32_t                                 subsampling_x;            // add chroma subsampling parameters
-        int32_t                                 subsampling_y;
+        uint16_t                                subsampling_x;            // add chroma subsampling parameters
+        uint16_t                                subsampling_y;
 
         // Picture deminsions
         uint16_t                                max_input_luma_width;
@@ -77,13 +77,13 @@ extern "C" {
         int32_t                                 cropping_right_offset;
         int32_t                                 cropping_top_offset;
         int32_t                                 cropping_bottom_offset;
-
+ 
         // Conformance Window flag
         uint32_t                                conformance_window_flag;
 
         // Bitdepth
-        EB_BITDEPTH                             input_bitdepth;
-        EB_BITDEPTH                             output_bitdepth;
+        //EB_BITDEPTH                             input_bitdepth;
+        //EB_BITDEPTH                             output_bitdepth;
 
         // Group of Pictures (GOP) Structure
         uint32_t                                max_ref_count;            // Maximum number of reference pictures, however each pred

--- a/Source/Lib/Common/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Common/Codec/EbSequenceControlSet.h
@@ -81,10 +81,6 @@ extern "C" {
         // Conformance Window flag
         uint32_t                                conformance_window_flag;
 
-        // Bitdepth
-        //EB_BITDEPTH                             input_bitdepth;
-        //EB_BITDEPTH                             output_bitdepth;
-
         // Group of Pictures (GOP) Structure
         uint32_t                                max_ref_count;            // Maximum number of reference pictures, however each pred
                                                             //   entry can be less.

--- a/Source/Lib/Common/Codec/EbTransQuantBuffers.c
+++ b/Source/Lib/Common/Codec/EbTransQuantBuffers.c
@@ -17,6 +17,7 @@ EbErrorType eb_trans_quant_buffers_ctor(
     transCoeffInitArray.maxWidth = SB_STRIDE_Y;
     transCoeffInitArray.maxHeight = SB_STRIDE_Y;
     transCoeffInitArray.bit_depth = EB_16BIT;
+    transCoeffInitArray.color_format = EB_YUV420;
     transCoeffInitArray.bufferEnableMask = PICTURE_BUFFER_DESC_FULL_MASK;
     transCoeffInitArray.left_padding = 0;
     transCoeffInitArray.right_padding = 0;
@@ -28,6 +29,7 @@ EbErrorType eb_trans_quant_buffers_ctor(
     ThirtyTwoBittransCoeffInitArray.maxWidth = SB_STRIDE_Y;
     ThirtyTwoBittransCoeffInitArray.maxHeight = SB_STRIDE_Y;
     ThirtyTwoBittransCoeffInitArray.bit_depth = EB_32BIT;
+    ThirtyTwoBittransCoeffInitArray.color_format = EB_YUV420;
     ThirtyTwoBittransCoeffInitArray.bufferEnableMask = PICTURE_BUFFER_DESC_FULL_MASK;
     ThirtyTwoBittransCoeffInitArray.left_padding = 0;
     ThirtyTwoBittransCoeffInitArray.right_padding = 0;

--- a/Source/Lib/Common/Codec/noise_model.c
+++ b/Source/Lib/Common/Codec/noise_model.c
@@ -1562,9 +1562,11 @@ EbErrorType denoise_and_model_ctor(EbPtr *object_dbl_ptr,
     struct aom_denoise_and_model_t *object_ptr = 0;
     denoise_and_model_init_data_t *init_data_ptr = (denoise_and_model_init_data_t*)object_init_data_ptr;
     EbErrorType return_error = EB_ErrorNone;
-    int32_t use_highbd = init_data_ptr->encoder_bit_depth > EB_8BIT ? 10 : 8;
+    uint32_t use_highbd = init_data_ptr->encoder_bit_depth > EB_8BIT ? 10 : 8;
 
     int32_t chroma_sub_log2[2] = { 1, 1 };  //todo: send chroma subsampling
+    chroma_sub_log2[0] = (init_data_ptr->encoder_color_format == EB_YUV444 ? 1 : 2) - 1;
+    chroma_sub_log2[1] = (init_data_ptr->encoder_color_format >= EB_YUV422 ? 1 : 2) - 1;
 
     return_error = aom_denoise_and_model_alloc(&object_ptr,
         init_data_ptr->encoder_bit_depth > EB_8BIT ? 10 : 8,

--- a/Source/Lib/Common/Codec/noise_model.h
+++ b/Source/Lib/Common/Codec/noise_model.h
@@ -217,6 +217,7 @@ extern "C" {
     {
         uint16_t          noise_level;
         uint32_t          encoder_bit_depth;
+        uint32_t          encoder_color_format;
 
         uint16_t          width;
         uint16_t          height;

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -902,6 +902,7 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
     uint32_t maxLookAheadDistance = 0;
 
     EbBool is16bit = (EbBool)(encHandlePtr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->static_config.encoder_bit_depth > EB_8BIT);
+    EbColorFormat color_format = encHandlePtr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->static_config.encoder_color_format;
 
     /************************************
     * Plateform detection
@@ -972,7 +973,8 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         inputData.right_padding = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->right_padding;
         inputData.top_padding = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->top_padding;
         inputData.bot_padding = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->bot_padding;
-        inputData.bit_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->output_bitdepth;
+        inputData.bit_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->encoder_bit_depth;
+        inputData.color_format = color_format;
         inputData.sb_sz = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz;
         inputData.max_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_sb_depth;
         inputData.is16bit = is16bit;
@@ -1033,7 +1035,7 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         inputData.right_padding = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->right_padding;
         inputData.top_padding = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->top_padding;
         inputData.bot_padding = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->bot_padding;
-        inputData.bit_depth = EB_8BIT;
+        inputData.bit_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->encoder_bit_depth;
         inputData.sb_sz = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz;
         inputData.sb_size_pix = scs_init.sb_size;
         inputData.max_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_sb_depth;
@@ -1085,7 +1087,8 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         // Initialize the various Picture types
         referencePictureBufferDescInitData.maxWidth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_width;
         referencePictureBufferDescInitData.maxHeight = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_height;
-        referencePictureBufferDescInitData.bit_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->input_bitdepth;
+        referencePictureBufferDescInitData.bit_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->encoder_bit_depth;
+        referencePictureBufferDescInitData.color_format = color_format;
         referencePictureBufferDescInitData.bufferEnableMask = PICTURE_BUFFER_DESC_FULL_MASK;
 
         referencePictureBufferDescInitData.left_padding = PAD_VALUE;
@@ -1094,10 +1097,6 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         referencePictureBufferDescInitData.bot_padding = PAD_VALUE;
 
         referencePictureBufferDescInitData.splitMode = EB_FALSE;
-
-        if (is16bit) {
-            referencePictureBufferDescInitData.bit_depth = EB_10BIT;
-        }
 
         EbReferenceObjectDescInitDataStructure.reference_picture_desc_init_data = referencePictureBufferDescInitData;
 
@@ -1121,7 +1120,8 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         // Currently, only Luma samples are needed in the PA
         referencePictureBufferDescInitData.maxWidth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_width;
         referencePictureBufferDescInitData.maxHeight = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_height;
-        referencePictureBufferDescInitData.bit_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->input_bitdepth;
+        referencePictureBufferDescInitData.bit_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->encoder_bit_depth;
+        referencePictureBufferDescInitData.color_format = EB_YUV420; //use 420 for picture analysis
 
         referencePictureBufferDescInitData.bufferEnableMask = 0;
 
@@ -1133,7 +1133,8 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
 
         quarterDecimPictureBufferDescInitData.maxWidth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_width >> 1;
         quarterDecimPictureBufferDescInitData.maxHeight = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_height >> 1;
-        quarterDecimPictureBufferDescInitData.bit_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->input_bitdepth;
+        quarterDecimPictureBufferDescInitData.bit_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->encoder_bit_depth;
+        quarterDecimPictureBufferDescInitData.color_format = EB_YUV420;
         quarterDecimPictureBufferDescInitData.bufferEnableMask = PICTURE_BUFFER_DESC_LUMA_MASK;
         quarterDecimPictureBufferDescInitData.left_padding = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 1;
         quarterDecimPictureBufferDescInitData.right_padding = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 1;
@@ -1143,7 +1144,8 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
 
         sixteenthDecimPictureBufferDescInitData.maxWidth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_width >> 2;
         sixteenthDecimPictureBufferDescInitData.maxHeight = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_height >> 2;
-        sixteenthDecimPictureBufferDescInitData.bit_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->input_bitdepth;
+        sixteenthDecimPictureBufferDescInitData.bit_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->encoder_bit_depth;
+        sixteenthDecimPictureBufferDescInitData.color_format = EB_YUV420;
         sixteenthDecimPictureBufferDescInitData.bufferEnableMask = PICTURE_BUFFER_DESC_LUMA_MASK;
         sixteenthDecimPictureBufferDescInitData.left_padding = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 2;
         sixteenthDecimPictureBufferDescInitData.right_padding = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 2;
@@ -1693,6 +1695,7 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
                 //1 +
                     processIndex], // Add port lookup logic here JMJ
             is16bit,
+            color_format,
             encHandlePtr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->max_input_luma_width,
             encHandlePtr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->max_input_luma_height
         );
@@ -1711,6 +1714,7 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
             encHandlePtr->encDecResultsConsumerFifoPtrArray[processIndex],
             encHandlePtr->dlfResultsProducerFifoPtrArray[processIndex],             //output to EC
             is16bit,
+            color_format,
             encHandlePtr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->max_input_luma_width,
             encHandlePtr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->max_input_luma_height
         );
@@ -1748,6 +1752,7 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
             encHandlePtr->pictureDemuxResultsProducerFifoPtrArray[
                 /*encHandlePtr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->source_based_operations_process_init_count*/ 1+ processIndex],
             is16bit,
+            color_format,
             encHandlePtr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->max_input_luma_width,
             encHandlePtr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->max_input_luma_height
         );
@@ -2097,9 +2102,10 @@ static uint32_t cap_look_ahead_distance(
     return lad;
 }
 
-void SetParamBasedOnInput(
-    SequenceControlSet       *sequence_control_set_ptr){
-
+void SetParamBasedOnInput(SequenceControlSet *sequence_control_set_ptr)
+{
+    uint16_t subsampling_x = sequence_control_set_ptr->subsampling_x;
+    uint16_t subsampling_y = sequence_control_set_ptr->subsampling_y;
     sequence_control_set_ptr->general_frame_only_constraint_flag = 0;
     sequence_control_set_ptr->general_progressive_source_flag = 1;
     sequence_control_set_ptr->general_interlaced_source_flag = 0;
@@ -2123,8 +2129,8 @@ void SetParamBasedOnInput(
         sequence_control_set_ptr->max_input_pad_bottom = 0;
     }
 
-    sequence_control_set_ptr->max_input_chroma_width = sequence_control_set_ptr->max_input_luma_width >> 1;
-    sequence_control_set_ptr->max_input_chroma_height = sequence_control_set_ptr->max_input_luma_height >> 1;
+    sequence_control_set_ptr->max_input_chroma_width = sequence_control_set_ptr->max_input_luma_width >> subsampling_x;
+    sequence_control_set_ptr->max_input_chroma_height = sequence_control_set_ptr->max_input_luma_height >> subsampling_y;
 
 
     // Configure the padding
@@ -2133,8 +2139,8 @@ void SetParamBasedOnInput(
     sequence_control_set_ptr->right_padding = BLOCK_SIZE_64 + 4;
     sequence_control_set_ptr->bot_padding = BLOCK_SIZE_64 + 4;
 
-    sequence_control_set_ptr->chroma_width = sequence_control_set_ptr->max_input_luma_width >> 1;
-    sequence_control_set_ptr->chroma_height = sequence_control_set_ptr->max_input_luma_height >> 1;
+    sequence_control_set_ptr->chroma_width = sequence_control_set_ptr->max_input_luma_width >> subsampling_x;
+    sequence_control_set_ptr->chroma_height = sequence_control_set_ptr->max_input_luma_height >> subsampling_y;
     sequence_control_set_ptr->luma_width = sequence_control_set_ptr->max_input_luma_width;
     sequence_control_set_ptr->luma_height = sequence_control_set_ptr->max_input_luma_height;
     sequence_control_set_ptr->static_config.source_width = sequence_control_set_ptr->max_input_luma_width;
@@ -2152,7 +2158,8 @@ void SetParamBasedOnInput(
 
 void CopyApiFromApp(
     SequenceControlSet       *sequence_control_set_ptr,
-    EbSvtAv1EncConfiguration   *pComponentParameterStructure) {
+    EbSvtAv1EncConfiguration   *pComponentParameterStructure)
+{
 
     uint32_t                  hmeRegionIndex = 0;
 
@@ -2288,6 +2295,16 @@ void CopyApiFromApp(
 
     // Misc
     sequence_control_set_ptr->static_config.encoder_bit_depth = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->encoder_bit_depth;
+    sequence_control_set_ptr->static_config.encoder_color_format = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->encoder_color_format;
+    if (sequence_control_set_ptr->static_config.encoder_color_format == EB_YUV400) {
+        SVT_LOG("SVT [Warning]: Color format EB_YUV400 not supported, set to EB_YUV420\n");
+        sequence_control_set_ptr->static_config.encoder_color_format = EB_YUV420;
+    }
+    sequence_control_set_ptr->chroma_format_idc = (uint32_t)(sequence_control_set_ptr->static_config.encoder_color_format);
+    sequence_control_set_ptr->encoder_bit_depth = (uint32_t)(sequence_control_set_ptr->static_config.encoder_bit_depth);
+
+    sequence_control_set_ptr->subsampling_x = (sequence_control_set_ptr->chroma_format_idc == EB_YUV444 ? 1 : 2) - 1;
+    sequence_control_set_ptr->subsampling_y = (sequence_control_set_ptr->chroma_format_idc >= EB_YUV422 ? 1 : 2) - 1;
     sequence_control_set_ptr->static_config.ten_bit_format = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->ten_bit_format;
     sequence_control_set_ptr->static_config.compressed_ten_bit_format = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->compressed_ten_bit_format;
 
@@ -2626,9 +2643,24 @@ static EbErrorType VerifySettings(
         SVT_LOG("Error instance %u: Encoder Bit Depth shall be only 8 or 10 \n", channelNumber + 1);
         return_error = EB_ErrorBadParameter;
     }
-    // Check if the encoder_bit_depth is conformant with the Profile constraint
-    if (config->profile == 1 && config->encoder_bit_depth == 10) {
-        SVT_LOG("Error instance %u: The encoder bit depth shall be equal to 8 for Main Profile\n", channelNumber + 1);
+    // Check if the EncoderBitDepth is conformant with the Profile constraint
+    if ((config->profile == 0 || config->profile == 1) && config->encoder_bit_depth > 10) {
+        SVT_LOG("Error instance %u: The encoder bit depth shall be equal to 8 or 10 for Main/High Profile\n", channelNumber + 1);
+        return_error = EB_ErrorBadParameter;
+    }
+
+    if (config->profile == 0 && config->encoder_color_format > EB_YUV420) {
+        SVT_LOG("Error instance %u: Non 420 color format requires profile 1 or 2\n", channelNumber + 1);
+        return_error = EB_ErrorBadParameter;
+    }
+
+    if (config->profile == 1 && config->encoder_color_format != EB_YUV444) {
+        SVT_LOG("Error instance %u: Profile 1 requires 4:4:4 color format\n", channelNumber + 1);
+        return_error = EB_ErrorBadParameter;
+    }
+
+    if (config->profile == 2 && config->encoder_bit_depth <= 10 && config->encoder_color_format != EB_YUV422) {
+        SVT_LOG("Error instance %u: Profile 2 bit-depth < 10 requires 4:2:2 color format\n", channelNumber + 1);
         return_error = EB_ErrorBadParameter;
     }
 
@@ -2793,7 +2825,7 @@ static void PrintLibParams(
             SVT_LOG("Level %.1f\t", (float)(config->level / 10));
     }
     SVT_LOG("\nSVT [config]: EncoderMode \t\t\t\t\t\t\t: %d ", config->enc_mode);
-    SVT_LOG("\nSVT [config]: encoder_bit_depth / compressed_ten_bit_format\t\t\t\t: %d / %d ", config->encoder_bit_depth, config->compressed_ten_bit_format);
+    SVT_LOG("\nSVT [config]: encoder_bit_depth / encoder_color_format / compressed_ten_bit_format\t\t\t\t: %d / %d ", config->encoder_bit_depth, config->encoder_color_format, config->compressed_ten_bit_format);
     SVT_LOG("\nSVT [config]: source_width / source_height\t\t\t\t\t: %d / %d ", config->source_width, config->source_height);
     if (config->frame_rate_denominator != 0 && config->frame_rate_numerator != 0)
         SVT_LOG("\nSVT [config]: Fps_Numerator / Fps_Denominator / Gop Size / intra_refresh_type \t: %d / %d / %d / %d", config->frame_rate_numerator > (1 << 16) ? config->frame_rate_numerator >> 16 : config->frame_rate_numerator,
@@ -3359,6 +3391,7 @@ static EbErrorType allocate_frame_buffer(
     input_picture_buffer_desc_init_data.maxWidth = (uint16_t)sequence_control_set_ptr->max_input_luma_width;
     input_picture_buffer_desc_init_data.maxHeight = (uint16_t)sequence_control_set_ptr->max_input_luma_height;
     input_picture_buffer_desc_init_data.bit_depth = (EB_BITDEPTH)config->encoder_bit_depth;
+    input_picture_buffer_desc_init_data.color_format = (EbColorFormat)config->encoder_color_format;
 
     if (config->compressed_ten_bit_format == 1) {
         input_picture_buffer_desc_init_data.bufferEnableMask = 0;

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -977,14 +977,13 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         inputData.color_format = color_format;
         inputData.sb_sz = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz;
         inputData.max_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_sb_depth;
-        inputData.is16bit = is16bit;
         inputData.ten_bit_format = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->static_config.ten_bit_format;
         inputData.compressed_ten_bit_format = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->static_config.compressed_ten_bit_format;
         encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->picture_control_set_pool_init_count += maxLookAheadDistance;
         inputData.enc_mode = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->static_config.enc_mode;
         inputData.speed_control = (uint8_t)encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->static_config.speed_control_flag;
         inputData.film_grain_noise_level = encHandlePtr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->static_config.film_grain_denoise_strength;
-        inputData.encoder_bit_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->static_config.encoder_bit_depth;
+        inputData.bit_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->static_config.encoder_bit_depth;
 
         inputData.ext_block_flag = (uint8_t)encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->static_config.ext_block_flag;
 
@@ -1039,7 +1038,6 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         inputData.sb_sz = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz;
         inputData.sb_size_pix = scs_init.sb_size;
         inputData.max_depth = encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_sb_depth;
-        inputData.is16bit = is16bit;
         return_error = eb_system_resource_ctor(
             &(encHandlePtr->pictureControlSetPoolPtrArray[instance_index]),
             encHandlePtr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->picture_control_set_pool_init_count_child, //EB_PictureControlSetPoolInitCountChild,
@@ -2825,7 +2823,7 @@ static void PrintLibParams(
             SVT_LOG("Level %.1f\t", (float)(config->level / 10));
     }
     SVT_LOG("\nSVT [config]: EncoderMode \t\t\t\t\t\t\t: %d ", config->enc_mode);
-    SVT_LOG("\nSVT [config]: encoder_bit_depth / encoder_color_format / compressed_ten_bit_format\t\t\t\t: %d / %d ", config->encoder_bit_depth, config->encoder_color_format, config->compressed_ten_bit_format);
+    SVT_LOG("\nSVT [config]: encoder_bit_depth / encoder_color_format / compressed_ten_bit_format\t\t\t\t: %d / %d / %d", config->encoder_bit_depth, config->encoder_color_format, config->compressed_ten_bit_format);
     SVT_LOG("\nSVT [config]: source_width / source_height\t\t\t\t\t: %d / %d ", config->source_width, config->source_height);
     if (config->frame_rate_denominator != 0 && config->frame_rate_numerator != 0)
         SVT_LOG("\nSVT [config]: Fps_Numerator / Fps_Denominator / Gop Size / intra_refresh_type \t: %d / %d / %d / %d", config->frame_rate_numerator > (1 << 16) ? config->frame_rate_numerator >> 16 : config->frame_rate_numerator,


### PR DESCRIPTION
- Enable 422/444 in internal data structures
- Down sample to 420 and use 420 for MD in PictureAnalysisKernel
- Enhance check for settings of different profile
- Clean up sample app, remove un-used paddings

Signed-off-by: Jing Li <jing.b.li@intel.com>