### PR TITLE
Fixed a 10BIT conformance problem; use default INTRA path @ encode pa…

### DIFF
--- a/Source/Lib/Common/Codec/EbCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbCodingLoop.c
@@ -3529,7 +3529,7 @@ EB_EXTERN void av1_encode_pass(
                     context_ptr->txb_itr = 0;
 #if ATB_EP
                     // Transform partitioning path (INTRA Luma/Chroma)
-                    if (cu_ptr->av1xd->use_intrabc == 0) {
+                    if (picture_control_set_ptr->parent_pcs_ptr->atb_mode && cu_ptr->av1xd->use_intrabc == 0) {
                         // Set the PU Loop Variables
                         pu_ptr = cu_ptr->prediction_unit_array;
                         // Generate Intra Luma Neighbor Modes


### PR DESCRIPTION
## Description
* Fixed a 10BIT conformance problem; use default INTRA path @ encode pass when 10BIT input (rather than the transform partitioning path). The transform partitioning path does not support yet 10BIT input .
* Used atb_mode to control INTRA path @ encode pass as atb_mode derivation already takes into account the input BIT_DEPTH.

Closes #366 

## Author

@hguermaz 

## Type of change

Bug fix.


