### PR TITLE
Turn on NSQ_ME_OPT by default

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -147,7 +147,7 @@ extern "C" {
 #define RC_FEEDBACK                       1 // Feedback from previous base layer is received before starting the next base layer frame
 #endif
 #define RED_CU                            1 // Bypass redundant CU
-#define NSQ_ME_OPT                        0 // NSQ ME Restructuring
+#define NSQ_ME_OPT                        1 // NSQ ME Restructuring
 #define BYPASS_USELESS_TX_SEARCH          0
 // Testing MACROS
 #define M9_NEAR_INJECTION                 0

--- a/Source/Lib/Common/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimation.c
@@ -1075,7 +1075,7 @@ void ExtSadCalculation(
     }
 
     sad_32x16[5] = p_sad16x16[10] + p_sad16x16[11];
-    if (sad < p_best_sad32x16[5]) {
+    if (sad_32x16[5] < p_best_sad32x16[5]) {
         p_best_sad32x16[5] = sad_32x16[5];
         p_best_mv32x16[5] = mv;
     }


### PR DESCRIPTION
## Description
Turn on NSQ_ME_OPT by default: SIMD optimization for ExtSadCalculation
Address bug fix mismatch when NSQ_ME_OPT is off

## Related issue:
#262 

## Performance gains:
Currently measure ~5% speed gain where non square partitions are selected. When a very large motion search is used, these gains could go as high as 3x the  encoder as it smooths the work flow of the multi-threaded motion estimation.
