### PR TITLE
Travis: inline anchors and add chown before ffmpeg configure to fix ccache ownership problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,6 @@ install:
   - pip install --user cpp-coveralls
   - export PATH=/Users/travis/Library/Python/2.7/bin:${PATH}
   #- if [ $TRAVIS_OS_NAME = osx ]; then brew install --HEAD valgrind; fi
-after_coveralls_script: &after_coveralls_script |
-  if [ $CC = "clang" ] && [ $TRAVIS_OS_NAME = linux ]; then
-    GCOV_FILE=llvm-cov GCOV_OPTIONS='gcov -pl'
-  else
-    GCOV_FILE=gcov GCOV_OPTIONS='\-lp'
-  fi
-  coveralls --root $TRAVIS_BUILD_DIR -i Source -E ".*gtest.*" -E ".*CMakeFiles.*" -E ".*third_party.*" -E ".*test/FilmGrainTest.cc" -E ".*ffmpeg.*" --gcov $GCOV_FILE --gcov-options "$GCOV_OPTIONS"
 script:
   - &base_script |
     cd $TRAVIS_BUILD_DIR/Build/linux/$build_type
@@ -149,7 +142,13 @@ matrix:
           sudo make install && cd $TRAVIS_BUILD_DIR &&
           ffmpeg -i akiyo_cif.y4m -vframes 150 -c:v libsvt_av1 test.mp4 &&
           ffmpeg -i bus_cif.y4m -nostdin -f rawvideo -pix_fmt yuv420p - | SvtAv1EncApp -i stdin -w 352 -h 288 -fps 30 -n 150 -b test2.ivf
-      after_script: *after_coveralls_script
+      after_script: &after_coveralls_script |
+        if [ $CC = "clang" ] && [ $TRAVIS_OS_NAME = linux ]; then
+          GCOV_FILE=llvm-cov GCOV_OPTIONS='gcov -pl'
+        else
+          GCOV_FILE=gcov GCOV_OPTIONS='\-lp'
+        fi
+        coveralls --root $TRAVIS_BUILD_DIR -i Source -E ".*gtest.*" -E ".*CMakeFiles.*" -E ".*third_party.*" -E ".*test/FilmGrainTest.cc" -E ".*ffmpeg.*" --gcov $GCOV_FILE --gcov-options "$GCOV_OPTIONS"
     - name: Coveralls osx+clang
       stage: Coveralls
       os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,7 @@ matrix:
         - git clone https://github.com/FFmpeg/FFmpeg --branch release/4.1 --depth=1 ffmpeg && cd ffmpeg
         - git apply $TRAVIS_BUILD_DIR/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
         - export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:/usr/local/lib/pkgconfig
+        - "sudo chown -R travis: $HOME/.ccache"
         - ./configure --enable-libsvtav1
         - make --quiet -j$(nproc) && sudo make install
     # GStreamer interation build

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,6 @@ install:
   - pip install --user cpp-coveralls
   - export PATH=/Users/travis/Library/Python/2.7/bin:${PATH}
   #- if [ $TRAVIS_OS_NAME = osx ]; then brew install --HEAD valgrind; fi
-base_script: &base_script |
-  cd $TRAVIS_BUILD_DIR/Build/linux/$build_type
-  cmake $TRAVIS_BUILD_DIR -G"Unix Makefiles" -DCMAKE_ASM_NASM_COMPILER=yasm -DCMAKE_BUILD_TYPE=$build_type ${CMAKE_EFLAGS[@]}
-  cmake -j $(if [ $TRAVIS_OS_NAME = osx ]; then sysctl -n hw.ncpu; else nproc; fi) --build . &&
-  sudo cmake --build . --target install && cd $TRAVIS_BUILD_DIR
 coveralls_script: &coveralls_script |
   SvtAv1EncApp -enc-mode 8 -w 720 -h 486 -fps 60 -i akiyo_cif.y4m -n 150 -b test1.ivf
   git clone https://github.com/FFmpeg/FFmpeg ffmpeg --depth=1 --branch release/4.1 && cd ffmpeg &&
@@ -71,7 +66,11 @@ after_coveralls_script: &after_coveralls_script |
   fi
   coveralls --root $TRAVIS_BUILD_DIR -i Source -E ".*gtest.*" -E ".*CMakeFiles.*" -E ".*third_party.*" -E ".*test/FilmGrainTest.cc" -E ".*ffmpeg.*" --gcov $GCOV_FILE --gcov-options "$GCOV_OPTIONS"
 script:
-  - *base_script
+  - &base_script |
+    cd $TRAVIS_BUILD_DIR/Build/linux/$build_type
+    cmake $TRAVIS_BUILD_DIR -G"Unix Makefiles" -DCMAKE_ASM_NASM_COMPILER=yasm -DCMAKE_BUILD_TYPE=$build_type ${CMAKE_EFLAGS[@]}
+    cmake -j $(if [ $TRAVIS_OS_NAME = osx ]; then sysctl -n hw.ncpu; else nproc; fi) --build . &&
+    sudo cmake --build . --target install && cd $TRAVIS_BUILD_DIR
   - SvtAv1EncApp -enc-mode 8 -w 720 -h 486 -fps 60 -i akiyo_cif.y4m -n 150 -b test1.ivf
 before_cache:
   - "sudo chown -R travis: $HOME/.ccache"

--- a/.travis.yml
+++ b/.travis.yml
@@ -138,6 +138,7 @@ matrix:
           git clone https://github.com/FFmpeg/FFmpeg ffmpeg --depth=1 --branch release/4.1 && cd ffmpeg &&
           git apply $TRAVIS_BUILD_DIR/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch &&
           ffmpegconfig=(--disable-everything --enable-{libsvtav1,encoder={libaom_av1,libsvt_av1,rawvideo},decoder={h264,rawvideo,yuv4,libaom_av1},muxer={fifo,matroska,ivf,mp4,rawvideo,webm,yuv4mpegpipe},demuxer={h264,ivf,matroska,mpegts,rawvideo,yuv4mpegpipe},parser={av1,h264,mpeg4video},bsf={av1_metadata,h264_metadata},protocol={data,file,pipe,unix},filter={fifo,fps,libvmaf,psnr,ssim,vmafmotion}})
+           sudo chown -R travis: $HOME/.ccache
           if ! ./configure ${ffmpegconfig[@]}; then cat ffbuild/config.log; fi &&
           make -s -j$(if [ $TRAVIS_OS_NAME = osx ]; then sysctl -n hw.ncpu; else nproc; fi) >/dev/null &&
           sudo make install && cd $TRAVIS_BUILD_DIR &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,16 +48,6 @@ install:
   - pip install --user cpp-coveralls
   - export PATH=/Users/travis/Library/Python/2.7/bin:${PATH}
   #- if [ $TRAVIS_OS_NAME = osx ]; then brew install --HEAD valgrind; fi
-coveralls_script: &coveralls_script |
-  SvtAv1EncApp -enc-mode 8 -w 720 -h 486 -fps 60 -i akiyo_cif.y4m -n 150 -b test1.ivf
-  git clone https://github.com/FFmpeg/FFmpeg ffmpeg --depth=1 --branch release/4.1 && cd ffmpeg &&
-  git apply $TRAVIS_BUILD_DIR/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch &&
-  ffmpegconfig=(--disable-everything --enable-{libsvtav1,encoder={libaom_av1,libsvt_av1,rawvideo},decoder={h264,rawvideo,yuv4,libaom_av1},muxer={fifo,matroska,ivf,mp4,rawvideo,webm,yuv4mpegpipe},demuxer={h264,ivf,matroska,mpegts,rawvideo,yuv4mpegpipe},parser={av1,h264,mpeg4video},bsf={av1_metadata,h264_metadata},protocol={data,file,pipe,unix},filter={fifo,fps,libvmaf,psnr,ssim,vmafmotion}})
-  if ! ./configure ${ffmpegconfig[@]}; then cat ffbuild/config.log; fi &&
-  make -s -j$(if [ $TRAVIS_OS_NAME = osx ]; then sysctl -n hw.ncpu; else nproc; fi) >/dev/null &&
-  sudo make install && cd $TRAVIS_BUILD_DIR &&
-  ffmpeg -i akiyo_cif.y4m -vframes 150 -c:v libsvt_av1 test.mp4 &&
-  ffmpeg -i bus_cif.y4m -nostdin -f rawvideo -pix_fmt yuv420p - | SvtAv1EncApp -i stdin -w 352 -h 288 -fps 30 -n 150 -b test2.ivf
 after_coveralls_script: &after_coveralls_script |
   if [ $CC = "clang" ] && [ $TRAVIS_OS_NAME = linux ]; then
     GCOV_FILE=llvm-cov GCOV_OPTIONS='gcov -pl'
@@ -149,7 +139,16 @@ matrix:
       env: COVERALLS_PARALLEL=true build_type=debug CMAKE_EFLAGS="-DCOVERAGE=ON"
       script:
         - *base_script
-        - *coveralls_script
+        - &coveralls_script |
+          SvtAv1EncApp -enc-mode 8 -w 720 -h 486 -fps 60 -i akiyo_cif.y4m -n 150 -b test1.ivf
+          git clone https://github.com/FFmpeg/FFmpeg ffmpeg --depth=1 --branch release/4.1 && cd ffmpeg &&
+          git apply $TRAVIS_BUILD_DIR/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch &&
+          ffmpegconfig=(--disable-everything --enable-{libsvtav1,encoder={libaom_av1,libsvt_av1,rawvideo},decoder={h264,rawvideo,yuv4,libaom_av1},muxer={fifo,matroska,ivf,mp4,rawvideo,webm,yuv4mpegpipe},demuxer={h264,ivf,matroska,mpegts,rawvideo,yuv4mpegpipe},parser={av1,h264,mpeg4video},bsf={av1_metadata,h264_metadata},protocol={data,file,pipe,unix},filter={fifo,fps,libvmaf,psnr,ssim,vmafmotion}})
+          if ! ./configure ${ffmpegconfig[@]}; then cat ffbuild/config.log; fi &&
+          make -s -j$(if [ $TRAVIS_OS_NAME = osx ]; then sysctl -n hw.ncpu; else nproc; fi) >/dev/null &&
+          sudo make install && cd $TRAVIS_BUILD_DIR &&
+          ffmpeg -i akiyo_cif.y4m -vframes 150 -c:v libsvt_av1 test.mp4 &&
+          ffmpeg -i bus_cif.y4m -nostdin -f rawvideo -pix_fmt yuv420p - | SvtAv1EncApp -i stdin -w 352 -h 288 -fps 30 -n 150 -b test2.ivf
       after_script: *after_coveralls_script
     - name: Coveralls osx+clang
       stage: Coveralls


### PR DESCRIPTION
Inline base_script, coveralls_script, and after_coveralls_script, add chown before configuring ffmpeg to try to prevent ffmpeg issues of ccache file ownership