### PR TITLE
test CMake: Use TARGET_OBJECTS for link libraries

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -63,30 +63,30 @@ file(GLOB all_files
 
 if (UNIX)
   # App Source Files
-    add_executable (SvtAv1UnitTests 
+    add_executable (SvtAv1UnitTests
       ${all_files})
 
     # Link the Encoder App
      target_link_libraries (SvtAv1UnitTests
-        COMMON_CODEC
-        COMMON_C_DEFAULT
-        COMMON_ASM_SSE2
-        COMMON_ASM_SSSE3
-        COMMON_ASM_SSE4_1
-        COMMON_ASM_AVX2
-        gtest_all 
+        $<TARGET_OBJECTS:COMMON_CODEC>
+        $<TARGET_OBJECTS:COMMON_C_DEFAULT>
+        $<TARGET_OBJECTS:COMMON_ASM_SSE2>
+        $<TARGET_OBJECTS:COMMON_ASM_SSSE3>
+        $<TARGET_OBJECTS:COMMON_ASM_SSE4_1>
+        $<TARGET_OBJECTS:COMMON_ASM_AVX2>
+        gtest_all
         pthread
         m)
 endif(UNIX)
 
 if (MSVC OR MSYS OR MINGW OR WIN32)
     set (lib_list
-    COMMON_CODEC
-    COMMON_C_DEFAULT
-    COMMON_ASM_SSE2
-    COMMON_ASM_SSSE3
-    COMMON_ASM_SSE4_1
-    COMMON_ASM_AVX2
+    $<TARGET_OBJECTS:COMMON_CODEC>
+    $<TARGET_OBJECTS:COMMON_C_DEFAULT>
+    $<TARGET_OBJECTS:COMMON_ASM_SSE2>
+    $<TARGET_OBJECTS:COMMON_ASM_SSSE3>
+    $<TARGET_OBJECTS:COMMON_ASM_SSE4_1>
+    $<TARGET_OBJECTS:COMMON_ASM_AVX2>
     gtest_all)
     cxx_executable_with_flags(SvtAv1UnitTests "${cxx_default}"
       "${lib_list}" ${all_files})


### PR DESCRIPTION
Closes #295 
Does not solve
```
../../../test/BitstreamReaderMock.cc: In function ‘void od_ec_dec_refill(od_ec_dec*)’:
../../../test/BitstreamReaderMock.cc:87:9: error: ‘OD_EC_WINDOW_SIZE’ was not declared in this scope
     s = OD_EC_WINDOW_SIZE - 9 - (cnt + 15);
         ^~~~~~~~~~~~~~~~~
../../../test/BitstreamReaderMock.cc: In function ‘void od_ec_dec_init(od_ec_dec*, const unsigned char*, uint32_t)’:
../../../test/BitstreamReaderMock.cc:146:28: error: ‘OD_EC_WINDOW_SIZE’ was not declared in this scope
     dec->tell_offs = 10 - (OD_EC_WINDOW_SIZE - 8);
                            ^~~~~~~~~~~~~~~~~
../../../test/BitstreamReaderMock.cc: In function ‘int od_ec_decode_bool_q15(od_ec_dec*, unsigned int)’:
../../../test/BitstreamReaderMock.cc:173:30: error: ‘OD_EC_WINDOW_SIZE’ was not declared in this scope
     vw = (od_ec_window)v << (OD_EC_WINDOW_SIZE - 16);
                              ^~~~~~~~~~~~~~~~~
../../../test/BitstreamReaderMock.cc: In function ‘int od_ec_decode_cdf_q15(od_ec_dec*, const uint16_t*, int)’:
../../../test/BitstreamReaderMock.cc:209:28: error: ‘OD_EC_WINDOW_SIZE’ was not declared in this scope
     c = (unsigned)(dif >> (OD_EC_WINDOW_SIZE - 16));
                            ^~~~~~~~~~~~~~~~~
```