### PR TITLE
Fix implicit declaration, avoid compile-time overflow, use correct time functions

### DIFF
--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -1212,10 +1212,10 @@ AppExitConditionType ProcessOutputStreamBuffer(
             *total_latency += (uint64_t)headerPtr->n_tick_count;
             *max_latency = (headerPtr->n_tick_count > *max_latency) ? headerPtr->n_tick_count : *max_latency;
 
-            EbFinishTime((uint64_t*)&finishsTime, (uint64_t*)&finishuTime);
+            FinishTime((uint64_t*)&finishsTime, (uint64_t*)&finishuTime);
 
             // total execution time, inc init time
-            EbComputeOverallElapsedTime(
+            ComputeOverallElapsedTime(
                 config->performance_context.lib_start_time[0],
                 config->performance_context.lib_start_time[1],
                 finishsTime,
@@ -1223,7 +1223,7 @@ AppExitConditionType ProcessOutputStreamBuffer(
                 &config->performance_context.total_execution_time);
 
             // total encode time
-            EbComputeOverallElapsedTime(
+            ComputeOverallElapsedTime(
                 config->performance_context.encode_start_time[0],
                 config->performance_context.encode_start_time[1],
                 finishsTime,

--- a/Source/Lib/Common/Codec/EbPictureAnalysisProcess.h
+++ b/Source/Lib/Common/Codec/EbPictureAnalysisProcess.h
@@ -42,6 +42,14 @@ void noise_extract_luma_weak(
     uint32_t               sb_origin_y,
     uint32_t               sb_origin_x);
 
+#if DOWN_SAMPLING_FILTERING
+void DownsampleFilteringInputPicture(
+    PictureParentControlSet       *picture_control_set_ptr,
+    EbPictureBufferDesc           *input_padded_picture_ptr,
+    EbPictureBufferDesc           *quarter_picture_ptr,
+    EbPictureBufferDesc *sixteenth_picture_ptr);
+#endif
+
 typedef void(*EbWeakLumaFilterType)(
     EbPictureBufferDesc *input_picture_ptr,
     EbPictureBufferDesc *denoised_picture_ptr,

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -15,6 +15,7 @@
 #include "EbUtility.h"
 #include "EbPictureControlSet.h"
 #include "EbSequenceControlSet.h"
+#include "EbPictureAnalysisProcess.h"
 #include "EbPictureAnalysisResults.h"
 #include "EbPictureDecisionProcess.h"
 #include "EbPictureDecisionResults.h"

--- a/Source/Lib/Common/Codec/EbSegmentation.c
+++ b/Source/Lib/Common/Codec/EbSegmentation.c
@@ -179,7 +179,7 @@ void find_segment_qps(
         PictureControlSet *picture_control_set_ptr) { //QP needs to be specified as qpindex, not qp.
 
     uint16_t *variancePtr;
-    uint16_t min_var = MAX_UNSIGNED_VALUE, max_var = MIN_UNSIGNED_VALUE, avg_var = 0;
+    uint16_t min_var = UINT16_MAX, max_var = MIN_UNSIGNED_VALUE, avg_var = 0;
     float strength = 2;//to tune
 
     // get range of variance


### PR DESCRIPTION
Before this pull request, these warnings were present, all of which are fixed now:

```
/Users/me/Downloads/SVT-AV1-master 3/Source/Lib/Common/Codec/EbPictureDecisionProcess.c: In function 'perform_simple_picture_analysis_for_overlay':
/Users/me/Downloads/SVT-AV1-master 3/Source/Lib/Common/Codec/EbPictureDecisionProcess.c:3144:9: warning: implicit declaration of function 'DownsampleFilteringInputPicture'; did you mean 'DownsampleDecimationInputPicture'? [-Wimplicit-function-declaration]
 3144 |         DownsampleFilteringInputPicture(
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |         DownsampleDecimationInputPicture
In file included from /Users/me/Downloads/SVT-AV1-master 3/Source/Lib/Common/Codec/EbBitstreamUnit.h:10,
                 from /Users/me/Downloads/SVT-AV1-master 3/Source/Lib/Common/Codec/EbEntropyCodingObject.h:11,
                 from /Users/me/Downloads/SVT-AV1-master 3/Source/Lib/Common/Codec/EbPictureControlSet.h:16,
                 from /Users/me/Downloads/SVT-AV1-master 3/Source/Lib/Common/Codec/EbSegmentation.h:22,
                 from /Users/me/Downloads/SVT-AV1-master 3/Source/Lib/Common/Codec/EbSegmentation.c:17:
/Users/me/Downloads/SVT-AV1-master 3/Source/Lib/Common/Codec/EbSegmentation.c: In function 'find_segment_qps':
/Users/me/Downloads/SVT-AV1-master 3/Source/Lib/Common/Codec/EbUtility.h:276:32: warning: conversion from 'unsigned int' to 'uint16_t' {aka 'short unsigned int'} changes value from '4294967295' to '65535' [-Woverflow]
  276 | #define MAX_UNSIGNED_VALUE     ~0u
      |                                ^
/Users/me/Downloads/SVT-AV1-master 3/Source/Lib/Common/Codec/EbSegmentation.c:182:24: note: in expansion of macro 'MAX_UNSIGNED_VALUE'
  182 |     uint16_t min_var = MAX_UNSIGNED_VALUE, max_var = MIN_UNSIGNED_VALUE, avg_var = 0;
      |                        ^~~~~~~~~~~~~~~~~~
/Users/me/Downloads/SVT-AV1-master 3/Source/Lib/Common/Codec/EbTemporalFiltering.c: In function 'pad_and_decimate_filtered_pic':
/Users/me/Downloads/SVT-AV1-master 3/Source/Lib/Common/Codec/EbTemporalFiltering.c:1580:9: warning: implicit declaration of function 'DownsampleFilteringInputPicture'; did you mean 'DownsampleDecimationInputPicture'? [-Wimplicit-function-declaration]
 1580 |         DownsampleFilteringInputPicture(
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |         DownsampleDecimationInputPicture
/Users/me/Downloads/SVT-AV1-master 3/Source/App/EncApp/EbAppProcessCmd.c: In function 'ProcessOutputStreamBuffer':
/Users/me/Downloads/SVT-AV1-master 3/Source/App/EncApp/EbAppProcessCmd.c:1215:13: warning: implicit declaration of function 'EbFinishTime'; did you mean 'FinishTime'? [-Wimplicit-function-declaration]
 1215 |             EbFinishTime((uint64_t*)&finishsTime, (uint64_t*)&finishuTime);
      |             ^~~~~~~~~~~~
      |             FinishTime
/Users/me/Downloads/SVT-AV1-master 3/Source/App/EncApp/EbAppProcessCmd.c:1218:13: warning: implicit declaration of function 'EbComputeOverallElapsedTime'; did you mean 'ComputeOverallElapsedTime'? [-Wimplicit-function-declaration]
 1218 |             EbComputeOverallElapsedTime(
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
      |             ComputeOverallElapsedTime

```