### PR TITLE
Bug fixes related to Chroma and 64x64 block size

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -70,6 +70,10 @@ extern "C" {
 #endif
 #define SHUT_ATB                          0 // ATB multi-mode signal
 #endif
+
+#define CHROMA_SEARCH_FIX                 1 // Fix a few bugs related to Chroma search
+#define INTRA64_FIX                       1 // Fix a bug where 64x64 are disabled for sub 720P
+#define CHROMA_SEARCH_MR                  1 // Enable chroma search for all layers in MR mode
 /**********************************************************************************/
 
 // New  presets

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1308,6 +1308,11 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
                 CHROMA_MODE_3;
     else
 #endif
+#if CHROMA_SEARCH_MR    
+    if (MR_MODE)
+        context_ptr->chroma_level = CHROMA_MODE_0;
+    else
+#endif
 #if SEARCH_UV_BASE
     if (picture_control_set_ptr->enc_mode == ENC_M0 && picture_control_set_ptr->temporal_layer_index == 0)
 #else

--- a/Source/Lib/Common/Codec/EbFullLoop.c
+++ b/Source/Lib/Common/Codec/EbFullLoop.c
@@ -4294,7 +4294,11 @@ uint32_t d2_inter_depth_block_decision(
         while (blk_geom->is_last_quadrant) {
             //get parent idx
             parent_depth_idx_mds = current_depth_idx_mds - parent_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth];
-            if (picture_control_set_ptr->slice_type == I_SLICE && parent_depth_idx_mds == 0)
+#if INTRA64_FIX
+            if (picture_control_set_ptr->slice_type == I_SLICE && parent_depth_idx_mds == 0 && sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128)
+#else
+            if (picture_control_set_ptr->slice_type == I_SLICE && parent_depth_idx_mds == 0) 
+#endif
                 parent_depth_cost = MAX_MODE_COST;
             else
                 compute_depth_costs(context_ptr, sequence_control_set_ptr, current_depth_idx_mds, parent_depth_idx_mds, ns_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth], &parent_depth_cost, &current_depth_cost);

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -5147,6 +5147,12 @@ void  inject_intra_candidates(
                             candidateArray[canTotalCnt].intra_chroma_mode = disable_cfl_flag ?
                                 context_ptr->best_uv_mode[openLoopIntraCandidate][MAX_ANGLE_DELTA + candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_Y]] :
                                 UV_CFL_PRED ;
+#if CHROMA_SEARCH_FIX
+                            candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_UV] = disable_cfl_flag ?
+                                context_ptr->best_uv_angle[candidateArray[canTotalCnt].intra_luma_mode][MAX_ANGLE_DELTA + candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_Y]] : 0;
+                            candidateArray[canTotalCnt].is_directional_chroma_mode_flag = disable_cfl_flag ?
+                                (uint8_t)av1_is_directional_mode((PredictionMode)(context_ptr->best_uv_mode[candidateArray[canTotalCnt].intra_luma_mode][MAX_ANGLE_DELTA + candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_Y]])) : 0;
+#endif
                         }
                         else {
                             // Hsan/Omar: why the restriction below ? (i.e. disable_ang_uv)
@@ -5158,6 +5164,10 @@ void  inject_intra_candidates(
                                 UV_DC_PRED;
                             candidateArray[canTotalCnt].intra_chroma_mode = disable_ang_uv && av1_is_directional_mode(candidateArray[canTotalCnt].intra_chroma_mode) ?
                                 UV_DC_PRED : candidateArray[canTotalCnt].intra_chroma_mode;
+#if CHROMA_SEARCH_FIX
+                            candidateArray[canTotalCnt].is_directional_chroma_mode_flag = (uint8_t)av1_is_directional_mode((PredictionMode)candidateArray[canTotalCnt].intra_chroma_mode);
+                            candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_UV] = 0;
+#endif
                         }
 #else
                         const int32_t disable_ang_uv = (context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4) && context_ptr->blk_geom->has_uv ? 1 : 0;
@@ -5171,11 +5181,17 @@ void  inject_intra_candidates(
 #endif
 #if CHROMA_DC_ONLY
                         candidateArray[canTotalCnt].intra_chroma_mode = UV_DC_PRED;
+#if CHROMA_SEARCH_FIX
+                        candidateArray[canTotalCnt].is_directional_chroma_mode_flag = (uint8_t)av1_is_directional_mode((PredictionMode)candidateArray[canTotalCnt].intra_chroma_mode);
+                        candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_UV] = 0;
+#endif
 #endif
                         candidateArray[canTotalCnt].cfl_alpha_signs = 0;
                         candidateArray[canTotalCnt].cfl_alpha_idx = 0;
+#if !CHROMA_SEARCH_FIX
                         candidateArray[canTotalCnt].is_directional_chroma_mode_flag = (uint8_t)av1_is_directional_mode((PredictionMode)candidateArray[canTotalCnt].intra_chroma_mode);
                         candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_UV] = 0;
+#endif
 #if ATB_TX_TYPE_SUPPORT_PER_TU
                         candidateArray[canTotalCnt].transform_type[0] = DCT_DCT;
 
@@ -5234,6 +5250,12 @@ void  inject_intra_candidates(
                 candidateArray[canTotalCnt].intra_chroma_mode = disable_cfl_flag ?
                     context_ptr->best_uv_mode[openLoopIntraCandidate][MAX_ANGLE_DELTA + candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_Y]] :
                     UV_CFL_PRED;
+#if CHROMA_SEARCH_FIX
+                candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_UV] = disable_cfl_flag ?
+                    context_ptr->best_uv_angle[candidateArray[canTotalCnt].intra_luma_mode][MAX_ANGLE_DELTA + candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_Y]] : 0;
+                candidateArray[canTotalCnt].is_directional_chroma_mode_flag = disable_cfl_flag ?
+                    (uint8_t)av1_is_directional_mode((PredictionMode)(context_ptr->best_uv_mode[candidateArray[canTotalCnt].intra_luma_mode][MAX_ANGLE_DELTA + candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_Y]])) : 0;
+#endif
             }
             else {
                 // Hsan/Omar: why the restriction below ? (i.e. disable_ang_uv)
@@ -5246,6 +5268,12 @@ void  inject_intra_candidates(
 
                 candidateArray[canTotalCnt].intra_chroma_mode = disable_ang_uv && av1_is_directional_mode(candidateArray[canTotalCnt].intra_chroma_mode) ?
                     UV_DC_PRED : candidateArray[canTotalCnt].intra_chroma_mode;
+
+#if CHROMA_SEARCH_FIX
+                candidateArray[canTotalCnt].is_directional_chroma_mode_flag = (uint8_t)av1_is_directional_mode((PredictionMode)candidateArray[canTotalCnt].intra_chroma_mode);
+                candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_UV] = 0;
+#endif
+
             }
 #else
             const int32_t disable_ang_uv = (context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4) && context_ptr->blk_geom->has_uv ? 1 : 0;
@@ -5260,11 +5288,17 @@ void  inject_intra_candidates(
 #endif
 #if CHROMA_DC_ONLY
             candidateArray[canTotalCnt].intra_chroma_mode = UV_DC_PRED;
+#if CHROMA_SEARCH_FIX
+            candidateArray[canTotalCnt].is_directional_chroma_mode_flag = (uint8_t)av1_is_directional_mode((PredictionMode)candidateArray[canTotalCnt].intra_chroma_mode);
+            candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_UV] = 0;
+#endif
 #endif
             candidateArray[canTotalCnt].cfl_alpha_signs = 0;
             candidateArray[canTotalCnt].cfl_alpha_idx = 0;
+#if !CHROMA_SEARCH_FIX
             candidateArray[canTotalCnt].is_directional_chroma_mode_flag = (uint8_t)av1_is_directional_mode((PredictionMode)candidateArray[canTotalCnt].intra_chroma_mode);
             candidateArray[canTotalCnt].angle_delta[PLANE_TYPE_UV] = 0;
+#endif
 #if ATB_TX_TYPE_SUPPORT_PER_TU
             candidateArray[canTotalCnt].transform_type[0] = DCT_DCT;
 


### PR DESCRIPTION
**Description**
Fix a few bugs relate to Chroma search (cost calculation, comparison between independent mode and DC)
Fix a bug where 64x64 are disabled for sub 720P resolution
Enable chroma search for all layers in MR mode

**Authors**
@anaghdin

**Type of change**
Feature improvement

**Tests and performance**
Expected Average PSNR-SSIM BD-rate gain in the range of -0.9% on the AOM test set, using 4 QP values: {20, 32, 43 and 55}. 

No Speed impact.