### PR TITLE
Allow inclusion of both SVT-AV1 and SVT-HEVC headers

### DIFF
--- a/Source/API/EbSvtAv1.h
+++ b/Source/API/EbSvtAv1.h
@@ -3,8 +3,8 @@
 * SPDX - License - Identifier: BSD - 2 - Clause - Patent
 */
 
-#ifndef EbCodec_h
-#define EbCodec_h
+#ifndef EbSvtAv1_h
+#define EbSvtAv1_h
 
 #ifdef __cplusplus
 extern "C" {
@@ -154,4 +154,4 @@ typedef struct EbSvtIOFormat            //former EbSvtEncInput
 }
 #endif // __cplusplus
 
-#endif // EbCodec_h
+#endif // EbSvtAv1_h

--- a/Source/API/EbSvtAv1Dec.h
+++ b/Source/API/EbSvtAv1Dec.h
@@ -3,8 +3,8 @@
 * SPDX - License - Identifier: BSD - 2 - Clause - Patent
 */
 
-#ifndef EbDecApi_h
-#define EbDecApi_h
+#ifndef EbSvtAv1Dec_h
+#define EbSvtAv1Dec_h
 
 #ifdef __cplusplus
 extern "C" {
@@ -334,4 +334,4 @@ typedef struct EbSvtAv1DecConfiguration
 }
 #endif // __cplusplus
 
-#endif // EbDecApi_h
+#endif // EbSvtAv1Dec_h

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -3,8 +3,8 @@
 * SPDX - License - Identifier: BSD - 2 - Clause - Patent
 */
 
-#ifndef EbApi_h
-#define EbApi_h
+#ifndef EbSvtAv1Enc_h
+#define EbSvtAv1Enc_h
 
 #ifdef __cplusplus
 extern "C" {
@@ -503,4 +503,4 @@ typedef struct EbSvtAv1EncConfiguration
 }
 #endif // __cplusplus
 
-#endif // EbApi_h
+#endif // EbSvtAv1Enc_h

--- a/Source/API/EbSvtAv1ErrorCodes.h
+++ b/Source/API/EbSvtAv1ErrorCodes.h
@@ -3,8 +3,8 @@
 * SPDX - License - Identifier: BSD - 2 - Clause - Patent
 */
 
-#ifndef EbErrorCodes_h
-#define EbErrorCodes_h
+#ifndef EbSvtAv1ErrorCodes_h
+#define EbSvtAv1ErrorCodes_h
 
 #ifdef __cplusplus
 extern "C" {
@@ -241,4 +241,4 @@ extern "C" {
 }
 #endif // __cplusplus
 
-#endif // EbErrorCodes_h
+#endif // EbSvtAv1ErrorCodes_h

--- a/Source/API/EbSvtAv1ExtFrameBuf.h
+++ b/Source/API/EbSvtAv1ExtFrameBuf.h
@@ -3,8 +3,8 @@
 * SPDX - License - Identifier: BSD - 2 - Clause - Patent
 */
 
-#ifndef EbExtFrameBuf_h
-#define EbExtFrameBuf_h
+#ifndef EbSvtAv1ExtFrameBuf_h
+#define EbSvtAv1ExtFrameBuf_h
 
 #ifdef __cplusplus
 extern "C" {

--- a/Source/API/EbSvtAv1Formats.h
+++ b/Source/API/EbSvtAv1Formats.h
@@ -13,8 +13,8 @@
  * PATENTS file, you can obtain it at www.aomedia.org/license/patent.
  */
 
-#ifndef EbFormats_h
-#define EbFormats_h
+#ifndef EbSvtAv1Formats_h
+#define EbSvtAv1Formats_h
 
 #ifdef __cplusplus
 extern "C" {
@@ -134,4 +134,4 @@ typedef enum EbChromaSamplePosition {
 }
 #endif // __cplusplus
 
-#endif // EbFormats_h
+#endif // EbSvtAv1Formats_h

--- a/Source/API/EbSvtAv1Time.h
+++ b/Source/API/EbSvtAv1Time.h
@@ -3,8 +3,8 @@
 * SPDX - License - Identifier: BSD - 2 - Clause - Patent
 */
 
-#ifndef EbTime_h
-#define EbTime_h
+#ifndef EbSvtAv1Time_h
+#define EbSvtAv1Time_h
 
 #define NANOSECS_PER_SEC ((uint32_t)(1000000000L))
 
@@ -15,5 +15,5 @@ void EbComputeOverallElapsedTimeMs(uint64_t Startseconds, uint64_t Startuseconds
 void EbSleep(uint64_t milliSeconds);
 void EbInjector(uint64_t processedFrameCount, uint32_t injector_frame_rate);
 
-#endif // EbTime_h
+#endif // EbSvtAv1Time_h
 /* File EOF */


### PR DESCRIPTION
Currently, both SVT-AV1 and SVT-HEVC use the same header guards. Including one skips the other.
Required by #73.

```c
$ cat a.c
#include <EbApi.h>
#include <EbSvtAv1Enc.h>

$ cc -E a.c $(pkg-config SvtAv1Enc SvtHevcEnc --cflags) | fgrep EbSvtAv1EncConfiguration

$ cat b.c
#include <EbSvtAv1Enc.h>

$ cc -E b.c $(pkg-config SvtAv1Enc SvtHevcEnc --cflags) | fgrep EbSvtAv1EncConfiguration
typedef struct EbSvtAv1EncConfiguration
} EbSvtAv1EncConfiguration;
        EbSvtAv1EncConfiguration *config_ptr);
        EbSvtAv1EncConfiguration *pComponentParameterStructure);
```
