### PR TITLE
sc detector tuning

### DIFF
--- a/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
@@ -4684,8 +4684,8 @@ unsigned int av1_get_sby_perpixel_variance(const aom_variance_fn_ptr_t *fn_ptr, 
 
 // Estimate if the source frame is screen content, based on the portion of
 // blocks that have no more than 4 (experimentally selected) luma colors.
-static void is_screen_content
-(   PictureParentControlSet     *picture_control_set_ptr,
+static void is_screen_content(   
+    PictureParentControlSet     *picture_control_set_ptr,
     const uint8_t               *src, 
     int                          use_hbd,
     int                          stride, 
@@ -4718,19 +4718,15 @@ static void is_screen_content
                 //buf.buf = (uint8_t *)src;
                 const aom_variance_fn_ptr_t *fn_ptr = &mefn_ptr[BLOCK_16X16];
 
-                const unsigned int var = 
+                const unsigned int var = av1_get_sby_perpixel_variance(fn_ptr, src + r * stride + c,stride, BLOCK_16X16);
                                /* use_hbd
                 ? av1_high_get_sby_perpixel_variance(cpi, &buf, BLOCK_16X16, bd)
                 : */
-                    av1_get_sby_perpixel_variance(fn_ptr, src + r * stride + c,stride, BLOCK_16X16);
-
                 if (var > var_thresh) ++counts_2;
             }
-
         }
     }
 
-    // The threshold is 10%. 
     picture_control_set_ptr->sc_content_detected = 
         (counts_1 * blk_h * blk_w * 10 > width * height) && 
         ( counts_2 * blk_h * blk_w * 15 > width * height) ;
@@ -4915,6 +4911,8 @@ void* picture_analysis_kernel(void *input_ptr)
                     0,
                     input_picture_ptr->stride_y,
                     sequence_control_set_ptr->seq_header.max_frame_width, sequence_control_set_ptr->seq_header.max_frame_height);
+                if (picture_control_set_ptr->sc_content_detected )
+                    printf ("\n\n\n\n ---------------------------------------------------\n\n\n");
             }
             else // off / on
                 picture_control_set_ptr->sc_content_detected = sequence_control_set_ptr->static_config.screen_content_mode;

--- a/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
@@ -4686,10 +4686,10 @@ unsigned int av1_get_sby_perpixel_variance(const aom_variance_fn_ptr_t *fn_ptr, 
 // blocks that have no more than 4 (experimentally selected) luma colors.
 static void is_screen_content(
     PictureParentControlSet     *picture_control_set_ptr,
-    const uint8_t               *src, 
+    const uint8_t               *src,
     int                          use_hbd,
-    int                          stride, 
-    int                         width, 
+    int                          stride,
+    int                         width,
     int                         height) {
     assert(src != NULL);
     const int blk_w = 16;
@@ -4727,8 +4727,8 @@ static void is_screen_content(
         }
     }
 
-    picture_control_set_ptr->sc_content_detected = 
-        (counts_1 * blk_h * blk_w * 10 > width * height) && 
+    picture_control_set_ptr->sc_content_detected =
+        (counts_1 * blk_h * blk_w * 10 > width * height) &&
         ( counts_2 * blk_h * blk_w * 15 > width * height) ;
 }
 

--- a/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
@@ -4684,7 +4684,7 @@ unsigned int av1_get_sby_perpixel_variance(const aom_variance_fn_ptr_t *fn_ptr, 
 
 // Estimate if the source frame is screen content, based on the portion of
 // blocks that have no more than 4 (experimentally selected) luma colors.
-static void is_screen_content(
+static void is_screen_content(   
     PictureParentControlSet     *picture_control_set_ptr,
     const uint8_t               *src,
     int                          use_hbd,
@@ -4911,7 +4911,8 @@ void* picture_analysis_kernel(void *input_ptr)
                     0,
                     input_picture_ptr->stride_y,
                     sequence_control_set_ptr->seq_header.max_frame_width, sequence_control_set_ptr->seq_header.max_frame_height);
-
+                if (picture_control_set_ptr->sc_content_detected )
+                    printf ("\n\n\n\n ---------------------------------------------------\n\n\n");
             }
             else // off / on
                 picture_control_set_ptr->sc_content_detected = sequence_control_set_ptr->static_config.screen_content_mode;

--- a/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
@@ -4684,7 +4684,7 @@ unsigned int av1_get_sby_perpixel_variance(const aom_variance_fn_ptr_t *fn_ptr, 
 
 // Estimate if the source frame is screen content, based on the portion of
 // blocks that have no more than 4 (experimentally selected) luma colors.
-static void is_screen_content(   
+static void is_screen_content(
     PictureParentControlSet     *picture_control_set_ptr,
     const uint8_t               *src,
     int                          use_hbd,
@@ -4911,8 +4911,6 @@ void* picture_analysis_kernel(void *input_ptr)
                     0,
                     input_picture_ptr->stride_y,
                     sequence_control_set_ptr->seq_header.max_frame_width, sequence_control_set_ptr->seq_header.max_frame_height);
-                if (picture_control_set_ptr->sc_content_detected )
-                    printf ("\n\n\n\n ---------------------------------------------------\n\n\n");
             }
             else // off / on
                 picture_control_set_ptr->sc_content_detected = sequence_control_set_ptr->static_config.screen_content_mode;

--- a/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
@@ -4654,15 +4654,55 @@ int av1_count_colors(const uint8_t *src, int stride, int rows, int cols,
         if (val_count[i]) ++n;
     return n;
 }
+extern aom_variance_fn_ptr_t mefn_ptr[BlockSizeS_ALL];
+
+// This is used as a reference when computing the source variance for the
+//  purposes of activity masking.
+// Eventually this should be replaced by custom no-reference routines,
+//  which will be faster.
+const uint8_t AV1_VAR_OFFS[MAX_SB_SIZE] = {
+  128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+  128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+  128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+  128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+  128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+  128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+  128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+  128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
+  128, 128, 128, 128, 128, 128, 128, 128
+};
+
+unsigned int av1_get_sby_perpixel_variance(const aom_variance_fn_ptr_t *fn_ptr, //const AV1_COMP *cpi,
+                                           const uint8_t *src,int stride,//const struct buf_2d *ref,
+                                           BlockSize bs) {
+  unsigned int sse;
+  const unsigned int var =
+      //cpi->fn_ptr[bs].vf(ref->buf, ref->stride, AV1_VAR_OFFS, 0, &sse);
+     fn_ptr->vf(src,  stride, AV1_VAR_OFFS, 0, &sse);
+  return ROUND_POWER_OF_TWO(var, num_pels_log2_lookup[bs]);
+}
+
 // Estimate if the source frame is screen content, based on the portion of
 // blocks that have no more than 4 (experimentally selected) luma colors.
-static int is_screen_content(const uint8_t *src, int use_hbd,
-    int stride, int width, int height) {
+static void is_screen_content
+(   PictureParentControlSet     *picture_control_set_ptr,
+    const uint8_t               *src, 
+    int                          use_hbd,
+    int                          stride, 
+    int                         width, 
+    int                         height) {
     assert(src != NULL);
-    int counts = 0;
     const int blk_w = 16;
     const int blk_h = 16;
-    const int limit = 4;
+    // These threshold values are selected experimentally.
+    const int color_thresh = 4;
+    const unsigned int var_thresh = 0;
+    // Counts of blocks with no more than color_thresh colors.
+    int counts_1 = 0;
+    // Counts of blocks with no more than color_thresh colors and variance larger
+    // than var_thresh.
+    int counts_2 = 0;
+
     for (int r = 0; r + blk_h <= height; r += blk_h) {
         for (int c = 0; c + blk_w <= width; c += blk_w) {
             int count_buf[1 << 12];  // Maximum (1 << 12) color levels.
@@ -4671,11 +4711,29 @@ static int is_screen_content(const uint8_t *src, int use_hbd,
                     blk_h, bd, count_buf)*/
                 : av1_count_colors(src + r * stride + c, stride, blk_w, blk_h,
                     count_buf);
-            if (n_colors > 1 && n_colors <= limit) counts++;
+            if (n_colors > 1 && n_colors <= color_thresh) {
+                ++counts_1;
+                //struct buf_2d buf;
+                //buf.stride = stride;
+                //buf.buf = (uint8_t *)src;
+                const aom_variance_fn_ptr_t *fn_ptr = &mefn_ptr[BLOCK_16X16];
+
+                const unsigned int var = 
+                               /* use_hbd
+                ? av1_high_get_sby_perpixel_variance(cpi, &buf, BLOCK_16X16, bd)
+                : */
+                    av1_get_sby_perpixel_variance(fn_ptr, src + r * stride + c,stride, BLOCK_16X16);
+
+                if (var > var_thresh) ++counts_2;
+            }
+
         }
     }
-    // The threshold is 10%.
-    return counts * blk_h * blk_w * 10 > width * height;
+
+    // The threshold is 10%. 
+    picture_control_set_ptr->sc_content_detected = 
+        (counts_1 * blk_h * blk_w * 10 > width * height) && 
+        ( counts_2 * blk_h * blk_w * 15 > width * height) ;
 }
 
 
@@ -4851,17 +4909,12 @@ void* picture_analysis_kernel(void *input_ptr)
                 asm_type);
 
             if (sequence_control_set_ptr->static_config.screen_content_mode == 2){ // auto detect
-                picture_control_set_ptr->sc_content_detected = is_screen_content(
+                is_screen_content(
+                    picture_control_set_ptr,
                     input_picture_ptr->buffer_y + input_picture_ptr->origin_x + input_picture_ptr->origin_y*input_picture_ptr->stride_y,
                     0,
                     input_picture_ptr->stride_y,
                     sequence_control_set_ptr->seq_header.max_frame_width, sequence_control_set_ptr->seq_header.max_frame_height);
-                if (picture_control_set_ptr->sc_content_detected) {
-                    if (picture_control_set_ptr->pic_avg_variance > 1000)
-                        picture_control_set_ptr->sc_content_detected = 1;
-                    else
-                        picture_control_set_ptr->sc_content_detected = 0;
-                }
             }
             else // off / on
                 picture_control_set_ptr->sc_content_detected = sequence_control_set_ptr->static_config.screen_content_mode;

--- a/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
@@ -4684,7 +4684,7 @@ unsigned int av1_get_sby_perpixel_variance(const aom_variance_fn_ptr_t *fn_ptr, 
 
 // Estimate if the source frame is screen content, based on the portion of
 // blocks that have no more than 4 (experimentally selected) luma colors.
-static void is_screen_content(   
+static void is_screen_content(
     PictureParentControlSet     *picture_control_set_ptr,
     const uint8_t               *src, 
     int                          use_hbd,
@@ -4911,8 +4911,7 @@ void* picture_analysis_kernel(void *input_ptr)
                     0,
                     input_picture_ptr->stride_y,
                     sequence_control_set_ptr->seq_header.max_frame_width, sequence_control_set_ptr->seq_header.max_frame_height);
-                if (picture_control_set_ptr->sc_content_detected )
-                    printf ("\n\n\n\n ---------------------------------------------------\n\n\n");
+
             }
             else // off / on
                 picture_control_set_ptr->sc_content_detected = sequence_control_set_ptr->static_config.screen_content_mode;


### PR DESCRIPTION
Description
Tune the screen content detector to consider block variance 

Authors
@okhlif 

Type of change
Detector improvement

Tests and performance
- Expected Average PSNR-SSIM BD-rate gain in the range of -0.2% on the AOM test set
- No Speed impact.