### PR TITLE
Use unaligned load commands in the intrinsics intra prediction kernels

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/EbIntraPrediction_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbIntraPrediction_Intrinsic_AVX2.c
@@ -6320,7 +6320,7 @@ static void dr_prediction_z2_Nx4_avx2(int32_t N, uint8_t *dst, ptrdiff_t stride,
             base_y_c128 = _mm_srai_epi32(y_c128, frac_bits_y);
             mask128 = _mm_cmpgt_epi32(min_base_y128, base_y_c128);
             base_y_c128 = _mm_andnot_si128(mask128, base_y_c128);
-            _mm_store_si128((__m128i *)base_y_c, base_y_c128);
+            _mm_storeu_si128((__m128i *)base_y_c, base_y_c128);
 
             a0_y = _mm256_castsi128_si256(
                 _mm_setr_epi32(left[base_y_c[0]], left[base_y_c[1]],
@@ -9253,7 +9253,7 @@ static void highbd_dr_prediction_z2_Nx4_avx2(
             base_y_c128 = _mm_srai_epi32(y_c128, frac_bits_y);
             mask128 = _mm_cmpgt_epi32(min_base_y128, base_y_c128);
             base_y_c128 = _mm_andnot_si128(mask128, base_y_c128);
-            _mm_store_si128((__m128i *)base_y_c, base_y_c128);
+            _mm_storeu_si128((__m128i *)base_y_c, base_y_c128);
 
             a0_y = _mm256_castsi128_si256(
                 _mm_setr_epi32(left[base_y_c[0]], left[base_y_c[1]],
@@ -10144,7 +10144,7 @@ void aom_paeth_predictor_16x8_avx2(uint8_t *dst, ptrdiff_t stride,
     const __m256i l16 = _mm256_shuffle_epi8(l, rep);
     const __m128i row = paeth_16x1_pred(&l16, &top, &tl16);
 
-    _mm_store_si128((__m128i *)dst, row);
+    _mm_storeu_si128((__m128i *)dst, row);
     dst += stride;
     rep = _mm256_add_epi16(rep, one);
   }
@@ -10168,7 +10168,7 @@ void aom_paeth_predictor_16x16_avx2(uint8_t *dst, ptrdiff_t stride,
     const __m256i l16 = _mm256_shuffle_epi8(l, rep);
     const __m128i row = paeth_16x1_pred(&l16, &top, &tl16);
 
-    _mm_store_si128((__m128i *)dst, row);
+    _mm_storeu_si128((__m128i *)dst, row);
     dst += stride;
     rep = _mm256_add_epi16(rep, one);
   }
@@ -10187,7 +10187,7 @@ void aom_paeth_predictor_16x32_avx2(uint8_t *dst, ptrdiff_t stride,
     const __m256i l16 = _mm256_shuffle_epi8(l, rep);
     const __m128i row = paeth_16x1_pred(&l16, &top, &tl16);
 
-    _mm_store_si128((__m128i *)dst, row);
+    _mm_storeu_si128((__m128i *)dst, row);
     dst += stride;
     rep = _mm256_add_epi16(rep, one);
   }
@@ -10198,7 +10198,7 @@ void aom_paeth_predictor_16x32_avx2(uint8_t *dst, ptrdiff_t stride,
     const __m256i l16 = _mm256_shuffle_epi8(l, rep);
     const __m128i row = paeth_16x1_pred(&l16, &top, &tl16);
 
-    _mm_store_si128((__m128i *)dst, row);
+    _mm_storeu_si128((__m128i *)dst, row);
     dst += stride;
     rep = _mm256_add_epi16(rep, one);
   }
@@ -10217,7 +10217,7 @@ void aom_paeth_predictor_16x64_avx2(uint8_t *dst, ptrdiff_t stride,
       const __m256i l16 = _mm256_shuffle_epi8(l, rep);
       const __m128i row = paeth_16x1_pred(&l16, &top, &tl16);
 
-      _mm_store_si128((__m128i *)dst, row);
+      _mm_storeu_si128((__m128i *)dst, row);
       dst += stride;
       rep = _mm256_add_epi16(rep, one);
     }
@@ -10277,8 +10277,8 @@ void aom_paeth_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
     const __m128i r0 = paeth_16x1_pred(&l16, &t0, &tl);
     const __m128i r1 = paeth_16x1_pred(&l16, &t1, &tl);
 
-    _mm_store_si128((__m128i *)dst, r0);
-    _mm_store_si128((__m128i *)(dst + 16), r1);
+    _mm_storeu_si128((__m128i *)dst, r0);
+    _mm_storeu_si128((__m128i *)(dst + 16), r1);
 
     dst += stride;
     rep = _mm256_add_epi16(rep, one);
@@ -10292,8 +10292,8 @@ void aom_paeth_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
     const __m128i r0 = paeth_16x1_pred(&l16, &t0, &tl);
     const __m128i r1 = paeth_16x1_pred(&l16, &t1, &tl);
 
-    _mm_store_si128((__m128i *)dst, r0);
-    _mm_store_si128((__m128i *)(dst + 16), r1);
+    _mm_storeu_si128((__m128i *)dst, r0);
+    _mm_storeu_si128((__m128i *)(dst + 16), r1);
 
     dst += stride;
     rep = _mm256_add_epi16(rep, one);
@@ -10317,8 +10317,8 @@ void aom_paeth_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
       const __m128i r0 = paeth_16x1_pred(&l16, &t0, &tl);
       const __m128i r1 = paeth_16x1_pred(&l16, &t1, &tl);
 
-      _mm_store_si128((__m128i *)dst, r0);
-      _mm_store_si128((__m128i *)(dst + 16), r1);
+      _mm_storeu_si128((__m128i *)dst, r0);
+      _mm_storeu_si128((__m128i *)(dst + 16), r1);
 
       dst += stride;
       rep = _mm256_add_epi16(rep, one);
@@ -10347,10 +10347,10 @@ void aom_paeth_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
       const __m128i r2 = paeth_16x1_pred(&l16, &t2, &tl);
       const __m128i r3 = paeth_16x1_pred(&l16, &t3, &tl);
 
-      _mm_store_si128((__m128i *)dst, r0);
-      _mm_store_si128((__m128i *)(dst + 16), r1);
-      _mm_store_si128((__m128i *)(dst + 32), r2);
-      _mm_store_si128((__m128i *)(dst + 48), r3);
+      _mm_storeu_si128((__m128i *)dst, r0);
+      _mm_storeu_si128((__m128i *)(dst + 16), r1);
+      _mm_storeu_si128((__m128i *)(dst + 32), r2);
+      _mm_storeu_si128((__m128i *)(dst + 48), r3);
 
       dst += stride;
       rep = _mm256_add_epi16(rep, one);
@@ -10379,10 +10379,10 @@ void aom_paeth_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
       const __m128i r2 = paeth_16x1_pred(&l16, &t2, &tl);
       const __m128i r3 = paeth_16x1_pred(&l16, &t3, &tl);
 
-      _mm_store_si128((__m128i *)dst, r0);
-      _mm_store_si128((__m128i *)(dst + 16), r1);
-      _mm_store_si128((__m128i *)(dst + 32), r2);
-      _mm_store_si128((__m128i *)(dst + 48), r3);
+      _mm_storeu_si128((__m128i *)dst, r0);
+      _mm_storeu_si128((__m128i *)(dst + 16), r1);
+      _mm_storeu_si128((__m128i *)(dst + 32), r2);
+      _mm_storeu_si128((__m128i *)(dst + 48), r3);
 
       dst += stride;
       rep = _mm256_add_epi16(rep, one);
@@ -10410,10 +10410,10 @@ void aom_paeth_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
     const __m128i r2 = paeth_16x1_pred(&l16, &t2, &tl);
     const __m128i r3 = paeth_16x1_pred(&l16, &t3, &tl);
 
-    _mm_store_si128((__m128i *)dst, r0);
-    _mm_store_si128((__m128i *)(dst + 16), r1);
-    _mm_store_si128((__m128i *)(dst + 32), r2);
-    _mm_store_si128((__m128i *)(dst + 48), r3);
+    _mm_storeu_si128((__m128i *)dst, r0);
+    _mm_storeu_si128((__m128i *)(dst + 16), r1);
+    _mm_storeu_si128((__m128i *)(dst + 32), r2);
+    _mm_storeu_si128((__m128i *)(dst + 48), r3);
 
     dst += stride;
     rep = _mm256_add_epi16(rep, one);

--- a/Source/Lib/Common/ASM_SSE2/EbIntraPrediction_AV1_Intrinsic_SSE2.c
+++ b/Source/Lib/Common/ASM_SSE2/EbIntraPrediction_AV1_Intrinsic_SSE2.c
@@ -57,8 +57,8 @@ static INLINE void dc_store_32xh(const __m128i *row, int32_t height, uint8_t *ds
     ptrdiff_t stride) {
     int32_t i;
     for (i = 0; i < height; ++i) {
-        _mm_store_si128((__m128i *)dst, *row);
-        _mm_store_si128((__m128i *)(dst + 16), *row);
+        _mm_storeu_si128((__m128i *)dst, *row);
+        _mm_storeu_si128((__m128i *)(dst + 16), *row);
         dst += stride;
     }
 }
@@ -257,8 +257,8 @@ static INLINE void v_predictor_32xh(uint8_t *dst, ptrdiff_t stride,
     const __m128i row0 = _mm_load_si128((__m128i const *)above);
     const __m128i row1 = _mm_load_si128((__m128i const *)(above + 16));
     for (int32_t i = 0; i < height; ++i) {
-        _mm_store_si128((__m128i *)dst, row0);
-        _mm_store_si128((__m128i *)(dst + 16), row1);
+        _mm_storeu_si128((__m128i *)dst, row0);
+        _mm_storeu_si128((__m128i *)(dst + 16), row1);
         dst += stride;
     }
 }
@@ -267,7 +267,7 @@ static INLINE void h_pred_store_16xh(const __m128i *row, int32_t h, uint8_t *dst
     ptrdiff_t stride) {
     int32_t i;
     for (i = 0; i < h; ++i) {
-        _mm_store_si128((__m128i *)dst, row[i]);
+        _mm_storeu_si128((__m128i *)dst, row[i]);
         dst += stride;
     }
 }
@@ -337,8 +337,8 @@ static INLINE void h_pred_store_32xh(const __m128i *row, int32_t h, uint8_t *dst
     ptrdiff_t stride) {
     int32_t i;
     for (i = 0; i < h; ++i) {
-        _mm_store_si128((__m128i *)dst, row[i]);
-        _mm_store_si128((__m128i *)(dst + 16), row[i]);
+        _mm_storeu_si128((__m128i *)dst, row[i]);
+        _mm_storeu_si128((__m128i *)(dst + 16), row[i]);
         dst += stride;
     }
 }
@@ -370,16 +370,16 @@ static INLINE void h_predictor_32xh(uint8_t *dst, ptrdiff_t stride,
         left4 = _mm_unpacklo_epi8(left4, left4);
         const __m128i r0 = _mm_shuffle_epi32(left4, 0x0);
         const __m128i r1 = _mm_shuffle_epi32(left4, 0x55);
-        _mm_store_si128((__m128i *)dst, r0);
-        _mm_store_si128((__m128i *)(dst + 16), r0);
-        _mm_store_si128((__m128i *)(dst + stride), r1);
-        _mm_store_si128((__m128i *)(dst + stride + 16), r1);
+        _mm_storeu_si128((__m128i *)dst, r0);
+        _mm_storeu_si128((__m128i *)(dst + 16), r0);
+        _mm_storeu_si128((__m128i *)(dst + stride), r1);
+        _mm_storeu_si128((__m128i *)(dst + stride + 16), r1);
         const __m128i r2 = _mm_shuffle_epi32(left4, 0xaa);
         const __m128i r3 = _mm_shuffle_epi32(left4, 0xff);
-        _mm_store_si128((__m128i *)(dst + stride * 2), r2);
-        _mm_store_si128((__m128i *)(dst + stride * 2 + 16), r2);
-        _mm_store_si128((__m128i *)(dst + stride * 3), r3);
-        _mm_store_si128((__m128i *)(dst + stride * 3 + 16), r3);
+        _mm_storeu_si128((__m128i *)(dst + stride * 2), r2);
+        _mm_storeu_si128((__m128i *)(dst + stride * 2 + 16), r2);
+        _mm_storeu_si128((__m128i *)(dst + stride * 3), r3);
+        _mm_storeu_si128((__m128i *)(dst + stride * 3 + 16), r3);
         left += 4;
         dst += stride * 4;
     } while (--i);
@@ -460,24 +460,24 @@ static INLINE void h_predictor_64xh(uint8_t *dst, ptrdiff_t stride,
         left4 = _mm_unpacklo_epi8(left4, left4);
         const __m128i r0 = _mm_shuffle_epi32(left4, 0x0);
         const __m128i r1 = _mm_shuffle_epi32(left4, 0x55);
-        _mm_store_si128((__m128i *)dst, r0);
-        _mm_store_si128((__m128i *)(dst + 16), r0);
-        _mm_store_si128((__m128i *)(dst + 32), r0);
-        _mm_store_si128((__m128i *)(dst + 48), r0);
-        _mm_store_si128((__m128i *)(dst + stride), r1);
-        _mm_store_si128((__m128i *)(dst + stride + 16), r1);
-        _mm_store_si128((__m128i *)(dst + stride + 32), r1);
-        _mm_store_si128((__m128i *)(dst + stride + 48), r1);
+        _mm_storeu_si128((__m128i *)dst, r0);
+        _mm_storeu_si128((__m128i *)(dst + 16), r0);
+        _mm_storeu_si128((__m128i *)(dst + 32), r0);
+        _mm_storeu_si128((__m128i *)(dst + 48), r0);
+        _mm_storeu_si128((__m128i *)(dst + stride), r1);
+        _mm_storeu_si128((__m128i *)(dst + stride + 16), r1);
+        _mm_storeu_si128((__m128i *)(dst + stride + 32), r1);
+        _mm_storeu_si128((__m128i *)(dst + stride + 48), r1);
         const __m128i r2 = _mm_shuffle_epi32(left4, 0xaa);
         const __m128i r3 = _mm_shuffle_epi32(left4, 0xff);
-        _mm_store_si128((__m128i *)(dst + stride * 2), r2);
-        _mm_store_si128((__m128i *)(dst + stride * 2 + 16), r2);
-        _mm_store_si128((__m128i *)(dst + stride * 2 + 32), r2);
-        _mm_store_si128((__m128i *)(dst + stride * 2 + 48), r2);
-        _mm_store_si128((__m128i *)(dst + stride * 3), r3);
-        _mm_store_si128((__m128i *)(dst + stride * 3 + 16), r3);
-        _mm_store_si128((__m128i *)(dst + stride * 3 + 32), r3);
-        _mm_store_si128((__m128i *)(dst + stride * 3 + 48), r3);
+        _mm_storeu_si128((__m128i *)(dst + stride * 2), r2);
+        _mm_storeu_si128((__m128i *)(dst + stride * 2 + 16), r2);
+        _mm_storeu_si128((__m128i *)(dst + stride * 2 + 32), r2);
+        _mm_storeu_si128((__m128i *)(dst + stride * 2 + 48), r2);
+        _mm_storeu_si128((__m128i *)(dst + stride * 3), r3);
+        _mm_storeu_si128((__m128i *)(dst + stride * 3 + 16), r3);
+        _mm_storeu_si128((__m128i *)(dst + stride * 3 + 32), r3);
+        _mm_storeu_si128((__m128i *)(dst + stride * 3 + 48), r3);
         left += 4;
         dst += stride * 4;
     } while (--i);

--- a/Source/Lib/Common/ASM_SSSE3/EbHighbdIntraPrediction_Intrinsic_SSSE3.c
+++ b/Source/Lib/Common/ASM_SSSE3/EbHighbdIntraPrediction_Intrinsic_SSSE3.c
@@ -534,7 +534,7 @@ void aom_paeth_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t stride,
     const __m128i l16 = _mm_shuffle_epi8(l, rep);
     const __m128i row = paeth_16x1_pred(&l16, &top0, &top1, &tl16);
 
-    _mm_store_si128((__m128i *)dst, row);
+    _mm_storeu_si128((__m128i *)dst, row);
     dst += stride;
     rep = _mm_add_epi16(rep, one);
   }
@@ -556,7 +556,7 @@ void aom_paeth_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     const __m128i l16 = _mm_shuffle_epi8(l, rep);
     const __m128i row = paeth_16x1_pred(&l16, &top0, &top1, &tl16);
 
-    _mm_store_si128((__m128i *)dst, row);
+    _mm_storeu_si128((__m128i *)dst, row);
     dst += stride;
     rep = _mm_add_epi16(rep, one);
   }
@@ -579,7 +579,7 @@ void aom_paeth_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const __m128i l16 = _mm_shuffle_epi8(l, rep);
     const __m128i row = paeth_16x1_pred(&l16, &top0, &top1, &tl16);
 
-    _mm_store_si128((__m128i *)dst, row);
+    _mm_storeu_si128((__m128i *)dst, row);
     dst += stride;
     rep = _mm_add_epi16(rep, one);
   }
@@ -603,7 +603,7 @@ void aom_paeth_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t stride,
     l16 = _mm_shuffle_epi8(l, rep);
     const __m128i row = paeth_16x1_pred(&l16, &top0, &top1, &tl16);
 
-    _mm_store_si128((__m128i *)dst, row);
+    _mm_storeu_si128((__m128i *)dst, row);
     dst += stride;
     rep = _mm_add_epi16(rep, one);
   }
@@ -614,7 +614,7 @@ void aom_paeth_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t stride,
     l16 = _mm_shuffle_epi8(l, rep);
     const __m128i row = paeth_16x1_pred(&l16, &top0, &top1, &tl16);
 
-    _mm_store_si128((__m128i *)dst, row);
+    _mm_storeu_si128((__m128i *)dst, row);
     dst += stride;
     rep = _mm_add_epi16(rep, one);
   }
@@ -636,7 +636,7 @@ void aom_paeth_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t stride,
     for (int i = 0; i < 16; ++i) {
       const __m128i l16 = _mm_shuffle_epi8(l, rep);
       const __m128i row = paeth_16x1_pred(&l16, &top0, &top1, &tl16);
-      _mm_store_si128((__m128i *)dst, row);
+      _mm_storeu_si128((__m128i *)dst, row);
       dst += stride;
       rep = _mm_add_epi16(rep, one);
     }
@@ -664,8 +664,8 @@ void aom_paeth_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     const __m128i r32l = paeth_16x1_pred(&l16, &al, &ah, &tl16);
     const __m128i r32h = paeth_16x1_pred(&l16, &bl, &bh, &tl16);
 
-    _mm_store_si128((__m128i *)dst, r32l);
-    _mm_store_si128((__m128i *)(dst + 16), r32h);
+    _mm_storeu_si128((__m128i *)dst, r32l);
+    _mm_storeu_si128((__m128i *)(dst + 16), r32h);
     dst += stride;
     rep = _mm_add_epi16(rep, one);
   }
@@ -694,8 +694,8 @@ void aom_paeth_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const __m128i r32l = paeth_16x1_pred(&l16, &al, &ah, &tl16);
     const __m128i r32h = paeth_16x1_pred(&l16, &bl, &bh, &tl16);
 
-    _mm_store_si128((__m128i *)dst, r32l);
-    _mm_store_si128((__m128i *)(dst + 16), r32h);
+    _mm_storeu_si128((__m128i *)dst, r32l);
+    _mm_storeu_si128((__m128i *)(dst + 16), r32h);
     dst += stride;
     rep = _mm_add_epi16(rep, one);
   }
@@ -724,8 +724,8 @@ void aom_paeth_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t stride,
     const __m128i r32l = paeth_16x1_pred(&l16, &al, &ah, &tl16);
     const __m128i r32h = paeth_16x1_pred(&l16, &bl, &bh, &tl16);
 
-    _mm_store_si128((__m128i *)dst, r32l);
-    _mm_store_si128((__m128i *)(dst + 16), r32h);
+    _mm_storeu_si128((__m128i *)dst, r32l);
+    _mm_storeu_si128((__m128i *)(dst + 16), r32h);
     dst += stride;
     rep = _mm_add_epi16(rep, one);
   }
@@ -737,8 +737,8 @@ void aom_paeth_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t stride,
     const __m128i r32l = paeth_16x1_pred(&l16, &al, &ah, &tl16);
     const __m128i r32h = paeth_16x1_pred(&l16, &bl, &bh, &tl16);
 
-    _mm_store_si128((__m128i *)dst, r32l);
-    _mm_store_si128((__m128i *)(dst + 16), r32h);
+    _mm_storeu_si128((__m128i *)dst, r32l);
+    _mm_storeu_si128((__m128i *)(dst + 16), r32h);
     dst += stride;
     rep = _mm_add_epi16(rep, one);
   }
@@ -768,8 +768,8 @@ void aom_paeth_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t stride,
       const __m128i r32l = paeth_16x1_pred(&l16, &al, &ah, &tl16);
       const __m128i r32h = paeth_16x1_pred(&l16, &bl, &bh, &tl16);
 
-      _mm_store_si128((__m128i *)dst, r32l);
-      _mm_store_si128((__m128i *)(dst + 16), r32h);
+      _mm_storeu_si128((__m128i *)dst, r32l);
+      _mm_storeu_si128((__m128i *)(dst + 16), r32h);
       dst += stride;
       rep = _mm_add_epi16(rep, one);
     }
@@ -808,10 +808,10 @@ void aom_paeth_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t stride,
       const __m128i r2 = paeth_16x1_pred(&l16, &cl, &ch, &tl16);
       const __m128i r3 = paeth_16x1_pred(&l16, &dl, &dh, &tl16);
 
-      _mm_store_si128((__m128i *)dst, r0);
-      _mm_store_si128((__m128i *)(dst + 16), r1);
-      _mm_store_si128((__m128i *)(dst + 32), r2);
-      _mm_store_si128((__m128i *)(dst + 48), r3);
+      _mm_storeu_si128((__m128i *)dst, r0);
+      _mm_storeu_si128((__m128i *)(dst + 16), r1);
+      _mm_storeu_si128((__m128i *)(dst + 32), r2);
+      _mm_storeu_si128((__m128i *)(dst + 48), r3);
       dst += stride;
       rep = _mm_add_epi16(rep, one);
     }
@@ -850,10 +850,10 @@ void aom_paeth_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t stride,
       const __m128i r2 = paeth_16x1_pred(&l16, &cl, &ch, &tl16);
       const __m128i r3 = paeth_16x1_pred(&l16, &dl, &dh, &tl16);
 
-      _mm_store_si128((__m128i *)dst, r0);
-      _mm_store_si128((__m128i *)(dst + 16), r1);
-      _mm_store_si128((__m128i *)(dst + 32), r2);
-      _mm_store_si128((__m128i *)(dst + 48), r3);
+      _mm_storeu_si128((__m128i *)dst, r0);
+      _mm_storeu_si128((__m128i *)(dst + 16), r1);
+      _mm_storeu_si128((__m128i *)(dst + 32), r2);
+      _mm_storeu_si128((__m128i *)(dst + 48), r3);
       dst += stride;
       rep = _mm_add_epi16(rep, one);
     }
@@ -891,10 +891,10 @@ void aom_paeth_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const __m128i r2 = paeth_16x1_pred(&l16, &cl, &ch, &tl16);
     const __m128i r3 = paeth_16x1_pred(&l16, &dl, &dh, &tl16);
 
-    _mm_store_si128((__m128i *)dst, r0);
-    _mm_store_si128((__m128i *)(dst + 16), r1);
-    _mm_store_si128((__m128i *)(dst + 32), r2);
-    _mm_store_si128((__m128i *)(dst + 48), r3);
+    _mm_storeu_si128((__m128i *)dst, r0);
+    _mm_storeu_si128((__m128i *)(dst + 16), r1);
+    _mm_storeu_si128((__m128i *)(dst + 32), r2);
+    _mm_storeu_si128((__m128i *)(dst + 48), r3);
     dst += stride;
     rep = _mm_add_epi16(rep, one);
   }


### PR DESCRIPTION
## Description
Use unaligned buffers commands in intra prediction as intra buffers are not guaranteed to be aligned

## Issues
Addresses crash
Closes #84 