### PR TITLE
y4m: fix parser error for y4m input

### DIFF
--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -670,7 +670,7 @@ static void ParseConfigFile(
                 // Cap the length of the variable name
                 argLen[0] = (argLen[0] > CONFIG_FILE_MAX_VAR_LEN - 1) ? CONFIG_FILE_MAX_VAR_LEN - 1 : argLen[0];
                 // Copy the variable name
-                EB_STRNCPY(varName, argv[0], argLen[0]);
+                EB_STRNCPY(varName, CONFIG_FILE_MAX_VAR_LEN, argv[0], argLen[0]);
                 // Null terminate the variable name
                 varName[argLen[0]] = CONFIG_FILE_NULL_CHAR;
 
@@ -679,7 +679,7 @@ static void ParseConfigFile(
                     // Cap the length of the variable
                     argLen[valueIndex+2] = (argLen[valueIndex+2] > CONFIG_FILE_MAX_VAR_LEN - 1) ? CONFIG_FILE_MAX_VAR_LEN - 1 : argLen[valueIndex+2];
                     // Copy the variable name
-                    EB_STRNCPY(varValue[valueIndex], argv[valueIndex+2], argLen[valueIndex+2]);
+                    EB_STRNCPY(varValue[valueIndex], CONFIG_FILE_MAX_VAR_LEN, argv[valueIndex+2], argLen[valueIndex+2]);
                     // Null terminate the variable name
                     varValue[valueIndex][argLen[valueIndex+2]] = CONFIG_FILE_NULL_CHAR;
 

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -139,8 +139,8 @@ extern errno_t strncpy_ss(char *dest, rsize_t dmax, const char *src, rsize_t sle
 /* string length */
 extern rsize_t strnlen_ss(const char *s, rsize_t smax);
 
-#define EB_STRNCPY(dst, src, count) \
-    strncpy_ss(dst, sizeof(dst), src, count)
+#define EB_STRNCPY(dst, dst_size, src, count)	\
+    strncpy_ss(dst, dst_size, src, count)
 
 #define EB_STRCPY(dst, size, src) \
     strcpy_ss(dst, size, src)

--- a/Source/App/EncApp/EbAppInputy4m.c
+++ b/Source/App/EncApp/EbAppInputy4m.c
@@ -20,12 +20,7 @@ char* copyUntilCharacterOrNewLine(char *src, char *dst, char chr){
         count++;
     }
 
-    if(count >= YFM_HEADER_MAX){
-        count = YFM_HEADER_MAX-1;
-    }
-
-    EB_STRNCPY(dst, src_init, count);
-    dst[count] = '\0';
+    EB_STRNCPY(dst, YFM_HEADER_MAX, src_init, count);
 
     return src;
 

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -2668,7 +2668,7 @@ extern void
 memset(dst, val, count)
 
 #define EB_STRNCPY(dst, src, count) \
-strncpy_ss(dst, sizeof(dst), src, count)
+strncpy_ss(dst, dst_size, src, count)
 
 #define EB_STRCPY(dst, size, src) \
 strcpy_ss(dst, size, src)


### PR DESCRIPTION
EB_STRNCPY assume the dest is a static array, so it will use sizeof(dst) to get the size
But it's not true in copyUntilCharacterOrNewLine. So the y4m as input is totally breaking.

Since we can't check the type of dst, assume it's static array is harmful.
Better let the user pass the dst size.