### PR TITLE
AppVeyor: Don't upload & deploy unnecessary artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,12 +12,13 @@ build:
 
 artifacts:
     - path: bin\Release\SvtAv1*.exe
+      name: $(APPVEYOR_PROJECT_NAME)
     - path: bin\Release\SvtAv1*.dll
-    - path: bin\Release\SvtAv1*.lib
+      name: $(APPVEYOR_PROJECT_NAME)
 
 deploy:
   - provider: GitHub
-    artifact: bin\Release\*.*
+    artifact: $(APPVEYOR_PROJECT_NAME)
     auth_token:
       secure: 'sf0pQXlPI+X6LoAR8QUJB74jjzNxcLGOXI3H0nbxJq8llvGPG/TAUd87hq5iHZXo'
     prerelease: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,12 +11,13 @@ build:
   project: svt-av1.sln
 
 artifacts:
-    - path: bin\Release\*.*
-      name: $(APPVEYOR_PROJECT_NAME)
+    - path: bin\Release\SvtAv1*.exe
+    - path: bin\Release\SvtAv1*.dll
+    - path: bin\Release\SvtAv1*.lib
 
 deploy:
   - provider: GitHub
-    artifact: $(APPVEYOR_PROJECT_NAME)
+    artifact: bin\Release\*.*
     auth_token:
       secure: 'sf0pQXlPI+X6LoAR8QUJB74jjzNxcLGOXI3H0nbxJq8llvGPG/TAUd87hq5iHZXo'
     prerelease: true


### PR DESCRIPTION
Stops AppVeyor from uploading the gtest and .exp artifacts after #181.