### PR TITLE
Incomplete SBs fix (rebased)

### DIFF
--- a/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
+++ b/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
@@ -1159,8 +1159,12 @@ void generate_av1_mvp_table(
     xd->tile.mi_row_start = tile->mi_row_start;
     xd->tile.mi_row_end = tile->mi_row_end;
 
+#if INCOMPLETE_SB_FIX
+    xd->mi_stride = picture_control_set_ptr->mi_stride;
+#else
     //these could be done at init time
     xd->mi_stride = picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->picture_width_in_sb*(BLOCK_SIZE_64 / 4);
+#endif
     const int32_t offset = mi_row * xd->mi_stride + mi_col;
     xd->mi = picture_control_set_ptr->mi_grid_base + offset;
 
@@ -1307,7 +1311,11 @@ void update_av1_mi_map(
     const BlockGeom                *blk_geom,
     PictureControlSet            *picture_control_set_ptr)
 {
+#if INCOMPLETE_SB_FIX
+    uint32_t mi_stride = picture_control_set_ptr->mi_stride;
+#else
     uint32_t mi_stride = picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->picture_width_in_sb*(BLOCK_SIZE_64 >> MI_SIZE_LOG2);
+#endif    
     int32_t mi_row = cu_origin_y >> MI_SIZE_LOG2;
     int32_t mi_col = cu_origin_x >> MI_SIZE_LOG2;
 
@@ -1383,7 +1391,11 @@ void update_mi_map(
     PictureControlSet            *picture_control_set_ptr)
 {
     UNUSED(cu_stats);
+#if INCOMPLETE_SB_FIX
+    uint32_t mi_stride = picture_control_set_ptr->mi_stride;
+#else
     uint32_t mi_stride = picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->picture_width_in_sb*(BLOCK_SIZE_64 >> MI_SIZE_LOG2);
+#endif    
     int32_t mi_row = cu_origin_y >> MI_SIZE_LOG2;
     int32_t mi_col = cu_origin_x >> MI_SIZE_LOG2;
 

--- a/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
+++ b/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
@@ -1315,7 +1315,7 @@ void update_av1_mi_map(
     uint32_t mi_stride = picture_control_set_ptr->mi_stride;
 #else
     uint32_t mi_stride = picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->picture_width_in_sb*(BLOCK_SIZE_64 >> MI_SIZE_LOG2);
-#endif    
+#endif
     int32_t mi_row = cu_origin_y >> MI_SIZE_LOG2;
     int32_t mi_col = cu_origin_x >> MI_SIZE_LOG2;
 
@@ -1395,7 +1395,7 @@ void update_mi_map(
     uint32_t mi_stride = picture_control_set_ptr->mi_stride;
 #else
     uint32_t mi_stride = picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->picture_width_in_sb*(BLOCK_SIZE_64 >> MI_SIZE_LOG2);
-#endif    
+#endif
     int32_t mi_row = cu_origin_y >> MI_SIZE_LOG2;
     int32_t mi_col = cu_origin_x >> MI_SIZE_LOG2;
 

--- a/Source/Lib/Common/Codec/EbCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbCodingLoop.c
@@ -2518,6 +2518,9 @@ void perform_intra_coding_loop(
         context_ptr->md_context->luma_txb_skip_context = 0;
         context_ptr->md_context->luma_dc_sign_context = 0;
         get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+            picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr,
+#endif
             COMPONENT_LUMA,
             picture_control_set_ptr->ep_luma_dc_sign_level_coeff_neighbor_array,
             txb_origin_x,
@@ -2763,6 +2766,9 @@ void perform_intra_coding_loop(
         context_ptr->md_context->cb_txb_skip_context = 0;
         context_ptr->md_context->cb_dc_sign_context = 0;
         get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+            picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr,
+#endif
             COMPONENT_CHROMA,
             picture_control_set_ptr->ep_cb_dc_sign_level_coeff_neighbor_array,
             cu_originx_uv,
@@ -2775,6 +2781,9 @@ void perform_intra_coding_loop(
         context_ptr->md_context->cr_txb_skip_context = 0;
         context_ptr->md_context->cr_dc_sign_context = 0;
         get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+            picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr,
+#endif
             COMPONENT_CHROMA,
             picture_control_set_ptr->ep_cr_dc_sign_level_coeff_neighbor_array,
             cu_originx_uv,
@@ -3425,10 +3434,12 @@ EB_EXTERN void av1_encode_pass(
 
         const BlockGeom * blk_geom = context_ptr->blk_geom = get_blk_geom_mds(blk_it);
         UNUSED(blk_geom);
-
         sb_ptr->cu_partition_array[blk_it] = context_ptr->md_context->md_cu_arr_nsq[blk_it].part;
-
+#if INCOMPLETE_SB_FIX
+        if (part != PARTITION_SPLIT && sequence_control_set_ptr->sb_geom[tbAddr].block_is_allowed[blk_it]) {
+#else
         if (part != PARTITION_SPLIT) {
+#endif
             int32_t offset_d1 = ns_blk_offset[(int32_t)part]; //cu_ptr->best_d1_blk; // TOCKECK
             int32_t num_d1_block = ns_blk_num[(int32_t)part]; // context_ptr->blk_geom->totns; // TOCKECK
 
@@ -3593,6 +3604,9 @@ EB_EXTERN void av1_encode_pass(
                            context_ptr->md_context->luma_txb_skip_context = 0;
                            context_ptr->md_context->luma_dc_sign_context = 0;
                            get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+                               picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr,
+#endif
                                COMPONENT_LUMA,
                                picture_control_set_ptr->ep_luma_dc_sign_level_coeff_neighbor_array,
                                context_ptr->cu_origin_x,
@@ -3606,6 +3620,9 @@ EB_EXTERN void av1_encode_pass(
                                context_ptr->md_context->cb_txb_skip_context = 0;
                                context_ptr->md_context->cb_dc_sign_context = 0;
                                get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+                                   picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr,
+#endif
                                    COMPONENT_CHROMA,
                                    picture_control_set_ptr->ep_cb_dc_sign_level_coeff_neighbor_array,
                                    cu_originx_uv,
@@ -3619,6 +3636,9 @@ EB_EXTERN void av1_encode_pass(
                                context_ptr->md_context->cr_txb_skip_context = 0;
                                context_ptr->md_context->cr_dc_sign_context = 0;
                                get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+                                   picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr,
+#endif
                                    COMPONENT_CHROMA,
                                    picture_control_set_ptr->ep_cr_dc_sign_level_coeff_neighbor_array,
                                    cu_originx_uv,
@@ -4338,6 +4358,9 @@ EB_EXTERN void av1_encode_pass(
                             context_ptr->md_context->luma_txb_skip_context = 0;
                             context_ptr->md_context->luma_dc_sign_context = 0;
                             get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+                                picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr,
+#endif
                                 COMPONENT_LUMA,
                                 picture_control_set_ptr->ep_luma_dc_sign_level_coeff_neighbor_array,
                                 txb_origin_x,
@@ -4351,6 +4374,9 @@ EB_EXTERN void av1_encode_pass(
                                 context_ptr->md_context->cb_txb_skip_context = 0;
                                 context_ptr->md_context->cb_dc_sign_context = 0;
                                 get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+                                    picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr,
+#endif
                                     COMPONENT_CHROMA,
                                     picture_control_set_ptr->ep_cb_dc_sign_level_coeff_neighbor_array,
                                     ROUND_UV(txb_origin_x) >> 1,
@@ -4363,6 +4389,9 @@ EB_EXTERN void av1_encode_pass(
                                 context_ptr->md_context->cr_txb_skip_context = 0;
                                 context_ptr->md_context->cr_dc_sign_context = 0;
                                 get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+                                    picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr,
+#endif
                                     COMPONENT_CHROMA,
                                     picture_control_set_ptr->ep_cr_dc_sign_level_coeff_neighbor_array,
                                     ROUND_UV(txb_origin_x) >> 1,
@@ -4772,6 +4801,9 @@ EB_EXTERN void av1_encode_pass(
                             context_ptr->md_context->luma_txb_skip_context = 0;
                             context_ptr->md_context->luma_dc_sign_context = 0;
                             get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+                                picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr,
+#endif
                                 COMPONENT_LUMA,
                                 picture_control_set_ptr->ep_luma_dc_sign_level_coeff_neighbor_array,
                                 txb_origin_x,
@@ -4786,6 +4818,9 @@ EB_EXTERN void av1_encode_pass(
                                 context_ptr->md_context->cb_txb_skip_context = 0;
                                 context_ptr->md_context->cb_dc_sign_context = 0;
                                 get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+                                    picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr,
+#endif
                                     COMPONENT_CHROMA,
                                     picture_control_set_ptr->ep_cb_dc_sign_level_coeff_neighbor_array,
                                     ROUND_UV(txb_origin_x) >> 1,
@@ -4799,6 +4834,9 @@ EB_EXTERN void av1_encode_pass(
                                 context_ptr->md_context->cr_txb_skip_context = 0;
                                 context_ptr->md_context->cr_dc_sign_context = 0;
                                 get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+                                    picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr,
+#endif
                                     COMPONENT_CHROMA,
                                     picture_control_set_ptr->ep_cr_dc_sign_level_coeff_neighbor_array,
                                     ROUND_UV(txb_origin_x) >> 1,

--- a/Source/Lib/Common/Codec/EbDeblockingFilter.c
+++ b/Source/Lib/Common/Codec/EbDeblockingFilter.c
@@ -913,8 +913,11 @@ static TxSize set_lpf_parameters(
 
     const int32_t mi_row = scale_vert | ((y << scale_vert) >> MI_SIZE_LOG2);
     const int32_t mi_col = scale_horz | ((x << scale_horz) >> MI_SIZE_LOG2);
-
+#if INCOMPLETE_SB_FIX
+    uint32_t mi_stride = pcs_ptr->mi_stride;
+#else
     uint32_t mi_stride = pcs_ptr->parent_pcs_ptr->sequence_control_set_ptr->picture_width_in_sb*(BLOCK_SIZE_64 >> MI_SIZE_LOG2);
+#endif    
     const int32_t offset = mi_row * mi_stride + mi_col;
     ModeInfo **mi = (pcs_ptr->mi_grid_base + offset);
     //MbModeInfo **mi = cm->mi_grid_visible + mi_row * cm->mi_stride + mi_col;
@@ -1143,7 +1146,11 @@ void av1_filter_block_plane_horz(
     const int32_t dst_stride = plane_ptr->dst.stride;
     const int32_t y_range = scs_ptr->seq_header.sb_size == BLOCK_128X128 ? (MAX_MIB_SIZE >> scale_vert) : (SB64_MIB_SIZE >> scale_vert);
     const int32_t x_range = scs_ptr->seq_header.sb_size == BLOCK_128X128 ? (MAX_MIB_SIZE >> scale_horz) : (SB64_MIB_SIZE >> scale_horz);
+#if INCOMPLETE_SB_FIX
+    uint32_t mi_stride = pcs_ptr->mi_stride;
+#else    
     uint32_t mi_stride = pcs_ptr->parent_pcs_ptr->sequence_control_set_ptr->picture_width_in_sb*(BLOCK_SIZE_64 >> MI_SIZE_LOG2);
+#endif    
     for (int32_t x = 0; x < x_range; x += col_step) {
         uint8_t *p = dst_ptr + ((x * MI_SIZE) << plane_ptr->is16Bit);
         for (int32_t y = 0; y < y_range;) {

--- a/Source/Lib/Common/Codec/EbDeblockingFilter.c
+++ b/Source/Lib/Common/Codec/EbDeblockingFilter.c
@@ -917,7 +917,7 @@ static TxSize set_lpf_parameters(
     uint32_t mi_stride = pcs_ptr->mi_stride;
 #else
     uint32_t mi_stride = pcs_ptr->parent_pcs_ptr->sequence_control_set_ptr->picture_width_in_sb*(BLOCK_SIZE_64 >> MI_SIZE_LOG2);
-#endif    
+#endif
     const int32_t offset = mi_row * mi_stride + mi_col;
     ModeInfo **mi = (pcs_ptr->mi_grid_base + offset);
     //MbModeInfo **mi = cm->mi_grid_visible + mi_row * cm->mi_stride + mi_col;
@@ -1148,9 +1148,9 @@ void av1_filter_block_plane_horz(
     const int32_t x_range = scs_ptr->seq_header.sb_size == BLOCK_128X128 ? (MAX_MIB_SIZE >> scale_horz) : (SB64_MIB_SIZE >> scale_horz);
 #if INCOMPLETE_SB_FIX
     uint32_t mi_stride = pcs_ptr->mi_stride;
-#else    
+#else
     uint32_t mi_stride = pcs_ptr->parent_pcs_ptr->sequence_control_set_ptr->picture_width_in_sb*(BLOCK_SIZE_64 >> MI_SIZE_LOG2);
-#endif    
+#endif
     for (int32_t x = 0; x < x_range; x += col_step) {
         uint8_t *p = dst_ptr + ((x * MI_SIZE) << plane_ptr->is16Bit);
         for (int32_t y = 0; y < y_range;) {

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -83,6 +83,7 @@ extern "C" {
 #define CHROMA_SEARCH_FIX                 1 // Fix a few bugs related to Chroma search
 #define INTRA64_FIX                       1 // Fix a bug where 64x64 are disabled for sub 720P
 #define CHROMA_SEARCH_MR                  1 // Enable chroma search for all layers in MR mode
+#define INCOMPLETE_SB_FIX                 1 // Handle the incomplete SBs properly based on the standard and consider all allowed blocks
 /**********************************************************************************/
 
 // New  presets

--- a/Source/Lib/Common/Codec/EbEntropyCoding.h
+++ b/Source/Lib/Common/Codec/EbEntropyCoding.h
@@ -178,6 +178,9 @@ extern "C" {
     }
 
     void get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+        SequenceControlSet *sequence_control_set_ptr,
+#endif
         const int32_t               plane,
         NeighborArrayUnit     *dc_sign_level_coeff_neighbor_array,
         uint32_t                  cu_origin_x,

--- a/Source/Lib/Common/Codec/EbFullLoop.c
+++ b/Source/Lib/Common/Codec/EbFullLoop.c
@@ -2275,11 +2275,17 @@ void product_full_loop(
         uint16_t tx_org_x = context_ptr->blk_geom->tx_org_x[txb_itr];
         uint16_t tx_org_y = context_ptr->blk_geom->tx_org_y[txb_itr];
 #endif
-
+#if INCOMPLETE_SB_FIX
+        int32_t cropped_tx_width = MIN(context_ptr->blk_geom->tx_width[tx_depth][txb_itr], sequence_control_set_ptr->seq_header.max_frame_width - (context_ptr->sb_origin_x + tx_org_x));
+        int32_t cropped_tx_height = MIN(context_ptr->blk_geom->tx_height[tx_depth][txb_itr], sequence_control_set_ptr->seq_header.max_frame_height - (context_ptr->sb_origin_y + tx_org_y));
+#endif
 #if FIXED_128x128_CONTEXT_UPDATE
         context_ptr->luma_txb_skip_context = 0;
         context_ptr->luma_dc_sign_context = 0;
         get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+            sequence_control_set_ptr,
+#endif
             COMPONENT_LUMA,
             context_ptr->luma_dc_sign_level_coeff_neighbor_array,
             context_ptr->sb_origin_x + tx_org_x,
@@ -2446,8 +2452,13 @@ void product_full_loop(
                 candidateBuffer->prediction_ptr->buffer_y + tu_origin_index,
                 candidateBuffer->prediction_ptr->stride_y,
 #if ATB_SUPPORT
+#if INCOMPLETE_SB_FIX
+                cropped_tx_width,
+                cropped_tx_height);
+#else
                 context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
                 context_ptr->blk_geom->tx_height[tx_depth][txb_itr]);
+#endif
 #else
                 context_ptr->blk_geom->tx_width[txb_itr],
                 context_ptr->blk_geom->tx_height[txb_itr]);
@@ -2462,8 +2473,13 @@ void product_full_loop(
                 &(((uint8_t*)candidateBuffer->recon_ptr->buffer_y)[tu_origin_index]),
                 candidateBuffer->recon_ptr->stride_y,
 #if ATB_SUPPORT
+#if INCOMPLETE_SB_FIX
+                cropped_tx_width,
+                cropped_tx_height);
+#else
                 context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
                 context_ptr->blk_geom->tx_height[tx_depth][txb_itr]);
+#endif
 #else
                 context_ptr->blk_geom->tx_width[txb_itr],
                 context_ptr->blk_geom->tx_height[txb_itr]);
@@ -3586,6 +3602,9 @@ void full_loop_r(
         context_ptr->cb_txb_skip_context = 0;
         context_ptr->cb_dc_sign_context = 0;
         get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+            sequence_control_set_ptr,
+#endif
             COMPONENT_CHROMA,
             context_ptr->cb_dc_sign_level_coeff_neighbor_array,
             ROUND_UV(context_ptr->sb_origin_x + txb_origin_x) >> 1,
@@ -3599,6 +3618,9 @@ void full_loop_r(
         context_ptr->cr_txb_skip_context = 0;
         context_ptr->cr_dc_sign_context = 0;
         get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+            sequence_control_set_ptr,
+#endif
             COMPONENT_CHROMA,
             context_ptr->cr_dc_sign_level_coeff_neighbor_array,
             ROUND_UV(context_ptr->sb_origin_x + txb_origin_x) >> 1,
@@ -3979,6 +4001,10 @@ void cu_full_distortion_fast_tu_mode_r(
         txb_origin_x = context_ptr->blk_geom->tx_org_x[txb_itr];
         txb_origin_y = context_ptr->blk_geom->tx_org_y[txb_itr];
 #endif
+#if INCOMPLETE_SB_FIX
+        int32_t cropped_tx_width_uv = MIN(context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr], picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.max_frame_width / 2 - ((context_ptr->sb_origin_x + ((txb_origin_x >> 3) << 3)) >> 1));
+        int32_t cropped_tx_height_uv = MIN(context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr], picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.max_frame_height / 2 - ((context_ptr->sb_origin_y + ((txb_origin_y >> 3) << 3)) >> 1));
+#endif
         tu_origin_index = txb_origin_x + txb_origin_y * candidateBuffer->residual_quant_coeff_ptr->stride_y;
         tu_chroma_origin_index = txb_1d_offset;
         // Reset the Bit Costs
@@ -4004,32 +4030,52 @@ void cu_full_distortion_fast_tu_mode_r(
                     input_picture_ptr->stride_cb,
                     candidateBuffer->prediction_ptr->buffer_cb + tu_uv_origin_index,
                     candidateBuffer->prediction_ptr->stride_cb,
+#if INCOMPLETE_SB_FIX
+                    cropped_tx_width_uv,
+                    cropped_tx_height_uv);
+#else
                     context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
                     context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr]);
+#endif
 
                 tuFullDistortion[1][DIST_CALC_RESIDUAL] = spatial_full_distortion_kernel_func_ptr_array[asm_type][Log2f(context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr]) - 2](
                     input_picture_ptr->buffer_cb + input_chroma_tu_origin_index,
                     input_picture_ptr->stride_cb,
                     &(((uint8_t*)candidateBuffer->recon_ptr->buffer_cb)[tu_uv_origin_index]),
                     candidateBuffer->recon_ptr->stride_cb,
+#if INCOMPLETE_SB_FIX
+                    cropped_tx_width_uv,
+                    cropped_tx_height_uv);
+#else
                     context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
                     context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr]);
+#endif
 
                 tuFullDistortion[2][DIST_CALC_PREDICTION] = spatial_full_distortion_kernel_func_ptr_array[asm_type][Log2f(context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr]) - 2](
                     input_picture_ptr->buffer_cr + input_chroma_tu_origin_index,
                     input_picture_ptr->stride_cr,
                     candidateBuffer->prediction_ptr->buffer_cr + tu_uv_origin_index,
                     candidateBuffer->prediction_ptr->stride_cr,
+#if INCOMPLETE_SB_FIX
+                    cropped_tx_width_uv,
+                    cropped_tx_height_uv);
+#else
                     context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
                     context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr]);
+#endif
 
                 tuFullDistortion[2][DIST_CALC_RESIDUAL] = spatial_full_distortion_kernel_func_ptr_array[asm_type][Log2f(context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr]) - 2](
                     input_picture_ptr->buffer_cr + input_chroma_tu_origin_index,
                     input_picture_ptr->stride_cr,
                     &(((uint8_t*)candidateBuffer->recon_ptr->buffer_cr)[tu_uv_origin_index]),
                     candidateBuffer->recon_ptr->stride_cr,
+#if INCOMPLETE_SB_FIX
+                    cropped_tx_width_uv,
+                    cropped_tx_height_uv);
+#else
                     context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
                     context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr]);
+#endif
 #else
                 tuFullDistortion[1][DIST_CALC_PREDICTION] = spatial_full_distortion_kernel_func_ptr_array[asm_type][Log2f(context_ptr->blk_geom->tx_width_uv[txb_itr]) - 2](
                     input_picture_ptr->buffer_cb + input_chroma_tu_origin_index,
@@ -4509,6 +4555,10 @@ uint32_t d2_inter_depth_block_decision(
                 parent_depth_cost = MAX_MODE_COST;
             else
                 compute_depth_costs(context_ptr, sequence_control_set_ptr, current_depth_idx_mds, parent_depth_idx_mds, ns_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth], &parent_depth_cost, &current_depth_cost);
+#if INCOMPLETE_SB_FIX
+            if (!sequence_control_set_ptr->sb_geom[lcuAddr].block_is_allowed[parent_depth_idx_mds])
+                parent_depth_cost = MAX_MODE_COST;
+#endif
             if (parent_depth_cost <= current_depth_cost) {
                 context_ptr->md_cu_arr_nsq[parent_depth_idx_mds].split_flag = EB_FALSE;
                 context_ptr->md_local_cu_unit[parent_depth_idx_mds].cost = parent_depth_cost;

--- a/Source/Lib/Common/Codec/EbInterPrediction.c
+++ b/Source/Lib/Common/Codec/EbInterPrediction.c
@@ -1045,7 +1045,11 @@ EbErrorType av1_inter_prediction(
         uint32_t mi_y = pu_origin_y;
 
         MacroBlockD  *xd = cu_ptr->av1xd;
+#if INCOMPLETE_SB_FIX
+        xd->mi_stride = picture_control_set_ptr->mi_stride;
+#else
         xd->mi_stride = picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->picture_width_in_sb*(BLOCK_SIZE_64 / 4);
+#endif
         const int32_t offset = (mi_y >> MI_SIZE_LOG2) * xd->mi_stride + (mi_x >> MI_SIZE_LOG2);
         xd->mi = picture_control_set_ptr->mi_grid_base + offset;
 
@@ -2137,7 +2141,11 @@ EbErrorType av1_inter_prediction_hbd(
         uint32_t mi_y = pu_origin_y;
 
         MacroBlockD  *xd = cu_ptr->av1xd;
+#if INCOMPLETE_SB_FIX
+        xd->mi_stride = picture_control_set_ptr->mi_stride;
+#else
         xd->mi_stride = picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->picture_width_in_sb*(BLOCK_SIZE_64 / 4);
+#endif
         const int32_t offset = (mi_y >> MI_SIZE_LOG2) * xd->mi_stride + (mi_x >> MI_SIZE_LOG2);
         xd->mi = picture_control_set_ptr->mi_grid_base + offset;
 

--- a/Source/Lib/Common/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.c
@@ -991,6 +991,18 @@ EbErrorType picture_control_set_ctor(
     EB_MALLOC(int8_t*, object_ptr->cu32x32_quant_coeff_num_map_array, sizeof(int8_t) * cu32x32QuantCoeffNumMapArraySize, EB_N_PTR);
 #endif
     //the granularity is 4x4
+#if INCOMPLETE_SB_FIX
+    EB_MALLOC(ModeInfo**, object_ptr->mi_grid_base, sizeof(ModeInfo*) * all_sb*(initDataPtr->sb_size_pix >> MI_SIZE_LOG2)*(initDataPtr->sb_size_pix >> MI_SIZE_LOG2), EB_N_PTR);
+
+    EB_MALLOC(ModeInfo*, object_ptr->mip, sizeof(ModeInfo) *all_sb*(initDataPtr->sb_size_pix >> MI_SIZE_LOG2)*(initDataPtr->sb_size_pix >> MI_SIZE_LOG2), EB_N_PTR);
+
+    memset(object_ptr->mip, 0, sizeof(ModeInfo) * all_sb*(initDataPtr->sb_size_pix >> MI_SIZE_LOG2)*(initDataPtr->sb_size_pix >> MI_SIZE_LOG2));
+
+    uint32_t miIdx;
+    for (miIdx = 0; miIdx < all_sb*(initDataPtr->sb_size_pix >> MI_SIZE_LOG2)*(initDataPtr->sb_size_pix >> MI_SIZE_LOG2); ++miIdx)
+        object_ptr->mi_grid_base[miIdx] = object_ptr->mip + miIdx;
+    object_ptr->mi_stride = picture_sb_w * (initDataPtr->sb_size_pix >> MI_SIZE_LOG2);
+#else
     EB_MALLOC(ModeInfo**, object_ptr->mi_grid_base, sizeof(ModeInfo*) * object_ptr->sb_total_count*(BLOCK_SIZE_64 / 4)*(BLOCK_SIZE_64 / 4), EB_N_PTR);
 
     EB_MALLOC(ModeInfo*, object_ptr->mip, sizeof(ModeInfo) * object_ptr->sb_total_count*(BLOCK_SIZE_64 / 4)*(BLOCK_SIZE_64 / 4), EB_N_PTR);
@@ -1002,6 +1014,7 @@ EbErrorType picture_control_set_ctor(
     for (miIdx = 0; miIdx < object_ptr->sb_total_count*(BLOCK_SIZE_64 >> MI_SIZE_LOG2)*(BLOCK_SIZE_64 >> MI_SIZE_LOG2); ++miIdx)
         object_ptr->mi_grid_base[miIdx] = object_ptr->mip + miIdx;
     object_ptr->mi_stride = pictureLcuWidth * (BLOCK_SIZE_64 / 4);
+#endif
     object_ptr->hash_table.p_lookup_table = NULL;
     av1_hash_table_create(&object_ptr->hash_table);
     return EB_ErrorNone;

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -13945,7 +13945,9 @@ extern "C" {
         uint8_t   height;
         uint8_t   is_complete_sb;
         EbBool    raster_scan_cu_validity[CU_MAX_COUNT];
+#if !INCOMPLETE_SB_FIX
         EbBool    block_is_inside_md_scan[BLOCK_MAX_COUNT_SB_128];
+#endif
         uint8_t   potential_logo_sb;
         uint8_t   is_edge_sb;
     } SbParams;
@@ -13960,6 +13962,9 @@ extern "C" {
         uint8_t    height;
         uint8_t    is_complete_sb;
         EbBool     block_is_inside_md_scan[BLOCK_MAX_COUNT_SB_128];
+#if INCOMPLETE_SB_FIX
+        EbBool     block_is_allowed[BLOCK_MAX_COUNT_SB_128];
+#endif
     } SbGeom;
 
     typedef struct CuStat

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -14469,6 +14469,9 @@ extern "C" {
         uint8_t                            cdf_mode;
         uint8_t                            nsq_present;
 #endif
+#if INCOMPLETE_SB_FIX
+        uint8_t                            over_boundary_block_mode;
+#endif
     } PictureControlSetInitData;
 
     typedef struct Av1Comp

--- a/Source/Lib/Common/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureManagerProcess.c
@@ -894,7 +894,9 @@ void* picture_manager_kernel(void *input_ptr)
                                 }
                             }
                         }
-
+#if INCOMPLETE_SB_FIX
+                        cm->mi_stride = ChildPictureControlSetPtr->mi_stride;
+#endif
                         // Picture edges
                         ConfigurePictureEdges(entrySequenceControlSetPtr, ChildPictureControlSetPtr);
 

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -6329,11 +6329,7 @@ EB_EXTERN EbErrorType mode_decision_sb(
                 picture_control_set_ptr,
                 context_ptr,
                 ss_mecontext,
-#if M8_SKIP_BLK
                 &skip_sub_blocks,
-#else
-                0xFFFFFFFF,
-#endif
                 lcuAddr,
                 bestCandidateBuffers);
 
@@ -6354,11 +6350,7 @@ EB_EXTERN EbErrorType mode_decision_sb(
             picture_control_set_ptr,
             context_ptr,
             ss_mecontext,
-#if M8_SKIP_BLK
             &skip_sub_blocks,
-#else
-            0xFFFFFFFF,
-#endif
             lcuAddr,
             bestCandidateBuffers);
 #endif

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -4338,7 +4338,7 @@ void AV1PerformFullLoop(
             end_tx_depth = 0;
 #else
         uint8_t end_tx_depth = get_end_tx_depth(context_ptr, picture_control_set_ptr->parent_pcs_ptr->atb_mode, candidate_ptr, context_ptr->blk_geom->bsize, candidateBuffer->candidate_ptr->type);
-#endif        
+#endif
         // Transform partitioning path (INTRA Luma)
         if (picture_control_set_ptr->parent_pcs_ptr->atb_mode && end_tx_depth && candidateBuffer->candidate_ptr->type == INTRA_MODE && candidateBuffer->candidate_ptr->use_intrabc == 0) {
             perform_intra_tx_partitioning(

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -3316,8 +3316,11 @@ uint64_t estimate_tx_size_bits(
     BlockSize bsize = blk_geom->bsize;
     const int32_t bw = mi_size_wide[bsize];
     const int32_t bh = mi_size_high[bsize];
+#if INCOMPLETE_SB_FIX
+    uint32_t mi_stride = pcsPtr->mi_stride;
+#else
     uint32_t mi_stride = pcsPtr->parent_pcs_ptr->sequence_control_set_ptr->picture_width_in_sb*(BLOCK_SIZE_64 >> MI_SIZE_LOG2);
-
+#endif
     set_mi_row_col(
         pcsPtr,
         xd,
@@ -3427,6 +3430,9 @@ void perform_intra_tx_partitioning(
             context_ptr->luma_txb_skip_context = 0;
             context_ptr->luma_dc_sign_context = 0;
             get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+                sequence_control_set_ptr,
+#endif
                 COMPONENT_LUMA,
                 context_ptr->tx_search_luma_dc_sign_level_coeff_neighbor_array,
                 context_ptr->sb_origin_x + tx_org_x,
@@ -3925,6 +3931,9 @@ void perform_intra_tx_partitioning(
             context_ptr->luma_txb_skip_context = 0;
             context_ptr->luma_dc_sign_context = 0;
             get_txb_ctx(
+#if INCOMPLETE_SB_FIX
+                sequence_control_set_ptr,
+#endif
                 COMPONENT_LUMA,
                 picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
                 context_ptr->sb_origin_x + tx_org_x,
@@ -4319,7 +4328,17 @@ void AV1PerformFullLoop(
         }
 #endif
 #if ATB_MD
+#if INCOMPLETE_SB_FIX
+        uint8_t end_tx_depth = 0;
+        // end_tx_depth set to zero for blocks which go beyond the picture boundaries
+        if ((context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x + context_ptr->blk_geom->bwidth < picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.max_frame_width &&
+            context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y + context_ptr->blk_geom->bheight < picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.max_frame_height))
+            end_tx_depth = get_end_tx_depth(context_ptr, picture_control_set_ptr->parent_pcs_ptr->atb_mode, candidate_ptr, context_ptr->blk_geom->bsize, candidateBuffer->candidate_ptr->type);
+        else
+            end_tx_depth = 0;
+#else
         uint8_t end_tx_depth = get_end_tx_depth(context_ptr, picture_control_set_ptr->parent_pcs_ptr->atb_mode, candidate_ptr, context_ptr->blk_geom->bsize, candidateBuffer->candidate_ptr->type);
+#endif        
         // Transform partitioning path (INTRA Luma)
         if (picture_control_set_ptr->parent_pcs_ptr->atb_mode && end_tx_depth && candidateBuffer->candidate_ptr->type == INTRA_MODE && candidateBuffer->candidate_ptr->use_intrabc == 0) {
             perform_intra_tx_partitioning(
@@ -6303,6 +6322,33 @@ EB_EXTERN EbErrorType mode_decision_sb(
         // Initialize tx_depth
         cu_ptr->tx_depth = 0;
 #endif
+#if  INCOMPLETE_SB_FIX
+        if (picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->sb_geom[lcuAddr].block_is_allowed[cu_ptr->mds_idx]) {
+            md_encode_block(
+                sequence_control_set_ptr,
+                picture_control_set_ptr,
+                context_ptr,
+                ss_mecontext,
+#if M8_SKIP_BLK
+                &skip_sub_blocks,
+#else
+                0xFFFFFFFF,
+#endif
+                lcuAddr,
+                bestCandidateBuffers);
+
+        }
+        else {
+            // If the block is out of the boundaries, md is not performed.
+            // - For square blocks, since the blocks can be further splitted, they are considered in d2_inter_depth_block_decision with cost of zero.
+            // - For non square blocks, since they can not be splitted further the cost is set to a large value (MAX_MODE_COST >> 4) to make sure they are not selected.
+            //   The value is set to MAX_MODE_COST >> 4 to make sure there is not overflow when adding costs.
+            if (context_ptr->blk_geom->shape != PART_N)
+                context_ptr->md_local_cu_unit[context_ptr->cu_ptr->mds_idx].cost = (MAX_MODE_COST >> 4);
+            else
+                context_ptr->md_local_cu_unit[context_ptr->cu_ptr->mds_idx].cost = 0;
+        }
+#else
         md_encode_block(
             sequence_control_set_ptr,
             picture_control_set_ptr,
@@ -6315,7 +6361,7 @@ EB_EXTERN EbErrorType mode_decision_sb(
 #endif
             lcuAddr,
             bestCandidateBuffers);
-
+#endif
         if (blk_geom->nsi + 1 == blk_geom->totns)
             d1_non_square_block_decision(context_ptr);
 

--- a/Source/Lib/Common/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Common/Codec/EbSequenceControlSet.c
@@ -359,6 +359,9 @@ EbErrorType copy_sequence_control_set(
     dst->extra_frames_to_ref_islice = src->extra_frames_to_ref_islice;
     dst->max_frame_window_to_ref_islice = src->max_frame_window_to_ref_islice;
 #endif
+#if INCOMPLETE_SB_FIX
+    dst->over_boundary_block_mode = src->over_boundary_block_mode;
+#endif
     return EB_ErrorNone;
 }
 
@@ -567,7 +570,7 @@ EbErrorType sb_geom_init(SequenceControlSet * sequence_control_set_ptr)
         for (md_scan_block_index = 0; md_scan_block_index < max_block_count ; md_scan_block_index++) {
             const BlockGeom * blk_geom = get_blk_geom_mds(md_scan_block_index);
 #if INCOMPLETE_SB_FIX
-            if (sequence_control_set_ptr->static_config.enc_mode == ENC_M0) {
+            if (sequence_control_set_ptr->over_boundary_block_mode == 1) {
                 sequence_control_set_ptr->sb_geom[sb_index].block_is_allowed[md_scan_block_index] =
                     ((sequence_control_set_ptr->sb_geom[sb_index].origin_x + blk_geom->origin_x + blk_geom->bwidth / 2 < sequence_control_set_ptr->seq_header.max_frame_width) &&
                     (sequence_control_set_ptr->sb_geom[sb_index].origin_y + blk_geom->origin_y + blk_geom->bheight / 2 < sequence_control_set_ptr->seq_header.max_frame_height)) ?

--- a/Source/Lib/Common/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Common/Codec/EbSequenceControlSet.h
@@ -227,7 +227,13 @@ extern "C" {
         uint64_t                                pred_count[5];
         uint64_t                                pred1_nfl_count[5];
 #endif
-
+#if INCOMPLETE_SB_FIX
+        /* over_boundary_block (mm-signal; 0: No over boundary blk allowed, 1: over boundary blk allowed)
+        *
+        * Default is 0.
+        * To enable when md_skip_blk is on*/
+        uint8_t                                 over_boundary_block_mode;
+#endif
         SeqHeader                               seq_header;
     } SequenceControlSet;
 

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -2219,10 +2219,12 @@ void SetParamBasedOnInput(SequenceControlSet *sequence_control_set_ptr)
     sequence_control_set_ptr->max_input_chroma_height = sequence_control_set_ptr->max_input_luma_height >> subsampling_y;
 
     // Configure the padding
+#if !INCOMPLETE_SB_FIX
     sequence_control_set_ptr->left_padding  = BLOCK_SIZE_64 + 4;
     sequence_control_set_ptr->top_padding = BLOCK_SIZE_64 + 4;
     sequence_control_set_ptr->right_padding = BLOCK_SIZE_64 + 4;
     sequence_control_set_ptr->bot_padding = BLOCK_SIZE_64 + 4;
+#endif
 
     sequence_control_set_ptr->chroma_width = sequence_control_set_ptr->max_input_luma_width >> subsampling_x;
     sequence_control_set_ptr->chroma_height = sequence_control_set_ptr->max_input_luma_height >> subsampling_y;
@@ -2242,6 +2244,13 @@ void SetParamBasedOnInput(SequenceControlSet *sequence_control_set_ptr)
 #if RC
     sequence_control_set_ptr->static_config.super_block_size = (sequence_control_set_ptr->static_config.rate_control_mode > 1) ? 64 : sequence_control_set_ptr->static_config.super_block_size;
    // sequence_control_set_ptr->static_config.hierarchical_levels = (sequence_control_set_ptr->static_config.rate_control_mode > 1) ? 3 : sequence_control_set_ptr->static_config.hierarchical_levels;
+#endif
+#if INCOMPLETE_SB_FIX
+    // Configure the padding
+    sequence_control_set_ptr->left_padding = BLOCK_SIZE_64 + 4;
+    sequence_control_set_ptr->top_padding = BLOCK_SIZE_64 + 4;
+    sequence_control_set_ptr->right_padding = BLOCK_SIZE_64 + 4;
+    sequence_control_set_ptr->bot_padding = sequence_control_set_ptr->static_config.super_block_size + 4;
 #endif
 #if ALT_REF_OVERLAY
     sequence_control_set_ptr->static_config.enable_overlays = sequence_control_set_ptr->static_config.enable_altrefs == EB_FALSE ||

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -2285,6 +2285,15 @@ void SetParamBasedOnInput(SequenceControlSet *sequence_control_set_ptr)
     else
         sequence_control_set_ptr->down_sampling_method_me_search = ME_DECIMATED_DOWNSAMPLED;
 #endif
+#if INCOMPLETE_SB_FIX
+    // Set over_boundary_block_mode     Settings
+    // 0                            0: not allowed
+    // 1                            1: allowed
+    if (sequence_control_set_ptr->static_config.enc_mode == ENC_M0)
+        sequence_control_set_ptr->over_boundary_block_mode = 1;
+    else
+        sequence_control_set_ptr->over_boundary_block_mode = 0;
+#endif
 #endif
 }
 


### PR DESCRIPTION
Description
Handle the incomplete SBs properly based on the standard and consider all allowed blocks

Authors
@anaghdin

Type of change
Feature improvement

Tests and performance
Expected Average PSNR-SSIM BD-rate gain in the range of -0.9% on the AOM test set, using 4 QP values: {20, 32, 43 and 55}.

No Speed impact.

TODOs:
If the cropped width is not 4, 8, 16, 32, 64 and 128, the block is not allowed. To be removed after intrinsic functions for NxM spatial_full_distortion_kernel_func_ptr_array are added
Only active for M0, to be evaluated for other modes