### PR TITLE
EB_MALLOC: remove duplicate code and do more check

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -2606,6 +2606,9 @@ app_malloc_count++;
 #else
 #ifdef _MSC_VER
 #define EB_ALLIGN_MALLOC(type, pointer, n_elements, pointer_class) \
+if (*(memory_map_index) >= MAX_NUM_PTR) { \
+    return EB_ErrorInsufficientResources; \
+} \
 pointer = (type) _aligned_malloc(n_elements,ALVALUE); \
 if (pointer == (type)EB_NULL) { \
     return EB_ErrorInsufficientResources; \
@@ -2620,13 +2623,13 @@ if (pointer == (type)EB_NULL) { \
         *total_lib_memory += ((n_elements) + (8 - ((n_elements) % 8))); \
     } \
 } \
-if (*(memory_map_index) >= MAX_NUM_PTR) { \
-    return EB_ErrorInsufficientResources; \
-} \
 lib_malloc_count++;
 
 #else
 #define EB_ALLIGN_MALLOC(type, pointer, n_elements, pointer_class) \
+if (*(memory_map_index) >= MAX_NUM_PTR) { \
+    return EB_ErrorInsufficientResources; \
+    } \
 if (posix_memalign((void**)(&(pointer)), ALVALUE, n_elements) != 0) { \
     return EB_ErrorInsufficientResources; \
         } \
@@ -2641,13 +2644,13 @@ if (posix_memalign((void**)(&(pointer)), ALVALUE, n_elements) != 0) { \
         *total_lib_memory += ((n_elements) + (8 - ((n_elements) % 8))); \
     } \
 } \
-if (*(memory_map_index) >= MAX_NUM_PTR) { \
-    return EB_ErrorInsufficientResources; \
-    } \
 lib_malloc_count++;
 #endif
 
 #define EB_MALLOC(type, pointer, n_elements, pointer_class) \
+if (*(memory_map_index) >= MAX_NUM_PTR) { \
+    return EB_ErrorInsufficientResources; \
+} \
 pointer = (type) malloc(n_elements); \
 if (pointer == (type)EB_NULL) { \
     return EB_ErrorInsufficientResources; \
@@ -2662,12 +2665,12 @@ if (pointer == (type)EB_NULL) { \
         *total_lib_memory += ((n_elements) + (8 - ((n_elements) % 8))); \
     } \
 } \
-if (*(memory_map_index) >= MAX_NUM_PTR) { \
-    return EB_ErrorInsufficientResources; \
-} \
 lib_malloc_count++;
 
 #define EB_CALLOC(type, pointer, count, size, pointer_class) \
+if (*(memory_map_index) >= MAX_NUM_PTR) { \
+    return EB_ErrorInsufficientResources; \
+} \
 pointer = (type) calloc(count, size); \
 if (pointer == (type)EB_NULL) { \
     return EB_ErrorInsufficientResources; \
@@ -2682,12 +2685,12 @@ else { \
         *total_lib_memory += ((count) + (8 - ((count) % 8))); \
     } \
 } \
-if (*(memory_map_index) >= MAX_NUM_PTR) { \
-    return EB_ErrorInsufficientResources; \
-} \
 lib_malloc_count++;
 
 #define EB_CREATESEMAPHORE(type, pointer, n_elements, pointer_class, initial_count, max_count) \
+if (*(memory_map_index) >= MAX_NUM_PTR) { \
+    return EB_ErrorInsufficientResources; \
+} \
 pointer = eb_create_semaphore(initial_count, max_count); \
 if (pointer == (type)EB_NULL) { \
     return EB_ErrorInsufficientResources; \
@@ -2702,12 +2705,12 @@ else { \
         *total_lib_memory += ((n_elements) + (8 - ((n_elements) % 8))); \
     } \
 } \
-if (*(memory_map_index) >= MAX_NUM_PTR) { \
-    return EB_ErrorInsufficientResources; \
-} \
 lib_semaphore_count++;
 
 #define EB_CREATEMUTEX(type, pointer, n_elements, pointer_class) \
+if (*(memory_map_index) >= MAX_NUM_PTR) { \
+    return EB_ErrorInsufficientResources; \
+} \
 pointer = eb_create_mutex(); \
 if (pointer == (type)EB_NULL){ \
     return EB_ErrorInsufficientResources; \
@@ -2721,9 +2724,6 @@ else { \
     else { \
         *total_lib_memory += ((n_elements) + (8 - ((n_elements) % 8))); \
     } \
-} \
-if (*(memory_map_index) >= MAX_NUM_PTR) { \
-    return EB_ErrorInsufficientResources; \
 } \
 lib_mutex_count++;
 #endif

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -2443,290 +2443,92 @@ extern    uint32_t                   lib_mutex_count;
 extern    uint32_t                   app_malloc_count;
 
 #define ALVALUE 32
-#define EB_APP_MALLOC(type, pointer, n_elements, pointer_class, return_type) \
-pointer = (type)malloc(n_elements); \
-if (pointer == (type)EB_NULL){ \
-    return return_type; \
-    } \
-    else { \
-    app_memory_map[*(app_memory_map_index)].ptr_type = pointer_class; \
-    app_memory_map[(*(app_memory_map_index))++].ptr = pointer; \
-    if (n_elements % 8 == 0) { \
-        *total_app_memory += (n_elements); \
-            } \
-            else { \
-        *total_app_memory += ((n_elements) + (8 - ((n_elements) % 8))); \
-    } \
-} \
-if (*(app_memory_map_index) >= MAX_APP_NUM_PTR) { \
-    return return_type; \
+
+#define EB_ADD_APP_MEM(pointer, size, pointer_class, count, release, return_type) \
+    do { \
+        if (！pointer) return return_type; \
+        if (*(app_memory_map_index) >= MAX_APP_NUM_PTR) { \
+            printf("Malloc has failed due to insuffucient resources"); \
+            release(pointer); \
+            return return_type; \
         } \
-app_malloc_count++;
+        app_memory_map[*(app_memory_map_index)].ptr_type = pointer_class; \
+        app_memory_map[(*(app_memory_map_index))++].ptr = pointer; \
+        *total_app_memory += (size + 7) / 8; \
+        count++; \
+    } while (0)
+
+#define EB_APP_MALLOC(type, pointer, n_elements, pointer_class, return_type) \
+    pointer = (type)malloc(n_elements); \
+    EB_ADD_APP_MEM(pointer, n_elements, pointer_class, app_malloc_count, return_type);
+
 
 #define EB_APP_MALLOC_NR(type, pointer, n_elements, pointer_class,return_type) \
-(void)return_type; \
-pointer = (type)malloc(n_elements); \
-if (pointer == (type)EB_NULL){ \
-    return_type = EB_ErrorInsufficientResources; \
-    printf("Malloc has failed due to insuffucient resources"); \
-    return; \
-    } \
-else { \
-    app_memory_map[*(app_memory_map_index)].ptr_type = pointer_class; \
-    app_memory_map[(*(app_memory_map_index))++].ptr = pointer; \
-    if (n_elements % 8 == 0) { \
-        *total_app_memory += (n_elements); \
-            } \
-            else { \
-        *total_app_memory += ((n_elements) + (8 - ((n_elements) % 8))); \
-    } \
-} \
-if (*(app_memory_map_index) >= MAX_APP_NUM_PTR) { \
-    return_type = EB_ErrorInsufficientResources; \
-    printf("Malloc has failed due to insuffucient resources"); \
-    return; \
-        } \
-app_malloc_count++;
+    pointer = (type)malloc(n_elements); \
+    EB_ADD_APP_MEM(pointer, n_elements, pointer_class, app_malloc_count, return_type);
 
 #define ALVALUE 32
 #if MEM_MAP_OPT
-#ifdef _MSC_VER
-#define EB_ALLIGN_MALLOC(type, pointer, n_elements, pointer_class) \
-    pointer = (type) _aligned_malloc(n_elements,ALVALUE); \
-    if (pointer == (type)EB_NULL) \
-        return EB_ErrorInsufficientResources; \
-    else { \
-        EbMemoryMapEntry *node = malloc(sizeof(EbMemoryMapEntry)); \
-        if (node == (EbMemoryMapEntry*)EB_NULL) return EB_ErrorInsufficientResources; \
+#define EB_ADD_MEM(pointer, size, pointer_class, count, release) \
+    do { \
+        EbMemoryMapEntry *node; \
+        if (!pointer) return EB_ErrorInsufficientResources; \
+        node = malloc(sizeof(EbMemoryMapEntry)); \
+        if (!node) { \
+            release(pointer); \
+            return EB_ErrorInsufficientResources; \
+        } \
         node->ptr_type         = pointer_class; \
         node->ptr              = (EbPtr)pointer;\
         node->prev_entry       = (EbPtr)memory_map;   \
         memory_map             = node;          \
         (*memory_map_index)++; \
-        if (n_elements % 8 == 0) \
-            *total_lib_memory += ((n_elements) + sizeof(EbMemoryMapEntry)); \
-        else \
-            *total_lib_memory += (((n_elements)+(8 - ((n_elements) % 8))) + sizeof(EbMemoryMapEntry)); \
-        lib_malloc_count++; \
-    }
+        *total_lib_memory += (size + 7) / 8 + sizeof(EbMemoryMapEntry); \
+        count++; \
+    } while (0)
 #else
-#define EB_ALLIGN_MALLOC(type, pointer, n_elements, pointer_class) \
-    if (posix_memalign((void**)(&(pointer)), ALVALUE, n_elements) != 0) \
-        return EB_ErrorInsufficientResources; \
-    else { \
-        pointer = (type) pointer;  \
-        EbMemoryMapEntry *node = malloc(sizeof(EbMemoryMapEntry)); \
-        if (node == (EbMemoryMapEntry*)EB_NULL) return EB_ErrorInsufficientResources; \
-        node->ptr_type         = pointer_class; \
-        node->ptr              = (EbPtr)pointer;\
-        node->prev_entry       = (EbPtr)memory_map;   \
-        memory_map             = node;          \
-        (*memory_map_index)++; \
-        if (n_elements % 8 == 0) \
-            *total_lib_memory += ((n_elements) + sizeof(EbMemoryMapEntry)); \
-        else \
-            *total_lib_memory += (((n_elements)+(8 - ((n_elements) % 8))) + sizeof(EbMemoryMapEntry)); \
-        lib_malloc_count++; \
-    }
+#define EB_ADD_MEM(pointer, size, pointer_class, count, release) \
+    do { \
+        if (!pointer) return EB_ErrorInsufficientResources; \
+        if (*(memory_map_index) >= MAX_NUM_PTR) { \
+            release(pointer); \
+            return EB_ErrorInsufficientResources; \
+        } \
+        memory_map[*(memory_map_index)].ptr_type = pointer_class; \
+        memory_map[(*(memory_map_index))++].ptr = pointer; \
+        *total_lib_memory += (size + 7) / 8; \
+        count++; \
+    } while (0)
 #endif
-#define EB_MALLOC(type, pointer, n_elements, pointer_class) \
-    pointer = (type) malloc(n_elements); \
-    if (pointer == (type)EB_NULL) \
-        return EB_ErrorInsufficientResources; \
-    else { \
-        EbMemoryMapEntry *node = malloc(sizeof(EbMemoryMapEntry)); \
-        if (node == (EbMemoryMapEntry*)EB_NULL) return EB_ErrorInsufficientResources; \
-        node->ptr_type         = pointer_class; \
-        node->ptr              = (EbPtr)pointer;\
-        node->prev_entry       = (EbPtr)memory_map;   \
-        memory_map             = node;          \
-        (*memory_map_index)++; \
-        if (n_elements % 8 == 0) \
-            *total_lib_memory += ((n_elements) + sizeof(EbMemoryMapEntry)); \
-        else \
-            *total_lib_memory += (((n_elements)+(8 - ((n_elements) % 8))) + sizeof(EbMemoryMapEntry)); \
-        lib_malloc_count++; \
-    }
 
-#define EB_CALLOC(type, pointer, n_elements, size, pointer_class) \
-    pointer = (type) calloc(n_elements, size); \
-    if (pointer == (type)EB_NULL) \
-        return EB_ErrorInsufficientResources; \
-    else { \
-        EbMemoryMapEntry *node = malloc(sizeof(EbMemoryMapEntry)); \
-        if (node == (EbMemoryMapEntry*)EB_NULL) return EB_ErrorInsufficientResources; \
-        node->ptr_type         = pointer_class; \
-        node->ptr              = (EbPtr)pointer;\
-        node->prev_entry       = (EbPtr)memory_map;   \
-        memory_map             = node;          \
-        (*memory_map_index)++; \
-        if (n_elements % 8 == 0) \
-            *total_lib_memory += ((n_elements) + sizeof(EbMemoryMapEntry)); \
-        else \
-            *total_lib_memory += (((n_elements)+(8 - ((n_elements) % 8))) + sizeof(EbMemoryMapEntry)); \
-        lib_malloc_count++; \
-    }
-
-#define EB_CREATESEMAPHORE(type, pointer, n_elements, pointer_class, initial_count, max_count) \
-    pointer = (type)eb_create_semaphore(initial_count, max_count); \
-    if (pointer == (type)EB_NULL) \
-        return EB_ErrorInsufficientResources; \
-    else { \
-        EbMemoryMapEntry *node = malloc(sizeof(EbMemoryMapEntry)); \
-        if (node == (EbMemoryMapEntry*)EB_NULL) return EB_ErrorInsufficientResources; \
-        node->ptr_type         = pointer_class; \
-        node->ptr              = (EbPtr)pointer;\
-        node->prev_entry       = (EbPtr)memory_map;   \
-        memory_map             = node;          \
-        (*memory_map_index)++;                  \
-        if (n_elements % 8 == 0)                \
-            *total_lib_memory += ((n_elements) + sizeof(EbMemoryMapEntry)); \
-        else \
-            *total_lib_memory += (((n_elements)+(8 - ((n_elements) % 8))) + sizeof(EbMemoryMapEntry)); \
-        lib_semaphore_count++; \
-    }
-#define EB_CREATEMUTEX(type, pointer, n_elements, pointer_class) \
-    pointer = eb_create_mutex(); \
-    if (pointer == (type)EB_NULL) \
-        return EB_ErrorInsufficientResources; \
-    else { \
-            EbMemoryMapEntry *node = malloc(sizeof(EbMemoryMapEntry)); \
-            if (node == (EbMemoryMapEntry*)EB_NULL) return EB_ErrorInsufficientResources; \
-            node->ptr_type         = pointer_class; \
-            node->ptr              = (EbPtr)pointer;\
-            node->prev_entry       = (EbPtr)memory_map;   \
-            memory_map             = node;          \
-            (*memory_map_index)++; \
-        if (n_elements % 8 == 0) \
-            *total_lib_memory += ((n_elements) + sizeof(EbMemoryMapEntry)); \
-        else \
-            *total_lib_memory += (((n_elements)+(8 - ((n_elements) % 8))) + sizeof(EbMemoryMapEntry)); \
-        lib_mutex_count++;\
-    }
-#else
 #ifdef _MSC_VER
 #define EB_ALLIGN_MALLOC(type, pointer, n_elements, pointer_class) \
-if (*(memory_map_index) >= MAX_NUM_PTR) { \
-    return EB_ErrorInsufficientResources; \
-} \
 pointer = (type) _aligned_malloc(n_elements,ALVALUE); \
-if (pointer == (type)EB_NULL) { \
-    return EB_ErrorInsufficientResources; \
-    } \
-    else { \
-    memory_map[*(memory_map_index)].ptr_type = pointer_class; \
-    memory_map[(*(memory_map_index))++].ptr = pointer; \
-    if (n_elements % 8 == 0) { \
-        *total_lib_memory += (n_elements); \
-    } \
-    else { \
-        *total_lib_memory += ((n_elements) + (8 - ((n_elements) % 8))); \
-    } \
-} \
-lib_malloc_count++;
+EB_ADD_MEM(pointer, n_elements, pointer_class, lib_malloc_count, _aligned_free);
 
 #else
 #define EB_ALLIGN_MALLOC(type, pointer, n_elements, pointer_class) \
-if (*(memory_map_index) >= MAX_NUM_PTR) { \
-    return EB_ErrorInsufficientResources; \
-    } \
 if (posix_memalign((void**)(&(pointer)), ALVALUE, n_elements) != 0) { \
     return EB_ErrorInsufficientResources; \
-        } \
-            else { \
-    pointer = (type) pointer;  \
-    memory_map[*(memory_map_index)].ptr_type = pointer_class; \
-    memory_map[(*(memory_map_index))++].ptr = pointer; \
-    if (n_elements % 8 == 0) { \
-        *total_lib_memory += (n_elements); \
-            } \
-            else { \
-        *total_lib_memory += ((n_elements) + (8 - ((n_elements) % 8))); \
-    } \
 } \
-lib_malloc_count++;
+EB_ADD_MEM(pointer, n_elements, pointer_class, lib_malloc_count, free);
 #endif
 
 #define EB_MALLOC(type, pointer, n_elements, pointer_class) \
-if (*(memory_map_index) >= MAX_NUM_PTR) { \
-    return EB_ErrorInsufficientResources; \
-} \
 pointer = (type) malloc(n_elements); \
-if (pointer == (type)EB_NULL) { \
-    return EB_ErrorInsufficientResources; \
-    } \
-    else { \
-    memory_map[*(memory_map_index)].ptr_type = pointer_class; \
-    memory_map[(*(memory_map_index))++].ptr = pointer; \
-    if (n_elements % 8 == 0) { \
-        *total_lib_memory += (n_elements); \
-    } \
-    else { \
-        *total_lib_memory += ((n_elements) + (8 - ((n_elements) % 8))); \
-    } \
-} \
-lib_malloc_count++;
+EB_ADD_MEM(pointer, n_elements, pointer_class, lib_malloc_count, free);
 
 #define EB_CALLOC(type, pointer, count, size, pointer_class) \
-if (*(memory_map_index) >= MAX_NUM_PTR) { \
-    return EB_ErrorInsufficientResources; \
-} \
 pointer = (type) calloc(count, size); \
-if (pointer == (type)EB_NULL) { \
-    return EB_ErrorInsufficientResources; \
-} \
-else { \
-    memory_map[*(memory_map_index)].ptr_type = pointer_class; \
-    memory_map[(*(memory_map_index))++].ptr = pointer; \
-    if (count % 8 == 0) { \
-        *total_lib_memory += (count); \
-    } \
-    else { \
-        *total_lib_memory += ((count) + (8 - ((count) % 8))); \
-    } \
-} \
-lib_malloc_count++;
+EB_ADD_MEM(pointer, n_elements, pointer_class, lib_malloc_count, free);
 
 #define EB_CREATESEMAPHORE(type, pointer, n_elements, pointer_class, initial_count, max_count) \
-if (*(memory_map_index) >= MAX_NUM_PTR) { \
-    return EB_ErrorInsufficientResources; \
-} \
 pointer = eb_create_semaphore(initial_count, max_count); \
-if (pointer == (type)EB_NULL) { \
-    return EB_ErrorInsufficientResources; \
-} \
-else { \
-    memory_map[*(memory_map_index)].ptr_type = pointer_class; \
-    memory_map[(*(memory_map_index))++].ptr = pointer; \
-    if (n_elements % 8 == 0) { \
-        *total_lib_memory += (n_elements); \
-    } \
-    else { \
-        *total_lib_memory += ((n_elements) + (8 - ((n_elements) % 8))); \
-    } \
-} \
-lib_semaphore_count++;
+EB_ADD_MEM(pointer, n_elements, pointer_class, lib_semaphore_count, eb_destroy_semaphore);
 
 #define EB_CREATEMUTEX(type, pointer, n_elements, pointer_class) \
-if (*(memory_map_index) >= MAX_NUM_PTR) { \
-    return EB_ErrorInsufficientResources; \
-} \
 pointer = eb_create_mutex(); \
-if (pointer == (type)EB_NULL){ \
-    return EB_ErrorInsufficientResources; \
-} \
-else { \
-    memory_map[*(memory_map_index)].ptr_type = pointer_class; \
-    memory_map[(*(memory_map_index))++].ptr = pointer; \
-    if (n_elements % 8 == 0) { \
-        *total_lib_memory += (n_elements); \
-    } \
-    else { \
-        *total_lib_memory += ((n_elements) + (8 - ((n_elements) % 8))); \
-    } \
-} \
-lib_mutex_count++;
-#endif
+EB_ADD_MEM(pointer, n_elements, pointer_class, lib_mutex_count, eb_destroy_mutex);
 
 #define EB_MEMORY() \
 printf("Total Number of Mallocs in Library: %d\n", lib_malloc_count); \


### PR DESCRIPTION
This PR will remove duplicate code in EB_MALLOC, original code is error-prone and hard to maintain.

The refact also addressed two issues:
1. resource leak when malloc(sizeof(EbMemoryMapEntry)) return NULL
https://github.com/OpenVisualCloud/SVT-AV1/blob/6a27563a29503376fd27e5049dd5460f3c431ff2/Source/Lib/Common/Codec/EbDefinitions.h#L2502-L2509
2. if the caller did not catch error returned by 
https://github.com/OpenVisualCloud/SVT-AV1/blob/6a27563a29503376fd27e5049dd5460f3c431ff2/Source/Lib/Common/Codec/EbDefinitions.h#L2598-L2599
calls EB_MALLOC again. This line
https://github.com/OpenVisualCloud/SVT-AV1/blob/6a27563a29503376fd27e5049dd5460f3c431ff2/Source/Lib/Common/Codec/EbDefinitions.h#L2589
will corrupt the memory