### PR TITLE
Statistics report functionality 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Adaptive Transform Block for INTRA
 - Adaptive QP scaling
 - Decoder - Support for Tiles and 10bit
+- API - add option to calculate / report PSNR values
 
 ## [0.5.0] - 2019-05-17
 

--- a/Config/Sample.cfg
+++ b/Config/Sample.cfg
@@ -12,7 +12,8 @@ ErrorFile                       : SVTEncoderLog.log       # Error log displaying
 UseQpFile                       : 0                       # When set to 1, overwrite the picture qp assignment using qp values in QpFile
 QpFile                          : SVTQPFile.txt           # File with rows of QP values corresponding to QP values for each frame
 
-StatFile                        : AV1SVTEncoderStat.log   # Optional output for frame statistics.
+StatReport                      : 0 					  # (0= OFF, 1=ON ) Calculates and outputs reconstructed PSNR values 
+StatFile                        : AV1SVTEncoderStat.log   # Optional output for frame statistics. (outputs per frame: QP / PSNR Y / PSNR U / PSNR V / byte count)
 #ReconFile                      : Recon.yuv               # optional output for recon [Enabled when valid file name is added]
 
 #====================== Encoding Presets ===============================

--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -116,6 +116,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **StreamFile** | -b | any string | null | output bitstream file path |
 | **ErrorFile** | -errlog | any string | stderr | error log displaying configuration or encode errors |
 | **UseQpFile** | -use-q-file | [0 - 1] | 0 | When set to 1, overwrite the picture qp assignment using qp values in QpFile |
+| **QpFile** | -qp-file | any string | Null | Path to qp file |
 | **StatReport** | -stat-report | [0 - 1] | 0 | When set to 1, calculate and display PSNR values |
 | **StatFile** | -stat-file | any string | Null | Path to statistics file if specified and StatReport is set to 1, per picture statistics are outputted in the file|
 | **EncoderMode** | -enc-mode | [0 - 8] | 8 | Encoder Preset [0,1,2,3,4,5,6,7,8] 0 = highest quality, 8 = highest speed |

--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -116,7 +116,8 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **StreamFile** | -b | any string | null | output bitstream file path |
 | **ErrorFile** | -errlog | any string | stderr | error log displaying configuration or encode errors |
 | **UseQpFile** | -use-q-file | [0 - 1] | 0 | When set to 1, overwrite the picture qp assignment using qp values in QpFile |
-| **QpFile** | -qp-file | any string | Null | Path to qp file |
+| **StatReport** | -stat-report | [0 - 1] | 0 | When set to 1, calculate and display PSNR values |
+| **StatFile** | -stat-file | any string | Null | Path to statistics file if specified and StatReport is set to 1, per picture statistics are outputted in the file|
 | **EncoderMode** | -enc-mode | [0 - 8] | 8 | Encoder Preset [0,1,2,3,4,5,6,7,8] 0 = highest quality, 8 = highest speed |
 | **EncoderBitDepth** | -bit-depth | [8 , 10] | 8 | specifies the bit depth of the input video |
 | **CompressedTenBitFormat** | -compressed-ten-bit-format | [0 - 1] | 0 | Offline packing of the 2bits: requires two bits packed input (0: OFF, 1: ON) |

--- a/Source/API/EbSvtAv1.h
+++ b/Source/API/EbSvtAv1.h
@@ -77,6 +77,9 @@ typedef struct EbBufferHeaderType
     // pic info
     uint32_t qp;
     uint32_t pic_type;
+    uint32_t luma_sse;
+    uint32_t cr_sse;
+    uint32_t cb_sse;
 
     // pic flags
     uint32_t flags;

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -169,6 +169,11 @@ typedef struct EbSvtAv1EncConfiguration
     * Default is 4. */
     uint32_t                 partition_depth;
 
+    /* Instruct the library to calculate the recon to source for PSNR calculation
+    *
+    * Default is 0.*/
+    uint32_t                 stat_report;
+
     // Quantization
     /* Initial quantization parameter for the Intra pictures used under constant
      * qp rate control mode.
@@ -373,8 +378,6 @@ typedef struct EbSvtAv1EncConfiguration
 
 /* To be deprecated.
  * Encoder configuration parameters below this line are to be deprecated. */
-
-    uint32_t                 stat_report;
 
     /* Flag to enable Hierarchical Motion Estimation 1/16th of the picture
     *

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -153,6 +153,11 @@ typedef struct EbPerformanceContext {
     double                    average_latency;
 
     uint64_t                  byte_count;
+    double                    sum_luma_psnr;
+    double                    sum_cr_psnr;
+    double                    sum_cb_psnr;
+    uint64_t                  sum_qp;
+
 }EbPerformanceContext;
 
 typedef struct EbConfig
@@ -165,6 +170,7 @@ typedef struct EbConfig
     FILE                    *bitstream_file;
     FILE                    *recon_file;
     FILE                    *error_log_file;
+    FILE                    *stat_file;
     FILE                    *buffer_file;
 
     FILE                    *qp_file;
@@ -173,6 +179,7 @@ typedef struct EbConfig
     unsigned char           y4m_buf[9];
 
     EbBool                  use_qp_file;
+    uint8_t                  stat_report;
 
     uint32_t                 frame_rate;
     uint32_t                 frame_rate_numerator;

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -175,6 +175,7 @@ EbErrorType CopyConfigurationParameters(
     callback_data->eb_enc_parameters.min_qp_allowed = config->min_qp_allowed;
     callback_data->eb_enc_parameters.qp = config->qp;
     callback_data->eb_enc_parameters.use_qp_file = (EbBool)config->use_qp_file;
+    callback_data->eb_enc_parameters.stat_report = (EbBool)config->stat_report;
     callback_data->eb_enc_parameters.disable_dlf_flag = (EbBool)config->disable_dlf_flag;
     callback_data->eb_enc_parameters.enable_warped_motion = (EbBool)config->enable_warped_motion;
     callback_data->eb_enc_parameters.use_default_me_hme = (EbBool)config->use_default_me_hme;

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -654,7 +654,7 @@ void ReconOutput(
     eb_release_mutex(encode_context_ptr->total_number_of_recon_frame_mutex);
 }
 
-void PsnrCalculations(
+void psnr_calculations(
     PictureControlSet    *picture_control_set_ptr,
     SequenceControlSet   *sequence_control_set_ptr){
     EbBool is16bit = (sequence_control_set_ptr->static_config.encoder_bit_depth > EB_8BIT);

--- a/Source/Lib/Common/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Common/Codec/EbPacketizationProcess.c
@@ -293,7 +293,18 @@ void* packetization_kernel(void *input_ptr)
             picture_control_set_ptr->parent_pcs_ptr->idr_flag ? EB_AV1_KEY_PICTURE :
             picture_control_set_ptr->slice_type : EB_AV1_NON_REF_PICTURE;
         output_stream_ptr->p_app_private = picture_control_set_ptr->parent_pcs_ptr->input_ptr->p_app_private;
+        output_stream_ptr->qp            = picture_control_set_ptr->parent_pcs_ptr->picture_qp;
 
+        if (sequence_control_set_ptr->static_config.stat_report){
+            output_stream_ptr->luma_sse = picture_control_set_ptr->parent_pcs_ptr->luma_sse;
+            output_stream_ptr->cr_sse   = picture_control_set_ptr->parent_pcs_ptr->cr_sse;
+            output_stream_ptr->cb_sse   = picture_control_set_ptr->parent_pcs_ptr->cb_sse;
+        } else {
+            output_stream_ptr->luma_sse = 0;
+            output_stream_ptr->cr_sse   = 0;
+            output_stream_ptr->cb_sse   = 0;
+        }
+            
         // Get Empty Rate Control Input Tasks
         eb_get_empty_object(
             context_ptr->rate_control_tasks_output_fifo_ptr,

--- a/Source/Lib/Common/Codec/EbRestProcess.c
+++ b/Source/Lib/Common/Codec/EbRestProcess.c
@@ -31,7 +31,7 @@ void av1_loop_restoration_filter_frame(Yv12BufferConfig *frame,
 void CopyStatisticsToRefObject(
     PictureControlSet    *picture_control_set_ptr,
     SequenceControlSet   *sequence_control_set_ptr);
-void PsnrCalculations(
+void psnr_calculations(
     PictureControlSet    *picture_control_set_ptr,
     SequenceControlSet   *sequence_control_set_ptr);
 void PadRefAndSetFlags(
@@ -292,12 +292,11 @@ void* rest_kernel(void *input_ptr)
                     sequence_control_set_ptr);
             }
 
-            //// PSNR Calculation
-            //if (sequence_control_set_ptr->static_config.stat_report) {
-            //    PsnrCalculations(
-            //        picture_control_set_ptr,
-            //        sequence_control_set_ptr);
-            //}
+            // PSNR Calculation
+            if (sequence_control_set_ptr->static_config.stat_report)
+                psnr_calculations(
+                    picture_control_set_ptr,
+                    sequence_control_set_ptr);
 
             // Pad the reference picture and set up TMVP flag and ref POC
             if (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE)

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -2713,6 +2713,11 @@ static EbErrorType VerifySettings(
         return_error = EB_ErrorBadParameter;
     }
 
+    if (config->stat_report > 1) {
+        SVT_LOG("Error instance %u : Invalid StatReport. StatReport must be [0 - 1]\n", channelNumber + 1);
+        return_error = EB_ErrorBadParameter;
+    }    
+
     if (config->high_dynamic_range_input > 1) {
         SVT_LOG("Error instance %u : Invalid HighDynamicRangeInput. HighDynamicRangeInput must be [0 - 1]\n", channelNumber + 1);
         return_error = EB_ErrorBadParameter;


### PR DESCRIPTION
## Description

* The stat report functionality allows the encoder to output per picture statistics [byte count / PSNR Y U V / QP ] to a file of the user's choosing. if the file is not specified, a summary of the average statistics are shown at the end of the encode. 
* This change added API field in the output structure to send out the sse values.
 
Closes #97 

## Type of change
New feature / Tool / API change

