### PR TITLE
Downsampling filtering

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -46,6 +46,7 @@ extern "C" {
 
 #define MRP_SUPPORT                       1// MRP Main Flag
 
+#define DOWN_SAMPLING_FILTERING           1 
 
 #define RDOQ_INTRA                        1 // Enable RDOQ INTRA (RDOQ INTER already active) 
 #define DC_SIGN_CONTEXT_EP                1 // Fixed DC level derivation & update @ encode pass

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -47,6 +47,7 @@ extern "C" {
 #define MRP_SUPPORT                       1// MRP Main Flag
 
 #define DOWN_SAMPLING_FILTERING           1 // Use down-sampling filtering (instead of down-sampling decimation) for 1/16th and 1/4th reference frame(s) generation @ ME and temporal filtering search, added the multi-mode signal down_sampling_method_me_search; filtering if M0, and decimation for M1 & higher
+#define DECIMATION_BUG_FIX                1 // Removed HME Level0 check @ 1/16th decimation to guarantee valid ZZ SAD and SCD data when HME Level0 is OFF  
 
 #define RDOQ_INTRA                        1 // Enable RDOQ INTRA (RDOQ INTER already active) 
 #define DC_SIGN_CONTEXT_EP                1 // Fixed DC level derivation & update @ encode pass

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -2845,6 +2845,14 @@ void(*ErrorHandler)(
 #define INVALID_POC                                 (((uint32_t) (~0)) - (((uint32_t) (~0)) >> 1))
 #define MAX_ELAPSED_IDR_COUNT                       1024
 
+#if DOWN_SAMPLING_FILTERING
+typedef enum DownSamplingMethod
+{
+    ME_FILTERED_DOWNSAMPLED  = 0,
+    ME_DECIMATED_DOWNSAMPLED = 1
+} DownSamplingMethod;
+#endif
+
 //***Segments***
 #define EB_SEGMENT_MIN_COUNT                        1
 #define EB_SEGMENT_MAX_COUNT                        64

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -46,7 +46,7 @@ extern "C" {
 
 #define MRP_SUPPORT                       1// MRP Main Flag
 
-#define DOWN_SAMPLING_FILTERING           1 
+#define DOWN_SAMPLING_FILTERING           1 // Use down-sampling filtering (instead of down-sampling decimation) for 1/16th and 1/4th reference frame(s) generation @ ME and temporal filtering search, added the multi-mode signal down_sampling_method_me_search; filtering if M0, and decimation for M1 & higher
 
 #define RDOQ_INTRA                        1 // Enable RDOQ INTRA (RDOQ INTER already active) 
 #define DC_SIGN_CONTEXT_EP                1 // Fixed DC level derivation & update @ encode pass

--- a/Source/Lib/Common/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimation.c
@@ -8329,8 +8329,14 @@ EbErrorType motion_estimate_lcu(
 
             refPicPtr = (EbPictureBufferDesc*)referenceObject->input_padded_picture_ptr;
 #if DOWN_SAMPLING_FILTERING
-            quarterRefPicPtr = (EbPictureBufferDesc*)referenceObject->quarter_filtered_picture_ptr;
-            sixteenthRefPicPtr = (EbPictureBufferDesc*)referenceObject->sixteenth_filtered_picture_ptr;
+            // Set 1/4 and 1/16 ME reference buffer(s); filtered or decimated
+            quarterRefPicPtr = (picture_control_set_ptr->down_sampling_method_me_search == 0) ?
+                (EbPictureBufferDesc*)referenceObject->quarter_filtered_picture_ptr :
+                (EbPictureBufferDesc*)referenceObject->quarter_decimated_picture_ptr;
+
+            sixteenthRefPicPtr = (picture_control_set_ptr->down_sampling_method_me_search == 0) ?
+                (EbPictureBufferDesc*)referenceObject->sixteenth_filtered_picture_ptr:
+                (EbPictureBufferDesc*)referenceObject->sixteenth_decimated_picture_ptr;
 #else
             quarterRefPicPtr = (EbPictureBufferDesc*)referenceObject->quarter_decimated_picture_ptr;
             sixteenthRefPicPtr = (EbPictureBufferDesc*)referenceObject->sixteenth_decimated_picture_ptr;

--- a/Source/Lib/Common/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimation.c
@@ -8151,10 +8151,10 @@ void SwapMeCandidate(
 *******************************************/
 EbErrorType motion_estimate_lcu(
         PictureParentControlSet   *picture_control_set_ptr,  // input parameter, Picture Control Set Ptr
-        uint32_t                       sb_index,              // input parameter, SB Index
-        uint32_t                       sb_origin_x,            // input parameter, SB Origin X
-        uint32_t                       sb_origin_y,            // input parameter, SB Origin X
-        MeContext                    *context_ptr,                        // input parameter, ME Context Ptr, used to store decimated/interpolated LCU/SR
+        uint32_t                   sb_index,              // input parameter, SB Index
+        uint32_t                   sb_origin_x,            // input parameter, SB Origin X
+        uint32_t                   sb_origin_y,            // input parameter, SB Origin X
+        MeContext                 *context_ptr,                        // input parameter, ME Context Ptr, used to store decimated/interpolated LCU/SR
         EbPictureBufferDesc       *input_ptr)              // input parameter, source Picture Ptr
 {
     EbErrorType return_error = EB_ErrorNone;
@@ -8330,11 +8330,11 @@ EbErrorType motion_estimate_lcu(
             refPicPtr = (EbPictureBufferDesc*)referenceObject->input_padded_picture_ptr;
 #if DOWN_SAMPLING_FILTERING
             // Set 1/4 and 1/16 ME reference buffer(s); filtered or decimated
-            quarterRefPicPtr = (picture_control_set_ptr->down_sampling_method_me_search == 0) ?
+            quarterRefPicPtr = (sequence_control_set_ptr->down_sampling_method_me_search == 0) ?
                 (EbPictureBufferDesc*)referenceObject->quarter_filtered_picture_ptr :
                 (EbPictureBufferDesc*)referenceObject->quarter_decimated_picture_ptr;
 
-            sixteenthRefPicPtr = (picture_control_set_ptr->down_sampling_method_me_search == 0) ?
+            sixteenthRefPicPtr = (sequence_control_set_ptr->down_sampling_method_me_search == 0) ?
                 (EbPictureBufferDesc*)referenceObject->sixteenth_filtered_picture_ptr:
                 (EbPictureBufferDesc*)referenceObject->sixteenth_decimated_picture_ptr;
 #else

--- a/Source/Lib/Common/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimation.c
@@ -8330,11 +8330,11 @@ EbErrorType motion_estimate_lcu(
             refPicPtr = (EbPictureBufferDesc*)referenceObject->input_padded_picture_ptr;
 #if DOWN_SAMPLING_FILTERING
             // Set 1/4 and 1/16 ME reference buffer(s); filtered or decimated
-            quarterRefPicPtr = (sequence_control_set_ptr->down_sampling_method_me_search == 0) ?
+            quarterRefPicPtr = (sequence_control_set_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) ?
                 (EbPictureBufferDesc*)referenceObject->quarter_filtered_picture_ptr :
                 (EbPictureBufferDesc*)referenceObject->quarter_decimated_picture_ptr;
 
-            sixteenthRefPicPtr = (sequence_control_set_ptr->down_sampling_method_me_search == 0) ?
+            sixteenthRefPicPtr = (sequence_control_set_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) ?
                 (EbPictureBufferDesc*)referenceObject->sixteenth_filtered_picture_ptr:
                 (EbPictureBufferDesc*)referenceObject->sixteenth_decimated_picture_ptr;
 #else

--- a/Source/Lib/Common/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimation.c
@@ -8328,9 +8328,13 @@ EbErrorType motion_estimate_lcu(
 #endif
 
             refPicPtr = (EbPictureBufferDesc*)referenceObject->input_padded_picture_ptr;
+#if DOWN_SAMPLING_FILTERING
+            quarterRefPicPtr = (EbPictureBufferDesc*)referenceObject->quarter_filtered_picture_ptr;
+            sixteenthRefPicPtr = (EbPictureBufferDesc*)referenceObject->sixteenth_filtered_picture_ptr;
+#else
             quarterRefPicPtr = (EbPictureBufferDesc*)referenceObject->quarter_decimated_picture_ptr;
             sixteenthRefPicPtr = (EbPictureBufferDesc*)referenceObject->sixteenth_decimated_picture_ptr;
-
+#endif
 #if BASE_LAYER_REF
             if (picture_control_set_ptr->temporal_layer_index > 0 || listIndex == 0 || ((ref0Poc != ref1Poc) && (listIndex == 1))) {
 #else

--- a/Source/Lib/Common/Codec/EbMotionEstimation.h
+++ b/Source/Lib/Common/Codec/EbMotionEstimation.h
@@ -77,6 +77,17 @@ void interpolate_search_region_AVC_chroma(
         uint32_t                   decim_stride,
         uint32_t                   decim_step);
 
+#if DOWN_SAMPLING_FILTERING
+    extern void downsample_2d(
+        uint8_t                   *input_samples,
+        uint32_t                   input_stride,
+        uint32_t                   input_area_width,
+        uint32_t                   input_area_height,
+        uint8_t                   *decim_samples,
+        uint32_t                   decim_stride,
+        uint32_t                   decim_step);
+#endif
+
     extern EbErrorType open_loop_intra_search_sb(
         PictureParentControlSet   *picture_control_set_ptr,
         uint32_t                       sb_index,

--- a/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
@@ -534,9 +534,13 @@ void* motion_estimation_kernel(void *input_ptr)
     uint32_t                       lcuRow;
 
     EbPaReferenceObject       *paReferenceObject;
+#if DOWN_SAMPLING_FILTERING
+    EbPictureBufferDesc       *quarter_picture_ptr;
+    EbPictureBufferDesc       *sixteenth_picture_ptr;
+#else
     EbPictureBufferDesc       *quarter_decimated_picture_ptr;
     EbPictureBufferDesc       *sixteenth_decimated_picture_ptr;
-
+#endif
     // Segments
     uint32_t                      segment_index;
     uint32_t                      xSegmentIndex;
@@ -564,11 +568,11 @@ void* motion_estimation_kernel(void *input_ptr)
         paReferenceObject = (EbPaReferenceObject*)picture_control_set_ptr->pa_reference_picture_wrapper_ptr->object_ptr;
 #if DOWN_SAMPLING_FILTERING
         // Set 1/4 and 1/16 ME input buffer(s); filtered or decimated
-        quarter_decimated_picture_ptr = (sequence_control_set_ptr->down_sampling_method_me_search == 0) ?
+        quarter_picture_ptr = (sequence_control_set_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) ?
             (EbPictureBufferDesc*)paReferenceObject->quarter_filtered_picture_ptr :
             (EbPictureBufferDesc*)paReferenceObject->quarter_decimated_picture_ptr;
 
-        sixteenth_decimated_picture_ptr = (sequence_control_set_ptr->down_sampling_method_me_search == 0) ?
+        sixteenth_picture_ptr = (sequence_control_set_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) ?
             (EbPictureBufferDesc*)paReferenceObject->sixteenth_filtered_picture_ptr :
             (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr;
 #else
@@ -659,7 +663,48 @@ void* motion_estimation_kernel(void *input_ptr)
 
                         context_ptr->me_context_ptr->sb_src_ptr = &input_padded_picture_ptr->buffer_y[bufferIndex];
                         context_ptr->me_context_ptr->sb_src_stride = input_padded_picture_ptr->stride_y;
+#if DOWN_SAMPLING_FILTERING
+                        // Load the 1/4 decimated SB from the 1/4 decimated input to the 1/4 intermediate SB buffer
+                        if (picture_control_set_ptr->enable_hme_level1_flag) {
+                            bufferIndex = (quarter_picture_ptr->origin_y + (sb_origin_y >> 1)) * quarter_picture_ptr->stride_y + quarter_picture_ptr->origin_x + (sb_origin_x >> 1);
 
+                            for (lcuRow = 0; lcuRow < (sb_height >> 1); lcuRow++) {
+                                EB_MEMCPY((&(context_ptr->me_context_ptr->quarter_sb_buffer[lcuRow * context_ptr->me_context_ptr->quarter_sb_buffer_stride])), (&(quarter_picture_ptr->buffer_y[bufferIndex + lcuRow * quarter_picture_ptr->stride_y])), (sb_width >> 1) * sizeof(uint8_t));
+                            }
+                        }
+
+                        // Load the 1/16 decimated SB from the 1/16 decimated input to the 1/16 intermediate SB buffer
+                        if (picture_control_set_ptr->enable_hme_level0_flag) {
+                            bufferIndex = (sixteenth_picture_ptr->origin_y + (sb_origin_y >> 2)) * sixteenth_picture_ptr->stride_y + sixteenth_picture_ptr->origin_x + (sb_origin_x >> 2);
+
+                            {
+                                uint8_t  *framePtr = &sixteenth_picture_ptr->buffer_y[bufferIndex];
+                                uint8_t  *localPtr = context_ptr->me_context_ptr->sixteenth_sb_buffer;
+#if USE_SAD_HMEL0
+                                if (context_ptr->me_context_ptr->hme_search_method == FULL_SAD_SEARCH) {
+                                    for (lcuRow = 0; lcuRow < (sb_height >> 2); lcuRow += 1) {
+                                        EB_MEMCPY(localPtr, framePtr, (sb_width >> 2) * sizeof(uint8_t));
+                                        localPtr += 16;
+                                        framePtr += sixteenth_picture_ptr->stride_y;
+                                    }
+                                }
+                                else {
+                                    for (lcuRow = 0; lcuRow < (sb_height >> 2); lcuRow += 2) {
+                                        EB_MEMCPY(localPtr, framePtr, (sb_width >> 2) * sizeof(uint8_t));
+                                        localPtr += 16;
+                                        framePtr += sixteenth_picture_ptr->stride_y << 1;
+                                    }
+                                }
+#else
+                                for (lcuRow = 0; lcuRow < (sb_height >> 2); lcuRow += 2) {
+                                    EB_MEMCPY(localPtr, framePtr, (sb_width >> 2) * sizeof(uint8_t));
+                                    localPtr += 16;
+                                    framePtr += sixteenth_decimated_picture_ptr->stride_y << 1;
+                                }
+#endif
+                            }
+                        }
+#else
                         // Load the 1/4 decimated SB from the 1/4 decimated input to the 1/4 intermediate SB buffer
                         if (picture_control_set_ptr->enable_hme_level1_flag) {
                             bufferIndex = (quarter_decimated_picture_ptr->origin_y + (sb_origin_y >> 1)) * quarter_decimated_picture_ptr->stride_y + quarter_decimated_picture_ptr->origin_x + (sb_origin_x >> 1);
@@ -700,7 +745,7 @@ void* motion_estimation_kernel(void *input_ptr)
 #endif
                             }
                         }
-
+#endif
 #if ALTREF_FILTERING_SUPPORT
                         context_ptr->me_context_ptr->me_alt_ref = EB_FALSE;
 #endif

--- a/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
@@ -562,9 +562,13 @@ void* motion_estimation_kernel(void *input_ptr)
         sequence_control_set_ptr = (SequenceControlSet*)picture_control_set_ptr->sequence_control_set_wrapper_ptr->object_ptr;
 
         paReferenceObject = (EbPaReferenceObject*)picture_control_set_ptr->pa_reference_picture_wrapper_ptr->object_ptr;
+#if DOWN_SAMPLING_FILTERING
+        quarter_decimated_picture_ptr = (EbPictureBufferDesc*)paReferenceObject->quarter_filtered_picture_ptr;
+        sixteenth_decimated_picture_ptr = (EbPictureBufferDesc*)paReferenceObject->sixteenth_filtered_picture_ptr;
+#else
         quarter_decimated_picture_ptr = (EbPictureBufferDesc*)paReferenceObject->quarter_decimated_picture_ptr;
         sixteenth_decimated_picture_ptr = (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr;
-
+#endif
         input_padded_picture_ptr = (EbPictureBufferDesc*)paReferenceObject->input_padded_picture_ptr;
 
         input_picture_ptr = picture_control_set_ptr->enhanced_picture_ptr;
@@ -739,7 +743,11 @@ void* motion_estimation_kernel(void *input_ptr)
                             context_ptr,
                             sequence_control_set_ptr,
                             picture_control_set_ptr,
+#if DOWN_SAMPLING_FILTERING
+                            (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr,
+#else
                             sixteenth_decimated_picture_ptr,
+#endif
                             xLcuStartIndex,
                             xLcuEndIndex,
                             yLcuStartIndex,

--- a/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
@@ -563,8 +563,14 @@ void* motion_estimation_kernel(void *input_ptr)
 
         paReferenceObject = (EbPaReferenceObject*)picture_control_set_ptr->pa_reference_picture_wrapper_ptr->object_ptr;
 #if DOWN_SAMPLING_FILTERING
-        quarter_decimated_picture_ptr = (EbPictureBufferDesc*)paReferenceObject->quarter_filtered_picture_ptr;
-        sixteenth_decimated_picture_ptr = (EbPictureBufferDesc*)paReferenceObject->sixteenth_filtered_picture_ptr;
+        // Set 1/4 and 1/16 ME input buffer(s); filtered or decimated
+        quarter_decimated_picture_ptr = (picture_control_set_ptr->down_sampling_method_me_search == 0) ?
+            (EbPictureBufferDesc*)paReferenceObject->quarter_filtered_picture_ptr :
+            (EbPictureBufferDesc*)paReferenceObject->quarter_decimated_picture_ptr;
+
+        sixteenth_decimated_picture_ptr = (picture_control_set_ptr->down_sampling_method_me_search == 0) ?
+            (EbPictureBufferDesc*)paReferenceObject->sixteenth_filtered_picture_ptr :
+            (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr;
 #else
         quarter_decimated_picture_ptr = (EbPictureBufferDesc*)paReferenceObject->quarter_decimated_picture_ptr;
         sixteenth_decimated_picture_ptr = (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr;
@@ -744,7 +750,7 @@ void* motion_estimation_kernel(void *input_ptr)
                             sequence_control_set_ptr,
                             picture_control_set_ptr,
 #if DOWN_SAMPLING_FILTERING
-                            (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr,
+                            (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr, // Hsan: always use decimated for ZZ SAD derivation until studying the trade offs and regenerating the activity threshold
 #else
                             sixteenth_decimated_picture_ptr,
 #endif

--- a/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
@@ -564,11 +564,11 @@ void* motion_estimation_kernel(void *input_ptr)
         paReferenceObject = (EbPaReferenceObject*)picture_control_set_ptr->pa_reference_picture_wrapper_ptr->object_ptr;
 #if DOWN_SAMPLING_FILTERING
         // Set 1/4 and 1/16 ME input buffer(s); filtered or decimated
-        quarter_decimated_picture_ptr = (picture_control_set_ptr->down_sampling_method_me_search == 0) ?
+        quarter_decimated_picture_ptr = (sequence_control_set_ptr->down_sampling_method_me_search == 0) ?
             (EbPictureBufferDesc*)paReferenceObject->quarter_filtered_picture_ptr :
             (EbPictureBufferDesc*)paReferenceObject->quarter_decimated_picture_ptr;
 
-        sixteenth_decimated_picture_ptr = (picture_control_set_ptr->down_sampling_method_me_search == 0) ?
+        sixteenth_decimated_picture_ptr = (sequence_control_set_ptr->down_sampling_method_me_search == 0) ?
             (EbPictureBufferDesc*)paReferenceObject->sixteenth_filtered_picture_ptr :
             (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr;
 #else

--- a/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
@@ -163,11 +163,11 @@ static void DownSampleChroma(EbPictureBufferDesc* input_picture_ptr, EbPictureBu
 void decimation_2d(
     uint8_t *  input_samples,      // input parameter, input samples Ptr
     uint32_t   input_stride,       // input parameter, input stride
-    uint32_t   input_area_width,    // input parameter, input area width
-    uint32_t   input_area_height,   // input parameter, input area height
+    uint32_t   input_area_width,   // input parameter, input area width
+    uint32_t   input_area_height,  // input parameter, input area height
     uint8_t *  decim_samples,      // output parameter, decimated samples Ptr
     uint32_t   decim_stride,       // input parameter, output stride
-    uint32_t   decim_step)        // input parameter, decimation amount in pixels
+    uint32_t   decim_step)         // input parameter, decimation amount in pixels
 {
     uint32_t horizontal_index;
     uint32_t vertical_index;
@@ -4985,11 +4985,13 @@ void* picture_analysis_kernel(void *input_ptr)
                 (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr);
 
             // 1/4 & 1/16 input picture downsampling through filtering
-            DownsampleFilteringInputPicture(
-                picture_control_set_ptr,
-                input_padded_picture_ptr,
-                (EbPictureBufferDesc*)paReferenceObject->quarter_filtered_picture_ptr,
-                (EbPictureBufferDesc*)paReferenceObject->sixteenth_filtered_picture_ptr);
+            if (sequence_control_set_ptr->down_sampling_method_me_search == 0) {
+                DownsampleFilteringInputPicture(
+                    picture_control_set_ptr,
+                    input_padded_picture_ptr,
+                    (EbPictureBufferDesc*)paReferenceObject->quarter_filtered_picture_ptr,
+                    (EbPictureBufferDesc*)paReferenceObject->sixteenth_filtered_picture_ptr);
+            }
 #else
             // 1/4 & 1/16 input picture decimation
             DecimateInputPicture(

--- a/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
@@ -174,11 +174,9 @@ void decimation_2d(
     uint32_t input_stripe_stride = input_stride * decim_step;
 
     for (vertical_index = 0; vertical_index < input_area_height; vertical_index += decim_step) {
-        for (horizontal_index = 0; horizontal_index < input_area_width; horizontal_index += decim_step) {
-
+        for (horizontal_index = 0; horizontal_index < input_area_width; horizontal_index += decim_step) 
             decim_samples[(horizontal_index >> (decim_step >> 1))] = input_samples[horizontal_index];
 
-        }
         input_samples += input_stripe_stride;
         decim_samples += decim_stride;
     }
@@ -4874,7 +4872,7 @@ void DownsampleFilteringInputPicture(
         if (picture_control_set_ptr->enable_hme_level0_flag) {
 
             // Sixteenth Input Picture Downsampling
-            if (picture_control_set_ptr->enable_hme_level1_flag) {
+            if (picture_control_set_ptr->enable_hme_level1_flag)
                 downsample_2d(
                     &quarter_picture_ptr->buffer_y[quarter_picture_ptr->origin_x + quarter_picture_ptr->origin_y * quarter_picture_ptr->stride_y],
                     quarter_picture_ptr->stride_y,
@@ -4883,8 +4881,7 @@ void DownsampleFilteringInputPicture(
                     &sixteenth_picture_ptr->buffer_y[sixteenth_picture_ptr->origin_x + sixteenth_picture_ptr->origin_x*sixteenth_picture_ptr->stride_y],
                     sixteenth_picture_ptr->stride_y,
                     2);
-            }
-            else {
+            else
                 downsample_2d(
                     &input_padded_picture_ptr->buffer_y[input_padded_picture_ptr->origin_x + input_padded_picture_ptr->origin_y * input_padded_picture_ptr->stride_y],
                     input_padded_picture_ptr->stride_y,
@@ -4893,7 +4890,7 @@ void DownsampleFilteringInputPicture(
                     &sixteenth_picture_ptr->buffer_y[sixteenth_picture_ptr->origin_x + sixteenth_picture_ptr->origin_x*sixteenth_picture_ptr->stride_y],
                     sixteenth_picture_ptr->stride_y,
                     4);
-            }
+            
             generate_padding(
                 &sixteenth_picture_ptr->buffer_y[0],
                 sixteenth_picture_ptr->stride_y,
@@ -5018,7 +5015,7 @@ void* picture_analysis_kernel(void *input_ptr)
                 (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr);
 
             // 1/4 & 1/16 input picture downsampling through filtering
-            if (sequence_control_set_ptr->down_sampling_method_me_search == 0) {
+            if (sequence_control_set_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) {
                 DownsampleFilteringInputPicture(
                     picture_control_set_ptr,
                     input_padded_picture_ptr,

--- a/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
@@ -155,7 +155,73 @@ static void DownSampleChroma(EbPictureBufferDesc* input_picture_ptr, EbPictureBu
 /************************************************
  * Picture Analysis Context Destructor
  ************************************************/
+#if DOWN_SAMPLING_FILTERING
+  /********************************************
+    * decimation_2d
+    *      decimates the input
+    ********************************************/
+void decimation_2d(
+    uint8_t *  input_samples,      // input parameter, input samples Ptr
+    uint32_t   input_stride,       // input parameter, input stride
+    uint32_t   input_area_width,    // input parameter, input area width
+    uint32_t   input_area_height,   // input parameter, input area height
+    uint8_t *  decim_samples,      // output parameter, decimated samples Ptr
+    uint32_t   decim_stride,       // input parameter, output stride
+    uint32_t   decim_step)        // input parameter, decimation amount in pixels
+{
+    uint32_t horizontal_index;
+    uint32_t vertical_index;
+    uint32_t input_stripe_stride = input_stride * decim_step;
 
+    for (vertical_index = 0; vertical_index < input_area_height; vertical_index += decim_step) {
+        for (horizontal_index = 0; horizontal_index < input_area_width; horizontal_index += decim_step) {
+
+            decim_samples[(horizontal_index >> (decim_step >> 1))] = input_samples[horizontal_index];
+
+        }
+        input_samples += input_stripe_stride;
+        decim_samples += decim_stride;
+    }
+
+    return;
+}
+
+/********************************************
+ * downsample_2d
+ *      downsamples the input
+ * Alternative implementation to decimation_2d that performs filtering (2x2, 0-phase)
+ ********************************************/
+void downsample_2d(
+    uint8_t *  input_samples,      // input parameter, input samples Ptr
+    uint32_t   input_stride,       // input parameter, input stride
+    uint32_t   input_area_width,    // input parameter, input area width
+    uint32_t   input_area_height,   // input parameter, input area height
+    uint8_t *  decim_samples,      // output parameter, decimated samples Ptr
+    uint32_t   decim_stride,       // input parameter, output stride
+    uint32_t   decim_step)        // input parameter, decimation amount in pixels
+{
+
+    uint32_t horizontal_index;
+    uint32_t vertical_index;
+    uint32_t input_stripe_stride = input_stride * decim_step;
+    uint32_t decim_horizontal_index;
+    const uint32_t half_decim_step = decim_step >> 1;
+
+    for (input_samples += half_decim_step * input_stride, vertical_index = half_decim_step; vertical_index < input_area_height; vertical_index += decim_step) {
+        uint8_t *prev_input_line = input_samples - input_stride;
+        for (horizontal_index = half_decim_step, decim_horizontal_index = 0; horizontal_index < input_area_width; horizontal_index += decim_step, decim_horizontal_index++) {
+            uint32_t sum = (uint32_t)prev_input_line[horizontal_index - 1] + (uint32_t)prev_input_line[horizontal_index] + (uint32_t)input_samples[horizontal_index - 1] + (uint32_t)input_samples[horizontal_index];
+            decim_samples[decim_horizontal_index] = (sum + 2) >> 2;
+
+        }
+        input_samples += input_stripe_stride;
+        decim_samples += decim_stride;
+    }
+
+    return;
+}
+
+#else
  /********************************************
   * decimation_2d
   *      decimates the input
@@ -181,7 +247,7 @@ void decimation_2d(
 
     return;
 }
-
+#endif
 /********************************************
 * CalculateHistogram
 *      creates n-bins histogram for the input
@@ -4733,6 +4799,75 @@ static int is_screen_content(const uint8_t *src, int use_hbd,
     return counts * blk_h * blk_w * 10 > width * height;
 }
 
+
+#if DOWN_SAMPLING_FILTERING
+/************************************************
+ * 1/4 & 1/16 input picture downsampling (filtering)
+ ************************************************/
+void DownsampleInputPicture(
+    PictureParentControlSet       *picture_control_set_ptr,
+    EbPictureBufferDesc           *input_padded_picture_ptr,
+    EbPictureBufferDesc           *quarter_picture_ptr,
+    EbPictureBufferDesc           *sixteenth_picture_ptr) {
+
+    // Downsample input picture for HME L0 and L1
+    if (picture_control_set_ptr->enable_hme_flag) {
+
+        if (picture_control_set_ptr->enable_hme_level1_flag) {
+            downsample_2d(
+                &input_padded_picture_ptr->buffer_y[input_padded_picture_ptr->origin_x + input_padded_picture_ptr->origin_y * input_padded_picture_ptr->stride_y],
+                input_padded_picture_ptr->stride_y,
+                input_padded_picture_ptr->width,
+                input_padded_picture_ptr->height,
+                &quarter_picture_ptr->buffer_y[quarter_picture_ptr->origin_x + quarter_picture_ptr->origin_x * quarter_picture_ptr->stride_y],
+                quarter_picture_ptr->stride_y,
+                2);
+            generate_padding(
+                &quarter_picture_ptr->buffer_y[0],
+                quarter_picture_ptr->stride_y,
+                quarter_picture_ptr->width,
+                quarter_picture_ptr->height,
+                quarter_picture_ptr->origin_x,
+                quarter_picture_ptr->origin_y);
+
+        }
+
+        if (picture_control_set_ptr->enable_hme_level0_flag) {
+
+            // Sixteenth Input Picture Downsampling
+            if (picture_control_set_ptr->enable_hme_level1_flag) {
+                downsample_2d(
+                    &quarter_picture_ptr->buffer_y[quarter_picture_ptr->origin_x + quarter_picture_ptr->origin_y * quarter_picture_ptr->stride_y],
+                    quarter_picture_ptr->stride_y,
+                    quarter_picture_ptr->width,
+                    quarter_picture_ptr->height,
+                    &sixteenth_picture_ptr->buffer_y[sixteenth_picture_ptr->origin_x + sixteenth_picture_ptr->origin_x*sixteenth_picture_ptr->stride_y],
+                    sixteenth_picture_ptr->stride_y,
+                    2);
+            }
+            else {
+                downsample_2d(
+                    &input_padded_picture_ptr->buffer_y[input_padded_picture_ptr->origin_x + input_padded_picture_ptr->origin_y * input_padded_picture_ptr->stride_y],
+                    input_padded_picture_ptr->stride_y,
+                    input_padded_picture_ptr->width,
+                    input_padded_picture_ptr->height,
+                    &sixteenth_picture_ptr->buffer_y[sixteenth_picture_ptr->origin_x + sixteenth_picture_ptr->origin_x*sixteenth_picture_ptr->stride_y],
+                    sixteenth_picture_ptr->stride_y,
+                    4);
+            }
+            generate_padding(
+                &sixteenth_picture_ptr->buffer_y[0],
+                sixteenth_picture_ptr->stride_y,
+                sixteenth_picture_ptr->width,
+                sixteenth_picture_ptr->height,
+                sixteenth_picture_ptr->origin_x,
+                sixteenth_picture_ptr->origin_y);
+
+        }
+    }
+}
+#endif
+
 /************************************************
  * Picture Analysis Kernel
  * The Picture Analysis Process pads & decimates the input pictures.
@@ -4755,8 +4890,10 @@ void* picture_analysis_kernel(void *input_ptr)
     EbPaReferenceObject           *paReferenceObject;
 
     EbPictureBufferDesc           *input_padded_picture_ptr;
+#if !DOWN_SAMPLING_FILTERING
     EbPictureBufferDesc           *quarter_decimated_picture_ptr;
     EbPictureBufferDesc           *sixteenth_decimated_picture_ptr;
+#endif
     EbPictureBufferDesc           *input_picture_ptr;
 
     // Variance
@@ -4784,9 +4921,10 @@ void* picture_analysis_kernel(void *input_ptr)
 
             paReferenceObject = (EbPaReferenceObject*)picture_control_set_ptr->pa_reference_picture_wrapper_ptr->object_ptr;
             input_padded_picture_ptr = (EbPictureBufferDesc*)paReferenceObject->input_padded_picture_ptr;
+#if !DOWN_SAMPLING_FILTERING
             quarter_decimated_picture_ptr = (EbPictureBufferDesc*)paReferenceObject->quarter_decimated_picture_ptr;
             sixteenth_decimated_picture_ptr = (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr;
-
+#endif
             // Variance
             picture_width_in_sb = (sequence_control_set_ptr->seq_header.max_frame_width + sequence_control_set_ptr->sb_sz - 1) / sequence_control_set_ptr->sb_sz;
             pictureHeighInLcu = (sequence_control_set_ptr->seq_header.max_frame_height + sequence_control_set_ptr->sb_sz - 1) / sequence_control_set_ptr->sb_sz;
@@ -4808,8 +4946,13 @@ void* picture_analysis_kernel(void *input_ptr)
                 picture_control_set_ptr,
                 input_picture_ptr,
                 sequence_control_set_ptr,
+#if DOWN_SAMPLING_FILTERING
+                (EbPictureBufferDesc*)paReferenceObject->quarter_decimated_picture_ptr,
+                (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr,
+#else
                 quarter_decimated_picture_ptr,
                 sixteenth_decimated_picture_ptr,
+#endif
                 sb_total_count,
                 asm_type);
 
@@ -4825,23 +4968,42 @@ void* picture_analysis_kernel(void *input_ptr)
             // Pad input picture to complete border LCUs
             PadPictureToMultipleOfLcuDimensions(
                 input_padded_picture_ptr);
+#if DOWN_SAMPLING_FILTERING
+            // 1/4 & 1/16 input picture decimation
+            DecimateInputPicture(
+                picture_control_set_ptr,
+                input_padded_picture_ptr,
+                (EbPictureBufferDesc*)paReferenceObject->quarter_decimated_picture_ptr,
+                (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr);
 
+            // 1/4 & 1/16 input picture downsampling through filtering
+            DownsampleInputPicture(
+                picture_control_set_ptr,
+                input_padded_picture_ptr,
+                (EbPictureBufferDesc*)paReferenceObject->quarter_filtered_picture_ptr,
+                (EbPictureBufferDesc*)paReferenceObject->sixteenth_filtered_picture_ptr);
+#else
             // 1/4 & 1/16 input picture decimation
             DecimateInputPicture(
                 picture_control_set_ptr,
                 input_padded_picture_ptr,
                 quarter_decimated_picture_ptr,
                 sixteenth_decimated_picture_ptr);
-
-        // Gathering statistics of input picture, including Variance Calculation, Histogram Bins
+#endif
+           // Gathering statistics of input picture, including Variance Calculation, Histogram Bins
             GatheringPictureStatistics(
                 sequence_control_set_ptr,
                 picture_control_set_ptr,
                 picture_control_set_ptr->chroma_downsampled_picture_ptr, //420 input_picture_ptr
                 input_padded_picture_ptr,
+#if DOWN_SAMPLING_FILTERING
+                (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr,
+#else
                 sixteenth_decimated_picture_ptr,
+#endif
                 sb_total_count,
                 asm_type);
+
             if (sequence_control_set_ptr->static_config.screen_content_mode == 2){ // auto detect
                 picture_control_set_ptr->sc_content_detected = is_screen_content(
                     input_picture_ptr->buffer_y + input_picture_ptr->origin_x + input_picture_ptr->origin_y*input_picture_ptr->stride_y,

--- a/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
@@ -4713,11 +4713,19 @@ void PadPictureToMultipleOfLcuDimensions(
 /************************************************
 * 1/4 & 1/16 input picture decimation
 ************************************************/
+#if DOWN_SAMPLING_FILTERING
+void DownsampleDecimationInputPicture(
+    PictureParentControlSet       *picture_control_set_ptr,
+    EbPictureBufferDesc           *input_padded_picture_ptr,
+    EbPictureBufferDesc           *quarter_decimated_picture_ptr,
+    EbPictureBufferDesc           *sixteenth_decimated_picture_ptr) {
+#else
 void DecimateInputPicture(
     PictureParentControlSet       *picture_control_set_ptr,
     EbPictureBufferDesc           *input_padded_picture_ptr,
     EbPictureBufferDesc           *quarter_decimated_picture_ptr,
     EbPictureBufferDesc           *sixteenth_decimated_picture_ptr) {
+#endif
     // Decimate input picture for HME L0 and L1
     if (picture_control_set_ptr->enable_hme_flag) {
         if (picture_control_set_ptr->enable_hme_level1_flag) {
@@ -4804,7 +4812,7 @@ static int is_screen_content(const uint8_t *src, int use_hbd,
 /************************************************
  * 1/4 & 1/16 input picture downsampling (filtering)
  ************************************************/
-void DownsampleInputPicture(
+void DownsampleFilteringInputPicture(
     PictureParentControlSet       *picture_control_set_ptr,
     EbPictureBufferDesc           *input_padded_picture_ptr,
     EbPictureBufferDesc           *quarter_picture_ptr,
@@ -4970,14 +4978,14 @@ void* picture_analysis_kernel(void *input_ptr)
                 input_padded_picture_ptr);
 #if DOWN_SAMPLING_FILTERING
             // 1/4 & 1/16 input picture decimation
-            DecimateInputPicture(
+            DownsampleDecimationInputPicture(
                 picture_control_set_ptr,
                 input_padded_picture_ptr,
                 (EbPictureBufferDesc*)paReferenceObject->quarter_decimated_picture_ptr,
                 (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr);
 
             // 1/4 & 1/16 input picture downsampling through filtering
-            DownsampleInputPicture(
+            DownsampleFilteringInputPicture(
                 picture_control_set_ptr,
                 input_padded_picture_ptr,
                 (EbPictureBufferDesc*)paReferenceObject->quarter_filtered_picture_ptr,

--- a/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
@@ -4941,13 +4941,13 @@ void* picture_analysis_kernel(void *input_ptr)
                 sequence_control_set_ptr,
                 input_picture_ptr);
 
-            // Pre processing operations performed on the input picture
+            // Pre processing operations performed on the input picture        
             PicturePreProcessingOperations(
                 picture_control_set_ptr,
                 input_picture_ptr,
                 sequence_control_set_ptr,
 #if DOWN_SAMPLING_FILTERING
-                (EbPictureBufferDesc*)paReferenceObject->quarter_decimated_picture_ptr,
+                (EbPictureBufferDesc*)paReferenceObject->quarter_decimated_picture_ptr, // Hsan: always use decimated until studying the trade offs 
                 (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr,
 #else
                 quarter_decimated_picture_ptr,
@@ -4997,7 +4997,7 @@ void* picture_analysis_kernel(void *input_ptr)
                 picture_control_set_ptr->chroma_downsampled_picture_ptr, //420 input_picture_ptr
                 input_padded_picture_ptr,
 #if DOWN_SAMPLING_FILTERING
-                (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr,
+                (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr, // Hsan: always use decimated until studying the trade offs 
 #else
                 sixteenth_decimated_picture_ptr,
 #endif

--- a/Source/Lib/Common/Codec/EbPictureBufferDesc.h
+++ b/Source/Lib/Common/Codec/EbPictureBufferDesc.h
@@ -296,6 +296,9 @@ extern "C" {
         uint16_t          top_padding;
         uint16_t          bot_padding;
         EbBool            split_mode;         //ON: allocate 8bit data seperately from nbit data
+#if DOWN_SAMPLING_FILTERING
+        EbBool            down_sampled_filtered;      
+#endif
     } EbPictureBufferDescInitData;
 
     /**************************************

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -14231,6 +14231,9 @@ extern "C" {
 #if ATB_SUPPORT
         uint8_t                               atb_mode;
 #endif
+#if DOWN_SAMPLING_FILTERING
+        uint8_t                               down_sampling_method_me_search;
+#endif
         //**********************************************************************************************************//
         FrameType                            av1_frame_type;
         Av1RpsNode                          av1_ref_signal;

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -14231,9 +14231,6 @@ extern "C" {
 #if ATB_SUPPORT
         uint8_t                               atb_mode;
 #endif
-#if DOWN_SAMPLING_FILTERING
-        uint8_t                               down_sampling_method_me_search;
-#endif
         //**********************************************************************************************************//
         FrameType                            av1_frame_type;
         Av1RpsNode                          av1_ref_signal;

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -1557,16 +1557,6 @@ EbErrorType signal_derivation_multi_processes_oq(
 
 #endif
 
-#if DOWN_SAMPLING_FILTERING
-        // Set down-sampling method     Settings
-        // 0                            0: filtering
-        // 1                            1: decimation
-        if (picture_control_set_ptr->enc_mode == ENC_M0) 
-            picture_control_set_ptr->down_sampling_method_me_search = 0;
-        else 
-            picture_control_set_ptr->down_sampling_method_me_search = 1;
-#endif
-
     return return_error;
 }
 
@@ -3148,11 +3138,13 @@ void perform_simple_picture_analysis_for_overlay(PictureParentControlSet     *pi
         (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr);
 
     // 1/4 & 1/16 input picture downsampling through filtering
-    DownsampleFilteringInputPicture(
-        picture_control_set_ptr,
-        input_padded_picture_ptr,
-        (EbPictureBufferDesc*)paReferenceObject->quarter_filtered_picture_ptr,
-        (EbPictureBufferDesc*)paReferenceObject->sixteenth_filtered_picture_ptr);
+    if (sequence_control_set_ptr->down_sampling_method_me_search == 0) {
+        DownsampleFilteringInputPicture(
+            picture_control_set_ptr,
+            input_padded_picture_ptr,
+            (EbPictureBufferDesc*)paReferenceObject->quarter_filtered_picture_ptr,
+            (EbPictureBufferDesc*)paReferenceObject->sixteenth_filtered_picture_ptr);
+    }
 #else
     // 1/4 & 1/16 input picture decimation
     DecimateInputPicture(

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -3140,7 +3140,7 @@ void perform_simple_picture_analysis_for_overlay(PictureParentControlSet     *pi
         (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr);
 
     // 1/4 & 1/16 input picture downsampling through filtering
-    if (sequence_control_set_ptr->down_sampling_method_me_search == 0) {
+    if (sequence_control_set_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) {
         DownsampleFilteringInputPicture(
             picture_control_set_ptr,
             input_padded_picture_ptr,

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -3141,14 +3141,14 @@ void perform_simple_picture_analysis_for_overlay(PictureParentControlSet     *pi
         input_padded_picture_ptr);
 #if DOWN_SAMPLING_FILTERING
     // 1/4 & 1/16 input picture decimation
-    DecimateInputPicture(
+    DownsampleDecimationInputPicture(
         picture_control_set_ptr,
         input_padded_picture_ptr,
         (EbPictureBufferDesc*)paReferenceObject->quarter_decimated_picture_ptr,
         (EbPictureBufferDesc*)paReferenceObject->sixteenth_decimated_picture_ptr);
 
     // 1/4 & 1/16 input picture downsampling through filtering
-    DownsampleInputPicture(
+    DownsampleFilteringInputPicture(
         picture_control_set_ptr,
         input_padded_picture_ptr,
         (EbPictureBufferDesc*)paReferenceObject->quarter_filtered_picture_ptr,

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -1557,6 +1557,16 @@ EbErrorType signal_derivation_multi_processes_oq(
 
 #endif
 
+#if DOWN_SAMPLING_FILTERING
+        // Set down-sampling method     Settings
+        // 0                            0: filtering
+        // 1                            1: decimation
+        if (picture_control_set_ptr->enc_mode == ENC_M0) 
+            picture_control_set_ptr->down_sampling_method_me_search = 0;
+        else 
+            picture_control_set_ptr->down_sampling_method_me_search = 1;
+#endif
+
     return return_error;
 }
 
@@ -3108,7 +3118,7 @@ void perform_simple_picture_analysis_for_overlay(PictureParentControlSet     *pi
         input_picture_ptr,
         sequence_control_set_ptr,
 #if DOWN_SAMPLING_FILTERING
-        paReferenceObject->quarter_decimated_picture_ptr,
+        paReferenceObject->quarter_decimated_picture_ptr, // Hsan: always use decimated until studying the trade offs 
         paReferenceObject->sixteenth_decimated_picture_ptr,
 #else
         quarter_decimated_picture_ptr,
@@ -3158,7 +3168,7 @@ void perform_simple_picture_analysis_for_overlay(PictureParentControlSet     *pi
         picture_control_set_ptr->chroma_downsampled_picture_ptr, //420 input_picture_ptr
         input_padded_picture_ptr,
 #if DOWN_SAMPLING_FILTERING
-        paReferenceObject->sixteenth_decimated_picture_ptr,
+        paReferenceObject->sixteenth_decimated_picture_ptr, // Hsan: always use decimated until studying the trade offs 
 #else
         sixteenth_decimated_picture_ptr,
 #endif

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -3103,20 +3103,22 @@ void perform_simple_picture_analysis_for_overlay(PictureParentControlSet     *pi
         input_picture_ptr);
 
     // Pre processing operations performed on the input picture
+#if DOWN_SAMPLING_FILTERING
+    PicturePreProcessingOperations(
+        picture_control_set_ptr,
+        sequence_control_set_ptr,
+        sb_total_count,
+        sequence_control_set_ptr->encode_context_ptr->asm_type);
+#else
     PicturePreProcessingOperations(
         picture_control_set_ptr,
         input_picture_ptr,
         sequence_control_set_ptr,
-#if DOWN_SAMPLING_FILTERING
-        paReferenceObject->quarter_decimated_picture_ptr, // Hsan: always use decimated until studying the trade offs 
-        paReferenceObject->sixteenth_decimated_picture_ptr,
-#else
         quarter_decimated_picture_ptr,
         sixteenth_decimated_picture_ptr,
-#endif
         sb_total_count,
         sequence_control_set_ptr->encode_context_ptr->asm_type);
-
+#endif
     if (input_picture_ptr->color_format >= EB_YUV422) {
         // Jing: Do the conversion of 422/444=>420 here since it's multi-threaded kernel
         //       Reuse the Y, only add cb/cr in the newly created buffer desc

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.h
@@ -91,7 +91,13 @@ void DecimateInputPicture(PictureParentControlSet       *picture_control_set_ptr
 void PadPictureToMultipleOfMinCuSizeDimensions(
         SequenceControlSet            *sequence_control_set_ptr,
         EbPictureBufferDesc           *input_picture_ptr);
-
+#if DOWN_SAMPLING_FILTERING
+void PicturePreProcessingOperations(
+    PictureParentControlSet       *picture_control_set_ptr,
+    SequenceControlSet            *sequence_control_set_ptr,
+    uint32_t                       sb_total_count,
+    EbAsm                          asm_type);
+#else
 void PicturePreProcessingOperations(
         PictureParentControlSet       *picture_control_set_ptr,
         EbPictureBufferDesc           *input_picture_ptr,
@@ -100,7 +106,7 @@ void PicturePreProcessingOperations(
         EbPictureBufferDesc           *sixteenth_decimated_picture_ptr,
         uint32_t                       sb_total_count,
         EbAsm                          asm_type);
-
+#endif
 void PadPictureToMultipleOfLcuDimensions(
         EbPictureBufferDesc   *input_padded_picture_ptr);
 

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.h
@@ -72,12 +72,18 @@ extern EbErrorType picture_decision_context_ctor(
 extern void* picture_decision_kernel(void *input_ptr);
 
 #if ALT_REF_SUPPORT
-
+#if DOWN_SAMPLING_FILTERING
+void DownsampleDecimationInputPicture(
+    PictureParentControlSet *picture_control_set_ptr,
+    EbPictureBufferDesc     *inputPaddedPicturePtr,
+    EbPictureBufferDesc     *quarterDecimatedPicturePtr,
+    EbPictureBufferDesc     *sixteenthDecimatedPicturePtr);
+#else
 void DecimateInputPicture(PictureParentControlSet       *picture_control_set_ptr,
                           EbPictureBufferDesc           *inputPaddedPicturePtr,
                           EbPictureBufferDesc           *quarterDecimatedPicturePtr,
                           EbPictureBufferDesc           *sixteenthDecimatedPicturePtr);
-
+#endif
 #endif
 
 #if ALT_REF_OVERLAY

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.h
@@ -92,8 +92,8 @@ void PicturePreProcessingOperations(
         SequenceControlSet            *sequence_control_set_ptr,
         EbPictureBufferDesc           *quarter_decimated_picture_ptr,
         EbPictureBufferDesc           *sixteenth_decimated_picture_ptr,
-        uint32_t                           sb_total_count,
-        EbAsm                           asm_type);
+        uint32_t                       sb_total_count,
+        EbAsm                          asm_type);
 
 void PadPictureToMultipleOfLcuDimensions(
         EbPictureBufferDesc   *input_padded_picture_ptr);

--- a/Source/Lib/Common/Codec/EbReferenceObject.c
+++ b/Source/Lib/Common/Codec/EbReferenceObject.c
@@ -244,5 +244,22 @@ EbErrorType eb_pa_reference_object_ctor(
         (EbPtr)(pictureBufferDescInitDataPtr + 2));
     if (return_error == EB_ErrorInsufficientResources)
         return EB_ErrorInsufficientResources;
+#if DOWN_SAMPLING_FILTERING
+    // Quarter Filtered reference picture constructor
+    paReferenceObject->quarter_filtered_picture_ptr = (EbPictureBufferDesc*)EB_NULL;
+    return_error = eb_picture_buffer_desc_ctor(
+        (EbPtr*) &(paReferenceObject->quarter_filtered_picture_ptr),
+        (EbPtr)(pictureBufferDescInitDataPtr + 1));
+    if (return_error == EB_ErrorInsufficientResources)
+        return EB_ErrorInsufficientResources;
+    // Sixteenth Filtered reference picture constructor
+    paReferenceObject->sixteenth_filtered_picture_ptr = (EbPictureBufferDesc*)EB_NULL;
+    return_error = eb_picture_buffer_desc_ctor(
+        (EbPtr*) &(paReferenceObject->sixteenth_filtered_picture_ptr),
+        (EbPtr)(pictureBufferDescInitDataPtr + 2));
+    if (return_error == EB_ErrorInsufficientResources)
+        return EB_ErrorInsufficientResources;
+#endif
+
     return EB_ErrorNone;
 }

--- a/Source/Lib/Common/Codec/EbReferenceObject.c
+++ b/Source/Lib/Common/Codec/EbReferenceObject.c
@@ -247,18 +247,22 @@ EbErrorType eb_pa_reference_object_ctor(
 #if DOWN_SAMPLING_FILTERING
     // Quarter Filtered reference picture constructor
     paReferenceObject->quarter_filtered_picture_ptr = (EbPictureBufferDesc*)EB_NULL;
-    return_error = eb_picture_buffer_desc_ctor(
-        (EbPtr*) &(paReferenceObject->quarter_filtered_picture_ptr),
-        (EbPtr)(pictureBufferDescInitDataPtr + 1));
-    if (return_error == EB_ErrorInsufficientResources)
-        return EB_ErrorInsufficientResources;
+    if ((pictureBufferDescInitDataPtr + 1)->down_sampled_filtered) {
+        return_error = eb_picture_buffer_desc_ctor(
+            (EbPtr*) &(paReferenceObject->quarter_filtered_picture_ptr),
+            (EbPtr)(pictureBufferDescInitDataPtr + 1));
+        if (return_error == EB_ErrorInsufficientResources)
+            return EB_ErrorInsufficientResources;
+    }
     // Sixteenth Filtered reference picture constructor
     paReferenceObject->sixteenth_filtered_picture_ptr = (EbPictureBufferDesc*)EB_NULL;
-    return_error = eb_picture_buffer_desc_ctor(
-        (EbPtr*) &(paReferenceObject->sixteenth_filtered_picture_ptr),
-        (EbPtr)(pictureBufferDescInitDataPtr + 2));
-    if (return_error == EB_ErrorInsufficientResources)
-        return EB_ErrorInsufficientResources;
+    if ((pictureBufferDescInitDataPtr + 2)->down_sampled_filtered) {
+        return_error = eb_picture_buffer_desc_ctor(
+            (EbPtr*) &(paReferenceObject->sixteenth_filtered_picture_ptr),
+            (EbPtr)(pictureBufferDescInitDataPtr + 2));
+        if (return_error == EB_ErrorInsufficientResources)
+            return EB_ErrorInsufficientResources;
+    }
 #endif
 
     return EB_ErrorNone;

--- a/Source/Lib/Common/Codec/EbReferenceObject.h
+++ b/Source/Lib/Common/Codec/EbReferenceObject.h
@@ -52,10 +52,14 @@ typedef struct EbPaReferenceObject
     EbPictureBufferDesc          *input_padded_picture_ptr;
     EbPictureBufferDesc          *quarter_decimated_picture_ptr;
     EbPictureBufferDesc          *sixteenth_decimated_picture_ptr;
-    uint16_t                        variance[MAX_NUMBER_OF_TREEBLOCKS_PER_PICTURE];
-    uint8_t                         y_mean[MAX_NUMBER_OF_TREEBLOCKS_PER_PICTURE];
-    EB_SLICE                        slice_type;
-    uint32_t                        dependent_pictures_count; //number of pic using this reference frame
+#if DOWN_SAMPLING_FILTERING
+    EbPictureBufferDesc          *quarter_filtered_picture_ptr;
+    EbPictureBufferDesc          *sixteenth_filtered_picture_ptr;
+#endif
+    uint16_t                      variance[MAX_NUMBER_OF_TREEBLOCKS_PER_PICTURE];
+    uint8_t                       y_mean[MAX_NUMBER_OF_TREEBLOCKS_PER_PICTURE];
+    EB_SLICE                      slice_type;
+    uint32_t                      dependent_pictures_count; //number of pic using this reference frame
 #if !BUG_FIX_PCS_LIVE_COUNT
     PictureParentControlSet      *p_pcs_ptr;
 #endif

--- a/Source/Lib/Common/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Common/Codec/EbSequenceControlSet.c
@@ -348,6 +348,9 @@ EbErrorType copy_sequence_control_set(
     dst->nsq_present    = src->nsq_present;
     dst->cdf_mode       = src->cdf_mode;
 #endif
+#if DOWN_SAMPLING_FILTERING
+    dst->down_sampling_method_me_search = src->down_sampling_method_me_search;
+#endif
 #if ALTREF_FILTERING_SUPPORT
     dst->tf_segment_column_count = src->tf_segment_column_count;
     dst->tf_segment_row_count = src->tf_segment_row_count;

--- a/Source/Lib/Common/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Common/Codec/EbSequenceControlSet.h
@@ -199,6 +199,13 @@ extern "C" {
         *
         * Default is 1. */
         uint8_t                                 nsq_present;
+
+#if DOWN_SAMPLING_FILTERING
+        /* Down-sampling method @ ME and alt-ref temporal filtering (mm-signal; 0: filtering, 1: decimation)
+        *
+        * Default is 0. */
+        uint8_t                                 down_sampling_method_me_search;
+#endif
 #endif
         uint8_t                                 trans_coeff_shape_array[2][8][4];    // [componantTypeIndex][resolutionIndex][levelIndex][tuSizeIndex]
         EbBlockMeanPrec                         block_mean_calc_prec;

--- a/Source/Lib/Common/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Common/Codec/EbTemporalFiltering.c
@@ -276,12 +276,13 @@ void create_ME_context_and_picture_control(MotionEstimationContext_t *context_pt
     EbPaReferenceObject *src_object = (EbPaReferenceObject*)picture_control_set_ptr_central->pa_reference_picture_wrapper_ptr->object_ptr;
     EbPictureBufferDesc *padded_pic_ptr = src_object->input_padded_picture_ptr;
 #if DOWN_SAMPLING_FILTERING
+    SequenceControlSet *sequence_control_set_ptr = (SequenceControlSet*)picture_control_set_ptr_central->sequence_control_set_wrapper_ptr->object_ptr;
     // Set 1/4 and 1/16 ME reference buffer(s); filtered or decimated
-    EbPictureBufferDesc * quarter_pic_ptr = (picture_control_set_ptr_central->down_sampling_method_me_search == 0) ?
+    EbPictureBufferDesc * quarter_pic_ptr = (sequence_control_set_ptr->down_sampling_method_me_search == 0) ?
         (EbPictureBufferDesc*)src_object->quarter_filtered_picture_ptr :
         (EbPictureBufferDesc*)src_object->quarter_decimated_picture_ptr;
 
-    EbPictureBufferDesc *sixteenth_pic_ptr = (picture_control_set_ptr_central->down_sampling_method_me_search == 0) ?
+    EbPictureBufferDesc *sixteenth_pic_ptr = (sequence_control_set_ptr->down_sampling_method_me_search == 0) ?
         (EbPictureBufferDesc*)src_object->sixteenth_filtered_picture_ptr :
         (EbPictureBufferDesc*)src_object->sixteenth_decimated_picture_ptr;
 #else
@@ -1584,11 +1585,14 @@ int pad_and_decimate_filtered_pic(PictureParentControlSet *picture_control_set_p
         (EbPictureBufferDesc*)src_object->sixteenth_decimated_picture_ptr);
 
     // 1/4 & 1/16 input picture downsampling through filtering
-    DownsampleFilteringInputPicture(
-        picture_control_set_ptr_central,
-        padded_pic_ptr,
-        (EbPictureBufferDesc*)src_object->quarter_filtered_picture_ptr,
-        (EbPictureBufferDesc*)src_object->sixteenth_filtered_picture_ptr);
+    SequenceControlSet *sequence_control_set_ptr = (SequenceControlSet*)picture_control_set_ptr_central->sequence_control_set_wrapper_ptr->object_ptr;
+    if (sequence_control_set_ptr->down_sampling_method_me_search == 0) {
+        DownsampleFilteringInputPicture(
+            picture_control_set_ptr_central,
+            padded_pic_ptr,
+            (EbPictureBufferDesc*)src_object->quarter_filtered_picture_ptr,
+            (EbPictureBufferDesc*)src_object->sixteenth_filtered_picture_ptr);
+    }
 #else
     DecimateInputPicture(picture_control_set_ptr_central,
         padded_pic_ptr,

--- a/Source/Lib/Common/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Common/Codec/EbTemporalFiltering.c
@@ -1586,13 +1586,12 @@ int pad_and_decimate_filtered_pic(PictureParentControlSet *picture_control_set_p
 
     // 1/4 & 1/16 input picture downsampling through filtering
     SequenceControlSet *sequence_control_set_ptr = (SequenceControlSet*)picture_control_set_ptr_central->sequence_control_set_wrapper_ptr->object_ptr;
-    if (sequence_control_set_ptr->down_sampling_method_me_search == 0) {
+    if (sequence_control_set_ptr->down_sampling_method_me_search == 0)
         DownsampleFilteringInputPicture(
             picture_control_set_ptr_central,
             padded_pic_ptr,
             (EbPictureBufferDesc*)src_object->quarter_filtered_picture_ptr,
             (EbPictureBufferDesc*)src_object->sixteenth_filtered_picture_ptr);
-    }
 #else
     DecimateInputPicture(picture_control_set_ptr_central,
         padded_pic_ptr,

--- a/Source/Lib/Common/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Common/Codec/EbTemporalFiltering.c
@@ -1577,14 +1577,14 @@ int pad_and_decimate_filtered_pic(PictureParentControlSet *picture_control_set_p
 
 #if DOWN_SAMPLING_FILTERING
     // 1/4 & 1/16 input picture decimation
-    DecimateInputPicture(
+    DownsampleDecimationInputPicture(
         picture_control_set_ptr_central,
         padded_pic_ptr,
         (EbPictureBufferDesc*)src_object->quarter_decimated_picture_ptr,
         (EbPictureBufferDesc*)src_object->sixteenth_decimated_picture_ptr);
 
     // 1/4 & 1/16 input picture downsampling through filtering
-    DownsampleInputPicture(
+    DownsampleFilteringInputPicture(
         picture_control_set_ptr_central,
         padded_pic_ptr,
         (EbPictureBufferDesc*)src_object->quarter_filtered_picture_ptr,

--- a/Source/Lib/Common/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Common/Codec/EbTemporalFiltering.c
@@ -276,8 +276,14 @@ void create_ME_context_and_picture_control(MotionEstimationContext_t *context_pt
     EbPaReferenceObject *src_object = (EbPaReferenceObject*)picture_control_set_ptr_central->pa_reference_picture_wrapper_ptr->object_ptr;
     EbPictureBufferDesc *padded_pic_ptr = src_object->input_padded_picture_ptr;
 #if DOWN_SAMPLING_FILTERING
-    EbPictureBufferDesc *quarter_pic_ptr = src_object->quarter_filtered_picture_ptr;
-    EbPictureBufferDesc *sixteenth_pic_ptr = src_object->sixteenth_filtered_picture_ptr;
+    // Set 1/4 and 1/16 ME reference buffer(s); filtered or decimated
+    EbPictureBufferDesc * quarter_pic_ptr = (picture_control_set_ptr_central->down_sampling_method_me_search == 0) ?
+        (EbPictureBufferDesc*)src_object->quarter_filtered_picture_ptr :
+        (EbPictureBufferDesc*)src_object->quarter_decimated_picture_ptr;
+
+    EbPictureBufferDesc *sixteenth_pic_ptr = (picture_control_set_ptr_central->down_sampling_method_me_search == 0) ?
+        (EbPictureBufferDesc*)src_object->sixteenth_filtered_picture_ptr :
+        (EbPictureBufferDesc*)src_object->sixteenth_decimated_picture_ptr;
 #else
     EbPictureBufferDesc *quarter_pic_ptr = src_object->quarter_decimated_picture_ptr;
     EbPictureBufferDesc *sixteenth_pic_ptr = src_object->sixteenth_decimated_picture_ptr;

--- a/Source/Lib/Common/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Common/Codec/EbTemporalFiltering.c
@@ -278,11 +278,11 @@ void create_ME_context_and_picture_control(MotionEstimationContext_t *context_pt
 #if DOWN_SAMPLING_FILTERING
     SequenceControlSet *sequence_control_set_ptr = (SequenceControlSet*)picture_control_set_ptr_central->sequence_control_set_wrapper_ptr->object_ptr;
     // Set 1/4 and 1/16 ME reference buffer(s); filtered or decimated
-    EbPictureBufferDesc * quarter_pic_ptr = (sequence_control_set_ptr->down_sampling_method_me_search == 0) ?
+    EbPictureBufferDesc * quarter_pic_ptr = (sequence_control_set_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) ?
         (EbPictureBufferDesc*)src_object->quarter_filtered_picture_ptr :
         (EbPictureBufferDesc*)src_object->quarter_decimated_picture_ptr;
 
-    EbPictureBufferDesc *sixteenth_pic_ptr = (sequence_control_set_ptr->down_sampling_method_me_search == 0) ?
+    EbPictureBufferDesc *sixteenth_pic_ptr = (sequence_control_set_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) ?
         (EbPictureBufferDesc*)src_object->sixteenth_filtered_picture_ptr :
         (EbPictureBufferDesc*)src_object->sixteenth_decimated_picture_ptr;
 #else
@@ -1586,7 +1586,7 @@ int pad_and_decimate_filtered_pic(PictureParentControlSet *picture_control_set_p
 
     // 1/4 & 1/16 input picture downsampling through filtering
     SequenceControlSet *sequence_control_set_ptr = (SequenceControlSet*)picture_control_set_ptr_central->sequence_control_set_wrapper_ptr->object_ptr;
-    if (sequence_control_set_ptr->down_sampling_method_me_search == 0)
+    if (sequence_control_set_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED)
         DownsampleFilteringInputPicture(
             picture_control_set_ptr_central,
             padded_pic_ptr,

--- a/Source/Lib/Common/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Common/Codec/EbTemporalFiltering.c
@@ -275,9 +275,13 @@ void create_ME_context_and_picture_control(MotionEstimationContext_t *context_pt
     // set the buffers with the original, quarter and sixteenth pixels version of the source frame
     EbPaReferenceObject *src_object = (EbPaReferenceObject*)picture_control_set_ptr_central->pa_reference_picture_wrapper_ptr->object_ptr;
     EbPictureBufferDesc *padded_pic_ptr = src_object->input_padded_picture_ptr;
+#if DOWN_SAMPLING_FILTERING
+    EbPictureBufferDesc *quarter_pic_ptr = src_object->quarter_filtered_picture_ptr;
+    EbPictureBufferDesc *sixteenth_pic_ptr = src_object->sixteenth_filtered_picture_ptr;
+#else
     EbPictureBufferDesc *quarter_pic_ptr = src_object->quarter_decimated_picture_ptr;
     EbPictureBufferDesc *sixteenth_pic_ptr = src_object->sixteenth_decimated_picture_ptr;
-
+#endif
     // Parts from MotionEstimationKernel()
     uint32_t sb_origin_x = (uint32_t)(blk_col * BW);
     uint32_t sb_origin_y = (uint32_t)(blk_row * BH);
@@ -1553,9 +1557,10 @@ int pad_and_decimate_filtered_pic(PictureParentControlSet *picture_control_set_p
     // reference structures (padded pictures + downsampled versions)
     EbPaReferenceObject *src_object = (EbPaReferenceObject*)picture_control_set_ptr_central->pa_reference_picture_wrapper_ptr->object_ptr;
     EbPictureBufferDesc *padded_pic_ptr = src_object->input_padded_picture_ptr;
+#if !DOWN_SAMPLING_FILTERING
     EbPictureBufferDesc *quarter_pic_ptr = src_object->quarter_decimated_picture_ptr;
     EbPictureBufferDesc *sixteenth_pic_ptr = src_object->sixteenth_decimated_picture_ptr;
-
+#endif
     generate_padding(
         &(padded_pic_ptr->buffer_y[0]),
         padded_pic_ptr->stride_y,
@@ -1564,11 +1569,26 @@ int pad_and_decimate_filtered_pic(PictureParentControlSet *picture_control_set_p
         padded_pic_ptr->origin_x,
         padded_pic_ptr->origin_y);
 
+#if DOWN_SAMPLING_FILTERING
+    // 1/4 & 1/16 input picture decimation
+    DecimateInputPicture(
+        picture_control_set_ptr_central,
+        padded_pic_ptr,
+        (EbPictureBufferDesc*)src_object->quarter_decimated_picture_ptr,
+        (EbPictureBufferDesc*)src_object->sixteenth_decimated_picture_ptr);
+
+    // 1/4 & 1/16 input picture downsampling through filtering
+    DownsampleInputPicture(
+        picture_control_set_ptr_central,
+        padded_pic_ptr,
+        (EbPictureBufferDesc*)src_object->quarter_filtered_picture_ptr,
+        (EbPictureBufferDesc*)src_object->sixteenth_filtered_picture_ptr);
+#else
     DecimateInputPicture(picture_control_set_ptr_central,
         padded_pic_ptr,
         quarter_pic_ptr,
         sixteenth_pic_ptr);
-
+#endif
     return 0;
 }
 

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -1127,9 +1127,13 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         EbReferenceObjectDescInitData     EbReferenceObjectDescInitDataStructure;
         EbPaReferenceObjectDescInitData   EbPaReferenceObjectDescInitDataStructure;
         EbPictureBufferDescInitData       referencePictureBufferDescInitData;
+#if DOWN_SAMPLING_FILTERING
+        EbPictureBufferDescInitData       quarterPictureBufferDescInitData;
+        EbPictureBufferDescInitData       sixteenthPictureBufferDescInitData;
+#else
         EbPictureBufferDescInitData       quarterDecimPictureBufferDescInitData;
         EbPictureBufferDescInitData       sixteenthDecimPictureBufferDescInitData;
-
+#endif
         // Initialize the various Picture types
         referencePictureBufferDescInitData.max_width = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_width;
         referencePictureBufferDescInitData.max_height = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_height;
@@ -1178,7 +1182,35 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         referencePictureBufferDescInitData.top_padding = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz + ME_FILTER_TAP;
         referencePictureBufferDescInitData.bot_padding = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz + ME_FILTER_TAP;
         referencePictureBufferDescInitData.split_mode = EB_FALSE;
+#if DOWN_SAMPLING_FILTERING
+        quarterPictureBufferDescInitData.max_width = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_width >> 1;
+        quarterPictureBufferDescInitData.max_height = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_height >> 1;
+        quarterPictureBufferDescInitData.bit_depth = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->encoder_bit_depth;
+        quarterPictureBufferDescInitData.color_format = EB_YUV420;
+        quarterPictureBufferDescInitData.buffer_enable_mask = PICTURE_BUFFER_DESC_LUMA_MASK;
+        quarterPictureBufferDescInitData.left_padding = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 1;
+        quarterPictureBufferDescInitData.right_padding = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 1;
+        quarterPictureBufferDescInitData.top_padding = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 1;
+        quarterPictureBufferDescInitData.bot_padding = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 1;
+        quarterPictureBufferDescInitData.split_mode = EB_FALSE;
+        quarterPictureBufferDescInitData.down_sampled_filtered = (enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->down_sampling_method_me_search == 0) ? EB_TRUE : EB_FALSE;
 
+        sixteenthPictureBufferDescInitData.max_width = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_width >> 2;
+        sixteenthPictureBufferDescInitData.max_height = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_height >> 2;
+        sixteenthPictureBufferDescInitData.bit_depth = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->encoder_bit_depth;
+        sixteenthPictureBufferDescInitData.color_format = EB_YUV420;
+        sixteenthPictureBufferDescInitData.buffer_enable_mask = PICTURE_BUFFER_DESC_LUMA_MASK;
+        sixteenthPictureBufferDescInitData.left_padding = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 2;
+        sixteenthPictureBufferDescInitData.right_padding = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 2;
+        sixteenthPictureBufferDescInitData.top_padding = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 2;
+        sixteenthPictureBufferDescInitData.bot_padding = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 2;
+        sixteenthPictureBufferDescInitData.split_mode = EB_FALSE;
+        sixteenthPictureBufferDescInitData.down_sampled_filtered = (enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->down_sampling_method_me_search == 0) ? EB_TRUE : EB_FALSE;
+
+        EbPaReferenceObjectDescInitDataStructure.reference_picture_desc_init_data = referencePictureBufferDescInitData;
+        EbPaReferenceObjectDescInitDataStructure.quarter_picture_desc_init_data = quarterPictureBufferDescInitData;
+        EbPaReferenceObjectDescInitDataStructure.sixteenth_picture_desc_init_data = sixteenthPictureBufferDescInitData;
+#else
         quarterDecimPictureBufferDescInitData.max_width = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_width >> 1;
         quarterDecimPictureBufferDescInitData.max_height = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_height >> 1;
         quarterDecimPictureBufferDescInitData.bit_depth = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->encoder_bit_depth;
@@ -1204,7 +1236,7 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         EbPaReferenceObjectDescInitDataStructure.reference_picture_desc_init_data = referencePictureBufferDescInitData;
         EbPaReferenceObjectDescInitDataStructure.quarter_picture_desc_init_data = quarterDecimPictureBufferDescInitData;
         EbPaReferenceObjectDescInitDataStructure.sixteenth_picture_desc_init_data = sixteenthDecimPictureBufferDescInitData;
-
+#endif
         // Reference Picture Buffers
         return_error = eb_system_resource_ctor(
             &enc_handle_ptr->pa_reference_picture_pool_ptr_array[instance_index],
@@ -2230,6 +2262,15 @@ void SetParamBasedOnInput(SequenceControlSet *sequence_control_set_ptr)
     sequence_control_set_ptr->nsq_present = (uint8_t)(sequence_control_set_ptr->static_config.enc_mode <= ENC_M5) ? 1 : 0;
 #else
     sequence_control_set_ptr->nsq_present = 1;
+#endif
+#if DOWN_SAMPLING_FILTERING
+    // Set down-sampling method     Settings
+    // 0                            0: filtering
+    // 1                            1: decimation
+    if (sequence_control_set_ptr->static_config.enc_mode == ENC_M0)
+        sequence_control_set_ptr->down_sampling_method_me_search = 0;
+    else
+        sequence_control_set_ptr->down_sampling_method_me_search = 1;
 #endif
 #endif
 }

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -1193,7 +1193,7 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         quarterPictureBufferDescInitData.top_padding = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 1;
         quarterPictureBufferDescInitData.bot_padding = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 1;
         quarterPictureBufferDescInitData.split_mode = EB_FALSE;
-        quarterPictureBufferDescInitData.down_sampled_filtered = (enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->down_sampling_method_me_search == 0) ? EB_TRUE : EB_FALSE;
+        quarterPictureBufferDescInitData.down_sampled_filtered = (enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) ? EB_TRUE : EB_FALSE;
 
         sixteenthPictureBufferDescInitData.max_width = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_width >> 2;
         sixteenthPictureBufferDescInitData.max_height = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_input_luma_height >> 2;
@@ -1205,7 +1205,7 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         sixteenthPictureBufferDescInitData.top_padding = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 2;
         sixteenthPictureBufferDescInitData.bot_padding = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz >> 2;
         sixteenthPictureBufferDescInitData.split_mode = EB_FALSE;
-        sixteenthPictureBufferDescInitData.down_sampled_filtered = (enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->down_sampling_method_me_search == 0) ? EB_TRUE : EB_FALSE;
+        sixteenthPictureBufferDescInitData.down_sampled_filtered = (enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) ? EB_TRUE : EB_FALSE;
 
         EbPaReferenceObjectDescInitDataStructure.reference_picture_desc_init_data = referencePictureBufferDescInitData;
         EbPaReferenceObjectDescInitDataStructure.quarter_picture_desc_init_data = quarterPictureBufferDescInitData;
@@ -2268,9 +2268,9 @@ void SetParamBasedOnInput(SequenceControlSet *sequence_control_set_ptr)
     // 0                            0: filtering
     // 1                            1: decimation
     if (sequence_control_set_ptr->static_config.enc_mode == ENC_M0)
-        sequence_control_set_ptr->down_sampling_method_me_search = 0;
+        sequence_control_set_ptr->down_sampling_method_me_search = ME_FILTERED_DOWNSAMPLED;
     else
-        sequence_control_set_ptr->down_sampling_method_me_search = 1;
+        sequence_control_set_ptr->down_sampling_method_me_search = ME_DECIMATED_DOWNSAMPLED;
 #endif
 #endif
 }


### PR DESCRIPTION
## Description
* Added down-sampling filtering support.
* Used the down-sampled filtered 1/16th and 1/4th input/reference frame(s) @ both ME and alt-ref temporal filtering .
* Added a multi-mode signal to control the down-sampling method; use the filtered if M0, and use the decimated if M1 or  higher.
* Removed HME Level 0 check @ 1/16 th decimation to guarantee valid ZZ SAD and SCD data when HME Level 0 is OFF (lossless bug fix).

## Author

@ikatsavounidisFB 
@hguermaz 

## Type of change

New feature/tool and bug fix.

## Tests and performance
* Bd-Rate gain(s):
Full sub-4K aom list: ~0.4% to aom_2pass_cpu0 on the.
Per resolution: ~0.7%, ~0.4% and ~0.2% to aom_2pass_cpu0 on 360p, 720p and 1080p respectively.

* Speed & memory footprint:
~0% speed deviation and ~0.3% memory increase in M0.
No memory or speed overhead in M1 & higher.

