### PR TITLE
IoK/FB/051719 - Offer new downsample_2d function to perform 2x2 bilinear

### DIFF
--- a/Build/XCode/build.sh
+++ b/Build/XCode/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Copyright(c) 2019 Intel Corporation
+# SPDX - License - Identifier: BSD - 2 - Clause - Patent
+#
+
+function cmake_ify {
+  
+    PATH=$PATH:/usr/local/bin/
+    cmake ..                                        \
+        -DCMAKE_ASM_NASM_COMPILER=$CMAKE_ASSEMBLER  \
+        -G Xcode                                    \
+        
+}
+
+# Defines
+CMAKE_ASSEMBLER=yasm
+
+mkdir _build && cd _build
+
+cmake_ify
+
+exit

--- a/Source/Lib/Common/ASM_AVX2/cfl_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/cfl_avx2.c
@@ -221,10 +221,8 @@ static INLINE __m256i _mm256_addl_epi16(__m256i a) {
                     _mm_unpacklo_epi16(l1, zeros)));
             }
             else {
-                if (width == 8) {
-                    l0 = _mm_add_epi16(_mm_loadu_si128(src),
-                        _mm_loadu_si128(src + CFL_BUF_LINE_I128));
-                }
+                l0 = _mm_add_epi16(_mm_loadu_si128(src),
+                    _mm_loadu_si128(src + CFL_BUF_LINE_I128));
                 sum = _mm_add_epi32(sum, _mm_add_epi32(_mm_unpacklo_epi16(l0, zeros),
                     _mm_unpackhi_epi16(l0, zeros)));
             }

--- a/Source/Lib/Common/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimation.c
@@ -8268,8 +8268,14 @@ EbErrorType motion_estimate_lcu(
             referenceObject = (EbPaReferenceObject*)picture_control_set_ptr->ref_pa_pic_ptr_array[listIndex]->object_ptr;
 #endif
             refPicPtr = (EbPictureBufferDesc*)referenceObject->input_padded_picture_ptr;
+#define FILTERING 0
+#if (FILTERING==1)
+            quarterRefPicPtr = (EbPictureBufferDesc*)referenceObject->quarter_filtered_picture_ptr;
+            sixteenthRefPicPtr = (EbPictureBufferDesc*)referenceObject->sixteenth_filtered_picture_ptr;
+#else
             quarterRefPicPtr = (EbPictureBufferDesc*)referenceObject->quarter_decimated_picture_ptr;
             sixteenthRefPicPtr = (EbPictureBufferDesc*)referenceObject->sixteenth_decimated_picture_ptr;
+#endif
 #if BASE_LAYER_REF
             if (picture_control_set_ptr->temporal_layer_index > 0 || listIndex == 0 || ((ref0Poc != ref1Poc) && (listIndex == 1))) {
 #else

--- a/Source/Lib/Common/Codec/EbMotionEstimation.h
+++ b/Source/Lib/Common/Codec/EbMotionEstimation.h
@@ -48,6 +48,14 @@ extern "C" {
         uint8_t                   *decim_samples,
         uint32_t                   decim_stride,
         uint32_t                   decim_step);
+    extern void downsample_2d_4(
+        uint8_t                   *input_samples,
+        uint32_t                   input_stride,
+        uint32_t                   input_area_width,
+        uint32_t                   input_area_height,
+        uint8_t                   *decim_samples,
+        uint32_t                   decim_stride,
+        uint32_t                   decim_step);
 
     
     extern EbErrorType open_loop_intra_search_sb(

--- a/Source/Lib/Common/Codec/EbMotionEstimation.h
+++ b/Source/Lib/Common/Codec/EbMotionEstimation.h
@@ -40,6 +40,14 @@ extern "C" {
         uint8_t                   *decim_samples,
         uint32_t                   decim_stride,
         uint32_t                   decim_step);
+    extern void downsample_2d(
+        uint8_t                   *input_samples,
+        uint32_t                   input_stride,
+        uint32_t                   input_area_width,
+        uint32_t                   input_area_height,
+        uint8_t                   *decim_samples,
+        uint32_t                   decim_stride,
+        uint32_t                   decim_step);
 
     
     extern EbErrorType open_loop_intra_search_sb(

--- a/Source/Lib/Common/Codec/EbReferenceObject.c
+++ b/Source/Lib/Common/Codec/EbReferenceObject.c
@@ -269,6 +269,24 @@ EbErrorType eb_pa_reference_object_ctor(
         return EB_ErrorInsufficientResources;
     }
 
+    // Quarter Filtered reference picture constructor
+    paReferenceObject->quarter_filtered_picture_ptr = (EbPictureBufferDesc*)EB_NULL;
+    return_error = eb_picture_buffer_desc_ctor(
+        (EbPtr*) &(paReferenceObject->quarter_filtered_picture_ptr),
+        (EbPtr)(pictureBufferDescInitDataPtr + 3));
+    if (return_error == EB_ErrorInsufficientResources) {
+        return EB_ErrorInsufficientResources;
+    }
+
+    // Sixteenth Filtered reference picture constructor
+    paReferenceObject->sixteenth_filtered_picture_ptr = (EbPictureBufferDesc*)EB_NULL;
+    return_error = eb_picture_buffer_desc_ctor(
+        (EbPtr*) &(paReferenceObject->sixteenth_filtered_picture_ptr),
+        (EbPtr)(pictureBufferDescInitDataPtr + 4));
+    if (return_error == EB_ErrorInsufficientResources) {
+        return EB_ErrorInsufficientResources;
+    }
+
     return EB_ErrorNone;
 }
 

--- a/Source/Lib/Common/Codec/EbReferenceObject.h
+++ b/Source/Lib/Common/Codec/EbReferenceObject.h
@@ -52,6 +52,8 @@ typedef struct EbPaReferenceObject
     EbPictureBufferDesc          *input_padded_picture_ptr;
     EbPictureBufferDesc          *quarter_decimated_picture_ptr;
     EbPictureBufferDesc          *sixteenth_decimated_picture_ptr;
+    EbPictureBufferDesc          *quarter_filtered_picture_ptr;
+    EbPictureBufferDesc          *sixteenth_filtered_picture_ptr;
     uint16_t                        variance[MAX_NUMBER_OF_TREEBLOCKS_PER_PICTURE];
     uint8_t                         y_mean[MAX_NUMBER_OF_TREEBLOCKS_PER_PICTURE];
     EB_SLICE                        slice_type;
@@ -70,6 +72,8 @@ typedef struct EbPaReferenceObjectDescInitData
     EbPictureBufferDescInitData   reference_picture_desc_init_data;
     EbPictureBufferDescInitData   quarter_picture_desc_init_data;
     EbPictureBufferDescInitData   sixteenth_picture_desc_init_data;
+    EbPictureBufferDescInitData   quarter_filtered_picture_desc_init_data;
+    EbPictureBufferDescInitData   sixteenth_filtered_picture_desc_init_data;
 } EbPaReferenceObjectDescInitData;
 
 /**************************************

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -1182,6 +1182,8 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         EbPictureBufferDescInitData       referencePictureBufferDescInitData;
         EbPictureBufferDescInitData       quarterDecimPictureBufferDescInitData;
         EbPictureBufferDescInitData       sixteenthDecimPictureBufferDescInitData;
+        EbPictureBufferDescInitData       quarterFilteredPictureBufferDescInitData;
+        EbPictureBufferDescInitData       sixteenthFilteredPictureBufferDescInitData;
 
         // Initialize the various Picture types
         referencePictureBufferDescInitData.max_width = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_width;
@@ -1246,6 +1248,7 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         quarterDecimPictureBufferDescInitData.bot_padding = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 1;
         quarterDecimPictureBufferDescInitData.split_mode = EB_FALSE;
 
+        memcpy(&quarterFilteredPictureBufferDescInitData, &quarterDecimPictureBufferDescInitData, sizeof(quarterDecimPictureBufferDescInitData));
 
         sixteenthDecimPictureBufferDescInitData.max_width = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_width >> 2;
         sixteenthDecimPictureBufferDescInitData.max_height = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_height >> 2;
@@ -1258,9 +1261,13 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         sixteenthDecimPictureBufferDescInitData.bot_padding = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 2;
         sixteenthDecimPictureBufferDescInitData.split_mode = EB_FALSE;
 
+        memcpy(&sixteenthFilteredPictureBufferDescInitData, &sixteenthDecimPictureBufferDescInitData, sizeof(sixteenthDecimPictureBufferDescInitData));
+
         EbPaReferenceObjectDescInitDataStructure.reference_picture_desc_init_data = referencePictureBufferDescInitData;
         EbPaReferenceObjectDescInitDataStructure.quarter_picture_desc_init_data = quarterDecimPictureBufferDescInitData;
         EbPaReferenceObjectDescInitDataStructure.sixteenth_picture_desc_init_data = sixteenthDecimPictureBufferDescInitData;
+        EbPaReferenceObjectDescInitDataStructure.quarter_filtered_picture_desc_init_data = quarterFilteredPictureBufferDescInitData;
+        EbPaReferenceObjectDescInitDataStructure.sixteenth_filtered_picture_desc_init_data = sixteenthFilteredPictureBufferDescInitData;
 
         // Reference Picture Buffers
         return_error = eb_system_resource_ctor(


### PR DESCRIPTION
filtering instead of decimation

- Controlled by #define DECIMATION (line 4954, EbPictureAnalysisProcess.c)
- Minor bug fixing in original decimation_2d
- Fix compiler warning in cfl_avx2.c
- Add XCode project generator script