### PR TITLE
docs/decoder: Fix the broken link

### DIFF
--- a/Docs/svt-av1_decoder_user_guide.md
+++ b/Docs/svt-av1_decoder_user_guide.md
@@ -2,7 +2,7 @@
 
 ## Table of Contents
 1. [Introduction](#introduction)
-2. [Known Limitations] (#known-limitations)
+2. [Known Limitations](#known-limitations)
 3. [Sample Application Guide](#sample-application-guide)    
     - [Running the decoder](#running-the-decoder)
 4. [Legal Disclaimer](#legal-disclaimer)


### PR DESCRIPTION
Hi,

There was extra whitespace which made `Known Limitations` not able to redirect properly.

BR,
Vibhoothi