### PR TITLE
CI: Add coding style check to Travis, cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,9 @@ matrix:
     # Coding style check
     - name: Style check
       stage: style
+      addons: skip
+      before_install: skip
+      install: skip
       script:
         - git grep -I -n -P "\t|\r| $" -- . ':(exclude)*/compat/*' && exit 1
         - git grep -I -n -i "david" -- . ':(exclude)THANKS.md' ':(exclude).gitlab-ci.yml' && exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,9 @@ matrix:
       compiler: gcc # gcc = clang in macOS, unecessary duplicate
   include:
     # Coding style check
+    - name: Style check
+      stage: style
+      script:
         - git grep -I -n -P "\t|\r| $" -- . ':(exclude)*/compat/*' && exit 1
         - git grep -I -n -i "david" -- . ':(exclude)THANKS.md' ':(exclude).gitlab-ci.yml' && exit 1
         - git grep -I -l -z "" -- . ':(exclude)*/compat/*' | while IFS= read -r -d '' i; do

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,7 @@ before_cache:
 matrix:
   fast_finish: true
   allow_failures:
+    - stage: style   ### REMOVE ASAP ###
     - name: Valgrind
     - env: COVERALLS_PARALLEL=true build_type=debug CMAKE_EFLAGS="-DCOVERAGE=ON"
     - name: Unit Tests Linux+gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ notifications:
 env:
   - build_type=release
 stages:
+  - name: style
   - name: test
   - name: unittest 
   - name: coveralls
@@ -86,6 +87,30 @@ matrix:
     - os: osx
       compiler: gcc # gcc = clang in macOS, unecessary duplicate
   include:
+    # Coding style check
+        - git grep -I -n -P "\t|\r| $" -- . ':(exclude)*/compat/*' && exit 1
+        - git grep -I -n -i "david" -- . ':(exclude)THANKS.md' ':(exclude).gitlab-ci.yml' && exit 1
+        - git grep -I -l -z "" -- . ':(exclude)*/compat/*' | while IFS= read -r -d '' i; do
+              if [ -n "$(tail -c 1 "$i")" ]; then
+                  echo "No newline at end of $i";
+                  exit 1;
+              fi;
+          done
+        - git remote rm upstream 2> /dev/null || true
+        - git remote add upstream https://code.videolan.org/videolan/dav1d.git
+        - git fetch -q upstream master
+        - for i in $(git rev-list HEAD ^upstream/master); do
+              echo "Checking commit message of $i";
+              msg="$(git log --format=%B -n 1 $i)";
+              if [ -n "$(echo "$msg" | awk "NR==2")" ]; then
+                  echo "Malformed commit message in $i, second line must be empty";
+                  exit 1;
+              fi;
+              if echo "$msg" | head -1 | grep -q '\.$'; then
+                  echo "Malformed commit message in $i, trailing period in subject line";
+                  exit 1;
+              fi;
+          done
     # FFmpeg interation build
     - name: FFmpeg patch
       stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,12 @@ language: c
 cache:
   ccache: true
   pip: true
-os:
-  - linux
-  - osx
+
+# Default settings
 dist: xenial
 osx_image: xcode10.1
-compiler:
-  - clang
-  - gcc
+compiler: gcc
+
 addons:
   apt:
     packages:
@@ -32,7 +30,7 @@ env:
 stages:
   - name: style
   - name: test
-  - name: unittest 
+  - name: unittest
   - name: coveralls
     if: type != pull_request
   - name: valgrind
@@ -117,7 +115,6 @@ matrix:
     # FFmpeg interation build
     - name: FFmpeg patch
       stage: test
-      compiler: gcc
       env: build_type=release
       script:
         # Build and install SVT-AV1
@@ -131,7 +128,6 @@ matrix:
     # GStreamer interation build
     - name: GStreamer patch
       stage: test
-      compiler: gcc
       env: build_type=release
       script:
       # Build and install SVT-AV1
@@ -143,8 +139,6 @@ matrix:
       - sudo make install
     - name: Coveralls Linux+gcc
       stage: Coveralls
-      os: linux
-      compiler: gcc
       env: COVERALLS_PARALLEL=true build_type=debug CMAKE_EFLAGS="-DCOVERAGE=ON"
       script:
         - *base_script
@@ -161,16 +155,12 @@ matrix:
       after_script: *after_coveralls_script
     - name: Valgrind
       stage: valgrind
-      compiler: gcc
-      os: linux
       env: build_type=debug
       script:
         - *base_script
         - valgrind -- SvtAv1EncApp -enc-mode 8 -w 720 -h 486 -fps 60 -i akiyo_cif.y4m -n 150 -b test1.ivf
     - name: Unit Tests Linux+gcc
       stage: unittest
-      os: linux
-      compiler: gcc
       env: build_type=debug CMAKE_EFLAGS="-DBUILD_TESTING=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/
       script:
         - *base_script


### PR DESCRIPTION
- Add coding style check (Borrowed from dav1d's [.gitlab-ci.yml](https://code.videolan.org/videolan/dav1d/blob/master/.gitlab-ci.yml))
- Sets Ubuntu 16.04 Xenial and GCC as default settings, only uses "os:" and "compiler:" if different
- Fixes coding style error (trailing white space) in "name: unittest"

For now the Style check is allowed to fail (waiting on #248), but that should be reversed as soon as possible.