### PR TITLE
EbDefinitions: Don't redefine fseeko64 and ftello64

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -25,8 +25,12 @@
 #define inline __inline
 #elif __GNUC__
 #define inline __inline__
+#ifndef fseeko64
 #define fseeko64 fseek
+#endif
+#ifndef ftello64
 #define ftello64 ftell
+#endif
 #else
 #error OS not supported
 #endif


### PR DESCRIPTION
musl already defines fseeko64 as fseek and ftello64 as ftello