### PR TITLE
Optimization the transformation in av1_fwd_txfm2d_64x64_avx2(),

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/highbd_fwd_txfm_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/highbd_fwd_txfm_avx2.c
@@ -239,36 +239,6 @@ static INLINE __m128i half_btf_small(const __m128i *w0, const __m128i *n0,
     return x;
 }
 
-static INLINE __m256i av1_round_shift_32_avx2(__m256i vec, int32_t bit) {
-    __m256i tmp, round;
-    round = _mm256_set1_epi32(1 << (bit - 1));
-    tmp = _mm256_add_epi32(vec, round);
-    return _mm256_srai_epi32(tmp, bit);
-}
-
-// out0 = in0*w0 + in1*w1
-// out1 = -in1*w0 + in0*w1
-#define btf_32_avx2_type0(w0, w1, in0, in1, out0, out1, bit) \
-  do {                                                         \
-    const __m256i ww0 = _mm256_set1_epi32(w0);                    \
-    const __m256i ww1 = _mm256_set1_epi32(w1);                    \
-    const __m256i in0_w0 = _mm256_mullo_epi32(in0, ww0);          \
-    const __m256i in1_w1 = _mm256_mullo_epi32(in1, ww1);          \
-    out0 = _mm256_add_epi32(in0_w0, in1_w1);                      \
-    out0 = av1_round_shift_32_avx2(out0, bit);               \
-    const __m256i in0_w1 = _mm256_mullo_epi32(in0, ww1);          \
-    const __m256i in1_w0 = _mm256_mullo_epi32(in1, ww0);          \
-    out1 = _mm256_sub_epi32(in0_w1, in1_w0);                      \
-    out1 = av1_round_shift_32_avx2(out1, bit);               \
-      } while (0)
-
-// out0 = in0*w0 + in1*w1
-// out1 = in1*w0 - in0*w1
-#define btf_32_avx2_type1(w0, w1, in0, in1, out0, out1, bit) \
-  do {                                                         \
-    btf_32_avx2_type0(w1, w0, in1, in0, out0, out1, bit);    \
-      } while (0)
-
 // out0 = in0*w0 + in1*w1
 // out1 = -in1*w0 + in0*w1
 #define btf_32_type0_avx2_new(ww0, ww1, in0, in1, out0, out1, r, bit) \
@@ -2221,8 +2191,8 @@ static INLINE void fadst4x8_col_avx2(__m256i *in, __m256i *output, int32_t bit,
     output[3] = _mm256_permute2x128_si256(out[2], out[3], 0x31);
 }
 
-static INLINE void fdct4x8_avx2(__m256i *input, __m256i *output, int32_t bit,
-    const int32_t col_num) {
+static INLINE void fdct4x8_avx2(__m256i *input, __m256i *output,
+    int32_t bit) {
     __m128i *in = (__m128i *)input;
     __m128i *out = (__m128i *)output;
     const int32_t *cospi = cospi_arr(bit);
@@ -2237,25 +2207,17 @@ static INLINE void fdct4x8_avx2(__m256i *input, __m256i *output, int32_t bit,
     const __m128i rnding = _mm_set1_epi32(1 << (bit - 1));
     __m128i u[8], v[8];
 
-    int32_t startidx = 0 * col_num;
-    int32_t endidx = 7 * col_num;
     // Even 8 points 0, 2, ..., 14
     // stage 0
     // stage 1
-    u[0] = _mm_add_epi32(in[startidx], in[endidx]);
-    v[7] = _mm_sub_epi32(in[startidx], in[endidx]);  // v[7]
-    startidx += col_num;
-    endidx -= col_num;
-    u[1] = _mm_add_epi32(in[startidx], in[endidx]);
-    u[6] = _mm_sub_epi32(in[startidx], in[endidx]);
-    startidx += col_num;
-    endidx -= col_num;
-    u[2] = _mm_add_epi32(in[startidx], in[endidx]);
-    u[5] = _mm_sub_epi32(in[startidx], in[endidx]);
-    startidx += col_num;
-    endidx -= col_num;
-    u[3] = _mm_add_epi32(in[startidx], in[endidx]);
-    v[4] = _mm_sub_epi32(in[startidx], in[endidx]);  // v[4]
+    u[0] = _mm_add_epi32(in[0], in[7]);
+    v[7] = _mm_sub_epi32(in[0], in[7]);  // v[7]
+    u[1] = _mm_add_epi32(in[1], in[6]);
+    u[6] = _mm_sub_epi32(in[1], in[6]);
+    u[2] = _mm_add_epi32(in[2], in[5]);
+    u[5] = _mm_sub_epi32(in[2], in[5]);
+    u[3] = _mm_add_epi32(in[3], in[4]);
+    v[4] = _mm_sub_epi32(in[3], in[4]);  // v[4]
 
     // stage 2
     v[0] = _mm_add_epi32(u[0], u[3]);
@@ -2281,24 +2243,24 @@ static INLINE void fdct4x8_avx2(__m256i *input, __m256i *output, int32_t bit,
     v[1] = _mm_mullo_epi32(v[1], cospi32);
     u[0] = _mm_add_epi32(v[0], v[1]);
     u[0] = _mm_add_epi32(u[0], rnding);
-    out[0 * col_num] = _mm_srai_epi32(u[0], bit);
+    out[0] = _mm_srai_epi32(u[0], bit);
 
     u[1] = _mm_sub_epi32(v[0], v[1]);
     u[1] = _mm_add_epi32(u[1], rnding);
-    out[4 * col_num] = _mm_srai_epi32(u[1], bit);
+    out[4] = _mm_srai_epi32(u[1], bit);
 
     // type 1
     v[0] = _mm_mullo_epi32(v[2], cospi48);
     v[1] = _mm_mullo_epi32(v[3], cospi16);
     u[2] = _mm_add_epi32(v[0], v[1]);
     u[2] = _mm_add_epi32(u[2], rnding);
-    out[2 * col_num] = _mm_srai_epi32(u[2], bit);
+    out[2] = _mm_srai_epi32(u[2], bit);
 
     v[0] = _mm_mullo_epi32(v[2], cospi16);
     v[1] = _mm_mullo_epi32(v[3], cospi48);
     u[3] = _mm_sub_epi32(v[1], v[0]);
     u[3] = _mm_add_epi32(u[3], rnding);
-    out[6 * col_num] = _mm_srai_epi32(u[3], bit);
+    out[6] = _mm_srai_epi32(u[3], bit);
 
     u[4] = _mm_add_epi32(v[4], v[5]);
     u[5] = _mm_sub_epi32(v[4], v[5]);
@@ -2311,25 +2273,25 @@ static INLINE void fdct4x8_avx2(__m256i *input, __m256i *output, int32_t bit,
     v[1] = _mm_mullo_epi32(u[7], cospi8);
     v[0] = _mm_add_epi32(v[0], v[1]);
     v[0] = _mm_add_epi32(v[0], rnding);
-    out[1 * col_num] = _mm_srai_epi32(v[0], bit);  // buf0[4]
+    out[1] = _mm_srai_epi32(v[0], bit);  // buf0[4]
 
     v[0] = _mm_mullo_epi32(u[4], cospi8);
     v[1] = _mm_mullo_epi32(u[7], cospi56);
     v[0] = _mm_sub_epi32(v[1], v[0]);
     v[0] = _mm_add_epi32(v[0], rnding);
-    out[7 * col_num] = _mm_srai_epi32(v[0], bit);  // buf0[7]
+    out[7] = _mm_srai_epi32(v[0], bit);  // buf0[7]
 
     v[0] = _mm_mullo_epi32(u[5], cospi24);
     v[1] = _mm_mullo_epi32(u[6], cospi40);
     v[0] = _mm_add_epi32(v[0], v[1]);
     v[0] = _mm_add_epi32(v[0], rnding);
-    out[5 * col_num] = _mm_srai_epi32(v[0], bit);  // buf0[5]
+    out[5] = _mm_srai_epi32(v[0], bit);  // buf0[5]
 
     v[0] = _mm_mullo_epi32(u[5], cospi40);
     v[1] = _mm_mullo_epi32(u[6], cospi24);
     v[0] = _mm_sub_epi32(v[1], v[0]);
     v[0] = _mm_add_epi32(v[0], rnding);
-    out[3 * col_num] = _mm_srai_epi32(v[0], bit);  // buf0[6]
+    out[3] = _mm_srai_epi32(v[0], bit);  // buf0[6]
 
 }
 
@@ -2728,394 +2690,378 @@ void av1_fwd_txfm2d_16x16_avx2(int16_t *input, int32_t *coeff, uint32_t stride, 
     (void)bd;
 }
 
-void av1_fdct32_new_avx2(const __m256i *input, __m256i *output,
-    int8_t cos_bit, const int32_t stride) {
-    __m256i buf0[32];
-    __m256i buf1[32];
-    const int32_t *cospi;
-    int32_t startidx = 0 * stride;
-    int32_t endidx = 31 * stride;
-    // stage 0
-    // stage 1
-    buf1[0] = _mm256_add_epi32(input[startidx], input[endidx]);
-    buf1[31] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += stride;
-    endidx -= stride;
-    buf1[1] = _mm256_add_epi32(input[startidx], input[endidx]);
-    buf1[30] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += stride;
-    endidx -= stride;
-    buf1[2] = _mm256_add_epi32(input[startidx], input[endidx]);
-    buf1[29] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += stride;
-    endidx -= stride;
-    buf1[3] = _mm256_add_epi32(input[startidx], input[endidx]);
-    buf1[28] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += stride;
-    endidx -= stride;
-    buf1[4] = _mm256_add_epi32(input[startidx], input[endidx]);
-    buf1[27] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += stride;
-    endidx -= stride;
-    buf1[5] = _mm256_add_epi32(input[startidx], input[endidx]);
-    buf1[26] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += stride;
-    endidx -= stride;
-    buf1[6] = _mm256_add_epi32(input[startidx], input[endidx]);
-    buf1[25] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += stride;
-    endidx -= stride;
-    buf1[7] = _mm256_add_epi32(input[startidx], input[endidx]);
-    buf1[24] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += stride;
-    endidx -= stride;
-    buf1[8] = _mm256_add_epi32(input[startidx], input[endidx]);
-    buf1[23] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += stride;
-    endidx -= stride;
-    buf1[9] = _mm256_add_epi32(input[startidx], input[endidx]);
-    buf1[22] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += stride;
-    endidx -= stride;
-    buf1[10] = _mm256_add_epi32(input[startidx], input[endidx]);
-    buf1[21] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += stride;
-    endidx -= stride;
-    buf1[11] = _mm256_add_epi32(input[startidx], input[endidx]);
-    buf1[20] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += stride;
-    endidx -= stride;
-    buf1[12] = _mm256_add_epi32(input[startidx], input[endidx]);
-    buf1[19] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += stride;
-    endidx -= stride;
-    buf1[13] = _mm256_add_epi32(input[startidx], input[endidx]);
-    buf1[18] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += stride;
-    endidx -= stride;
-    buf1[14] = _mm256_add_epi32(input[startidx], input[endidx]);
-    buf1[17] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += stride;
-    endidx -= stride;
-    buf1[15] = _mm256_add_epi32(input[startidx], input[endidx]);
-    buf1[16] = _mm256_sub_epi32(input[startidx], input[endidx]);
-
-    // stage 2
-    cospi = cospi_arr(cos_bit);
-    buf0[0] = _mm256_add_epi32(buf1[0], buf1[15]);
-    buf0[15] = _mm256_sub_epi32(buf1[0], buf1[15]);
-    buf0[1] = _mm256_add_epi32(buf1[1], buf1[14]);
-    buf0[14] = _mm256_sub_epi32(buf1[1], buf1[14]);
-    buf0[2] = _mm256_add_epi32(buf1[2], buf1[13]);
-    buf0[13] = _mm256_sub_epi32(buf1[2], buf1[13]);
-    buf0[3] = _mm256_add_epi32(buf1[3], buf1[12]);
-    buf0[12] = _mm256_sub_epi32(buf1[3], buf1[12]);
-    buf0[4] = _mm256_add_epi32(buf1[4], buf1[11]);
-    buf0[11] = _mm256_sub_epi32(buf1[4], buf1[11]);
-    buf0[5] = _mm256_add_epi32(buf1[5], buf1[10]);
-    buf0[10] = _mm256_sub_epi32(buf1[5], buf1[10]);
-    buf0[6] = _mm256_add_epi32(buf1[6], buf1[9]);
-    buf0[9] = _mm256_sub_epi32(buf1[6], buf1[9]);
-    buf0[7] = _mm256_add_epi32(buf1[7], buf1[8]);
-    buf0[8] = _mm256_sub_epi32(buf1[7], buf1[8]);
-    buf0[16] = buf1[16];
-    buf0[17] = buf1[17];
-    buf0[18] = buf1[18];
-    buf0[19] = buf1[19];
-    btf_32_avx2_type0(-cospi[32], cospi[32], buf1[20], buf1[27], buf0[20],
-        buf0[27], cos_bit);
-    btf_32_avx2_type0(-cospi[32], cospi[32], buf1[21], buf1[26], buf0[21],
-        buf0[26], cos_bit);
-    btf_32_avx2_type0(-cospi[32], cospi[32], buf1[22], buf1[25], buf0[22],
-        buf0[25], cos_bit);
-    btf_32_avx2_type0(-cospi[32], cospi[32], buf1[23], buf1[24], buf0[23],
-        buf0[24], cos_bit);
-    buf0[28] = buf1[28];
-    buf0[29] = buf1[29];
-    buf0[30] = buf1[30];
-    buf0[31] = buf1[31];
-
-    // stage 3
-    cospi = cospi_arr(cos_bit);
-    buf1[0] = _mm256_add_epi32(buf0[0], buf0[7]);
-    buf1[7] = _mm256_sub_epi32(buf0[0], buf0[7]);
-    buf1[1] = _mm256_add_epi32(buf0[1], buf0[6]);
-    buf1[6] = _mm256_sub_epi32(buf0[1], buf0[6]);
-    buf1[2] = _mm256_add_epi32(buf0[2], buf0[5]);
-    buf1[5] = _mm256_sub_epi32(buf0[2], buf0[5]);
-    buf1[3] = _mm256_add_epi32(buf0[3], buf0[4]);
-    buf1[4] = _mm256_sub_epi32(buf0[3], buf0[4]);
-    buf1[8] = buf0[8];
-    buf1[9] = buf0[9];
-    btf_32_avx2_type0(-cospi[32], cospi[32], buf0[10], buf0[13], buf1[10],
-        buf1[13], cos_bit);
-    btf_32_avx2_type0(-cospi[32], cospi[32], buf0[11], buf0[12], buf1[11],
-        buf1[12], cos_bit);
-    buf1[14] = buf0[14];
-    buf1[15] = buf0[15];
-    buf1[16] = _mm256_add_epi32(buf0[16], buf0[23]);
-    buf1[23] = _mm256_sub_epi32(buf0[16], buf0[23]);
-    buf1[17] = _mm256_add_epi32(buf0[17], buf0[22]);
-    buf1[22] = _mm256_sub_epi32(buf0[17], buf0[22]);
-    buf1[18] = _mm256_add_epi32(buf0[18], buf0[21]);
-    buf1[21] = _mm256_sub_epi32(buf0[18], buf0[21]);
-    buf1[19] = _mm256_add_epi32(buf0[19], buf0[20]);
-    buf1[20] = _mm256_sub_epi32(buf0[19], buf0[20]);
-    buf1[24] = _mm256_sub_epi32(buf0[31], buf0[24]);
-    buf1[31] = _mm256_add_epi32(buf0[31], buf0[24]);
-    buf1[25] = _mm256_sub_epi32(buf0[30], buf0[25]);
-    buf1[30] = _mm256_add_epi32(buf0[30], buf0[25]);
-    buf1[26] = _mm256_sub_epi32(buf0[29], buf0[26]);
-    buf1[29] = _mm256_add_epi32(buf0[29], buf0[26]);
-    buf1[27] = _mm256_sub_epi32(buf0[28], buf0[27]);
-    buf1[28] = _mm256_add_epi32(buf0[28], buf0[27]);
-
-    // stage 4
-    cospi = cospi_arr(cos_bit);
-    buf0[0] = _mm256_add_epi32(buf1[0], buf1[3]);
-    buf0[3] = _mm256_sub_epi32(buf1[0], buf1[3]);
-    buf0[1] = _mm256_add_epi32(buf1[1], buf1[2]);
-    buf0[2] = _mm256_sub_epi32(buf1[1], buf1[2]);
-    buf0[4] = buf1[4];
-    btf_32_avx2_type0(-cospi[32], cospi[32], buf1[5], buf1[6], buf0[5], buf0[6],
-        cos_bit);
-    buf0[7] = buf1[7];
-    buf0[8] = _mm256_add_epi32(buf1[8], buf1[11]);
-    buf0[11] = _mm256_sub_epi32(buf1[8], buf1[11]);
-    buf0[9] = _mm256_add_epi32(buf1[9], buf1[10]);
-    buf0[10] = _mm256_sub_epi32(buf1[9], buf1[10]);
-    buf0[12] = _mm256_sub_epi32(buf1[15], buf1[12]);
-    buf0[15] = _mm256_add_epi32(buf1[15], buf1[12]);
-    buf0[13] = _mm256_sub_epi32(buf1[14], buf1[13]);
-    buf0[14] = _mm256_add_epi32(buf1[14], buf1[13]);
-    buf0[16] = buf1[16];
-    buf0[17] = buf1[17];
-    btf_32_avx2_type0(-cospi[16], cospi[48], buf1[18], buf1[29], buf0[18],
-        buf0[29], cos_bit);
-    btf_32_avx2_type0(-cospi[16], cospi[48], buf1[19], buf1[28], buf0[19],
-        buf0[28], cos_bit);
-    btf_32_avx2_type0(-cospi[48], -cospi[16], buf1[20], buf1[27], buf0[20],
-        buf0[27], cos_bit);
-    btf_32_avx2_type0(-cospi[48], -cospi[16], buf1[21], buf1[26], buf0[21],
-        buf0[26], cos_bit);
-    buf0[22] = buf1[22];
-    buf0[23] = buf1[23];
-    buf0[24] = buf1[24];
-    buf0[25] = buf1[25];
-    buf0[30] = buf1[30];
-    buf0[31] = buf1[31];
-
-    // stage 5
-    cospi = cospi_arr(cos_bit);
-    btf_32_avx2_type0(cospi[32], cospi[32], buf0[0], buf0[1], buf1[0], buf1[1],
-        cos_bit);
-    btf_32_avx2_type1(cospi[48], cospi[16], buf0[2], buf0[3], buf1[2], buf1[3],
-        cos_bit);
-    buf1[4] = _mm256_add_epi32(buf0[4], buf0[5]);
-    buf1[5] = _mm256_sub_epi32(buf0[4], buf0[5]);
-    buf1[6] = _mm256_sub_epi32(buf0[7], buf0[6]);
-    buf1[7] = _mm256_add_epi32(buf0[7], buf0[6]);
-    buf1[8] = buf0[8];
-    btf_32_avx2_type0(-cospi[16], cospi[48], buf0[9], buf0[14], buf1[9],
-        buf1[14], cos_bit);
-    btf_32_avx2_type0(-cospi[48], -cospi[16], buf0[10], buf0[13], buf1[10],
-        buf1[13], cos_bit);
-    buf1[11] = buf0[11];
-    buf1[12] = buf0[12];
-    buf1[15] = buf0[15];
-    buf1[16] = _mm256_add_epi32(buf0[16], buf0[19]);
-    buf1[19] = _mm256_sub_epi32(buf0[16], buf0[19]);
-    buf1[17] = _mm256_add_epi32(buf0[17], buf0[18]);
-    buf1[18] = _mm256_sub_epi32(buf0[17], buf0[18]);
-    buf1[20] = _mm256_sub_epi32(buf0[23], buf0[20]);
-    buf1[23] = _mm256_add_epi32(buf0[23], buf0[20]);
-    buf1[21] = _mm256_sub_epi32(buf0[22], buf0[21]);
-    buf1[22] = _mm256_add_epi32(buf0[22], buf0[21]);
-    buf1[24] = _mm256_add_epi32(buf0[24], buf0[27]);
-    buf1[27] = _mm256_sub_epi32(buf0[24], buf0[27]);
-    buf1[25] = _mm256_add_epi32(buf0[25], buf0[26]);
-    buf1[26] = _mm256_sub_epi32(buf0[25], buf0[26]);
-    buf1[28] = _mm256_sub_epi32(buf0[31], buf0[28]);
-    buf1[31] = _mm256_add_epi32(buf0[31], buf0[28]);
-    buf1[29] = _mm256_sub_epi32(buf0[30], buf0[29]);
-    buf1[30] = _mm256_add_epi32(buf0[30], buf0[29]);
-
-    // stage 6
-    cospi = cospi_arr(cos_bit);
-    buf0[0] = buf1[0];
-    buf0[1] = buf1[1];
-    buf0[2] = buf1[2];
-    buf0[3] = buf1[3];
-    btf_32_avx2_type1(cospi[56], cospi[8], buf1[4], buf1[7], buf0[4], buf0[7],
-        cos_bit);
-    btf_32_avx2_type1(cospi[24], cospi[40], buf1[5], buf1[6], buf0[5], buf0[6],
-        cos_bit);
-    buf0[8] = _mm256_add_epi32(buf1[8], buf1[9]);
-    buf0[9] = _mm256_sub_epi32(buf1[8], buf1[9]);
-    buf0[10] = _mm256_sub_epi32(buf1[11], buf1[10]);
-    buf0[11] = _mm256_add_epi32(buf1[11], buf1[10]);
-    buf0[12] = _mm256_add_epi32(buf1[12], buf1[13]);
-    buf0[13] = _mm256_sub_epi32(buf1[12], buf1[13]);
-    buf0[14] = _mm256_sub_epi32(buf1[15], buf1[14]);
-    buf0[15] = _mm256_add_epi32(buf1[15], buf1[14]);
-    buf0[16] = buf1[16];
-    btf_32_avx2_type0(-cospi[8], cospi[56], buf1[17], buf1[30], buf0[17],
-        buf0[30], cos_bit);
-    btf_32_avx2_type0(-cospi[56], -cospi[8], buf1[18], buf1[29], buf0[18],
-        buf0[29], cos_bit);
-    buf0[19] = buf1[19];
-    buf0[20] = buf1[20];
-    btf_32_avx2_type0(-cospi[40], cospi[24], buf1[21], buf1[26], buf0[21],
-        buf0[26], cos_bit);
-    btf_32_avx2_type0(-cospi[24], -cospi[40], buf1[22], buf1[25], buf0[22],
-        buf0[25], cos_bit);
-    buf0[23] = buf1[23];
-    buf0[24] = buf1[24];
-    buf0[27] = buf1[27];
-    buf0[28] = buf1[28];
-    buf0[31] = buf1[31];
-
-    // stage 7
-    cospi = cospi_arr(cos_bit);
-    buf1[0] = buf0[0];
-    buf1[1] = buf0[1];
-    buf1[2] = buf0[2];
-    buf1[3] = buf0[3];
-    buf1[4] = buf0[4];
-    buf1[5] = buf0[5];
-    buf1[6] = buf0[6];
-    buf1[7] = buf0[7];
-    btf_32_avx2_type1(cospi[60], cospi[4], buf0[8], buf0[15], buf1[8], buf1[15],
-        cos_bit);
-    btf_32_avx2_type1(cospi[28], cospi[36], buf0[9], buf0[14], buf1[9],
-        buf1[14], cos_bit);
-    btf_32_avx2_type1(cospi[44], cospi[20], buf0[10], buf0[13], buf1[10],
-        buf1[13], cos_bit);
-    btf_32_avx2_type1(cospi[12], cospi[52], buf0[11], buf0[12], buf1[11],
-        buf1[12], cos_bit);
-    buf1[16] = _mm256_add_epi32(buf0[16], buf0[17]);
-    buf1[17] = _mm256_sub_epi32(buf0[16], buf0[17]);
-    buf1[18] = _mm256_sub_epi32(buf0[19], buf0[18]);
-    buf1[19] = _mm256_add_epi32(buf0[19], buf0[18]);
-    buf1[20] = _mm256_add_epi32(buf0[20], buf0[21]);
-    buf1[21] = _mm256_sub_epi32(buf0[20], buf0[21]);
-    buf1[22] = _mm256_sub_epi32(buf0[23], buf0[22]);
-    buf1[23] = _mm256_add_epi32(buf0[23], buf0[22]);
-    buf1[24] = _mm256_add_epi32(buf0[24], buf0[25]);
-    buf1[25] = _mm256_sub_epi32(buf0[24], buf0[25]);
-    buf1[26] = _mm256_sub_epi32(buf0[27], buf0[26]);
-    buf1[27] = _mm256_add_epi32(buf0[27], buf0[26]);
-    buf1[28] = _mm256_add_epi32(buf0[28], buf0[29]);
-    buf1[29] = _mm256_sub_epi32(buf0[28], buf0[29]);
-    buf1[30] = _mm256_sub_epi32(buf0[31], buf0[30]);
-    buf1[31] = _mm256_add_epi32(buf0[31], buf0[30]);
-
-    // stage 8
-    cospi = cospi_arr(cos_bit);
-    buf0[0] = buf1[0];
-    buf0[1] = buf1[1];
-    buf0[2] = buf1[2];
-    buf0[3] = buf1[3];
-    buf0[4] = buf1[4];
-    buf0[5] = buf1[5];
-    buf0[6] = buf1[6];
-    buf0[7] = buf1[7];
-    buf0[8] = buf1[8];
-    buf0[9] = buf1[9];
-    buf0[10] = buf1[10];
-    buf0[11] = buf1[11];
-    buf0[12] = buf1[12];
-    buf0[13] = buf1[13];
-    buf0[14] = buf1[14];
-    buf0[15] = buf1[15];
-    btf_32_avx2_type1(cospi[62], cospi[2], buf1[16], buf1[31], buf0[16],
-        buf0[31], cos_bit);
-    btf_32_avx2_type1(cospi[30], cospi[34], buf1[17], buf1[30], buf0[17],
-        buf0[30], cos_bit);
-    btf_32_avx2_type1(cospi[46], cospi[18], buf1[18], buf1[29], buf0[18],
-        buf0[29], cos_bit);
-    btf_32_avx2_type1(cospi[14], cospi[50], buf1[19], buf1[28], buf0[19],
-        buf0[28], cos_bit);
-    btf_32_avx2_type1(cospi[54], cospi[10], buf1[20], buf1[27], buf0[20],
-        buf0[27], cos_bit);
-    btf_32_avx2_type1(cospi[22], cospi[42], buf1[21], buf1[26], buf0[21],
-        buf0[26], cos_bit);
-    btf_32_avx2_type1(cospi[38], cospi[26], buf1[22], buf1[25], buf0[22],
-        buf0[25], cos_bit);
-    btf_32_avx2_type1(cospi[6], cospi[58], buf1[23], buf1[24], buf0[23],
-        buf0[24], cos_bit);
-
-    startidx = 0 * stride;
-    endidx = 31 * stride;
-    // stage 9
-    output[startidx] = buf0[0];
-    output[endidx] = buf0[31];
-    startidx += stride;
-    endidx -= stride;
-    output[startidx] = buf0[16];
-    output[endidx] = buf0[15];
-    startidx += stride;
-    endidx -= stride;
-    output[startidx] = buf0[8];
-    output[endidx] = buf0[23];
-    startidx += stride;
-    endidx -= stride;
-    output[startidx] = buf0[24];
-    output[endidx] = buf0[7];
-    startidx += stride;
-    endidx -= stride;
-    output[startidx] = buf0[4];
-    output[endidx] = buf0[27];
-    startidx += stride;
-    endidx -= stride;
-    output[startidx] = buf0[20];
-    output[endidx] = buf0[11];
-    startidx += stride;
-    endidx -= stride;
-    output[startidx] = buf0[12];
-    output[endidx] = buf0[19];
-    startidx += stride;
-    endidx -= stride;
-    output[startidx] = buf0[28];
-    output[endidx] = buf0[3];
-    startidx += stride;
-    endidx -= stride;
-    output[startidx] = buf0[2];
-    output[endidx] = buf0[29];
-    startidx += stride;
-    endidx -= stride;
-    output[startidx] = buf0[18];
-    output[endidx] = buf0[13];
-    startidx += stride;
-    endidx -= stride;
-    output[startidx] = buf0[10];
-    output[endidx] = buf0[21];
-    startidx += stride;
-    endidx -= stride;
-    output[startidx] = buf0[26];
-    output[endidx] = buf0[5];
-    startidx += stride;
-    endidx -= stride;
-    output[startidx] = buf0[6];
-    output[endidx] = buf0[25];
-    startidx += stride;
-    endidx -= stride;
-    output[startidx] = buf0[22];
-    output[endidx] = buf0[9];
-    startidx += stride;
-    endidx -= stride;
-    output[startidx] = buf0[14];
-    output[endidx] = buf0[17];
-    startidx += stride;
-    endidx -= stride;
-    output[startidx] = buf0[30];
-    output[endidx] = buf0[1];
-}
-
-void av1_fdct64_new_avx2(const __m256i *input, __m256i *output, int8_t cos_bit,
-    const int32_t in_stride, const int32_t out_stride) {
+static void av1_fdct32_new_avx2(const __m256i *input, __m256i *output,
+    int8_t cos_bit, const int32_t col_num, const int32_t stride) {
     const int32_t *cospi = cospi_arr(cos_bit);
     const __m256i __rounding = _mm256_set1_epi32(1 << (cos_bit - 1));
+    const int32_t columns = col_num >> 3;
+
+    __m256i cospi_m32 = _mm256_set1_epi32(-cospi[32]);
+    __m256i cospi_p32 = _mm256_set1_epi32(cospi[32]);
+    __m256i cospi_m16 = _mm256_set1_epi32(-cospi[16]);
+    __m256i cospi_p48 = _mm256_set1_epi32(cospi[48]);
+    __m256i cospi_m48 = _mm256_set1_epi32(-cospi[48]);
+    __m256i cospi_m08 = _mm256_set1_epi32(-cospi[8]);
+    __m256i cospi_p56 = _mm256_set1_epi32(cospi[56]);
+    __m256i cospi_m56 = _mm256_set1_epi32(-cospi[56]);
+    __m256i cospi_p40 = _mm256_set1_epi32(cospi[40]);
+    __m256i cospi_m40 = _mm256_set1_epi32(-cospi[40]);
+    __m256i cospi_p24 = _mm256_set1_epi32(cospi[24]);
+    __m256i cospi_m24 = _mm256_set1_epi32(-cospi[24]);
+    __m256i cospi_p16 = _mm256_set1_epi32(cospi[16]);
+    __m256i cospi_p08 = _mm256_set1_epi32(cospi[8]);
+    __m256i cospi_p04 = _mm256_set1_epi32(cospi[4]);
+    __m256i cospi_p60 = _mm256_set1_epi32(cospi[60]);
+    __m256i cospi_p36 = _mm256_set1_epi32(cospi[36]);
+    __m256i cospi_p28 = _mm256_set1_epi32(cospi[28]);
+    __m256i cospi_p20 = _mm256_set1_epi32(cospi[20]);
+    __m256i cospi_p44 = _mm256_set1_epi32(cospi[44]);
+    __m256i cospi_p52 = _mm256_set1_epi32(cospi[52]);
+    __m256i cospi_p12 = _mm256_set1_epi32(cospi[12]);
+    __m256i cospi_p02 = _mm256_set1_epi32(cospi[2]);
+    __m256i cospi_p06 = _mm256_set1_epi32(cospi[6]);
+    __m256i cospi_p62 = _mm256_set1_epi32(cospi[62]);
+    __m256i cospi_p34 = _mm256_set1_epi32(cospi[34]);
+    __m256i cospi_p30 = _mm256_set1_epi32(cospi[30]);
+    __m256i cospi_p18 = _mm256_set1_epi32(cospi[18]);
+    __m256i cospi_p46 = _mm256_set1_epi32(cospi[46]);
+    __m256i cospi_p50 = _mm256_set1_epi32(cospi[50]);
+    __m256i cospi_p14 = _mm256_set1_epi32(cospi[14]);
+    __m256i cospi_p10 = _mm256_set1_epi32(cospi[10]);
+    __m256i cospi_p54 = _mm256_set1_epi32(cospi[54]);
+    __m256i cospi_p42 = _mm256_set1_epi32(cospi[42]);
+    __m256i cospi_p22 = _mm256_set1_epi32(cospi[22]);
+    __m256i cospi_p26 = _mm256_set1_epi32(cospi[26]);
+    __m256i cospi_p38 = _mm256_set1_epi32(cospi[38]);
+    __m256i cospi_p58 = _mm256_set1_epi32(cospi[58]);
+
+    __m256i buf0[32];
+    __m256i buf1[32];
+
+    for (int32_t col = 0; col < columns; col++) {
+        const __m256i *in = &input[col];
+        __m256i *out = &output[col];
+
+        // stage 0
+        // stage 1
+        buf1[0] = _mm256_add_epi32(in[0 * stride], in[31 * stride]);
+        buf1[31] = _mm256_sub_epi32(in[0 * stride], in[31 * stride]);
+        buf1[1] = _mm256_add_epi32(in[1 * stride], in[30 * stride]);
+        buf1[30] = _mm256_sub_epi32(in[1 * stride], in[30 * stride]);
+        buf1[2] = _mm256_add_epi32(in[2 * stride], in[29 * stride]);
+        buf1[29] = _mm256_sub_epi32(in[2 * stride], in[29 * stride]);
+        buf1[3] = _mm256_add_epi32(in[3 * stride], in[28 * stride]);
+        buf1[28] = _mm256_sub_epi32(in[3 * stride], in[28 * stride]);
+        buf1[4] = _mm256_add_epi32(in[4 * stride], in[27 * stride]);
+        buf1[27] = _mm256_sub_epi32(in[4 * stride], in[27 * stride]);
+        buf1[5] = _mm256_add_epi32(in[5 * stride], in[26 * stride]);
+        buf1[26] = _mm256_sub_epi32(in[5 * stride], in[26 * stride]);
+        buf1[6] = _mm256_add_epi32(in[6 * stride], in[25 * stride]);
+        buf1[25] = _mm256_sub_epi32(in[6 * stride], in[25 * stride]);
+        buf1[7] = _mm256_add_epi32(in[7 * stride], in[24 * stride]);
+        buf1[24] = _mm256_sub_epi32(in[7 * stride], in[24 * stride]);
+        buf1[8] = _mm256_add_epi32(in[8 * stride], in[23 * stride]);
+        buf1[23] = _mm256_sub_epi32(in[8 * stride], in[23 * stride]);
+        buf1[9] = _mm256_add_epi32(in[9 * stride], in[22 * stride]);
+        buf1[22] = _mm256_sub_epi32(in[9 * stride], in[22 * stride]);
+        buf1[10] = _mm256_add_epi32(in[10 * stride], in[21 * stride]);
+        buf1[21] = _mm256_sub_epi32(in[10 * stride], in[21 * stride]);
+        buf1[11] = _mm256_add_epi32(in[11 * stride], in[20 * stride]);
+        buf1[20] = _mm256_sub_epi32(in[11 * stride], in[20 * stride]);
+        buf1[12] = _mm256_add_epi32(in[12 * stride], in[19 * stride]);
+        buf1[19] = _mm256_sub_epi32(in[12 * stride], in[19 * stride]);
+        buf1[13] = _mm256_add_epi32(in[13 * stride], in[18 * stride]);
+        buf1[18] = _mm256_sub_epi32(in[13 * stride], in[18 * stride]);
+        buf1[14] = _mm256_add_epi32(in[14 * stride], in[17 * stride]);
+        buf1[17] = _mm256_sub_epi32(in[14 * stride], in[17 * stride]);
+        buf1[15] = _mm256_add_epi32(in[15 * stride], in[16 * stride]);
+        buf1[16] = _mm256_sub_epi32(in[15 * stride], in[16 * stride]);
+
+        // stage 2
+        buf0[0] = _mm256_add_epi32(buf1[0], buf1[15]);
+        buf0[15] = _mm256_sub_epi32(buf1[0], buf1[15]);
+        buf0[1] = _mm256_add_epi32(buf1[1], buf1[14]);
+        buf0[14] = _mm256_sub_epi32(buf1[1], buf1[14]);
+        buf0[2] = _mm256_add_epi32(buf1[2], buf1[13]);
+        buf0[13] = _mm256_sub_epi32(buf1[2], buf1[13]);
+        buf0[3] = _mm256_add_epi32(buf1[3], buf1[12]);
+        buf0[12] = _mm256_sub_epi32(buf1[3], buf1[12]);
+        buf0[4] = _mm256_add_epi32(buf1[4], buf1[11]);
+        buf0[11] = _mm256_sub_epi32(buf1[4], buf1[11]);
+        buf0[5] = _mm256_add_epi32(buf1[5], buf1[10]);
+        buf0[10] = _mm256_sub_epi32(buf1[5], buf1[10]);
+        buf0[6] = _mm256_add_epi32(buf1[6], buf1[9]);
+        buf0[9] = _mm256_sub_epi32(buf1[6], buf1[9]);
+        buf0[7] = _mm256_add_epi32(buf1[7], buf1[8]);
+        buf0[8] = _mm256_sub_epi32(buf1[7], buf1[8]);
+        buf0[16] = buf1[16];
+        buf0[17] = buf1[17];
+        buf0[18] = buf1[18];
+        buf0[19] = buf1[19];
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, buf1[20], buf1[27],
+            buf0[20], buf0[27], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, buf1[21], buf1[26],
+            buf0[21], buf0[26], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, buf1[22], buf1[25],
+            buf0[22], buf0[25], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, buf1[23], buf1[24],
+            buf0[23], buf0[24], __rounding, cos_bit);
+        buf0[28] = buf1[28];
+        buf0[29] = buf1[29];
+        buf0[30] = buf1[30];
+        buf0[31] = buf1[31];
+
+        // stage 3
+        buf1[0] = _mm256_add_epi32(buf0[0], buf0[7]);
+        buf1[7] = _mm256_sub_epi32(buf0[0], buf0[7]);
+        buf1[1] = _mm256_add_epi32(buf0[1], buf0[6]);
+        buf1[6] = _mm256_sub_epi32(buf0[1], buf0[6]);
+        buf1[2] = _mm256_add_epi32(buf0[2], buf0[5]);
+        buf1[5] = _mm256_sub_epi32(buf0[2], buf0[5]);
+        buf1[3] = _mm256_add_epi32(buf0[3], buf0[4]);
+        buf1[4] = _mm256_sub_epi32(buf0[3], buf0[4]);
+        buf1[8] = buf0[8];
+        buf1[9] = buf0[9];
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, buf0[10], buf0[13],
+            buf1[10], buf1[13], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, buf0[11], buf0[12],
+            buf1[11], buf1[12], __rounding, cos_bit);
+        buf1[14] = buf0[14];
+        buf1[15] = buf0[15];
+        buf1[16] = _mm256_add_epi32(buf0[16], buf0[23]);
+        buf1[23] = _mm256_sub_epi32(buf0[16], buf0[23]);
+        buf1[17] = _mm256_add_epi32(buf0[17], buf0[22]);
+        buf1[22] = _mm256_sub_epi32(buf0[17], buf0[22]);
+        buf1[18] = _mm256_add_epi32(buf0[18], buf0[21]);
+        buf1[21] = _mm256_sub_epi32(buf0[18], buf0[21]);
+        buf1[19] = _mm256_add_epi32(buf0[19], buf0[20]);
+        buf1[20] = _mm256_sub_epi32(buf0[19], buf0[20]);
+        buf1[24] = _mm256_sub_epi32(buf0[31], buf0[24]);
+        buf1[31] = _mm256_add_epi32(buf0[31], buf0[24]);
+        buf1[25] = _mm256_sub_epi32(buf0[30], buf0[25]);
+        buf1[30] = _mm256_add_epi32(buf0[30], buf0[25]);
+        buf1[26] = _mm256_sub_epi32(buf0[29], buf0[26]);
+        buf1[29] = _mm256_add_epi32(buf0[29], buf0[26]);
+        buf1[27] = _mm256_sub_epi32(buf0[28], buf0[27]);
+        buf1[28] = _mm256_add_epi32(buf0[28], buf0[27]);
+
+        // stage 4
+        buf0[0] = _mm256_add_epi32(buf1[0], buf1[3]);
+        buf0[3] = _mm256_sub_epi32(buf1[0], buf1[3]);
+        buf0[1] = _mm256_add_epi32(buf1[1], buf1[2]);
+        buf0[2] = _mm256_sub_epi32(buf1[1], buf1[2]);
+        buf0[4] = buf1[4];
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, buf1[5], buf1[6],
+            buf0[5], buf0[6], __rounding, cos_bit);
+        buf0[7] = buf1[7];
+        buf0[8] = _mm256_add_epi32(buf1[8], buf1[11]);
+        buf0[11] = _mm256_sub_epi32(buf1[8], buf1[11]);
+        buf0[9] = _mm256_add_epi32(buf1[9], buf1[10]);
+        buf0[10] = _mm256_sub_epi32(buf1[9], buf1[10]);
+        buf0[12] = _mm256_sub_epi32(buf1[15], buf1[12]);
+        buf0[15] = _mm256_add_epi32(buf1[15], buf1[12]);
+        buf0[13] = _mm256_sub_epi32(buf1[14], buf1[13]);
+        buf0[14] = _mm256_add_epi32(buf1[14], buf1[13]);
+        buf0[16] = buf1[16];
+        buf0[17] = buf1[17];
+        btf_32_type0_avx2_new(cospi_m16, cospi_p48, buf1[18], buf1[29],
+            buf0[18], buf0[29], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m16, cospi_p48, buf1[19], buf1[28],
+            buf0[19], buf0[28], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m48, cospi_m16, buf1[20], buf1[27],
+            buf0[20], buf0[27], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m48, cospi_m16, buf1[21], buf1[26],
+            buf0[21], buf0[26], __rounding, cos_bit);
+        buf0[22] = buf1[22];
+        buf0[23] = buf1[23];
+        buf0[24] = buf1[24];
+        buf0[25] = buf1[25];
+        buf0[30] = buf1[30];
+        buf0[31] = buf1[31];
+
+        // stage 5
+        btf_32_type0_avx2_new(cospi_p32, cospi_p32, buf0[0], buf0[1],
+            buf1[0], buf1[1], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p48, cospi_p16, buf0[2], buf0[3],
+            buf1[2], buf1[3], __rounding, cos_bit);
+        buf1[4] = _mm256_add_epi32(buf0[4], buf0[5]);
+        buf1[5] = _mm256_sub_epi32(buf0[4], buf0[5]);
+        buf1[6] = _mm256_sub_epi32(buf0[7], buf0[6]);
+        buf1[7] = _mm256_add_epi32(buf0[7], buf0[6]);
+        buf1[8] = buf0[8];
+        btf_32_type0_avx2_new(cospi_m16, cospi_p48, buf0[9], buf0[14],
+            buf1[9], buf1[14], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m48, cospi_m16, buf0[10], buf0[13],
+            buf1[10], buf1[13], __rounding, cos_bit);
+        buf1[11] = buf0[11];
+        buf1[12] = buf0[12];
+        buf1[15] = buf0[15];
+        buf1[16] = _mm256_add_epi32(buf0[16], buf0[19]);
+        buf1[19] = _mm256_sub_epi32(buf0[16], buf0[19]);
+        buf1[17] = _mm256_add_epi32(buf0[17], buf0[18]);
+        buf1[18] = _mm256_sub_epi32(buf0[17], buf0[18]);
+        buf1[20] = _mm256_sub_epi32(buf0[23], buf0[20]);
+        buf1[23] = _mm256_add_epi32(buf0[23], buf0[20]);
+        buf1[21] = _mm256_sub_epi32(buf0[22], buf0[21]);
+        buf1[22] = _mm256_add_epi32(buf0[22], buf0[21]);
+        buf1[24] = _mm256_add_epi32(buf0[24], buf0[27]);
+        buf1[27] = _mm256_sub_epi32(buf0[24], buf0[27]);
+        buf1[25] = _mm256_add_epi32(buf0[25], buf0[26]);
+        buf1[26] = _mm256_sub_epi32(buf0[25], buf0[26]);
+        buf1[28] = _mm256_sub_epi32(buf0[31], buf0[28]);
+        buf1[31] = _mm256_add_epi32(buf0[31], buf0[28]);
+        buf1[29] = _mm256_sub_epi32(buf0[30], buf0[29]);
+        buf1[30] = _mm256_add_epi32(buf0[30], buf0[29]);
+
+        // stage 6
+        buf0[0] = buf1[0];
+        buf0[1] = buf1[1];
+        buf0[2] = buf1[2];
+        buf0[3] = buf1[3];
+        btf_32_type1_avx2_new(cospi_p56, cospi_p08, buf1[4], buf1[7],
+            buf0[4], buf0[7], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p24, cospi_p40, buf1[5], buf1[6],
+            buf0[5], buf0[6], __rounding, cos_bit);
+        buf0[8] = _mm256_add_epi32(buf1[8], buf1[9]);
+        buf0[9] = _mm256_sub_epi32(buf1[8], buf1[9]);
+        buf0[10] = _mm256_sub_epi32(buf1[11], buf1[10]);
+        buf0[11] = _mm256_add_epi32(buf1[11], buf1[10]);
+        buf0[12] = _mm256_add_epi32(buf1[12], buf1[13]);
+        buf0[13] = _mm256_sub_epi32(buf1[12], buf1[13]);
+        buf0[14] = _mm256_sub_epi32(buf1[15], buf1[14]);
+        buf0[15] = _mm256_add_epi32(buf1[15], buf1[14]);
+        buf0[16] = buf1[16];
+        btf_32_type0_avx2_new(cospi_m08, cospi_p56, buf1[17], buf1[30],
+            buf0[17], buf0[30], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m56, cospi_m08, buf1[18], buf1[29],
+            buf0[18],
+            buf0[29], __rounding, cos_bit);
+        buf0[19] = buf1[19];
+        buf0[20] = buf1[20];
+        btf_32_type0_avx2_new(cospi_m40, cospi_p24, buf1[21], buf1[26],
+            buf0[21], buf0[26], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m24, cospi_m40, buf1[22], buf1[25],
+            buf0[22], buf0[25], __rounding, cos_bit);
+        buf0[23] = buf1[23];
+        buf0[24] = buf1[24];
+        buf0[27] = buf1[27];
+        buf0[28] = buf1[28];
+        buf0[31] = buf1[31];
+
+        // stage 7
+        buf1[0] = buf0[0];
+        buf1[1] = buf0[1];
+        buf1[2] = buf0[2];
+        buf1[3] = buf0[3];
+        buf1[4] = buf0[4];
+        buf1[5] = buf0[5];
+        buf1[6] = buf0[6];
+        buf1[7] = buf0[7];
+        btf_32_type1_avx2_new(cospi_p60, cospi_p04, buf0[8], buf0[15],
+            buf1[8], buf1[15], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p28, cospi_p36, buf0[9], buf0[14],
+            buf1[9], buf1[14], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p44, cospi_p20, buf0[10], buf0[13],
+            buf1[10], buf1[13], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p12, cospi_p52, buf0[11], buf0[12],
+            buf1[11], buf1[12], __rounding, cos_bit);
+        buf1[16] = _mm256_add_epi32(buf0[16], buf0[17]);
+        buf1[17] = _mm256_sub_epi32(buf0[16], buf0[17]);
+        buf1[18] = _mm256_sub_epi32(buf0[19], buf0[18]);
+        buf1[19] = _mm256_add_epi32(buf0[19], buf0[18]);
+        buf1[20] = _mm256_add_epi32(buf0[20], buf0[21]);
+        buf1[21] = _mm256_sub_epi32(buf0[20], buf0[21]);
+        buf1[22] = _mm256_sub_epi32(buf0[23], buf0[22]);
+        buf1[23] = _mm256_add_epi32(buf0[23], buf0[22]);
+        buf1[24] = _mm256_add_epi32(buf0[24], buf0[25]);
+        buf1[25] = _mm256_sub_epi32(buf0[24], buf0[25]);
+        buf1[26] = _mm256_sub_epi32(buf0[27], buf0[26]);
+        buf1[27] = _mm256_add_epi32(buf0[27], buf0[26]);
+        buf1[28] = _mm256_add_epi32(buf0[28], buf0[29]);
+        buf1[29] = _mm256_sub_epi32(buf0[28], buf0[29]);
+        buf1[30] = _mm256_sub_epi32(buf0[31], buf0[30]);
+        buf1[31] = _mm256_add_epi32(buf0[31], buf0[30]);
+
+        // stage 8
+        buf0[0] = buf1[0];
+        buf0[1] = buf1[1];
+        buf0[2] = buf1[2];
+        buf0[3] = buf1[3];
+        buf0[4] = buf1[4];
+        buf0[5] = buf1[5];
+        buf0[6] = buf1[6];
+        buf0[7] = buf1[7];
+        buf0[8] = buf1[8];
+        buf0[9] = buf1[9];
+        buf0[10] = buf1[10];
+        buf0[11] = buf1[11];
+        buf0[12] = buf1[12];
+        buf0[13] = buf1[13];
+        buf0[14] = buf1[14];
+        buf0[15] = buf1[15];
+        btf_32_type1_avx2_new(cospi_p62, cospi_p02, buf1[16], buf1[31],
+            buf0[16], buf0[31], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p30, cospi_p34, buf1[17], buf1[30],
+            buf0[17], buf0[30], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p46, cospi_p18, buf1[18], buf1[29],
+            buf0[18], buf0[29], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p14, cospi_p50, buf1[19], buf1[28],
+            buf0[19], buf0[28], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p54, cospi_p10, buf1[20], buf1[27],
+            buf0[20], buf0[27], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p22, cospi_p42, buf1[21], buf1[26],
+            buf0[21], buf0[26], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p38, cospi_p26, buf1[22], buf1[25],
+            buf0[22], buf0[25], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p06, cospi_p58, buf1[23], buf1[24],
+            buf0[23], buf0[24], __rounding, cos_bit);
+
+        // stage 9
+        out[0 * stride] = buf0[0];
+        out[1 * stride] = buf0[16];
+        out[2 * stride] = buf0[8];
+        out[3 * stride] = buf0[24];
+        out[4 * stride] = buf0[4];
+        out[5 * stride] = buf0[20];
+        out[6 * stride] = buf0[12];
+        out[7 * stride] = buf0[28];
+        out[8 * stride] = buf0[2];
+        out[9 * stride] = buf0[18];
+        out[10 * stride] = buf0[10];
+        out[11 * stride] = buf0[26];
+        out[12 * stride] = buf0[6];
+        out[13 * stride] = buf0[22];
+        out[14 * stride] = buf0[14];
+        out[15 * stride] = buf0[30];
+        out[16 * stride] = buf0[1];
+        out[17 * stride] = buf0[17];
+        out[18 * stride] = buf0[9];
+        out[19 * stride] = buf0[25];
+        out[20 * stride] = buf0[5];
+        out[21 * stride] = buf0[21];
+        out[22 * stride] = buf0[13];
+        out[23 * stride] = buf0[29];
+        out[24 * stride] = buf0[3];
+        out[25 * stride] = buf0[19];
+        out[26 * stride] = buf0[11];
+        out[27 * stride] = buf0[27];
+        out[28 * stride] = buf0[7];
+        out[29 * stride] = buf0[23];
+        out[30 * stride] = buf0[15];
+        out[31 * stride] = buf0[31];
+    }
+}
+
+static void av1_fdct32_new_line_wraper_avx2(const __m256i *input,
+    __m256i *output, int8_t cos_bit, const int32_t stride) {
+    av1_fdct32_new_avx2(input, output, cos_bit, 8, stride);
+}
+
+static void av1_fdct64_new_avx2(const __m256i *input, __m256i *output,
+    int8_t cos_bit, const int32_t col_num, const int32_t stride) {
+    const int32_t *cospi = cospi_arr(cos_bit);
+    const __m256i __rounding = _mm256_set1_epi32(1 << (cos_bit - 1));
+    const int32_t columns = col_num >> 3;
 
     __m256i cospi_m32 = _mm256_set1_epi32(-cospi[32]);
     __m256i cospi_p32 = _mm256_set1_epi32(cospi[32]);
@@ -3196,878 +3142,714 @@ void av1_fdct64_new_avx2(const __m256i *input, __m256i *output, int8_t cos_bit,
     __m256i cospi_p03 = _mm256_set1_epi32(cospi[3]);
     __m256i cospi_p61 = _mm256_set1_epi32(cospi[61]);
 
-    int32_t startidx = 0 * in_stride;
-    int32_t endidx = 63 * in_stride;
-    // stage 1
-    __m256i x1[64];
-    x1[0] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[63] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[1] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[62] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[2] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[61] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[3] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[60] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[4] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[59] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[5] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[58] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[6] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[57] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[7] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[56] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[8] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[55] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[9] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[54] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[10] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[53] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[11] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[52] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[12] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[51] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[13] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[50] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[14] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[49] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[15] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[48] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[16] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[47] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[17] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[46] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[18] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[45] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[19] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[44] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[20] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[43] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[21] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[42] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[22] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[41] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[23] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[40] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[24] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[39] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[25] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[38] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[26] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[37] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[27] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[36] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[28] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[35] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[29] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[34] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[30] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[33] = _mm256_sub_epi32(input[startidx], input[endidx]);
-    startidx += in_stride;
-    endidx -= in_stride;
-    x1[31] = _mm256_add_epi32(input[startidx], input[endidx]);
-    x1[32] = _mm256_sub_epi32(input[startidx], input[endidx]);
+    for (int32_t col = 0; col < columns; col++) {
+        const __m256i *in = &input[col];
+        __m256i *out = &output[col];
 
-    // stage 2
-    __m256i x2[64];
-    x2[0] = _mm256_add_epi32(x1[0], x1[31]);
-    x2[31] = _mm256_sub_epi32(x1[0], x1[31]);
-    x2[1] = _mm256_add_epi32(x1[1], x1[30]);
-    x2[30] = _mm256_sub_epi32(x1[1], x1[30]);
-    x2[2] = _mm256_add_epi32(x1[2], x1[29]);
-    x2[29] = _mm256_sub_epi32(x1[2], x1[29]);
-    x2[3] = _mm256_add_epi32(x1[3], x1[28]);
-    x2[28] = _mm256_sub_epi32(x1[3], x1[28]);
-    x2[4] = _mm256_add_epi32(x1[4], x1[27]);
-    x2[27] = _mm256_sub_epi32(x1[4], x1[27]);
-    x2[5] = _mm256_add_epi32(x1[5], x1[26]);
-    x2[26] = _mm256_sub_epi32(x1[5], x1[26]);
-    x2[6] = _mm256_add_epi32(x1[6], x1[25]);
-    x2[25] = _mm256_sub_epi32(x1[6], x1[25]);
-    x2[7] = _mm256_add_epi32(x1[7], x1[24]);
-    x2[24] = _mm256_sub_epi32(x1[7], x1[24]);
-    x2[8] = _mm256_add_epi32(x1[8], x1[23]);
-    x2[23] = _mm256_sub_epi32(x1[8], x1[23]);
-    x2[9] = _mm256_add_epi32(x1[9], x1[22]);
-    x2[22] = _mm256_sub_epi32(x1[9], x1[22]);
-    x2[10] = _mm256_add_epi32(x1[10], x1[21]);
-    x2[21] = _mm256_sub_epi32(x1[10], x1[21]);
-    x2[11] = _mm256_add_epi32(x1[11], x1[20]);
-    x2[20] = _mm256_sub_epi32(x1[11], x1[20]);
-    x2[12] = _mm256_add_epi32(x1[12], x1[19]);
-    x2[19] = _mm256_sub_epi32(x1[12], x1[19]);
-    x2[13] = _mm256_add_epi32(x1[13], x1[18]);
-    x2[18] = _mm256_sub_epi32(x1[13], x1[18]);
-    x2[14] = _mm256_add_epi32(x1[14], x1[17]);
-    x2[17] = _mm256_sub_epi32(x1[14], x1[17]);
-    x2[15] = _mm256_add_epi32(x1[15], x1[16]);
-    x2[16] = _mm256_sub_epi32(x1[15], x1[16]);
-    x2[32] = x1[32];
-    x2[33] = x1[33];
-    x2[34] = x1[34];
-    x2[35] = x1[35];
-    x2[36] = x1[36];
-    x2[37] = x1[37];
-    x2[38] = x1[38];
-    x2[39] = x1[39];
-    btf_32_type0_avx2_new(cospi_m32, cospi_p32, x1[40], x1[55], x2[40], x2[55],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m32, cospi_p32, x1[41], x1[54], x2[41], x2[54],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m32, cospi_p32, x1[42], x1[53], x2[42], x2[53],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m32, cospi_p32, x1[43], x1[52], x2[43], x2[52],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m32, cospi_p32, x1[44], x1[51], x2[44], x2[51],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m32, cospi_p32, x1[45], x1[50], x2[45], x2[50],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m32, cospi_p32, x1[46], x1[49], x2[46], x2[49],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m32, cospi_p32, x1[47], x1[48], x2[47], x2[48],
-        __rounding, cos_bit);
-    x2[56] = x1[56];
-    x2[57] = x1[57];
-    x2[58] = x1[58];
-    x2[59] = x1[59];
-    x2[60] = x1[60];
-    x2[61] = x1[61];
-    x2[62] = x1[62];
-    x2[63] = x1[63];
+        // stage 1
+        __m256i x1[64];
+        x1[0] = _mm256_add_epi32(in[0 * stride], in[63 * stride]);
+        x1[63] = _mm256_sub_epi32(in[0 * stride], in[63 * stride]);
+        x1[1] = _mm256_add_epi32(in[1 * stride], in[62 * stride]);
+        x1[62] = _mm256_sub_epi32(in[1 * stride], in[62 * stride]);
+        x1[2] = _mm256_add_epi32(in[2 * stride], in[61 * stride]);
+        x1[61] = _mm256_sub_epi32(in[2 * stride], in[61 * stride]);
+        x1[3] = _mm256_add_epi32(in[3 * stride], in[60 * stride]);
+        x1[60] = _mm256_sub_epi32(in[3 * stride], in[60 * stride]);
+        x1[4] = _mm256_add_epi32(in[4 * stride], in[59 * stride]);
+        x1[59] = _mm256_sub_epi32(in[4 * stride], in[59 * stride]);
+        x1[5] = _mm256_add_epi32(in[5 * stride], in[58 * stride]);
+        x1[58] = _mm256_sub_epi32(in[5 * stride], in[58 * stride]);
+        x1[6] = _mm256_add_epi32(in[6 * stride], in[57 * stride]);
+        x1[57] = _mm256_sub_epi32(in[6 * stride], in[57 * stride]);
+        x1[7] = _mm256_add_epi32(in[7 * stride], in[56 * stride]);
+        x1[56] = _mm256_sub_epi32(in[7 * stride], in[56 * stride]);
+        x1[8] = _mm256_add_epi32(in[8 * stride], in[55 * stride]);
+        x1[55] = _mm256_sub_epi32(in[8 * stride], in[55 * stride]);
+        x1[9] = _mm256_add_epi32(in[9 * stride], in[54 * stride]);
+        x1[54] = _mm256_sub_epi32(in[9 * stride], in[54 * stride]);
+        x1[10] = _mm256_add_epi32(in[10 * stride], in[53 * stride]);
+        x1[53] = _mm256_sub_epi32(in[10 * stride], in[53 * stride]);
+        x1[11] = _mm256_add_epi32(in[11 * stride], in[52 * stride]);
+        x1[52] = _mm256_sub_epi32(in[11 * stride], in[52 * stride]);
+        x1[12] = _mm256_add_epi32(in[12 * stride], in[51 * stride]);
+        x1[51] = _mm256_sub_epi32(in[12 * stride], in[51 * stride]);
+        x1[13] = _mm256_add_epi32(in[13 * stride], in[50 * stride]);
+        x1[50] = _mm256_sub_epi32(in[13 * stride], in[50 * stride]);
+        x1[14] = _mm256_add_epi32(in[14 * stride], in[49 * stride]);
+        x1[49] = _mm256_sub_epi32(in[14 * stride], in[49 * stride]);
+        x1[15] = _mm256_add_epi32(in[15 * stride], in[48 * stride]);
+        x1[48] = _mm256_sub_epi32(in[15 * stride], in[48 * stride]);
+        x1[16] = _mm256_add_epi32(in[16 * stride], in[47 * stride]);
+        x1[47] = _mm256_sub_epi32(in[16 * stride], in[47 * stride]);
+        x1[17] = _mm256_add_epi32(in[17 * stride], in[46 * stride]);
+        x1[46] = _mm256_sub_epi32(in[17 * stride], in[46 * stride]);
+        x1[18] = _mm256_add_epi32(in[18 * stride], in[45 * stride]);
+        x1[45] = _mm256_sub_epi32(in[18 * stride], in[45 * stride]);
+        x1[19] = _mm256_add_epi32(in[19 * stride], in[44 * stride]);
+        x1[44] = _mm256_sub_epi32(in[19 * stride], in[44 * stride]);
+        x1[20] = _mm256_add_epi32(in[20 * stride], in[43 * stride]);
+        x1[43] = _mm256_sub_epi32(in[20 * stride], in[43 * stride]);
+        x1[21] = _mm256_add_epi32(in[21 * stride], in[42 * stride]);
+        x1[42] = _mm256_sub_epi32(in[21 * stride], in[42 * stride]);
+        x1[22] = _mm256_add_epi32(in[22 * stride], in[41 * stride]);
+        x1[41] = _mm256_sub_epi32(in[22 * stride], in[41 * stride]);
+        x1[23] = _mm256_add_epi32(in[23 * stride], in[40 * stride]);
+        x1[40] = _mm256_sub_epi32(in[23 * stride], in[40 * stride]);
+        x1[24] = _mm256_add_epi32(in[24 * stride], in[39 * stride]);
+        x1[39] = _mm256_sub_epi32(in[24 * stride], in[39 * stride]);
+        x1[25] = _mm256_add_epi32(in[25 * stride], in[38 * stride]);
+        x1[38] = _mm256_sub_epi32(in[25 * stride], in[38 * stride]);
+        x1[26] = _mm256_add_epi32(in[26 * stride], in[37 * stride]);
+        x1[37] = _mm256_sub_epi32(in[26 * stride], in[37 * stride]);
+        x1[27] = _mm256_add_epi32(in[27 * stride], in[36 * stride]);
+        x1[36] = _mm256_sub_epi32(in[27 * stride], in[36 * stride]);
+        x1[28] = _mm256_add_epi32(in[28 * stride], in[35 * stride]);
+        x1[35] = _mm256_sub_epi32(in[28 * stride], in[35 * stride]);
+        x1[29] = _mm256_add_epi32(in[29 * stride], in[34 * stride]);
+        x1[34] = _mm256_sub_epi32(in[29 * stride], in[34 * stride]);
+        x1[30] = _mm256_add_epi32(in[30 * stride], in[33 * stride]);
+        x1[33] = _mm256_sub_epi32(in[30 * stride], in[33 * stride]);
+        x1[31] = _mm256_add_epi32(in[31 * stride], in[32 * stride]);
+        x1[32] = _mm256_sub_epi32(in[31 * stride], in[32 * stride]);
 
-    // stage 3
-    __m256i x3[64];
-    x3[0] = _mm256_add_epi32(x2[0], x2[15]);
-    x3[15] = _mm256_sub_epi32(x2[0], x2[15]);
-    x3[1] = _mm256_add_epi32(x2[1], x2[14]);
-    x3[14] = _mm256_sub_epi32(x2[1], x2[14]);
-    x3[2] = _mm256_add_epi32(x2[2], x2[13]);
-    x3[13] = _mm256_sub_epi32(x2[2], x2[13]);
-    x3[3] = _mm256_add_epi32(x2[3], x2[12]);
-    x3[12] = _mm256_sub_epi32(x2[3], x2[12]);
-    x3[4] = _mm256_add_epi32(x2[4], x2[11]);
-    x3[11] = _mm256_sub_epi32(x2[4], x2[11]);
-    x3[5] = _mm256_add_epi32(x2[5], x2[10]);
-    x3[10] = _mm256_sub_epi32(x2[5], x2[10]);
-    x3[6] = _mm256_add_epi32(x2[6], x2[9]);
-    x3[9] = _mm256_sub_epi32(x2[6], x2[9]);
-    x3[7] = _mm256_add_epi32(x2[7], x2[8]);
-    x3[8] = _mm256_sub_epi32(x2[7], x2[8]);
-    x3[16] = x2[16];
-    x3[17] = x2[17];
-    x3[18] = x2[18];
-    x3[19] = x2[19];
-    btf_32_type0_avx2_new(cospi_m32, cospi_p32, x2[20], x2[27], x3[20], x3[27],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m32, cospi_p32, x2[21], x2[26], x3[21], x3[26],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m32, cospi_p32, x2[22], x2[25], x3[22], x3[25],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m32, cospi_p32, x2[23], x2[24], x3[23], x3[24],
-        __rounding, cos_bit);
-    x3[28] = x2[28];
-    x3[29] = x2[29];
-    x3[30] = x2[30];
-    x3[31] = x2[31];
-    x3[32] = _mm256_add_epi32(x2[32], x2[47]);
-    x3[47] = _mm256_sub_epi32(x2[32], x2[47]);
-    x3[33] = _mm256_add_epi32(x2[33], x2[46]);
-    x3[46] = _mm256_sub_epi32(x2[33], x2[46]);
-    x3[34] = _mm256_add_epi32(x2[34], x2[45]);
-    x3[45] = _mm256_sub_epi32(x2[34], x2[45]);
-    x3[35] = _mm256_add_epi32(x2[35], x2[44]);
-    x3[44] = _mm256_sub_epi32(x2[35], x2[44]);
-    x3[36] = _mm256_add_epi32(x2[36], x2[43]);
-    x3[43] = _mm256_sub_epi32(x2[36], x2[43]);
-    x3[37] = _mm256_add_epi32(x2[37], x2[42]);
-    x3[42] = _mm256_sub_epi32(x2[37], x2[42]);
-    x3[38] = _mm256_add_epi32(x2[38], x2[41]);
-    x3[41] = _mm256_sub_epi32(x2[38], x2[41]);
-    x3[39] = _mm256_add_epi32(x2[39], x2[40]);
-    x3[40] = _mm256_sub_epi32(x2[39], x2[40]);
-    x3[48] = _mm256_sub_epi32(x2[63], x2[48]);
-    x3[63] = _mm256_add_epi32(x2[63], x2[48]);
-    x3[49] = _mm256_sub_epi32(x2[62], x2[49]);
-    x3[62] = _mm256_add_epi32(x2[62], x2[49]);
-    x3[50] = _mm256_sub_epi32(x2[61], x2[50]);
-    x3[61] = _mm256_add_epi32(x2[61], x2[50]);
-    x3[51] = _mm256_sub_epi32(x2[60], x2[51]);
-    x3[60] = _mm256_add_epi32(x2[60], x2[51]);
-    x3[52] = _mm256_sub_epi32(x2[59], x2[52]);
-    x3[59] = _mm256_add_epi32(x2[59], x2[52]);
-    x3[53] = _mm256_sub_epi32(x2[58], x2[53]);
-    x3[58] = _mm256_add_epi32(x2[58], x2[53]);
-    x3[54] = _mm256_sub_epi32(x2[57], x2[54]);
-    x3[57] = _mm256_add_epi32(x2[57], x2[54]);
-    x3[55] = _mm256_sub_epi32(x2[56], x2[55]);
-    x3[56] = _mm256_add_epi32(x2[56], x2[55]);
+        // stage 2
+        __m256i x2[64];
+        x2[0] = _mm256_add_epi32(x1[0], x1[31]);
+        x2[31] = _mm256_sub_epi32(x1[0], x1[31]);
+        x2[1] = _mm256_add_epi32(x1[1], x1[30]);
+        x2[30] = _mm256_sub_epi32(x1[1], x1[30]);
+        x2[2] = _mm256_add_epi32(x1[2], x1[29]);
+        x2[29] = _mm256_sub_epi32(x1[2], x1[29]);
+        x2[3] = _mm256_add_epi32(x1[3], x1[28]);
+        x2[28] = _mm256_sub_epi32(x1[3], x1[28]);
+        x2[4] = _mm256_add_epi32(x1[4], x1[27]);
+        x2[27] = _mm256_sub_epi32(x1[4], x1[27]);
+        x2[5] = _mm256_add_epi32(x1[5], x1[26]);
+        x2[26] = _mm256_sub_epi32(x1[5], x1[26]);
+        x2[6] = _mm256_add_epi32(x1[6], x1[25]);
+        x2[25] = _mm256_sub_epi32(x1[6], x1[25]);
+        x2[7] = _mm256_add_epi32(x1[7], x1[24]);
+        x2[24] = _mm256_sub_epi32(x1[7], x1[24]);
+        x2[8] = _mm256_add_epi32(x1[8], x1[23]);
+        x2[23] = _mm256_sub_epi32(x1[8], x1[23]);
+        x2[9] = _mm256_add_epi32(x1[9], x1[22]);
+        x2[22] = _mm256_sub_epi32(x1[9], x1[22]);
+        x2[10] = _mm256_add_epi32(x1[10], x1[21]);
+        x2[21] = _mm256_sub_epi32(x1[10], x1[21]);
+        x2[11] = _mm256_add_epi32(x1[11], x1[20]);
+        x2[20] = _mm256_sub_epi32(x1[11], x1[20]);
+        x2[12] = _mm256_add_epi32(x1[12], x1[19]);
+        x2[19] = _mm256_sub_epi32(x1[12], x1[19]);
+        x2[13] = _mm256_add_epi32(x1[13], x1[18]);
+        x2[18] = _mm256_sub_epi32(x1[13], x1[18]);
+        x2[14] = _mm256_add_epi32(x1[14], x1[17]);
+        x2[17] = _mm256_sub_epi32(x1[14], x1[17]);
+        x2[15] = _mm256_add_epi32(x1[15], x1[16]);
+        x2[16] = _mm256_sub_epi32(x1[15], x1[16]);
+        x2[32] = x1[32];
+        x2[33] = x1[33];
+        x2[34] = x1[34];
+        x2[35] = x1[35];
+        x2[36] = x1[36];
+        x2[37] = x1[37];
+        x2[38] = x1[38];
+        x2[39] = x1[39];
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, x1[40], x1[55],
+            x2[40], x2[55], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, x1[41], x1[54],
+            x2[41], x2[54], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, x1[42], x1[53],
+            x2[42], x2[53], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, x1[43], x1[52],
+            x2[43], x2[52], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, x1[44], x1[51],
+            x2[44], x2[51], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, x1[45], x1[50],
+            x2[45], x2[50], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, x1[46], x1[49],
+            x2[46], x2[49], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, x1[47], x1[48],
+            x2[47], x2[48], __rounding, cos_bit);
+        x2[56] = x1[56];
+        x2[57] = x1[57];
+        x2[58] = x1[58];
+        x2[59] = x1[59];
+        x2[60] = x1[60];
+        x2[61] = x1[61];
+        x2[62] = x1[62];
+        x2[63] = x1[63];
 
-    // stage 4
-    __m256i x4[64];
-    x4[0] = _mm256_add_epi32(x3[0], x3[7]);
-    x4[7] = _mm256_sub_epi32(x3[0], x3[7]);
-    x4[1] = _mm256_add_epi32(x3[1], x3[6]);
-    x4[6] = _mm256_sub_epi32(x3[1], x3[6]);
-    x4[2] = _mm256_add_epi32(x3[2], x3[5]);
-    x4[5] = _mm256_sub_epi32(x3[2], x3[5]);
-    x4[3] = _mm256_add_epi32(x3[3], x3[4]);
-    x4[4] = _mm256_sub_epi32(x3[3], x3[4]);
-    x4[8] = x3[8];
-    x4[9] = x3[9];
-    btf_32_type0_avx2_new(cospi_m32, cospi_p32, x3[10], x3[13], x4[10], x4[13],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m32, cospi_p32, x3[11], x3[12], x4[11], x4[12],
-        __rounding, cos_bit);
-    x4[14] = x3[14];
-    x4[15] = x3[15];
-    x4[16] = _mm256_add_epi32(x3[16], x3[23]);
-    x4[23] = _mm256_sub_epi32(x3[16], x3[23]);
-    x4[17] = _mm256_add_epi32(x3[17], x3[22]);
-    x4[22] = _mm256_sub_epi32(x3[17], x3[22]);
-    x4[18] = _mm256_add_epi32(x3[18], x3[21]);
-    x4[21] = _mm256_sub_epi32(x3[18], x3[21]);
-    x4[19] = _mm256_add_epi32(x3[19], x3[20]);
-    x4[20] = _mm256_sub_epi32(x3[19], x3[20]);
-    x4[24] = _mm256_sub_epi32(x3[31], x3[24]);
-    x4[31] = _mm256_add_epi32(x3[31], x3[24]);
-    x4[25] = _mm256_sub_epi32(x3[30], x3[25]);
-    x4[30] = _mm256_add_epi32(x3[30], x3[25]);
-    x4[26] = _mm256_sub_epi32(x3[29], x3[26]);
-    x4[29] = _mm256_add_epi32(x3[29], x3[26]);
-    x4[27] = _mm256_sub_epi32(x3[28], x3[27]);
-    x4[28] = _mm256_add_epi32(x3[28], x3[27]);
-    x4[32] = x3[32];
-    x4[33] = x3[33];
-    x4[34] = x3[34];
-    x4[35] = x3[35];
-    btf_32_type0_avx2_new(cospi_m16, cospi_p48, x3[36], x3[59], x4[36], x4[59],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m16, cospi_p48, x3[37], x3[58], x4[37], x4[58],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m16, cospi_p48, x3[38], x3[57], x4[38], x4[57],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m16, cospi_p48, x3[39], x3[56], x4[39], x4[56],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m48, cospi_m16, x3[40], x3[55], x4[40], x4[55],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m48, cospi_m16, x3[41], x3[54], x4[41], x4[54],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m48, cospi_m16, x3[42], x3[53], x4[42], x4[53],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m48, cospi_m16, x3[43], x3[52], x4[43], x4[52],
-        __rounding, cos_bit);
-    x4[44] = x3[44];
-    x4[45] = x3[45];
-    x4[46] = x3[46];
-    x4[47] = x3[47];
-    x4[48] = x3[48];
-    x4[49] = x3[49];
-    x4[50] = x3[50];
-    x4[51] = x3[51];
-    x4[60] = x3[60];
-    x4[61] = x3[61];
-    x4[62] = x3[62];
-    x4[63] = x3[63];
+        // stage 3
+        __m256i x3[64];
+        x3[0] = _mm256_add_epi32(x2[0], x2[15]);
+        x3[15] = _mm256_sub_epi32(x2[0], x2[15]);
+        x3[1] = _mm256_add_epi32(x2[1], x2[14]);
+        x3[14] = _mm256_sub_epi32(x2[1], x2[14]);
+        x3[2] = _mm256_add_epi32(x2[2], x2[13]);
+        x3[13] = _mm256_sub_epi32(x2[2], x2[13]);
+        x3[3] = _mm256_add_epi32(x2[3], x2[12]);
+        x3[12] = _mm256_sub_epi32(x2[3], x2[12]);
+        x3[4] = _mm256_add_epi32(x2[4], x2[11]);
+        x3[11] = _mm256_sub_epi32(x2[4], x2[11]);
+        x3[5] = _mm256_add_epi32(x2[5], x2[10]);
+        x3[10] = _mm256_sub_epi32(x2[5], x2[10]);
+        x3[6] = _mm256_add_epi32(x2[6], x2[9]);
+        x3[9] = _mm256_sub_epi32(x2[6], x2[9]);
+        x3[7] = _mm256_add_epi32(x2[7], x2[8]);
+        x3[8] = _mm256_sub_epi32(x2[7], x2[8]);
+        x3[16] = x2[16];
+        x3[17] = x2[17];
+        x3[18] = x2[18];
+        x3[19] = x2[19];
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, x2[20], x2[27],
+            x3[20], x3[27], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, x2[21], x2[26],
+            x3[21], x3[26], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, x2[22], x2[25],
+            x3[22], x3[25], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, x2[23], x2[24],
+            x3[23], x3[24], __rounding, cos_bit);
+        x3[28] = x2[28];
+        x3[29] = x2[29];
+        x3[30] = x2[30];
+        x3[31] = x2[31];
+        x3[32] = _mm256_add_epi32(x2[32], x2[47]);
+        x3[47] = _mm256_sub_epi32(x2[32], x2[47]);
+        x3[33] = _mm256_add_epi32(x2[33], x2[46]);
+        x3[46] = _mm256_sub_epi32(x2[33], x2[46]);
+        x3[34] = _mm256_add_epi32(x2[34], x2[45]);
+        x3[45] = _mm256_sub_epi32(x2[34], x2[45]);
+        x3[35] = _mm256_add_epi32(x2[35], x2[44]);
+        x3[44] = _mm256_sub_epi32(x2[35], x2[44]);
+        x3[36] = _mm256_add_epi32(x2[36], x2[43]);
+        x3[43] = _mm256_sub_epi32(x2[36], x2[43]);
+        x3[37] = _mm256_add_epi32(x2[37], x2[42]);
+        x3[42] = _mm256_sub_epi32(x2[37], x2[42]);
+        x3[38] = _mm256_add_epi32(x2[38], x2[41]);
+        x3[41] = _mm256_sub_epi32(x2[38], x2[41]);
+        x3[39] = _mm256_add_epi32(x2[39], x2[40]);
+        x3[40] = _mm256_sub_epi32(x2[39], x2[40]);
+        x3[48] = _mm256_sub_epi32(x2[63], x2[48]);
+        x3[63] = _mm256_add_epi32(x2[63], x2[48]);
+        x3[49] = _mm256_sub_epi32(x2[62], x2[49]);
+        x3[62] = _mm256_add_epi32(x2[62], x2[49]);
+        x3[50] = _mm256_sub_epi32(x2[61], x2[50]);
+        x3[61] = _mm256_add_epi32(x2[61], x2[50]);
+        x3[51] = _mm256_sub_epi32(x2[60], x2[51]);
+        x3[60] = _mm256_add_epi32(x2[60], x2[51]);
+        x3[52] = _mm256_sub_epi32(x2[59], x2[52]);
+        x3[59] = _mm256_add_epi32(x2[59], x2[52]);
+        x3[53] = _mm256_sub_epi32(x2[58], x2[53]);
+        x3[58] = _mm256_add_epi32(x2[58], x2[53]);
+        x3[54] = _mm256_sub_epi32(x2[57], x2[54]);
+        x3[57] = _mm256_add_epi32(x2[57], x2[54]);
+        x3[55] = _mm256_sub_epi32(x2[56], x2[55]);
+        x3[56] = _mm256_add_epi32(x2[56], x2[55]);
 
-    // stage 5
-    __m256i x5[64];
-    x5[0] = _mm256_add_epi32(x4[0], x4[3]);
-    x5[3] = _mm256_sub_epi32(x4[0], x4[3]);
-    x5[1] = _mm256_add_epi32(x4[1], x4[2]);
-    x5[2] = _mm256_sub_epi32(x4[1], x4[2]);
-    x5[4] = x4[4];
-    btf_32_type0_avx2_new(cospi_m32, cospi_p32, x4[5], x4[6], x5[5], x5[6],
-        __rounding, cos_bit);
-    x5[7] = x4[7];
-    x5[8] = _mm256_add_epi32(x4[8], x4[11]);
-    x5[11] = _mm256_sub_epi32(x4[8], x4[11]);
-    x5[9] = _mm256_add_epi32(x4[9], x4[10]);
-    x5[10] = _mm256_sub_epi32(x4[9], x4[10]);
-    x5[12] = _mm256_sub_epi32(x4[15], x4[12]);
-    x5[15] = _mm256_add_epi32(x4[15], x4[12]);
-    x5[13] = _mm256_sub_epi32(x4[14], x4[13]);
-    x5[14] = _mm256_add_epi32(x4[14], x4[13]);
-    x5[16] = x4[16];
-    x5[17] = x4[17];
-    btf_32_type0_avx2_new(cospi_m16, cospi_p48, x4[18], x4[29], x5[18], x5[29],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m16, cospi_p48, x4[19], x4[28], x5[19], x5[28],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m48, cospi_m16, x4[20], x4[27], x5[20], x5[27],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m48, cospi_m16, x4[21], x4[26], x5[21], x5[26],
-        __rounding, cos_bit);
-    x5[22] = x4[22];
-    x5[23] = x4[23];
-    x5[24] = x4[24];
-    x5[25] = x4[25];
-    x5[30] = x4[30];
-    x5[31] = x4[31];
-    x5[32] = _mm256_add_epi32(x4[32], x4[39]);
-    x5[39] = _mm256_sub_epi32(x4[32], x4[39]);
-    x5[33] = _mm256_add_epi32(x4[33], x4[38]);
-    x5[38] = _mm256_sub_epi32(x4[33], x4[38]);
-    x5[34] = _mm256_add_epi32(x4[34], x4[37]);
-    x5[37] = _mm256_sub_epi32(x4[34], x4[37]);
-    x5[35] = _mm256_add_epi32(x4[35], x4[36]);
-    x5[36] = _mm256_sub_epi32(x4[35], x4[36]);
-    x5[40] = _mm256_sub_epi32(x4[47], x4[40]);
-    x5[47] = _mm256_add_epi32(x4[47], x4[40]);
-    x5[41] = _mm256_sub_epi32(x4[46], x4[41]);
-    x5[46] = _mm256_add_epi32(x4[46], x4[41]);
-    x5[42] = _mm256_sub_epi32(x4[45], x4[42]);
-    x5[45] = _mm256_add_epi32(x4[45], x4[42]);
-    x5[43] = _mm256_sub_epi32(x4[44], x4[43]);
-    x5[44] = _mm256_add_epi32(x4[44], x4[43]);
-    x5[48] = _mm256_add_epi32(x4[48], x4[55]);
-    x5[55] = _mm256_sub_epi32(x4[48], x4[55]);
-    x5[49] = _mm256_add_epi32(x4[49], x4[54]);
-    x5[54] = _mm256_sub_epi32(x4[49], x4[54]);
-    x5[50] = _mm256_add_epi32(x4[50], x4[53]);
-    x5[53] = _mm256_sub_epi32(x4[50], x4[53]);
-    x5[51] = _mm256_add_epi32(x4[51], x4[52]);
-    x5[52] = _mm256_sub_epi32(x4[51], x4[52]);
-    x5[56] = _mm256_sub_epi32(x4[63], x4[56]);
-    x5[63] = _mm256_add_epi32(x4[63], x4[56]);
-    x5[57] = _mm256_sub_epi32(x4[62], x4[57]);
-    x5[62] = _mm256_add_epi32(x4[62], x4[57]);
-    x5[58] = _mm256_sub_epi32(x4[61], x4[58]);
-    x5[61] = _mm256_add_epi32(x4[61], x4[58]);
-    x5[59] = _mm256_sub_epi32(x4[60], x4[59]);
-    x5[60] = _mm256_add_epi32(x4[60], x4[59]);
+        // stage 4
+        __m256i x4[64];
+        x4[0] = _mm256_add_epi32(x3[0], x3[7]);
+        x4[7] = _mm256_sub_epi32(x3[0], x3[7]);
+        x4[1] = _mm256_add_epi32(x3[1], x3[6]);
+        x4[6] = _mm256_sub_epi32(x3[1], x3[6]);
+        x4[2] = _mm256_add_epi32(x3[2], x3[5]);
+        x4[5] = _mm256_sub_epi32(x3[2], x3[5]);
+        x4[3] = _mm256_add_epi32(x3[3], x3[4]);
+        x4[4] = _mm256_sub_epi32(x3[3], x3[4]);
+        x4[8] = x3[8];
+        x4[9] = x3[9];
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, x3[10], x3[13],
+            x4[10], x4[13], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, x3[11], x3[12],
+            x4[11], x4[12], __rounding, cos_bit);
+        x4[14] = x3[14];
+        x4[15] = x3[15];
+        x4[16] = _mm256_add_epi32(x3[16], x3[23]);
+        x4[23] = _mm256_sub_epi32(x3[16], x3[23]);
+        x4[17] = _mm256_add_epi32(x3[17], x3[22]);
+        x4[22] = _mm256_sub_epi32(x3[17], x3[22]);
+        x4[18] = _mm256_add_epi32(x3[18], x3[21]);
+        x4[21] = _mm256_sub_epi32(x3[18], x3[21]);
+        x4[19] = _mm256_add_epi32(x3[19], x3[20]);
+        x4[20] = _mm256_sub_epi32(x3[19], x3[20]);
+        x4[24] = _mm256_sub_epi32(x3[31], x3[24]);
+        x4[31] = _mm256_add_epi32(x3[31], x3[24]);
+        x4[25] = _mm256_sub_epi32(x3[30], x3[25]);
+        x4[30] = _mm256_add_epi32(x3[30], x3[25]);
+        x4[26] = _mm256_sub_epi32(x3[29], x3[26]);
+        x4[29] = _mm256_add_epi32(x3[29], x3[26]);
+        x4[27] = _mm256_sub_epi32(x3[28], x3[27]);
+        x4[28] = _mm256_add_epi32(x3[28], x3[27]);
+        x4[32] = x3[32];
+        x4[33] = x3[33];
+        x4[34] = x3[34];
+        x4[35] = x3[35];
+        btf_32_type0_avx2_new(cospi_m16, cospi_p48, x3[36], x3[59],
+            x4[36], x4[59], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m16, cospi_p48, x3[37], x3[58],
+            x4[37], x4[58], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m16, cospi_p48, x3[38], x3[57],
+            x4[38], x4[57], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m16, cospi_p48, x3[39], x3[56],
+            x4[39], x4[56], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m48, cospi_m16, x3[40], x3[55],
+            x4[40], x4[55], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m48, cospi_m16, x3[41], x3[54],
+            x4[41], x4[54], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m48, cospi_m16, x3[42], x3[53],
+            x4[42], x4[53], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m48, cospi_m16, x3[43], x3[52],
+            x4[43], x4[52], __rounding, cos_bit);
+        x4[44] = x3[44];
+        x4[45] = x3[45];
+        x4[46] = x3[46];
+        x4[47] = x3[47];
+        x4[48] = x3[48];
+        x4[49] = x3[49];
+        x4[50] = x3[50];
+        x4[51] = x3[51];
+        x4[60] = x3[60];
+        x4[61] = x3[61];
+        x4[62] = x3[62];
+        x4[63] = x3[63];
 
-    // stage 6
-    __m256i x6[64];
-    btf_32_type0_avx2_new(cospi_p32, cospi_p32, x5[0], x5[1], x6[0], x6[1],
-        __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p48, cospi_p16, x5[2], x5[3], x6[2], x6[3],
-        __rounding, cos_bit);
-    x6[4] = _mm256_add_epi32(x5[4], x5[5]);
-    x6[5] = _mm256_sub_epi32(x5[4], x5[5]);
-    x6[6] = _mm256_sub_epi32(x5[7], x5[6]);
-    x6[7] = _mm256_add_epi32(x5[7], x5[6]);
-    x6[8] = x5[8];
-    btf_32_type0_avx2_new(cospi_m16, cospi_p48, x5[9], x5[14], x6[9], x6[14],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m48, cospi_m16, x5[10], x5[13], x6[10], x6[13],
-        __rounding, cos_bit);
-    x6[11] = x5[11];
-    x6[12] = x5[12];
-    x6[15] = x5[15];
-    x6[16] = _mm256_add_epi32(x5[16], x5[19]);
-    x6[19] = _mm256_sub_epi32(x5[16], x5[19]);
-    x6[17] = _mm256_add_epi32(x5[17], x5[18]);
-    x6[18] = _mm256_sub_epi32(x5[17], x5[18]);
-    x6[20] = _mm256_sub_epi32(x5[23], x5[20]);
-    x6[23] = _mm256_add_epi32(x5[23], x5[20]);
-    x6[21] = _mm256_sub_epi32(x5[22], x5[21]);
-    x6[22] = _mm256_add_epi32(x5[22], x5[21]);
-    x6[24] = _mm256_add_epi32(x5[24], x5[27]);
-    x6[27] = _mm256_sub_epi32(x5[24], x5[27]);
-    x6[25] = _mm256_add_epi32(x5[25], x5[26]);
-    x6[26] = _mm256_sub_epi32(x5[25], x5[26]);
-    x6[28] = _mm256_sub_epi32(x5[31], x5[28]);
-    x6[31] = _mm256_add_epi32(x5[31], x5[28]);
-    x6[29] = _mm256_sub_epi32(x5[30], x5[29]);
-    x6[30] = _mm256_add_epi32(x5[30], x5[29]);
-    x6[32] = x5[32];
-    x6[33] = x5[33];
-    btf_32_type0_avx2_new(cospi_m08, cospi_p56, x5[34], x5[61], x6[34], x6[61],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m08, cospi_p56, x5[35], x5[60], x6[35], x6[60],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m56, cospi_m08, x5[36], x5[59], x6[36], x6[59],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m56, cospi_m08, x5[37], x5[58], x6[37], x6[58],
-        __rounding, cos_bit);
-    x6[38] = x5[38];
-    x6[39] = x5[39];
-    x6[40] = x5[40];
-    x6[41] = x5[41];
-    btf_32_type0_avx2_new(cospi_m40, cospi_p24, x5[42], x5[53], x6[42], x6[53],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m40, cospi_p24, x5[43], x5[52], x6[43], x6[52],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m24, cospi_m40, x5[44], x5[51], x6[44], x6[51],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m24, cospi_m40, x5[45], x5[50], x6[45], x6[50],
-        __rounding, cos_bit);
-    x6[46] = x5[46];
-    x6[47] = x5[47];
-    x6[48] = x5[48];
-    x6[49] = x5[49];
-    x6[54] = x5[54];
-    x6[55] = x5[55];
-    x6[56] = x5[56];
-    x6[57] = x5[57];
-    x6[62] = x5[62];
-    x6[63] = x5[63];
+        // stage 5
+        __m256i x5[64];
+        x5[0] = _mm256_add_epi32(x4[0], x4[3]);
+        x5[3] = _mm256_sub_epi32(x4[0], x4[3]);
+        x5[1] = _mm256_add_epi32(x4[1], x4[2]);
+        x5[2] = _mm256_sub_epi32(x4[1], x4[2]);
+        x5[4] = x4[4];
+        btf_32_type0_avx2_new(cospi_m32, cospi_p32, x4[5], x4[6],
+            x5[5], x5[6], __rounding, cos_bit);
+        x5[7] = x4[7];
+        x5[8] = _mm256_add_epi32(x4[8], x4[11]);
+        x5[11] = _mm256_sub_epi32(x4[8], x4[11]);
+        x5[9] = _mm256_add_epi32(x4[9], x4[10]);
+        x5[10] = _mm256_sub_epi32(x4[9], x4[10]);
+        x5[12] = _mm256_sub_epi32(x4[15], x4[12]);
+        x5[15] = _mm256_add_epi32(x4[15], x4[12]);
+        x5[13] = _mm256_sub_epi32(x4[14], x4[13]);
+        x5[14] = _mm256_add_epi32(x4[14], x4[13]);
+        x5[16] = x4[16];
+        x5[17] = x4[17];
+        btf_32_type0_avx2_new(cospi_m16, cospi_p48, x4[18], x4[29],
+            x5[18], x5[29], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m16, cospi_p48, x4[19], x4[28],
+            x5[19], x5[28], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m48, cospi_m16, x4[20], x4[27],
+            x5[20], x5[27], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m48, cospi_m16, x4[21], x4[26],
+            x5[21], x5[26], __rounding, cos_bit);
+        x5[22] = x4[22];
+        x5[23] = x4[23];
+        x5[24] = x4[24];
+        x5[25] = x4[25];
+        x5[30] = x4[30];
+        x5[31] = x4[31];
+        x5[32] = _mm256_add_epi32(x4[32], x4[39]);
+        x5[39] = _mm256_sub_epi32(x4[32], x4[39]);
+        x5[33] = _mm256_add_epi32(x4[33], x4[38]);
+        x5[38] = _mm256_sub_epi32(x4[33], x4[38]);
+        x5[34] = _mm256_add_epi32(x4[34], x4[37]);
+        x5[37] = _mm256_sub_epi32(x4[34], x4[37]);
+        x5[35] = _mm256_add_epi32(x4[35], x4[36]);
+        x5[36] = _mm256_sub_epi32(x4[35], x4[36]);
+        x5[40] = _mm256_sub_epi32(x4[47], x4[40]);
+        x5[47] = _mm256_add_epi32(x4[47], x4[40]);
+        x5[41] = _mm256_sub_epi32(x4[46], x4[41]);
+        x5[46] = _mm256_add_epi32(x4[46], x4[41]);
+        x5[42] = _mm256_sub_epi32(x4[45], x4[42]);
+        x5[45] = _mm256_add_epi32(x4[45], x4[42]);
+        x5[43] = _mm256_sub_epi32(x4[44], x4[43]);
+        x5[44] = _mm256_add_epi32(x4[44], x4[43]);
+        x5[48] = _mm256_add_epi32(x4[48], x4[55]);
+        x5[55] = _mm256_sub_epi32(x4[48], x4[55]);
+        x5[49] = _mm256_add_epi32(x4[49], x4[54]);
+        x5[54] = _mm256_sub_epi32(x4[49], x4[54]);
+        x5[50] = _mm256_add_epi32(x4[50], x4[53]);
+        x5[53] = _mm256_sub_epi32(x4[50], x4[53]);
+        x5[51] = _mm256_add_epi32(x4[51], x4[52]);
+        x5[52] = _mm256_sub_epi32(x4[51], x4[52]);
+        x5[56] = _mm256_sub_epi32(x4[63], x4[56]);
+        x5[63] = _mm256_add_epi32(x4[63], x4[56]);
+        x5[57] = _mm256_sub_epi32(x4[62], x4[57]);
+        x5[62] = _mm256_add_epi32(x4[62], x4[57]);
+        x5[58] = _mm256_sub_epi32(x4[61], x4[58]);
+        x5[61] = _mm256_add_epi32(x4[61], x4[58]);
+        x5[59] = _mm256_sub_epi32(x4[60], x4[59]);
+        x5[60] = _mm256_add_epi32(x4[60], x4[59]);
 
-    // stage 7
-    __m256i x7[64];
-    x7[0] = x6[0];
-    x7[1] = x6[1];
-    x7[2] = x6[2];
-    x7[3] = x6[3];
-    btf_32_type1_avx2_new(cospi_p56, cospi_p08, x6[4], x6[7], x7[4], x7[7],
-        __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p24, cospi_p40, x6[5], x6[6], x7[5], x7[6],
-        __rounding, cos_bit);
-    x7[8] = _mm256_add_epi32(x6[8], x6[9]);
-    x7[9] = _mm256_sub_epi32(x6[8], x6[9]);
-    x7[10] = _mm256_sub_epi32(x6[11], x6[10]);
-    x7[11] = _mm256_add_epi32(x6[11], x6[10]);
-    x7[12] = _mm256_add_epi32(x6[12], x6[13]);
-    x7[13] = _mm256_sub_epi32(x6[12], x6[13]);
-    x7[14] = _mm256_sub_epi32(x6[15], x6[14]);
-    x7[15] = _mm256_add_epi32(x6[15], x6[14]);
-    x7[16] = x6[16];
-    btf_32_type0_avx2_new(cospi_m08, cospi_p56, x6[17], x6[30], x7[17], x7[30],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m56, cospi_m08, x6[18], x6[29], x7[18], x7[29],
-        __rounding, cos_bit);
-    x7[19] = x6[19];
-    x7[20] = x6[20];
-    btf_32_type0_avx2_new(cospi_m40, cospi_p24, x6[21], x6[26], x7[21], x7[26],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m24, cospi_m40, x6[22], x6[25], x7[22], x7[25],
-        __rounding, cos_bit);
-    x7[23] = x6[23];
-    x7[24] = x6[24];
-    x7[27] = x6[27];
-    x7[28] = x6[28];
-    x7[31] = x6[31];
-    x7[32] = _mm256_add_epi32(x6[32], x6[35]);
-    x7[35] = _mm256_sub_epi32(x6[32], x6[35]);
-    x7[33] = _mm256_add_epi32(x6[33], x6[34]);
-    x7[34] = _mm256_sub_epi32(x6[33], x6[34]);
-    x7[36] = _mm256_sub_epi32(x6[39], x6[36]);
-    x7[39] = _mm256_add_epi32(x6[39], x6[36]);
-    x7[37] = _mm256_sub_epi32(x6[38], x6[37]);
-    x7[38] = _mm256_add_epi32(x6[38], x6[37]);
-    x7[40] = _mm256_add_epi32(x6[40], x6[43]);
-    x7[43] = _mm256_sub_epi32(x6[40], x6[43]);
-    x7[41] = _mm256_add_epi32(x6[41], x6[42]);
-    x7[42] = _mm256_sub_epi32(x6[41], x6[42]);
-    x7[44] = _mm256_sub_epi32(x6[47], x6[44]);
-    x7[47] = _mm256_add_epi32(x6[47], x6[44]);
-    x7[45] = _mm256_sub_epi32(x6[46], x6[45]);
-    x7[46] = _mm256_add_epi32(x6[46], x6[45]);
-    x7[48] = _mm256_add_epi32(x6[48], x6[51]);
-    x7[51] = _mm256_sub_epi32(x6[48], x6[51]);
-    x7[49] = _mm256_add_epi32(x6[49], x6[50]);
-    x7[50] = _mm256_sub_epi32(x6[49], x6[50]);
-    x7[52] = _mm256_sub_epi32(x6[55], x6[52]);
-    x7[55] = _mm256_add_epi32(x6[55], x6[52]);
-    x7[53] = _mm256_sub_epi32(x6[54], x6[53]);
-    x7[54] = _mm256_add_epi32(x6[54], x6[53]);
-    x7[56] = _mm256_add_epi32(x6[56], x6[59]);
-    x7[59] = _mm256_sub_epi32(x6[56], x6[59]);
-    x7[57] = _mm256_add_epi32(x6[57], x6[58]);
-    x7[58] = _mm256_sub_epi32(x6[57], x6[58]);
-    x7[60] = _mm256_sub_epi32(x6[63], x6[60]);
-    x7[63] = _mm256_add_epi32(x6[63], x6[60]);
-    x7[61] = _mm256_sub_epi32(x6[62], x6[61]);
-    x7[62] = _mm256_add_epi32(x6[62], x6[61]);
+        // stage 6
+        __m256i x6[64];
+        btf_32_type0_avx2_new(cospi_p32, cospi_p32, x5[0], x5[1],
+            x6[0], x6[1], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p48, cospi_p16, x5[2], x5[3],
+            x6[2], x6[3], __rounding, cos_bit);
+        x6[4] = _mm256_add_epi32(x5[4], x5[5]);
+        x6[5] = _mm256_sub_epi32(x5[4], x5[5]);
+        x6[6] = _mm256_sub_epi32(x5[7], x5[6]);
+        x6[7] = _mm256_add_epi32(x5[7], x5[6]);
+        x6[8] = x5[8];
+        btf_32_type0_avx2_new(cospi_m16, cospi_p48, x5[9], x5[14],
+            x6[9], x6[14], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m48, cospi_m16, x5[10], x5[13],
+            x6[10], x6[13], __rounding, cos_bit);
+        x6[11] = x5[11];
+        x6[12] = x5[12];
+        x6[15] = x5[15];
+        x6[16] = _mm256_add_epi32(x5[16], x5[19]);
+        x6[19] = _mm256_sub_epi32(x5[16], x5[19]);
+        x6[17] = _mm256_add_epi32(x5[17], x5[18]);
+        x6[18] = _mm256_sub_epi32(x5[17], x5[18]);
+        x6[20] = _mm256_sub_epi32(x5[23], x5[20]);
+        x6[23] = _mm256_add_epi32(x5[23], x5[20]);
+        x6[21] = _mm256_sub_epi32(x5[22], x5[21]);
+        x6[22] = _mm256_add_epi32(x5[22], x5[21]);
+        x6[24] = _mm256_add_epi32(x5[24], x5[27]);
+        x6[27] = _mm256_sub_epi32(x5[24], x5[27]);
+        x6[25] = _mm256_add_epi32(x5[25], x5[26]);
+        x6[26] = _mm256_sub_epi32(x5[25], x5[26]);
+        x6[28] = _mm256_sub_epi32(x5[31], x5[28]);
+        x6[31] = _mm256_add_epi32(x5[31], x5[28]);
+        x6[29] = _mm256_sub_epi32(x5[30], x5[29]);
+        x6[30] = _mm256_add_epi32(x5[30], x5[29]);
+        x6[32] = x5[32];
+        x6[33] = x5[33];
+        btf_32_type0_avx2_new(cospi_m08, cospi_p56, x5[34], x5[61],
+            x6[34], x6[61], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m08, cospi_p56, x5[35], x5[60],
+            x6[35], x6[60], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m56, cospi_m08, x5[36], x5[59],
+            x6[36], x6[59], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m56, cospi_m08, x5[37], x5[58],
+            x6[37], x6[58], __rounding, cos_bit);
+        x6[38] = x5[38];
+        x6[39] = x5[39];
+        x6[40] = x5[40];
+        x6[41] = x5[41];
+        btf_32_type0_avx2_new(cospi_m40, cospi_p24, x5[42], x5[53],
+            x6[42], x6[53], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m40, cospi_p24, x5[43], x5[52],
+            x6[43], x6[52], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m24, cospi_m40, x5[44], x5[51],
+            x6[44], x6[51], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m24, cospi_m40, x5[45], x5[50],
+            x6[45], x6[50], __rounding, cos_bit);
+        x6[46] = x5[46];
+        x6[47] = x5[47];
+        x6[48] = x5[48];
+        x6[49] = x5[49];
+        x6[54] = x5[54];
+        x6[55] = x5[55];
+        x6[56] = x5[56];
+        x6[57] = x5[57];
+        x6[62] = x5[62];
+        x6[63] = x5[63];
 
-    // stage 8
-    __m256i x8[64];
-    x8[0] = x7[0];
-    x8[1] = x7[1];
-    x8[2] = x7[2];
-    x8[3] = x7[3];
-    x8[4] = x7[4];
-    x8[5] = x7[5];
-    x8[6] = x7[6];
-    x8[7] = x7[7];
-    btf_32_type1_avx2_new(cospi_p60, cospi_p04, x7[8], x7[15], x8[8], x8[15],
-        __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p28, cospi_p36, x7[9], x7[14], x8[9], x8[14],
-        __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p44, cospi_p20, x7[10], x7[13], x8[10], x8[13],
-        __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p12, cospi_p52, x7[11], x7[12], x8[11], x8[12],
-        __rounding, cos_bit);
-    x8[16] = _mm256_add_epi32(x7[16], x7[17]);
-    x8[17] = _mm256_sub_epi32(x7[16], x7[17]);
-    x8[18] = _mm256_sub_epi32(x7[19], x7[18]);
-    x8[19] = _mm256_add_epi32(x7[19], x7[18]);
-    x8[20] = _mm256_add_epi32(x7[20], x7[21]);
-    x8[21] = _mm256_sub_epi32(x7[20], x7[21]);
-    x8[22] = _mm256_sub_epi32(x7[23], x7[22]);
-    x8[23] = _mm256_add_epi32(x7[23], x7[22]);
-    x8[24] = _mm256_add_epi32(x7[24], x7[25]);
-    x8[25] = _mm256_sub_epi32(x7[24], x7[25]);
-    x8[26] = _mm256_sub_epi32(x7[27], x7[26]);
-    x8[27] = _mm256_add_epi32(x7[27], x7[26]);
-    x8[28] = _mm256_add_epi32(x7[28], x7[29]);
-    x8[29] = _mm256_sub_epi32(x7[28], x7[29]);
-    x8[30] = _mm256_sub_epi32(x7[31], x7[30]);
-    x8[31] = _mm256_add_epi32(x7[31], x7[30]);
-    x8[32] = x7[32];
-    btf_32_type0_avx2_new(cospi_m04, cospi_p60, x7[33], x7[62], x8[33], x8[62],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m60, cospi_m04, x7[34], x7[61], x8[34], x8[61],
-        __rounding, cos_bit);
-    x8[35] = x7[35];
-    x8[36] = x7[36];
-    btf_32_type0_avx2_new(cospi_m36, cospi_p28, x7[37], x7[58], x8[37], x8[58],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m28, cospi_m36, x7[38], x7[57], x8[38], x8[57],
-        __rounding, cos_bit);
-    x8[39] = x7[39];
-    x8[40] = x7[40];
-    btf_32_type0_avx2_new(cospi_m20, cospi_p44, x7[41], x7[54], x8[41], x8[54],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m44, cospi_m20, x7[42], x7[53], x8[42], x8[53],
-        __rounding, cos_bit);
-    x8[43] = x7[43];
-    x8[44] = x7[44];
-    btf_32_type0_avx2_new(cospi_m52, cospi_p12, x7[45], x7[50], x8[45], x8[50],
-        __rounding, cos_bit);
-    btf_32_type0_avx2_new(cospi_m12, cospi_m52, x7[46], x7[49], x8[46], x8[49],
-        __rounding, cos_bit);
-    x8[47] = x7[47];
-    x8[48] = x7[48];
-    x8[51] = x7[51];
-    x8[52] = x7[52];
-    x8[55] = x7[55];
-    x8[56] = x7[56];
-    x8[59] = x7[59];
-    x8[60] = x7[60];
-    x8[63] = x7[63];
+        // stage 7
+        __m256i x7[64];
+        x7[0] = x6[0];
+        x7[1] = x6[1];
+        x7[2] = x6[2];
+        x7[3] = x6[3];
+        btf_32_type1_avx2_new(cospi_p56, cospi_p08, x6[4], x6[7],
+            x7[4], x7[7], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p24, cospi_p40, x6[5], x6[6],
+            x7[5], x7[6], __rounding, cos_bit);
+        x7[8] = _mm256_add_epi32(x6[8], x6[9]);
+        x7[9] = _mm256_sub_epi32(x6[8], x6[9]);
+        x7[10] = _mm256_sub_epi32(x6[11], x6[10]);
+        x7[11] = _mm256_add_epi32(x6[11], x6[10]);
+        x7[12] = _mm256_add_epi32(x6[12], x6[13]);
+        x7[13] = _mm256_sub_epi32(x6[12], x6[13]);
+        x7[14] = _mm256_sub_epi32(x6[15], x6[14]);
+        x7[15] = _mm256_add_epi32(x6[15], x6[14]);
+        x7[16] = x6[16];
+        btf_32_type0_avx2_new(cospi_m08, cospi_p56, x6[17], x6[30],
+            x7[17], x7[30], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m56, cospi_m08, x6[18], x6[29],
+            x7[18], x7[29], __rounding, cos_bit);
+        x7[19] = x6[19];
+        x7[20] = x6[20];
+        btf_32_type0_avx2_new(cospi_m40, cospi_p24, x6[21], x6[26],
+            x7[21], x7[26], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m24, cospi_m40, x6[22], x6[25],
+            x7[22], x7[25], __rounding, cos_bit);
+        x7[23] = x6[23];
+        x7[24] = x6[24];
+        x7[27] = x6[27];
+        x7[28] = x6[28];
+        x7[31] = x6[31];
+        x7[32] = _mm256_add_epi32(x6[32], x6[35]);
+        x7[35] = _mm256_sub_epi32(x6[32], x6[35]);
+        x7[33] = _mm256_add_epi32(x6[33], x6[34]);
+        x7[34] = _mm256_sub_epi32(x6[33], x6[34]);
+        x7[36] = _mm256_sub_epi32(x6[39], x6[36]);
+        x7[39] = _mm256_add_epi32(x6[39], x6[36]);
+        x7[37] = _mm256_sub_epi32(x6[38], x6[37]);
+        x7[38] = _mm256_add_epi32(x6[38], x6[37]);
+        x7[40] = _mm256_add_epi32(x6[40], x6[43]);
+        x7[43] = _mm256_sub_epi32(x6[40], x6[43]);
+        x7[41] = _mm256_add_epi32(x6[41], x6[42]);
+        x7[42] = _mm256_sub_epi32(x6[41], x6[42]);
+        x7[44] = _mm256_sub_epi32(x6[47], x6[44]);
+        x7[47] = _mm256_add_epi32(x6[47], x6[44]);
+        x7[45] = _mm256_sub_epi32(x6[46], x6[45]);
+        x7[46] = _mm256_add_epi32(x6[46], x6[45]);
+        x7[48] = _mm256_add_epi32(x6[48], x6[51]);
+        x7[51] = _mm256_sub_epi32(x6[48], x6[51]);
+        x7[49] = _mm256_add_epi32(x6[49], x6[50]);
+        x7[50] = _mm256_sub_epi32(x6[49], x6[50]);
+        x7[52] = _mm256_sub_epi32(x6[55], x6[52]);
+        x7[55] = _mm256_add_epi32(x6[55], x6[52]);
+        x7[53] = _mm256_sub_epi32(x6[54], x6[53]);
+        x7[54] = _mm256_add_epi32(x6[54], x6[53]);
+        x7[56] = _mm256_add_epi32(x6[56], x6[59]);
+        x7[59] = _mm256_sub_epi32(x6[56], x6[59]);
+        x7[57] = _mm256_add_epi32(x6[57], x6[58]);
+        x7[58] = _mm256_sub_epi32(x6[57], x6[58]);
+        x7[60] = _mm256_sub_epi32(x6[63], x6[60]);
+        x7[63] = _mm256_add_epi32(x6[63], x6[60]);
+        x7[61] = _mm256_sub_epi32(x6[62], x6[61]);
+        x7[62] = _mm256_add_epi32(x6[62], x6[61]);
 
-    // stage 9
-    __m256i x9[64];
-    x9[0] = x8[0];
-    x9[1] = x8[1];
-    x9[2] = x8[2];
-    x9[3] = x8[3];
-    x9[4] = x8[4];
-    x9[5] = x8[5];
-    x9[6] = x8[6];
-    x9[7] = x8[7];
-    x9[8] = x8[8];
-    x9[9] = x8[9];
-    x9[10] = x8[10];
-    x9[11] = x8[11];
-    x9[12] = x8[12];
-    x9[13] = x8[13];
-    x9[14] = x8[14];
-    x9[15] = x8[15];
-    btf_32_type1_avx2_new(cospi_p62, cospi_p02, x8[16], x8[31], x9[16], x9[31],
-        __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p30, cospi_p34, x8[17], x8[30], x9[17], x9[30],
-        __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p46, cospi_p18, x8[18], x8[29], x9[18], x9[29],
-        __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p14, cospi_p50, x8[19], x8[28], x9[19], x9[28],
-        __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p54, cospi_p10, x8[20], x8[27], x9[20], x9[27],
-        __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p22, cospi_p42, x8[21], x8[26], x9[21], x9[26],
-        __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p38, cospi_p26, x8[22], x8[25], x9[22], x9[25],
-        __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p06, cospi_p58, x8[23], x8[24], x9[23], x9[24],
-        __rounding, cos_bit);
-    x9[32] = _mm256_add_epi32(x8[32], x8[33]);
-    x9[33] = _mm256_sub_epi32(x8[32], x8[33]);
-    x9[34] = _mm256_sub_epi32(x8[35], x8[34]);
-    x9[35] = _mm256_add_epi32(x8[35], x8[34]);
-    x9[36] = _mm256_add_epi32(x8[36], x8[37]);
-    x9[37] = _mm256_sub_epi32(x8[36], x8[37]);
-    x9[38] = _mm256_sub_epi32(x8[39], x8[38]);
-    x9[39] = _mm256_add_epi32(x8[39], x8[38]);
-    x9[40] = _mm256_add_epi32(x8[40], x8[41]);
-    x9[41] = _mm256_sub_epi32(x8[40], x8[41]);
-    x9[42] = _mm256_sub_epi32(x8[43], x8[42]);
-    x9[43] = _mm256_add_epi32(x8[43], x8[42]);
-    x9[44] = _mm256_add_epi32(x8[44], x8[45]);
-    x9[45] = _mm256_sub_epi32(x8[44], x8[45]);
-    x9[46] = _mm256_sub_epi32(x8[47], x8[46]);
-    x9[47] = _mm256_add_epi32(x8[47], x8[46]);
-    x9[48] = _mm256_add_epi32(x8[48], x8[49]);
-    x9[49] = _mm256_sub_epi32(x8[48], x8[49]);
-    x9[50] = _mm256_sub_epi32(x8[51], x8[50]);
-    x9[51] = _mm256_add_epi32(x8[51], x8[50]);
-    x9[52] = _mm256_add_epi32(x8[52], x8[53]);
-    x9[53] = _mm256_sub_epi32(x8[52], x8[53]);
-    x9[54] = _mm256_sub_epi32(x8[55], x8[54]);
-    x9[55] = _mm256_add_epi32(x8[55], x8[54]);
-    x9[56] = _mm256_add_epi32(x8[56], x8[57]);
-    x9[57] = _mm256_sub_epi32(x8[56], x8[57]);
-    x9[58] = _mm256_sub_epi32(x8[59], x8[58]);
-    x9[59] = _mm256_add_epi32(x8[59], x8[58]);
-    x9[60] = _mm256_add_epi32(x8[60], x8[61]);
-    x9[61] = _mm256_sub_epi32(x8[60], x8[61]);
-    x9[62] = _mm256_sub_epi32(x8[63], x8[62]);
-    x9[63] = _mm256_add_epi32(x8[63], x8[62]);
+        // stage 8
+        __m256i x8[64];
+        x8[0] = x7[0];
+        x8[1] = x7[1];
+        x8[2] = x7[2];
+        x8[3] = x7[3];
+        x8[4] = x7[4];
+        x8[5] = x7[5];
+        x8[6] = x7[6];
+        x8[7] = x7[7];
 
-    // stage 10
-    __m256i x10[64];
-    x10[0] = x9[0];
-    x10[1] = x9[1];
-    x10[2] = x9[2];
-    x10[3] = x9[3];
-    x10[4] = x9[4];
-    x10[5] = x9[5];
-    x10[6] = x9[6];
-    x10[7] = x9[7];
-    x10[8] = x9[8];
-    x10[9] = x9[9];
-    x10[10] = x9[10];
-    x10[11] = x9[11];
-    x10[12] = x9[12];
-    x10[13] = x9[13];
-    x10[14] = x9[14];
-    x10[15] = x9[15];
-    x10[16] = x9[16];
-    x10[17] = x9[17];
-    x10[18] = x9[18];
-    x10[19] = x9[19];
-    x10[20] = x9[20];
-    x10[21] = x9[21];
-    x10[22] = x9[22];
-    x10[23] = x9[23];
-    x10[24] = x9[24];
-    x10[25] = x9[25];
-    x10[26] = x9[26];
-    x10[27] = x9[27];
-    x10[28] = x9[28];
-    x10[29] = x9[29];
-    x10[30] = x9[30];
-    x10[31] = x9[31];
-    btf_32_type1_avx2_new(cospi_p63, cospi_p01, x9[32], x9[63], x10[32],
-        x10[63], __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p31, cospi_p33, x9[33], x9[62], x10[33],
-        x10[62], __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p47, cospi_p17, x9[34], x9[61], x10[34],
-        x10[61], __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p15, cospi_p49, x9[35], x9[60], x10[35],
-        x10[60], __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p55, cospi_p09, x9[36], x9[59], x10[36],
-        x10[59], __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p23, cospi_p41, x9[37], x9[58], x10[37],
-        x10[58], __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p39, cospi_p25, x9[38], x9[57], x10[38],
-        x10[57], __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p07, cospi_p57, x9[39], x9[56], x10[39],
-        x10[56], __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p59, cospi_p05, x9[40], x9[55], x10[40],
-        x10[55], __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p27, cospi_p37, x9[41], x9[54], x10[41],
-        x10[54], __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p43, cospi_p21, x9[42], x9[53], x10[42],
-        x10[53], __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p11, cospi_p53, x9[43], x9[52], x10[43],
-        x10[52], __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p51, cospi_p13, x9[44], x9[51], x10[44],
-        x10[51], __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p19, cospi_p45, x9[45], x9[50], x10[45],
-        x10[50], __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p35, cospi_p29, x9[46], x9[49], x10[46],
-        x10[49], __rounding, cos_bit);
-    btf_32_type1_avx2_new(cospi_p03, cospi_p61, x9[47], x9[48], x10[47],
-        x10[48], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p60, cospi_p04, x7[8], x7[15],
+            x8[8], x8[15], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p28, cospi_p36, x7[9], x7[14],
+            x8[9], x8[14], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p44, cospi_p20, x7[10], x7[13],
+            x8[10], x8[13], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p12, cospi_p52, x7[11], x7[12],
+            x8[11], x8[12], __rounding, cos_bit);
+        x8[16] = _mm256_add_epi32(x7[16], x7[17]);
+        x8[17] = _mm256_sub_epi32(x7[16], x7[17]);
+        x8[18] = _mm256_sub_epi32(x7[19], x7[18]);
+        x8[19] = _mm256_add_epi32(x7[19], x7[18]);
+        x8[20] = _mm256_add_epi32(x7[20], x7[21]);
+        x8[21] = _mm256_sub_epi32(x7[20], x7[21]);
+        x8[22] = _mm256_sub_epi32(x7[23], x7[22]);
+        x8[23] = _mm256_add_epi32(x7[23], x7[22]);
+        x8[24] = _mm256_add_epi32(x7[24], x7[25]);
+        x8[25] = _mm256_sub_epi32(x7[24], x7[25]);
+        x8[26] = _mm256_sub_epi32(x7[27], x7[26]);
+        x8[27] = _mm256_add_epi32(x7[27], x7[26]);
+        x8[28] = _mm256_add_epi32(x7[28], x7[29]);
+        x8[29] = _mm256_sub_epi32(x7[28], x7[29]);
+        x8[30] = _mm256_sub_epi32(x7[31], x7[30]);
+        x8[31] = _mm256_add_epi32(x7[31], x7[30]);
+        x8[32] = x7[32];
+        btf_32_type0_avx2_new(cospi_m04, cospi_p60, x7[33], x7[62],
+            x8[33], x8[62], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m60, cospi_m04, x7[34], x7[61],
+            x8[34], x8[61], __rounding, cos_bit);
+        x8[35] = x7[35];
+        x8[36] = x7[36];
+        btf_32_type0_avx2_new(cospi_m36, cospi_p28, x7[37], x7[58],
+            x8[37], x8[58], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m28, cospi_m36, x7[38], x7[57],
+            x8[38], x8[57], __rounding, cos_bit);
+        x8[39] = x7[39];
+        x8[40] = x7[40];
+        btf_32_type0_avx2_new(cospi_m20, cospi_p44, x7[41], x7[54],
+            x8[41], x8[54], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m44, cospi_m20, x7[42], x7[53],
+            x8[42], x8[53], __rounding, cos_bit);
+        x8[43] = x7[43];
+        x8[44] = x7[44];
+        btf_32_type0_avx2_new(cospi_m52, cospi_p12, x7[45], x7[50],
+            x8[45], x8[50], __rounding, cos_bit);
+        btf_32_type0_avx2_new(cospi_m12, cospi_m52, x7[46], x7[49],
+            x8[46], x8[49], __rounding, cos_bit);
+        x8[47] = x7[47];
+        x8[48] = x7[48];
+        x8[51] = x7[51];
+        x8[52] = x7[52];
+        x8[55] = x7[55];
+        x8[56] = x7[56];
+        x8[59] = x7[59];
+        x8[60] = x7[60];
+        x8[63] = x7[63];
 
-    startidx = 0 * out_stride;
-    endidx = 63 * out_stride;
-    // stage 11
-    output[startidx] = x10[0];
-    output[endidx] = x10[63];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[32];
-    output[endidx] = x10[31];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[16];
-    output[endidx] = x10[47];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[48];
-    output[endidx] = x10[15];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[8];
-    output[endidx] = x10[55];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[40];
-    output[endidx] = x10[23];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[24];
-    output[endidx] = x10[39];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[56];
-    output[endidx] = x10[7];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[4];
-    output[endidx] = x10[59];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[36];
-    output[endidx] = x10[27];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[20];
-    output[endidx] = x10[43];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[52];
-    output[endidx] = x10[11];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[12];
-    output[endidx] = x10[51];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[44];
-    output[endidx] = x10[19];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[28];
-    output[endidx] = x10[35];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[60];
-    output[endidx] = x10[3];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[2];
-    output[endidx] = x10[61];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[34];
-    output[endidx] = x10[29];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[18];
-    output[endidx] = x10[45];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[50];
-    output[endidx] = x10[13];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[10];
-    output[endidx] = x10[53];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[42];
-    output[endidx] = x10[21];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[26];
-    output[endidx] = x10[37];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[58];
-    output[endidx] = x10[5];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[6];
-    output[endidx] = x10[57];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[38];
-    output[endidx] = x10[25];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[22];
-    output[endidx] = x10[41];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[54];
-    output[endidx] = x10[9];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[14];
-    output[endidx] = x10[49];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[46];
-    output[endidx] = x10[17];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[30];
-    output[endidx] = x10[33];
-    startidx += out_stride;
-    endidx -= out_stride;
-    output[startidx] = x10[62];
-    output[endidx] = x10[1];
-}
+        // stage 9
+        __m256i x9[64];
+        x9[0] = x8[0];
+        x9[1] = x8[1];
+        x9[2] = x8[2];
+        x9[3] = x8[3];
+        x9[4] = x8[4];
+        x9[5] = x8[5];
+        x9[6] = x8[6];
+        x9[7] = x8[7];
+        x9[8] = x8[8];
+        x9[9] = x8[9];
+        x9[10] = x8[10];
+        x9[11] = x8[11];
+        x9[12] = x8[12];
+        x9[13] = x8[13];
+        x9[14] = x8[14];
+        x9[15] = x8[15];
+        btf_32_type1_avx2_new(cospi_p62, cospi_p02, x8[16], x8[31],
+            x9[16], x9[31], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p30, cospi_p34, x8[17], x8[30],
+            x9[17], x9[30], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p46, cospi_p18, x8[18], x8[29],
+            x9[18], x9[29], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p14, cospi_p50, x8[19], x8[28],
+            x9[19], x9[28], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p54, cospi_p10, x8[20], x8[27],
+            x9[20], x9[27], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p22, cospi_p42, x8[21], x8[26],
+            x9[21], x9[26], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p38, cospi_p26, x8[22], x8[25],
+            x9[22], x9[25], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p06, cospi_p58, x8[23], x8[24],
+            x9[23], x9[24], __rounding, cos_bit);
+        x9[32] = _mm256_add_epi32(x8[32], x8[33]);
+        x9[33] = _mm256_sub_epi32(x8[32], x8[33]);
+        x9[34] = _mm256_sub_epi32(x8[35], x8[34]);
+        x9[35] = _mm256_add_epi32(x8[35], x8[34]);
+        x9[36] = _mm256_add_epi32(x8[36], x8[37]);
+        x9[37] = _mm256_sub_epi32(x8[36], x8[37]);
+        x9[38] = _mm256_sub_epi32(x8[39], x8[38]);
+        x9[39] = _mm256_add_epi32(x8[39], x8[38]);
+        x9[40] = _mm256_add_epi32(x8[40], x8[41]);
+        x9[41] = _mm256_sub_epi32(x8[40], x8[41]);
+        x9[42] = _mm256_sub_epi32(x8[43], x8[42]);
+        x9[43] = _mm256_add_epi32(x8[43], x8[42]);
+        x9[44] = _mm256_add_epi32(x8[44], x8[45]);
+        x9[45] = _mm256_sub_epi32(x8[44], x8[45]);
+        x9[46] = _mm256_sub_epi32(x8[47], x8[46]);
+        x9[47] = _mm256_add_epi32(x8[47], x8[46]);
+        x9[48] = _mm256_add_epi32(x8[48], x8[49]);
+        x9[49] = _mm256_sub_epi32(x8[48], x8[49]);
+        x9[50] = _mm256_sub_epi32(x8[51], x8[50]);
+        x9[51] = _mm256_add_epi32(x8[51], x8[50]);
+        x9[52] = _mm256_add_epi32(x8[52], x8[53]);
+        x9[53] = _mm256_sub_epi32(x8[52], x8[53]);
+        x9[54] = _mm256_sub_epi32(x8[55], x8[54]);
+        x9[55] = _mm256_add_epi32(x8[55], x8[54]);
+        x9[56] = _mm256_add_epi32(x8[56], x8[57]);
+        x9[57] = _mm256_sub_epi32(x8[56], x8[57]);
+        x9[58] = _mm256_sub_epi32(x8[59], x8[58]);
+        x9[59] = _mm256_add_epi32(x8[59], x8[58]);
+        x9[60] = _mm256_add_epi32(x8[60], x8[61]);
+        x9[61] = _mm256_sub_epi32(x8[60], x8[61]);
+        x9[62] = _mm256_sub_epi32(x8[63], x8[62]);
+        x9[63] = _mm256_add_epi32(x8[63], x8[62]);
 
-static INLINE void int16_array_with_stride_to_int32_array_without_stride(
-    const int16_t *input, int32_t stride, int32_t *output, int32_t txfm1d_size) {
-    int32_t r, c;
-    for (r = 0; r < txfm1d_size; r++) {
-        for (c = 0; c < txfm1d_size; c++) {
-            output[r * txfm1d_size + c] = (int32_t)input[r * stride + c];
-        }
+        // stage 10
+        __m256i x10[64];
+        out[0 * stride] = x9[0];
+        out[32 * stride] = x9[1];
+        out[16 * stride] = x9[2];
+        out[48 * stride] = x9[3];
+        out[8 * stride] = x9[4];
+        out[40 * stride] = x9[5];
+        out[24 * stride] = x9[6];
+        out[56 * stride] = x9[7];
+        out[4 * stride] = x9[8];
+        out[36 * stride] = x9[9];
+        out[20 * stride] = x9[10];
+        out[52 * stride] = x9[11];
+        out[12 * stride] = x9[12];
+        out[44 * stride] = x9[13];
+        out[28 * stride] = x9[14];
+        out[60 * stride] = x9[15];
+        out[2 * stride] = x9[16];
+        out[34 * stride] = x9[17];
+        out[18 * stride] = x9[18];
+        out[50 * stride] = x9[19];
+        out[10 * stride] = x9[20];
+        out[42 * stride] = x9[21];
+        out[26 * stride] = x9[22];
+        out[58 * stride] = x9[23];
+        out[6 * stride] = x9[24];
+        out[38 * stride] = x9[25];
+        out[22 * stride] = x9[26];
+        out[54 * stride] = x9[27];
+        out[14 * stride] = x9[28];
+        out[46 * stride] = x9[29];
+        out[30 * stride] = x9[30];
+        out[62 * stride] = x9[31];
+        btf_32_type1_avx2_new(cospi_p63, cospi_p01, x9[32], x9[63],
+            x10[32], x10[63], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p31, cospi_p33, x9[33], x9[62],
+            x10[33], x10[62], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p47, cospi_p17, x9[34], x9[61],
+            x10[34], x10[61], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p15, cospi_p49, x9[35], x9[60],
+            x10[35], x10[60], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p55, cospi_p09, x9[36], x9[59],
+            x10[36], x10[59], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p23, cospi_p41, x9[37], x9[58],
+            x10[37], x10[58], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p39, cospi_p25, x9[38], x9[57],
+            x10[38], x10[57], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p07, cospi_p57, x9[39], x9[56],
+            x10[39], x10[56], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p59, cospi_p05, x9[40], x9[55],
+            x10[40], x10[55], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p27, cospi_p37, x9[41], x9[54],
+            x10[41], x10[54], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p43, cospi_p21, x9[42], x9[53],
+            x10[42], x10[53], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p11, cospi_p53, x9[43], x9[52],
+            x10[43], x10[52], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p51, cospi_p13, x9[44], x9[51],
+            x10[44], x10[51], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p19, cospi_p45, x9[45], x9[50],
+            x10[45], x10[50], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p35, cospi_p29, x9[46], x9[49],
+            x10[46], x10[49], __rounding, cos_bit);
+        btf_32_type1_avx2_new(cospi_p03, cospi_p61, x9[47], x9[48],
+            x10[47], x10[48], __rounding, cos_bit);
+
+        // stage 11
+        out[1 * stride] = x10[32];
+        out[3 * stride] = x10[48];
+        out[5 * stride] = x10[40];
+        out[7 * stride] = x10[56];
+        out[9 * stride] = x10[36];
+        out[11 * stride] = x10[52];
+        out[13 * stride] = x10[44];
+        out[15 * stride] = x10[60];
+        out[17 * stride] = x10[34];
+        out[19 * stride] = x10[50];
+        out[21 * stride] = x10[42];
+        out[23 * stride] = x10[58];
+        out[25 * stride] = x10[38];
+        out[27 * stride] = x10[54];
+        out[29 * stride] = x10[46];
+        out[31 * stride] = x10[62];
+        out[33 * stride] = x10[33];
+        out[35 * stride] = x10[49];
+        out[37 * stride] = x10[41];
+        out[39 * stride] = x10[57];
+        out[41 * stride] = x10[37];
+        out[43 * stride] = x10[53];
+        out[45 * stride] = x10[45];
+        out[47 * stride] = x10[61];
+        out[49 * stride] = x10[35];
+        out[51 * stride] = x10[51];
+        out[53 * stride] = x10[43];
+        out[55 * stride] = x10[59];
+        out[57 * stride] = x10[39];
+        out[59 * stride] = x10[55];
+        out[61 * stride] = x10[47];
+        out[63 * stride] = x10[63];
     }
 }
 
@@ -4076,9 +3858,11 @@ static INLINE void av1_round_shift_array_32_avx2(__m256i *input,
     const int32_t size,
     const int32_t bit) {
     if (bit > 0) {
+        __m256i round = _mm256_set1_epi32(1 << (bit - 1));
         int32_t i;
         for (i = 0; i < size; i++) {
-            output[i] = av1_round_shift_32_avx2(input[i], bit);
+            output[i] = _mm256_srai_epi32(
+                _mm256_add_epi32(input[i], round), bit);
         }
     }
     else {
@@ -4092,28 +3876,22 @@ static INLINE void av1_round_shift_array_32_avx2(__m256i *input,
 typedef void(*TxfmFuncAVX2)(const __m256i *input, __m256i *output,
     const int8_t cos_bit, const int8_t *stage_range);
 
-static void fdct32x32_avx2(const __m256i *input, __m256i *output,
+static INLINE void fdct32x32_avx2(const __m256i *input, __m256i *output,
     const int8_t cos_bit, const int8_t *stage_range) {
     const int32_t txfm_size = 32;
     const int32_t num_per_256 = 8;
     int32_t col_num = txfm_size / num_per_256;
     int32_t col;
     (void)stage_range;
-    for (col = 0; col < col_num; col++) {
-        av1_fdct32_new_avx2((input + col), (output + col), cos_bit, col_num);
-    }
+    av1_fdct32_new_avx2(input, output, cos_bit, txfm_size, col_num);
 }
 
-static void fdct64x64_avx2(const __m256i *input, __m256i *output,
-    const int8_t cos_bit, const int8_t *stage_range) {
+static INLINE void fdct64x64_avx2(const __m256i *input, __m256i *output,
+    const int8_t cos_bit) {
     const int32_t txfm_size = 64;
     const int32_t num_per_256 = 8;
     int32_t col_num = txfm_size / num_per_256;
-    (void)stage_range;
-    for (int32_t col = 0; col < col_num; col++) {
-        av1_fdct64_new_avx2((input + col), (output + col), cos_bit, col_num,
-            col_num);
-    }
+    av1_fdct64_new_avx2(input, output, cos_bit, txfm_size, col_num);
 }
 
 static INLINE void fidtx4x8_row_avx2(__m256i *input, __m256i *output, int32_t bit, int32_t col_num) {
@@ -4224,10 +4002,7 @@ static void fidtx32x8_avx2(const __m256i *in, __m256i *out, int8_t bit, int32_t 
     out[4 * 7] = _mm256_slli_epi32(in[4 * 7], 1);
 }
 
-static void fidtx64x64_avx2(const __m256i *input, __m256i *output,
-    const int8_t cos_bit, const int8_t *stage_range) {
-    (void)stage_range;
-    (void)cos_bit;
+static void fidtx64x64_avx2(const __m256i *input, __m256i *output) {
     const int32_t bits = 12;       // NewSqrt2Bits = 12
     const int32_t sqrt = 4 * 5793; // 4 * NewSqrt2
     const int32_t col_num = 8;
@@ -4247,11 +4022,29 @@ static INLINE TxfmFuncAVX2 fwd_txfm_type_to_func(TXFM_TYPE txfm_type) {
     switch (txfm_type) {
     case TXFM_TYPE_DCT32: return fdct32x32_avx2; break;
     case TXFM_TYPE_IDENTITY32: return fidtx32x32_avx2; break;
-    case TXFM_TYPE_DCT64: return fdct64x64_avx2; break;
-    case TXFM_TYPE_IDENTITY64: return fidtx64x64_avx2; break;
     default: assert(0);
     }
     return NULL;
+}
+
+static INLINE void load_buffer_32x32_avx2(const int16_t *input,
+    __m256i *output, int32_t stride) {
+    __m128i temp[4];
+    int32_t i;
+
+    for (i = 0; i < 32; ++i) {
+        temp[0] = _mm_loadu_si128((const __m128i *)(input + 0 * 8));
+        temp[1] = _mm_load_si128((const __m128i *)(input + 1 * 8));
+        temp[2] = _mm_load_si128((const __m128i *)(input + 2 * 8));
+        temp[3] = _mm_load_si128((const __m128i *)(input + 3 * 8));
+
+        output[0] = _mm256_cvtepi16_epi32(temp[0]);
+        output[1] = _mm256_cvtepi16_epi32(temp[1]);
+        output[2] = _mm256_cvtepi16_epi32(temp[2]);
+        output[3] = _mm256_cvtepi16_epi32(temp[3]);
+        input += stride;
+        output += 4;
+    }
 }
 
 static INLINE void fwd_txfm2d_32x32_avx2(const int16_t *input, int32_t *output,
@@ -4274,8 +4067,7 @@ static INLINE void fwd_txfm2d_32x32_avx2(const int16_t *input, int32_t *output,
     int32_t num_per_256 = 8;
     int32_t txfm2d_size_256 = txfm_size * txfm_size / num_per_256;
 
-    int16_array_with_stride_to_int32_array_without_stride(input, stride, txfm_buf,
-        txfm_size);
+    load_buffer_32x32_avx2(input, buf_256, stride);
     av1_round_shift_array_32_avx2(buf_256, out_256, txfm2d_size_256, -shift[0]);
     txfm_func_col(out_256, buf_256, cos_bit_col, stage_range_col);
     av1_round_shift_array_32_avx2(buf_256, out_256, txfm2d_size_256, -shift[1]);
@@ -4285,7 +4077,8 @@ static INLINE void fwd_txfm2d_32x32_avx2(const int16_t *input, int32_t *output,
     transpose_32_avx2(txfm_size, buf_256, out_256);
 }
 
-void av1_fwd_txfm2d_32x32_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
+void av1_fwd_txfm2d_32x32_avx2(int16_t *input, int32_t *output,
+    uint32_t stride, TxType tx_type, uint8_t  bd)
 {
     DECLARE_ALIGNED(32, int32_t, txfm_buf[1024]);
     TXFM_2D_FLIP_CFG cfg;
@@ -4794,47 +4587,80 @@ void av1_fwd_txfm2d_pf_32x32_avx2(int16_t *input, int32_t *output, uint32_t stri
     fwd_txfm2d_pf_32x32_avx2(input, output, stride, &cfg, txfm_buf);
 }
 #endif
-static INLINE void fwd_txfm2d_64x64_avx2(const int16_t *input,
-    int32_t *output, const int32_t stride,
-    const TXFM_2D_FLIP_CFG *cfg,
-    int32_t *txfm_buf) {
-    assert(cfg->tx_size < TX_SIZES);
-    const int32_t txfm_size = tx_size_wide[cfg->tx_size];
-    const int8_t *shift = cfg->shift;
-    const int8_t *stage_range_col = cfg->stage_range_col;
-    const int8_t *stage_range_row = cfg->stage_range_row;
-    const int8_t cos_bit_col = cfg->cos_bit_col;
-    const int8_t cos_bit_row = cfg->cos_bit_row;
-    const TxfmFuncAVX2 txfm_func_col = fwd_txfm_type_to_func(cfg->txfm_type_col);
-    const TxfmFuncAVX2 txfm_func_row = fwd_txfm_type_to_func(cfg->txfm_type_row);
-    __m256i *buf_256 = (__m256i *)txfm_buf;
-    __m256i *out_256 = (__m256i *)output;
-    const int32_t num_per_256 = 8;
-    int32_t txfm2d_size_256 = txfm_size * txfm_size / num_per_256;
-    int32_t col_num = txfm_size / num_per_256;
-    ASSERT(txfm_func_col != NULL);
-    ASSERT(txfm_func_row != NULL);
 
-    int16_array_with_stride_to_int32_array_without_stride(input, stride, output,
-        txfm_size);
-    /*col wise transform*/
-    txfm_func_col(out_256, buf_256, cos_bit_col, stage_range_col);
-    av1_round_shift_array_32_avx2(buf_256, out_256, txfm2d_size_256, -shift[1]);
-    transpose_8nx8n(out_256, buf_256, 64, 64);
+static INLINE void load_buffer_64x64_avx2(const int16_t *input,
+    int32_t stride, __m256i *output) {
+    __m128i x0, x1, x2, x3, x4, x5, x6, x7;
+    __m256i v0, v1, v2, v3, v4, v5, v6, v7;
+    int32_t i;
 
-    /*row wise transform*/
-    txfm_func_row(buf_256, out_256, cos_bit_row, stage_range_row);
-    av1_round_shift_array_32_avx2(out_256, buf_256, txfm2d_size_256, -shift[2]);
-    transpose_8nx8n(buf_256, out_256, 64, 64);
+    for (i = 0; i < 64; ++i) {
+        x0 = _mm_loadu_si128((const __m128i *)(input + 0 * 8));
+        x1 = _mm_loadu_si128((const __m128i *)(input + 1 * 8));
+        x2 = _mm_loadu_si128((const __m128i *)(input + 2 * 8));
+        x3 = _mm_loadu_si128((const __m128i *)(input + 3 * 8));
+        x4 = _mm_loadu_si128((const __m128i *)(input + 4 * 8));
+        x5 = _mm_loadu_si128((const __m128i *)(input + 5 * 8));
+        x6 = _mm_loadu_si128((const __m128i *)(input + 6 * 8));
+        x7 = _mm_loadu_si128((const __m128i *)(input + 7 * 8));
+
+        v0 = _mm256_cvtepi16_epi32(x0);
+        v1 = _mm256_cvtepi16_epi32(x1);
+        v2 = _mm256_cvtepi16_epi32(x2);
+        v3 = _mm256_cvtepi16_epi32(x3);
+        v4 = _mm256_cvtepi16_epi32(x4);
+        v5 = _mm256_cvtepi16_epi32(x5);
+        v6 = _mm256_cvtepi16_epi32(x6);
+        v7 = _mm256_cvtepi16_epi32(x7);
+
+        _mm256_storeu_si256(output + 0, v0);
+        _mm256_storeu_si256(output + 1, v1);
+        _mm256_storeu_si256(output + 2, v2);
+        _mm256_storeu_si256(output + 3, v3);
+        _mm256_storeu_si256(output + 4, v4);
+        _mm256_storeu_si256(output + 5, v5);
+        _mm256_storeu_si256(output + 6, v6);
+        _mm256_storeu_si256(output + 7, v7);
+
+        input += stride;
+        output += 8;
+    }
 }
 
-void av1_fwd_txfm2d_64x64_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
-{
-    DECLARE_ALIGNED(32, int32_t, txfm_buf[4096]);
-    TXFM_2D_FLIP_CFG cfg;
-    Av1TransformConfig(tx_type, TX_64X64, &cfg);
+void av1_fwd_txfm2d_64x64_avx2(int16_t *input, int32_t *output,
+    uint32_t stride, TxType tx_type, uint8_t  bd) {
     (void)bd;
-    fwd_txfm2d_64x64_avx2(input, output, stride, &cfg, txfm_buf);
+    __m256i in[512];
+    __m256i *out = (__m256i *)output;
+    const int32_t txw_idx = tx_size_wide_log2[TX_64X64] - tx_size_wide_log2[0];
+    const int32_t txh_idx = tx_size_high_log2[TX_64X64] - tx_size_high_log2[0];
+    const int8_t *shift = fwd_txfm_shift_ls[TX_64X64];
+
+    switch (tx_type) {
+    case IDTX:
+        load_buffer_64x64_avx2(input, stride, out);
+        fidtx64x64_avx2(out, in);
+        av1_round_shift_array_32_avx2(in, out, 512, -shift[1]);
+        transpose_8nx8n(out, in, 64, 64);
+
+        /*row wise transform*/
+        fidtx64x64_avx2(in, out);
+        av1_round_shift_array_32_avx2(out, in, 512, -shift[2]);
+        transpose_8nx8n(in, out, 64, 64);
+        break;
+    case DCT_DCT:
+        load_buffer_64x64_avx2(input, stride, out);
+        fdct64x64_avx2(out, in, fwd_cos_bit_col[txw_idx][txh_idx]);
+        av1_round_shift_array_32_avx2(in, out, 512, -shift[1]);
+        transpose_8nx8n(out, in, 64, 64);
+
+        /*row wise transform*/
+        fdct64x64_avx2(in, out, fwd_cos_bit_row[txw_idx][txh_idx]);
+        av1_round_shift_array_32_avx2(out, in, 512, -shift[2]);
+        transpose_8nx8n(in, out, 64, 64);
+        break;
+    default: assert(0);
+    }
 }
 
 static INLINE void load_buffer_32_avx2(const int16_t *input, __m256i *in,
@@ -4966,20 +4792,25 @@ static INLINE void av1_round_shift_rect_array_32_avx2(__m256i *input,
     const int32_t bit,
     const int32_t val) {
     const __m256i sqrt2 = _mm256_set1_epi32(val);
+    const __m256i round2 = _mm256_set1_epi32(1 << (NewSqrt2Bits - 1));
+    int32_t i;
     if (bit > 0) {
-        int32_t i;
+        const __m256i round1 = _mm256_set1_epi32(1 << (bit - 1));
+        __m256i r0, r1, r2, r3;
         for (i = 0; i < size; i++) {
-            const __m256i r0 = av1_round_shift_32_avx2(input[i], bit);
-            const __m256i r1 = _mm256_mullo_epi32(sqrt2, r0);
-            output[i] = av1_round_shift_32_avx2(r1, NewSqrt2Bits);
+            r0 = _mm256_add_epi32(input[i], round1);
+            r1 = _mm256_srai_epi32(r0, bit);
+            r2 = _mm256_mullo_epi32(sqrt2, r1);
+            r3 = _mm256_add_epi32(r2, round2);
+            output[i]  = _mm256_srai_epi32(r3, NewSqrt2Bits);
         }
-    }
-    else {
-        int32_t i;
+    } else {
+        __m256i r0, r1, r2;
         for (i = 0; i < size; i++) {
-            const __m256i r0 = _mm256_slli_epi32(input[i], -bit);
-            const __m256i r1 = _mm256_mullo_epi32(sqrt2, r0);
-            output[i] = av1_round_shift_32_avx2(r1, NewSqrt2Bits);
+            r0 = _mm256_slli_epi32(input[i], -bit);
+            r1 = _mm256_mullo_epi32(sqrt2, r0);
+            r2 = _mm256_add_epi32(r1, round2);
+            output[i] = _mm256_srai_epi32(r2, NewSqrt2Bits);
         }
     }
 }
@@ -5001,18 +4832,15 @@ void av1_fwd_txfm2d_32x64_avx2(int16_t *input, int32_t *output, uint32_t stride,
 
     // column transform
     load_buffer_32x8n(input, in, stride, 0, 0, shift[0], txfm_size_row);
-    for (int32_t i = 0; i < num_col; i++) {
-        av1_fdct64_new_avx2((in + i), (in + i), bitcol, num_col, num_col);
-    }
+    av1_fdct64_new_avx2(in, in, bitcol, txfm_size_col, num_col);
+
     for (int32_t i = 0; i < num_row; i++) {
         col_txfm_16x16_rounding((in + i * txfm_size_col), -shift[1]);
     }
     transpose_8nx8n(in, outcoef256, txfm_size_col, txfm_size_row);
 
     // row transform
-    for (int32_t i = 0; i < num_row; i++) {
-        av1_fdct32_new_avx2((outcoef256 + i), (in + i), bitrow, num_row);
-    }
+    av1_fdct32_new_avx2(outcoef256, in, bitrow, txfm_size_row, num_row);
     transpose_8nx8n(in, outcoef256, txfm_size_row, txfm_size_col);
     av1_round_shift_rect_array_32_avx2(outcoef256, outcoef256, 256, -shift[2],
         NewSqrt2);
@@ -5040,9 +4868,8 @@ void av1_fwd_txfm2d_64x32_avx2(int16_t *input, int32_t *output, uint32_t stride,
         load_buffer_32_avx2(input + 32 + i * stride, in + 4 + i * 8, 8, 0, 0, shift[0]);
     }
 
-    for (int32_t i = 0; i < num_col; i++) {
-        av1_fdct32_new_avx2((in + i), (in + i), bitcol, num_col);
-    }
+    av1_fdct32_new_avx2(in, in, bitcol, txfm_size_col, num_col);
+
 
     for (int32_t i = 0; i < num_col; i++) {
         col_txfm_16x16_rounding((in + i * txfm_size_row), -shift[1]);
@@ -5050,9 +4877,7 @@ void av1_fwd_txfm2d_64x32_avx2(int16_t *input, int32_t *output, uint32_t stride,
     transpose_8nx8n(in, outcoef256, txfm_size_col, txfm_size_row);
 
     // row transform
-    for (int32_t i = 0; i < num_row; i++) {
-        av1_fdct64_new_avx2((outcoef256 + i), (in + i), bitrow, num_row, num_row);
-    }
+    av1_fdct64_new_avx2(outcoef256, in, bitrow, txfm_size_row, num_row);
     transpose_8nx8n(in, outcoef256, txfm_size_row, txfm_size_col);
     av1_round_shift_rect_array_32_avx2(outcoef256, outcoef256, 256,
         -shift[2], NewSqrt2);
@@ -5082,9 +4907,7 @@ void av1_fwd_txfm2d_16x64_avx2(int16_t *input, int32_t *output, uint32_t stride,
             ud_flip, lr_flip, shift[0]);
     }
 
-    for (int32_t i = 0; i < num_col; i++) {
-        av1_fdct64_new_avx2(in + i, outcoeff256 + i, bitcol, num_col, num_col);
-    }
+    av1_fdct64_new_avx2(in, outcoeff256, bitcol, txfm_size_col, num_col);
 
     col_txfm_16x16_rounding(outcoeff256, -shift[1]);
     col_txfm_16x16_rounding(outcoeff256 + 32, -shift[1]);
@@ -5131,15 +4954,13 @@ void av1_fwd_txfm2d_64x16_avx2(int16_t *input, int32_t *output, uint32_t stride,
     col_txfm_16x16_rounding(outcoeff256 + 96, -shift[1]);
     transpose_8nx8n(outcoeff256, in, txfm_size_col, txfm_size_row);
     // row tranform
-    for (int32_t i = 0; i < num_row; i++) {
-        av1_fdct64_new_avx2(in + i, in + i, bitrow, num_row, num_row);
-    }
+    av1_fdct64_new_avx2(in, in, bitrow, txfm_size_row, num_row);
     transpose_8nx8n(in, outcoeff256, txfm_size_row, txfm_size_col);
     (void)bd;
 }
 
 static const fwd_transform_1d_avx2 col_fwdtxfm_8x32_arr[TX_TYPES] = {
-    av1_fdct32_new_avx2,    // DCT_DCT
+    av1_fdct32_new_line_wraper_avx2,// DCT_DCT
     NULL,                   // ADST_DCT
     NULL,                   // DCT_ADST
     NULL,                   // ADST_ADST
@@ -5489,7 +5310,8 @@ void av1_fwd_txfm2d_16x8_avx2(int16_t *input, int32_t *output, uint32_t stride, 
     (void)bd;
 }
 
-void av1_fwd_txfm2d_4x8_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
+void av1_fwd_txfm2d_4x8_avx2(int16_t *input, int32_t *output, uint32_t stride,
+    TxType tx_type, uint8_t  bd)
 {
     __m256i in[4];
     __m256i outcoeff256[4];
@@ -5503,7 +5325,7 @@ void av1_fwd_txfm2d_4x8_avx2(int16_t *input, int32_t *output, uint32_t stride, T
     switch (tx_type) {
     case DCT_DCT:
         load_buffer_4x8_avx2(input, in, stride, 0, 0, shift[0]);
-        fdct4x8_avx2(in, in, bitcol, 1);
+        fdct4x8_avx2(in, in, bitcol);
         col_txfm_8x4_rounding(in, -shift[1]);
         transpose_4x8_avx2(in, outcoeff256);
         fdct4x8_col_avx2(outcoeff256, in, bitrow, 1);
@@ -5521,7 +5343,7 @@ void av1_fwd_txfm2d_4x8_avx2(int16_t *input, int32_t *output, uint32_t stride, T
         break;
     case DCT_ADST:
         load_buffer_4x8_avx2(input, in, stride, 0, 0, shift[0]);
-        fdct4x8_avx2(in, in, bitcol, 1);
+        fdct4x8_avx2(in, in, bitcol);
         col_txfm_8x4_rounding(in, -shift[1]);
         transpose_4x8_avx2(in, outcoeff256);
         fadst4x8_col_avx2(outcoeff256, in, bitrow, 1);
@@ -5548,7 +5370,7 @@ void av1_fwd_txfm2d_4x8_avx2(int16_t *input, int32_t *output, uint32_t stride, T
         break;
     case DCT_FLIPADST:
         load_buffer_4x8_avx2(input, in, stride, 0, 1, shift[0]);
-        fdct4x8_avx2(in, in, bitcol, 1);
+        fdct4x8_avx2(in, in, bitcol);
         col_txfm_8x4_rounding(in, -shift[1]);
         transpose_4x8_avx2(in, outcoeff256);
         fadst4x8_col_avx2(outcoeff256, in, bitrow, 1);
@@ -5593,7 +5415,7 @@ void av1_fwd_txfm2d_4x8_avx2(int16_t *input, int32_t *output, uint32_t stride, T
         break;
     case V_DCT:
         load_buffer_4x8_avx2(input, in, stride, 0, 0, shift[0]);
-        fdct4x8_avx2(in, in, bitcol, 1);
+        fdct4x8_avx2(in, in, bitcol);
         col_txfm_8x4_rounding(in, -shift[1]);
         transpose_4x8_avx2(in, outcoeff256);
         fidtx4x8_col_avx2(outcoeff256, in, bitrow, 1);
@@ -5667,7 +5489,7 @@ void av1_fwd_txfm2d_8x4_avx2(int16_t *input, int32_t *output, uint32_t stride,
         load_buffer_8x4_avx2(input, in, stride, 0, 0, shift[0]);
         fdct4x8_row_avx2(in, in, bitcol, 1);
         col_txfm_8x4_rounding(in, -shift[1]);
-        fdct4x8_avx2(in, outcoeff256, bitrow, 1);
+        fdct4x8_avx2(in, outcoeff256, bitrow);
         av1_round_shift_rect_array_32_avx2(outcoeff256, in, 4, -shift[2],
             NewSqrt2);
         transpose_4x8_avx2(in, outcoeff256);
@@ -5676,7 +5498,7 @@ void av1_fwd_txfm2d_8x4_avx2(int16_t *input, int32_t *output, uint32_t stride,
         load_buffer_8x4_avx2(input, in, stride, 0, 0, shift[0]);
         fadst4x8_row_avx2(in, in, bitcol, 1);
         col_txfm_8x4_rounding(in, -shift[1]);
-        fdct4x8_avx2(in, outcoeff256, bitrow, 1);
+        fdct4x8_avx2(in, outcoeff256, bitrow);
         av1_round_shift_rect_array_32_avx2(outcoeff256, in, 4, -shift[2],
             NewSqrt2);
         transpose_4x8_avx2(in, outcoeff256);
@@ -5703,7 +5525,7 @@ void av1_fwd_txfm2d_8x4_avx2(int16_t *input, int32_t *output, uint32_t stride,
         load_buffer_8x4_avx2(input, in, stride, 1, 0, shift[0]);
         fadst4x8_row_avx2(in, in, bitcol, 1);
         col_txfm_8x4_rounding(in, -shift[1]);
-        fdct4x8_avx2(in, outcoeff256, bitrow, 1);
+        fdct4x8_avx2(in, outcoeff256, bitrow);
         av1_round_shift_rect_array_32_avx2(outcoeff256, in, 4, -shift[2],
             NewSqrt2);
         transpose_4x8_avx2(in, outcoeff256);
@@ -5766,7 +5588,7 @@ void av1_fwd_txfm2d_8x4_avx2(int16_t *input, int32_t *output, uint32_t stride,
         load_buffer_8x4_avx2(input, in, stride, 0, 0, shift[0]);
         fidtx4x8_row_avx2(in, in, bitcol, 1);
         col_txfm_8x4_rounding(in, -shift[1]);
-        fdct4x8_avx2(in, outcoeff256, bitrow, 1);
+        fdct4x8_avx2(in, outcoeff256, bitrow);
         av1_round_shift_rect_array_32_avx2(outcoeff256, in, 4, -shift[2],
             NewSqrt2);
         transpose_4x8_avx2(in, outcoeff256);


### PR DESCRIPTION
av1_fwd_txfm2d_32x64_avx2()

Implemented load from int16_array_with_stride_to_int32_array_without_stride()
to AVX2, and other optimizations.

The increase in encoding speed was measured by ~ 1.4% in M6
Kernel Av1EstimateTransform take 7.1% insted of 8.5%