### PR TITLE
QP Scaling Tuning

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -41,6 +41,8 @@ extern "C" {
 
 
 #define INCOMPLETE_SB_FIX                 1 // Handle the incomplete SBs properly based on the standard and consider all allowed blocks
+#define QPS_TUNING                        1 // Tune the QPS algorithm to consider ALR_REF filtering and movement of the pictures
+                                            // Update to a more accurate QPS complexity metric
 #define CDEF_AVX_OPT                      1
 #define MR_MODE                           0
 #define EIGTH_PEL_MV                      0

--- a/Source/Lib/Common/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Common/Codec/EbInitialRateControlProcess.c
@@ -848,9 +848,21 @@ void UpdateBeaInfoOverTime(
 
             if (temporaryPictureControlSetPtr->slice_type == I_SLICE || temporaryPictureControlSetPtr->end_of_sequence_flag)
                 break;
-            if (lcuIdx == 0)
-                me_dist_pic_count++;
-            me_dist += (temporaryPictureControlSetPtr->slice_type == I_SLICE) ? 0 : (uint64_t)temporaryPictureControlSetPtr->rc_me_distortion[lcuIdx];
+#if QPS_TUNING
+            // Limit the distortion to Layer 0, 1 and 2 only. Higher layers have close temporal distance and lower distortion that might contaminate the data
+            if (temporaryPictureControlSetPtr->temporal_layer_index < 3) {
+#endif
+                if (lcuIdx == 0)
+                    me_dist_pic_count++;
+                me_dist += (temporaryPictureControlSetPtr->slice_type == I_SLICE) ? 0 : (uint64_t)temporaryPictureControlSetPtr->rc_me_distortion[lcuIdx];
+#if QPS_TUNING
+            }
+            // Store the filtered_sse of next ALT_REF picture in the I slice to be used in QP Scaling
+            if (picture_control_set_ptr->slice_type == I_SLICE && picture_control_set_ptr->filtered_sse == 0 && lcuIdx == 0 && temporaryPictureControlSetPtr->temporal_layer_index == 0) {
+                picture_control_set_ptr->filtered_sse = temporaryPictureControlSetPtr->filtered_sse;
+                picture_control_set_ptr->filtered_sse_uv = temporaryPictureControlSetPtr->filtered_sse_uv;
+            }
+#endif
             nonMovingIndexOverSlidingWindow += temporaryPictureControlSetPtr->non_moving_index_array[lcuIdx];
 
             // Increment the inputQueueIndex Iterator

--- a/Source/Lib/Common/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Common/Codec/EbInitialRateControlProcess.c
@@ -849,8 +849,8 @@ void UpdateBeaInfoOverTime(
             if (temporaryPictureControlSetPtr->slice_type == I_SLICE || temporaryPictureControlSetPtr->end_of_sequence_flag)
                 break;
 #if QPS_TUNING
-            // Limit the distortion to Layer 0, 1 and 2 only. Higher layers have close temporal distance and lower distortion that might contaminate the data
-            if (temporaryPictureControlSetPtr->temporal_layer_index < 3) {
+            // Limit the distortion to lower layers 0, 1 and 2 only. Higher layers have close temporal distance and lower distortion that might contaminate the data
+            if (temporaryPictureControlSetPtr->temporal_layer_index < MAX((int8_t)picture_control_set_ptr->hierarchical_levels - 1, 2) ) {
 #endif
                 if (lcuIdx == 0)
                     me_dist_pic_count++;

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -14296,6 +14296,11 @@ extern "C" {
         uint8_t                               tf_segments_column_count;
         uint8_t                               tf_segments_row_count;
         uint8_t                               altref_nframes;
+#if QPS_TUNING
+        uint64_t                              filtered_sse; // the normalized SSE between filtered and original alt_ref with 8 bit precision.
+                                                            // I Slice has the value of the next ALT_REF picture
+        uint64_t                              filtered_sse_uv;
+#endif
     } PictureParentControlSet;
 
     typedef struct PictureControlSetInitData

--- a/Source/Lib/Common/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Common/Codec/EbRateControlProcess.c
@@ -3232,10 +3232,21 @@ enum {
 } FRAME_UPDATE_TYPE;
 
 // that are not marked as coded with 0,0 motion in the first pass.
-#define STATIC_KF_GROUP_THRESH 99
 #define FAST_MOVING_KF_GROUP_THRESH 5
+#if QPS_TUNING
+#define MEDIUM_MOVING_KF_GROUP_THRESH  30
+#define STATIC_KF_GROUP_THRESH         80
+#define MAX_QPS_COMP_I                100
+#define MAX_QPS_COMP_NONI             300
+#define HIGH_QPS_COMP_THRESHOLD        80
+#define LOW_QPS_COMP_THRESHOLD         40
+#define HIGH_FILTERED_THRESHOLD     (4<<8) // 8 bit precision
+#define LOW_FILTERED_THRESHOLD      (1<<8) // 8 bit precision
+#else
+#define STATIC_KF_GROUP_THRESH 99
 #define MAX_QPS_COMP_I        60
 #define MAX_QPS_COMP_NONI    200
+#endif
 #define QPS_SW_THRESH          8
 
 #define ASSIGN_MINQ_TABLE(bit_depth, name)                   \
@@ -3403,10 +3414,26 @@ static int adaptive_qindex_calc(
         rc->worst_quality = MAXQ;
         rc->best_quality = MINQ;
         int max_qp_scaling_avg_comp_I = sequence_control_set_ptr->input_resolution < 2 ? (MAX_QPS_COMP_I >> 1) : MAX_QPS_COMP_I;
+#if QPS_TUNING
+        // Update the complexity for very fast moving content.
+        if (picture_control_set_ptr->parent_pcs_ptr->kf_zeromotion_pct <= FAST_MOVING_KF_GROUP_THRESH)
+            picture_control_set_ptr->parent_pcs_ptr->qp_scaling_average_complexity = max_qp_scaling_avg_comp_I;
 
+        // For the low filtered ALT_REF pictures (next ALT_REF) where complexity is low and picture is static, decrease the complexity/QP of the I_SLICE.
+        // The improved area will be propagated to future frames
+        if (picture_control_set_ptr->parent_pcs_ptr->qp_scaling_average_complexity <= LOW_QPS_COMP_THRESHOLD &&
+            picture_control_set_ptr->parent_pcs_ptr->filtered_sse < LOW_FILTERED_THRESHOLD && picture_control_set_ptr->parent_pcs_ptr->filtered_sse_uv < LOW_FILTERED_THRESHOLD &&
+            picture_control_set_ptr->parent_pcs_ptr->kf_zeromotion_pct > STATIC_KF_GROUP_THRESH)
+            picture_control_set_ptr->parent_pcs_ptr->qp_scaling_average_complexity >>= 1;
+
+        // For the highly filtered ALT_REF pictures (next ALT_REF), increase the complexity/QP of the I_SLICE to save on rate
+        if (picture_control_set_ptr->parent_pcs_ptr->filtered_sse + picture_control_set_ptr->parent_pcs_ptr->filtered_sse_uv >= HIGH_FILTERED_THRESHOLD)
+            picture_control_set_ptr->parent_pcs_ptr->qp_scaling_average_complexity = max_qp_scaling_avg_comp_I;
+#else
         // Update the complexity for very fast moving content
         if (picture_control_set_ptr->parent_pcs_ptr->kf_zeromotion_pct <= FAST_MOVING_KF_GROUP_THRESH)
             picture_control_set_ptr->parent_pcs_ptr->qp_scaling_average_complexity <<= 1;
+#endif
         picture_control_set_ptr->parent_pcs_ptr->qp_scaling_average_complexity = MIN(max_qp_scaling_avg_comp_I, picture_control_set_ptr->parent_pcs_ptr->qp_scaling_average_complexity);
 
         // cross multiplication to derive kf_boost from non_moving_average_score; kf_boost range is [kf_low,kf_high], and non_moving_average_score range [0,max_qp_scaling_avg_comp_I]
@@ -3429,8 +3456,20 @@ static int adaptive_qindex_calc(
     else if (!is_src_frame_alt_ref &&
         (refresh_golden_frame || is_intrl_arf_boost ||
             refresh_alt_ref_frame)) {
+#if QPS_TUNING
+        // Clip the complexity of highly complex pictures to maximum.
+        if (picture_control_set_ptr->parent_pcs_ptr->qp_scaling_average_complexity > HIGH_QPS_COMP_THRESHOLD)
+            picture_control_set_ptr->parent_pcs_ptr->qp_scaling_average_complexity = MAX_QPS_COMP_NONI;
+#endif
         rc->gfu_boost = (((MAX_QPS_COMP_NONI - (picture_control_set_ptr->parent_pcs_ptr->qp_scaling_average_complexity))  * (gf_high - gf_low)) / MAX_QPS_COMP_NONI) + gf_low;
+#if QPS_TUNING
+        // For the highly filtered ALT_REF pictures or where complexity is medium or picture is medium moving, add a boost to decrease the QP of the ALT_REF.
+        // The improved area will be propagated to future frames
+        rc->arf_boost_factor = (picture_control_set_ptr->parent_pcs_ptr->qp_scaling_average_complexity > LOW_QPS_COMP_THRESHOLD || picture_control_set_ptr->parent_pcs_ptr->kf_zeromotion_pct < MEDIUM_MOVING_KF_GROUP_THRESH || picture_control_set_ptr->parent_pcs_ptr->filtered_sse >= HIGH_FILTERED_THRESHOLD) ?
+            (float_t)1.3 : 1;
+#else
         rc->arf_boost_factor = 1;
+#endif
         q = active_worst_quality;
 
         // non ref frame or repeated frames with re-encode

--- a/Source/Lib/Common/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Common/Codec/EbResourceCoordinationProcess.c
@@ -756,7 +756,10 @@ void* resource_coordination_kernel(void *input_ptr)
             signal_derivation_pre_analysis_oq(
                 sequence_control_set_ptr,
                 picture_control_set_ptr);
-
+#if QPS_TUNING
+            picture_control_set_ptr->filtered_sse = 0;
+            picture_control_set_ptr->filtered_sse_uv = 0;
+#endif
             // Rate Control
             // Set the ME Distortion and OIS Historgrams to zero
             if (sequence_control_set_ptr->static_config.rate_control_mode) {


### PR DESCRIPTION
Description
Tune the QPS algorithm to consider ALR_REF filtering and movement of the pictures.
Update to a more accurate QPS complexity metric.

Authors
@anaghdin

Type of change
Feature improvement

Tests and performance
Expected Average PSNR-SSIM BD-rate gain in the range of -1.3% on the AOM test set, using 4 QP values: {20, 32, 43 and 55}.

No Speed impact.

Closes #294