### PR TITLE
Improve Temporal Filtering

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/av1_inv_txfm_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/av1_inv_txfm_avx2.c
@@ -16,6 +16,10 @@
 #include "av1_inv_txfm_ssse3.h"
 #include "EbTransforms.h"
 
+ // Sqrt2, Sqrt2^2, Sqrt2^3, Sqrt2^4, Sqrt2^5
+static int32_t NewSqrt2list[TX_SIZES] = { 5793, 2 * 4096, 2 * 5793, 4 * 4096,
+                                          4 * 5793 };
+
 static INLINE void idct16_stage5_avx2(__m256i *x1, const int32_t *cospi,
     const __m256i _r, int8_t cos_bit) {
     const __m256i cospi_m32_p32 = pair_set_w16_epi16(-cospi[32], cospi[32]);

--- a/Source/Lib/Common/ASM_SSSE3/av1_inv_txfm_ssse3.c
+++ b/Source/Lib/Common/ASM_SSSE3/av1_inv_txfm_ssse3.c
@@ -20,6 +20,10 @@
 
 // TODO(binpengsmail@gmail.com): replace some for loop with do {} while
 
+    // Sqrt2, Sqrt2^2, Sqrt2^3, Sqrt2^4, Sqrt2^5
+static int32_t NewSqrt2list[TX_SIZES] = { 5793, 2 * 4096, 2 * 5793, 4 * 4096,
+                                          4 * 5793 };
+
 static void idct4_new_sse2(const __m128i *input, __m128i *output,
     int8_t cos_bit) {
     (void)cos_bit;

--- a/Source/Lib/Common/ASM_SSSE3/av1_inv_txfm_ssse3.h
+++ b/Source/Lib/Common/ASM_SSSE3/av1_inv_txfm_ssse3.h
@@ -86,10 +86,6 @@ extern "C" {
       IIDENTITY_1D, IADST_1D,     IIDENTITY_1D, IFLIPADST_1D,
     };
 
-    // Sqrt2, Sqrt2^2, Sqrt2^3, Sqrt2^4, Sqrt2^5
-    static int32_t NewSqrt2list[TX_SIZES] = { 5793, 2 * 4096, 2 * 5793, 4 * 4096,
-                                              4 * 5793 };
-
     DECLARE_ALIGNED(16, static const int16_t, av1_eob_to_eobxy_8x8_default[8]) = {
       0x0707, 0x0707, 0x0707, 0x0707, 0x0707, 0x0707, 0x0707, 0x0707,
     };

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -48,7 +48,8 @@ extern "C" {
 #define EIGTH_PEL_MV                      0
 #define IMPROVE_ALTREF_TF                 1 // Improve Temporal Filtering for the BASE AltRef 
 #if IMPROVE_ALTREF_TF
-#define ALTREF_EIGHTH_PEL_SEARCH          1 // Add 1/8 sub-pel search/compensation @ Temporal Filtering
+#define ALTREF_TF_EIGHTH_PEL_SEARCH       1 // Add 1/8 sub-pel search/compensation @ Temporal Filtering
+#define ALTREF_TF_ADAPTIVE_WINDOW_SIZE    1 // Add the ability to use dynamic/asymmetric window for AltRef temporal filtering, add the ability to derive the activity within past and future frames @ picture decision, and add a logic to derive window size from activity
 #endif
 
 //FOR DEBUGGING - Do not remove

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -46,7 +46,7 @@ extern "C" {
 #define CDEF_AVX_OPT                      1
 #define MR_MODE                           0
 #define EIGTH_PEL_MV                      0
-#define IMPROVE_ALTREF_TF                 1 // Improve Temporal Filtering for the BASE AltRef 
+#define IMPROVE_ALTREF_TF                 1 // Improve Temporal Filtering for the BASE AltRef
 #if IMPROVE_ALTREF_TF
 #define ALTREF_TF_EIGHTH_PEL_SEARCH       1 // Add 1/8 sub-pel search/compensation @ Temporal Filtering
 #define ALTREF_TF_ADAPTIVE_WINDOW_SIZE    1 // Add the ability to use dynamic/asymmetric window for AltRef temporal filtering, add the ability to derive the activity within past and future frames @ picture decision, and add a logic to derive window size from activity

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -46,6 +46,10 @@ extern "C" {
 #define CDEF_AVX_OPT                      1
 #define MR_MODE                           0
 #define EIGTH_PEL_MV                      0
+#define IMPROVE_ALTREF_TF                 1 // Improve Temporal Filtering for the BASE AltRef 
+#if IMPROVE_ALTREF_TF
+#define ALTREF_EIGHTH_PEL_SEARCH          1 // Add 1/8 sub-pel search/compensation @ Temporal Filtering
+#endif
 
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC                         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -46,12 +46,8 @@ extern "C" {
 #define CDEF_AVX_OPT                      1
 #define MR_MODE                           0
 #define EIGTH_PEL_MV                      0
-#define IMPROVE_ALTREF_TF                 1 // Improve Temporal Filtering for the BASE AltRef
-#if IMPROVE_ALTREF_TF
 #define ALTREF_TF_EIGHTH_PEL_SEARCH       1 // Add 1/8 sub-pel search/compensation @ Temporal Filtering
 #define ALTREF_TF_ADAPTIVE_WINDOW_SIZE    1 // Add the ability to use dynamic/asymmetric window for AltRef temporal filtering, add the ability to derive the activity within past and future frames @ picture decision, and add a logic to derive window size from activity
-#endif
-
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC                         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch
 

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -14300,7 +14300,12 @@ extern "C" {
         int16_t                               tf_segments_total_count;
         uint8_t                               tf_segments_column_count;
         uint8_t                               tf_segments_row_count;
+#if ALTREF_TF_ADAPTIVE_WINDOW_SIZE
+        uint8_t                               past_altref_nframes;
+        uint8_t                               future_altref_nframes;
+#else
         uint8_t                               altref_nframes;
+#endif
 #if QPS_TUNING
         uint64_t                              filtered_sse; // the normalized SSE between filtered and original alt_ref with 8 bit precision.
                                                             // I Slice has the value of the next ALT_REF picture

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -3354,7 +3354,7 @@ void* picture_decision_kernel(void *input_ptr)
                                         break;
                                 }
                                 picture_control_set_ptr->future_altref_nframes = pic_itr - index_center;
-                                printf("\nPOC %d\t PAST %d\t FUTURE %d\n", picture_control_set_ptr->picture_number, picture_control_set_ptr->past_altref_nframes, picture_control_set_ptr->future_altref_nframes);
+                                //printf("\nPOC %d\t PAST %d\t FUTURE %d\n", picture_control_set_ptr->picture_number, picture_control_set_ptr->past_altref_nframes, picture_control_set_ptr->future_altref_nframes);
 #else
                                 //get the final number of pictures to use for the temporal filtering
                                 altref_nframes = (uint8_t)(actual_past_pics + 1 + actual_future_pics);

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -3308,14 +3308,7 @@ void* picture_decision_kernel(void *input_ptr)
 
 #if ALTREF_TF_ADAPTIVE_WINDOW_SIZE
                                 int index_center = (uint8_t)(picture_control_set_ptr->sequence_control_set_ptr->static_config.altref_nframes / 2);
-
                                 int pic_itr;
-
-                                // adjust the starting point of buffer_y of the starting pixel values of the source picture
-                                EbByte src = picture_control_set_ptr->temp_filt_pcs_list[index_center]->enhanced_picture_ptr->buffer_y +
-                                    picture_control_set_ptr->temp_filt_pcs_list[index_center]->enhanced_picture_ptr->origin_y*picture_control_set_ptr->temp_filt_pcs_list[index_center]->enhanced_picture_ptr->stride_y +
-                                    picture_control_set_ptr->temp_filt_pcs_list[index_center]->enhanced_picture_ptr->origin_x;
-
                                 int ahd;
                                 uint32_t regionInPictureWidthIndex;
                                 uint32_t regionInPictureHeightIndex;

--- a/Source/Lib/Common/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Common/Codec/EbTemporalFiltering.c
@@ -772,7 +772,7 @@ void tf_inter_prediction(
     MeContext* context_ptr,
     EbPictureBufferDesc *pic_ptr_ref,
     EbByte *pred,
-#if ALTREF_EIGHTH_PEL_SEARCH
+#if ALTREF_TF_EIGHTH_PEL_SEARCH
     int* stride_pred,
     EbByte* src,
     int* stride_src,
@@ -831,7 +831,7 @@ void tf_inter_prediction(
                 //AV1 MVs are always in 1/8th pel precision.
                 mv_unit.mv->x = mv_unit.mv->x << 1;
                 mv_unit.mv->y = mv_unit.mv->y << 1;
-#if ALTREF_EIGHTH_PEL_SEARCH
+#if ALTREF_TF_EIGHTH_PEL_SEARCH
                 uint64_t best_distortion = (uint64_t)~0;
                 signed short best_mv_x;
                 signed short best_mv_y;
@@ -1198,7 +1198,11 @@ void uni_motion_compensation(MeContext* context_ptr,
 static EbErrorType produce_temporally_filtered_pic(PictureParentControlSet **list_picture_control_set_ptr,
                                             EbPictureBufferDesc **list_input_picture_ptr,
                                             uint8_t altref_strength,
+#if ALTREF_TF_ADAPTIVE_WINDOW_SIZE
+                                            uint8_t index_center,
+#else
                                             uint8_t altref_nframes,
+#endif
                                             uint8_t **alt_ref_buffer,
 #if QPS_TUNING
                                             uint64_t *filtered_sse,
@@ -1213,7 +1217,9 @@ static EbErrorType produce_temporally_filtered_pic(PictureParentControlSet **lis
     uint32_t *accum[COLOR_CHANNELS] = { accumulator, accumulator + BLK_PELS, accumulator + (BLK_PELS<<1) };
     uint16_t *count[COLOR_CHANNELS] = { counter, counter + BLK_PELS, counter + (BLK_PELS<<1) };
     EbByte pred[COLOR_CHANNELS] = { predictor, predictor + BLK_PELS, predictor + (BLK_PELS<<1) };
+#if !ALTREF_TF_ADAPTIVE_WINDOW_SIZE
     int index_center;
+#endif
     uint32_t blk_row, blk_col;
     int stride_pred[COLOR_CHANNELS] = {BW, BW_CH, BW_CH};
     uint16_t blk_width_ch = BW_CH;
@@ -1224,13 +1230,12 @@ static EbErrorType produce_temporally_filtered_pic(PictureParentControlSet **lis
 
     PictureParentControlSet *picture_control_set_ptr_central;
     EbPictureBufferDesc *input_picture_ptr_central;
-
+#if !ALTREF_TF_ADAPTIVE_WINDOW_SIZE
     // index of the center frame
     index_center = (uint8_t)(altref_nframes / 2);
-
+#endif
     picture_control_set_ptr_central = list_picture_control_set_ptr[index_center];
     input_picture_ptr_central = list_input_picture_ptr[index_center];
-
     EbAsm asm_type = picture_control_set_ptr_central->sequence_control_set_ptr->encode_context_ptr->asm_type;
 
     uint32_t blk_cols = (uint32_t)(input_picture_ptr_central->width + BW - 1) / BW; // I think only the part of the picture
@@ -1300,7 +1305,11 @@ static EbErrorType produce_temporally_filtered_pic(PictureParentControlSet **lis
             populate_list_with_value(blk_fw, 16, INIT_WEIGHT);
 
             // for every frame to filter
+#if ALTREF_TF_ADAPTIVE_WINDOW_SIZE
+            for (frame_index = 0; frame_index < (picture_control_set_ptr_central->past_altref_nframes + picture_control_set_ptr_central->future_altref_nframes + 1); frame_index++) {
+#else
             for (frame_index = 0; frame_index < altref_nframes; frame_index++) {
+#endif
                 // first position of the frame buffer according to frame index
                 src_frame_index[C_Y] = list_input_picture_ptr[frame_index]->buffer_y +
                         list_input_picture_ptr[frame_index]->origin_y*list_input_picture_ptr[frame_index]->stride_y +
@@ -1375,7 +1384,7 @@ static EbErrorType produce_temporally_filtered_pic(PictureParentControlSet **lis
                         context_ptr,
                         list_input_picture_ptr[frame_index],
                         pred,
-#if ALTREF_EIGHTH_PEL_SEARCH
+#if ALTREF_TF_EIGHTH_PEL_SEARCH
                         stride_pred,
                         src_altref_index,
                         stride,
@@ -1678,17 +1687,24 @@ void init_temporal_filtering(PictureParentControlSet **list_picture_control_set_
                                     PictureParentControlSet *picture_control_set_ptr_central,
                                     MotionEstimationContext_t *me_context_ptr,
                                     int32_t segment_index) {
+#if ALTREF_TF_ADAPTIVE_WINDOW_SIZE
+    uint8_t *altref_strength_ptr, index_center;
+#else
     uint8_t *altref_strength_ptr, *altref_nframes_ptr, index_center;
+#endif
     EbPictureBufferDesc *input_picture_ptr;
     uint8_t *alt_ref_buffer[COLOR_CHANNELS];
-
+#if !ALTREF_TF_ADAPTIVE_WINDOW_SIZE
     // number of frames to filter
     altref_nframes_ptr = &(picture_control_set_ptr_central->altref_nframes);
+#endif
     altref_strength_ptr = &(picture_control_set_ptr_central->altref_strength);
-
     // index of the central source frame
+#if ALTREF_TF_ADAPTIVE_WINDOW_SIZE
+    index_center = picture_control_set_ptr_central->past_altref_nframes;
+#else
     index_center = (uint8_t)(*altref_nframes_ptr / 2);
-
+#endif
     // source central frame picture buffer
     input_picture_ptr = picture_control_set_ptr_central->enhanced_picture_ptr;
 
@@ -1702,7 +1718,11 @@ void init_temporal_filtering(PictureParentControlSet **list_picture_control_set_
         adjust_filter_params(input_picture_ptr, altref_strength_ptr);
 
         // Pad chroma reference samples - once only per picture
+#if ALTREF_TF_ADAPTIVE_WINDOW_SIZE
+        for (int i = 0 ; i < (picture_control_set_ptr_central->past_altref_nframes + picture_control_set_ptr_central->future_altref_nframes + 1); i++) {
+#else
         for (int i = 0; i < *altref_nframes_ptr; i++) {
+#endif
             if (i != index_center) {
                 EbPictureBufferDesc *pic_ptr_ref = list_picture_control_set_ptr[i]->enhanced_picture_ptr;
 
@@ -1726,8 +1746,11 @@ void init_temporal_filtering(PictureParentControlSet **list_picture_control_set_
 
     // populate source frames picture buffer list
     EbPictureBufferDesc *list_input_picture_ptr[ALTREF_MAX_NFRAMES] = { NULL };
-
+#if ALTREF_TF_ADAPTIVE_WINDOW_SIZE
+    for (int i = 0; i < (picture_control_set_ptr_central->past_altref_nframes + picture_control_set_ptr_central->future_altref_nframes + 1); i++)
+#else
     for(int i = 0; i < *altref_nframes_ptr; i++)
+#endif
         list_input_picture_ptr[i] = list_picture_control_set_ptr[i]->enhanced_picture_ptr;
 
     alt_ref_buffer[C_Y] = picture_control_set_ptr_central->enhanced_picture_ptr->buffer_y +
@@ -1741,7 +1764,11 @@ void init_temporal_filtering(PictureParentControlSet **list_picture_control_set_
                           (picture_control_set_ptr_central->enhanced_picture_ptr->origin_y / 2)*picture_control_set_ptr_central->enhanced_picture_ptr->stride_cr;
 #if QPS_TUNING
     uint64_t filtered_sse, filtered_sse_uv;
+#if ALTREF_TF_ADAPTIVE_WINDOW_SIZE
+    produce_temporally_filtered_pic(list_picture_control_set_ptr, list_input_picture_ptr, *altref_strength_ptr, index_center, alt_ref_buffer, &filtered_sse, &filtered_sse_uv, (MotionEstimationContext_t *)me_context_ptr, segment_index);
+#else
     produce_temporally_filtered_pic(list_picture_control_set_ptr, list_input_picture_ptr, *altref_strength_ptr, *altref_nframes_ptr, alt_ref_buffer, &filtered_sse, &filtered_sse_uv, (MotionEstimationContext_t *)me_context_ptr, segment_index);
+#endif
 #else
     produce_temporally_filtered_pic(list_picture_control_set_ptr, list_input_picture_ptr, *altref_strength_ptr, *altref_nframes_ptr, alt_ref_buffer, (MotionEstimationContext_t *) me_context_ptr,segment_index);
 #endif

--- a/Source/Lib/Common/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Common/Codec/EbTemporalFiltering.c
@@ -864,8 +864,8 @@ void tf_inter_prediction(
                             asm_type);
 
 
-                        uint8_t *pred_Y_ptr = pred[C_Y] + 16 * idx_y*stride_pred[C_Y] + 16 * idx_x;
-                        uint8_t *src_Y_ptr = src[C_Y] + 16 * idx_y*stride_src[C_Y] + 16 * idx_x;
+                        uint8_t *pred_Y_ptr = pred[C_Y] + bsize * idx_y*stride_pred[C_Y] + bsize * idx_x;
+                        uint8_t *src_Y_ptr = src[C_Y] + bsize * idx_y*stride_src[C_Y] + bsize * idx_x;
 
                         const aom_variance_fn_ptr_t *fn_ptr = &mefn_ptr[BLOCK_16X16];
                         unsigned int sse;
@@ -878,7 +878,7 @@ void tf_inter_prediction(
                     }
                 }
 
-                // Perform final pass using the 1/16 MV
+                // Perform final pass using the 1/8 MV
                 //AV1 MVs are always in 1/8th pel precision.
                 mv_unit.mv->x = best_mv_x;
                 mv_unit.mv->y = best_mv_y;

--- a/Source/Lib/Common/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Common/Codec/EbTemporalFiltering.c
@@ -833,8 +833,8 @@ void tf_inter_prediction(
                 mv_unit.mv->y = mv_unit.mv->y << 1;
 #if ALTREF_TF_EIGHTH_PEL_SEARCH
                 uint64_t best_distortion = (uint64_t)~0;
-                signed short best_mv_x;
-                signed short best_mv_y;
+                signed short best_mv_x = 0;
+                signed short best_mv_y = 0;
                 signed short mv_x = (_MVXT(context_ptr->p_best_mv16x16[mv_index])) << 1;
                 signed short mv_y = (_MVYT(context_ptr->p_best_mv16x16[mv_index])) << 1;
 

--- a/Source/Lib/Common/Codec/EbTemporalFiltering.h
+++ b/Source/Lib/Common/Codec/EbTemporalFiltering.h
@@ -62,7 +62,7 @@
 
 #define OD_DIVU_DMAX (1024)
 #if ALTREF_TF_ADAPTIVE_WINDOW_SIZE
-#define AHD_TH_WEIGHT 50 
+#define AHD_TH_WEIGHT 50
 #endif
 void init_temporal_filtering(PictureParentControlSet **list_picture_control_set_ptr,
     PictureParentControlSet *picture_control_set_ptr_central,

--- a/Source/Lib/Common/Codec/EbTemporalFiltering.h
+++ b/Source/Lib/Common/Codec/EbTemporalFiltering.h
@@ -61,7 +61,9 @@
 #define THRES_DIFF_HIGH 12000
 
 #define OD_DIVU_DMAX (1024)
-
+#if ALTREF_TF_ADAPTIVE_WINDOW_SIZE
+#define AHD_TH_WEIGHT 50 
+#endif
 void init_temporal_filtering(PictureParentControlSet **list_picture_control_set_ptr,
     PictureParentControlSet *picture_control_set_ptr_central,
     MotionEstimationContext_t *me_context_ptr,


### PR DESCRIPTION
## Description
Improved Temporal Filtering for the BASE AltRef.
* Added 1/8 sub-pel search/compensation.
* Added the ability to use dynamic/asymmetric window, added the ability to derive the activity within past and future frames @ picture decision, and added a logic to derive window size from activity.

Closes #447.

## Author

@hguermaz 

## Type of change

New feature/tool.

## Tests and performance
* BD-Rate to aom cpu0-2pass: ~0.4% gain.
* Speed:  less than 1% speed increase. 
* Memory footprint: negligible deviation.