### PR TITLE
Adaptive QP scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Inital decoder implementation
 - Static library support  
 - Alt-ref pictures - temporal filtering
+- Adaptive QP scaling
 
 ## [0.5.0] - 2019-05-17
 

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -42,7 +42,7 @@ extern "C" {
 #endif
 
 #define PCS_ME_FIX                        1 // pcs flags shall not be set in seg based process
-
+#define ADAPTIVE_QP_SCALING               1 // Adaptive QP scaling. Change the QP based on the content. 
 
 #define MRP_SUPPORT                       1// MRP Main Flag
 

--- a/Source/Lib/Common/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimation.c
@@ -9762,9 +9762,11 @@ EbErrorType motion_estimate_lcu(
 #endif
 
     }
-
+#if ADAPTIVE_QP_SCALING
+    {
+#else
     if (sequence_control_set_ptr->static_config.rate_control_mode) {
-
+#endif
         // Compute the sum of the distortion of all 16 16x16 (best) blocks in the LCU
         picture_control_set_ptr->rc_me_distortion[sb_index] = 0;
 #if MRP_ME

--- a/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
@@ -496,18 +496,14 @@ EbErrorType ComputeDecimatedZzSad(
             }
 #if ADAPTIVE_QP_SCALING
             // Keep track of non moving LCUs for QP modulation
-            if (decimatedLcuCollocatedSad < ((decimatedLcuWidth * decimatedLcuHeight) * 2)) {
+            if (decimatedLcuCollocatedSad < ((decimatedLcuWidth * decimatedLcuHeight) * 2)) 
                 previous_picture_control_set_wrapper_ptr->non_moving_index_array[sb_index] = BEA_CLASS_0_ZZ_COST;
-            }
-            else if (decimatedLcuCollocatedSad < ((decimatedLcuWidth * decimatedLcuHeight) * 4)) {
+            else if (decimatedLcuCollocatedSad < ((decimatedLcuWidth * decimatedLcuHeight) * 4)) 
                 previous_picture_control_set_wrapper_ptr->non_moving_index_array[sb_index] = BEA_CLASS_1_ZZ_COST;
-            }
-            else if (decimatedLcuCollocatedSad < ((decimatedLcuWidth * decimatedLcuHeight) * 8)) {
+            else if (decimatedLcuCollocatedSad < ((decimatedLcuWidth * decimatedLcuHeight) * 8)) 
                 previous_picture_control_set_wrapper_ptr->non_moving_index_array[sb_index] = BEA_CLASS_2_ZZ_COST;
-            }
-            else {
+            else 
                 previous_picture_control_set_wrapper_ptr->non_moving_index_array[sb_index] = BEA_CLASS_3_ZZ_COST;
-            }
 #else
             // Keep track of non moving LCUs for QP modulation
             if (decimatedLcuCollocatedSad < ((decimatedLcuWidth * decimatedLcuHeight) * 2) >> non_moving_th_shift[sequence_control_set_ptr->input_resolution]) {

--- a/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
@@ -379,8 +379,9 @@ EbErrorType motion_estimation_context_ctor(
 /***************************************************************************************************
 * ZZ Decimated SAD Computation
 ***************************************************************************************************/
+#if !ADAPTIVE_QP_SCALING
 int non_moving_th_shift[4] = { 4, 2, 0, 0 };
-
+#endif
 EbErrorType ComputeDecimatedZzSad(
     MotionEstimationContext_t   *context_ptr,
     SequenceControlSet        *sequence_control_set_ptr,
@@ -493,8 +494,21 @@ EbErrorType ComputeDecimatedZzSad(
 #endif
                 decimatedLcuCollocatedSad = (uint32_t)~0;
             }
-
-
+#if ADAPTIVE_QP_SCALING
+            // Keep track of non moving LCUs for QP modulation
+            if (decimatedLcuCollocatedSad < ((decimatedLcuWidth * decimatedLcuHeight) * 2)) {
+                previous_picture_control_set_wrapper_ptr->non_moving_index_array[sb_index] = BEA_CLASS_0_ZZ_COST;
+            }
+            else if (decimatedLcuCollocatedSad < ((decimatedLcuWidth * decimatedLcuHeight) * 4)) {
+                previous_picture_control_set_wrapper_ptr->non_moving_index_array[sb_index] = BEA_CLASS_1_ZZ_COST;
+            }
+            else if (decimatedLcuCollocatedSad < ((decimatedLcuWidth * decimatedLcuHeight) * 8)) {
+                previous_picture_control_set_wrapper_ptr->non_moving_index_array[sb_index] = BEA_CLASS_2_ZZ_COST;
+            }
+            else {
+                previous_picture_control_set_wrapper_ptr->non_moving_index_array[sb_index] = BEA_CLASS_3_ZZ_COST;
+            }
+#else
             // Keep track of non moving LCUs for QP modulation
             if (decimatedLcuCollocatedSad < ((decimatedLcuWidth * decimatedLcuHeight) * 2) >> non_moving_th_shift[sequence_control_set_ptr->input_resolution]) {
                 previous_picture_control_set_wrapper_ptr->non_moving_index_array[sb_index] = BEA_CLASS_0_ZZ_COST;
@@ -508,6 +522,7 @@ EbErrorType ComputeDecimatedZzSad(
             else { 
                 previous_picture_control_set_wrapper_ptr->non_moving_index_array[sb_index] = BEA_CLASS_3_ZZ_COST;
             }
+#endif
         }
     }
 

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -14135,6 +14135,10 @@ extern "C" {
         uint32_t                              zz_cost_average;                    // used by ModeDecisionConfigurationProcess()
 #endif
         uint16_t                              non_moving_index_average;            // used by ModeDecisionConfigurationProcess()
+
+#if ADAPTIVE_QP_SCALING
+        uint16_t                              qp_scaling_average_complexity;
+#endif
 #if !MEMORY_FOOTPRINT_OPT
         EbBool                               *sb_isolated_non_homogeneous_area_array;            // used by ModeDecisionConfigurationProcess()
         uint8_t                              *cu32x32_clean_sparse_coeff_map_array; //32x32 cu array for clean sparse coeff

--- a/Source/Lib/Common/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Common/Codec/EbRateControlProcess.c
@@ -3608,6 +3608,12 @@ enum {
 
 // that are not marked as coded with 0,0 motion in the first pass.
 #define STATIC_KF_GROUP_THRESH 99
+#if ADAPTIVE_QP_SCALING
+#define FAST_MOVING_KF_GROUP_THRESH 5
+#define MAX_QPS_COMP_I        60
+#define MAX_QPS_COMP_NONI    200
+#define QPS_SW_THRESH          8
+#endif
 
 #define ASSIGN_MINQ_TABLE(bit_depth, name)                   \
   do {                                                       \
@@ -3770,7 +3776,16 @@ static int adaptive_qindex_calc(
         picture_control_set_ptr->parent_pcs_ptr->hierarchical_levels - picture_control_set_ptr->parent_pcs_ptr->temporal_layer_index;
 
     const int bit_depth = sequence_control_set_ptr->static_config.encoder_bit_depth;
-
+#if ADAPTIVE_QP_SCALING
+    // Since many frames can be processed at the same time, storing/using arf_q in rc param is not sufficient and will create a run to run.
+    // So, for each frame, arf_q is updated based on the qp of its references.
+    if (picture_control_set_ptr->ref_slice_type_array[0][0] != I_SLICE) {
+        rc->arf_q = MAX(rc->arf_q, ((picture_control_set_ptr->ref_pic_qp_array[0][0] << 2) + 2));
+    }
+    if ((picture_control_set_ptr->slice_type == B_SLICE) && (picture_control_set_ptr->ref_slice_type_array[1][0] != I_SLICE)) {
+        rc->arf_q = MAX(rc->arf_q, ((picture_control_set_ptr->ref_pic_qp_array[1][0] << 2) + 2));
+    }
+#endif 
     if (frame_is_intra_only(picture_control_set_ptr->parent_pcs_ptr)) {
 
         // Not forced keyframe.
@@ -3779,17 +3794,28 @@ static int adaptive_qindex_calc(
 
         rc->worst_quality = MAXQ;
         rc->best_quality = MINQ;
+#if ADAPTIVE_QP_SCALING
+        int max_qp_scaling_avg_comp_I = sequence_control_set_ptr->input_resolution < 2 ? (MAX_QPS_COMP_I >> 1) : MAX_QPS_COMP_I;
 
+        // Update the complexity for very fast moving content
+        if (picture_control_set_ptr->parent_pcs_ptr->kf_zeromotion_pct <= FAST_MOVING_KF_GROUP_THRESH)
+            picture_control_set_ptr->parent_pcs_ptr->qp_scaling_average_complexity <<= 1;
+        picture_control_set_ptr->parent_pcs_ptr->qp_scaling_average_complexity = CLIP3(0, max_qp_scaling_avg_comp_I, picture_control_set_ptr->parent_pcs_ptr->qp_scaling_average_complexity);
+
+        // cross multiplication to derive kf_boost from non_moving_average_score; kf_boost range is [kf_low,kf_high], and non_moving_average_score range [0,max_qp_scaling_avg_comp_I]
+        rc->kf_boost = (((max_qp_scaling_avg_comp_I - (picture_control_set_ptr->parent_pcs_ptr->qp_scaling_average_complexity))  * (kf_high - kf_low)) / max_qp_scaling_avg_comp_I) + kf_low;
+#else
         // cross multiplication to derive kf_boost from non_moving_average_score; kf_boost range is [kf_low,kf_high], and non_moving_average_score range [NON_MOVING_SCORE_0,NON_MOVING_SCORE_3]
         rc->kf_boost = (((NON_MOVING_SCORE_3 - picture_control_set_ptr->parent_pcs_ptr->non_moving_index_average)  * (kf_high - kf_low)) / NON_MOVING_SCORE_3) + kf_low;
-
+#endif
         // Baseline value derived from cpi->active_worst_quality and kf boost.
         active_best_quality =
             get_kf_active_quality(rc, active_worst_quality, bit_depth);
+#if !ADAPTIVE_QP_SCALING
         if (picture_control_set_ptr->parent_pcs_ptr->kf_zeromotion_pct >= STATIC_KF_GROUP_THRESH) {
             active_best_quality /= 3;
         }
-
+#endif
         // Allow somewhat lower kf minq with small image formats.
         if ((cm->width * cm->height) <= (352 * 288)) {
             q_adj_factor -= 0.25;
@@ -3807,8 +3833,11 @@ static int adaptive_qindex_calc(
     else if (!is_src_frame_alt_ref &&
         (refresh_golden_frame || is_intrl_arf_boost ||
             refresh_alt_ref_frame)) {
-
+#if ADAPTIVE_QP_SCALING
+        rc->gfu_boost = (((MAX_QPS_COMP_NONI - (picture_control_set_ptr->parent_pcs_ptr->qp_scaling_average_complexity))  * (gf_high - gf_low)) / MAX_QPS_COMP_NONI) + gf_low;
+#else
         rc->gfu_boost = (((NON_MOVING_SCORE_3 - picture_control_set_ptr->parent_pcs_ptr->non_moving_index_average)  * (gf_high - gf_low)) / NON_MOVING_SCORE_3) + gf_low;
+#endif     
         rc->arf_boost_factor = 1;
         q = active_worst_quality;
 
@@ -3830,6 +3859,11 @@ static int adaptive_qindex_calc(
             else {
                 active_best_quality = rc->arf_q;
             }
+#if ADAPTIVE_QP_SCALING
+            // active_best_quality is updated with the q index of the reference
+            if (rf_level == GF_ARF_LOW)
+                active_best_quality = (active_best_quality + cq_level + 1) / 2;
+#else
             // non Based Ref frames && !P
             if (new_bwdref_update_rule && is_intrl_arf_boost) {
                 while (this_height < picture_control_set_ptr->parent_pcs_ptr->hierarchical_levels /*gf_group->pyramid_height*/) {
@@ -3843,6 +3877,7 @@ static int adaptive_qindex_calc(
                 if (rf_level == GF_ARF_LOW)
                     active_best_quality = (active_best_quality + cq_level + 1) / 2;
             }
+#endif
         }
     }
     else {
@@ -3983,6 +4018,32 @@ void* rate_control_kernel(void *input_ptr)
                 if (sequence_control_set_ptr->static_config.enable_qp_scaling_flag && picture_control_set_ptr->parent_pcs_ptr->qp_on_the_fly == EB_FALSE) {
                     const int32_t qindex = quantizer_to_qindex[(uint8_t)sequence_control_set_ptr->qp];
                     const double q_val = av1_convert_qindex_to_q(qindex, (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth);
+#if ADAPTIVE_QP_SCALING
+                    // if there are need enough pictures in the LAD/SlidingWindow, the adaptive QP scaling is not used
+                    if (picture_control_set_ptr->parent_pcs_ptr->frames_in_sw >= QPS_SW_THRESH) {
+                        int32_t new_qindex = adaptive_qindex_calc(
+                            picture_control_set_ptr,
+                            &rc,
+                            qindex);
+
+                        picture_control_set_ptr->parent_pcs_ptr->base_qindex =
+                            (uint8_t)CLIP3(
+                            (int32_t)quantizer_to_qindex[sequence_control_set_ptr->static_config.min_qp_allowed],
+                                (int32_t)quantizer_to_qindex[sequence_control_set_ptr->static_config.max_qp_allowed],
+                                (int32_t)(new_qindex));
+                    }
+                    else if (picture_control_set_ptr->slice_type == I_SLICE) {
+                        const int32_t delta_qindex = av1_compute_qdelta(
+                            q_val,
+                            q_val * 0.25,
+                            (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth);
+                        picture_control_set_ptr->parent_pcs_ptr->base_qindex =
+                            (uint8_t)CLIP3(
+                            (int32_t)quantizer_to_qindex[sequence_control_set_ptr->static_config.min_qp_allowed],
+                                (int32_t)quantizer_to_qindex[sequence_control_set_ptr->static_config.max_qp_allowed],
+                                (int32_t)(qindex + delta_qindex));
+                    }
+#else                     
                     if (picture_control_set_ptr->slice_type == I_SLICE) {
                         int32_t new_qindex = adaptive_qindex_calc(
                             picture_control_set_ptr,
@@ -3995,6 +4056,7 @@ void* rate_control_kernel(void *input_ptr)
                                 (int32_t)quantizer_to_qindex[sequence_control_set_ptr->static_config.max_qp_allowed],
                                 (int32_t)(new_qindex));
                     }
+#endif
                     else {
                         const  double delta_rate_new[2][6] =
                         { { 0.40, 0.7, 0.85, 1.0, 1.0, 1.0 },


### PR DESCRIPTION
## Description
Change the QP based on the content. Adaptive QP scaling was previously active in I slices only.
Updated the algorithm to use a new metric for all frames. The metric is defined as normalized ME distortion (16x16 based from list 0) over frames in the look ahead.
If number of frames in the LAD/SW is less than 8, the adaptive QP scaling algorithm is turned off.

Associated with Issue #294
Closes #294

## Authors

@anaghdin

## Type of change

Feature improvement

## Tests and performance

Expected Average PSNR-SSIM BD-rate gain in the range of -2.4% on the AOM test set, using 4 QP values: {20, 32, 43 and 55}. Note that the maximum gain is achieved when ALT_REF is enabled

No Speed impact.

## TODO items:

The algorithm can be further improved using other information from LAD or ALR_REF filtering

