### PR TITLE
Disable overlay pictures (used by the Alt-refs) by default

### DIFF
--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -535,7 +535,7 @@ void eb_config_ctor(EbConfig *config_ptr)
     config_ptr->enable_altrefs                       = EB_TRUE;
     config_ptr->altref_strength                      = 5;
     config_ptr->altref_nframes                       = 7;
-    config_ptr->enable_overlays                      = EB_TRUE;
+    config_ptr->enable_overlays                      = EB_FALSE;
     // --- end: ALTREF_FILTERING_SUPPORT
 
     return;

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -3024,7 +3024,7 @@ EbErrorType eb_svt_enc_init_parameter(
 	config_ptr->enable_altrefs = EB_TRUE;
     config_ptr->altref_nframes = 7;
     config_ptr->altref_strength = 5;
-    config_ptr->enable_overlays = EB_TRUE;
+    config_ptr->enable_overlays = EB_FALSE;
 
     return return_error;
 }


### PR DESCRIPTION
## Description

A bug was found after merging the Alt-ref pictures support and disabling the encoding of the overlay pictures seems to be fixing it. So, this should be disabled by default until the problem is fixed. 

## TODO items

The issue will be debugged and a bug fix PR will be submitted.