### PR TITLE
Use prefix for asm files using AOM's method, add a note about macOS fd limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ The SVT-AV1 Encoder adapts to the system that is being ran on. The memory requir
 * __Build Instructions__
 	 -	./Build/linux/build.sh <release | debug> (if none specified, both release and debug will be built)
 
+  - __Note about macOS__
+    - It is necessary to increase the amount of available file descriptors due to the limit being very low. The instructions to do so can be found [here](https://apple.lib.utah.edu/open-file-limits-on-os-x-what-they-are-why-increase-them-and-how-to-increase-them/).
 
 * __Sample Binaries location__
      -    Binaries can be found under Bin/Release and / or Bin/Debug
@@ -107,7 +109,7 @@ For the binaries to operate properly on your system, the following conditions ha
 ## Demo features and limitations
 
 -  **Multi-instance support:** The multi-instance functionality is a demo feature implemented in the SVT-AV1 Encoder sample application as an example of one sample application using multiple encoding libraries. Encoding using the multi-instance support is limited to only 6 simultaneous streams. For example two channels encoding on Windows: SvtAV1EncApp.exe -nch 2 -c firstchannel.cfg secondchannel.cfg
--  **Features enabled:** The library will display an error message any feature combination that is not currently supported. 
+-  **Features enabled:** The library will display an error message any feature combination that is not currently supported.
 
 ## How to Contribute
 

--- a/Source/Lib/Common/ASM_SSE2/EbPictureOperators_SSE2.asm
+++ b/Source/Lib/Common/ASM_SSE2/EbPictureOperators_SSE2.asm
@@ -1,14 +1,13 @@
-; 
+;
 ; Copyright(c) 2019 Intel Corporation
 ; SPDX - License - Identifier: BSD - 2 - Clause - Patent
-; 
+;
 
 %include "x64inc.asm"
 %include "x64Macro.asm"
 section .text
 ; ----------------------------------------------------------------------------------------
 
-cglobal _picture_copy_kernel_sse2
 cglobal picture_copy_kernel_sse2
 
 ; Requirement: areaWidthInBytes = 4, 8, 12, 16, 24, 32, 48, 64 or 128
@@ -210,7 +209,6 @@ Label_PictureCopyKernel_SSE2_WIDTH16:
     ret
 ; ----------------------------------------------------------------------------------------
 
-cglobal _zero_out_coeff4x4_sse
 cglobal zero_out_coeff4x4_sse
 
     lea             r0,             [r0+2*r2]
@@ -230,7 +228,6 @@ cglobal zero_out_coeff4x4_sse
 
 ; ----------------------------------------------------------------------------------------
 
-cglobal _zero_out_coeff8x8_sse2
 cglobal zero_out_coeff8x8_sse2
 
 ; TODO: use "movdqa" if coeff_buffer is guaranteed to be 16-byte aligned.
@@ -253,7 +250,6 @@ cglobal zero_out_coeff8x8_sse2
 
 ; ----------------------------------------------------------------------------------------
 
-cglobal _zero_out_coeff16x16_sse2
 cglobal zero_out_coeff16x16_sse2
 
 ; TODO: use "movdqa" if coeff_buffer is guaranteed to be 16-byte aligned.
@@ -303,7 +299,6 @@ cglobal zero_out_coeff16x16_sse2
 
 ; ----------------------------------------------------------------------------------------
 
-cglobal _zero_out_coeff32x32_sse2
 cglobal zero_out_coeff32x32_sse2
 
 ; TODO: use "movdqa" if coeff_buffer is guaranteed to be 16-byte aligned.
@@ -355,7 +350,6 @@ Label_ZeroOutCoeff32x32_SSE2_01:
 
 ; ----------------------------------------------------------------------------------------
 
-cglobal _picture_average_kernel_sse2
 cglobal picture_average_kernel_sse2
 
 ; Requirement: pu_width         = 4, 8, 12, 16, 24, 32, 48 or 64
@@ -526,7 +520,7 @@ Label_PictureAverageKernel_SSE2_WIDTH48:
     pavgb           xmm0,            xmm6
     movdqu          xmm6,            [src1+16]
     pavgb           xmm1,            xmm6
-    movdqu          xmm6,            [src1+32]            
+    movdqu          xmm6,            [src1+32]
     pavgb           xmm2,            xmm6
     movdqu          xmm6,            [src1+src1_stride]
     pavgb           xmm3,            xmm6
@@ -626,8 +620,6 @@ Label_PictureAverageKernel_SSE2_WIDTH16:
     ret
 
 ; ----------------------------------------------------------------------------------------
-    cglobal _Log2f_SSE2
     cglobal Log2f_SSE2
     bsr rax, r0
     ret
-

--- a/Source/Lib/Common/ASM_SSE2/x64RegisterUtil.asm
+++ b/Source/Lib/Common/ASM_SSE2/x64RegisterUtil.asm
@@ -1,7 +1,7 @@
-; 
+;
 ; Copyright(c) 2019 Intel Corporation
 ; SPDX - License - Identifier: BSD - 2 - Clause - Patent
-; 
+;
 
 %include "x64inc.asm"
 
@@ -21,7 +21,6 @@ section .text
 ; So if RunEmms() is called according to the above cases,
 ; then the "emms" instruction in all other assembly functions can be removed.
 
-cglobal _RunEmms
 cglobal RunEmms
     emms
     ret

--- a/Source/Lib/Common/ASM_SSE2/x64inc.asm
+++ b/Source/Lib/Common/ASM_SSE2/x64inc.asm
@@ -1,7 +1,7 @@
-; 
+;
 ; Copyright(c) 2019 Intel Corporation
 ; SPDX - License - Identifier: BSD - 2 - Clause - Patent
-; 
+;
 
 %ifdef PREFIX
     %define mangle(x) _ %+ x
@@ -12,6 +12,9 @@
 %macro cglobal 1
     %assign stack_offset 0
     %xdefine %1 mangle(%1)
+    %ifidn   __OUTPUT_FORMAT__,macho64
+    %define %1 _ %+ %1
+    %endif
     global %1
     %1:
 %endmacro
@@ -310,7 +313,7 @@ bits 64
     ADD_RSP 16
     movdqu          xmm11,      [rsp]
     ADD_RSP 16
-    movdqu          xmm10,      [rsp] 
+    movdqu          xmm10,      [rsp]
     ADD_RSP 16
     movdqu          xmm9,       [rsp]
     ADD_RSP 16

--- a/Source/Lib/Common/Codec/EbThreads.c
+++ b/Source/Lib/Common/Codec/EbThreads.c
@@ -196,7 +196,7 @@ EbHandle eb_create_semaphore(uint32_t initial_count, uint32_t max_count)
         NULL);                          // semaphore is not named
     return semaphore_handle;
 
-#elif defined(__linux__) 
+#elif defined(__linux__)
     EbHandle semaphore_handle = NULL;
     (void)max_count;
 
@@ -216,6 +216,7 @@ EbHandle eb_create_semaphore(uint32_t initial_count, uint32_t max_count)
         fprintf(stderr, "errno: %d\n", errno);
         return NULL;
     }
+    sem_unlink(name);
     return s;
 #endif // _WIN32
 
@@ -268,7 +269,7 @@ EbErrorType eb_destroy_semaphore(EbHandle semaphore_handle)
 
 #ifdef _WIN32
     return_error = !CloseHandle((HANDLE)semaphore_handle) ? EB_ErrorDestroySemaphoreFailed : EB_ErrorNone;
-#elif defined(__linux__) 
+#elif defined(__linux__)
     return_error = sem_destroy((sem_t*)semaphore_handle) ? EB_ErrorDestroySemaphoreFailed : EB_ErrorNone;
     free(semaphore_handle);
 #elif defined(__APPLE__)


### PR DESCRIPTION
Asm prefix part taken from <https://aomedia.googlesource.com/aom/+/master/aom_ports/x86_abi_support.asm#95>.

Named semaphores must be unlinked else they will be orphaned but still contribute to the global semaphore count. As long as they are unlinked after being opened, they should not be orphaned. 
<https://bugs.chromium.org/p/nativeclient/issues/detail?id=686>