### PR TITLE
CI: Add binary identicality test to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,14 +148,13 @@ matrix:
     - name: Binary Identical?
       stage: test
       script:
-       - export PATH="$HOME:$PATH"
        - *base_script
        - mv -t $HOME akiyo_cif.y4m
        - SvtAv1EncApp -enc-mode 8 -i $HOME/akiyo_cif.y4m -n 120 -b test-pr-m8.ivf
        - SvtAv1EncApp -enc-mode 0 -i $HOME/akiyo_cif.y4m -n 3 -b test-pr-m0.ivf
        - mv -t $HOME test-pr-m8.ivf test-pr-m0.ivf
        - cd $HOME && rm -rf SVT-AV1
-       - git clone https://github.com/OpenVisualCloud/SVT-AV1.git && cd SVT-AV1
+       - git clone --depth 1 https://github.com/OpenVisualCloud/SVT-AV1.git && cd SVT-AV1
        - *before_install
        - *base_script
        - SvtAv1EncApp -enc-mode 8 -i $HOME/akiyo_cif.y4m -n 120 -b test-master-m8.ivf

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ before_cache:
 matrix:
   fast_finish: true
   allow_failures:
+    - name: Binary Identical?
     - name: Valgrind
     - env: COVERALLS_PARALLEL=true build_type=debug CMAKE_EFLAGS="-DCOVERAGE=ON"
     - name: Unit Tests Linux+gcc
@@ -143,6 +144,25 @@ matrix:
       - cmake .
       - make --quiet -j$(nproc)
       - sudo make install
+    # Tests if .ivf files are identical on binary level
+    - name: Binary Identical?
+      stage: test
+      script:
+       - export PATH="$HOME:$PATH"
+       - *base_script
+       - mv -t $HOME akiyo_cif.y4m
+       - SvtAv1EncApp -enc-mode 8 -i $HOME/akiyo_cif.y4m -n 120 -b test-pr-m8.ivf
+       - SvtAv1EncApp -enc-mode 0 -i $HOME/akiyo_cif.y4m -n 3 -b test-pr-m0.ivf
+       - mv -t $HOME test-pr-m8.ivf test-pr-m0.ivf
+       - cd $HOME && rm -rf SVT-AV1
+       - git clone https://github.com/OpenVisualCloud/SVT-AV1.git && cd SVT-AV1
+       - *before_install
+       - *base_script
+       - SvtAv1EncApp -enc-mode 8 -i $HOME/akiyo_cif.y4m -n 120 -b test-master-m8.ivf
+       - SvtAv1EncApp -enc-mode 0 -i $HOME/akiyo_cif.y4m -n 3 -b test-master-m0.ivf
+       - mv -t $HOME test-master-m8.ivf test-master-m0.ivf && cd $HOME
+       - diff test-pr-m8.ivf test-master-m8.ivf
+       - diff test-pr-m0.ivf test-master-m0.ivf
     - name: Coveralls Linux+gcc
       stage: Coveralls
       os: linux


### PR DESCRIPTION
Adds a binary identicality test to Travis. The test compares two encodes (enc-mode 0 and 8) encoded from the PR to encodes from the master branch to check if they are bit-identical. It can be used as a check for PRs where no change in bitstream is expected.

**Examples:**
- [A run that passed](https://travis-ci.com/EwoutH/SVT-AV1/jobs/207970232)
- [A run that failed](https://travis-ci.com/EwoutH/SVT-AV1/jobs/207970997)

The whole test is allowed to fail, because of course sometimes we actually want to change the bitstream.