### PR TITLE
Style: add syntax stuff for the code blocks in STYLE.md

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -1,5 +1,5 @@
 
-## Code Style
+# Code Style
 
 This style guide comes from `dav1d`: https://code.videolan.org/videolan/dav1d/wikis/Coding-style
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,7 +1,7 @@
 
 # Code Style
 
-This style guide comes from `dav1d`: https://code.videolan.org/videolan/dav1d/wikis/Coding-style
+This style guide comes from `dav1d`: <https://code.videolan.org/videolan/dav1d/wikis/Coding-style>
 
 Tabs vs Spaces
 **No tabs,** only spaces; 4-space indentation;

--- a/STYLE.md
+++ b/STYLE.md
@@ -188,3 +188,24 @@ struct {
 *
 ********************************************************************************/
 ```
+
+## Post-coding
+
+After coding, make sure to trim any trailing white space
+E.g.
+`find . -name <Filename> -type f -exec sed -i 's/[[:space:]]*$//' {} \;`
+or
+`sed -i 's/[[:space:]]*$//' <Filename>`
+for bash
+
+``` Powershell
+ls -Recurse -File [-Filter *.c] | ForEach-Object{$(Get-Content $_.FullName | Foreach {Write-Output "$($_.TrimEnd())`n"}) | Set-Content -NoNewline $_.FullName}
+```
+
+Or
+
+``` Powershell
+Get-content <filename> | Foreach {Write-Output "$($_.TrimEnd())`n"}) | Set-Content -NoNewline <filename>
+```
+
+For Powershell

--- a/STYLE.md
+++ b/STYLE.md
@@ -3,7 +3,7 @@
 
 This style guide comes from `dav1d`: <https://code.videolan.org/videolan/dav1d/wikis/Coding-style>
 
-Tabs vs Spaces
+Tabs vs Spaces\
 **No tabs,** only spaces; 4-space indentation;
 
 Be aware that some tools might add tabs when auto aligning the code, please check your commits with a diff tool for tabs.

--- a/STYLE.md
+++ b/STYLE.md
@@ -25,7 +25,7 @@ const int my_var = (something1 +
                     something2) * something3;
 ```
 
-use `CamelCase` for types and `under_score` for variable names (`TypeName my_instance;`)
+use `CamelCase` for types and `under_score` for variable names (`TypeName my_instance;`)\
 we use const where possible, except in forward function declarations in header files, where we only use it for const-arrays:
 
 `int my_func(const array *values, int arg);`

--- a/STYLE.md
+++ b/STYLE.md
@@ -191,12 +191,20 @@ struct {
 
 ## Post-coding
 
-After coding, make sure to trim any trailing white space
-E.g.
-`find . -name <Filename> -type f -exec sed -i 's/[[:space:]]*$//' {} \;`
+After coding, make sure to trim any trailing white space\
+E.g. For bash:
+
+``` bash
+find . -name <Filename> -type f -exec sed -i 's/[[:space:]]*$//' {} \;
+```
+
 or
-`sed -i 's/[[:space:]]*$//' <Filename>`
-for bash
+
+``` bash
+sed -i 's/[[:space:]]*$//' <Filename>
+```
+
+For Powershell:
 
 ``` Powershell
 ls -Recurse -File [-Filter *.c] | ForEach-Object{$(Get-Content $_.FullName | Foreach {Write-Output "$($_.TrimEnd())`n"}) | Set-Content -NoNewline $_.FullName}
@@ -207,5 +215,3 @@ Or
 ``` Powershell
 Get-content <filename> | Foreach {Write-Output "$($_.TrimEnd())`n"}) | Set-Content -NoNewline <filename>
 ```
-
-For Powershell

--- a/STYLE.md
+++ b/STYLE.md
@@ -10,17 +10,21 @@ Be aware that some tools might add tabs when auto aligning the code, please chec
 
 for multi-line statements, the indentation of the next line depends on the context of the statement and braces around it. For example, if you have a long assignment, you can choose to either align it to the = of the first line, or (if that leads to less lines of code) just indent 1 level further from the first line's indentation level:
 
-```
+``` c
 const int my_var = something1 &&
                    something2;
 ```
+
 or
-```
+
+``` c
 const int my_var = something1 +
     something2 - something3 * something4;
 ```
+
 However, if there are braces, the first non-whitespace character of the line should be aligned with the brace level that it is part of:
-```
+
+``` c
 const int my_var = (something1 +
                     something2) * something3;
 ```
@@ -28,25 +32,27 @@ const int my_var = (something1 +
 use `CamelCase` for types and `under_score` for variable names (`TypeName my_instance;`)\
 we use const where possible, except in forward function declarations in header files, where we only use it for const-arrays:
 
-`int my_func(const array *values, int arg);`
+``` c
+int my_func(const array *values, int arg);
 
 [..]
 
-```
 int my_func(const array *const values, const int num) {
-    ..
+    [..]
 }
 ```
 
 braces go on the same line for single-line statements, but on a new line for multi-line statements:
 
-```
+``` c
 static void function(const int argument) {
     do_something();
 }
 ```
+
 versus
-```
+
+``` c
 static void function(const int argument1,
                      const int argument2)
 {
@@ -56,19 +62,23 @@ static void function(const int argument1,
 
 braces are only necessary for multi-line code blocks or multi-line condition statements;
 
-```
+``` c
 if (condition1 && condition2)
     do_something();
 ```
+
 and
-```
+
+``` c
 if (condition) {
     do_something_1();
     do_something_2();
 }
 ```
+
 and
-```
+
+``` c
 if (condition1 &&
     condition2)
 {
@@ -78,15 +88,17 @@ if (condition1 &&
 
 switch/case are indented at the same level, and the code block is indented one level deeper:
 
-```
+``` c
 switch (a) {
 case 1:
     bla();
     break;
 }
 ```
+
 but for very trivial blocks, you can also put everything on one single line
-```
+
+``` c
 switch (a) {
 case 1: bla(); break;
 }
@@ -99,7 +111,8 @@ use sized types (`uint8_t`, `int16_t`, etc.) for vector/array variables where th
 use dynamic types (`pixel`, `coef`, etc.) so multi-bitdepth templating works as it should.
 
 ## Doxygen Documentation
-```
+
+``` c
 /* File level Description */
 
 /*********************************************************************************


### PR DESCRIPTION
Could I add a note about using sed to remove trailing whitespace after coding? It's been quite annoying when the commits include deletion of whitespace, filling up the commit.

`find . -name <Filename> -type f -exec sed -i 's/[[:space:]]*$//' {} \;`
or
`sed -i 's/[[:space:]]*$//' <Filename>`
for bash

``` Powershell
ls -Recurse -File [-Filter *.c] | ForEach-Object{$(Get-Content $_.FullName | Foreach {Write-Output "$($_.TrimEnd())`n"}) | Set-Content -NoNewline $_.FullName}
```
for powershell

(I don't think it's possible for command prompt)