### PR TITLE
[SIMD] Wiener Filter AVX2

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/EbPictureOperators_AVX2.h
+++ b/Source/Lib/Common/ASM_AVX2/EbPictureOperators_AVX2.h
@@ -6,7 +6,9 @@
 #ifndef EbPictureOperators_AVX2
 #define EbPictureOperators_AVX2
 
+#include <immintrin.h>
 #include "EbDefinitions.h"
+#include "EbPictureOperators_SSE2.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -145,6 +147,14 @@ extern "C" {
         uint64_t  distortion_result[DIST_CALC_TOTAL],
         uint32_t  area_width,
         uint32_t  area_height);
+
+    static INLINE int32_t Hadd32_AVX2_INTRIN(const __m256i src) {
+        const __m128i src_L = _mm256_extracti128_si256(src, 0);
+        const __m128i src_H = _mm256_extracti128_si256(src, 1);
+        const __m128i sum = _mm_add_epi32(src_L, src_H);
+
+        return Hadd32_SSE2_INTRIN(sum);
+    }
 
     uint64_t spatial_full_distortion_kernel4x_n_avx2_intrin(
         uint8_t   *input,

--- a/Source/Lib/Common/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
@@ -2688,13 +2688,6 @@ void ResidualKernel_avx2(
         }
     }
 }
-static INLINE int32_t Hadd32_AVX2_INTRIN(const __m256i src) {
-    const __m128i src_L = _mm256_extracti128_si256(src, 0);
-    const __m128i src_H = _mm256_extracti128_si256(src, 1);
-    const __m128i sum = _mm_add_epi32(src_L, src_H);
-
-    return Hadd32_SSE2_INTRIN(sum);
-}
 
 static INLINE void Distortion_AVX2_INTRIN(const __m256i input,
     const __m256i recon, __m256i *const sum) {

--- a/Source/Lib/Common/ASM_AVX2/pickrst_avx2.h
+++ b/Source/Lib/Common/ASM_AVX2/pickrst_avx2.h
@@ -1,0 +1,809 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
+#ifndef AOM_DSP_X86_PICKRST_AVX2_H_
+#define AOM_DSP_X86_PICKRST_AVX2_H_
+
+#include <immintrin.h>  // AVX2
+#include "aom_dsp_rtcd.h"
+#include "EbPictureOperators_AVX2.h"
+#include "EbRestoration.h"
+#include "transpose_sse2.h"
+#include "transpose_avx2.h"
+
+EB_ALIGN(16)
+static const uint8_t mask_8bit[16][16] = {
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0xFF, 0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0xFF, 0xFF, 0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0, 0, 0, 0, 0, 0, 0},
+    {0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0,
+     0,
+     0,
+     0,
+     0,
+     0},
+    {0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0,
+     0,
+     0,
+     0,
+     0},
+    {0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0,
+     0,
+     0,
+     0},
+    {0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0,
+     0,
+     0},
+    {0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0,
+     0},
+    {0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0xFF,
+     0}};
+
+EB_ALIGN(32)
+static const uint16_t mask_16bit[16][16] = {
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0xFFFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0xFFFF, 0xFFFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0xFFFF, 0xFFFF, 0xFFFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0xFFFF, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    {0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0,
+     0,
+     0,
+     0,
+     0,
+     0,
+     0,
+     0,
+     0,
+     0},
+    {0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0,
+     0,
+     0,
+     0,
+     0,
+     0,
+     0,
+     0,
+     0},
+    {0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0,
+     0,
+     0,
+     0,
+     0,
+     0,
+     0,
+     0},
+    {0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0,
+     0,
+     0,
+     0,
+     0,
+     0,
+     0},
+    {0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0,
+     0,
+     0,
+     0,
+     0,
+     0},
+    {0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0,
+     0,
+     0,
+     0,
+     0},
+    {0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0,
+     0,
+     0,
+     0},
+    {0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0,
+     0,
+     0},
+    {0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0,
+     0},
+    {0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0xFFFF,
+     0}};
+
+static INLINE void add_six_32_to_64_avx2(const __m256i src, __m256i *const sum,
+                                         __m128i *const sum128) {
+    const __m256i s0 = _mm256_cvtepi32_epi64(_mm256_extracti128_si256(src, 0));
+    const __m128i s1 = _mm_cvtepi32_epi64(_mm256_extracti128_si256(src, 1));
+    *sum = _mm256_add_epi64(*sum, s0);
+    *sum128 = _mm_add_epi64(*sum128, s1);
+}
+
+static INLINE __m128i add_hi_lo_64_avx2(const __m256i src) {
+    const __m128i s0 = _mm256_extracti128_si256(src, 0);
+    const __m128i s1 = _mm256_extracti128_si256(src, 1);
+    return _mm_add_epi64(s0, s1);
+}
+
+static INLINE __m128i sub_hi_lo_32_avx2(const __m256i src) {
+    const __m128i s0 = _mm256_extracti128_si256(src, 0);
+    const __m128i s1 = _mm256_extracti128_si256(src, 1);
+    return _mm_sub_epi32(s1, s0);
+}
+
+static INLINE __m256i hadd_32x8_to_64x4_avx2(const __m256i src) {
+    const __m256i s0 = _mm256_cvtepi32_epi64(_mm256_extracti128_si256(src, 0));
+    const __m256i s1 = _mm256_cvtepi32_epi64(_mm256_extracti128_si256(src, 1));
+    return _mm256_add_epi64(s0, s1);
+}
+
+static INLINE __m256i hsub_32x8_to_64x4_avx2(const __m256i src) {
+    const __m256i s0 = _mm256_cvtepi32_epi64(_mm256_extracti128_si256(src, 0));
+    const __m256i s1 = _mm256_cvtepi32_epi64(_mm256_extracti128_si256(src, 1));
+    return _mm256_sub_epi64(s1, s0);
+}
+
+static INLINE __m128i hadd_64_avx2(const __m256i src) {
+    const __m256i t0 = _mm256_srli_si256(src, 8);
+    const __m256i sum = _mm256_add_epi64(src, t0);
+    const __m128i sum0 = _mm256_extracti128_si256(sum, 0);  // 00+01 10+11
+    const __m128i sum1 = _mm256_extracti128_si256(sum, 1);  // 02+03 12+13
+    return _mm_add_epi64(sum0, sum1);  // 00+01+02+03 10+11+12+13
+}
+
+static INLINE __m128i hadd_two_64_avx2(const __m256i src0, const __m256i src1) {
+    const __m256i t0 = _mm256_unpacklo_epi64(src0, src1);  // 00 10  02 12
+    const __m256i t1 = _mm256_unpackhi_epi64(src0, src1);  // 01 11  03 13
+    const __m256i sum = _mm256_add_epi64(t0, t1);  // 00+01 10+11  02+03 12+13
+    const __m128i sum0 = _mm256_extracti128_si256(sum, 0);  // 00+01 10+11
+    const __m128i sum1 = _mm256_extracti128_si256(sum, 1);  // 02+03 12+13
+    return _mm_add_epi64(sum0, sum1);  // 00+01+02+03 10+11+12+13
+}
+
+static INLINE __m128i hadd_two_32_to_64_avx2(const __m256i src0,
+                                             const __m256i src1) {
+    const __m256i s0 = hadd_32x8_to_64x4_avx2(src0);  // 00 01  02 03
+    const __m256i s1 = hadd_32x8_to_64x4_avx2(src1);  // 10 11  12 13
+    return hadd_two_64_avx2(s0, s1);
+}
+
+static INLINE __m128i hadd_two_32_avx2(const __m256i src0, const __m256i src1) {
+    const __m256i s01 = _mm256_hadd_epi32(src0, src1);      // 0 0 1 1  0 0 1 1
+    const __m128i sum0 = _mm256_extracti128_si256(s01, 0);  // 0 0 1 1
+    const __m128i sum1 = _mm256_extracti128_si256(s01, 1);  // 0 0 1 1
+    const __m128i sum = _mm_add_epi32(sum0, sum1);          // 0 0 1 1
+    return _mm_hadd_epi32(sum, sum);                        // 0 1 0 1
+}
+
+static INLINE __m128i hadd_four_32_avx2(const __m256i src0, const __m256i src1,
+                                        const __m256i src2,
+                                        const __m256i src3) {
+    const __m256i s01 = _mm256_hadd_epi32(src0, src1);  // 0 0 1 1  0 0 1 1
+    const __m256i s23 = _mm256_hadd_epi32(src2, src3);  // 2 2 3 3  2 2 3 3
+    const __m256i s0123 = _mm256_hadd_epi32(s01, s23);  // 0 1 2 3  0 1 2 3
+    const __m128i sum0 = _mm256_extracti128_si256(s0123, 0);  // 0 1 2 3
+    const __m128i sum1 = _mm256_extracti128_si256(s0123, 1);  // 0 1 2 3
+    return _mm_add_epi32(sum0, sum1);                         // 0 1 2 3
+}
+
+static INLINE __m256i hadd_four_64_avx2(const __m256i src0, const __m256i src1,
+                                        const __m256i src2,
+                                        const __m256i src3) {
+    __m256i s[2], t[4];
+
+    // 00 01  02 03
+    // 10 11  12 13
+    // 20 21  22 23
+    // 30 31  32 33
+
+    t[0] = _mm256_unpacklo_epi64(src0, src1);  // 00 10  02 12
+    t[1] = _mm256_unpackhi_epi64(src0, src1);  // 01 11  03 13
+    t[2] = _mm256_unpacklo_epi64(src2, src3);  // 20 30  22 32
+    t[3] = _mm256_unpackhi_epi64(src2, src3);  // 21 31  23 33
+
+    s[0] = _mm256_add_epi64(t[0], t[1]);  // 00+01 10+11  02+03 12+13
+    s[1] = _mm256_add_epi64(t[2], t[3]);  // 20+21 30+31  22+23 32+33
+
+    // 00+01 10+11  20+21 30+31
+    t[0] = _mm256_inserti128_si256(s[0], _mm256_extracti128_si256(s[1], 0), 1);
+    // 02+03 12+13  22+23 32+33
+    t[1] = _mm256_inserti128_si256(s[1], _mm256_extracti128_si256(s[0], 1), 0);
+
+    // 00+01+02+03 10+11+12+13  20+21+22+23 30+31+32+33
+    return _mm256_add_epi64(t[0], t[1]);
+}
+
+// inputs' value range is 31-bit
+static INLINE __m128i hadd_two_31_to_64_avx2(const __m256i src0,
+                                             const __m256i src1) {
+    __m256i s;
+    s = _mm256_hadd_epi32(src0, src1);      // 0 0 1 1  0 0 1 1
+    s = hadd_32x8_to_64x4_avx2(s);          // 0 0 1 1
+    s = _mm256_permute4x64_epi64(s, 0xD8);  // 0 1 0 1
+
+    return add_hi_lo_64_avx2(s);
+}
+
+static INLINE __m256i hadd_x_64_avx2(const __m256i src01, const __m256i src23) {
+    // 0 0 1 1
+    // 2 2 3 3
+    const __m256i t0 = _mm256_unpacklo_epi64(src01, src23);  // 0 2 1 3
+    const __m256i t1 = _mm256_unpackhi_epi64(src01, src23);  // 0 2 1 3
+    const __m256i t = _mm256_add_epi64(t0, t1);              // 0 2 1 3
+
+    return _mm256_permute4x64_epi64(t, 0xD8);  // 0 1 2 3
+}
+
+// inputs' value range is 31-bit
+static INLINE __m256i hadd_four_31_to_64_avx2(const __m256i src0,
+                                              const __m256i src1,
+                                              const __m256i src2,
+                                              const __m256i src3) {
+    __m256i s[2];
+    s[0] = _mm256_hadd_epi32(src0, src1);  // 0 0 1 1  0 0 1 1
+    s[1] = _mm256_hadd_epi32(src2, src3);  // 2 2 3 3  2 2 3 3
+    s[0] = hadd_32x8_to_64x4_avx2(s[0]);   // 0 0 1 1
+    s[1] = hadd_32x8_to_64x4_avx2(s[1]);   // 2 2 3 3
+
+    return hadd_x_64_avx2(s[0], s[1]);
+}
+
+static INLINE __m256i hadd_four_32_to_64_avx2(const __m256i src0,
+                                              const __m256i src1,
+                                              const __m256i src2,
+                                              const __m256i src3) {
+    __m256i s[4];
+
+    s[0] = hadd_32x8_to_64x4_avx2(src0);  // 00 01  02 03
+    s[1] = hadd_32x8_to_64x4_avx2(src1);  // 10 11  12 13
+    s[2] = hadd_32x8_to_64x4_avx2(src2);  // 20 21  22 23
+    s[3] = hadd_32x8_to_64x4_avx2(src3);  // 30 31  32 33
+
+    return hadd_four_64_avx2(s[0], s[1], s[2], s[3]);
+}
+
+static INLINE void madd_sse2(const __m128i src, const __m128i dgd,
+                             __m128i *sum) {
+    const __m128i sd = _mm_madd_epi16(src, dgd);
+    *sum = _mm_add_epi32(*sum, sd);
+}
+
+static INLINE void madd_avx2(const __m256i src, const __m256i dgd,
+                             __m256i *sum) {
+    const __m256i sd = _mm256_madd_epi16(src, dgd);
+    *sum = _mm256_add_epi32(*sum, sd);
+}
+
+static INLINE void msub_avx2(const __m256i src, const __m256i dgd,
+                             __m256i *sum) {
+    const __m256i sd = _mm256_madd_epi16(src, dgd);
+    *sum = _mm256_sub_epi32(*sum, sd);
+}
+
+static void _mm_storeh_epi64(__m128i *p, __m128i x) {
+    _mm_storeh_pd((double *)p, _mm_castsi128_pd(x));
+}
+
+static INLINE void update_2_stats_sse2(const int64_t *const src,
+                                       const __m128i delta,
+                                       int64_t *const dst) {
+    const __m128i s = _mm_loadu_si128((__m128i *)src);
+    const __m128i d = _mm_add_epi64(s, delta);
+    _mm_storeu_si128((__m128i *)dst, d);
+}
+
+static INLINE void update_4_stats_avx2(const int64_t *const src,
+                                       const __m128i delta,
+                                       int64_t *const dst) {
+    const __m256i s = _mm256_loadu_si256((__m256i *)src);
+    const __m256i dlt = _mm256_cvtepi32_epi64(delta);
+    const __m256i d = _mm256_add_epi64(s, dlt);
+    _mm256_storeu_si256((__m256i *)dst, d);
+}
+
+static INLINE void update_4_stats_highbd_avx2(const int64_t *const src,
+                                              const __m256i delta,
+                                              int64_t *const dst) {
+    const __m256i s = _mm256_loadu_si256((__m256i *)src);
+    const __m256i d = _mm256_add_epi64(s, delta);
+    _mm256_storeu_si256((__m256i *)dst, d);
+}
+
+static INLINE void update_5_stats_avx2(const int64_t *const src,
+                                       const __m128i delta,
+                                       const int64_t delta4,
+                                       int64_t *const dst) {
+    update_4_stats_avx2(src + 0, delta, dst + 0);
+    dst[4] = src[4] + delta4;
+}
+
+static INLINE void update_5_stats_highbd_avx2(const int64_t *const src,
+                                              const __m256i delta,
+                                              const int64_t delta4,
+                                              int64_t *const dst) {
+    update_4_stats_highbd_avx2(src + 0, delta, dst + 0);
+    dst[4] = src[4] + delta4;
+}
+
+static INLINE void update_8_stats_avx2(const int64_t *const src,
+                                       const __m256i delta,
+                                       int64_t *const dst) {
+    update_4_stats_avx2(src + 0, _mm256_extracti128_si256(delta, 0), dst + 0);
+    update_4_stats_avx2(src + 4, _mm256_extracti128_si256(delta, 1), dst + 4);
+}
+
+static INLINE void hadd_update_4_stats_avx2(const int64_t *const src,
+                                            const __m256i deltas[4],
+                                            int64_t *const dst) {
+    const __m128i delta =
+        hadd_four_32_avx2(deltas[0], deltas[1], deltas[2], deltas[3]);
+    update_4_stats_avx2(src, delta, dst);
+}
+
+static INLINE void hadd_update_4_stats_highbd_avx2(const int64_t *const src,
+                                                   const __m256i deltas[4],
+                                                   int64_t *const dst) {
+    const __m256i delta =
+        hadd_four_31_to_64_avx2(deltas[0], deltas[1], deltas[2], deltas[3]);
+    update_4_stats_highbd_avx2(src, delta, dst);
+}
+
+static INLINE void hadd_update_6_stats_avx2(const int64_t *const src,
+                                            const __m256i deltas[6],
+                                            int64_t *const dst) {
+    const __m128i delta0123 =
+        hadd_four_32_avx2(deltas[0], deltas[1], deltas[2], deltas[3]);
+    const __m128i delta45 = hadd_two_32_avx2(deltas[4], deltas[5]);
+    const __m128i delta45T = _mm_cvtepi32_epi64(delta45);
+    update_4_stats_avx2(src + 0, delta0123, dst + 0);
+    update_2_stats_sse2(src + 4, delta45T, dst + 4);
+}
+
+static INLINE void hadd_update_6_stats_highbd_avx2(const int64_t *const src,
+                                                   const __m256i deltas[6],
+                                                   int64_t *const dst) {
+    const __m256i delta0123 =
+        hadd_four_31_to_64_avx2(deltas[0], deltas[1], deltas[2], deltas[3]);
+    const __m128i delta45 = hadd_two_31_to_64_avx2(deltas[4], deltas[5]);
+    update_4_stats_highbd_avx2(src + 0, delta0123, dst + 0);
+    update_2_stats_sse2(src + 4, delta45, dst + 4);
+}
+
+static INLINE void load_more_16_avx2(const int16_t *const src,
+                                     const int32_t width, const __m256i org,
+                                     __m256i *const dst) {
+    *dst = _mm256_srli_si256(org, 2);
+    *dst = _mm256_insert_epi16(*dst, *(int32_t *)src, 7);
+    *dst = _mm256_insert_epi16(*dst, *(int32_t *)(src + width), 15);
+}
+
+static INLINE void load_more_32_avx2(const int16_t *const src,
+                                     const int32_t width, __m256i *const dst) {
+    *dst = _mm256_srli_si256(*dst, 4);
+    *dst = _mm256_insert_epi32(*dst, *(int32_t *)src, 3);
+    *dst = _mm256_insert_epi32(*dst, *(int32_t *)(src + width), 7);
+}
+
+static INLINE void load_more_64_avx2(const int16_t *const src,
+                                     const int32_t width, __m256i *const dst) {
+    *dst = _mm256_srli_si256(*dst, 8);
+    *dst = _mm256_insert_epi64(*dst, *(int64_t *)src, 1);
+    *dst = _mm256_insert_epi64(*dst, *(int64_t *)(src + width), 3);
+}
+
+static INLINE __m256i load_win7_avx2(const int16_t *const d,
+                                     const int32_t width) {
+    // 16-bit idx: 0, 4, 1, 5, 2, 6, 3, 7
+    const __m256i shf = _mm256_setr_epi8(0,
+                                         1,
+                                         8,
+                                         9,
+                                         2,
+                                         3,
+                                         10,
+                                         11,
+                                         4,
+                                         5,
+                                         12,
+                                         13,
+                                         6,
+                                         7,
+                                         14,
+                                         15,
+                                         0,
+                                         1,
+                                         8,
+                                         9,
+                                         2,
+                                         3,
+                                         10,
+                                         11,
+                                         4,
+                                         5,
+                                         12,
+                                         13,
+                                         6,
+                                         7,
+                                         14,
+                                         15);
+    // 00s 01s 02s 03s 04s 05s 06s 07s
+    const __m128i ds = _mm_load_si128((__m128i *)d);
+    // 00e 01e 02e 03e 04e 05e 06e 07e
+    const __m128i de = _mm_loadu_si128((__m128i *)(d + width));
+    const __m256i t0 =
+        _mm256_inserti128_si256(_mm256_castsi128_si256(ds), de, 1);
+    // 00s 01s 02s 03s 00e 01e 02e 03e  04s 05s 06s 07s 04e 05e 06e 07e
+    const __m256i t1 = _mm256_permute4x64_epi64(t0, 0xD8);
+    // 00s 00e 01s 01e 02s 02e 03s 03e  04s 04e 05s 05e 06s 06e 07s 07e
+    return _mm256_shuffle_epi8(t1, shf);
+}
+
+static INLINE void step3_win3_avx2(const int16_t **const d,
+                                   const int32_t d_stride, const int32_t width,
+                                   const int32_t h4, __m256i *const dd,
+                                   __m256i deltas[WIENER_WIN_3TAP]) {
+    // 16-bit idx: 0, 2, 4, 6, 1, 3, 5, 7, 0, 2, 4, 6, 1, 3, 5, 7
+    const __m256i shf = _mm256_setr_epi8(0,
+                                         1,
+                                         4,
+                                         5,
+                                         8,
+                                         9,
+                                         12,
+                                         13,
+                                         2,
+                                         3,
+                                         6,
+                                         7,
+                                         10,
+                                         11,
+                                         14,
+                                         15,
+                                         0,
+                                         1,
+                                         4,
+                                         5,
+                                         8,
+                                         9,
+                                         12,
+                                         13,
+                                         2,
+                                         3,
+                                         6,
+                                         7,
+                                         10,
+                                         11,
+                                         14,
+                                         15);
+
+    int32_t y = h4;
+    do {
+        __m256i ds[WIENER_WIN_3TAP];
+
+        // 00s 01s 10s 11s 20s 21s 30s 31s  00e 01e 10e 11e 20e 21e 30e 31e
+        *dd = _mm256_insert_epi32(*dd, *(int32_t *)(*d + 2 * d_stride), 2);
+        *dd = _mm256_insert_epi32(
+            *dd, *(int32_t *)(*d + 2 * d_stride + width), 6);
+        *dd = _mm256_insert_epi32(*dd, *(int32_t *)(*d + 3 * d_stride), 3);
+        *dd = _mm256_insert_epi32(
+            *dd, *(int32_t *)(*d + 3 * d_stride + width), 7);
+        // 00s 10s 20s 30s 01s 11s 21s 31s  00e 10e 20e 30e 01e 11e 21e 31e
+        ds[0] = _mm256_shuffle_epi8(*dd, shf);
+
+        // 10s 11s 20s 21s 30s 31s 40s 41s  10e 11e 20e 21e 30e 31e 40e 41e
+        load_more_32_avx2(*d + 4 * d_stride, width, dd);
+        // 10s 20s 30s 40s 11s 21s 31s 41s  10e 20e 30e 40e 11e 21e 31e 41e
+        ds[1] = _mm256_shuffle_epi8(*dd, shf);
+
+        // 20s 21s 30s 31s 40s 41s 50s 51s  20e 21e 30e 31e 40e 41e 50e 51e
+        load_more_32_avx2(*d + 5 * d_stride, width, dd);
+        // 20s 30s 40s 50s 21s 31s 41s 51s  20e 30e 40e 50e 21e 31e 41e 51e
+        ds[2] = _mm256_shuffle_epi8(*dd, shf);
+
+        madd_avx2(ds[0], ds[0], &deltas[0]);
+        madd_avx2(ds[0], ds[1], &deltas[1]);
+        madd_avx2(ds[0], ds[2], &deltas[2]);
+
+        *dd = _mm256_srli_si256(*dd, 8);
+        *d += 4 * d_stride;
+        y -= 4;
+    } while (y);
+}
+
+static INLINE void step3_win5_avx2(const int16_t **const d,
+                                   const int32_t d_stride, const int32_t width,
+                                   const int32_t height, __m256i *const dd,
+                                   __m256i ds[WIENER_WIN_CHROMA],
+                                   __m256i deltas[WIENER_WIN_CHROMA]) {
+    // 16-bit idx: 0, 4, 1, 5, 2, 6, 3, 7
+    const __m256i shf = _mm256_setr_epi8(0,
+                                         1,
+                                         8,
+                                         9,
+                                         2,
+                                         3,
+                                         10,
+                                         11,
+                                         4,
+                                         5,
+                                         12,
+                                         13,
+                                         6,
+                                         7,
+                                         14,
+                                         15,
+                                         0,
+                                         1,
+                                         8,
+                                         9,
+                                         2,
+                                         3,
+                                         10,
+                                         11,
+                                         4,
+                                         5,
+                                         12,
+                                         13,
+                                         6,
+                                         7,
+                                         14,
+                                         15);
+
+    int32_t y = height;
+    do {
+        *d += 2 * d_stride;
+
+        // 30s 31s 32s 33s 40s 41s 42s 43s  30e 31e 32e 33e 40e 41e 42e 43e
+        load_more_64_avx2(*d + 2 * d_stride, width, dd);
+        // 30s 40s 31s 41s 32s 42s 33s 43s  30e 40e 31e 41e 32e 42e 33e 43e
+        ds[3] = _mm256_shuffle_epi8(*dd, shf);
+
+        // 40s 41s 42s 43s 50s 51s 52s 53s  40e 41e 42e 43e 50e 51e 52e 53e
+        load_more_64_avx2(*d + 3 * d_stride, width, dd);
+        // 40s 50s 41s 51s 42s 52s 43s 53s  40e 50e 41e 51e 42e 52e 43e 53e
+        ds[4] = _mm256_shuffle_epi8(*dd, shf);
+
+        madd_avx2(ds[0], ds[0], &deltas[0]);
+        madd_avx2(ds[0], ds[1], &deltas[1]);
+        madd_avx2(ds[0], ds[2], &deltas[2]);
+        madd_avx2(ds[0], ds[3], &deltas[3]);
+        madd_avx2(ds[0], ds[4], &deltas[4]);
+
+        ds[0] = ds[2];
+        ds[1] = ds[3];
+        ds[2] = ds[4];
+        y -= 2;
+    } while (y);
+}
+
+static INLINE void step3_win7_avx2(const int16_t **const d,
+                                   const int32_t d_stride, const int32_t width,
+                                   const int32_t height, __m256i ds[WIENER_WIN],
+                                   __m256i deltas[WIENER_WIN]) {
+    const __m256i const_n1_0 = _mm256_setr_epi16(0xFFFF,
+                                                 0,
+                                                 0xFFFF,
+                                                 0,
+                                                 0xFFFF,
+                                                 0,
+                                                 0xFFFF,
+                                                 0,
+                                                 0xFFFF,
+                                                 0,
+                                                 0xFFFF,
+                                                 0,
+                                                 0xFFFF,
+                                                 0,
+                                                 0xFFFF,
+                                                 0);
+
+    int32_t y = height;
+    do {
+        __m256i dd;
+
+        dd = ds[0];
+        dd = _mm256_xor_si256(dd, const_n1_0);
+        dd = _mm256_sub_epi16(dd, const_n1_0);
+
+        // 60s 60e 61s 61e 62s 62e 63s 63e  64s 64e 65s 65e 66s 66e 67s 67e
+        ds[6] = load_win7_avx2(*d, width);
+
+        madd_avx2(dd, ds[0], &deltas[0]);
+        madd_avx2(dd, ds[1], &deltas[1]);
+        madd_avx2(dd, ds[2], &deltas[2]);
+        madd_avx2(dd, ds[3], &deltas[3]);
+        madd_avx2(dd, ds[4], &deltas[4]);
+        madd_avx2(dd, ds[5], &deltas[5]);
+        madd_avx2(dd, ds[6], &deltas[6]);
+
+        ds[0] = ds[1];
+        ds[1] = ds[2];
+        ds[2] = ds[3];
+        ds[3] = ds[4];
+        ds[4] = ds[5];
+        ds[5] = ds[6];
+        *d += d_stride;
+    } while (--y);
+}
+
+#endif  // AOM_DSP_X86_PICKRST_AVX2_H_

--- a/Source/Lib/Common/ASM_AVX2/transpose_avx2.h
+++ b/Source/Lib/Common/ASM_AVX2/transpose_avx2.h
@@ -1,0 +1,205 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
+#ifndef AOM_DSP_X86_TRANSPOSE_AVX2_H_
+#define AOM_DSP_X86_TRANSPOSE_AVX2_H_
+
+#include <immintrin.h>  // AVX2
+
+static INLINE __m256i _mm256_unpacklo_epi128(const __m256i in0,
+                                             const __m256i in1) {
+    return _mm256_inserti128_si256(in0, _mm256_extracti128_si256(in1, 0), 1);
+}
+
+static INLINE __m256i _mm256_unpackhi_epi128(const __m256i in0,
+                                             const __m256i in1) {
+    return _mm256_inserti128_si256(in1, _mm256_extracti128_si256(in0, 1), 0);
+}
+
+static INLINE void transpose_32bit_8x8_avx2(const __m256i *const in,
+                                            __m256i *const out) {
+    // Unpack 32 bit elements. Goes from:
+    // in[0]: 00 01 02 03  04 05 06 07
+    // in[1]: 10 11 12 13  14 15 16 17
+    // in[2]: 20 21 22 23  24 25 26 27
+    // in[3]: 30 31 32 33  34 35 36 37
+    // in[4]: 40 41 42 43  44 45 46 47
+    // in[5]: 50 51 52 53  54 55 56 57
+    // in[6]: 60 61 62 63  64 65 66 67
+    // in[7]: 70 71 72 73  74 75 76 77
+    // to:
+    // a0:    00 10 01 11  04 14 05 15
+    // a1:    20 30 21 31  24 34 25 35
+    // a2:    40 50 41 51  44 54 45 55
+    // a3:    60 70 61 71  64 74 65 75
+    // a4:    02 12 03 13  06 16 07 17
+    // a5:    22 32 23 33  26 36 27 37
+    // a6:    42 52 43 53  46 56 47 57
+    // a7:    62 72 63 73  66 76 67 77
+    const __m256i a0 = _mm256_unpacklo_epi32(in[0], in[1]);
+    const __m256i a1 = _mm256_unpacklo_epi32(in[2], in[3]);
+    const __m256i a2 = _mm256_unpacklo_epi32(in[4], in[5]);
+    const __m256i a3 = _mm256_unpacklo_epi32(in[6], in[7]);
+    const __m256i a4 = _mm256_unpackhi_epi32(in[0], in[1]);
+    const __m256i a5 = _mm256_unpackhi_epi32(in[2], in[3]);
+    const __m256i a6 = _mm256_unpackhi_epi32(in[4], in[5]);
+    const __m256i a7 = _mm256_unpackhi_epi32(in[6], in[7]);
+
+    // Unpack 64 bit elements resulting in:
+    // b0: 00 10 20 30  04 14 24 34
+    // b1: 40 50 60 70  44 54 64 74
+    // b2: 01 11 21 31  05 15 25 35
+    // b3: 41 51 61 71  45 55 65 75
+    // b4: 02 12 22 32  06 16 26 36
+    // b5: 42 52 62 72  46 56 66 76
+    // b6: 03 13 23 33  07 17 27 37
+    // b7: 43 53 63 73  47 57 67 77
+    const __m256i b0 = _mm256_unpacklo_epi64(a0, a1);
+    const __m256i b1 = _mm256_unpacklo_epi64(a2, a3);
+    const __m256i b2 = _mm256_unpackhi_epi64(a0, a1);
+    const __m256i b3 = _mm256_unpackhi_epi64(a2, a3);
+    const __m256i b4 = _mm256_unpacklo_epi64(a4, a5);
+    const __m256i b5 = _mm256_unpacklo_epi64(a6, a7);
+    const __m256i b6 = _mm256_unpackhi_epi64(a4, a5);
+    const __m256i b7 = _mm256_unpackhi_epi64(a6, a7);
+
+    // Unpack 128 bit elements resulting in:
+    // out[0]: 00 10 20 30  40 50 60 70
+    // out[1]: 01 11 21 31  41 51 61 71
+    // out[2]: 02 12 22 32  42 52 62 72
+    // out[3]: 03 13 23 33  43 53 63 73
+    // out[4]: 04 14 24 34  44 54 64 74
+    // out[5]: 05 15 25 35  45 55 65 75
+    // out[6]: 06 16 26 36  46 56 66 76
+    // out[7]: 07 17 27 37  47 57 67 77
+    out[0] = _mm256_unpacklo_epi128(b0, b1);
+    out[1] = _mm256_unpacklo_epi128(b2, b3);
+    out[2] = _mm256_unpacklo_epi128(b4, b5);
+    out[3] = _mm256_unpacklo_epi128(b6, b7);
+    out[4] = _mm256_unpackhi_epi128(b0, b1);
+    out[5] = _mm256_unpackhi_epi128(b2, b3);
+    out[6] = _mm256_unpackhi_epi128(b4, b5);
+    out[7] = _mm256_unpackhi_epi128(b6, b7);
+}
+
+static INLINE void transpose_64bit_4x4_avx2(const __m256i *const in,
+                                            __m256i *const out) {
+    // Unpack 32 bit elements. Goes from:
+    // in[0]: 00 01 02 03
+    // in[1]: 10 11 12 13
+    // in[2]: 20 21 22 23
+    // in[3]: 30 31 32 33
+    // to:
+    // a0:    00 10 02 12
+    // a1:    20 30 22 32
+    // a2:    01 11 03 13
+    // a3:    21 31 23 33
+    const __m256i a0 = _mm256_unpacklo_epi64(in[0], in[1]);
+    const __m256i a1 = _mm256_unpacklo_epi64(in[2], in[3]);
+    const __m256i a2 = _mm256_unpackhi_epi64(in[0], in[1]);
+    const __m256i a3 = _mm256_unpackhi_epi64(in[2], in[3]);
+
+    // Unpack 64 bit elements resulting in:
+    // out[0]: 00 10 20 30
+    // out[1]: 01 11 21 31
+    // out[2]: 02 12 22 32
+    // out[3]: 03 13 23 33
+    out[0] = _mm256_inserti128_si256(a0, _mm256_extracti128_si256(a1, 0), 1);
+    out[1] = _mm256_inserti128_si256(a2, _mm256_extracti128_si256(a3, 0), 1);
+    out[2] = _mm256_inserti128_si256(a1, _mm256_extracti128_si256(a0, 1), 0);
+    out[3] = _mm256_inserti128_si256(a3, _mm256_extracti128_si256(a2, 1), 0);
+}
+
+static INLINE void transpose_64bit_4x6_avx2(const __m256i *const in,
+                                            __m256i *const out) {
+    // Unpack 64 bit elements. Goes from:
+    // in[0]: 00 01  02 03
+    // in[1]: 10 11  12 13
+    // in[2]: 20 21  22 23
+    // in[3]: 30 31  32 33
+    // in[4]: 40 41  42 43
+    // in[5]: 50 51  52 53
+    // to:
+    // a0:    00 10  02 12
+    // a1:    20 30  22 32
+    // a2:    40 50  42 52
+    // a4:    01 11  03 13
+    // a5:    21 31  23 33
+    // a6:    41 51  43 53
+    const __m256i a0 = _mm256_unpacklo_epi64(in[0], in[1]);
+    const __m256i a1 = _mm256_unpacklo_epi64(in[2], in[3]);
+    const __m256i a2 = _mm256_unpacklo_epi64(in[4], in[5]);
+    const __m256i a4 = _mm256_unpackhi_epi64(in[0], in[1]);
+    const __m256i a5 = _mm256_unpackhi_epi64(in[2], in[3]);
+    const __m256i a6 = _mm256_unpackhi_epi64(in[4], in[5]);
+
+    // Unpack 128 bit elements resulting in:
+    // b0: 00 10  20 30
+    // b1: 40 50  40 50
+    // b2: 01 11  21 31
+    // b3: 41 51  41 51
+    // b4: 02 12  22 32
+    // b5: 42 52  42 52
+    // b6: 03 13  23 33
+    // b7: 43 53  43 53
+    out[0] = _mm256_unpacklo_epi128(a0, a1);
+    out[1] = _mm256_unpacklo_epi128(a2, a2);
+    out[2] = _mm256_unpacklo_epi128(a4, a5);
+    out[3] = _mm256_unpacklo_epi128(a6, a6);
+    out[4] = _mm256_unpackhi_epi128(a0, a1);
+    out[5] = _mm256_unpackhi_epi128(a2, a2);
+    out[6] = _mm256_unpackhi_epi128(a4, a5);
+    out[7] = _mm256_unpackhi_epi128(a6, a6);
+}
+
+static INLINE void transpose_64bit_4x8_avx2(const __m256i *const in,
+                                            __m256i *const out) {
+    // Unpack 64 bit elements. Goes from:
+    // in[0]: 00 01  02 03
+    // in[1]: 10 11  12 13
+    // in[2]: 20 21  22 23
+    // in[3]: 30 31  32 33
+    // in[4]: 40 41  42 43
+    // in[5]: 50 51  52 53
+    // in[6]: 60 61  62 63
+    // in[7]: 70 71  72 73
+    // to:
+    // a0:    00 10  02 12
+    // a1:    20 30  22 32
+    // a2:    40 50  42 52
+    // a3:    60 70  62 72
+    // a4:    01 11  03 13
+    // a5:    21 31  23 33
+    // a6:    41 51  43 53
+    // a7:    61 71  63 73
+    const __m256i a0 = _mm256_unpacklo_epi64(in[0], in[1]);
+    const __m256i a1 = _mm256_unpacklo_epi64(in[2], in[3]);
+    const __m256i a2 = _mm256_unpacklo_epi64(in[4], in[5]);
+    const __m256i a3 = _mm256_unpacklo_epi64(in[6], in[7]);
+    const __m256i a4 = _mm256_unpackhi_epi64(in[0], in[1]);
+    const __m256i a5 = _mm256_unpackhi_epi64(in[2], in[3]);
+    const __m256i a6 = _mm256_unpackhi_epi64(in[4], in[5]);
+    const __m256i a7 = _mm256_unpackhi_epi64(in[6], in[7]);
+
+    // Unpack 128 bit elements resulting in:
+    // b0: 00 10  20 30
+    // b1: 40 50  60 70
+    // b2: 01 11  21 31
+    // b3: 41 51  61 71
+    // b4: 02 12  22 32
+    // b5: 42 52  62 72
+    // b6: 03 13  23 33
+    // b7: 43 53  63 73
+    out[0] = _mm256_unpacklo_epi128(a0, a1);
+    out[1] = _mm256_unpacklo_epi128(a2, a3);
+    out[2] = _mm256_unpacklo_epi128(a4, a5);
+    out[3] = _mm256_unpacklo_epi128(a6, a7);
+    out[4] = _mm256_unpackhi_epi128(a0, a1);
+    out[5] = _mm256_unpackhi_epi128(a2, a3);
+    out[6] = _mm256_unpackhi_epi128(a4, a5);
+    out[7] = _mm256_unpackhi_epi128(a6, a7);
+}
+
+#endif  // AOM_DSP_X86_TRANSPOSE_AVX2_H_

--- a/Source/Lib/Common/Codec/EbRestorationPick.c
+++ b/Source/Lib/Common/Codec/EbRestorationPick.c
@@ -788,6 +788,352 @@ void av1_compute_stats_c(int32_t wiener_win, const uint8_t *dgd, const uint8_t *
     }
 }
 
+#if 0
+// Note: Don't delete! This is the code base for optimizations, and 4.8x, 9x or
+//       16x faster than the above original C version for win 3, 5 and 7
+//       respectively, while keeping the bit-exactness.
+
+// Demostration of TAP 3:
+//                       (Left Edge)         (Left Edge)
+//  \lj   00    10    20      01    11    21      02    12    22
+// ki-------------------------------------------------------------
+// 00| 00X00 00X10 00X20 | 00X01 00X11 00X21 | 00X02 00X12 00X22 |(Top Edge)
+// 10|       10x10 10x20 | 10X01 10x11 10x21 | 10X02 10x12 10x22 |(Top Row)
+// 20|             20x20 | 20X01 20x11 20x21 | 20X02 20x12 20x22 |
+//   |                   --------------------|-------------------|
+// 01|                     01x01 01x11 01x21 | 01x02 01x12 01x22 |(Top Edge)
+// 11|                           11x11 11x21 | 11x02 11x12 11x22 |(Mid Rows)
+// 21|                                 21x21 | 21x02 21x12 21x22 |
+//   |                                       --------------------|
+// 02|                                         02x02 02x12 02x22 |(Top Edge)
+// 12|                                               12x12 12x22 |(Btm Row)
+// 22|                                                     22x22 |
+//   -------------------------------------------------------------
+// kiXlj means the multiply–accumulate must be calculated from scratch, and
+// starts from a[k * a_stride + i] * b[l * b_stride + j].
+// kixlj means the multiply–accumulate could be derived from a neighbor.
+
+static INLINE void sub_avg_block(const uint8_t *src, const int32_t src_stride,
+                                 const uint8_t avg, const int32_t width,
+                                 const int32_t height, int16_t *dst,
+                                 const int32_t dst_stride) {
+    for (int32_t i = 0; i < height; i++) {
+        for (int32_t j = 0; j < width; j++)
+            dst[i * dst_stride + j] = (int16_t)src[i * src_stride + j] - avg;
+    }
+}
+
+void av1_compute_stats_base(int32_t wiener_win, const uint8_t *dgd,
+                            const uint8_t *src, int32_t h_start, int32_t h_end,
+                            int32_t v_start, int32_t v_end, int32_t dgd_stride,
+                            int32_t src_stride, int64_t *M, int64_t *H) {
+    const int32_t wiener_win2 = wiener_win * wiener_win;
+    const int32_t wiener_halfwin = wiener_win >> 1;
+    const uint8_t avg =
+        find_average(dgd, h_start, h_end, v_start, v_end, dgd_stride);
+    const int32_t width = h_end - h_start;
+    const int32_t height = v_end - v_start;
+    const int32_t d_stride = (width + 2 * wiener_halfwin + 15) & ~15;
+    const int32_t s_stride = (width + 15) & ~15;
+    // The maximum input size is width * height, which is
+    // (9 / 4) * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX. Enlarge to
+    // 3 * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX considering
+    // paddings.
+    int16_t d[3 * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX];
+    int16_t s[3 * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX];
+    int32_t i, j, k, l, x, y;
+
+    sub_avg_block(src + v_start * src_stride + h_start,
+                  src_stride,
+                  avg,
+                  width,
+                  height,
+                  s,
+                  s_stride);
+    sub_avg_block(dgd + (v_start - wiener_halfwin) * dgd_stride + h_start -
+                      wiener_halfwin,
+                  dgd_stride,
+                  avg,
+                  width + 2 * wiener_halfwin,
+                  height + 2 * wiener_halfwin,
+                  d,
+                  d_stride);
+
+    // Step 1: Calculate the top edge of the whole matrix, i.e., the top edge of
+    // each triangle and square on the top row.
+    // Demostration of TAP 3:
+    //                       (Left Edge)         (Left Edge)
+    //  \lj   00    10    20      01    11    21      02    12    22
+    // ki-------------------------------------------------------------
+    // 00| 00X00 00X10 00X20 | 00X01 00X11 00X21 | 00X02 00X12 00X22 |(Top Edge)
+    // 10|                                                           |(Top Row)
+    // 20|                                                           |
+    //   |                   --------------------|-------------------|
+    // 01|                                                           |(Top Edge)
+    // 11|                                                           |(Mid Rows)
+    // 21|                                                           |
+    //   |                                       --------------------|
+    // 02|                                                           |(Top Edge)
+    // 12|                                                           |(Btm Row)
+    // 22|                                                           |
+    //   -------------------------------------------------------------
+    for (j = 0; j < wiener_win; j++) {
+        for (l = 0; l < wiener_win; l++) {
+            int64_t sumM = 0;
+            int64_t sumH = 0;
+
+            for (y = 0; y < height; y++) {
+                for (x = 0; x < width; x++) {
+                    sumM += s[y * s_stride + x] * d[(l + y) * d_stride + j + x];
+                    sumH += d[y * d_stride + x] * d[(l + y) * d_stride + j + x];
+                }
+            }
+
+            M[j * wiener_win + l] = sumM;
+            H[j * wiener_win + l] = sumH;
+        }
+    }
+
+    // Step 2: Calculate the left edge of each square on the top row.
+    // Demostration of TAP 3:
+    //                       (Left Edge)         (Left Edge)
+    //  \lj   00    10    20      01    11    21      02    12    22
+    // ki-------------------------------------------------------------
+    // 00|                                                           |(Top Edge)
+    // 10|                   | 10X01             | 10X02             |(Top Row)
+    // 20|                   | 20X01             | 20X02             |
+    //   |                   --------------------|-------------------|
+    // 01|                                                           |(Top Edge)
+    // 11|                                                           |(Mid Rows)
+    // 21|                                                           |
+    //   |                                       --------------------|
+    // 02|                                                           |(Top Edge)
+    // 12|                                                           |(Btm Row)
+    // 22|                                                           |
+    //   -------------------------------------------------------------
+    for (j = 1; j < wiener_win; j++) {
+        for (k = 1; k < wiener_win; k++) {
+            int64_t sumH = 0;
+
+            for (y = 0; y < height; y++) {
+                for (x = 0; x < width; x++)
+                    sumH += d[(k + y) * d_stride + x] * d[y * d_stride + j + x];
+            }
+
+            H[k * wiener_win2 + j * wiener_win] = sumH;
+        }
+    }
+
+    // Step 3: Derive the top edge of each triangle along the diagonal. No
+    // triangle in top row.
+    // Demostration of TAP 3:
+    //                       (Left Edge)         (Left Edge)
+    //  \lj   00    10    20      01    11    21      02    12    22
+    // ki-------------------------------------------------------------
+    // 00|                                                           |(Top Edge)
+    // 10|                                                           |(Top Row)
+    // 20|                                                           |
+    //   |                   --------------------|-------------------|
+    // 01|                     01x01 01x11 01x21 |                   |(Top Edge)
+    // 11|                                                           |(Mid Rows)
+    // 21|                                                           |
+    //   |                                       --------------------|
+    // 02|                                         02x02 02x12 02x22 |(Top Edge)
+    // 12|                                                           |(Btm Row)
+    // 22|                                                           |
+    //   -------------------------------------------------------------
+    for (i = 1; i < wiener_win; i++) {
+        for (l = 0; l < wiener_win; l++) {
+            int32_t delta = 0;
+
+            for (y = 0; y < height; y++) {
+                delta -=
+                    d[y * d_stride + i - 1] * d[(l + y) * d_stride + i - 1];
+                delta += d[y * d_stride + i - 1 + width] *
+                         d[(l + y) * d_stride + i - 1 + width];
+            }
+
+            H[i * wiener_win * wiener_win2 + i * wiener_win + l] =
+                H[(i - 1) * wiener_win * wiener_win2 + (i - 1) * wiener_win +
+                  l] +
+                delta;
+        }
+    }
+
+    // Step 4: Derive the top and left edge of each square. No square in top and
+    // bottom row. (There is only 1 square in this step for TAP 3, but there are
+    // many for TAP 5 and 7.)
+    // Demostration of TAP 3:
+    //                       (Left Edge)         (Left Edge)
+    //  \lj   00    10    20      01    11    21      02    12    22
+    // ki-------------------------------------------------------------
+    // 00|                                                           |(Top Edge)
+    // 10|                                                           |(Top Row)
+    // 20|                                                           |
+    //   |                   --------------------|-------------------|
+    // 01|                                       | 01x02 01x12 01x22 |(Top Edge)
+    // 11|                                       | 11x02             |(Mid Rows)
+    // 21|                                       | 21x02             |
+    //   |                                       --------------------|
+    // 02|                                                           |(Top Edge)
+    // 12|                                                           |(Btm Row)
+    // 22|                                                           |
+    //   -------------------------------------------------------------
+    for (i = 1; i < wiener_win - 1; i++) {
+        for (j = i + 1; j < wiener_win; j++) {
+            for (l = 0; l < wiener_win; l++) {
+                int32_t delta = 0;
+
+                for (y = 0; y < height; y++) {
+                    delta -=
+                        d[y * d_stride + i - 1] * d[(l + y) * d_stride + j - 1];
+                    delta += d[y * d_stride + i - 1 + width] *
+                             d[(l + y) * d_stride + j - 1 + width];
+                }
+
+                H[i * wiener_win * wiener_win2 + j * wiener_win + l] =
+                    H[(i - 1) * wiener_win * wiener_win2 +
+                      (j - 1) * wiener_win + l] +
+                    delta;
+            }
+
+            for (k = 1; k < wiener_win; k++) {
+                int32_t delta = 0;
+
+                for (y = 0; y < height; y++) {
+                    delta -=
+                        d[(k + y) * d_stride + i - 1] * d[y * d_stride + j - 1];
+                    delta += d[(k + y) * d_stride + i - 1 + width] *
+                             d[y * d_stride + j - 1 + width];
+                }
+
+                H[(i * wiener_win + k) * wiener_win2 + j * wiener_win] =
+                    H[((i - 1) * wiener_win + k) * wiener_win2 +
+                      (j - 1) * wiener_win] +
+                    delta;
+            }
+        }
+    }
+
+    // Step 5: Derive other points of each square. No square in bottom row.
+    // Demostration of TAP 3:
+    //                       (Left Edge)         (Left Edge)
+    //  \lj   00    10    20      01    11    21      02    12    22
+    // ki-------------------------------------------------------------
+    // 00|                   |                   |                   |(Top Edge)
+    // 10|                   |       10x11 10x21 |       10x12 10x22 |(Top Row)
+    // 20|                   |       20x11 20x21 |       20x12 20x22 |
+    //   |                   --------------------|-------------------|
+    // 01|                                       |                   |(Top Edge)
+    // 11|                                       |       11x12 11x22 |(Mid Rows)
+    // 21|                                       |       21x12 21x22 |
+    //   |                                       --------------------|
+    // 02|                                                           |(Top Edge)
+    // 12|                                                           |(Btm Row)
+    // 22|                                                           |
+    //   -------------------------------------------------------------
+    for (i = 0; i < wiener_win - 1; i++) {
+        for (j = i + 1; j < wiener_win; j++) {
+            for (k = 1; k < wiener_win; k++) {
+                for (l = 1; l < wiener_win; l++) {
+                    int32_t delta = 0;
+
+                    for (x = 0; x < width; x++) {
+                        delta -= d[(k - 1) * d_stride + i + x] *
+                                 d[(l - 1) * d_stride + j + x];
+                        delta += d[(k - 1 + height) * d_stride + i + x] *
+                                 d[(l - 1 + height) * d_stride + j + x];
+                    }
+
+                    H[(i * wiener_win + k) * wiener_win2 + j * wiener_win + l] =
+                        H[(i * wiener_win + k - 1) * wiener_win2 +
+                          j * wiener_win + l - 1] +
+                        delta;
+                }
+            }
+        }
+    }
+
+    // Step 6: Derive other points of each upper triangle along the diagonal.
+    // Demostration of TAP 3:
+    //                       (Left Edge)         (Left Edge)
+    //  \lj   00    10    20      01    11    21      02    12    22
+    // ki-------------------------------------------------------------
+    // 00|                   |                   |                   |(Top Edge)
+    // 10|       10x10 10x20 |                   |                   |(Top Row)
+    // 20|             20x20 |                   |                   |
+    //   |                   --------------------|-------------------|
+    // 01|                                       |                   |(Top Edge)
+    // 11|                           11x11 11x21 |                   |(Mid Rows)
+    // 21|                                 21x21 |                   |
+    //   |                                       --------------------|
+    // 02|                                                           |(Top Edge)
+    // 12|                                               12x12 12x22 |(Btm Row)
+    // 22|                                                     22x22 |
+    //   -------------------------------------------------------------
+    for (i = 0; i < wiener_win; i++) {
+        for (k = 1; k < wiener_win; k++) {
+            for (l = k; l < wiener_win; l++) {
+                int32_t delta = 0;
+
+                for (x = 0; x < width; x++) {
+                    delta -= d[(k - 1) * d_stride + i + x] *
+                             d[(l - 1) * d_stride + i + x];
+                    delta += d[(k - 1 + height) * d_stride + i + x] *
+                             d[(l - 1 + height) * d_stride + i + x];
+                }
+
+                H[(i * wiener_win + k) * wiener_win2 + i * wiener_win + l] =
+                    H[(i * wiener_win + k - 1) * wiener_win2 + i * wiener_win +
+                      l - 1] +
+                    delta;
+            }
+        }
+    }
+
+    // H is a symmetric matrix, so we only need to fill out the upper triangle.
+    // We can copy it down to the lower triangle outside the (i, j) loops.
+    // Divided into 4x4 squares to do load-and-transpose-and-store in
+    // optimization.
+    // Demostration of TAP 3:
+    //  \lj   00    10    20    01      11    21    02    12      22
+    // ki-------------------------------------------------------------
+    // 00|                                                           |
+    //   |------                                                     |
+    // 10| 00X10                                                     |
+    // 20| 00X20 10x20                                               |
+    // 01| 00X01 10X01 20X01                                         |
+    // 11| 00X11 10x11 20x11 01x11                                   |
+    //   |--------------------------                                 |
+    // 21| 00X21 10x21 20x21 01x21 | 11x21                           |
+    // 02| 00X02 10X02 20X02 01x02 | 11x02 21x02                     |
+    // 12| 00X12 10x12 20x12 01x12 | 11x12 21x12 02x12               |
+    // 22| 00X22 10x22 20x22 01x22 | 11x22 21x22 02x22 12x22 |       |
+    //   -------------------------------------------------------------
+    for (i = 0; i < wiener_win2; i++) {
+        for (j = i + 1; j < wiener_win2; j++)
+            H[j * wiener_win2 + i] = H[i * wiener_win2 + j];
+    }
+
+    // Finally we get the whole matrix.
+    // Demostration of TAP 3:
+    //  \lj   00    10    20      01    11    21      02    12    22
+    // ki-------------------------------------------------------------
+    // 00| 00X00 00X10 00X20 | 00X01 00X11 00X21 | 00X02 00X12 00X22 |
+    // 10| 00X10 10x10 10x20 | 10X01 10x11 10x21 | 10X02 10x12 10x22 |
+    // 20| 00X20 10x20 20x20 | 20X01 20x11 20x21 | 20X02 20x12 20x22 |
+    //   |-----------------------------------------------------------|
+    // 01| 00X01 10X01 20X01 | 01x01 01x11 01x21 | 01x02 01x12 01x22 |
+    // 11| 00X11 10x11 20x11 | 01x11 11x11 11x21 | 11x02 11x12 11x22 |
+    // 21| 00X21 10x21 20x21 | 01x21 11x21 21x21 | 21x02 21x12 21x22 |
+    //   |-----------------------------------------------------------|
+    // 02| 00X02 10X02 20X02 | 01x02 11x02 21x02 | 02x02 02x12 02x22 |
+    // 12| 00X12 10x12 20x12 | 01x12 11x12 21x12 | 02x12 12x12 12x22 |
+    // 22| 00X22 10x22 20x22 | 01x22 11x22 21x22 | 02x22 12x22 22x22 |
+    //   -------------------------------------------------------------
+}
+#endif
+
 void av1_compute_stats_highbd_c(int32_t wiener_win, const uint8_t *dgd8,
     const uint8_t *src8, int32_t h_start, int32_t h_end,
     int32_t v_start, int32_t v_end, int32_t dgd_stride,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,6 +56,7 @@ enable_testing()
 
 file(GLOB all_files
     "*.h"
+    "*.c"
     "*.cc"
     "ref/*.h"
     "ref/*.cc"

--- a/test/EbUnitTest.h
+++ b/test/EbUnitTest.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
+#ifndef EbUnitTest_h
+#define EbUnitTest_h
+
+#include "EbDefinitions.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static const int EB_UNIT_TEST_NUM = 10;
+static const int EB_UNIT_TEST_MAX_BD = 12;
+
+extern void *eb_unit_test_buf_alligned;    // 256-byte aligned buffer
+extern void *eb_unit_test_buf_unalligned;  // unaligned buffer
+extern const char eb_unit_test_result_str[2][25];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EbUnitTest_h

--- a/test/EbUnitTestUtility.c
+++ b/test/EbUnitTestUtility.c
@@ -1,0 +1,505 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
+// EbUnitTestUtility.c
+//  -Unit test utility
+//      -Randomize Data
+//      -Compare Data
+//      -Log Data
+//      -Compute Overall Elapsed Millisecond
+
+/***************************************
+ * Includes
+ ***************************************/
+#ifdef _WIN32
+#include <time.h>
+#include <windows.h>
+#elif defined(__linux__) || defined(__APPLE__)
+#include <sys/time.h>
+#include <time.h>
+#else
+#error OS/Platform not supported.
+#endif
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "EbUnitTest.h"
+#include "EbUnitTestUtility.h"
+//#include "EbTime.h"
+
+/***************************************
+ * Randomize Data
+ ***************************************/
+void eb_buf_random_void(void *const buf, const uint32_t sizeBuf) {
+    uint8_t *const buffer = (uint8_t *)buf;
+
+    for (uint32_t i = 0; i < sizeBuf; i++)
+        buffer[i] = (uint8_t)(rand() % 256);
+}
+
+void eb_buf_random_s8(int8_t *const buf, const uint32_t sizeBuf) {
+    eb_buf_random_void(buf, sizeBuf);
+}
+
+void eb_buf_random_s8_with_max(int8_t *const buf, const uint32_t sizeBuf,
+                               const uint8_t max) {
+    for (uint32_t i = 0; i < sizeBuf; i++) {
+        const uint32_t val = rand() % (max + 1);
+        const uint32_t sign = rand() & 1;
+        buf[i] = (int8_t)(sign ? val : 0 - val);
+    }
+}
+
+void eb_buf_random_u8(uint8_t *const buf, const uint32_t sizeBuf) {
+    eb_buf_random_void(buf, sizeBuf);
+}
+
+void eb_buf_random_u8_to_0_or_255(uint8_t *const buf, const uint32_t sizeBuf) {
+    for (uint32_t i = 0; i < sizeBuf; i++)
+        buf[i] = (rand() > (RAND_MAX >> 1)) ? 255 : 0;
+}
+
+void eb_buf_random_u8_to_255(uint8_t *const buf, const uint32_t sizeBuf) {
+    memset(buf, 255, sizeBuf);
+}
+
+void eb_buf_random_u8_to_large(uint8_t *const buf, const uint32_t sizeBuf) {
+    for (uint32_t i = 0; i < sizeBuf; i++)
+        buf[i] = 255 - (rand() % 10);
+}
+
+void eb_buf_random_u8_to_near_value(uint8_t *const buf, const uint32_t sizeBuf,
+                                    const uint8_t val, const uint32_t range) {
+    for (uint32_t i = 0; i < sizeBuf; i++) {
+        int32_t v = val;
+        v += (rand() % range);
+        v -= (rand() % range);
+        if (v > 255)
+            v = 255;
+        if (v < 0)
+            v = 0;
+        buf[i] = (uint8_t)v;
+    }
+}
+
+void eb_buf_random_u8_to_small(uint8_t *const buf, const uint32_t sizeBuf) {
+    for (uint32_t i = 0; i < sizeBuf; i++)
+        buf[i] = (rand() % 10);
+}
+
+void eb_buf_random_u8_to_small_or_large(uint8_t *const buf,
+                                        const uint32_t sizeBuf) {
+    for (uint32_t i = 0; i < sizeBuf; i++)
+        buf[i] =
+            (rand() > (RAND_MAX >> 1)) ? (rand() % 10) : (255 - (rand() % 10));
+}
+
+void eb_buf_random_u8_with_max(uint8_t *const buf, const uint32_t sizeBuf,
+                               const uint8_t max) {
+    for (uint32_t i = 0; i < sizeBuf; i++)
+        buf[i] = (uint8_t)((uint32_t)rand() % (max + 1));
+}
+
+void eb_buf_random_s16(int16_t *const buf, const uint32_t sizeBuf) {
+    eb_buf_random_void(buf, sizeof(*buf) * sizeBuf);
+}
+
+void eb_buf_random_s16_to_bd(int16_t *const buf, const uint32_t sizeBuf,
+                             const uint32_t bd) {
+    const int16_t max = (1 << bd) - 1;
+
+    for (uint32_t i = 0; i < sizeBuf; i++)
+        buf[i] = (rand() & 1) ? max : -max;
+}
+
+void eb_buf_random_s16_with_bd(int16_t *const buf, const uint32_t sizeBuf,
+                               const uint32_t bd) {
+    assert(bd >= 8);
+
+    for (uint32_t i = 0; i < sizeBuf; i++) {
+        const uint32_t val = rand() % (1 << bd);
+        const uint32_t sign = rand() & 1;
+        buf[i] = (int16_t)(sign ? val : 0 - val);
+    }
+}
+
+void eb_buf_random_s16_with_max(int16_t *const buf, const uint32_t sizeBuf,
+                                const uint16_t max) {
+    for (uint32_t i = 0; i < sizeBuf; i++) {
+        const uint32_t val = rand() % (max + 1);
+        const uint32_t sign = rand() & 1;
+        buf[i] = (int16_t)(sign ? val : 0 - val);
+    }
+}
+
+void eb_buf_random_u16(uint16_t *const buf, const uint32_t sizeBuf) {
+    eb_buf_random_void(buf, sizeof(*buf) * sizeBuf);
+}
+
+void eb_buf_random_u16_to_0_or_1023(uint16_t *const buf,
+                                    const uint32_t sizeBuf) {
+    for (uint32_t i = 0; i < sizeBuf; i++)
+        buf[i] = (rand() > (RAND_MAX >> 1)) ? 1023 : 0;
+}
+
+void eb_buf_random_u16_to_0_or_bd(uint16_t *const buf, const uint32_t sizeBuf,
+                                  const uint32_t bd) {
+    const uint16_t max = (uint16_t)((1 << bd) - 1);
+
+    for (uint32_t i = 0; i < sizeBuf; i++)
+        buf[i] = (rand() > (RAND_MAX >> 1)) ? max : 0;
+}
+
+void eb_buf_random_u16_to_bd(uint16_t *const buf, const uint32_t sizeBuf,
+                             const uint32_t bd) {
+    const uint16_t max = (uint16_t)((1 << bd) - 1);
+
+    for (uint32_t i = 0; i < sizeBuf; i++)
+        buf[i] = max;
+}
+
+void eb_buf_random_u16_with_bd(uint16_t *const buf, const uint32_t sizeBuf,
+                               const uint32_t bd) {
+    assert(bd >= 8);
+
+    for (uint32_t i = 0; i < sizeBuf; i++)
+        buf[i] = (uint16_t)((uint32_t)rand() % (1 << bd));
+}
+
+void eb_buf_random_u16_with_max(uint16_t *const buf, const uint32_t sizeBuf,
+                                const uint32_t max) {
+    for (uint32_t i = 0; i < sizeBuf; i++)
+        buf[i] = (uint16_t)((uint32_t)rand() % (max + 1));
+}
+
+void eb_buf_random_s32(int32_t *const buf, const uint32_t sizeBuf) {
+    eb_buf_random_void(buf, sizeof(*buf) * sizeBuf);
+}
+
+void eb_buf_random_s32_with_max(int32_t *const buf, const uint32_t sizeBuf,
+                                const int32_t max) {
+    for (uint32_t i = 0; i < sizeBuf; i++)
+        buf[i] = (rand() & 1) ? max : -max;
+}
+
+void eb_buf_random_u32(uint32_t *const buf, const uint32_t sizeBuf) {
+    eb_buf_random_void(buf, sizeof(*buf) * sizeBuf);
+}
+
+void eb_buf_random_u32_with_max(uint32_t *const buf, const uint32_t sizeBuf,
+                                const uint32_t max) {
+    eb_buf_random_void(buf, sizeof(*buf) * sizeBuf);
+
+    for (uint32_t i = 0; i < sizeBuf; i++)
+        buf[i] %= (max + 1);
+}
+
+void eb_buf_random_s64(int64_t *const buf, const uint32_t sizeBuf) {
+    eb_buf_random_void(buf, sizeof(*buf) * sizeBuf);
+}
+
+void eb_buf_random_u64(uint64_t *const buf, const uint32_t sizeBuf) {
+    eb_buf_random_void(buf, sizeof(*buf) * sizeBuf);
+}
+
+void eb_buf_random_ptrdiff_with_max(ptrdiff_t *const buf,
+                                    const uint32_t sizeBuf,
+                                    const ptrdiff_t max) {
+    eb_buf_random_void(buf, sizeof(*buf) * sizeBuf);
+
+    for (uint32_t i = 0; i < sizeBuf; i++)
+        buf[i] %= (max + 1);
+}
+
+uint32_t eb_create_random_aligned_stride(const uint32_t width,
+                                         const uint32_t align) {
+    uint32_t stride;
+
+    eb_buf_random_u32_with_max(&stride, 1, 100);
+    stride += width + align;
+    stride -= stride % align;
+    return stride;
+}
+
+/***************************************
+ * Compare Data
+ ***************************************/
+#define BUF_COMPARE_FUNCTION(name, type)                         \
+    EbBool name(const type *const buf1,                          \
+                const type *const buf2,                          \
+                const size_t bufSize) {                          \
+        EbBool result = EB_TRUE;                                 \
+                                                                 \
+        for (uint32_t i = 0; i < bufSize; i++) {                 \
+            if (buf1[i] != buf2[i]) {                            \
+                printf("\nbuf1[%3d] = 0x%8x\tbuf2[%3d] = 0x%8x", \
+                       i,                                        \
+                       buf1[i],                                  \
+                       i,                                        \
+                       buf2[i]);                                 \
+                result = EB_FALSE;                               \
+            }                                                    \
+        }                                                        \
+                                                                 \
+        if (!result)                                             \
+            printf("\n\n");                                      \
+                                                                 \
+        return result;                                           \
+    }
+
+BUF_COMPARE_FUNCTION(eb_buf_compare_u8, uint8_t)
+BUF_COMPARE_FUNCTION(eb_buf_compare_s8, int8_t)
+BUF_COMPARE_FUNCTION(eb_buf_compare_u16, uint16_t)
+BUF_COMPARE_FUNCTION(eb_buf_compare_s16, int16_t)
+BUF_COMPARE_FUNCTION(eb_buf_compare_u32, uint32_t)
+BUF_COMPARE_FUNCTION(eb_buf_compare_s32, int32_t)
+
+#define IMAGE_COMPARE_FUNCTION(name, type)                                 \
+    EbBool name(const type *buf1,                                          \
+                const type *buf2,                                          \
+                const size_t width,                                        \
+                const size_t height,                                       \
+                const size_t stride) {                                     \
+        EbBool result = EB_TRUE;                                           \
+                                                                           \
+        buf1 -= stride;                                                    \
+        buf2 -= stride;                                                    \
+                                                                           \
+        for (int32_t i = -1; i < (int32_t)height + 1;                      \
+             i++, buf1 += stride, buf2 += stride) {                        \
+            for (uint32_t j = 0; j < stride; j++) {                        \
+                if (buf1[j] != buf2[j]) {                                  \
+                    printf("\nbuf1[%3d][%3d] = 0x%16" PRIx64               \
+                           "\tbuf2[%3d][%3d] = 0x%16" PRIx64,              \
+                           i,                                              \
+                           j,                                              \
+                           (uint64_t)buf1[j],                              \
+                           i,                                              \
+                           j,                                              \
+                           (uint64_t)buf2[j]);                             \
+                    if ((i < 0) || (i >= (int32_t)height) || (j >= width)) \
+                        printf(" (outside image)");                        \
+                    result = EB_FALSE;                                     \
+                }                                                          \
+            }                                                              \
+        }                                                                  \
+                                                                           \
+        if (!result)                                                       \
+            printf("\n\n");                                                \
+        return result;                                                     \
+    }
+
+IMAGE_COMPARE_FUNCTION(eb_image_compare_u8, uint8_t)
+IMAGE_COMPARE_FUNCTION(eb_image_compare_s8, int8_t)
+IMAGE_COMPARE_FUNCTION(eb_image_compare_u16, uint16_t)
+IMAGE_COMPARE_FUNCTION(eb_image_compare_s16, int16_t)
+IMAGE_COMPARE_FUNCTION(eb_image_compare_u32, uint32_t)
+IMAGE_COMPARE_FUNCTION(eb_image_compare_s32, int32_t)
+IMAGE_COMPARE_FUNCTION(eb_image_compare_u64, uint64_t)
+
+/***************************************
+ * Log Data
+ ***************************************/
+void eb_unit_test_log_s8(const char *const nameBuf, const int8_t *const buf,
+                         const uint32_t sizeBuf) {
+    printf("%16s = ", nameBuf);
+
+    if (sizeBuf == 1)
+        printf("%d\n", buf[0]);
+    else {
+        for (uint32_t i = 0; i < sizeBuf; i++) {
+            printf("%4d,", buf[i]);
+            if (!((i + 1) % 32))
+                printf("\n  ");
+        }
+        printf("\n");
+    }
+}
+
+void eb_unit_test_log_u8(const char *const nameBuf, const uint8_t *const buf,
+                         const uint32_t sizeBuf) {
+    printf("%16s = ", nameBuf);
+
+    if (sizeBuf == 1)
+        printf("%u\n", buf[0]);
+    else {
+        for (uint32_t i = 0; i < sizeBuf; i++) {
+            printf("%4u,", buf[i]);
+            if (!((i + 1) % 32))
+                printf("\n  ");
+        }
+        printf("\n");
+    }
+}
+
+void eb_unit_test_log_s16(const char *const nameBuf, const int16_t *const buf,
+                          const uint32_t sizeBuf) {
+    printf("%16s = ", nameBuf);
+
+    if (sizeBuf == 1)
+        printf("%d\n", buf[0]);
+    else {
+        for (uint32_t i = 0; i < sizeBuf; i++) {
+            printf("%10d,", buf[i]);
+            if (!((i + 1) % 32))
+                printf("\n  ");
+        }
+        printf("\n");
+    }
+}
+
+void eb_unit_test_log_u16(const char *const nameBuf, const uint16_t *const buf,
+                          const uint32_t sizeBuf) {
+    printf("%16s = ", nameBuf);
+
+    if (sizeBuf == 1)
+        printf("%d\n", buf[0]);
+    else {
+        for (uint32_t i = 0; i < sizeBuf; i++) {
+            printf("%10u,", buf[i]);
+            if (!((i + 1) % 32))
+                printf("\n  ");
+        }
+        printf("\n");
+    }
+}
+
+void eb_unit_test_log_s32(const char *const nameBuf, const int32_t *const buf,
+                          const uint32_t sizeBuf) {
+    printf("%16s = ", nameBuf);
+
+    if (sizeBuf == 1)
+        printf("%d\n", buf[0]);
+    else {
+        for (uint32_t i = 0; i < sizeBuf; i++) {
+            printf("%10d,", buf[i]);
+            if (!((i + 1) % 32))
+                printf("\n  ");
+        }
+        printf("\n");
+    }
+}
+
+void eb_unit_test_log_u32(const char *const nameBuf, const uint32_t *const buf,
+                          const uint32_t sizeBuf) {
+    printf("%16s = ", nameBuf);
+
+    if (sizeBuf == 1)
+        printf("%u\n", buf[0]);
+    else {
+        for (uint32_t i = 0; i < sizeBuf; i++) {
+            printf("%10u,", buf[i]);
+            if (!((i + 1) % 32))
+                printf("\n  ");
+        }
+        printf("\n");
+    }
+}
+
+void eb_unit_test_log_s64(const char *const nameBuf, const int64_t *const buf,
+                          const uint32_t sizeBuf) {
+    printf("%16s = ", nameBuf);
+
+    if (sizeBuf == 1)
+        printf("%" PRIx64 "\n", buf[0]);
+    else {
+        for (uint32_t i = 0; i < sizeBuf; i++) {
+            printf("%10" PRIx64 ",", buf[i]);
+            if (!((i + 1) % 32))
+                printf("\n  ");
+        }
+        printf("\n");
+    }
+}
+
+void eb_unit_test_log_u64(const char *const nameBuf, const uint64_t *const buf,
+                          const uint32_t sizeBuf) {
+    printf("%16s = ", nameBuf);
+
+    if (sizeBuf == 1)
+        printf("%" PRIu64 "\n", buf[0]);
+    else {
+        for (uint32_t i = 0; i < sizeBuf; i++) {
+            printf("%10" PRIu64 ",", buf[i]);
+            if (!((i + 1) % 32))
+                printf("\n  ");
+        }
+        printf("\n");
+    }
+}
+
+void eb_unit_test_log_ptrdiff(const char *const nameBuf,
+                              const ptrdiff_t *const buf,
+                              const uint32_t sizeBuf) {
+    printf("%16s = ", nameBuf);
+
+    if (sizeBuf == 1)
+        printf("%" PRIu64 "\n", buf[0]);
+    else {
+        for (uint32_t i = 0; i < sizeBuf; i++) {
+            printf("%10" PRIu64 ",", buf[i]);
+            if (!((i + 1) % 32))
+                printf("\n  ");
+        }
+        printf("\n");
+    }
+}
+
+void eb_unit_test_log_bool(const char *const nameBuf, const EbBool *const buf,
+                           const uint32_t sizeBuf) {
+    printf("%16s = ", nameBuf);
+
+    if (sizeBuf == 1)
+        printf("%u\n", buf[0]);
+    else {
+        for (uint32_t i = 0; i < sizeBuf; i++) {
+            printf("%10u,", buf[i]);
+            if (!((i + 1) % 32))
+                printf("\n  ");
+        }
+        printf("\n");
+    }
+}
+
+void eb_unit_test_log_double(const char *const nameBuf, const double *const buf,
+                             const uint32_t sizeBuf) {
+    printf("%16s = ", nameBuf);
+
+    if (sizeBuf == 1)
+        printf("%f\n", buf[0]);
+    else {
+        for (uint32_t i = 0; i < sizeBuf; i++) {
+            printf("%10f,", buf[i]);
+            if (!((i + 1) % 32))
+                printf("\n  ");
+        }
+        printf("\n");
+    }
+}
+
+#define LOG_IMAGE_FUNCTION(name, type)                \
+    void name(const char *const nameBuf,              \
+              const type *const buf,                  \
+              const uint32_t width,                   \
+              const uint32_t height,                  \
+              const ptrdiff_t stride) {               \
+        printf("%16s = ", nameBuf);                   \
+                                                      \
+        for (uint32_t i = 0; i < height; i++) {       \
+            for (uint32_t j = 0; j < width; j++)      \
+                printf("%10d,", buf[i * stride + j]); \
+            printf("\n  ");                           \
+        }                                             \
+                                                      \
+        printf("\n");                                 \
+    }
+
+LOG_IMAGE_FUNCTION(eb_unit_test_log_image_u8, uint8_t)
+LOG_IMAGE_FUNCTION(eb_unit_test_log_image_s16, int16_t)
+LOG_IMAGE_FUNCTION(eb_unit_test_log_image_u16, uint16_t)
+LOG_IMAGE_FUNCTION(eb_unit_test_log_image_s32, int32_t)
+LOG_IMAGE_FUNCTION(eb_unit_test_log_image_u32, uint32_t)

--- a/test/EbUnitTestUtility.h
+++ b/test/EbUnitTestUtility.h
@@ -1,0 +1,195 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
+#ifndef EbUnitTestUtility_h
+#define EbUnitTestUtility_h
+
+#include <stddef.h>
+#include <stdint.h>
+#include "EbDefinitions.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define Eb_UNIT_TEST_BUF_SIZE 0x04000000
+#define Eb_UNIT_TEST_BUF_ALIGN_BYTE 256
+#define Eb_UNIT_TEST_BUF_UNALIGN_BYTE 3
+#define NELEMENTS(x) (int)(sizeof(x) / sizeof(x[0]))
+
+extern void eb_buf_random_void(void *const buf, const uint32_t sizeBuf);
+extern void eb_buf_random_s8(int8_t *const buf, const uint32_t sizeBuf);
+extern void eb_buf_random_s8_with_max(int8_t *const buf, const uint32_t sizeBuf,
+                                      const uint8_t max);
+extern void eb_buf_random_u8(uint8_t *const buf, const uint32_t sizeBuf);
+extern void eb_buf_random_u8_to_0_or_255(uint8_t *const buf,
+                                         const uint32_t sizeBuf);
+extern void eb_buf_random_u8_to_255(uint8_t *const buf, const uint32_t sizeBuf);
+extern void eb_buf_random_u8_to_large(uint8_t *const buf,
+                                      const uint32_t sizeBuf);
+extern void eb_buf_random_u8_to_near_value(uint8_t *const buf,
+                                           const uint32_t sizeBuf,
+                                           const uint8_t val,
+                                           const uint32_t range);
+extern void eb_buf_random_u8_to_small(uint8_t *const buf,
+                                      const uint32_t sizeBuf);
+extern void eb_buf_random_u8_to_small_or_large(uint8_t *const buf,
+                                               const uint32_t sizeBuf);
+extern void eb_buf_random_u8_with_max(uint8_t *const buf,
+                                      const uint32_t sizeBuf,
+                                      const uint8_t max);
+extern void eb_buf_random_s16(int16_t *const buf, const uint32_t sizeBuf);
+extern void eb_buf_random_s16_to_bd(int16_t *const buf, const uint32_t sizeBuf,
+                                    const uint32_t bd);
+extern void eb_buf_random_s16_with_bd(int16_t *const buf,
+                                      const uint32_t sizeBuf,
+                                      const uint32_t bd);
+extern void eb_buf_random_s16_with_max(int16_t *const buf,
+                                       const uint32_t sizeBuf,
+                                       const uint16_t max);
+extern void eb_buf_random_u16(uint16_t *const buf, const uint32_t sizeBuf);
+extern void eb_buf_random_u16_to_0_or_1023(uint16_t *const buf,
+                                           const uint32_t sizeBuf);
+extern void eb_buf_random_u16_to_0_or_bd(uint16_t *const buf,
+                                         const uint32_t sizeBuf,
+                                         const uint32_t bd);
+extern void eb_buf_random_u16_to_bd(uint16_t *const buf, const uint32_t sizeBuf,
+                                    const uint32_t bd);
+extern void eb_buf_random_u16_with_bd(uint16_t *const buf,
+                                      const uint32_t sizeBuf,
+                                      const uint32_t bd);
+extern void eb_buf_random_u16_with_max(uint16_t *const buf,
+                                       const uint32_t sizeBuf,
+                                       const uint32_t max);
+extern void eb_buf_random_s32(int32_t *const buf, const uint32_t sizeBuf);
+extern void eb_buf_random_s32_with_max(int32_t *const buf,
+                                       const uint32_t sizeBuf,
+                                       const int32_t max);
+extern void eb_buf_random_u32(uint32_t *const buf, const uint32_t sizeBuf);
+extern void eb_buf_random_u32_with_max(uint32_t *const buf,
+                                       const uint32_t sizeBuf,
+                                       const uint32_t max);
+extern void eb_buf_random_s64(int64_t *const buf, const uint32_t sizeBuf);
+extern void eb_buf_random_u64(uint64_t *const buf, const uint32_t sizeBuf);
+extern void eb_buf_random_ptrdiff_with_max(ptrdiff_t *const buf,
+                                           const uint32_t sizeBuf,
+                                           const ptrdiff_t max);
+
+extern uint32_t eb_create_random_aligned_stride(const uint32_t width,
+                                                const uint32_t align);
+
+extern EbBool eb_buf_compare_u8(const uint8_t *const buf1,
+                                const uint8_t *const buf2,
+                                const size_t bufSize);
+extern EbBool eb_buf_compare_s8(const int8_t *const buf1,
+                                const int8_t *const buf2, const size_t bufSize);
+extern EbBool eb_buf_compare_u16(const uint16_t *const buf1,
+                                 const uint16_t *const buf2,
+                                 const size_t bufSize);
+extern EbBool eb_buf_compare_s16(const int16_t *const buf1,
+                                 const int16_t *const buf2,
+                                 const size_t bufSize);
+extern EbBool eb_buf_compare_u32(const uint32_t *const buf1,
+                                 const uint32_t *const buf2,
+                                 const size_t bufSize);
+extern EbBool eb_buf_compare_s32(const int32_t *const buf1,
+                                 const int32_t *const buf2,
+                                 const size_t bufSize);
+
+extern EbBool eb_image_compare_u8(const uint8_t *buf1, const uint8_t *buf2,
+                                  const size_t width, const size_t height,
+                                  const size_t stride);
+extern EbBool eb_image_compare_s8(const int8_t *buf1, const int8_t *buf2,
+                                  const size_t width, const size_t height,
+                                  const size_t stride);
+extern EbBool eb_image_compare_u16(const uint16_t *buf1, const uint16_t *buf2,
+                                   const size_t width, const size_t height,
+                                   const size_t stride);
+extern EbBool eb_image_compare_s16(const int16_t *buf1, const int16_t *buf2,
+                                   const size_t width, const size_t height,
+                                   const size_t stride);
+extern EbBool eb_image_compare_u32(const uint32_t *buf1, const uint32_t *buf2,
+                                   const size_t width, const size_t height,
+                                   const size_t stride);
+extern EbBool eb_image_compare_s32(const int32_t *buf1, const int32_t *buf2,
+                                   const size_t width, const size_t height,
+                                   const size_t stride);
+extern EbBool eb_image_compare_u64(const uint64_t *buf1, const uint64_t *buf2,
+                                   const size_t width, const size_t height,
+                                   const size_t stride);
+
+extern void eb_unit_test_log_s8(const char *const nameBuf,
+                                const int8_t *const buf,
+                                const uint32_t sizeBuf);
+extern void eb_unit_test_log_u8(const char *const nameBuf,
+                                const uint8_t *const buf,
+                                const uint32_t sizeBuf);
+extern void eb_unit_test_log_s16(const char *const nameBuf,
+                                 const int16_t *const buf,
+                                 const uint32_t sizeBuf);
+extern void eb_unit_test_log_u16(const char *const nameBuf,
+                                 const uint16_t *const buf,
+                                 const uint32_t sizeBuf);
+extern void eb_unit_test_log_s32(const char *const nameBuf,
+                                 const int32_t *const buf,
+                                 const uint32_t sizeBuf);
+extern void eb_unit_test_log_u32(const char *const nameBuf,
+                                 const uint32_t *const buf,
+                                 const uint32_t sizeBuf);
+extern void eb_unit_test_log_s64(const char *const nameBuf,
+                                 const int64_t *const buf,
+                                 const uint32_t sizeBuf);
+extern void eb_unit_test_log_u64(const char *const nameBuf,
+                                 const uint64_t *const buf,
+                                 const uint32_t sizeBuf);
+extern void eb_unit_test_log_ptrdiff(const char *const nameBuf,
+                                     const ptrdiff_t *const buf,
+                                     const uint32_t sizeBuf);
+extern void eb_unit_test_log_bool(const char *const nameBuf,
+                                  const EbBool *const buf,
+                                  const uint32_t sizeBuf);
+extern void eb_unit_test_log_double(const char *const nameBuf,
+                                    const double *const buf,
+                                    const uint32_t sizeBuf);
+
+extern void eb_unit_test_log_image_u8(const char *const nameBuf,
+                                      const uint8_t *const buf,
+                                      const uint32_t width,
+                                      const uint32_t height,
+                                      const ptrdiff_t stride);
+extern void eb_unit_test_log_image_s16(const char *const nameBuf,
+                                       const int16_t *const buf,
+                                       const uint32_t width,
+                                       const uint32_t height,
+                                       const ptrdiff_t stride);
+extern void eb_unit_test_log_image_u16(const char *const nameBuf,
+                                       const uint16_t *const buf,
+                                       const uint32_t width,
+                                       const uint32_t height,
+                                       const ptrdiff_t stride);
+extern void eb_unit_test_log_image_s32(const char *const nameBuf,
+                                       const int32_t *const buf,
+                                       const uint32_t width,
+                                       const uint32_t height,
+                                       const ptrdiff_t stride);
+extern void eb_unit_test_log_image_u32(const char *const nameBuf,
+                                       const uint32_t *const buf,
+                                       const uint32_t width,
+                                       const uint32_t height,
+                                       const ptrdiff_t stride);
+
+extern void EbStartTime(uint64_t *Startseconds, uint64_t *Startuseconds);
+extern void EbFinishTime(uint64_t *Finishseconds, uint64_t *Finishuseconds);
+extern void EbComputeOverallElapsedTimeMs(uint64_t Startseconds,
+                                          uint64_t Startuseconds,
+                                          uint64_t Finishseconds,
+                                          uint64_t Finishuseconds,
+                                          double *duration);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // EbUnitTestUtility_h

--- a/test/RestorationPickTest.cc
+++ b/test/RestorationPickTest.cc
@@ -1,0 +1,565 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
+#include "gtest/gtest.h"
+#include "aom_dsp_rtcd.h"
+#include "EbDefinitions.h"
+#include "EbRestoration.h"
+#include "EbUnitTestUtility.h"
+
+#include <immintrin.h>  // AVX2
+#include "synonyms.h"
+#include "synonyms_avx2.h"
+#include "EbPictureOperators_AVX2.h"
+#include "EbRestorationPick.h"
+
+static const int32_t sizes[2] = {RESTORATION_UNITSIZE_MAX,
+                                 RESTORATION_UNITSIZE_MAX * 3 / 2};
+
+static const int32_t wins[3] = {WIENER_WIN_3TAP, WIENER_WIN_CHROMA, WIENER_WIN};
+
+static void init_data(uint8_t **dgd, int32_t *dgd_stride, uint8_t **src,
+                      int32_t *src_stride, const int idx) {
+    *dgd_stride =
+        eb_create_random_aligned_stride(2 * RESTORATION_UNITSIZE_MAX, 64);
+    *src_stride =
+        eb_create_random_aligned_stride(2 * RESTORATION_UNITSIZE_MAX, 64);
+    *dgd = (uint8_t *)malloc(sizeof(**dgd) * 2 * RESTORATION_UNITSIZE_MAX *
+                             *dgd_stride);
+    *src = (uint8_t *)malloc(sizeof(**src) * 2 * RESTORATION_UNITSIZE_MAX *
+                             *src_stride);
+
+    if (!idx) {
+        memset(*dgd,
+               0,
+               sizeof(**dgd) * 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride);
+        memset(*src,
+               0,
+               sizeof(**src) * 2 * RESTORATION_UNITSIZE_MAX * *src_stride);
+    } else if (1 == idx) {
+        eb_buf_random_u8_to_255(*dgd,
+                                2 * RESTORATION_UNITSIZE_MAX * *dgd_stride);
+        eb_buf_random_u8_to_255(*src,
+                                2 * RESTORATION_UNITSIZE_MAX * *src_stride);
+    } else if (2 == idx) {
+        eb_buf_random_u8_to_255(*dgd,
+                                2 * RESTORATION_UNITSIZE_MAX * *dgd_stride);
+        memset(*src,
+               0,
+               sizeof(**src) * 2 * RESTORATION_UNITSIZE_MAX * *src_stride);
+    } else if (3 == idx) {
+        memset(*dgd,
+               0,
+               sizeof(**dgd) * 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride);
+        eb_buf_random_u8_to_255(*src,
+                                2 * RESTORATION_UNITSIZE_MAX * *src_stride);
+    } else if (4 == idx) {
+        eb_buf_random_u8_to_0_or_255(
+            *dgd, 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride);
+        eb_buf_random_u8_to_0_or_255(
+            *src, 2 * RESTORATION_UNITSIZE_MAX * *src_stride);
+    } else {
+        eb_buf_random_u8(*dgd, 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride);
+        eb_buf_random_u8(*src, 2 * RESTORATION_UNITSIZE_MAX * *src_stride);
+    }
+}
+
+static void init_data_highbd(uint16_t **dgd, int32_t *dgd_stride,
+                             uint16_t **src, int32_t *src_stride,
+                             const AomBitDepth bd, const int idx) {
+    *dgd_stride =
+        eb_create_random_aligned_stride(2 * RESTORATION_UNITSIZE_MAX, 64);
+    *src_stride =
+        eb_create_random_aligned_stride(2 * RESTORATION_UNITSIZE_MAX, 64);
+    *dgd = (uint16_t *)malloc(sizeof(**dgd) * 2 * RESTORATION_UNITSIZE_MAX *
+                              *dgd_stride);
+    *src = (uint16_t *)malloc(sizeof(**src) * 2 * RESTORATION_UNITSIZE_MAX *
+                              *src_stride);
+
+    if (!idx) {
+        memset(*dgd,
+               0,
+               sizeof(**dgd) * 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride);
+        memset(*src,
+               0,
+               sizeof(**src) * 2 * RESTORATION_UNITSIZE_MAX * *src_stride);
+    } else if (1 == idx) {
+        eb_buf_random_u16_to_bd(
+            *dgd, 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride, bd);
+        eb_buf_random_u16_to_bd(
+            *src, 2 * RESTORATION_UNITSIZE_MAX * *src_stride, bd);
+    } else if (2 == idx) {
+        eb_buf_random_u16_to_bd(
+            *dgd, 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride, bd);
+        memset(*src,
+               0,
+               sizeof(**src) * 2 * RESTORATION_UNITSIZE_MAX * *src_stride);
+    } else if (3 == idx) {
+        memset(*dgd,
+               0,
+               sizeof(**dgd) * 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride);
+        eb_buf_random_u16_to_bd(
+            *src, 2 * RESTORATION_UNITSIZE_MAX * *src_stride, bd);
+    } else if (4 == idx) {
+        eb_buf_random_u16_to_0_or_bd(
+            *dgd, 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride, bd);
+        eb_buf_random_u16_to_0_or_bd(
+            *src, 2 * RESTORATION_UNITSIZE_MAX * *src_stride, bd);
+    } else if (5 == idx) {
+        // Trigger the 32-bit overflow in Step 3 and 4 for AOM_BITS_12.
+        eb_buf_random_u16_to_bd(
+            *dgd, 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride, bd);
+        for (int i = 0; i < 2 * RESTORATION_UNITSIZE_MAX; i++) {
+            memset(*dgd + i * *dgd_stride, 0, sizeof(**dgd) * 20);
+        }
+        memset(*src,
+               0,
+               sizeof(**src) * 2 * RESTORATION_UNITSIZE_MAX * *src_stride);
+    } else if (6 == idx) {
+        // Trigger the 32-bit overflow in Step 5 and 6 for AOM_BITS_12.
+        eb_buf_random_u16_to_bd(
+            *dgd, 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride, bd);
+        memset(*dgd, 0, sizeof(**dgd) * 2 * RESTORATION_UNITSIZE_MAX * 20);
+        memset(*src,
+               0,
+               sizeof(**src) * 2 * RESTORATION_UNITSIZE_MAX * *src_stride);
+    } else {
+        eb_buf_random_u16_with_bd(
+            *dgd, 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride, bd);
+        eb_buf_random_u16_with_bd(
+            *src, 2 * RESTORATION_UNITSIZE_MAX * *src_stride, bd);
+    }
+}
+
+static void uninit_data(uint8_t *dgd, uint8_t *src) {
+    free(dgd);
+    free(src);
+}
+
+static void uninit_data_highbd(uint16_t *dgd, uint16_t *src) {
+    free(dgd);
+    free(src);
+}
+
+static void init_output(int64_t M_org[WIENER_WIN2], int64_t M_opt[WIENER_WIN2],
+                        int64_t H_org[WIENER_WIN2 * WIENER_WIN2],
+                        int64_t H_opt[WIENER_WIN2 * WIENER_WIN2]) {
+    eb_buf_random_s64(M_org, WIENER_WIN2);
+    eb_buf_random_s64(M_opt, WIENER_WIN2);
+    eb_buf_random_s64(H_org, WIENER_WIN2 * WIENER_WIN2);
+    eb_buf_random_s64(H_opt, WIENER_WIN2 * WIENER_WIN2);
+    memcpy(M_opt, M_org, sizeof(*M_org) * WIENER_WIN2);
+    memcpy(H_opt, H_org, sizeof(*H_org) * WIENER_WIN2 * WIENER_WIN2);
+}
+
+TEST(EbRestorationPick, compute_stats) {
+    uint8_t *dgd, *src;
+    int32_t dgd_stride, src_stride;
+    int64_t M_org[WIENER_WIN2], M_opt[WIENER_WIN2];
+    int64_t H_org[WIENER_WIN2 * WIENER_WIN2], H_opt[WIENER_WIN2 * WIENER_WIN2];
+
+    init_output(M_org, M_opt, H_org, H_opt);
+
+    for (int i = 0; i < 2; i++) {
+        for (int j = 0; j < 6; j++) {
+            init_data(&dgd, &dgd_stride, &src, &src_stride, j);
+            uint8_t *const d = dgd + WIENER_WIN * dgd_stride;
+            uint8_t *const s = src + WIENER_WIN * src_stride;
+
+            for (int wn_filter_mode = 0; wn_filter_mode <= 2;
+                 wn_filter_mode++) {
+                for (int plane = 0; plane <= 1; plane++) {
+                    const int32_t wn_luma = wn_filter_mode == 1
+                                                ? WIENER_WIN_3TAP
+                                                : wn_filter_mode == 2
+                                                      ? WIENER_WIN_CHROMA
+                                                      : WIENER_WIN;
+                    const int32_t wiener_win = wn_filter_mode == 1
+                                                   ? WIENER_WIN_3TAP
+                                                   : (plane == AOM_PLANE_Y)
+                                                         ? wn_luma
+                                                         : WIENER_WIN_CHROMA;
+
+                    for (int start = 0; start <= 2; start += 2) {
+                        const int32_t h_start = start;
+                        const int32_t v_start = start;
+
+                        for (int end = 0; end < 32; end += 2) {
+                            const int32_t h_end =
+                                RESTORATION_UNITSIZE_MAX * 3 / 2 + end;
+                            const int32_t v_end =
+                                RESTORATION_UNITSIZE_MAX * 3 / 2 + end;
+
+                            av1_compute_stats_c(wiener_win,
+                                                d,
+                                                s,
+                                                h_start,
+                                                h_end,
+                                                v_start,
+                                                v_end,
+                                                dgd_stride,
+                                                src_stride,
+                                                M_org,
+                                                H_org);
+                            av1_compute_stats_avx2(wiener_win,
+                                                   d,
+                                                   s,
+                                                   h_start,
+                                                   h_end,
+                                                   v_start,
+                                                   v_end,
+                                                   dgd_stride,
+                                                   src_stride,
+                                                   M_opt,
+                                                   H_opt);
+
+                            for (int idx = 0; idx < WIENER_WIN2; idx++) {
+                                if (M_org[idx] != M_opt[idx]) {
+                                    printf(
+                                        "\n M: width = %d, height = %d, "
+                                        "wiener_win=%d, idx=%d, [%d, %d]",
+                                        h_end - h_start,
+                                        v_end - v_start,
+                                        wiener_win,
+                                        idx,
+                                        idx / (wiener_win * wiener_win),
+                                        idx % (wiener_win * wiener_win));
+                                }
+                                EXPECT_EQ(M_org[idx], M_opt[idx]);
+                            }
+                            for (int idx = 0; idx < WIENER_WIN2 * WIENER_WIN2;
+                                 idx++) {
+                                if (H_org[idx] != H_opt[idx]) {
+                                    printf(
+                                        "\n H: width = %d, height = %d, "
+                                        "wiener_win=%d, idx=%d, [%d, %d]",
+                                        h_end - h_start,
+                                        v_end - v_start,
+                                        wiener_win,
+                                        idx,
+                                        idx / (wiener_win * wiener_win),
+                                        idx % (wiener_win * wiener_win));
+                                }
+                                EXPECT_EQ(H_org[idx], H_opt[idx]);
+                            }
+                        }
+                    }
+                }
+            }
+
+            uninit_data(dgd, src);
+        }
+    }
+}
+
+TEST(EbRestorationPick, compute_stats_highbd) {
+    uint16_t *dgd, *src;
+    int32_t dgd_stride, src_stride;
+    int64_t M_org[WIENER_WIN2], M_opt[WIENER_WIN2];
+    int64_t H_org[WIENER_WIN2 * WIENER_WIN2], H_opt[WIENER_WIN2 * WIENER_WIN2];
+
+    init_output(M_org, M_opt, H_org, H_opt);
+
+    for (int bd = AOM_BITS_8; bd <= AOM_BITS_12; bd += 2) {
+        const AomBitDepth bit_depth = (AomBitDepth)bd;
+
+        for (int i = 0; i < 2; i++) {
+            for (int j = 0; j < 8; j++) {
+                init_data_highbd(
+                    &dgd, &dgd_stride, &src, &src_stride, bit_depth, j);
+                const uint16_t *const d =
+                    dgd + WIENER_WIN * dgd_stride + WIENER_WIN;
+                const uint16_t *const s =
+                    src + WIENER_WIN * src_stride + WIENER_WIN;
+                const uint8_t *const dgd8 = CONVERT_TO_BYTEPTR(d);
+                const uint8_t *const src8 = CONVERT_TO_BYTEPTR(s);
+
+                for (int wn_filter_mode = 0; wn_filter_mode <= 2;
+                     wn_filter_mode++) {
+                    for (int plane = 0; plane <= 1; plane++) {
+                        const int32_t wn_luma = wn_filter_mode == 1
+                                                    ? WIENER_WIN_3TAP
+                                                    : wn_filter_mode == 2
+                                                          ? WIENER_WIN_CHROMA
+                                                          : WIENER_WIN;
+                        const int32_t wiener_win =
+                            wn_filter_mode == 1
+                                ? WIENER_WIN_3TAP
+                                : (plane == AOM_PLANE_Y) ? wn_luma
+                                                         : WIENER_WIN_CHROMA;
+
+                        for (int size_mode = 0; size_mode < 2; size_mode++) {
+                            for (int start = 0; start <= 2; start += 2) {
+                                const int32_t h_start = start;
+                                const int32_t v_start = start;
+
+                                for (int end = 0; end <= 2; end += 2) {
+                                    const int32_t h_end =
+                                        sizes[size_mode] + end;
+                                    const int32_t v_end =
+                                        sizes[size_mode] + end;
+
+                                    av1_compute_stats_highbd_c(wiener_win,
+                                                               dgd8,
+                                                               src8,
+                                                               h_start,
+                                                               h_end,
+                                                               v_start,
+                                                               v_end,
+                                                               dgd_stride,
+                                                               src_stride,
+                                                               M_org,
+                                                               H_org,
+                                                               bit_depth);
+                                    av1_compute_stats_highbd_avx2(wiener_win,
+                                                                  dgd8,
+                                                                  src8,
+                                                                  h_start,
+                                                                  h_end,
+                                                                  v_start,
+                                                                  v_end,
+                                                                  dgd_stride,
+                                                                  src_stride,
+                                                                  M_opt,
+                                                                  H_opt,
+                                                                  bit_depth);
+
+                                    for (int idx = 0; idx < WIENER_WIN2;
+                                         idx++) {
+                                        if (M_org[idx] != M_opt[idx]) {
+                                            printf(
+                                                "\n M: bd=%d, width = %d, "
+                                                "height = %d, wiener_win=%d, "
+                                                "idx=%d, [%d, %d]",
+                                                bd,
+                                                h_end - h_start,
+                                                v_end - v_start,
+                                                wiener_win,
+                                                idx,
+                                                idx / (wiener_win * wiener_win),
+                                                idx %
+                                                    (wiener_win * wiener_win));
+                                        }
+                                        EXPECT_EQ(M_org[idx], M_opt[idx]);
+                                    }
+                                    for (int idx = 0;
+                                         idx < WIENER_WIN2 * WIENER_WIN2;
+                                         idx++) {
+                                        if (H_org[idx] != H_opt[idx]) {
+                                            printf(
+                                                "\n H: bd=%d, width = %d, "
+                                                "height = %d, wiener_win=%d, "
+                                                "idx=%d, [%d, %d]",
+                                                bd,
+                                                h_end - h_start,
+                                                v_end - v_start,
+                                                wiener_win,
+                                                idx,
+                                                idx / (wiener_win * wiener_win),
+                                                idx %
+                                                    (wiener_win * wiener_win));
+                                        }
+                                        EXPECT_EQ(H_org[idx], H_opt[idx]);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                uninit_data_highbd(dgd, src);
+            }
+        }
+    }
+}
+
+#if 0
+
+TEST(EbRestorationPick, compute_stats_speed) {
+    uint8_t *dgd, *src;
+    int32_t dgd_stride, src_stride;
+    int64_t M_org[WIENER_WIN2], M_opt[WIENER_WIN2];
+    int64_t H_org[WIENER_WIN2 * WIENER_WIN2], H_opt[WIENER_WIN2 * WIENER_WIN2];
+    bool result = EB_TRUE;
+    double time_c, time_o;
+    uint64_t start_time_seconds, start_time_useconds;
+    uint64_t middle_time_seconds, middle_time_useconds;
+    uint64_t finish_time_seconds, finish_time_useconds;
+
+    init_output(M_org, M_opt, H_org, H_opt);
+    init_data(&dgd, &dgd_stride, &src, &src_stride, 5);
+    uint8_t *const d = dgd + WIENER_WIN * dgd_stride;
+    uint8_t *const s = src + WIENER_WIN * src_stride;
+    const int32_t h_start = 0;
+    const int32_t v_start = 0;
+    const int32_t h_end = RESTORATION_UNITSIZE_MAX;
+    const int32_t v_end = RESTORATION_UNITSIZE_MAX;
+
+    for (int j = 0; j < 3; j++) {
+        const int32_t wiener_win = wins[j];
+        const uint64_t num_loop = 100000 / (wiener_win * wiener_win);
+
+        EbStartTime(&start_time_seconds, &start_time_useconds);
+
+        for (uint64_t i = 0; i < num_loop; i++) {
+            av1_compute_stats_c(wiener_win,
+                                d,
+                                s,
+                                h_start,
+                                h_end,
+                                v_start,
+                                v_end,
+                                dgd_stride,
+                                src_stride,
+                                M_org,
+                                H_org);
+        }
+
+        EbStartTime(&middle_time_seconds, &middle_time_useconds);
+
+        for (uint64_t i = 0; i < num_loop; i++) {
+            av1_compute_stats_avx2(wiener_win,
+                                   d,
+                                   s,
+                                   h_start,
+                                   h_end,
+                                   v_start,
+                                   v_end,
+                                   dgd_stride,
+                                   src_stride,
+                                   M_opt,
+                                   H_opt);
+        }
+
+        EbStartTime(&finish_time_seconds, &finish_time_useconds);
+        EbComputeOverallElapsedTimeMs(start_time_seconds,
+                                      start_time_useconds,
+                                      middle_time_seconds,
+                                      middle_time_useconds,
+                                      &time_c);
+        EbComputeOverallElapsedTimeMs(middle_time_seconds,
+                                      middle_time_useconds,
+                                      finish_time_seconds,
+                                      finish_time_useconds,
+                                      &time_o);
+
+        for (int idx = 0; idx < WIENER_WIN2; idx++) {
+            EXPECT_EQ(M_org[idx], M_opt[idx]);
+        }
+        for (int idx = 0; idx < WIENER_WIN2 * WIENER_WIN2; idx++) {
+            EXPECT_EQ(H_org[idx], H_opt[idx]);
+        }
+
+        printf("Average Nanoseconds per Function Call\n");
+        printf("    av1_compute_stats_avx2(%d)   : %6.2f\n",
+               wiener_win,
+               1000000 * time_c / num_loop);
+        printf(
+            "    av1_compute_stats_avx512(%d) : %6.2f   (Comparison: "
+            "%5.2fx)\n",
+            wiener_win,
+            1000000 * time_o / num_loop,
+            time_c / time_o);
+    }
+}
+
+TEST(EbRestorationPick, compute_stats_highbd_speed) {
+    uint16_t *dgd, *src;
+    int32_t dgd_stride, src_stride;
+    int64_t M_org[WIENER_WIN2], M_opt[WIENER_WIN2];
+    int64_t H_org[WIENER_WIN2 * WIENER_WIN2], H_opt[WIENER_WIN2 * WIENER_WIN2];
+    bool result = EB_TRUE;
+    double time_c, time_o;
+    uint64_t start_time_seconds, start_time_useconds;
+    uint64_t middle_time_seconds, middle_time_useconds;
+    uint64_t finish_time_seconds, finish_time_useconds;
+
+    init_output(M_org, M_opt, H_org, H_opt);
+    const int32_t h_start = 0;
+    const int32_t v_start = 0;
+    const int32_t h_end = RESTORATION_UNITSIZE_MAX;
+    const int32_t v_end = RESTORATION_UNITSIZE_MAX;
+
+    for (int bd = AOM_BITS_8; bd <= AOM_BITS_12; bd += 2) {
+        const AomBitDepth bit_depth = (AomBitDepth)bd;
+        init_data_highbd(&dgd, &dgd_stride, &src, &src_stride, bit_depth, 7);
+        uint16_t *const d = dgd + WIENER_WIN * dgd_stride;
+        uint16_t *const s = src + WIENER_WIN * src_stride;
+        const uint8_t *const dgd8 = CONVERT_TO_BYTEPTR(d);
+        const uint8_t *const src8 = CONVERT_TO_BYTEPTR(s);
+
+        for (int j = 0; j < 3; j++) {
+            const int32_t wiener_win = wins[j];
+            const uint64_t num_loop = 1000000 / (wiener_win * wiener_win);
+
+            EbStartTime(&start_time_seconds, &start_time_useconds);
+
+            for (uint64_t i = 0; i < num_loop; i++) {
+                av1_compute_stats_highbd_c(wiener_win,
+                                           dgd8,
+                                           src8,
+                                           h_start,
+                                           h_end,
+                                           v_start,
+                                           v_end,
+                                           dgd_stride,
+                                           src_stride,
+                                           M_org,
+                                           H_org,
+                                           bit_depth);
+            }
+
+            EbStartTime(&middle_time_seconds, &middle_time_useconds);
+
+            for (uint64_t i = 0; i < num_loop; i++) {
+                av1_compute_stats_highbd_avx2(wiener_win,
+                                              dgd8,
+                                              src8,
+                                              h_start,
+                                              h_end,
+                                              v_start,
+                                              v_end,
+                                              dgd_stride,
+                                              src_stride,
+                                              M_opt,
+                                              H_opt,
+                                              bit_depth);
+            }
+
+            EbStartTime(&finish_time_seconds, &finish_time_useconds);
+            EbComputeOverallElapsedTimeMs(start_time_seconds,
+                                          start_time_useconds,
+                                          middle_time_seconds,
+                                          middle_time_useconds,
+                                          &time_c);
+            EbComputeOverallElapsedTimeMs(middle_time_seconds,
+                                          middle_time_useconds,
+                                          finish_time_seconds,
+                                          finish_time_useconds,
+                                          &time_o);
+
+            for (int idx = 0; idx < WIENER_WIN2; idx++) {
+                EXPECT_EQ(M_org[idx], M_opt[idx]);
+            }
+            for (int idx = 0; idx < WIENER_WIN2 * WIENER_WIN2; idx++) {
+                EXPECT_EQ(H_org[idx], H_opt[idx]);
+            }
+
+            printf("Average Nanoseconds per Function Call\n");
+            printf("    av1_compute_stats_highbd_avx2(%d)   : %6.2f\n",
+                   wiener_win,
+                   1000000 * time_c / num_loop);
+            printf(
+                "    av1_compute_stats_highbd_avx512(%d) : %6.2f   "
+                "(Comparison: "
+                "%5.2fx)\n",
+                wiener_win,
+                1000000 * time_o / num_loop,
+                time_c / time_o);
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
## Description
Redo weiner filter avx2 optimizations, and add unit test code.

## Expected gain per kernel
Speedup against original c and avx2 functions (low bitdepth):
TAP 3:  66x 17x
TAP 5: 125x 21x
TAP 7: 188x 20x

Speedup against original c and avx2 functions (high bitdepth):
8-bit
TAP 3:  57x N/A
TAP 5: 113x 59x
TAP 7: 167x 65x

10-bit or 12-bit
TAP 3:  41x N/A
TAP 5:  80x 42x
TAP 7: 128x 50x

Associated with Issue #262
