### PR TITLE
Adding support for segmentation

### DIFF
--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -113,7 +113,6 @@ typedef struct EbSvtAv1EncConfiguration
      *
      * Default is 0. */
     uint32_t                 frame_rate_numerator;
-
     /* Frame rate denominator. When zero, the encoder will use -fps if
      * FrameRateNumerator is also zero, otherwise an error is returned.
      *
@@ -281,10 +280,17 @@ typedef struct EbSvtAv1EncConfiguration
      *
      * Default is 0. */
     uint32_t                 min_qp_allowed;
+
     /* Flag to signal the content being a screen sharing content type
     *
     * Default is 2. */
     uint32_t                 screen_content_mode;
+
+    /* Enable adaptive quantization within a frame using segmentation.
+     *
+     * Default is FALSE. */
+     EbBool                 enable_adaptive_quantization;
+
     // Tresholds
     /* Flag to signal that the input yuv is HDR10 BT2020 using SMPTE ST2048, requires
      *

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -88,6 +88,7 @@
 #define TARGET_BIT_RATE_TOKEN           "-tbr"
 #define MAX_QP_TOKEN                    "-max-qp"
 #define MIN_QP_TOKEN                    "-min-qp"
+#define ADAPTIVE_QP_ENABLE_TOKEN        "-adaptive-quantization"
 #define LOOK_AHEAD_DIST_TOKEN           "-lad"
 #define SUPER_BLOCK_SIZE_TOKEN          "-sb-size"
 #define TILE_ROW_TOKEN                   "-tile-rows"
@@ -197,6 +198,7 @@ static void SetRateControlMode                  (const char *value, EbConfig *cf
 static void SetTargetBitRate                    (const char *value, EbConfig *cfg) {cfg->target_bit_rate = strtoul(value, NULL, 0);};
 static void SetMaxQpAllowed                     (const char *value, EbConfig *cfg) {cfg->max_qp_allowed = strtoul(value, NULL, 0);};
 static void SetMinQpAllowed                     (const char *value, EbConfig *cfg) {cfg->min_qp_allowed = strtoul(value, NULL, 0);};
+static void SetAdaptiveQuantization             (const char *value, EbConfig *cfg) {cfg->enable_adaptive_quantization = (EbBool)strtol(value,  NULL, 0);};
 static void SetEnableHmeLevel1Flag              (const char *value, EbConfig *cfg) {cfg->enable_hme_level1_flag  = (EbBool)strtoul(value, NULL, 0);};
 static void SetEnableHmeLevel2Flag              (const char *value, EbConfig *cfg) {cfg->enable_hme_level2_flag  = (EbBool)strtoul(value, NULL, 0);};
 static void SetCfgSearchAreaWidth               (const char *value, EbConfig *cfg) {cfg->search_area_width = strtoul(value, NULL, 0);};
@@ -227,6 +229,7 @@ static void SetHighDynamicRangeInput            (const char *value, EbConfig *cf
 static void SetProfile                          (const char *value, EbConfig *cfg) {cfg->profile                          = strtol(value,  NULL, 0);};
 static void SetTier                             (const char *value, EbConfig *cfg) {cfg->tier                             = strtol(value,  NULL, 0);};
 static void SetLevel                            (const char *value, EbConfig *cfg) {
+
     if (strtoul( value, NULL,0) != 0 || EB_STRCMP(value, "0") == 0 )
         cfg->level = (uint32_t)(10*strtod(value,  NULL));
     else
@@ -303,6 +306,8 @@ config_entry_t config_entry[] = {
     { SINGLE_INPUT, TARGET_BIT_RATE_TOKEN, "TargetBitRate", SetTargetBitRate },
     { SINGLE_INPUT, MAX_QP_TOKEN, "MaxQpAllowed", SetMaxQpAllowed },
     { SINGLE_INPUT, MIN_QP_TOKEN, "MinQpAllowed", SetMinQpAllowed },
+    { SINGLE_INPUT, ADAPTIVE_QP_ENABLE_TOKEN, "AdaptiveQuantization", SetAdaptiveQuantization },
+
     // DLF
     { SINGLE_INPUT, LOOP_FILTER_DISABLE_TOKEN, "LoopFilterDisable", SetDisableDlfFlag },
     // LOCAL WARPED MOTION
@@ -407,6 +412,8 @@ void eb_config_ctor(EbConfig *config_ptr)
 #else
     config_ptr->min_qp_allowed                       = 0;
 #endif
+
+    config_ptr->enable_adaptive_quantization         = EB_FALSE;
     config_ptr->base_layer_switch_mode               = 0;
     config_ptr->enc_mode                              = MAX_ENC_PRESET;
     config_ptr->intra_period                          = -2;

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -286,6 +286,8 @@ typedef struct EbConfig
     uint32_t                 max_qp_allowed;
     uint32_t                 min_qp_allowed;
 
+    EbBool                 enable_adaptive_quantization;
+
     /****************************************
      * Optional Features
      ****************************************/

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -173,6 +173,7 @@ EbErrorType CopyConfigurationParameters(
     callback_data->eb_enc_parameters.target_bit_rate = config->target_bit_rate;
     callback_data->eb_enc_parameters.max_qp_allowed = config->max_qp_allowed;
     callback_data->eb_enc_parameters.min_qp_allowed = config->min_qp_allowed;
+    callback_data->eb_enc_parameters.enable_adaptive_quantization = (EbBool)config->enable_adaptive_quantization;
     callback_data->eb_enc_parameters.qp = config->qp;
     callback_data->eb_enc_parameters.use_qp_file = (EbBool)config->use_qp_file;
     callback_data->eb_enc_parameters.disable_dlf_flag = (EbBool)config->disable_dlf_flag;

--- a/Source/Lib/Common/Codec/EbCabacContextModel.c
+++ b/Source/Lib/Common/Codec/EbCabacContextModel.c
@@ -1005,7 +1005,7 @@ void init_mode_probs(FRAME_CONTEXT *fc) {
     av1_copy(fc->skip_mode_cdfs, default_skip_mode_cdfs);
     av1_copy(fc->skip_cdfs, default_skip_cdfs);
     av1_copy(fc->intra_inter_cdf, default_intra_inter_cdf);
-    for (int32_t i = 0; i < SPATIAL_PREDICTION_PROBS; i++)
+    for (uint32_t i = 0; i < SPATIAL_PREDICTION_PROBS; i++)
         av1_copy(fc->seg.spatial_pred_seg_cdf[i], default_spatial_pred_seg_tree_cdf[i]);
     av1_copy(fc->tx_size_cdf, default_tx_size_cdf);
     av1_copy(fc->delta_q_cdf, default_delta_q_cdf);

--- a/Source/Lib/Common/Codec/EbCabacContextModel.c
+++ b/Source/Lib/Common/Codec/EbCabacContextModel.c
@@ -856,29 +856,30 @@ static const AomCdfProb default_delta_lf_cdf[CDF_SIZE(DELTA_LF_PROBS + 1)] = {
     AOM_CDF4(28160, 32120, 32677)
 };
 
-//// FIXME(someone) need real defaults here
-//static const AomCdfProb default_seg_tree_cdf[CDF_SIZE(MAX_SEGMENTS)] = {
-//    AOM_CDF8(4096, 8192, 12288, 16384, 20480, 24576, 28672)
-//};
-//
-//static const AomCdfProb
-//default_segment_pred_cdf[SEG_TEMPORAL_PRED_CTXS][CDF_SIZE(2)] = {
-//    { AOM_CDF2(128 * 128) }, { AOM_CDF2(128 * 128) }, { AOM_CDF2(128 * 128) }
-//};
-//
-//static const AomCdfProb
-//default_spatial_pred_seg_tree_cdf[SPATIAL_PREDICTION_PROBS][CDF_SIZE(
-//MAX_SEGMENTS)] = {
-//    {
-//        AOM_CDF8(5622, 7893, 16093, 18233, 27809, 28373, 32533),
-//    },
-//    {
-//        AOM_CDF8(14274, 18230, 22557, 24935, 29980, 30851, 32344),
-//    },
-//    {
-//        AOM_CDF8(27527, 28487, 28723, 28890, 32397, 32647, 32679),
-//    },
-//};
+
+static const AomCdfProb default_seg_tree_cdf[CDF_SIZE(MAX_SEGMENTS)] = {
+    AOM_CDF8(4096, 8192, 12288, 16384, 20480, 24576, 28672)
+};
+
+static const AomCdfProb
+default_segment_pred_cdf[SEG_TEMPORAL_PRED_CTXS][CDF_SIZE(2)] = {
+    { AOM_CDF2(128 * 128) }, { AOM_CDF2(128 * 128) }, { AOM_CDF2(128 * 128) }
+};
+
+static const AomCdfProb
+default_spatial_pred_seg_tree_cdf[SPATIAL_PREDICTION_PROBS][CDF_SIZE(
+MAX_SEGMENTS)] = {
+    {
+        AOM_CDF8(5622, 7893, 16093, 18233, 27809, 28373, 32533),
+    },
+    {
+        AOM_CDF8(14274, 18230, 22557, 24935, 29980, 30851, 32344),
+    },
+    {
+        AOM_CDF8(27527, 28487, 28723, 28890, 32397, 32647, 32679),
+    },
+};
+
 
 static const AomCdfProb default_tx_size_cdf[MAX_TX_CATS][TX_SIZE_CONTEXTS]
 [CDF_SIZE(MAX_TX_DEPTH + 1)] = {
@@ -986,8 +987,8 @@ void init_mode_probs(FRAME_CONTEXT *fc) {
     av1_copy(fc->interintra_cdf, default_interintra_cdf);
     av1_copy(fc->wedge_interintra_cdf, default_wedge_interintra_cdf);
     av1_copy(fc->interintra_mode_cdf, default_interintra_mode_cdf);
-    //   av1_copy(fc->seg.pred_cdf, default_segment_pred_cdf);
-   //    av1_copy(fc->seg.tree_cdf, default_seg_tree_cdf);
+    av1_copy(fc->seg.pred_cdf, default_segment_pred_cdf);
+    av1_copy(fc->seg.tree_cdf, default_seg_tree_cdf);
     av1_copy(fc->filter_intra_cdfs, default_filter_intra_cdfs);
     av1_copy(fc->filter_intra_mode_cdf, default_filter_intra_mode_cdf);
     av1_copy(fc->switchable_restore_cdf, default_switchable_restore_cdf);
@@ -1004,9 +1005,8 @@ void init_mode_probs(FRAME_CONTEXT *fc) {
     av1_copy(fc->skip_mode_cdfs, default_skip_mode_cdfs);
     av1_copy(fc->skip_cdfs, default_skip_cdfs);
     av1_copy(fc->intra_inter_cdf, default_intra_inter_cdf);
-    //    for (int32_t i = 0; i < SPATIAL_PREDICTION_PROBS; i++)
-    //        av1_copy(fc->seg.spatial_pred_seg_cdf[i],
-    //        default_spatial_pred_seg_tree_cdf[i]);
+    for (int32_t i = 0; i < SPATIAL_PREDICTION_PROBS; i++)
+        av1_copy(fc->seg.spatial_pred_seg_cdf[i], default_spatial_pred_seg_tree_cdf[i]);
     av1_copy(fc->tx_size_cdf, default_tx_size_cdf);
     av1_copy(fc->delta_q_cdf, default_delta_q_cdf);
     av1_copy(fc->delta_lf_cdf, default_delta_lf_cdf);
@@ -4549,9 +4549,9 @@ void av1_reset_cdf_symbol_counters(FRAME_CONTEXT *fc) {
     reset_nmv_counter(&fc->nmvc);
     reset_nmv_counter(&fc->ndvc);
     RESET_CDF_COUNTER(fc->intrabc_cdf, 2);
-    //  RESET_CDF_COUNTER(fc->seg.tree_cdf, MAX_SEGMENTS);
-    //  RESET_CDF_COUNTER(fc->seg.pred_cdf, 2);
-    //  RESET_CDF_COUNTER(fc->seg.spatial_pred_seg_cdf, MAX_SEGMENTS);
+    RESET_CDF_COUNTER(fc->seg.tree_cdf, MAX_SEGMENTS);
+    RESET_CDF_COUNTER(fc->seg.pred_cdf, 2);
+    RESET_CDF_COUNTER(fc->seg.spatial_pred_seg_cdf, MAX_SEGMENTS);
     RESET_CDF_COUNTER(fc->filter_intra_cdfs, 2);
     RESET_CDF_COUNTER(fc->filter_intra_mode_cdf, FILTER_INTRA_MODES);
     RESET_CDF_COUNTER(fc->switchable_restore_cdf, RESTORE_SWITCHABLE_TYPES);

--- a/Source/Lib/Common/Codec/EbCabacContextModel.h
+++ b/Source/Lib/Common/Codec/EbCabacContextModel.h
@@ -18,6 +18,8 @@
 #define EbCabacContextModel_h
 
 #include "EbDefinitions.h"
+#include "EbSegmentationParams.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -44,6 +46,11 @@ extern "C" {
     This function converts from one representation to the other (and is its own
     inverse).*/
 #define AOM_ICDF(x) (CDF_PROB_TOP - (x))
+
+#define SEG_TEMPORAL_PRED_CTXS 3
+#define SPATIAL_PREDICTION_PROBS 3
+#define SEG_TREE_PROBS (MAX_SEGMENTS - 1)
+
 
 #if CDF_SHIFT == 0
 
@@ -1013,6 +1020,7 @@ extern "C" {
         AomCdfProb comp_ref_type_cdf[COMP_REF_TYPE_CONTEXTS][CDF_SIZE(2)];
         AomCdfProb uni_comp_ref_cdf[UNI_COMP_REF_CONTEXTS][UNIDIR_COMP_REFS - 1]
             [CDF_SIZE(2)];
+
         AomCdfProb comp_ref_cdf[REF_CONTEXTS][FWD_REFS - 1][CDF_SIZE(2)];
         AomCdfProb comp_bwdref_cdf[REF_CONTEXTS][BWD_REFS - 1][CDF_SIZE(2)];
         AomCdfProb txfm_partition_cdf[TXFM_PARTITION_CONTEXTS][CDF_SIZE(2)];

--- a/Source/Lib/Common/Codec/EbCabacContextModel.h
+++ b/Source/Lib/Common/Codec/EbCabacContextModel.h
@@ -50,8 +50,7 @@ extern "C" {
 #define SEG_TEMPORAL_PRED_CTXS 3
 #define SPATIAL_PREDICTION_PROBS 3
 #define SEG_TREE_PROBS (MAX_SEGMENTS - 1)
-
-
+    
 #if CDF_SHIFT == 0
 
 #define AOM_CDF2(a0) AOM_ICDF(a0), AOM_ICDF(CDF_PROB_TOP), 0

--- a/Source/Lib/Common/Codec/EbCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbCodingLoop.c
@@ -3419,7 +3419,7 @@ EB_EXTERN void av1_encode_pass(
 
                 // for now, segmentation independent of sharpness/delta QP.
                 if(picture_control_set_ptr->parent_pcs_ptr->segmentation_params.segmentation_enabled){
-                    ApplySegmentationBasedQuantization(
+                    apply_segmentation_based_quantization(
                             blk_geom,
                             picture_control_set_ptr,
                             sb_ptr,

--- a/Source/Lib/Common/Codec/EbCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbCodingLoop.c
@@ -22,6 +22,7 @@
 #include "EbDeblockingFilter.h"
 #include "EbPictureOperators.h"
 
+#include "EbSegmentation.h"
 #include "EbModeDecisionProcess.h"
 #include "EbEncDecProcess.h"
 #include "EbSvtAv1ErrorCodes.h"
@@ -586,9 +587,13 @@ static void Av1EncodeLoop(
             context_ptr->trans_coeff_shape_luma);
 #endif
 
+        int32_t seg_qp = picture_control_set_ptr->parent_pcs_ptr->segmentation_params.segmentation_enabled ?
+                         picture_control_set_ptr->parent_pcs_ptr->segmentation_params.feature_data[context_ptr->cu_ptr->segment_id][SEG_LVL_ALT_Q] : 0;
+
 #if DC_SIGN_CONTEXT_EP
         cu_ptr->quantized_dc[0][context_ptr->txb_itr] = av1_quantize_inv_quantize(
 #else
+
         av1_quantize_inv_quantize(
 #endif
             sb_ptr->picture_control_set_ptr,
@@ -598,11 +603,13 @@ static void Av1EncodeLoop(
             ((int32_t*)coeffSamplesTB->buffer_y) + coeff1dOffset,
             ((int32_t*)inverse_quant_buffer->buffer_y) + coeff1dOffset,
             qp,
+            seg_qp,
 #if ATB_SUPPORT
             context_ptr->blk_geom->tx_width[cu_ptr->tx_depth][context_ptr->txb_itr],
             context_ptr->blk_geom->tx_height[cu_ptr->tx_depth][context_ptr->txb_itr],
             context_ptr->blk_geom->txsize[cu_ptr->tx_depth][context_ptr->txb_itr],
 #else
+            seg_qp,
             context_ptr->blk_geom->tx_width[context_ptr->txb_itr],
             context_ptr->blk_geom->tx_height[context_ptr->txb_itr],
             context_ptr->blk_geom->txsize[context_ptr->txb_itr],
@@ -1006,9 +1013,14 @@ static void Av1EncodeLoop(
 #else
             context_ptr->trans_coeff_shape_chroma);
 #endif
+
+        int32_t seg_qp = picture_control_set_ptr->parent_pcs_ptr->segmentation_params.segmentation_enabled ?
+                         picture_control_set_ptr->parent_pcs_ptr->segmentation_params.feature_data[context_ptr->cu_ptr->segment_id][SEG_LVL_ALT_Q] : 0;
+
 #if DC_SIGN_CONTEXT_EP
         cu_ptr->quantized_dc[1][context_ptr->txb_itr] = av1_quantize_inv_quantize(
 #else
+
         av1_quantize_inv_quantize(
 #endif
             sb_ptr->picture_control_set_ptr,
@@ -1018,6 +1030,7 @@ static void Av1EncodeLoop(
             ((int32_t*)coeffSamplesTB->buffer_cb) + context_ptr->coded_area_sb_uv,
             ((int32_t*)inverse_quant_buffer->buffer_cb) + context_ptr->coded_area_sb_uv,
             qp,
+            seg_qp,
 #if ATB_SUPPORT
             context_ptr->blk_geom->tx_width_uv[cu_ptr->tx_depth][context_ptr->txb_itr],
             context_ptr->blk_geom->tx_height_uv[cu_ptr->tx_depth][context_ptr->txb_itr],
@@ -1090,6 +1103,7 @@ static void Av1EncodeLoop(
             ((int32_t*)coeffSamplesTB->buffer_cr) + context_ptr->coded_area_sb_uv,
             ((TranLow*)inverse_quant_buffer->buffer_cr) + context_ptr->coded_area_sb_uv,
             qp,
+            seg_qp,
 #if ATB_SUPPORT
             context_ptr->blk_geom->tx_width_uv[cu_ptr->tx_depth][context_ptr->txb_itr],
             context_ptr->blk_geom->tx_height_uv[cu_ptr->tx_depth][context_ptr->txb_itr],
@@ -1317,6 +1331,9 @@ static void Av1EncodeLoop16bit(
 #else
                 context_ptr->trans_coeff_shape_luma);
 #endif
+
+            int32_t seg_qp = picture_control_set_ptr->parent_pcs_ptr->segmentation_params.segmentation_enabled ?
+                             picture_control_set_ptr->parent_pcs_ptr->segmentation_params.feature_data[context_ptr->cu_ptr->segment_id][SEG_LVL_ALT_Q] : 0;
 #if DC_SIGN_CONTEXT_EP
             cu_ptr->quantized_dc[0][context_ptr->txb_itr] = av1_quantize_inv_quantize(
 #else
@@ -1329,6 +1346,7 @@ static void Av1EncodeLoop16bit(
                 ((int32_t*)coeffSamplesTB->buffer_y) + coeff1dOffset,
                 ((int32_t*)inverse_quant_buffer->buffer_y) + coeff1dOffset,
                 qp,
+                seg_qp,
 #if ATB_SUPPORT
                 context_ptr->blk_geom->tx_width[cu_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height[cu_ptr->tx_depth][context_ptr->txb_itr],
@@ -1539,9 +1557,13 @@ static void Av1EncodeLoop16bit(
 #else
                 context_ptr->trans_coeff_shape_chroma);
 #endif
+            int32_t seg_qp = picture_control_set_ptr->parent_pcs_ptr->segmentation_params.segmentation_enabled ?
+                             picture_control_set_ptr->parent_pcs_ptr->segmentation_params.feature_data[context_ptr->cu_ptr->segment_id][SEG_LVL_ALT_Q] : 0;
+
 #if DC_SIGN_CONTEXT_EP
             cu_ptr->quantized_dc[1][context_ptr->txb_itr] = av1_quantize_inv_quantize(
 #else
+
             av1_quantize_inv_quantize(
 #endif
                 sb_ptr->picture_control_set_ptr,
@@ -1551,6 +1573,7 @@ static void Av1EncodeLoop16bit(
                 ((int32_t*)coeffSamplesTB->buffer_cb) + context_ptr->coded_area_sb_uv,
                 ((int32_t*)inverse_quant_buffer->buffer_cb) + context_ptr->coded_area_sb_uv,
                 qp,
+                seg_qp,
 #if ATB_SUPPORT
                 context_ptr->blk_geom->tx_width_uv[cu_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height_uv[cu_ptr->tx_depth][context_ptr->txb_itr],
@@ -1624,6 +1647,7 @@ static void Av1EncodeLoop16bit(
                 ((int32_t*)coeffSamplesTB->buffer_cr) + context_ptr->coded_area_sb_uv,
                 ((int32_t*)inverse_quant_buffer->buffer_cr) + context_ptr->coded_area_sb_uv,
                 qp,
+                seg_qp,
 #if ATB_SUPPORT
                 context_ptr->blk_geom->tx_width_uv[cu_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height_uv[cu_ptr->tx_depth][context_ptr->txb_itr],
@@ -2404,6 +2428,8 @@ void Store16bitInputSrc(
     for (rowIt = 0; rowIt < lcuH; rowIt++)
         memcpy(toPtr + rowIt * picture_control_set_ptr->input_frame16bit->stride_cr, fromPtr + rowIt * context_ptr->input_sample16bit_buffer->stride_cr, lcuW * 2);
 }
+
+
 
 void update_av1_mi_map(
     CodingUnit        *cu_ptr,
@@ -3390,12 +3416,23 @@ EB_EXTERN void av1_encode_pass(
                 }
 
 #else
-                cu_ptr->qp = (sequence_control_set_ptr->static_config.improve_sharpness) ? context_ptr->qpm_qp : picture_control_set_ptr->picture_qp;
-                sb_ptr->qp = (sequence_control_set_ptr->static_config.improve_sharpness) ? context_ptr->qpm_qp : picture_control_set_ptr->picture_qp;
-#if !MEMORY_FOOTPRINT_OPT
-                cu_ptr->org_delta_qp = cu_ptr->delta_qp;
+
+                // for now, segmentation independent of sharpness/delta QP.
+                if(picture_control_set_ptr->parent_pcs_ptr->segmentation_params.segmentation_enabled){
+                    ApplySegmentationBasedQuantization(
+                            blk_geom,
+                            picture_control_set_ptr,
+                            sb_ptr,
+                            cu_ptr);
+
+                    sb_ptr->qp = cu_ptr->qp;
+                } else{
+                    cu_ptr->qp = (sequence_control_set_ptr->static_config.improve_sharpness) ? context_ptr->qpm_qp : picture_control_set_ptr->picture_qp;
+                    sb_ptr->qp = (sequence_control_set_ptr->static_config.improve_sharpness) ? context_ptr->qpm_qp : picture_control_set_ptr->picture_qp;
+                }
+
 #endif
-#endif
+
 #if !MEMORY_FOOTPRINT_OPT
 #if !ADD_DELTA_QP_SUPPORT
                 //CHKN remove usage of depth

--- a/Source/Lib/Common/Codec/EbCodingUnit.h
+++ b/Source/Lib/Common/Codec/EbCodingUnit.h
@@ -404,6 +404,8 @@ extern "C" {
 #endif
         uint32_t                    is_inter_ctx;
         uint32_t                    interp_filters;
+        uint8_t                      segment_id;
+        uint8_t                      seg_id_predicted;  // valid only when temporal_update is enabled
         PartitionType               part;
         PART                        shape;
         uint16_t                    mds_idx;     //equivalent of leaf_index in the nscu context. we will keep both for now and use the right one on a case by case basis.

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -203,6 +203,17 @@ EbErrorType enc_dec_context_ctor(
     return EB_ErrorNone;
 }
 
+
+/**************************************************
+ * Reset Segmentation Map
+ *************************************************/
+static void ResetSegmentationMap(SegmentationNeighborMap *segmentation_map){
+    if(segmentation_map->data!=NULL)
+        EB_MEMSET(segmentation_map->data, ~0, segmentation_map->map_size);
+}
+
+
+
 /**************************************************
  * Reset Mode Decision Neighbor Arrays
  *************************************************/
@@ -288,8 +299,11 @@ static void ResetEncDec(
     else
         context_ptr->reference_object_write_ptr = (EbReferenceObject*)EB_NULL;
 #endif
-    if (segment_index == 0)
+    if (segment_index == 0){
         ResetEncodePassNeighborArrays(picture_control_set_ptr);
+        ResetSegmentationMap(picture_control_set_ptr->segmentation_neighbor_map);
+    }
+
     return;
 }
 

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -203,16 +203,13 @@ EbErrorType enc_dec_context_ctor(
     return EB_ErrorNone;
 }
 
-
 /**************************************************
  * Reset Segmentation Map
  *************************************************/
-static void ResetSegmentationMap(SegmentationNeighborMap *segmentation_map){
+static void reset_segmentation_map(SegmentationNeighborMap *segmentation_map){
     if(segmentation_map->data!=NULL)
         EB_MEMSET(segmentation_map->data, ~0, segmentation_map->map_size);
 }
-
-
 
 /**************************************************
  * Reset Mode Decision Neighbor Arrays
@@ -301,7 +298,7 @@ static void ResetEncDec(
 #endif
     if (segment_index == 0){
         ResetEncodePassNeighborArrays(picture_control_set_ptr);
-        ResetSegmentationMap(picture_control_set_ptr->segmentation_neighbor_map);
+        reset_segmentation_map(picture_control_set_ptr->segmentation_neighbor_map);
     }
 
     return;

--- a/Source/Lib/Common/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Common/Codec/EbEntropyCoding.c
@@ -5973,8 +5973,7 @@ void code_tx_size(
 }
 #endif
 
-
-static INLINE int GetSegmentId(Av1Common *cm,
+static INLINE int get_segment_id(Av1Common *cm,
                                const uint8_t *segment_ids,
                                BlockSize bsize,
                                int mi_row, int mi_col) {
@@ -5994,10 +5993,10 @@ static INLINE int GetSegmentId(Av1Common *cm,
     return segment_id;
 }
 
-int GetSpatialSegPrediction(PictureControlSet *picture_control_set_ptr,
-                            uint32_t blkOriginX,
-                            uint32_t blkOriginY,
-                            int *cdf_index) {
+int get_spatial_seg_prediction(PictureControlSet *picture_control_set_ptr,
+                               uint32_t blkOriginX,
+                               uint32_t blkOriginY,
+                               int *cdf_index) {
 
     int prev_ul = -1;  // top left segment_id
     int prev_l = -1;   // left segment_id
@@ -6014,13 +6013,13 @@ int GetSpatialSegPrediction(PictureControlSet *picture_control_set_ptr,
 //    SVT_LOG("Left available = %d, Up Available = %d ", left_available, up_available);
 
     if ((up_available) && (left_available)) {
-        prev_ul = GetSegmentId(cm, segmentation_map->data, BLOCK_4X4, mi_row - 1, mi_col - 1);
+        prev_ul = get_segment_id(cm, segmentation_map->data, BLOCK_4X4, mi_row - 1, mi_col - 1);
     }
     if (up_available) {
-        prev_u = GetSegmentId(cm, segmentation_map->data, BLOCK_4X4, mi_row - 1, mi_col - 0);
+        prev_u = get_segment_id(cm, segmentation_map->data, BLOCK_4X4, mi_row - 1, mi_col - 0);
     }
     if (left_available) {
-        prev_l = GetSegmentId(cm, segmentation_map->data, BLOCK_4X4, mi_row - 0, mi_col - 1);
+        prev_l = get_segment_id(cm, segmentation_map->data, BLOCK_4X4, mi_row - 0, mi_col - 1);
     }
     // Pick CDF index based on number of matching/out-of-bounds segment IDs.
     if (prev_ul < 0 || prev_u < 0 || prev_l < 0) /* Edge case */
@@ -6125,7 +6124,7 @@ void WriteSegmentId(PictureControlSet *picture_control_set_ptr,
     if (!segmentationParams->segmentation_enabled)
         return;
     int cdf_num;
-    const int pred = GetSpatialSegPrediction(picture_control_set_ptr, blkOriginX, blkOriginY, &cdf_num);
+    const int pred = get_spatial_seg_prediction(picture_control_set_ptr, blkOriginX, blkOriginY, &cdf_num);
     if (skip_coeff) {
 //        SVT_LOG("BlockY = %d, BlockX = %d \n", blkOriginY>>2, blkOriginX>>2);
         UpdateSegmentationMap(picture_control_set_ptr, bsize, blkOriginX, blkOriginY, pred);

--- a/Source/Lib/Common/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Common/Codec/EbEntropyCoding.c
@@ -24,6 +24,7 @@
 #include "EbSvtAv1ErrorCodes.h"
 #include "EbTransforms.h"
 #include "EbEntropyCodingProcess.h"
+#include "EbSegmentation.h"
 
 #include "aom_dsp_rtcd.h"
 
@@ -1415,6 +1416,7 @@ static void EncodeSkipCoeffAv1(
     uint32_t                  cu_origin_y,
     NeighborArrayUnit    *skip_coeff_neighbor_array)
 {
+    //TODO: need to code in syntax for segmentation map + skip
     uint32_t skipCoeffLeftNeighborIndex = get_neighbor_array_unit_left_index(
         skip_coeff_neighbor_array,
         cu_origin_y);
@@ -1600,6 +1602,8 @@ static void EncodeSkipModeAv1(
     uint32_t                  cu_origin_y,
     NeighborArrayUnit    *skip_flag_neighbor_array)
 {
+
+    //TODO: not coded in syntax for skip mode/ref-frame/global-mv in segmentation map
     uint32_t skipFlagLeftNeighborIndex = get_neighbor_array_unit_left_index(
         skip_flag_neighbor_array,
         cu_origin_y);
@@ -3434,6 +3438,41 @@ static void encode_restoration_mode(PictureParentControlSet *pcs_ptr,
     }
 }
 
+
+static void encode_segmentation(PictureParentControlSet *pcsPtr, struct AomWriteBitBuffer *wb) {
+    SegmentationParams *segmentation_params = &pcsPtr->segmentation_params;
+    aom_wb_write_bit(wb, segmentation_params->segmentation_enabled);
+    if (segmentation_params->segmentation_enabled) {
+        if (!(pcsPtr->primary_ref_frame==PRIMARY_REF_NONE)) {
+            aom_wb_write_bit(wb, segmentation_params->segmentation_update_map);
+            if (segmentation_params->segmentation_update_map) {
+                aom_wb_write_bit(wb, segmentation_params->segmentation_temporal_update);
+            }
+            aom_wb_write_bit(wb, segmentation_params->segmentation_update_map);
+        }
+        if (segmentation_params->segmentation_update_map) {
+            for (int i = 0; i < MAX_SEGMENTS; i++) {
+                for (int j = 0; j < SEG_LVL_MAX; j++) {
+                    aom_wb_write_bit(wb, segmentation_params->feature_enabled[i][j]);
+                    if (segmentation_params->feature_enabled[i][j]) {
+                        //TODO: add clamping
+                        if (segmentation_feature_signed[j]) {
+                            aom_wb_write_inv_signed_literal(wb, segmentation_params->feature_data[i][j],
+                                                            segmentation_feature_bits[j]);
+                        } else {
+                            aom_wb_write_literal(wb, segmentation_params->feature_data[i][j],
+                                                 segmentation_feature_bits[j]);
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+
+}
+
+
 static void encode_loopfilter(PictureParentControlSet *pcs_ptr, struct AomWriteBitBuffer *wb) {
     assert(!pcs_ptr->coded_lossless);
     if (pcs_ptr->allow_intrabc) return;
@@ -4633,8 +4672,8 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
     write_tile_info(pcs_ptr, /*saved_wb,*/ wb);
 
     encode_quantization(pcs_ptr, wb);
-
-    aom_wb_write_bit(wb, 0);
+    encode_segmentation(pcs_ptr, wb);
+    //aom_wb_write_bit(wb, 0);
     //encode_segmentation(cm, xd, wb);
         //if (pcs_ptr->delta_q_present_flag)
            // assert(delta_q_allowed == 1 && pcs_ptr->base_qindex > 0);
@@ -5489,6 +5528,7 @@ static void write_intrabc_info(
     }
 }
 
+
 #if ATB_EC
 static INLINE int block_signals_txsize(BlockSize bsize) {
     return bsize > BLOCK_4X4;
@@ -5932,6 +5972,238 @@ void code_tx_size(
         skip);
 }
 #endif
+
+
+static INLINE int GetSegmentId(Av1Common *cm,
+                               const uint8_t *segment_ids,
+                               BlockSize bsize,
+                               int mi_row, int mi_col) {
+    const int mi_offset = mi_row * cm->mi_cols + mi_col;
+    const int bw = mi_size_wide[bsize];
+    const int bh = mi_size_high[bsize];
+    const int xmis = AOMMIN(cm->mi_cols - mi_col, bw);
+    const int ymis = AOMMIN(cm->mi_rows - mi_row, bh);
+    int x, y, segment_id = MAX_SEGMENTS;
+
+    for (y = 0; y < ymis; ++y)
+        for (x = 0; x < xmis; ++x)
+            segment_id =
+                    AOMMIN(segment_id, segment_ids[mi_offset + y * cm->mi_cols + x]);
+
+    assert(segment_id >= 0 && segment_id < MAX_SEGMENTS);
+    return segment_id;
+}
+
+int GetSpatialSegPrediction(PictureControlSet *picture_control_set_ptr,
+                            uint32_t blkOriginX,
+                            uint32_t blkOriginY,
+                            int *cdf_index) {
+
+    int prev_ul = -1;  // top left segment_id
+    int prev_l = -1;   // left segment_id
+    int prev_u = -1;   // top segment_id
+
+    uint32_t mi_col = blkOriginX >> MI_SIZE_LOG2;
+    uint32_t mi_row = blkOriginY >> MI_SIZE_LOG2;
+
+    EbBool left_available = mi_col > 0 ? EB_TRUE : EB_FALSE;
+    EbBool up_available = mi_row > 0 ? EB_TRUE : EB_FALSE;
+    Av1Common *cm = picture_control_set_ptr->parent_pcs_ptr->av1_cm;
+    SegmentationNeighborMap *segmentation_map = picture_control_set_ptr->segmentation_neighbor_map;
+
+//    SVT_LOG("Left available = %d, Up Available = %d ", left_available, up_available);
+
+    if ((up_available) && (left_available)) {
+        prev_ul = GetSegmentId(cm, segmentation_map->data, BLOCK_4X4, mi_row - 1, mi_col - 1);
+    }
+    if (up_available) {
+        prev_u = GetSegmentId(cm, segmentation_map->data, BLOCK_4X4, mi_row - 1, mi_col - 0);
+    }
+    if (left_available) {
+        prev_l = GetSegmentId(cm, segmentation_map->data, BLOCK_4X4, mi_row - 0, mi_col - 1);
+    }
+    // Pick CDF index based on number of matching/out-of-bounds segment IDs.
+    if (prev_ul < 0 || prev_u < 0 || prev_l < 0) /* Edge case */
+        *cdf_index = 0;
+    else if ((prev_ul == prev_u) && (prev_ul == prev_l))
+        *cdf_index = 2;
+    else if ((prev_ul == prev_u) || (prev_ul == prev_l) || (prev_u == prev_l))
+        *cdf_index = 1;
+    else
+        *cdf_index = 0;
+
+    // If 2 or more are identical returns that as predictor, otherwise prev_l.
+    if (prev_u == -1)  // edge case
+        return prev_l == -1 ? 0 : prev_l;
+    if (prev_l == -1)  // edge case
+        return prev_u;
+    return (prev_ul == prev_u) ? prev_u : prev_l;
+
+}
+
+
+int av1_neg_interleave(int x, int ref, int max) {
+    assert(x < max);
+    const int diff = x - ref;
+    if (!ref) return x;
+    if (ref >= (max - 1)) return -x + max - 1;
+    if (2 * ref < max) {
+        if (abs(diff) <= ref) {
+            if (diff > 0)
+                return (diff << 1) - 1;
+            else
+                return ((-diff) << 1);
+        }
+        return x;
+    } else {
+        if (abs(diff) < (max - ref)) {
+            if (diff > 0)
+                return (diff << 1) - 1;
+            else
+                return ((-diff) << 1);
+        }
+        return (max - x) - 1;
+    }
+}
+
+
+int av1_get_pred_context_seg_id(PictureControlSet *picture_control_set_ptr,
+                                CodingUnit *cu_ptr,
+                                uint32_t blkOriginX,
+                                uint32_t blkOriginY) {
+    NeighborArrayUnit *seg_id_pred_neighbor_array = picture_control_set_ptr->segmentation_id_pred_array;
+    uint32_t top_idx = get_neighbor_array_unit_top_index(seg_id_pred_neighbor_array, blkOriginX);
+    uint32_t left_idx = get_neighbor_array_unit_left_index(seg_id_pred_neighbor_array, blkOriginY);
+
+    const int above_pred = cu_ptr->av1xd->up_available ? seg_id_pred_neighbor_array->top_array[top_idx] : 0;
+    const int left_pred = cu_ptr->av1xd->left_available ? seg_id_pred_neighbor_array->left_array[left_idx] : 0;
+    return above_pred + left_pred;
+}
+
+AomCdfProb *av1_get_pred_cdf_seg_id(PictureControlSet *picture_control_set_ptr,
+                                      FRAME_CONTEXT *frameContext,
+                                      CodingUnit *cu_ptr,
+                                      uint32_t blkOriginX,
+                                      uint32_t blkOriginY) {
+    struct segmentation_probs *segp = &frameContext->seg;
+    return segp->spatial_pred_seg_cdf[av1_get_pred_context_seg_id(picture_control_set_ptr, cu_ptr, blkOriginX, blkOriginY)];
+}
+
+static INLINE void UpdateSegmentationMap(PictureControlSet *picture_control_set_ptr,
+                                         BlockSize bsize,
+                                         uint32_t blkOriginX,
+                                         uint32_t blkOriginY,
+                                         uint8_t segment_id){
+
+    Av1Common *cm = picture_control_set_ptr->parent_pcs_ptr->av1_cm;
+    uint8_t *segment_ids = picture_control_set_ptr->segmentation_neighbor_map->data;
+    uint32_t mi_col = blkOriginX >> MI_SIZE_LOG2;
+    uint32_t mi_row = blkOriginY >> MI_SIZE_LOG2;
+    const int mi_offset = mi_row * cm->mi_cols + mi_col;
+    const int bw = mi_size_wide[bsize];
+    const int bh = mi_size_high[bsize];
+    const int xmis = AOMMIN(cm->mi_cols - mi_col, bw);
+    const int ymis = AOMMIN(cm->mi_rows - mi_row, bh);
+    int x, y;
+
+    for (y = 0; y < ymis; ++y)
+        for (x = 0; x < xmis; ++x)
+            segment_ids[mi_offset + y * cm->mi_cols + x] = segment_id;
+
+}
+
+void WriteSegmentId(PictureControlSet *picture_control_set_ptr,
+                    FRAME_CONTEXT *frameContext,
+                    AomWriter *ecWriter,
+                    BlockSize bsize,
+                    uint32_t blkOriginX,
+                    uint32_t blkOriginY,
+                    CodingUnit *cu_ptr,
+                    EbBool skip_coeff) {
+
+    SegmentationParams *segmentationParams = &picture_control_set_ptr->parent_pcs_ptr->segmentation_params;
+    if (!segmentationParams->segmentation_enabled)
+        return;
+    int cdf_num;
+    const int pred = GetSpatialSegPrediction(picture_control_set_ptr, blkOriginX, blkOriginY, &cdf_num);
+    if (skip_coeff) {
+//        SVT_LOG("BlockY = %d, BlockX = %d \n", blkOriginY>>2, blkOriginX>>2);
+        UpdateSegmentationMap(picture_control_set_ptr, bsize, blkOriginX, blkOriginY, pred);
+        cu_ptr->segment_id = pred;
+        return;
+    }
+    const int coded_id = av1_neg_interleave(cu_ptr->segment_id, pred, segmentationParams->last_active_seg_id + 1);
+    struct segmentation_probs *segp = &frameContext->seg;
+    AomCdfProb *pred_cdf = segp->spatial_pred_seg_cdf[cdf_num];
+    aom_write_symbol(ecWriter, coded_id, pred_cdf, MAX_SEGMENTS);
+    UpdateSegmentationMap(picture_control_set_ptr, bsize, blkOriginX, blkOriginY, cu_ptr->segment_id);
+//    SVT_LOG("BlockY = %d, BlockX = %d, Segmentation  pred = %d, skip_coeff = %d, coded_id = %d, pred_cdf = %d \n", blkOriginY>>2, blkOriginX>>2, pred, skip_coeff, coded_id, *pred_cdf);
+}
+
+
+void WriteInterSegmentId(PictureControlSet *picture_control_set_ptr,
+                         FRAME_CONTEXT *frameContext,
+                         AomWriter *ecWriter,
+                         const BlockGeom *blockGeom,
+                         uint32_t blkOriginX,
+                         uint32_t blkOriginY,
+                         CodingUnit *cu_ptr,
+                         EbBool skip,
+                         int pre_skip) {
+    SegmentationParams *segmentationParams = &picture_control_set_ptr->parent_pcs_ptr->segmentation_params;
+    if (!segmentationParams->segmentation_enabled)
+        return;
+
+    if (segmentationParams->segmentation_update_map) {
+        if (pre_skip) {
+            if (!segmentationParams->seg_id_pre_skip)
+                return;
+        } else {
+            if (segmentationParams->seg_id_pre_skip)
+                return;
+            if (skip) {
+                WriteSegmentId(picture_control_set_ptr, frameContext, ecWriter, blockGeom->bsize, blkOriginX, blkOriginY, cu_ptr, 1);
+                if (segmentationParams->segmentation_temporal_update){
+                    printf("ERROR: Temporal update is not supported yet! \n");
+                    assert(0);
+//                    cu_ptr->seg_id_predicted = 0;
+                }
+                return;
+            }
+        }
+
+        if (segmentationParams->segmentation_temporal_update) {
+            printf("ERROR: Temporal update is not supported yet! \n");
+            assert(0);
+//            const int pred_flag = cu_ptr->seg_id_predicted;
+//            aom_cdf_prob *pred_cdf = av1_get_pred_cdf_seg_id(picture_control_set_ptr, frameContext, cu_ptr, blkOriginX, blkOriginY);
+//            aom_write_symbol(ecWriter, pred_flag, pred_cdf, 2);
+//            if (!pred_flag) {
+//                WriteSegmentId(picture_control_set_ptr, frameContext, ecWriter, blockGeom->bsize, blkOriginX, blkOriginY, cu_ptr, 0);
+//            }
+//            if (pred_flag) {2
+//                UpdateSegmentationMap(picture_control_set_ptr, blockGeom->bsize, blkOriginX, blkOriginY, cu_ptr->segment_id);
+//            }
+//            neighbor_array_unit_mode_write(
+//                    picture_control_set_ptr->segmentation_id_pred_array,
+//                    &(cu_ptr->segment_id),
+//                    blkOriginX,
+//                    blkOriginY,
+//                    blockGeom->bwidth,
+//                    blockGeom->bheight,
+//                    NEIGHBOR_ARRAY_UNIT_FULL_MASK);
+
+        } else {
+            WriteSegmentId(picture_control_set_ptr, frameContext, ecWriter, blockGeom->bsize, blkOriginX, blkOriginY, cu_ptr, 0);
+        }
+
+
+    }
+
+
+}
+
+
 EbErrorType write_modes_b(
     PictureControlSet     *picture_control_set_ptr,
     EntropyCodingContext  *context_ptr,
@@ -5988,6 +6260,10 @@ assert(bsize < BlockSizeS_ALL);
 #endif
     if (picture_control_set_ptr->slice_type == I_SLICE) {
         //const int32_t skip = write_skip(cm, xd, mbmi->segment_id, mi, w);
+        if (picture_control_set_ptr->parent_pcs_ptr->segmentation_params.seg_id_pre_skip)
+            WriteSegmentId(picture_control_set_ptr, frameContext, ec_writer,  blk_geom->bsize,  blkOriginX, blkOriginY, cu_ptr,
+                           skipCoeff);
+
         EncodeSkipCoeffAv1(
             frameContext,
             ec_writer,
@@ -5995,6 +6271,10 @@ assert(bsize < BlockSizeS_ALL);
             blkOriginX,
             blkOriginY,
             skip_coeff_neighbor_array);
+
+        if (!picture_control_set_ptr->parent_pcs_ptr->segmentation_params.seg_id_pre_skip)
+            WriteSegmentId(picture_control_set_ptr, frameContext, ec_writer,  blk_geom->bsize,  blkOriginX, blkOriginY, cu_ptr,
+                           skipCoeff);
 
         write_cdef(
             sequence_control_set_ptr,
@@ -6121,6 +6401,8 @@ assert(bsize < BlockSizeS_ALL);
         }
     }
     else {
+        WriteInterSegmentId(picture_control_set_ptr, frameContext, ec_writer, blk_geom,  blkOriginX, blkOriginY, cu_ptr,
+                            0, 1);
         if (picture_control_set_ptr->parent_pcs_ptr->skip_mode_flag && is_comp_ref_allowed(bsize)) {
             EncodeSkipModeAv1(
                 frameContext,
@@ -6143,6 +6425,8 @@ assert(bsize < BlockSizeS_ALL);
                 skip_coeff_neighbor_array);
         }
 
+        WriteInterSegmentId(picture_control_set_ptr, frameContext, ec_writer, blk_geom,  blkOriginX, blkOriginY, cu_ptr,
+                            skipCoeff, 0);
         write_cdef(
             sequence_control_set_ptr,
             picture_control_set_ptr, /*cm,*/

--- a/Source/Lib/Common/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Common/Codec/EbEntropyCoding.c
@@ -6012,15 +6012,15 @@ int get_spatial_seg_prediction(PictureControlSet *picture_control_set_ptr,
 
 //    SVT_LOG("Left available = %d, Up Available = %d ", left_available, up_available);
 
-    if ((up_available) && (left_available)) {
+    if ((up_available) && (left_available))
         prev_ul = get_segment_id(cm, segmentation_map->data, BLOCK_4X4, mi_row - 1, mi_col - 1);
-    }
-    if (up_available) {
+
+    if (up_available)
         prev_u = get_segment_id(cm, segmentation_map->data, BLOCK_4X4, mi_row - 1, mi_col - 0);
-    }
-    if (left_available) {
+
+    if (left_available)
         prev_l = get_segment_id(cm, segmentation_map->data, BLOCK_4X4, mi_row - 0, mi_col - 1);
-    }
+
     // Pick CDF index based on number of matching/out-of-bounds segment IDs.
     if (prev_ul < 0 || prev_u < 0 || prev_l < 0) /* Edge case */
         *cdf_index = 0;
@@ -6088,11 +6088,11 @@ AomCdfProb *av1_get_pred_cdf_seg_id(PictureControlSet *picture_control_set_ptr,
     return segp->spatial_pred_seg_cdf[av1_get_pred_context_seg_id(picture_control_set_ptr, cu_ptr, blkOriginX, blkOriginY)];
 }
 
-static INLINE void UpdateSegmentationMap(PictureControlSet *picture_control_set_ptr,
-                                         BlockSize bsize,
-                                         uint32_t blkOriginX,
-                                         uint32_t blkOriginY,
-                                         uint8_t segment_id){
+static INLINE void update_segmentation_map(PictureControlSet *picture_control_set_ptr,
+                                           BlockSize bsize,
+                                           uint32_t blkOriginX,
+                                           uint32_t blkOriginY,
+                                           uint8_t segment_id){
 
     Av1Common *cm = picture_control_set_ptr->parent_pcs_ptr->av1_cm;
     uint8_t *segment_ids = picture_control_set_ptr->segmentation_neighbor_map->data;
@@ -6111,14 +6111,14 @@ static INLINE void UpdateSegmentationMap(PictureControlSet *picture_control_set_
 
 }
 
-void WriteSegmentId(PictureControlSet *picture_control_set_ptr,
-                    FRAME_CONTEXT *frameContext,
-                    AomWriter *ecWriter,
-                    BlockSize bsize,
-                    uint32_t blkOriginX,
-                    uint32_t blkOriginY,
-                    CodingUnit *cu_ptr,
-                    EbBool skip_coeff) {
+void write_segment_id(PictureControlSet *picture_control_set_ptr,
+                      FRAME_CONTEXT *frameContext,
+                      AomWriter *ecWriter,
+                      BlockSize bsize,
+                      uint32_t blkOriginX,
+                      uint32_t blkOriginY,
+                      CodingUnit *cu_ptr,
+                      EbBool skip_coeff) {
 
     SegmentationParams *segmentationParams = &picture_control_set_ptr->parent_pcs_ptr->segmentation_params;
     if (!segmentationParams->segmentation_enabled)
@@ -6127,7 +6127,7 @@ void WriteSegmentId(PictureControlSet *picture_control_set_ptr,
     const int pred = get_spatial_seg_prediction(picture_control_set_ptr, blkOriginX, blkOriginY, &cdf_num);
     if (skip_coeff) {
 //        SVT_LOG("BlockY = %d, BlockX = %d \n", blkOriginY>>2, blkOriginX>>2);
-        UpdateSegmentationMap(picture_control_set_ptr, bsize, blkOriginX, blkOriginY, pred);
+        update_segmentation_map(picture_control_set_ptr, bsize, blkOriginX, blkOriginY, pred);
         cu_ptr->segment_id = pred;
         return;
     }
@@ -6135,20 +6135,20 @@ void WriteSegmentId(PictureControlSet *picture_control_set_ptr,
     struct segmentation_probs *segp = &frameContext->seg;
     AomCdfProb *pred_cdf = segp->spatial_pred_seg_cdf[cdf_num];
     aom_write_symbol(ecWriter, coded_id, pred_cdf, MAX_SEGMENTS);
-    UpdateSegmentationMap(picture_control_set_ptr, bsize, blkOriginX, blkOriginY, cu_ptr->segment_id);
+    update_segmentation_map(picture_control_set_ptr, bsize, blkOriginX, blkOriginY, cu_ptr->segment_id);
 //    SVT_LOG("BlockY = %d, BlockX = %d, Segmentation  pred = %d, skip_coeff = %d, coded_id = %d, pred_cdf = %d \n", blkOriginY>>2, blkOriginX>>2, pred, skip_coeff, coded_id, *pred_cdf);
 }
 
 
-void WriteInterSegmentId(PictureControlSet *picture_control_set_ptr,
-                         FRAME_CONTEXT *frameContext,
-                         AomWriter *ecWriter,
-                         const BlockGeom *blockGeom,
-                         uint32_t blkOriginX,
-                         uint32_t blkOriginY,
-                         CodingUnit *cu_ptr,
-                         EbBool skip,
-                         int pre_skip) {
+void write_inter_segment_id(PictureControlSet *picture_control_set_ptr,
+                            FRAME_CONTEXT *frameContext,
+                            AomWriter *ecWriter,
+                            const BlockGeom *blockGeom,
+                            uint32_t blkOriginX,
+                            uint32_t blkOriginY,
+                            CodingUnit *cu_ptr,
+                            EbBool skip,
+                            int pre_skip) {
     SegmentationParams *segmentationParams = &picture_control_set_ptr->parent_pcs_ptr->segmentation_params;
     if (!segmentationParams->segmentation_enabled)
         return;
@@ -6161,7 +6161,8 @@ void WriteInterSegmentId(PictureControlSet *picture_control_set_ptr,
             if (segmentationParams->seg_id_pre_skip)
                 return;
             if (skip) {
-                WriteSegmentId(picture_control_set_ptr, frameContext, ecWriter, blockGeom->bsize, blkOriginX, blkOriginY, cu_ptr, 1);
+                write_segment_id(picture_control_set_ptr, frameContext, ecWriter, blockGeom->bsize, blkOriginX,
+                                 blkOriginY, cu_ptr, 1);
                 if (segmentationParams->segmentation_temporal_update){
                     printf("ERROR: Temporal update is not supported yet! \n");
                     assert(0);
@@ -6181,7 +6182,7 @@ void WriteInterSegmentId(PictureControlSet *picture_control_set_ptr,
 //                WriteSegmentId(picture_control_set_ptr, frameContext, ecWriter, blockGeom->bsize, blkOriginX, blkOriginY, cu_ptr, 0);
 //            }
 //            if (pred_flag) {2
-//                UpdateSegmentationMap(picture_control_set_ptr, blockGeom->bsize, blkOriginX, blkOriginY, cu_ptr->segment_id);
+//                update_segmentation_map(picture_control_set_ptr, blockGeom->bsize, blkOriginX, blkOriginY, cu_ptr->segment_id);
 //            }
 //            neighbor_array_unit_mode_write(
 //                    picture_control_set_ptr->segmentation_id_pred_array,
@@ -6193,7 +6194,8 @@ void WriteInterSegmentId(PictureControlSet *picture_control_set_ptr,
 //                    NEIGHBOR_ARRAY_UNIT_FULL_MASK);
 
         } else {
-            WriteSegmentId(picture_control_set_ptr, frameContext, ecWriter, blockGeom->bsize, blkOriginX, blkOriginY, cu_ptr, 0);
+            write_segment_id(picture_control_set_ptr, frameContext, ecWriter, blockGeom->bsize, blkOriginX, blkOriginY,
+                             cu_ptr, 0);
         }
 
 
@@ -6260,8 +6262,9 @@ assert(bsize < BlockSizeS_ALL);
     if (picture_control_set_ptr->slice_type == I_SLICE) {
         //const int32_t skip = write_skip(cm, xd, mbmi->segment_id, mi, w);
         if (picture_control_set_ptr->parent_pcs_ptr->segmentation_params.seg_id_pre_skip)
-            WriteSegmentId(picture_control_set_ptr, frameContext, ec_writer,  blk_geom->bsize,  blkOriginX, blkOriginY, cu_ptr,
-                           skipCoeff);
+            write_segment_id(picture_control_set_ptr, frameContext, ec_writer, blk_geom->bsize, blkOriginX, blkOriginY,
+                             cu_ptr,
+                             skipCoeff);
 
         EncodeSkipCoeffAv1(
             frameContext,
@@ -6272,8 +6275,9 @@ assert(bsize < BlockSizeS_ALL);
             skip_coeff_neighbor_array);
 
         if (!picture_control_set_ptr->parent_pcs_ptr->segmentation_params.seg_id_pre_skip)
-            WriteSegmentId(picture_control_set_ptr, frameContext, ec_writer,  blk_geom->bsize,  blkOriginX, blkOriginY, cu_ptr,
-                           skipCoeff);
+            write_segment_id(picture_control_set_ptr, frameContext, ec_writer, blk_geom->bsize, blkOriginX, blkOriginY,
+                             cu_ptr,
+                             skipCoeff);
 
         write_cdef(
             sequence_control_set_ptr,
@@ -6400,8 +6404,9 @@ assert(bsize < BlockSizeS_ALL);
         }
     }
     else {
-        WriteInterSegmentId(picture_control_set_ptr, frameContext, ec_writer, blk_geom,  blkOriginX, blkOriginY, cu_ptr,
-                            0, 1);
+        write_inter_segment_id(picture_control_set_ptr, frameContext, ec_writer, blk_geom, blkOriginX, blkOriginY,
+                               cu_ptr,
+                               0, 1);
         if (picture_control_set_ptr->parent_pcs_ptr->skip_mode_flag && is_comp_ref_allowed(bsize)) {
             EncodeSkipModeAv1(
                 frameContext,
@@ -6424,8 +6429,9 @@ assert(bsize < BlockSizeS_ALL);
                 skip_coeff_neighbor_array);
         }
 
-        WriteInterSegmentId(picture_control_set_ptr, frameContext, ec_writer, blk_geom,  blkOriginX, blkOriginY, cu_ptr,
-                            skipCoeff, 0);
+        write_inter_segment_id(picture_control_set_ptr, frameContext, ec_writer, blk_geom, blkOriginX, blkOriginY,
+                               cu_ptr,
+                               skipCoeff, 0);
         write_cdef(
             sequence_control_set_ptr,
             picture_control_set_ptr, /*cm,*/

--- a/Source/Lib/Common/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Common/Codec/EbEntropyCodingProcess.c
@@ -73,6 +73,7 @@ static void EntropyCodingResetNeighborArrays(PictureControlSet *picture_control_
 #if ATB_EC
     neighbor_array_unit_reset(picture_control_set_ptr->txfm_context_array);
 #endif
+    neighbor_array_unit_reset(picture_control_set_ptr->segmentation_id_pred_array);
     return;
 }
 

--- a/Source/Lib/Common/Codec/EbFullLoop.c
+++ b/Source/Lib/Common/Codec/EbFullLoop.c
@@ -20,6 +20,7 @@
 #include "EbFullLoop.h"
 #include "EbRateDistortionCost.h"
 #include "aom_dsp_rtcd.h"
+
 #ifdef __GNUC__
 #define LIKELY(v) __builtin_expect(v, 1)
 #define UNLIKELY(v) __builtin_expect(v, 0)
@@ -1713,12 +1714,14 @@ void av1_quantize_inv_quantize(
     int32_t                     *quant_coeff,
     int32_t                     *recon_coeff,
     uint32_t                     qp,
+    int32_t                segmentation_qp_offset,
     uint32_t                     width,
     uint32_t                     height,
     TxSize                       txsize,
     uint16_t                    *eob,
     EbAsm                        asm_type,
     uint32_t                    *count_non_zero_coeffs,
+
 #if !PF_N2_SUPPORT
     EbPfMode                     pf_mode,
 #endif
@@ -1762,7 +1765,7 @@ void av1_quantize_inv_quantize(
 #if ADD_DELTA_QP_SUPPORT
     uint32_t qIndex = qp;
 #else
-    uint32_t qIndex = picture_control_set_ptr->parent_pcs_ptr->base_qindex;
+    uint32_t qIndex = picture_control_set_ptr->parent_pcs_ptr->base_qindex + segmentation_qp_offset ;
 #endif
     if (bit_increment == 0) {
         if (component_type == COMPONENT_LUMA) {
@@ -2157,6 +2160,11 @@ void product_full_loop(
 #else
             context_ptr->pf_md_mode);
 #endif
+
+
+
+        int32_t seg_qp = picture_control_set_ptr->parent_pcs_ptr->segmentation_params.segmentation_enabled ?
+                         picture_control_set_ptr->parent_pcs_ptr->segmentation_params.feature_data[context_ptr->cu_ptr->segment_id][SEG_LVL_ALT_Q] : 0;
 #if DC_SIGN_CONTEXT_FIX
         candidateBuffer->candidate_ptr->quantized_dc[0][txb_itr] = av1_quantize_inv_quantize(
 #else
@@ -2169,6 +2177,7 @@ void product_full_loop(
             &(((int32_t*)candidateBuffer->residual_quant_coeff_ptr->buffer_y)[txb_1d_offset]),
             &(((int32_t*)candidateBuffer->recon_coeff_ptr->buffer_y)[txb_1d_offset]),
             qp,
+            seg_qp,
 #if ATB_SUPPORT
             context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
             context_ptr->blk_geom->tx_height[tx_depth][txb_itr],
@@ -2594,6 +2603,9 @@ void product_full_loop_tx_search(
                 PLANE_TYPE_Y,
                 context_ptr->pf_md_mode);
 
+            int32_t seg_qp = picture_control_set_ptr->parent_pcs_ptr->segmentation_params.segmentation_enabled ?
+                             picture_control_set_ptr->parent_pcs_ptr->segmentation_params.feature_data[context_ptr->cu_ptr->segment_id][SEG_LVL_ALT_Q] : 0;
+
             av1_quantize_inv_quantize(
                 picture_control_set_ptr,
                 context_ptr,
@@ -2602,6 +2614,8 @@ void product_full_loop_tx_search(
                 &(((int32_t*)candidateBuffer->residual_quant_coeff_ptr->buffer_y)[tu_origin_index]),
                 &(((int32_t*)candidateBuffer->recon_coeff_ptr->buffer_y)[tu_origin_index]),
                 context_ptr->cu_ptr->qp,
+                seg_qp,
+
 #if ATB_SUPPORT
                 context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
                 context_ptr->blk_geom->tx_height[tx_depth][txb_itr],
@@ -2945,6 +2959,9 @@ void encode_pass_tx_search(
 #else
             context_ptr->trans_coeff_shape_luma);
 #endif
+        int32_t seg_qp = picture_control_set_ptr->parent_pcs_ptr->segmentation_params.segmentation_enabled ?
+                         picture_control_set_ptr->parent_pcs_ptr->segmentation_params.feature_data[context_ptr->cu_ptr->segment_id][SEG_LVL_ALT_Q] : 0;
+
 
         av1_quantize_inv_quantize(
             sb_ptr->picture_control_set_ptr,
@@ -2954,6 +2971,7 @@ void encode_pass_tx_search(
             ((int32_t*)coeffSamplesTB->buffer_y) + coeff1dOffset,
             ((int32_t*)inverse_quant_buffer->buffer_y) + coeff1dOffset,
             qp,
+            seg_qp,
 #if ATB_SUPPORT
             context_ptr->blk_geom->tx_width[cu_ptr->tx_depth][context_ptr->txb_itr],
             context_ptr->blk_geom->tx_height[cu_ptr->tx_depth][context_ptr->txb_itr],
@@ -3191,6 +3209,9 @@ void encode_pass_tx_search_hbd(
 #else
             context_ptr->trans_coeff_shape_luma);
 #endif
+        int32_t seg_qp = picture_control_set_ptr->parent_pcs_ptr->segmentation_params.segmentation_enabled ?
+                         picture_control_set_ptr->parent_pcs_ptr->segmentation_params.feature_data[context_ptr->cu_ptr->segment_id][SEG_LVL_ALT_Q] : 0;
+
         av1_quantize_inv_quantize(
             sb_ptr->picture_control_set_ptr,
             context_ptr->md_context,
@@ -3199,6 +3220,7 @@ void encode_pass_tx_search_hbd(
             ((int32_t*)coeffSamplesTB->buffer_y) + coeff1dOffset,
             ((int32_t*)inverse_quant_buffer->buffer_y) + coeff1dOffset,
             qp,
+            seg_qp,
 #if ATB_SUPPORT
             context_ptr->blk_geom->tx_width[cu_ptr->tx_depth][context_ptr->txb_itr],
             context_ptr->blk_geom->tx_height[cu_ptr->tx_depth][context_ptr->txb_itr],
@@ -3445,6 +3467,9 @@ void full_loop_r(
 #else
                 correctedPFMode);
 #endif
+
+            int32_t seg_qp = picture_control_set_ptr->parent_pcs_ptr->segmentation_params.segmentation_enabled ?
+                             picture_control_set_ptr->parent_pcs_ptr->segmentation_params.feature_data[context_ptr->cu_ptr->segment_id][SEG_LVL_ALT_Q] : 0;
 #if DC_SIGN_CONTEXT_FIX
             candidateBuffer->candidate_ptr->quantized_dc[1][0] = av1_quantize_inv_quantize(
 #else
@@ -3457,6 +3482,7 @@ void full_loop_r(
                 &(((int32_t*)candidateBuffer->residual_quant_coeff_ptr->buffer_cb)[txb_1d_offset]),
                 &(((int32_t*)candidateBuffer->recon_coeff_ptr->buffer_cb)[txb_1d_offset]),
                 cb_qp,
+                seg_qp,
 #if ATB_SUPPORT
                 context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
                 context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr],
@@ -3596,6 +3622,9 @@ void full_loop_r(
 #else
                 correctedPFMode);
 #endif
+            int32_t seg_qp = picture_control_set_ptr->parent_pcs_ptr->segmentation_params.segmentation_enabled ?
+                             picture_control_set_ptr->parent_pcs_ptr->segmentation_params.feature_data[context_ptr->cu_ptr->segment_id][SEG_LVL_ALT_Q] : 0;
+
 #if DC_SIGN_CONTEXT_FIX
             candidateBuffer->candidate_ptr->quantized_dc[2][0] = av1_quantize_inv_quantize(
 #else
@@ -3608,6 +3637,7 @@ void full_loop_r(
                 &(((int32_t*)candidateBuffer->residual_quant_coeff_ptr->buffer_cr)[txb_1d_offset]),
                 &(((int32_t*)candidateBuffer->recon_coeff_ptr->buffer_cr)[txb_1d_offset]),
                 cb_qp,
+                seg_qp,
 #if ATB_SUPPORT
                 context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
                 context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr],

--- a/Source/Lib/Common/Codec/EbFullLoop.c
+++ b/Source/Lib/Common/Codec/EbFullLoop.c
@@ -2161,8 +2161,6 @@ void product_full_loop(
             context_ptr->pf_md_mode);
 #endif
 
-
-
         int32_t seg_qp = picture_control_set_ptr->parent_pcs_ptr->segmentation_params.segmentation_enabled ?
                          picture_control_set_ptr->parent_pcs_ptr->segmentation_params.feature_data[context_ptr->cu_ptr->segment_id][SEG_LVL_ALT_Q] : 0;
 #if DC_SIGN_CONTEXT_FIX

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -22,6 +22,7 @@
 #include "EbRateControlTables.h"
 #include "EbRestoration.h"
 #include "noise_model.h"
+#include "EbSegmentationParams.h"
 
 #if CABAC_UP
 #include "EbMdRateEstimation.h"
@@ -13883,6 +13884,10 @@ extern "C" {
         NeighborArrayUnit                  *inter_pred_dir_neighbor_array;
         NeighborArrayUnit                  *ref_frame_type_neighbor_array;
         NeighborArrayUnit32                *interpolation_type_neighbor_array;
+
+        NeighborArrayUnit                  *segmentation_id_pred_array;
+        SegmentationNeighborMap              *segmentation_neighbor_map;
+
         ModeInfo                            **mi_grid_base; //2 SB Rows of mi Data are enough
 
         ModeInfo                             *mip;
@@ -14311,6 +14316,10 @@ extern "C" {
         int32_t                               cdef_uv_strengths[CDEF_MAX_STRENGTHS];
         int32_t                               cdef_bits;
         int32_t                               delta_q_present_flag;
+
+        // Segmentation related parameters
+        SegmentationParams                    segmentation_params;
+
 #if ADD_DELTA_QP_SUPPORT
         // Resolution of delta quant
         uint8_t                               delta_q_res;
@@ -14332,6 +14341,7 @@ extern "C" {
         // superblock's actual lf and current lf.
         int32_t                               prev_delta_lf_from_base;
         int32_t                               current_delta_lf_from_base;
+
         // For this experiment, we have four frame filter levels for different plane
         // and direction. So, to support the per superblock update, we need to add
         // a few more params as below.
@@ -14345,6 +14355,7 @@ extern "C" {
         // SEG_LVL_ALT_LF_Y_H = 2;
         // SEG_LVL_ALT_LF_U   = 3;
         // SEG_LVL_ALT_LF_V   = 4;
+//
         int32_t                               prev_delta_lf[FRAME_LF_COUNT];
         int32_t                               curr_delta_lf[FRAME_LF_COUNT];
 #endif

--- a/Source/Lib/Common/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Common/Codec/EbRateControlProcess.c
@@ -3761,7 +3761,7 @@ void* rate_control_kernel(void *input_ptr)
                 }
 #endif
                 picture_control_set_ptr->parent_pcs_ptr->picture_qp = picture_control_set_ptr->picture_qp;
-                SetupSegmentation(
+                setup_segmentation(
                         picture_control_set_ptr,
                         sequence_control_set_ptr,
                         context_ptr,

--- a/Source/Lib/Common/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Common/Codec/EbRateControlProcess.c
@@ -28,6 +28,8 @@
 #include "EbRateControlTasks.h"
 #include "RateControlModel.h"
 
+#include "EbSegmentation.h"
+
 // calculate the QP based on the QP scaling
 uint32_t qp_scaling_calc(
     SequenceControlSet *sequence_control_set_ptr,
@@ -3759,6 +3761,13 @@ void* rate_control_kernel(void *input_ptr)
                 }
 #endif
                 picture_control_set_ptr->parent_pcs_ptr->picture_qp = picture_control_set_ptr->picture_qp;
+                SetupSegmentation(
+                        picture_control_set_ptr,
+                        sequence_control_set_ptr,
+                        context_ptr,
+                        rate_control_layer_ptr,
+                        rate_control_param_ptr
+                );
             }
             else {
                 // ***Rate Control***

--- a/Source/Lib/Common/Codec/EbRateControlProcess.h
+++ b/Source/Lib/Common/Codec/EbRateControlProcess.h
@@ -142,6 +142,9 @@ typedef struct RateControlLayerContext
     uint32_t   temporal_index;
 
     uint64_t   alpha;
+    //segmentation
+    int32_t                    prev_segment_qps[MAX_SEGMENTS];
+
 } RateControlLayerContext;
 
 typedef struct RateControlIntervalParamContext
@@ -290,6 +293,7 @@ typedef struct RateControlLayerContext
 
     uint64_t                  alpha;
 } RateControlLayerContext;
+
 
 typedef struct RateControlIntervalParamContext
 {

--- a/Source/Lib/Common/Codec/EbSegmentation.c
+++ b/Source/Lib/Common/Codec/EbSegmentation.c
@@ -1,3 +1,18 @@
+/*
+* Copyright(c) 2019 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+/*
+* Copyright (c) 2016, Alliance for Open Media. All rights reserved
+*
+* This source code is subject to the terms of the BSD 2 Clause License and
+* the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+* was not distributed with this source code in the LICENSE file, you can
+* obtain it at www.aomedia.org/license/software. If the Alliance for Open
+* Media Patent License 1.0 was not distributed with this source code in the
+* PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+*/
 
 #include "EbSegmentation.h"
 #include "EbSegmentationParams.h"
@@ -102,7 +117,7 @@ uint16_t GetVarianceForCU(const BlockGeom *blk_geom,
 
 }
 
-void ApplySegmentationBasedQuantization(
+void apply_segmentation_based_quantization(
         const BlockGeom *blk_geom,
         PictureControlSet *picture_control_set_ptr,
         LargestCodingUnit *sb_ptr,
@@ -123,7 +138,7 @@ void ApplySegmentationBasedQuantization(
 
 }
 
-void SetupSegmentation(
+void setup_segmentation(
         PictureControlSet *picture_control_set_ptr,
         SequenceControlSet *sequence_control_set_ptr,
         RateControlContext *context_ptr,
@@ -137,17 +152,18 @@ void SetupSegmentation(
         segmentation_params->segmentation_update_data = 1; //always updating for now. Need to set this based on actual deltas
         segmentation_params->segmentation_update_map = 1;
         segmentation_params->segmentation_temporal_update = EB_FALSE; //!(picture_control_set_ptr->parent_pcs_ptr->av1FrameType == KEY_FRAME || picture_control_set_ptr->parent_pcs_ptr->av1FrameType == INTRA_ONLY_FRAME);
-        FindSegmentQps(segmentation_params, picture_control_set_ptr);
-        TemporallyUpdateQPs(segment_qps, rateControlLayerPtr->prev_segment_qps, segmentation_params->segmentation_temporal_update);
+        find_segment_qps(segmentation_params, picture_control_set_ptr);
+        temporally_update_qps(segment_qps, rateControlLayerPtr->prev_segment_qps,
+                              segmentation_params->segmentation_temporal_update);
         for (int i = 0; i < MAX_SEGMENTS; i++) {
             segmentation_params->feature_enabled[i][SEG_LVL_ALT_Q] = 1;
         }
-        CalculateSegmentationData(segmentation_params);
+        calculate_segmentation_data(segmentation_params);
     }
 
 }
 
-void CalculateSegmentationData(SegmentationParams *segmentation_params) {
+void calculate_segmentation_data(SegmentationParams *segmentation_params) {
     for (int i = 0; i < MAX_SEGMENTS; i++) {
         for (int j = 0; j < SEG_LVL_MAX; j++) {
             if (segmentation_params->feature_enabled[i][j]) {
@@ -160,7 +176,7 @@ void CalculateSegmentationData(SegmentationParams *segmentation_params) {
     }
 }
 
-void FindSegmentQps(
+void find_segment_qps(
         SegmentationParams *segmentation_params,
         PictureControlSet *picture_control_set_ptr
 ) { //QP needs to be specified as qpindex, not qp.
@@ -201,7 +217,7 @@ void FindSegmentQps(
 
 }
 
-void TemporallyUpdateQPs(
+void temporally_update_qps(
         int32_t *segment_qp_ptr,
         int32_t *prev_segment_qp_ptr,
         EbBool temporal_update

--- a/Source/Lib/Common/Codec/EbSegmentation.c
+++ b/Source/Lib/Common/Codec/EbSegmentation.c
@@ -22,16 +22,16 @@ const int segmentation_feature_signed[SEG_LVL_MAX] = {
         1, 1, 1, 1, 1, 0, 0, 0
 };
 
-const int segmentation_feature_bits[SEG_LVL_MAX] = { 8, 6, 6, 6, 6, 3, 0, 0 };
+const int segmentation_feature_bits[SEG_LVL_MAX] = {8, 6, 6, 6, 6, 3, 0, 0};
 
-const int segmentation_feature_max[SEG_LVL_MAX] = { MAXQ,
-                                                           MAX_LOOP_FILTER,
-                                                           MAX_LOOP_FILTER,
-                                                           MAX_LOOP_FILTER,
-                                                           MAX_LOOP_FILTER,
-                                                           7,
-                                                           0,
-                                                           0 };
+const int segmentation_feature_max[SEG_LVL_MAX] = {MAXQ,
+                                                   MAX_LOOP_FILTER,
+                                                   MAX_LOOP_FILTER,
+                                                   MAX_LOOP_FILTER,
+                                                   MAX_LOOP_FILTER,
+                                                   7,
+                                                   0,
+                                                   0};
 
 
 static const uint8_t q_index_to_quantizer[] = {
@@ -51,8 +51,8 @@ static const uint8_t q_index_to_quantizer[] = {
 };
 
 
-uint16_t GetVarianceForCU(const BlockGeom *blk_geom,
-                          uint16_t *variance_ptr) {
+uint16_t get_variance_for_cu(const BlockGeom *blk_geom,
+                             uint16_t *variance_ptr) {
     int index0, index1;
     //Assumes max CU size is 64
     switch (blk_geom->bsize) {
@@ -96,12 +96,12 @@ uint16_t GetVarianceForCU(const BlockGeom *blk_geom,
             break;
 
         case BLOCK_32X64:
-            index0 =  ME_TIER_ZERO_PU_32x32_0 + ((blk_geom->origin_x >> 5) + (blk_geom->origin_y >> 4));
+            index0 = ME_TIER_ZERO_PU_32x32_0 + ((blk_geom->origin_x >> 5) + (blk_geom->origin_y >> 4));
             index1 = index0 + 1;
             break;
 
         case BLOCK_64X32:
-            index0 =  ME_TIER_ZERO_PU_32x32_0 + ((blk_geom->origin_x >> 5) + (blk_geom->origin_y >> 4));
+            index0 = ME_TIER_ZERO_PU_32x32_0 + ((blk_geom->origin_x >> 5) + (blk_geom->origin_y >> 4));
             index1 = index0 + (blk_geom->origin_y >> 4);
             break;
 
@@ -121,11 +121,10 @@ void apply_segmentation_based_quantization(
         const BlockGeom *blk_geom,
         PictureControlSet *picture_control_set_ptr,
         LargestCodingUnit *sb_ptr,
-        CodingUnit *cu_ptr
-) {
+        CodingUnit *cu_ptr) {
     uint16_t *variance_ptr = picture_control_set_ptr->parent_pcs_ptr->variance[sb_ptr->index];
     SegmentationParams *segmentation_params = &picture_control_set_ptr->parent_pcs_ptr->segmentation_params;
-    uint16_t variance = GetVarianceForCU(blk_geom, variance_ptr);
+    uint16_t variance = get_variance_for_cu(blk_geom, variance_ptr);
     for (int i = 0; i < MAX_SEGMENTS; i++) {
         if (variance <= segmentation_params->variance_bin_edge[i]) {
             cu_ptr->segment_id = i;
@@ -143,8 +142,7 @@ void setup_segmentation(
         SequenceControlSet *sequence_control_set_ptr,
         RateControlContext *context_ptr,
         RateControlLayerContext *rateControlLayerPtr,
-        RateControlIntervalParamContext *rateControlParamPtr
-) {
+        RateControlIntervalParamContext *rateControlParamPtr) {
     SegmentationParams *segmentation_params = &picture_control_set_ptr->parent_pcs_ptr->segmentation_params;
     segmentation_params->segmentation_enabled = (EbBool) sequence_control_set_ptr->static_config.enable_adaptive_quantization;
     if (segmentation_params->segmentation_enabled) {
@@ -155,9 +153,9 @@ void setup_segmentation(
         find_segment_qps(segmentation_params, picture_control_set_ptr);
         temporally_update_qps(segment_qps, rateControlLayerPtr->prev_segment_qps,
                               segmentation_params->segmentation_temporal_update);
-        for (int i = 0; i < MAX_SEGMENTS; i++) {
+        for (int i = 0; i < MAX_SEGMENTS; i++)
             segmentation_params->feature_enabled[i][SEG_LVL_ALT_Q] = 1;
-        }
+
         calculate_segmentation_data(segmentation_params);
     }
 
@@ -178,8 +176,7 @@ void calculate_segmentation_data(SegmentationParams *segmentation_params) {
 
 void find_segment_qps(
         SegmentationParams *segmentation_params,
-        PictureControlSet *picture_control_set_ptr
-) { //QP needs to be specified as qpindex, not qp.
+        PictureControlSet *picture_control_set_ptr) { //QP needs to be specified as qpindex, not qp.
 
     uint16_t *variancePtr;
     uint16_t min_var = MAX_UNSIGNED_VALUE, max_var = MIN_UNSIGNED_VALUE, avg_var = 0;
@@ -220,8 +217,7 @@ void find_segment_qps(
 void temporally_update_qps(
         int32_t *segment_qp_ptr,
         int32_t *prev_segment_qp_ptr,
-        EbBool temporal_update
-) {
+        EbBool temporal_update) {
     for (int i = 0; i < MAX_SEGMENTS; i++) {
         int32_t diff = segment_qp_ptr[i] - prev_segment_qp_ptr[i];
         prev_segment_qp_ptr[i] = segment_qp_ptr[i];

--- a/Source/Lib/Common/Codec/EbSegmentation.c
+++ b/Source/Lib/Common/Codec/EbSegmentation.c
@@ -1,0 +1,215 @@
+
+#include "EbSegmentation.h"
+#include "EbSegmentationParams.h"
+#include "EbMotionEstimationContext.h"
+
+const int segmentation_feature_signed[SEG_LVL_MAX] = {
+        1, 1, 1, 1, 1, 0, 0, 0
+};
+
+const int segmentation_feature_bits[SEG_LVL_MAX] = { 8, 6, 6, 6, 6, 3, 0, 0 };
+
+const int segmentation_feature_max[SEG_LVL_MAX] = { MAXQ,
+                                                           MAX_LOOP_FILTER,
+                                                           MAX_LOOP_FILTER,
+                                                           MAX_LOOP_FILTER,
+                                                           MAX_LOOP_FILTER,
+                                                           7,
+                                                           0,
+                                                           0 };
+
+
+static const uint8_t q_index_to_quantizer[] = {
+        0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5,
+        6, 6, 6, 6, 7, 7, 7, 7, 8, 8, 8, 8, 9, 9, 9, 9, 10, 10, 10, 10, 11, 11, 11, 11,
+        12, 12, 12, 12, 13, 13, 13, 13, 14, 14, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16,
+        17, 17, 17, 17, 18, 18, 18, 18, 19, 19, 19, 19, 20, 20, 20, 20, 21, 21, 21, 21,
+        22, 22, 22, 22, 23, 23, 23, 23, 24, 24, 24, 24, 25, 25, 25, 25, 26, 26, 26, 26,
+        27, 27, 27, 27, 28, 28, 28, 28, 29, 29, 29, 29, 30, 30, 30, 30, 31, 31, 31, 31,
+        32, 32, 32, 32, 33, 33, 33, 33, 34, 34, 34, 34, 35, 35, 35, 35, 36, 36, 36, 36,
+        37, 37, 37, 37, 38, 38, 38, 38, 39, 39, 39, 39, 40, 40, 40, 40, 41, 41, 41, 41,
+        42, 42, 42, 42, 43, 43, 43, 43, 44, 44, 44, 44, 45, 45, 45, 45, 46, 46, 46, 46,
+        47, 47, 47, 47, 48, 48, 48, 48, 49, 49, 49, 49, 50, 50, 50, 50, 51, 51, 51, 51,
+        52, 52, 52, 52, 53, 53, 53, 53, 54, 54, 54, 54, 55, 55, 55, 55, 56, 56, 56, 56,
+        57, 57, 57, 57, 58, 58, 58, 58, 59, 59, 59, 59, 60, 60, 60, 60,
+        61, 61, 61, 61, 61, 62, 62, 62, 62, 62, 62, 63
+};
+
+
+uint16_t GetVarianceForCU(const BlockGeom *blk_geom,
+                          uint16_t *variance_ptr) {
+    int index0, index1;
+    //Assumes max CU size is 64
+    switch (blk_geom->bsize) {
+        case BLOCK_4X4:
+        case BLOCK_4X8:
+        case BLOCK_8X4:
+        case BLOCK_8X8:
+            index0 = index1 = ME_TIER_ZERO_PU_8x8_0 + ((blk_geom->origin_x >> 3) + blk_geom->origin_y);
+            break;
+
+        case BLOCK_8X16:
+            index0 = ME_TIER_ZERO_PU_8x8_0 + ((blk_geom->origin_x >> 3) + blk_geom->origin_y);
+            index1 = index0 + 1;
+            break;
+
+        case BLOCK_16X8:
+            index0 = ME_TIER_ZERO_PU_8x8_0 + ((blk_geom->origin_x >> 3) + blk_geom->origin_y);
+            index1 = index0 + blk_geom->origin_y;
+            break;
+
+        case BLOCK_4X16:
+        case BLOCK_16X4:
+        case BLOCK_16X16:
+            index0 = index1 = ME_TIER_ZERO_PU_16x16_0 + ((blk_geom->origin_x >> 4) + (blk_geom->origin_y >> 2));
+            break;
+
+        case BLOCK_16X32:
+            index0 = ME_TIER_ZERO_PU_16x16_0 + ((blk_geom->origin_x >> 4) + (blk_geom->origin_y >> 2));
+            index1 = index0 + 1;
+            break;
+
+        case BLOCK_32X16:
+            index0 = ME_TIER_ZERO_PU_16x16_0 + ((blk_geom->origin_x >> 4) + (blk_geom->origin_y >> 2));
+            index1 = index0 + (blk_geom->origin_y >> 2);
+            break;
+
+        case BLOCK_8X32:
+        case BLOCK_32X8:
+        case BLOCK_32X32:
+            index0 = index1 = ME_TIER_ZERO_PU_32x32_0 + ((blk_geom->origin_x >> 5) + (blk_geom->origin_y >> 4));
+            break;
+
+        case BLOCK_32X64:
+            index0 =  ME_TIER_ZERO_PU_32x32_0 + ((blk_geom->origin_x >> 5) + (blk_geom->origin_y >> 4));
+            index1 = index0 + 1;
+            break;
+
+        case BLOCK_64X32:
+            index0 =  ME_TIER_ZERO_PU_32x32_0 + ((blk_geom->origin_x >> 5) + (blk_geom->origin_y >> 4));
+            index1 = index0 + (blk_geom->origin_y >> 4);
+            break;
+
+        case BLOCK_64X64:
+        case BLOCK_16X64:
+        case BLOCK_64X16:
+        default:
+            index0 = index1 = 0;
+            break;
+
+    }
+    return (variance_ptr[index0] + variance_ptr[index1]) >> 1;
+
+}
+
+void ApplySegmentationBasedQuantization(
+        const BlockGeom *blk_geom,
+        PictureControlSet *picture_control_set_ptr,
+        LargestCodingUnit *sb_ptr,
+        CodingUnit *cu_ptr
+) {
+    uint16_t *variance_ptr = picture_control_set_ptr->parent_pcs_ptr->variance[sb_ptr->index];
+    SegmentationParams *segmentation_params = &picture_control_set_ptr->parent_pcs_ptr->segmentation_params;
+    uint16_t variance = GetVarianceForCU(blk_geom, variance_ptr);
+    for (int i = 0; i < MAX_SEGMENTS; i++) {
+        if (variance <= segmentation_params->variance_bin_edge[i]) {
+            cu_ptr->segment_id = i;
+            break;
+        }
+    }
+    int32_t q_index = picture_control_set_ptr->parent_pcs_ptr->base_qindex +
+                      picture_control_set_ptr->parent_pcs_ptr->segmentation_params.feature_data[cu_ptr->segment_id][SEG_LVL_ALT_Q];
+    cu_ptr->qp = q_index_to_quantizer[q_index];
+
+}
+
+void SetupSegmentation(
+        PictureControlSet *picture_control_set_ptr,
+        SequenceControlSet *sequence_control_set_ptr,
+        RateControlContext *context_ptr,
+        RateControlLayerContext *rateControlLayerPtr,
+        RateControlIntervalParamContext *rateControlParamPtr
+) {
+    SegmentationParams *segmentation_params = &picture_control_set_ptr->parent_pcs_ptr->segmentation_params;
+    segmentation_params->segmentation_enabled = (EbBool) sequence_control_set_ptr->static_config.enable_adaptive_quantization;
+    if (segmentation_params->segmentation_enabled) {
+        int32_t segment_qps[MAX_SEGMENTS];
+        segmentation_params->segmentation_update_data = 1; //always updating for now. Need to set this based on actual deltas
+        segmentation_params->segmentation_update_map = 1;
+        segmentation_params->segmentation_temporal_update = EB_FALSE; //!(picture_control_set_ptr->parent_pcs_ptr->av1FrameType == KEY_FRAME || picture_control_set_ptr->parent_pcs_ptr->av1FrameType == INTRA_ONLY_FRAME);
+        FindSegmentQps(segmentation_params, picture_control_set_ptr);
+        TemporallyUpdateQPs(segment_qps, rateControlLayerPtr->prev_segment_qps, segmentation_params->segmentation_temporal_update);
+        for (int i = 0; i < MAX_SEGMENTS; i++) {
+            segmentation_params->feature_enabled[i][SEG_LVL_ALT_Q] = 1;
+        }
+        CalculateSegmentationData(segmentation_params);
+    }
+
+}
+
+void CalculateSegmentationData(SegmentationParams *segmentation_params) {
+    for (int i = 0; i < MAX_SEGMENTS; i++) {
+        for (int j = 0; j < SEG_LVL_MAX; j++) {
+            if (segmentation_params->feature_enabled[i][j]) {
+                segmentation_params->last_active_seg_id = i;
+                if (j >= SEG_LVL_REF_FRAME) {
+                    segmentation_params->seg_id_pre_skip = 1;
+                }
+            }
+        }
+    }
+}
+
+void FindSegmentQps(
+        SegmentationParams *segmentation_params,
+        PictureControlSet *picture_control_set_ptr
+) { //QP needs to be specified as qpindex, not qp.
+
+    uint16_t *variancePtr;
+    uint16_t min_var = MAX_UNSIGNED_VALUE, max_var = MIN_UNSIGNED_VALUE, avg_var = 0;
+    float strength = 2;//to tune
+
+    // get range of variance
+    for (uint32_t lcuIdx = 0; lcuIdx < picture_control_set_ptr->sb_total_count; ++lcuIdx) {
+        variancePtr = picture_control_set_ptr->parent_pcs_ptr->variance[lcuIdx];
+        uint32_t var_index, local_avg = 0;
+        // Loop over all 8x8s in a 64x64
+        for (var_index = ME_TIER_ZERO_PU_8x8_0; var_index <= ME_TIER_ZERO_PU_8x8_63; var_index++) {
+            max_var = MAX(max_var, variancePtr[var_index]);
+            min_var = MIN(min_var, variancePtr[var_index]);
+            local_avg += variancePtr[var_index];
+        }
+        avg_var += (local_avg >> 6);
+    }
+    avg_var /= picture_control_set_ptr->sb_total_count;
+    avg_var = Log2f(avg_var);
+
+    //get variance bin edges & QPs
+    uint16_t min_var_log = Log2f(MAX(1, min_var));
+    uint16_t max_var_log = Log2f(MAX(1, max_var));
+    uint16_t step_size = (max_var_log - min_var_log) <= MAX_SEGMENTS ? 1 : ROUND(
+            ((float) (max_var_log - min_var_log)) / MAX_SEGMENTS);
+    uint16_t bin_edge = min_var_log + step_size;
+    uint16_t bin_center = bin_edge >> 1;
+
+    for (int i = 0; i < MAX_SEGMENTS; i++) {
+        segmentation_params->variance_bin_edge[i] = POW2(bin_edge);
+        segmentation_params->feature_data[i][SEG_LVL_ALT_Q] = ROUND(strength * (MAX(1, bin_center) - avg_var));
+        bin_edge += step_size;
+        bin_center += step_size;
+    }
+
+}
+
+void TemporallyUpdateQPs(
+        int32_t *segment_qp_ptr,
+        int32_t *prev_segment_qp_ptr,
+        EbBool temporal_update
+) {
+    for (int i = 0; i < MAX_SEGMENTS; i++) {
+        int32_t diff = segment_qp_ptr[i] - prev_segment_qp_ptr[i];
+        prev_segment_qp_ptr[i] = segment_qp_ptr[i];
+        segment_qp_ptr[i] = temporal_update ? diff : segment_qp_ptr[i];
+    }
+}
+

--- a/Source/Lib/Common/Codec/EbSegmentation.h
+++ b/Source/Lib/Common/Codec/EbSegmentation.h
@@ -1,25 +1,37 @@
+/*
+* Copyright(c) 2019 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+/*
+* Copyright (c) 2016, Alliance for Open Media. All rights reserved
+*
+* This source code is subject to the terms of the BSD 2 Clause License and
+* the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+* was not distributed with this source code in the LICENSE file, you can
+* obtain it at www.aomedia.org/license/software. If the Alliance for Open
+* Media Patent License 1.0 was not distributed with this source code in the
+* PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+*/
 
 
 #ifndef SVT_AV1_EBSEGMENTATION_H
 #define SVT_AV1_EBSEGMENTATION_H
 
-
-#include <stdint.h>
 #include "EbDefinitions.h"
 #include "EbPictureControlSet.h"
 #include "EbSequenceControlSet.h"
 #include "EbRateControlProcess.h"
 
 
-
-void ApplySegmentationBasedQuantization(
-        const BlockGeom * blk_geom,
+void apply_segmentation_based_quantization(
+        const BlockGeom *blk_geom,
         PictureControlSet *picture_control_set_ptr,
         LargestCodingUnit *sb_ptr,
         CodingUnit *cu_ptr
 );
 
-void SetupSegmentation(
+void setup_segmentation(
         PictureControlSet *picture_control_set_ptr,
         SequenceControlSet *sequence_control_set_ptr,
         RateControlContext *context_ptr,
@@ -27,18 +39,18 @@ void SetupSegmentation(
         RateControlIntervalParamContext *rateControlParamPtr
 );
 
-void FindSegmentQps(
+void find_segment_qps(
         SegmentationParams *segmentation_params,
         PictureControlSet *picture_control_set_ptr
 );
 
-void TemporallyUpdateQPs(
+void temporally_update_qps(
         int32_t *segment_qp_ptr,
         int32_t *prev_segment_qp_ptr,
         EbBool temporal_update
 );
 
-void CalculateSegmentationData(
+void calculate_segmentation_data(
         SegmentationParams *segmentation_params
 );
 

--- a/Source/Lib/Common/Codec/EbSegmentation.h
+++ b/Source/Lib/Common/Codec/EbSegmentation.h
@@ -1,0 +1,47 @@
+
+
+#ifndef SVT_AV1_EBSEGMENTATION_H
+#define SVT_AV1_EBSEGMENTATION_H
+
+
+#include <stdint.h>
+#include "EbDefinitions.h"
+#include "EbPictureControlSet.h"
+#include "EbSequenceControlSet.h"
+#include "EbRateControlProcess.h"
+
+
+
+void ApplySegmentationBasedQuantization(
+        const BlockGeom * blk_geom,
+        PictureControlSet *picture_control_set_ptr,
+        LargestCodingUnit *sb_ptr,
+        CodingUnit *cu_ptr
+);
+
+void SetupSegmentation(
+        PictureControlSet *picture_control_set_ptr,
+        SequenceControlSet *sequence_control_set_ptr,
+        RateControlContext *context_ptr,
+        RateControlLayerContext *rateControlLayerPtr,
+        RateControlIntervalParamContext *rateControlParamPtr
+);
+
+void FindSegmentQps(
+        SegmentationParams *segmentation_params,
+        PictureControlSet *picture_control_set_ptr
+);
+
+void TemporallyUpdateQPs(
+        int32_t *segment_qp_ptr,
+        int32_t *prev_segment_qp_ptr,
+        EbBool temporal_update
+);
+
+void CalculateSegmentationData(
+        SegmentationParams *segmentation_params
+);
+
+#endif //SVT_AV1_EBSEGMENTATIONS_H
+
+

--- a/Source/Lib/Common/Codec/EbSegmentationParams.h
+++ b/Source/Lib/Common/Codec/EbSegmentationParams.h
@@ -1,0 +1,74 @@
+
+
+#ifndef SVT_AV1_EBSEGMENTATIONPARAMS_H
+#define SVT_AV1_EBSEGMENTATIONPARAMS_H
+
+
+enum {
+    SEG_LVL_ALT_Q,       // Use alternate Quantizer
+    SEG_LVL_ALT_LF_Y_V,  // Use alternate loop filter value on y plane vertical
+    SEG_LVL_ALT_LF_Y_H,  // Use alternate loop filter value on y plane horizontal
+    SEG_LVL_ALT_LF_U,    // Use alternate loop filter value on u plane
+    SEG_LVL_ALT_LF_V,    // Use alternate loop filter value on v plane
+    SEG_LVL_REF_FRAME,   // Optional Segment reference frame
+    SEG_LVL_SKIP,        // Optional Segment (0,0) + skip mode
+    SEG_LVL_GLOBALMV,
+    SEG_LVL_MAX
+} UENUM1BYTE(SEG_LVL_FEATURES);
+
+typedef struct{
+    uint8_t *data;
+    uint32_t map_size;
+} SegmentationNeighborMap;
+
+typedef struct {
+    /*!< 1: Indicates that this frame makes use of the segmentation tool
+    *   0: Indicates that the frame does not use segmentation*/
+    uint8_t     segmentation_enabled;
+
+    /*!< 1: Indicates that the segmentation map are updated during the decoding
+     *      of this frame
+     *   0: Indicates that the segmentation map from the previous frame is used*/
+    uint8_t     segmentation_update_map;
+
+    /*!< 1: Indicates that the updates to the segmentation map are coded
+     *      relative to the existing segmentation map
+     *   0: Indicates that the new segmentation map is coded without reference
+     *      to the existing segmentation map */
+    uint8_t     segmentation_temporal_update;
+
+    /*!<1: Indicates that new parameters are about to be specified for each segment
+     *  0: Indicates that the segmentation parameters should keep their existing
+     *     values*/
+    uint8_t     segmentation_update_data;
+
+    /*!< Specifies the feature data for a segment feature */
+    int16_t     feature_data[MAX_SEGMENTS][SEG_LVL_MAX];
+
+    /*!< Specifies the feature enabled for a segment feature */
+    int16_t     feature_enabled[MAX_SEGMENTS][SEG_LVL_MAX];
+
+    /*!< Specifies the feature enabled for a segment feature */
+    int16_t     seg_qm_level[MAX_SEGMENTS][SEG_LVL_MAX];
+
+    /*!< Specifies the highest numbered segment id that has some enabled feature*/
+    uint8_t     last_active_seg_id;
+
+    /*!< 1: Indicates that the segment id will be read before the skip syntax element
+     *   0: Indicates that the skip syntax element will be read first */
+    uint8_t     seg_id_pre_skip;
+
+    //qp-binning related
+    int16_t variance_bin_edge[MAX_SEGMENTS];
+
+} SegmentationParams;
+
+
+
+
+extern const int segmentation_feature_bits[SEG_LVL_MAX];
+extern const int segmentation_feature_signed[SEG_LVL_MAX];
+extern const int segmentation_feature_max[SEG_LVL_MAX];
+
+
+#endif //SVT_AV1_EBSEGMENTATIONPARAMS_H

--- a/Source/Lib/Common/Codec/EbSegmentationParams.h
+++ b/Source/Lib/Common/Codec/EbSegmentationParams.h
@@ -1,3 +1,18 @@
+/*
+* Copyright(c) 2019 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+/*
+* Copyright (c) 2016, Alliance for Open Media. All rights reserved
+*
+* This source code is subject to the terms of the BSD 2 Clause License and
+* the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+* was not distributed with this source code in the LICENSE file, you can
+* obtain it at www.aomedia.org/license/software. If the Alliance for Open
+* Media Patent License 1.0 was not distributed with this source code in the
+* PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+*/
 
 
 #ifndef SVT_AV1_EBSEGMENTATIONPARAMS_H
@@ -62,9 +77,6 @@ typedef struct {
     int16_t variance_bin_edge[MAX_SEGMENTS];
 
 } SegmentationParams;
-
-
-
 
 extern const int segmentation_feature_bits[SEG_LVL_MAX];
 extern const int segmentation_feature_signed[SEG_LVL_MAX];

--- a/Source/Lib/Common/Codec/EbTransforms.h
+++ b/Source/Lib/Common/Codec/EbTransforms.h
@@ -3906,7 +3906,6 @@ extern "C" {
 #if DC_SIGN_CONTEXT_FIX
     extern int32_t av1_quantize_inv_quantize(
 #else
-    extern void av1_quantize_inv_quantize(
 #endif
         PictureControlSet             *picture_control_set_ptr,
         ModeDecisionContext           *md_context,
@@ -3915,6 +3914,7 @@ extern "C" {
         int32_t                       *quant_coeff,
         int32_t                       *recon_coeff,
         uint32_t                       qp,
+        int32_t              segmentation_qp_offset,
         uint32_t                       width,
         uint32_t                       height,
         TxSize                         txsize,

--- a/Source/Lib/Decoder/Codec/EbDecStruct.h
+++ b/Source/Lib/Decoder/Codec/EbDecStruct.h
@@ -29,17 +29,7 @@ extern "C" {
 #define MAX_TILE_ROWS_AV1 64
 #define MAX_TILE_COLS_AV1 64
 
-enum {
-    SEG_LVL_ALT_Q,       // Use alternate Quantizer
-    SEG_LVL_ALT_LF_Y_V,  // Use alternate loop filter value on y plane vertical
-    SEG_LVL_ALT_LF_Y_H,  // Use alternate loop filter value on y plane horizontal
-    SEG_LVL_ALT_LF_U,    // Use alternate loop filter value on u plane
-    SEG_LVL_ALT_LF_V,    // Use alternate loop filter value on v plane
-    SEG_LVL_REF_FRAME,   // Optional Segment reference frame
-    SEG_LVL_SKIP,        // Optional Segment (0,0) + skip mode
-    SEG_LVL_GLOBALMV,
-    SEG_LVL_MAX
-} UENUM1BYTE(SEG_LVL_FEATURES);
+
 
 typedef struct FrameSize {
     /*!< Width of the frame in luma samples */
@@ -152,43 +142,6 @@ typedef struct QuantizationParams {
     uint8_t     qm_v;
 } QuantizationParams;
 
-typedef struct SegmentationParams {
-    /*!< 1: Indicates that this frame makes use of the segmentation tool
-     *   0: Indicates that the frame does not use segmentation*/
-    uint8_t     segmentation_enabled;
-
-    /*!< 1: Indicates that the segmentation map are updated during the decoding
-     *      of this frame
-     *   0: Indicates that the segmentation map from the previous frame is used*/
-    uint8_t     segmentation_update_map;
-
-    /*!< 1: Indicates that the updates to the segmentation map are coded
-     *      relative to the existing segmentation map
-     *   0: Indicates that the new segmentation map is coded without reference
-     *      to the existing segmentation map */
-    uint8_t     segmentation_temporal_update;
-
-    /*!<1: Indicates that new parameters are about to be specified for each segment
-     *  0: Indicates that the segmentation parameters should keep their existing
-     *     values*/
-    uint8_t     segmentation_update_data;
-
-    /*!< Specifies the feature data for a segment feature */
-    int16_t     feature_data[MAX_SEGMENTS][SEG_LVL_MAX];
-
-    /*!< Specifies the feature enabled for a segment feature */
-    int16_t     feature_enabled[MAX_SEGMENTS][SEG_LVL_MAX];
-
-    /*!< Specifies the feature enabled for a segment feature */
-    int16_t     seg_qm_level[MAX_SEGMENTS][SEG_LVL_MAX];
-
-    /*!< Specifies the highest numbered segment id that has some enabled feature*/
-    uint8_t     last_active_seg_id;
-
-    /*!< 1: Indicates that the segment id will be read before the skip syntax element
-     *   0: Indicates that the skip syntax element will be read first */
-    uint8_t     seg_id_pre_skip;
-} SegmentationParams;
 
 typedef struct DeltaQParams {
     /*!< Specifies whether quantizer index delta values are present */

--- a/Source/Lib/Decoder/Codec/EbObuParse.h
+++ b/Source/Lib/Decoder/Codec/EbObuParse.h
@@ -60,20 +60,6 @@ enum {
   SEQ_LEVEL_MAX = 31
 } UENUM1BYTE(AV1_LEVEL);
 
-static const int segmentation_feature_signed[SEG_LVL_MAX] = {
-  1, 1, 1, 1, 1, 0, 0, 0
-};
-
-static const int segmentation_feature_bits[SEG_LVL_MAX] = { 8, 6, 6, 6, 6, 3, 0, 0 };
-
-static const int segmentation_feature_max[SEG_LVL_MAX] = { MAXQ,
-                                                       MAX_LOOP_FILTER,
-                                                       MAX_LOOP_FILTER,
-                                                       MAX_LOOP_FILTER,
-                                                       MAX_LOOP_FILTER,
-                                                       7,
-                                                       0,
-                                                       0 };
 
 typedef struct ParseNbr4x4Ctxt {
     /* Buffer holding the segment ID of all 4x4 blocks in the frame. */

--- a/Source/Lib/Encoder/Codec/CMakeLists.txt
+++ b/Source/Lib/Encoder/Codec/CMakeLists.txt
@@ -38,6 +38,7 @@ file(GLOB all_files
     "*.h"
     "*.c")
  
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     list(APPEND PLATFORM_LIBS m)
 endif()

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -2370,6 +2370,10 @@ void CopyApiFromApp(
         ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->min_qp_allowed :
         1; // lossless coding not supported
 
+    //Segmentation
+    //TODO: check RC mode and set only when RC is enabled in the final version.
+    sequence_control_set_ptr->static_config.enable_adaptive_quantization = pComponentParameterStructure->enable_adaptive_quantization;
+
     // Misc
     sequence_control_set_ptr->static_config.encoder_bit_depth = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->encoder_bit_depth;
     sequence_control_set_ptr->static_config.encoder_color_format = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->encoder_color_format;

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -2122,6 +2122,9 @@ void SetDefaultConfigurationParameters(
     sequence_control_set_ptr->cropping_top_offset = 0;
     sequence_control_set_ptr->cropping_bottom_offset = 0;
 
+    //Segmentation
+    sequence_control_set_ptr->static_config.enable_adaptive_quantization = 0;
+
     return;
 }
 
@@ -2724,6 +2727,11 @@ static EbErrorType VerifySettings(
 
     if (config->screen_content_mode > 2) {
         SVT_LOG("Error instance %u : Invalid screen_content_mode. screen_content_mode must be [0 - 2]\n", channelNumber + 1);
+        return_error = EB_ErrorBadParameter;
+    }
+
+    if(sequence_control_set_ptr->static_config.enable_adaptive_quantization>1){
+        SVT_LOG("Error instance %u : Invalid enable_adaptive_quantization. enable_adaptive_quantization must be [0/1]\n", channelNumber + 1);
         return_error = EB_ErrorBadParameter;
     }
 


### PR DESCRIPTION
Initial set of commits to enable segmentation. Uses a very basic variance-based adaptive quantization to test the path. While not thoroughly tested, the feature is relatively stable. PR created so that future changes can easily be added and we do not keep running into merge conflicts.
Rec-dec match tested for RC off. There may still be errors though, so not expected for wide use yet.