### PR TITLE
Fix chroma artifacts in high density presets

### DIFF
--- a/Source/Lib/Common/Codec/EbCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbCodingLoop.c
@@ -2510,7 +2510,7 @@ EB_EXTERN void av1_encode_pass(
                     // Partition Loop
                     context_ptr->txb_itr = 0;
                     // Transform partitioning path (INTRA Luma/Chroma)
-                    if (picture_control_set_ptr->parent_pcs_ptr->atb_mode && cu_ptr->av1xd->use_intrabc == 0) {
+                    if (sequence_control_set_ptr->static_config.encoder_bit_depth == EB_8BIT && cu_ptr->av1xd->use_intrabc == 0) {
                         // Set the PU Loop Variables
                         pu_ptr = cu_ptr->prediction_unit_array;
                         // Generate Intra Luma Neighbor Modes


### PR DESCRIPTION
## Description
Fix the atb check in the encode pass to separate the 10-bit and 8bit paths rather than atb_mode paths

## Issues
Closes #400 
Ref #424