### PR TITLE
10 bit path for Mode Decision: intra part

### DIFF
--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -244,6 +244,11 @@ typedef struct EbSvtAv1EncConfiguration
     uint32_t                 search_area_height;
 
     // MD Parameters
+    /* Enable the use of HBD (10-bit) at the nmode decision step
+    *
+    * Default is 0. */
+    EbBool                   enable_hbd_mode_decision;
+
     /* Enable the use of Constrained Intra, which yields sending two picture
      * parameter sets in the elementary streams .
      *

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -244,7 +244,7 @@ typedef struct EbSvtAv1EncConfiguration
     uint32_t                 search_area_height;
 
     // MD Parameters
-    /* Enable the use of HBD (10-bit) at the nmode decision step
+    /* Enable the use of HBD (10-bit) at the mode decision step
     *
     * Default is 0. */
     EbBool                   enable_hbd_mode_decision;

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -83,6 +83,7 @@
 #define ALTREF_NFRAMES                  "-altref-nframes"
 #define ENABLE_OVERLAYS                 "-enable-overlays"
 // --- end: ALTREF_FILTERING_SUPPORT
+#define HBD_MD_ENABLE_TOKEN             "-hbd-md"
 #define CONSTRAINED_INTRA_ENABLE_TOKEN  "-constrd-intra"
 #define IMPROVE_SHARPNESS_TOKEN         "-sharp"
 #define HDR_INPUT_TOKEN                 "-hdr"
@@ -231,6 +232,7 @@ static void SetAltRefStrength                   (const char *value, EbConfig *cf
 static void SetAltRefNFrames                    (const char *value, EbConfig *cfg) {cfg->altref_nframes = (uint8_t)strtoul(value, NULL, 0);};
 static void SetEnableOverlays                   (const char *value, EbConfig *cfg) { cfg->enable_overlays = (EbBool)strtoul(value, NULL, 0); };
 // --- end: ALTREF_FILTERING_SUPPORT
+static void SetEnableHBDModeDecision            (const char *value, EbConfig *cfg) {cfg->enable_hbd_mode_decision = (EbBool)strtoul(value, NULL, 0);};
 static void SetEnableConstrainedIntra           (const char *value, EbConfig *cfg) {cfg->constrained_intra                                             = (EbBool)strtoul(value, NULL, 0);};
 static void SetImproveSharpness                 (const char *value, EbConfig *cfg) {cfg->improve_sharpness               = (EbBool)strtol(value,  NULL, 0);};
 static void SetHighDynamicRangeInput            (const char *value, EbConfig *cfg) {cfg->high_dynamic_range_input            = strtol(value,  NULL, 0);};
@@ -341,6 +343,7 @@ config_entry_t config_entry[] = {
     { SINGLE_INPUT, HME_SRCH_T_L0_HEIGHT_TOKEN, "HmeLevel0TotalSearchAreaHeight", SetCfgHmeLevel0TotalSearchAreaHeight },
     // MD Parameters
     { SINGLE_INPUT, SCREEN_CONTENT_TOKEN, "ScreenContentMode", SetScreenContentMode},
+    { SINGLE_INPUT, HBD_MD_ENABLE_TOKEN, "HighBitDepthModeDecision", SetEnableHBDModeDecision },
     { SINGLE_INPUT, CONSTRAINED_INTRA_ENABLE_TOKEN, "ConstrainedIntra", SetEnableConstrainedIntra},
     // Thread Management
     { SINGLE_INPUT, THREAD_MGMNT, "logicalProcessors", SetLogicalProcessors },
@@ -463,6 +466,7 @@ void eb_config_ctor(EbConfig *config_ptr)
     config_ptr->hme_level2_search_area_in_height_array[0]  = 1;
     config_ptr->hme_level2_search_area_in_height_array[1]  = 1;
     config_ptr->screen_content_mode                  = 2;
+    config_ptr->enable_hbd_mode_decision             = EB_FALSE;
     config_ptr->constrained_intra                    = 0;
     config_ptr->film_grain_denoise_strength          = 0;
 
@@ -848,6 +852,11 @@ static EbErrorType VerifySettings(EbConfig *config, uint32_t channelNumber)
         return_error = EB_ErrorBadParameter;
     }
 
+    // HBD mode decision
+    if (config->enable_hbd_mode_decision != 0 && config->enable_hbd_mode_decision != 1) {
+        fprintf(config->error_log_file, "Error instance %u: Invalid HBD mode decision flag [0 - 1], your input: %d\n", channelNumber + 1, config->target_socket);
+        return_error = EB_ErrorBadParameter;
+    }
     return return_error;
 }
 

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -857,6 +857,9 @@ static EbErrorType VerifySettings(EbConfig *config, uint32_t channelNumber)
         fprintf(config->error_log_file, "Error instance %u: Invalid HBD mode decision flag [0 - 1], your input: %d\n", channelNumber + 1, config->target_socket);
         return_error = EB_ErrorBadParameter;
     }
+    if (config->enable_hbd_mode_decision == 1 && config->encoder_bit_depth != 10)
+        config->enable_hbd_mode_decision = 0;
+
     return return_error;
 }
 

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -279,6 +279,7 @@ typedef struct EbConfig
      * MD Parameters
      ****************************************/
     EbBool                  constrained_intra;
+    EbBool                  enable_hbd_mode_decision;
 
     int32_t                  tile_columns;
     int32_t                  tile_rows;

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -191,6 +191,7 @@ EbErrorType CopyConfigurationParameters(
     callback_data->eb_enc_parameters.hme_level0_total_search_area_width = config->hme_level0_total_search_area_width;
     callback_data->eb_enc_parameters.hme_level0_total_search_area_height = config->hme_level0_total_search_area_height;
     callback_data->eb_enc_parameters.screen_content_mode = (EbBool)config->screen_content_mode;
+    callback_data->eb_enc_parameters.enable_hbd_mode_decision = (EbBool)config->enable_hbd_mode_decision;
     callback_data->eb_enc_parameters.constrained_intra = (EbBool)config->constrained_intra;
     callback_data->eb_enc_parameters.channel_id = config->channel_id;
     callback_data->eb_enc_parameters.active_channel_count = config->active_channel_count;

--- a/Source/Lib/Common/ASM_AVX2/EbPictureOperators_AVX2.h
+++ b/Source/Lib/Common/ASM_AVX2/EbPictureOperators_AVX2.h
@@ -158,8 +158,10 @@ extern "C" {
 
     uint64_t spatial_full_distortion_kernel_avx2(
         uint8_t *input,
+        uint32_t input_offset,
         uint32_t input_stride,
         uint8_t *recon,
+        uint32_t recon_offset,
         uint32_t recon_stride,
         uint32_t area_width,
         uint32_t area_height);

--- a/Source/Lib/Common/ASM_AVX2/EbPictureOperators_AVX2.h
+++ b/Source/Lib/Common/ASM_AVX2/EbPictureOperators_AVX2.h
@@ -166,51 +166,64 @@ extern "C" {
 
     uint64_t spatial_full_distortion_kernel4x_n_avx2_intrin(
         uint8_t   *input,
+        uint32_t   input_offset,
         uint32_t   input_stride,
         uint8_t   *recon,
+        uint32_t   recon_offset,
         uint32_t   recon_stride,
         uint32_t   area_width,
         uint32_t   area_height);
 
     uint64_t spatial_full_distortion_kernel8x_n_avx2_intrin(
         uint8_t   *input,
+        uint32_t   input_offset,
         uint32_t   input_stride,
         uint8_t   *recon,
+        uint32_t   recon_offset,
         uint32_t   recon_stride,
         uint32_t   area_width,
         uint32_t   area_height);
 
     uint64_t spatial_full_distortion_kernel16x_n_avx2_intrin(
         uint8_t   *input,
+        uint32_t   input_offset,
         uint32_t   input_stride,
         uint8_t   *recon,
+        uint32_t   recon_offset,
         uint32_t   recon_stride,
         uint32_t   area_width,
         uint32_t   area_height);
 
     uint64_t spatial_full_distortion_kernel32x_n_avx2_intrin(
         uint8_t   *input,
+        uint32_t   input_offset,
         uint32_t   input_stride,
         uint8_t   *recon,
+        uint32_t   recon_offset,
         uint32_t   recon_stride,
         uint32_t   area_width,
         uint32_t   area_height);
 
     uint64_t spatial_full_distortion_kernel64x_n_avx2_intrin(
         uint8_t   *input,
+        uint32_t   input_offset,
         uint32_t   input_stride,
         uint8_t   *recon,
+        uint32_t   recon_offset,
         uint32_t   recon_stride,
         uint32_t   area_width,
         uint32_t   area_height);
 
     uint64_t spatial_full_distortion_kernel128x_n_avx2_intrin(
         uint8_t   *input,
+        uint32_t   input_offset,
         uint32_t   input_stride,
         uint8_t   *recon,
+        uint32_t   recon_offset,
         uint32_t   recon_stride,
         uint32_t   area_width,
         uint32_t   area_height);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/Lib/Common/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
@@ -2700,8 +2700,10 @@ static INLINE void Distortion_AVX2_INTRIN(const __m256i input,
 
 uint64_t spatial_full_distortion_kernel4x_n_avx2_intrin(
     uint8_t   *input,
+    uint32_t   input_offset,
     uint32_t   input_stride,
     uint8_t   *recon,
+    uint32_t   recon_offset,
     uint32_t   recon_stride,
     uint32_t   area_width,
     uint32_t   area_height)
@@ -2709,7 +2711,8 @@ uint64_t spatial_full_distortion_kernel4x_n_avx2_intrin(
     int32_t row_count = area_height;
     __m256i sum = _mm256_setzero_si256();
     __m128i sum_L, sum_H, s;
-
+    input += input_offset;
+    recon += recon_offset;
     (void)area_width;
 
     do {
@@ -2735,15 +2738,18 @@ uint64_t spatial_full_distortion_kernel4x_n_avx2_intrin(
 
 uint64_t spatial_full_distortion_kernel8x_n_avx2_intrin(
     uint8_t   *input,
+    uint32_t   input_offset,
     uint32_t   input_stride,
     uint8_t   *recon,
+    uint32_t   recon_offset,
     uint32_t   recon_stride,
     uint32_t   area_width,
     uint32_t   area_height)
 {
     int32_t row_count = area_height;
     __m256i sum = _mm256_setzero_si256();
-
+    input += input_offset;
+    recon += recon_offset;
     (void)area_width;
 
     do {
@@ -2776,15 +2782,18 @@ static INLINE void SpatialFullDistortionKernel16_AVX2_INTRIN(
 
 uint64_t spatial_full_distortion_kernel16x_n_avx2_intrin(
     uint8_t   *input,
+    uint32_t   input_offset,
     uint32_t   input_stride,
     uint8_t   *recon,
+    uint32_t   recon_offset,
     uint32_t   recon_stride,
     uint32_t   area_width,
     uint32_t   area_height)
 {
     int32_t row_count = area_height;
     __m256i sum = _mm256_setzero_si256();
-
+    input += input_offset;
+    recon += recon_offset;
     (void)area_width;
 
     do {
@@ -2838,15 +2847,18 @@ static INLINE void SpatialFullDistortionKernel64_AVX2_INTRIN(
 
 uint64_t spatial_full_distortion_kernel32x_n_avx2_intrin(
     uint8_t   *input,
+    uint32_t   input_offset,
     uint32_t   input_stride,
     uint8_t   *recon,
+    uint32_t   recon_offset,
     uint32_t   recon_stride,
     uint32_t   area_width,
     uint32_t   area_height)
 {
     int32_t row_count = area_height;
     __m256i sum = _mm256_setzero_si256();
-
+    input += input_offset;
+    recon += recon_offset;
     (void)area_width;
 
     do {
@@ -2860,15 +2872,18 @@ uint64_t spatial_full_distortion_kernel32x_n_avx2_intrin(
 
 uint64_t spatial_full_distortion_kernel64x_n_avx2_intrin(
     uint8_t   *input,
+    uint32_t   input_offset,
     uint32_t   input_stride,
     uint8_t   *recon,
+    uint32_t   recon_offset,
     uint32_t   recon_stride,
     uint32_t   area_width,
     uint32_t   area_height)
 {
     int32_t row_count = area_height;
     __m256i sum = _mm256_setzero_si256();
-
+    input += input_offset;
+    recon += recon_offset;
     (void)area_width;
 
     do {
@@ -2882,15 +2897,18 @@ uint64_t spatial_full_distortion_kernel64x_n_avx2_intrin(
 
 uint64_t spatial_full_distortion_kernel128x_n_avx2_intrin(
     uint8_t   *input,
+    uint32_t   input_offset,
     uint32_t   input_stride,
     uint8_t   *recon,
+    uint32_t   recon_offset,
     uint32_t   recon_stride,
     uint32_t   area_width,
     uint32_t   area_height)
 {
     int32_t row_count = area_height;
     __m256i sum = _mm256_setzero_si256();
-
+    input += input_offset;
+    recon += recon_offset;
     (void)area_width;
 
     do {

--- a/Source/Lib/Common/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
@@ -2925,13 +2925,17 @@ uint64_t spatial_full_distortion_kernel128x_n_avx2_intrin(
 
 uint64_t spatial_full_distortion_kernel_avx2(
     uint8_t   *input,
+    uint32_t   input_offset,
     uint32_t   input_stride,
     uint8_t   *recon,
+    uint32_t   recon_offset,
     uint32_t   recon_stride,
     uint32_t   area_width,
     uint32_t   area_height)
 {
     const uint32_t leftover = area_width & 31;
+    input += input_offset;
+    recon += recon_offset;
     int32_t h;
     __m256i sum = _mm256_setzero_si256();
     __m128i sum_L, sum_H, s;

--- a/Source/Lib/Common/ASM_SSE2/EbPictureOperators_Intrinsic_SSE2.c
+++ b/Source/Lib/Common/ASM_SSE2/EbPictureOperators_Intrinsic_SSE2.c
@@ -867,15 +867,18 @@ static INLINE __m128i Distortion_SSE2_INTRIN(const __m128i input,
 
 uint64_t spatial_full_distortion_kernel4x_n_sse2_intrin(
     uint8_t   *input,
+    uint32_t   input_offset,
     uint32_t   input_stride,
     uint8_t   *recon,
+    uint32_t   recon_offset,
     uint32_t   recon_stride,
     uint32_t   area_width,
     uint32_t   area_height)
 {
     int32_t row_count = area_height;
     __m128i sum = _mm_setzero_si128();
-
+    input += input_offset;
+    recon += recon_offset;
     (void)area_width;
 
     do {
@@ -893,15 +896,18 @@ uint64_t spatial_full_distortion_kernel4x_n_sse2_intrin(
 
 uint64_t spatial_full_distortion_kernel8x_n_sse2_intrin(
     uint8_t   *input,
+    uint32_t   input_offset,
     uint32_t   input_stride,
     uint8_t   *recon,
+    uint32_t   recon_offset,
     uint32_t   recon_stride,
     uint32_t   area_width,
     uint32_t   area_height)
 {
     int32_t row_count = area_height;
     __m128i sum = _mm_setzero_si128();
-
+    input += input_offset;
+    recon += recon_offset;
     (void)area_width;
 
     do {
@@ -947,15 +953,18 @@ static INLINE void SpatialFullDistortionKernel64_SSE2_INTRIN(
 
 uint64_t spatial_full_distortion_kernel16x_n_sse2_intrin(
     uint8_t   *input,
+    uint32_t   input_offset,
     uint32_t   input_stride,
     uint8_t   *recon,
+    uint32_t   recon_offset,
     uint32_t   recon_stride,
     uint32_t   area_width,
     uint32_t   area_height)
 {
     int32_t row_count = area_height;
     __m128i sum = _mm_setzero_si128();
-
+    input += input_offset;
+    recon += recon_offset;
     (void)area_width;
 
     do {
@@ -969,15 +978,18 @@ uint64_t spatial_full_distortion_kernel16x_n_sse2_intrin(
 
 uint64_t spatial_full_distortion_kernel32x_n_sse2_intrin(
     uint8_t   *input,
+    uint32_t   input_offset,
     uint32_t   input_stride,
     uint8_t   *recon,
+    uint32_t   recon_offset,
     uint32_t   recon_stride,
     uint32_t   area_width,
     uint32_t   area_height)
 {
     int32_t row_count = area_height;
     __m128i sum = _mm_setzero_si128();
-
+    input += input_offset;
+    recon += recon_offset;
     (void)area_width;
 
     do {
@@ -991,15 +1003,18 @@ uint64_t spatial_full_distortion_kernel32x_n_sse2_intrin(
 
 uint64_t spatial_full_distortion_kernel64x_n_sse2_intrin(
     uint8_t   *input,
+    uint32_t   input_offset,
     uint32_t   input_stride,
     uint8_t   *recon,
+    uint32_t   recon_offset,
     uint32_t   recon_stride,
     uint32_t   area_width,
     uint32_t   area_height)
 {
     int32_t row_count = area_height;
     __m128i sum = _mm_setzero_si128();
-
+    input += input_offset;
+    recon += recon_offset;
     (void)area_width;
 
     do {
@@ -1013,15 +1028,18 @@ uint64_t spatial_full_distortion_kernel64x_n_sse2_intrin(
 
 uint64_t spatial_full_distortion_kernel128x_n_sse2_intrin(
     uint8_t   *input,
+    uint32_t   input_offset,
     uint32_t   input_stride,
     uint8_t   *recon,
+    uint32_t   recon_offset,
     uint32_t   recon_stride,
     uint32_t   area_width,
     uint32_t   area_height)
 {
     int32_t row_count = area_height;
     __m128i sum = _mm_setzero_si128();
-
+    input += input_offset;
+    recon += recon_offset;
     (void)area_width;
 
     do {

--- a/Source/Lib/Common/ASM_SSE2/EbPictureOperators_SSE2.h
+++ b/Source/Lib/Common/ASM_SSE2/EbPictureOperators_SSE2.h
@@ -176,48 +176,60 @@ extern "C" {
 
     uint64_t spatial_full_distortion_kernel4x_n_sse2_intrin(
         uint8_t   *input,
+        uint32_t   input_offset,
         uint32_t   input_stride,
         uint8_t   *recon,
+        uint32_t   recon_offset,
         uint32_t   recon_stride,
         uint32_t   area_width,
         uint32_t   area_height);
 
     uint64_t spatial_full_distortion_kernel8x_n_sse2_intrin(
         uint8_t   *input,
+        uint32_t   input_offset,
         uint32_t   input_stride,
         uint8_t   *recon,
+        uint32_t   recon_offset,
         uint32_t   recon_stride,
         uint32_t   area_width,
         uint32_t   area_height);
 
     uint64_t spatial_full_distortion_kernel16x_n_sse2_intrin(
         uint8_t   *input,
+        uint32_t   input_offset,
         uint32_t   input_stride,
         uint8_t   *recon,
+        uint32_t   recon_offset,
         uint32_t   recon_stride,
         uint32_t   area_width,
         uint32_t   area_height);
 
     uint64_t spatial_full_distortion_kernel32x_n_sse2_intrin(
         uint8_t   *input,
+        uint32_t   input_offset,
         uint32_t   input_stride,
         uint8_t   *recon,
+        uint32_t   recon_offset,
         uint32_t   recon_stride,
         uint32_t   area_width,
         uint32_t   area_height);
 
     uint64_t spatial_full_distortion_kernel64x_n_sse2_intrin(
         uint8_t   *input,
+        uint32_t   input_offset,
         uint32_t   input_stride,
         uint8_t   *recon,
+        uint32_t   recon_offset,
         uint32_t   recon_stride,
         uint32_t   area_width,
         uint32_t   area_height);
 
     uint64_t spatial_full_distortion_kernel128x_n_sse2_intrin(
         uint8_t   *input,
+        uint32_t   input_offset,
         uint32_t   input_stride,
         uint8_t   *recon,
+        uint32_t   recon_offset,
         uint32_t   recon_stride,
         uint32_t   area_width,
         uint32_t   area_height);

--- a/Source/Lib/Common/C_DEFAULT/EbComputeSAD_C.c
+++ b/Source/Lib/Common/C_DEFAULT/EbComputeSAD_C.c
@@ -67,6 +67,28 @@ uint32_t fast_loop_nx_m_sad_kernel(
     return sad;
 }
 
+uint32_t sad_16b_kernel(
+    uint16_t  *src,                            // input parameter, source samples Ptr
+    uint32_t  src_stride,                      // input parameter, source stride
+    uint16_t  *ref,                            // input parameter, reference samples Ptr
+    uint32_t  ref_stride,                      // input parameter, reference stride
+    uint32_t  height,                         // input parameter, block height (M)
+    uint32_t  width)                          // input parameter, block width (N)
+{
+    uint32_t x, y;
+    uint32_t sad = 0;
+
+    for (y = 0; y < height; y++) {
+        for (x = 0; x < width; x++)
+            sad += EB_ABS_DIFF(src[x], ref[x]);
+        src += src_stride;
+        ref += ref_stride;
+    }
+
+    return sad;
+}
+
+
 void sad_loop_kernel(
     uint8_t  *src,                            // input parameter, source samples Ptr
     uint32_t  src_stride,                      // input parameter, source stride

--- a/Source/Lib/Common/C_DEFAULT/EbPictureOperators_C.c
+++ b/Source/Lib/Common/C_DEFAULT/EbPictureOperators_C.c
@@ -39,16 +39,19 @@ void picture_copy_kernel(
 
 uint64_t spatial_full_distortion_kernel_c(
     uint8_t   *input,
+    uint32_t   input_offset,
     uint32_t   input_stride,
     uint8_t   *recon,
+    uint32_t   recon_offset,
     uint32_t   recon_stride,
     uint32_t   area_width,
     uint32_t   area_height)
 {
     uint32_t  columnIndex;
     uint32_t  row_index = 0;
-
     uint64_t  spatialDistortion = 0;
+    input += input_offset;
+    recon += recon_offset;
 
     while (row_index < area_height) {
         columnIndex = 0;

--- a/Source/Lib/Common/C_DEFAULT/EbPictureOperators_C.h
+++ b/Source/Lib/Common/C_DEFAULT/EbPictureOperators_C.h
@@ -21,8 +21,10 @@ extern "C" {
 
     uint64_t spatial_full_distortion_kernel_c(
         uint8_t *input,
+        uint32_t input_offset,
         uint32_t input_stride,
         uint8_t *recon,
+        uint32_t recon_offset,
         uint32_t recon_stride,
         uint32_t area_width,
         uint32_t area_height);

--- a/Source/Lib/Common/Codec/EbCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbCodingLoop.c
@@ -102,7 +102,7 @@ void residual_kernel(
     uint32_t   area_height)
 {
 
-    if (hbd)
+    if (hbd) {
         residual_kernel16bit(
             ((uint16_t*)input) + input_offset,
             input_stride,
@@ -112,7 +112,7 @@ void residual_kernel(
             residual_stride,
             area_width,
             area_height);
-    else
+    } else {
         ResidualKernel(
             &(input[input_offset]),
             input_stride,
@@ -122,6 +122,7 @@ void residual_kernel(
             residual_stride,
             area_width,
             area_height);
+    }
 }
 
 /***************************************************

--- a/Source/Lib/Common/Codec/EbCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbCodingLoop.c
@@ -31,54 +31,9 @@
 #include "EbIntraPrediction.h"
 #include "aom_dsp_rtcd.h"
 #include "EbCodingLoop.h"
+
 void av1_set_ref_frame(MvReferenceFrame *rf,
     int8_t ref_frame_type);
-extern void av1_predict_intra_block(
-    TileInfo                    *tile,
-    STAGE                       stage,
-    const BlockGeom            *blk_geom,
-    const Av1Common *cm,
-    int32_t wpx,
-    int32_t hpx,
-    TxSize tx_size,
-    PredictionMode mode,
-    int32_t angle_delta,
-    int32_t use_palette,
-    FilterIntraMode filter_intra_mode,
-    uint8_t* topNeighArray,
-    uint8_t* leftNeighArray,
-    EbPictureBufferDesc  *recon_buffer,
-    int32_t col_off,
-    int32_t row_off,
-    int32_t plane,
-    BlockSize bsize,
-    uint32_t tu_org_x_pict,
-    uint32_t tu_org_y_pict,
-    uint32_t bl_org_x_pict,
-    uint32_t bl_org_y_pict,
-    uint32_t bl_org_x_mb,
-    uint32_t bl_org_y_mb);
-
-void av1_predict_intra_block_16bit(
-    TileInfo               *tile,
-    EncDecContext         *context_ptr,
-    const Av1Common *cm,
-    int32_t wpx,
-    int32_t hpx,
-    TxSize tx_size,
-    PredictionMode mode,
-    int32_t angle_delta,
-    int32_t use_palette,
-    FilterIntraMode filter_intra_mode,
-    uint16_t* topNeighArray,
-    uint16_t* leftNeighArray,
-    EbPictureBufferDesc  *recon_buffer,
-    int32_t col_off,
-    int32_t row_off,
-    int32_t plane,
-    BlockSize bsize,
-    uint32_t bl_org_x_pict,
-    uint32_t bl_org_y_pict);
 
 /*******************************************
 * set Penalize Skip Flag
@@ -126,6 +81,48 @@ typedef void(*EB_AV1_GENERATE_RECON_FUNC_PTR)(
     uint32_t                 component_mask,
     uint16_t                *eob,
     EbAsm                 asm_type);
+
+
+/*******************************************
+* Residual Kernel 8-16bit
+    Computes the residual data
+*******************************************/
+void residual_kernel(
+    uint8_t   *input,
+    uint32_t   input_offset,
+    uint32_t   input_stride,
+    uint8_t   *pred,
+    uint32_t   pred_offset,
+    uint32_t   pred_stride,
+    int16_t   *residual,
+    uint32_t   residual_offset,
+    uint32_t   residual_stride,
+    EbBool     hbd,
+    uint32_t   area_width,
+    uint32_t   area_height)
+{
+
+    if (hbd)
+        residual_kernel16bit(
+            ((uint16_t*)input) + input_offset,
+            input_stride,
+            ((uint16_t*)pred) + pred_offset,
+            pred_stride,
+            residual + residual_offset,
+            residual_stride,
+            area_width,
+            area_height);
+    else
+        ResidualKernel(
+            &(input[input_offset]),
+            input_stride,
+            &(pred[pred_offset]),
+            pred_stride,
+            residual + residual_offset,
+            residual_stride,
+            area_width,
+            area_height);
+}
 
 /***************************************************
 * Update Intra Mode Neighbor Arrays
@@ -1576,37 +1573,41 @@ EbErrorType Av1QpModulationLcu(
 }
 
 #endif
+
 void Store16bitInputSrc(
-    EncDecContext         *context_ptr,
-    PictureControlSet     *picture_control_set_ptr,
+    EbPictureBufferDesc     *input_sample16bit_buffer,
+    PictureControlSet       *picture_control_set_ptr,
     uint32_t                 lcuX,
     uint32_t                 lcuY,
     uint32_t                 lcuW,
-    uint32_t                 lcuH ){
+    uint32_t                 lcuH )
+{
     uint32_t rowIt;
     uint16_t* fromPtr;
     uint16_t* toPtr;
 
-    fromPtr = (uint16_t*)context_ptr->input_sample16bit_buffer->buffer_y;
+    fromPtr = (uint16_t*)input_sample16bit_buffer->buffer_y;
     toPtr = (uint16_t*)picture_control_set_ptr->input_frame16bit->buffer_y + (lcuX + picture_control_set_ptr->input_frame16bit->origin_x) + (lcuY + picture_control_set_ptr->input_frame16bit->origin_y)*picture_control_set_ptr->input_frame16bit->stride_y;
 
     for (rowIt = 0; rowIt < lcuH; rowIt++)
-        memcpy(toPtr + rowIt * picture_control_set_ptr->input_frame16bit->stride_y, fromPtr + rowIt * context_ptr->input_sample16bit_buffer->stride_y, lcuW * 2);
+        memcpy(toPtr + rowIt * picture_control_set_ptr->input_frame16bit->stride_y, fromPtr + rowIt * input_sample16bit_buffer->stride_y, lcuW * 2);
+
     lcuX = lcuX / 2;
     lcuY = lcuY / 2;
     lcuW = lcuW / 2;
     lcuH = lcuH / 2;
 
-    fromPtr = (uint16_t*)context_ptr->input_sample16bit_buffer->buffer_cb;
+    fromPtr = (uint16_t*)input_sample16bit_buffer->buffer_cb;
     toPtr = (uint16_t*)picture_control_set_ptr->input_frame16bit->buffer_cb + (lcuX + picture_control_set_ptr->input_frame16bit->origin_x / 2) + (lcuY + picture_control_set_ptr->input_frame16bit->origin_y / 2)*picture_control_set_ptr->input_frame16bit->stride_cb;
 
     for (rowIt = 0; rowIt < lcuH; rowIt++)
-        memcpy(toPtr + rowIt * picture_control_set_ptr->input_frame16bit->stride_cb, fromPtr + rowIt * context_ptr->input_sample16bit_buffer->stride_cb, lcuW * 2);
-    fromPtr = (uint16_t*)context_ptr->input_sample16bit_buffer->buffer_cr;
+        memcpy(toPtr + rowIt * picture_control_set_ptr->input_frame16bit->stride_cb, fromPtr + rowIt * input_sample16bit_buffer->stride_cb, lcuW * 2);
+
+    fromPtr = (uint16_t*)input_sample16bit_buffer->buffer_cr;
     toPtr = (uint16_t*)picture_control_set_ptr->input_frame16bit->buffer_cr + (lcuX + picture_control_set_ptr->input_frame16bit->origin_x / 2) + (lcuY + picture_control_set_ptr->input_frame16bit->origin_y / 2)*picture_control_set_ptr->input_frame16bit->stride_cb;
 
     for (rowIt = 0; rowIt < lcuH; rowIt++)
-        memcpy(toPtr + rowIt * picture_control_set_ptr->input_frame16bit->stride_cr, fromPtr + rowIt * context_ptr->input_sample16bit_buffer->stride_cr, lcuW * 2);
+        memcpy(toPtr + rowIt * picture_control_set_ptr->input_frame16bit->stride_cr, fromPtr + rowIt * input_sample16bit_buffer->stride_cr, lcuW * 2);
 }
 
 
@@ -1702,7 +1703,8 @@ void perform_intra_coding_loop(
 
             av1_predict_intra_block_16bit(
                 &sb_ptr->tile_info,
-                context_ptr,
+                ED_STAGE,
+                context_ptr->blk_geom,
                 picture_control_set_ptr->parent_pcs_ptr->av1_cm,
                 context_ptr->blk_geom->tx_width[cu_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height[cu_ptr->tx_depth][context_ptr->txb_itr],
@@ -1718,8 +1720,12 @@ void perform_intra_coding_loop(
                 0,
                 0,
                 context_ptr->blk_geom->bsize,
+                txb_origin_x,
+                txb_origin_y,
                 context_ptr->cu_origin_x,
-                context_ptr->cu_origin_y);
+                context_ptr->cu_origin_y,
+                0,
+                0);
         }
         else {
             uint8_t    topNeighArray[64 * 2 + 1];
@@ -1948,7 +1954,8 @@ void perform_intra_coding_loop(
 
                 av1_predict_intra_block_16bit(
                     &sb_ptr->tile_info,
-                    context_ptr,
+                    ED_STAGE,
+                    context_ptr->blk_geom,
                     picture_control_set_ptr->parent_pcs_ptr->av1_cm,
                     plane ? context_ptr->blk_geom->bwidth_uv : context_ptr->blk_geom->tx_width[cu_ptr->tx_depth][context_ptr->txb_itr],
                     plane ? context_ptr->blk_geom->bheight_uv : context_ptr->blk_geom->tx_height[cu_ptr->tx_depth][context_ptr->txb_itr],
@@ -1965,8 +1972,12 @@ void perform_intra_coding_loop(
                     0,
                     plane,
                     context_ptr->blk_geom->bsize,
+                    txb_origin_x,
+                    txb_origin_y,
                     plane ? context_ptr->cu_origin_x : context_ptr->cu_origin_x,
-                    plane ? context_ptr->cu_origin_y : context_ptr->cu_origin_y);
+                    plane ? context_ptr->cu_origin_y : context_ptr->cu_origin_y,
+                    0,
+                    0);
             }
         }
         else {
@@ -2364,7 +2375,8 @@ EB_EXTERN void av1_encode_pass(
                 asm_type);
         }
 
-        Store16bitInputSrc(context_ptr, picture_control_set_ptr, sb_origin_x, sb_origin_y, sb_width, sb_height);
+        if (picture_control_set_ptr->hbd_mode_decision == 0)
+            Store16bitInputSrc(context_ptr->input_sample16bit_buffer, picture_control_set_ptr, sb_origin_x, sb_origin_y, sb_width, sb_height);
     }
 
     if ((sequence_control_set_ptr->input_resolution == INPUT_SIZE_4K_RANGE) && !picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) {
@@ -2744,7 +2756,8 @@ EB_EXTERN void av1_encode_pass(
                                         mode = cu_ptr->pred_mode; //PredictionMode mode,
                                     av1_predict_intra_block_16bit(
                                         &sb_ptr->tile_info,
-                                        context_ptr,
+                                        ED_STAGE,
+                                        context_ptr->blk_geom,
                                         picture_control_set_ptr->parent_pcs_ptr->av1_cm,                  //const Av1Common *cm,
                                         plane ? blk_geom->bwidth_uv : blk_geom->bwidth,                  //int32_t wpx,
                                         plane ? blk_geom->bheight_uv : blk_geom->bheight,                  //int32_t hpx,
@@ -2761,8 +2774,12 @@ EB_EXTERN void av1_encode_pass(
                                         0,                                                          //int32_t row_off,
                                         plane,                                                      //int32_t plane,
                                         blk_geom->bsize,                  //uint32_t puSize,
+                                        context_ptr->cu_origin_x,
+                                        context_ptr->cu_origin_y,
                                         context_ptr->cu_origin_x,  //uint32_t cuOrgX,
-                                        context_ptr->cu_origin_y);   //uint32_t cuOrgY
+                                        context_ptr->cu_origin_y,
+                                        0,                          // MD ONLY - NOT USED BY ENCDEC
+                                        0);                         //uint32_t cuOrgY
                                 }
                             }
                             else {

--- a/Source/Lib/Common/Codec/EbCodingLoop.h
+++ b/Source/Lib/Common/Codec/EbCodingLoop.h
@@ -95,6 +95,39 @@ extern "C" {
         EncDecContext         *context_ptr);
 #endif
 
+void pack2d_src(
+    uint8_t     *in8_bit_buffer,
+    uint32_t     in8_stride,
+    uint8_t     *inn_bit_buffer,
+    uint32_t     inn_stride,
+    uint16_t    *out16_bit_buffer,
+    uint32_t     out_stride,
+    uint32_t     width,
+    uint32_t     height,
+    EbAsm     asm_type);
+
+void Store16bitInputSrc(
+    EbPictureBufferDesc     *input_sample16bit_buffer,
+    PictureControlSet       *picture_control_set_ptr,
+    uint32_t                 lcuX,
+    uint32_t                 lcuY,
+    uint32_t                 lcuW,
+    uint32_t                 lcuH);
+
+void residual_kernel(
+    uint8_t   *input,
+    uint32_t   input_offset,
+    uint32_t   input_stride,
+    uint8_t   *pred,
+    uint32_t   pred_offset,
+    uint32_t   pred_stride,
+    int16_t   *residual,
+    uint32_t   residual_offset,
+    uint32_t   residual_stride,
+    EbBool     hbd,
+    uint32_t   area_width,
+    uint32_t   area_height);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/Lib/Common/Codec/EbCodingUnit.h
+++ b/Source/Lib/Common/Codec/EbCodingUnit.h
@@ -380,6 +380,8 @@ extern "C" {
         uint16_t                    mds_idx;     //equivalent of leaf_index in the nscu context. we will keep both for now and use the right one on a case by case basis.
         uint8_t                    *neigh_left_recon[3];  //only for MD
         uint8_t                    *neigh_top_recon[3];
+        uint16_t                   *neigh_left_recon_16bit[3];
+        uint16_t                   *neigh_top_recon_16bit[3];
         uint32_t                    best_d1_blk;
         uint8_t                     tx_depth;
     } CodingUnit;

--- a/Source/Lib/Common/Codec/EbComputeSAD.h
+++ b/Source/Lib/Common/Codec/EbComputeSAD.h
@@ -236,6 +236,14 @@ extern "C" {
         combined_averaging_ssd_avx2,
     };
 
+uint32_t sad_16b_kernel(
+    uint16_t  *src,                           // input parameter, source samples Ptr
+    uint32_t  src_stride,                     // input parameter, source stride
+    uint16_t  *ref,                           // input parameter, reference samples Ptr
+    uint32_t  ref_stride,                     // input parameter, reference stride
+    uint32_t  height,                         // input parameter, block height (M)
+    uint32_t  width);                         // input parameter, block width (N)
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -98,8 +98,10 @@ EbErrorType enc_dec_context_ctor(
     EbFifo                *picture_demux_fifo_ptr,
     EbBool                  is16bit,
     EbColorFormat           color_format,
+    EbBool                  enable_hbd_mode_decision,
     uint32_t                max_input_luma_width,
-    uint32_t                max_input_luma_height){
+    uint32_t                max_input_luma_height)
+{
     (void)max_input_luma_width;
     (void)max_input_luma_height;
 
@@ -190,7 +192,10 @@ EbErrorType enc_dec_context_ctor(
     EB_NEW(
         context_ptr->md_context,
         mode_decision_context_ctor,
-        color_format, 0, 0);
+        color_format, 0, 0, enable_hbd_mode_decision);
+
+    if (enable_hbd_mode_decision)
+        context_ptr->md_context->input_sample16bit_buffer = context_ptr->input_sample16bit_buffer;
 
     context_ptr->md_context->enc_dec_context_ptr = context_ptr;
 
@@ -222,6 +227,13 @@ static void ResetEncodePassNeighborArrays(PictureControlSet *picture_control_set
     neighbor_array_unit_reset(picture_control_set_ptr->ep_luma_dc_sign_level_coeff_neighbor_array);
     neighbor_array_unit_reset(picture_control_set_ptr->ep_cb_dc_sign_level_coeff_neighbor_array);
     neighbor_array_unit_reset(picture_control_set_ptr->ep_cr_dc_sign_level_coeff_neighbor_array);
+    // TODO(Joel): 8-bit ep_luma_recon_neighbor_array (Cb,Cr) when is16bit==0?
+    EbBool is16bit = (EbBool)(picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->static_config.encoder_bit_depth > EB_8BIT);
+    if (is16bit) {
+        neighbor_array_unit_reset(picture_control_set_ptr->ep_luma_recon_neighbor_array16bit);
+        neighbor_array_unit_reset(picture_control_set_ptr->ep_cb_recon_neighbor_array16bit);
+        neighbor_array_unit_reset(picture_control_set_ptr->ep_cr_recon_neighbor_array16bit);
+    }
     return;
 }
 

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -271,7 +271,8 @@ static void ResetEncDec(
         &context_ptr->fast_chroma_lambda,
         &context_ptr->full_chroma_lambda,
         (uint8_t)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
-        context_ptr->qp_index);
+        context_ptr->qp_index,
+        picture_control_set_ptr->hbd_mode_decision);
 
     // Slice Type
     slice_type =
@@ -329,7 +330,8 @@ static void EncDecConfigureLcu(
         &context_ptr->fast_chroma_lambda,
         &context_ptr->full_chroma_lambda,
         (uint8_t)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
-        context_ptr->qp_index);
+        context_ptr->qp_index,
+        picture_control_set_ptr->hbd_mode_decision);
 
     return;
 }

--- a/Source/Lib/Common/Codec/EbEncDecProcess.h
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.h
@@ -140,6 +140,7 @@ extern "C" {
         EbFifo                *picture_demux_fifo_ptr,
         EbBool                   is16bit,
         EbColorFormat            color_format,
+        EbBool                   enable_hbd_mode_decision,
         uint32_t                 max_input_luma_width,
         uint32_t                 max_input_luma_height);
 

--- a/Source/Lib/Common/Codec/EbFullLoop.c
+++ b/Source/Lib/Common/Codec/EbFullLoop.c
@@ -1926,6 +1926,7 @@ int32_t av1_quantize_inv_quantize(
     EbBool is_inter = (pred_mode >= NEARESTMV);
 
     EbBool perform_rdoq = (md_context->trellis_quant_coeff_optimization && component_type == COMPONENT_LUMA && !is_intra_bc);
+    perform_rdoq = perform_rdoq && !picture_control_set_ptr->hbd_mode_decision;
 
     // Hsan: set to FALSE until adding x86 quantize_fp
     EbBool perform_quantize_fp = picture_control_set_ptr->enc_mode == ENC_M0 ? EB_TRUE: EB_FALSE;
@@ -2016,6 +2017,7 @@ void product_full_loop(
     ModeDecisionCandidateBuffer  *candidateBuffer,
     ModeDecisionContext          *context_ptr,
     PictureControlSet            *picture_control_set_ptr,
+    EbPictureBufferDesc          *input_picture_ptr,
     uint32_t                          qp,
     uint32_t                          *y_count_non_zero_coeffs,
     uint64_t                         *y_coeff_bits,
@@ -2069,7 +2071,7 @@ void product_full_loop(
             context_ptr->blk_geom->txsize[tx_depth][txb_itr],
             &context_ptr->three_quad_energy,
             context_ptr->transform_inner_array_ptr,
-            0,
+            picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
             candidateBuffer->candidate_ptr->transform_type[txb_itr],
             asm_type,
             PLANE_TYPE_Y,
@@ -2093,7 +2095,7 @@ void product_full_loop(
             asm_type,
             &(y_count_non_zero_coeffs[txb_itr]),
             COMPONENT_LUMA,
-            BIT_INCREMENT_8BIT,
+            picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
             candidateBuffer->candidate_ptr->transform_type[txb_itr],
             candidateBuffer,
             context_ptr->luma_txb_skip_context,
@@ -2103,31 +2105,28 @@ void product_full_loop(
             EB_FALSE);
 
         if (context_ptr->spatial_sse_full_loop) {
-            EbPictureBufferDesc          *input_picture_ptr = picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
             uint32_t input_tu_origin_index = (context_ptr->sb_origin_x + tx_org_x + input_picture_ptr->origin_x) + ((context_ptr->sb_origin_y + tx_org_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_y);
             uint32_t y_has_coeff           = y_count_non_zero_coeffs[txb_itr] > 0;
 
             if (y_has_coeff) {
-                (void)context_ptr;
-                uint8_t     *pred_buffer = &(candidateBuffer->prediction_ptr->buffer_y[tu_origin_index]);
-                uint8_t     *rec_buffer = &(candidateBuffer->recon_ptr->buffer_y[tu_origin_index]);
-
-                uint32_t j;
-
-                for (j = 0; j < context_ptr->blk_geom->tx_height[tx_depth][txb_itr]; j++)
-                    memcpy(rec_buffer + j * candidateBuffer->recon_ptr->stride_y, pred_buffer + j * candidateBuffer->prediction_ptr->stride_y, context_ptr->blk_geom->tx_width[tx_depth][txb_itr]);
-
-                av1_inv_transform_recon8bit(
-                    &(((int32_t*)candidateBuffer->recon_coeff_ptr->buffer_y)[txb_1d_offset]),
-                    rec_buffer,
+                inv_transform_recon_copy(
+                    candidateBuffer->prediction_ptr->buffer_y,
+                    tu_origin_index,
+                    candidateBuffer->prediction_ptr->stride_y,
+                    candidateBuffer->recon_ptr->buffer_y,
+                    tu_origin_index,
                     candidateBuffer->recon_ptr->stride_y,
+                    (int32_t*) candidateBuffer->recon_coeff_ptr->buffer_y,
+                    txb_1d_offset,
+                    context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
+                    context_ptr->blk_geom->tx_height[tx_depth][txb_itr],
+                    picture_control_set_ptr->hbd_mode_decision,
                     context_ptr->blk_geom->txsize[tx_depth][txb_itr],
                     candidateBuffer->candidate_ptr->transform_type[txb_itr],
                     PLANE_TYPE_Y,
-                    (uint16_t)candidateBuffer->candidate_ptr->eob[0][txb_itr]);
-            }
-            else {
-                picture_copy8_bit(
+                    (uint32_t)candidateBuffer->candidate_ptr->eob[0][txb_itr]);
+            } else {
+                picture_copy(
                     candidateBuffer->prediction_ptr,
                     tu_origin_index,
                     0,
@@ -2139,12 +2138,21 @@ void product_full_loop(
                     0,
                     0,
                     PICTURE_BUFFER_DESC_Y_FLAG,
+                    picture_control_set_ptr->hbd_mode_decision,
                     asm_type);
             }
-            tuFullDistortion[0][DIST_CALC_PREDICTION] = spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                input_picture_ptr->buffer_y + input_tu_origin_index,
+            }
+
+            EbSpatialFullDistType spatial_full_dist_type_fun = picture_control_set_ptr->hbd_mode_decision ?
+                full_distortion_kernel16_bits :
+                spatial_full_distortion_kernel_func_ptr_array[asm_type];
+
+            tuFullDistortion[0][DIST_CALC_PREDICTION] = spatial_full_dist_type_fun(
+                input_picture_ptr->buffer_y,
+                input_tu_origin_index,
                 input_picture_ptr->stride_y,
-                candidateBuffer->prediction_ptr->buffer_y + tu_origin_index,
+                candidateBuffer->prediction_ptr->buffer_y,
+                tu_origin_index,
                 candidateBuffer->prediction_ptr->stride_y,
 #if INCOMPLETE_SB_FIX
                 cropped_tx_width,
@@ -2153,10 +2161,13 @@ void product_full_loop(
                 context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
                 context_ptr->blk_geom->tx_height[tx_depth][txb_itr]);
 #endif
-            tuFullDistortion[0][DIST_CALC_RESIDUAL] = spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                input_picture_ptr->buffer_y + input_tu_origin_index,
+
+            tuFullDistortion[0][DIST_CALC_RESIDUAL] = spatial_full_dist_type_fun(
+                input_picture_ptr->buffer_y,
+                input_tu_origin_index,
                 input_picture_ptr->stride_y,
-                &(((uint8_t*)candidateBuffer->recon_ptr->buffer_y)[tu_origin_index]),
+                candidateBuffer->recon_ptr->buffer_y,
+                tu_origin_index,
                 candidateBuffer->recon_ptr->stride_y,
 #if INCOMPLETE_SB_FIX
                 cropped_tx_width,
@@ -2367,7 +2378,7 @@ void product_full_loop_tx_search(
                 context_ptr->blk_geom->txsize[tx_depth][txb_itr],
                 &context_ptr->three_quad_energy,
                 context_ptr->transform_inner_array_ptr,
-                0,
+                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 tx_type,
                 asm_type,
                 PLANE_TYPE_Y,
@@ -2385,7 +2396,6 @@ void product_full_loop_tx_search(
                 &(((int32_t*)candidateBuffer->recon_coeff_ptr->buffer_y)[tu_origin_index]),
                 context_ptr->cu_ptr->qp,
                 seg_qp,
-
                 context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
                 context_ptr->blk_geom->tx_height[tx_depth][txb_itr],
                 context_ptr->blk_geom->txsize[tx_depth][txb_itr],
@@ -2393,7 +2403,7 @@ void product_full_loop_tx_search(
                 asm_type,
                 &yCountNonZeroCoeffsTemp,
                 COMPONENT_LUMA,
-                BIT_INCREMENT_8BIT,
+                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 tx_type,
                 candidateBuffer,
                 context_ptr->luma_txb_skip_context,
@@ -2408,28 +2418,25 @@ void product_full_loop_tx_search(
 
 
             if (context_ptr->spatial_sse_full_loop) {
-                if (yCountNonZeroCoeffsTemp) {
-
-                    uint8_t *pred_buffer = &(candidateBuffer->prediction_ptr->buffer_y[tu_origin_index]);
-                    uint8_t *rec_buffer = &(candidateBuffer->recon_ptr->buffer_y[tu_origin_index]);
-
-                    uint32_t j;
-                    for (j = 0; j < context_ptr->blk_geom->tx_height[tx_depth][txb_itr]; j++)
-                        memcpy(rec_buffer + j * candidateBuffer->recon_ptr->stride_y, pred_buffer + j * candidateBuffer->prediction_ptr->stride_y, context_ptr->blk_geom->tx_width[tx_depth][txb_itr]);
-
-                    av1_inv_transform_recon8bit(
-                        &(((int32_t*)candidateBuffer->recon_coeff_ptr->buffer_y)[tu_origin_index]),
-                        rec_buffer,
+                if (yCountNonZeroCoeffsTemp)
+                    inv_transform_recon_copy(
+                        candidateBuffer->prediction_ptr->buffer_y,
+                        tu_origin_index,
+                        candidateBuffer->prediction_ptr->stride_y,
+                        candidateBuffer->recon_ptr->buffer_y,
+                        tu_origin_index,
                         candidateBuffer->recon_ptr->stride_y,
+                        (int32_t*) candidateBuffer->recon_coeff_ptr->buffer_y,
+                        tu_origin_index,
+                        context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
+                        context_ptr->blk_geom->tx_height[tx_depth][txb_itr],
+                        picture_control_set_ptr->hbd_mode_decision,
                         context_ptr->blk_geom->txsize[tx_depth][txb_itr],
                         tx_type,
                         PLANE_TYPE_Y,
                         (uint16_t)candidateBuffer->candidate_ptr->eob[0][txb_itr]);
-
-                }
-                else {
-
-                    picture_copy8_bit(
+                else
+                    picture_copy(
                         candidateBuffer->prediction_ptr,
                         tu_origin_index,
                         0,
@@ -2441,23 +2448,32 @@ void product_full_loop_tx_search(
                         0,
                         0,
                         PICTURE_BUFFER_DESC_Y_FLAG,
+                        picture_control_set_ptr->hbd_mode_decision,
                         asm_type);
-                }
-                EbPictureBufferDesc *input_picture_ptr = picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
+
+                EbPictureBufferDesc *input_picture_ptr = picture_control_set_ptr->hbd_mode_decision ?
+                    picture_control_set_ptr->input_frame16bit : picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
                 uint32_t input_tu_origin_index = (context_ptr->sb_origin_x + txb_origin_x + input_picture_ptr->origin_x) + ((context_ptr->sb_origin_y + txb_origin_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_y);
 
-                tuFullDistortion[0][DIST_CALC_PREDICTION] = spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                    input_picture_ptr->buffer_y + input_tu_origin_index,
+                EbSpatialFullDistType spatial_full_dist_type_fun = picture_control_set_ptr->hbd_mode_decision ?
+                    full_distortion_kernel16_bits : spatial_full_distortion_kernel_func_ptr_array[asm_type];
+
+                tuFullDistortion[0][DIST_CALC_PREDICTION] = spatial_full_dist_type_fun(
+                    input_picture_ptr->buffer_y,
+                    input_tu_origin_index,
                     input_picture_ptr->stride_y,
-                    candidateBuffer->prediction_ptr->buffer_y + tu_origin_index,
+                    candidateBuffer->prediction_ptr->buffer_y,
+                    tu_origin_index,
                     candidateBuffer->prediction_ptr->stride_y,
                     context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
                     context_ptr->blk_geom->tx_height[tx_depth][txb_itr]);
 
-                tuFullDistortion[0][DIST_CALC_RESIDUAL] = spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                    input_picture_ptr->buffer_y + input_tu_origin_index,
+                tuFullDistortion[0][DIST_CALC_RESIDUAL] = spatial_full_dist_type_fun(
+                    input_picture_ptr->buffer_y,
+                    input_tu_origin_index,
                     input_picture_ptr->stride_y,
-                    &(((uint8_t*)candidateBuffer->recon_ptr->buffer_y)[tu_origin_index]),
+                    candidateBuffer->recon_ptr->buffer_y,
+                    tu_origin_index,
                     candidateBuffer->recon_ptr->stride_y,
                     context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
                     context_ptr->blk_geom->tx_height[tx_depth][txb_itr]);
@@ -2953,6 +2969,58 @@ void encode_pass_tx_search_hbd(
     if (is_inter)
         txb_ptr->transform_type[PLANE_TYPE_UV] = txb_ptr->transform_type[PLANE_TYPE_Y];
 }
+
+void inv_transform_recon_copy(
+    uint8_t    *pred_buffer,
+    uint32_t    pred_offset,
+    uint32_t    pred_stride,
+    uint8_t    *rec_buffer,
+    uint32_t    rec_offset,
+    uint32_t    rec_stride,
+    int32_t    *rec_coeff_buffer,
+    uint32_t    coeff_offset,
+    uint32_t    width,
+    uint32_t    height,
+    EbBool      hbd,
+    TxSize      txsize,
+    TxType      transform_type,
+    PlaneType   component_type,
+    uint32_t    eob)
+{
+    if (hbd) {
+        uint16_t *pred_buffer_off = ((uint16_t*) pred_buffer) + pred_offset;
+        uint16_t *rec_buffer_off = ((uint16_t*) rec_buffer) + rec_offset;
+
+        for (uint32_t j = 0; j < height; j++)
+            memcpy(rec_buffer_off + j * rec_stride, pred_buffer_off + j * pred_stride, sizeof(uint16_t) * width);
+
+        av1_inv_transform_recon(
+            rec_coeff_buffer + coeff_offset,
+            CONVERT_TO_BYTEPTR(rec_buffer_off),
+            rec_stride,
+            txsize,
+            BIT_INCREMENT_10BIT,
+            transform_type,
+            component_type,
+            eob);
+    } else {
+        uint8_t *pred_buffer_off = pred_buffer + pred_offset;
+        uint8_t *rec_buffer_off = rec_buffer + rec_offset;
+
+        for (uint32_t j = 0; j < height; j++)
+            memcpy(rec_buffer_off + j * rec_stride, pred_buffer_off + j * pred_stride, width);
+
+        av1_inv_transform_recon8bit(
+            rec_coeff_buffer + coeff_offset,
+            rec_buffer_off,
+            rec_stride,
+            txsize,
+            transform_type,
+            component_type,
+            eob);
+    }
+}
+
 /****************************************
  ************  Full loop ****************
 ****************************************/
@@ -3051,7 +3119,7 @@ void full_loop_r(
                 context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr],
                 &context_ptr->three_quad_energy,
                 context_ptr->transform_inner_array_ptr,
-                0,
+                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 candidateBuffer->candidate_ptr->transform_type_uv,
                 asm_type,
                 PLANE_TYPE_UV,
@@ -3075,7 +3143,7 @@ void full_loop_r(
                 asm_type,
                 &(cb_count_non_zero_coeffs[txb_itr]),
                 COMPONENT_CHROMA_CB,
-                BIT_INCREMENT_8BIT,
+                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 candidateBuffer->candidate_ptr->transform_type_uv,
                 candidateBuffer,
                 0,
@@ -3087,26 +3155,25 @@ void full_loop_r(
             if (context_ptr->spatial_sse_full_loop) {
                 uint32_t cb_has_coeff = cb_count_non_zero_coeffs[txb_itr] > 0;
 
-                if (cb_has_coeff) {
-                    uint8_t     *pred_buffer = &(candidateBuffer->prediction_ptr->buffer_cb[tuCbOriginIndex]);
-                    uint8_t     *rec_buffer = &(candidateBuffer->recon_ptr->buffer_cb[tuCbOriginIndex]);
-
-                    uint32_t j;
-
-                    for (j = 0; j < context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr]; j++)
-                        memcpy(rec_buffer + j * candidateBuffer->recon_ptr->stride_cb, pred_buffer + j * candidateBuffer->prediction_ptr->stride_cb, context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr]);
-
-                    av1_inv_transform_recon8bit(
-                        &(((int32_t*)candidateBuffer->recon_coeff_ptr->buffer_cb)[txb_1d_offset]),
-                        rec_buffer,
+                if (cb_has_coeff)
+                    inv_transform_recon_copy(
+                        candidateBuffer->prediction_ptr->buffer_cb,
+                        tuCbOriginIndex,
+                        candidateBuffer->prediction_ptr->stride_cb,
+                        candidateBuffer->recon_ptr->buffer_cb,
+                        tuCbOriginIndex,
                         candidateBuffer->recon_ptr->stride_cb,
+                        (int32_t*) candidateBuffer->recon_coeff_ptr->buffer_cb,
+                        txb_1d_offset,
+                        context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
+                        context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr],
+                        picture_control_set_ptr->hbd_mode_decision,
                         context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr],
                         candidateBuffer->candidate_ptr->transform_type_uv,
                         PLANE_TYPE_UV,
-                        (uint16_t)candidateBuffer->candidate_ptr->eob[1][txb_itr]);
-                }
-                else {
-                    picture_copy8_bit(
+                        (uint32_t)candidateBuffer->candidate_ptr->eob[1][txb_itr]);
+                else
+                    picture_copy(
                         candidateBuffer->prediction_ptr,
                         0,
                         tuCbOriginIndex,
@@ -3118,8 +3185,8 @@ void full_loop_r(
                         context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
                         context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr],
                         PICTURE_BUFFER_DESC_Cb_FLAG,
+                        picture_control_set_ptr->hbd_mode_decision,
                         asm_type);
-                }
             }
         }
 
@@ -3139,7 +3206,7 @@ void full_loop_r(
                 context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr],
                 &context_ptr->three_quad_energy,
                 context_ptr->transform_inner_array_ptr,
-                0,
+                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 candidateBuffer->candidate_ptr->transform_type_uv,
                 asm_type,
                 PLANE_TYPE_UV,
@@ -3163,7 +3230,7 @@ void full_loop_r(
                 asm_type,
                 &(cr_count_non_zero_coeffs[txb_itr]),
                 COMPONENT_CHROMA_CR,
-                BIT_INCREMENT_8BIT,
+                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 candidateBuffer->candidate_ptr->transform_type_uv,
                 candidateBuffer,
                 0,
@@ -3174,25 +3241,26 @@ void full_loop_r(
 
             if (context_ptr->spatial_sse_full_loop) {
                 uint32_t cr_has_coeff = cr_count_non_zero_coeffs[txb_itr] > 0;
-                if (cr_has_coeff) {
-                    uint8_t     *pred_buffer = &(candidateBuffer->prediction_ptr->buffer_cr[tuCbOriginIndex]);
-                    uint8_t     *rec_buffer = &(candidateBuffer->recon_ptr->buffer_cr[tuCbOriginIndex]);
 
-                    uint32_t j;
-                    for (j = 0; j < context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr]; j++)
-                        memcpy(rec_buffer + j * candidateBuffer->recon_ptr->stride_cr, pred_buffer + j * candidateBuffer->prediction_ptr->stride_cr, context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr]);
-
-                    av1_inv_transform_recon8bit(
-                        &(((int32_t*)candidateBuffer->recon_coeff_ptr->buffer_cr)[txb_1d_offset]),
-                        rec_buffer,
+                if (cr_has_coeff)
+                    inv_transform_recon_copy(
+                        candidateBuffer->prediction_ptr->buffer_cr,
+                        tuCrOriginIndex,
+                        candidateBuffer->prediction_ptr->stride_cr,
+                        candidateBuffer->recon_ptr->buffer_cr,
+                        tuCrOriginIndex,
                         candidateBuffer->recon_ptr->stride_cr,
+                        (int32_t*) candidateBuffer->recon_coeff_ptr->buffer_cr,
+                        txb_1d_offset,
+                        context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
+                        context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr],
+                        picture_control_set_ptr->hbd_mode_decision,
                         context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr],
                         candidateBuffer->candidate_ptr->transform_type_uv,
                         PLANE_TYPE_UV,
-                        (uint16_t)candidateBuffer->candidate_ptr->eob[2][txb_itr]);
-                }
-                else {
-                    picture_copy8_bit(
+                        (uint32_t)candidateBuffer->candidate_ptr->eob[2][txb_itr]);
+                else
+                    picture_copy(
                         candidateBuffer->prediction_ptr,
                         0,
                         tuCbOriginIndex,
@@ -3204,10 +3272,11 @@ void full_loop_r(
                         context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
                         context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr],
                         PICTURE_BUFFER_DESC_Cr_FLAG,
+                        picture_control_set_ptr->hbd_mode_decision,
                         asm_type);
-                }
             }
         }
+
         txb_1d_offset += context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr] * context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr];
 
         ++txb_itr;
@@ -3223,6 +3292,7 @@ void cu_full_distortion_fast_tu_mode_r(
     ModeDecisionContext          *context_ptr,
     ModeDecisionCandidate        *candidate_ptr,
     PictureControlSet            *picture_control_set_ptr,
+    EbPictureBufferDesc          *input_picture_ptr,
     uint64_t                      cbFullDistortion[DIST_CALC_TOTAL],
     uint64_t                      crFullDistortion[DIST_CALC_TOTAL],
     uint32_t                      count_non_zero_coeffs[3][MAX_NUM_OF_TU_PER_CU],
@@ -3277,14 +3347,18 @@ void cu_full_distortion_fast_tu_mode_r(
             countNonZeroCoeffsAll[2] = count_non_zero_coeffs[2][currentTuIndex];
 
             if (is_full_loop && context_ptr->spatial_sse_full_loop) {
-                EbPictureBufferDesc          *input_picture_ptr = picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
                 uint32_t input_chroma_tu_origin_index = (((context_ptr->sb_origin_y + ((txb_origin_y >> 3) << 3)) >> 1) + (input_picture_ptr->origin_y >> 1)) * input_picture_ptr->stride_cb + (((context_ptr->sb_origin_x + ((txb_origin_x >> 3) << 3)) >> 1) + (input_picture_ptr->origin_x >> 1));
                 uint32_t tu_uv_origin_index = (((txb_origin_x >> 3) << 3) + (((txb_origin_y >> 3) << 3) * candidateBuffer->residual_quant_coeff_ptr->stride_cb)) >> 1;
 
-                tuFullDistortion[1][DIST_CALC_PREDICTION] = spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                    input_picture_ptr->buffer_cb + input_chroma_tu_origin_index,
+                EbSpatialFullDistType spatial_full_dist_type_fun = picture_control_set_ptr->hbd_mode_decision ?
+                    full_distortion_kernel16_bits : spatial_full_distortion_kernel_func_ptr_array[asm_type];
+
+                tuFullDistortion[1][DIST_CALC_PREDICTION] = spatial_full_dist_type_fun(
+                    input_picture_ptr->buffer_cb,
+                    input_chroma_tu_origin_index,
                     input_picture_ptr->stride_cb,
-                    candidateBuffer->prediction_ptr->buffer_cb + tu_uv_origin_index,
+                    candidateBuffer->prediction_ptr->buffer_cb,
+                    tu_uv_origin_index,
                     candidateBuffer->prediction_ptr->stride_cb,
 #if INCOMPLETE_SB_FIX
                     cropped_tx_width_uv,
@@ -3294,10 +3368,12 @@ void cu_full_distortion_fast_tu_mode_r(
                     context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr]);
 #endif
 
-                tuFullDistortion[1][DIST_CALC_RESIDUAL] = spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                    input_picture_ptr->buffer_cb + input_chroma_tu_origin_index,
+                tuFullDistortion[1][DIST_CALC_RESIDUAL] = spatial_full_dist_type_fun(
+                    input_picture_ptr->buffer_cb,
+                    input_chroma_tu_origin_index,
                     input_picture_ptr->stride_cb,
-                    &(((uint8_t*)candidateBuffer->recon_ptr->buffer_cb)[tu_uv_origin_index]),
+                    candidateBuffer->recon_ptr->buffer_cb,
+                    tu_uv_origin_index,
                     candidateBuffer->recon_ptr->stride_cb,
 #if INCOMPLETE_SB_FIX
                     cropped_tx_width_uv,
@@ -3307,10 +3383,12 @@ void cu_full_distortion_fast_tu_mode_r(
                     context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr]);
 #endif
 
-                tuFullDistortion[2][DIST_CALC_PREDICTION] = spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                    input_picture_ptr->buffer_cr + input_chroma_tu_origin_index,
+                tuFullDistortion[2][DIST_CALC_PREDICTION] = spatial_full_dist_type_fun(
+                    input_picture_ptr->buffer_cr,
+                    input_chroma_tu_origin_index,
                     input_picture_ptr->stride_cr,
-                    candidateBuffer->prediction_ptr->buffer_cr + tu_uv_origin_index,
+                    candidateBuffer->prediction_ptr->buffer_cr,
+                    tu_uv_origin_index,
                     candidateBuffer->prediction_ptr->stride_cr,
 #if INCOMPLETE_SB_FIX
                     cropped_tx_width_uv,
@@ -3320,10 +3398,12 @@ void cu_full_distortion_fast_tu_mode_r(
                     context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr]);
 #endif
 
-                tuFullDistortion[2][DIST_CALC_RESIDUAL] = spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                    input_picture_ptr->buffer_cr + input_chroma_tu_origin_index,
+                tuFullDistortion[2][DIST_CALC_RESIDUAL] = spatial_full_dist_type_fun(
+                    input_picture_ptr->buffer_cr,
+                    input_chroma_tu_origin_index,
                     input_picture_ptr->stride_cr,
-                    &(((uint8_t*)candidateBuffer->recon_ptr->buffer_cr)[tu_uv_origin_index]),
+                    candidateBuffer->recon_ptr->buffer_cr,
+                    tu_uv_origin_index,
                     candidateBuffer->recon_ptr->stride_cr,
 #if INCOMPLETE_SB_FIX
                     cropped_tx_width_uv,

--- a/Source/Lib/Common/Codec/EbFullLoop.c
+++ b/Source/Lib/Common/Codec/EbFullLoop.c
@@ -2141,7 +2141,6 @@ void product_full_loop(
                     picture_control_set_ptr->hbd_mode_decision,
                     asm_type);
             }
-            }
 
             EbSpatialFullDistType spatial_full_dist_type_fun = picture_control_set_ptr->hbd_mode_decision ?
                 full_distortion_kernel16_bits :

--- a/Source/Lib/Common/Codec/EbFullLoop.h
+++ b/Source/Lib/Common/Codec/EbFullLoop.h
@@ -29,6 +29,7 @@ extern "C" {
         ModeDecisionContext            *context_ptr,
         ModeDecisionCandidate           *candidate_ptr,
         PictureControlSet            *picture_control_set_ptr,
+        EbPictureBufferDesc          *input_picture_ptr,
         uint64_t                          cbFullDistortion[DIST_CALC_TOTAL],
         uint64_t                          crFullDistortion[DIST_CALC_TOTAL],
         uint32_t                          count_non_zero_coeffs[3][MAX_NUM_OF_TU_PER_CU],
@@ -42,15 +43,34 @@ extern "C" {
         ModeDecisionCandidateBuffer  *candidateBuffer,
         ModeDecisionContext          *context_ptr,
         PictureControlSet            *picture_control_set_ptr,
-        uint32_t                          qp,
-        uint32_t                           *y_count_non_zero_coeffs,
-        uint64_t                         *y_coeff_bits,
-        uint64_t                         *y_full_distortion);
+        EbPictureBufferDesc          *input_picture_ptr,
+        uint32_t                      qp,
+        uint32_t                     *y_count_non_zero_coeffs,
+        uint64_t                     *y_coeff_bits,
+        uint64_t                     *y_full_distortion);
 
     void product_full_loop_tx_search(
         ModeDecisionCandidateBuffer  *candidateBuffer,
         ModeDecisionContext          *context_ptr,
         PictureControlSet            *picture_control_set_ptr);
+
+    void inv_transform_recon_copy(
+        uint8_t    *pred_buffer,
+        uint32_t    pred_offset,
+        uint32_t    pred_stride,
+        uint8_t    *rec_buffer,
+        uint32_t    rec_offset,
+        uint32_t    rec_stride,
+        int32_t    *rec_coeff_buffer,
+        uint32_t    coeff_offset,
+        uint32_t    width,
+        uint32_t    height,
+        EbBool      hbd,
+        TxSize      txsize,
+        TxType      transform_type,
+        PlaneType   component_type,
+        uint32_t    eob);
+
     extern uint32_t d2_inter_depth_block_decision(
         ModeDecisionContext          *context_ptr,
         uint32_t                        blk_mds,

--- a/Source/Lib/Common/Codec/EbIntraPrediction.h
+++ b/Source/Lib/Common/Codec/EbIntraPrediction.h
@@ -754,6 +754,58 @@ cfl_subtract_average_fn get_subtract_average_fn_c(TxSize tx_size);
         return sub_avg[tx_size % TX_SIZES_ALL];                                 \
       }
 
+void av1_predict_intra_block(
+    TileInfo *tile,
+    STAGE stage,
+    const BlockGeom *blk_geom,
+    const Av1Common *cm,
+    int32_t wpx,
+    int32_t hpx,
+    TxSize tx_size,
+    PredictionMode mode,
+    int32_t angle_delta,
+    int32_t use_palette,
+    FilterIntraMode filter_intra_mode,
+    uint8_t* topNeighArray,
+    uint8_t* leftNeighArray,
+    EbPictureBufferDesc *recon_buffer,
+    int32_t col_off,
+    int32_t row_off,
+    int32_t plane,
+    BlockSize bsize,
+    uint32_t tu_org_x_pict,
+    uint32_t tu_org_y_pict,
+    uint32_t bl_org_x_pict,
+    uint32_t bl_org_y_pict,
+    uint32_t bl_org_x_mb,
+    uint32_t bl_org_y_mb);
+
+void av1_predict_intra_block_16bit(
+    TileInfo * tile,
+    STAGE stage,
+    const BlockGeom * blk_geom,
+    const Av1Common *cm,
+    int32_t wpx,
+    int32_t hpx,
+    TxSize tx_size,
+    PredictionMode mode,
+    int32_t angle_delta,
+    int32_t use_palette,
+    FilterIntraMode filter_intra_mode,
+    uint16_t* topNeighArray,
+    uint16_t* leftNeighArray,
+    EbPictureBufferDesc  *recon_buffer,
+    int32_t col_off,
+    int32_t row_off,
+    int32_t plane,
+    BlockSize bsize,
+    uint32_t tu_org_x_pict,
+    uint32_t tu_org_y_pict,
+    uint32_t bl_org_x_pict,
+    uint32_t bl_org_y_pict,
+    uint32_t bl_org_x_mb,
+    uint32_t bl_org_y_mb);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -177,6 +177,7 @@ static void mode_decision_candidate_buffer_dctor(EbPtr p)
 ***************************************/
 EbErrorType mode_decision_candidate_buffer_ctor(
     ModeDecisionCandidateBuffer    *buffer_ptr,
+    EbBitDepthEnum                  max_bitdepth,
     uint64_t                       *fast_cost_ptr,
     uint64_t                       *full_cost_ptr,
     uint64_t                       *full_cost_skip_ptr,
@@ -193,7 +194,7 @@ EbErrorType mode_decision_candidate_buffer_ctor(
     // Init Picture Data
     pictureBufferDescInitData.max_width = MAX_SB_SIZE;
     pictureBufferDescInitData.max_height = MAX_SB_SIZE;
-    pictureBufferDescInitData.bit_depth = EB_8BIT;
+    pictureBufferDescInitData.bit_depth = max_bitdepth;
     pictureBufferDescInitData.color_format = EB_YUV420;
     pictureBufferDescInitData.buffer_enable_mask = PICTURE_BUFFER_DESC_FULL_MASK;
     pictureBufferDescInitData.left_padding = 0;
@@ -232,7 +233,6 @@ EbErrorType mode_decision_candidate_buffer_ctor(
         eb_picture_buffer_desc_ctor,
         (EbPtr)&pictureBufferDescInitData);
 
-    // Video Buffers
     EB_NEW(
         buffer_ptr->prediction_ptr_temp,
         eb_picture_buffer_desc_ctor,

--- a/Source/Lib/Common/Codec/EbModeDecision.h
+++ b/Source/Lib/Common/Codec/EbModeDecision.h
@@ -252,6 +252,7 @@ extern "C" {
     **************************************/
     extern EbErrorType mode_decision_candidate_buffer_ctor(
         ModeDecisionCandidateBuffer    *buffer_ptr,
+        EbBitDepthEnum                  max_bitdepth,
         uint64_t                       *fast_cost_ptr,
         uint64_t                       *full_cost_ptr,
         uint64_t                       *full_cost_skip_ptr,

--- a/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
@@ -1774,7 +1774,7 @@ void* mode_decision_configuration_kernel(void *input_ptr)
         Quants *const quantsMd = &picture_control_set_ptr->parent_pcs_ptr->quantsMd;
         Dequants *const dequantsMd = &picture_control_set_ptr->parent_pcs_ptr->deqMd;
         av1_build_quantizer(
-            (AomBitDepth)8,
+            picture_control_set_ptr->hbd_mode_decision ? AOM_BITS_10 : AOM_BITS_8,
             picture_control_set_ptr->parent_pcs_ptr->y_dc_delta_q,
             picture_control_set_ptr->parent_pcs_ptr->u_dc_delta_q,
             picture_control_set_ptr->parent_pcs_ptr->u_ac_delta_q,

--- a/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
@@ -1802,7 +1802,8 @@ void* mode_decision_configuration_kernel(void *input_ptr)
             &lambdaSad,
             &lambdaSse,
             (uint8_t)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
-            context_ptr->qp_index);
+            context_ptr->qp_index,
+            picture_control_set_ptr->hbd_mode_decision);
         context_ptr->lambda = (uint64_t)lambdaSad;
 
         // Slice Type

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.c
@@ -328,8 +328,8 @@ void Av1lambdaAssign(
     uint32_t                    *fast_chroma_lambda,
     uint32_t                    *full_chroma_lambda,
     uint8_t                      bit_depth,
-    uint16_t                     qp_index)
-
+    uint16_t                     qp_index,
+    EbBool                       hbd_mode_decision)
 {
     if (bit_depth == 8) {
         *full_lambda = av1_lambda_mode_decision8_bit_sse[qp_index];
@@ -338,6 +338,10 @@ void Av1lambdaAssign(
     else if (bit_depth == 10) {
         *full_lambda = av1lambda_mode_decision10_bit_sse[qp_index];
         *fast_lambda = av1lambda_mode_decision10_bit_sad[qp_index];
+        if (hbd_mode_decision) {
+            *full_lambda *= 16;
+            *fast_lambda *= 4;
+        }
     }
     else if (bit_depth == 12) {
         *full_lambda = av1lambda_mode_decision12_bit_sse[qp_index];
@@ -388,7 +392,8 @@ void reset_mode_decision(
         &context_ptr->fast_chroma_lambda,
         &context_ptr->full_chroma_lambda,
         (uint8_t)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
-        context_ptr->qp_index);
+        context_ptr->qp_index,
+        picture_control_set_ptr->hbd_mode_decision);
     // Slice Type
     slice_type =
         (picture_control_set_ptr->parent_pcs_ptr->idr_flag == EB_TRUE) ? I_SLICE :
@@ -474,7 +479,8 @@ void mode_decision_configure_lcu(
         &context_ptr->fast_chroma_lambda,
         &context_ptr->full_chroma_lambda,
         (uint8_t)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
-        context_ptr->qp_index);
+        context_ptr->qp_index,
+        picture_control_set_ptr->hbd_mode_decision);
 
     return;
 }

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.c
@@ -69,6 +69,13 @@ EbErrorType mode_decision_context_ctor(
     // Trasform Scratch Memory
     EB_MALLOC(context_ptr->transform_inner_array_ptr, 3120); //refer to EbInvTransform_SSE2.as. case 32x32
 
+    // Cfl scratch memory
+    if (context_ptr->hbd_mode_decision) {
+        EB_ALLIGN_MALLOC(uint16_t *, context_ptr->cfl_temp_luma_recon16bit, sizeof(uint16_t) * 128 * 128, EB_A_PTR);
+    } else {
+        EB_ALLIGN_MALLOC(uint8_t *, context_ptr->cfl_temp_luma_recon, sizeof(uint8_t) * 128 * 128, EB_A_PTR);
+    }
+
     // MD rate Estimation tables
     EB_MALLOC_ARRAY(context_ptr->md_rate_estimation_ptr, 1);
     context_ptr->is_md_rate_estimation_ptr_owner = EB_TRUE;

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -235,7 +235,8 @@ extern "C" {
         uint8_t                         bipred3x3_injection;
         uint8_t                         interpolation_filter_search_blk_size;
         uint8_t                         redundant_blk;
-        uint8_t                         cfl_temp_luma_recon[2 * 128 * 128];
+        uint8_t                         *cfl_temp_luma_recon;
+        uint16_t                        *cfl_temp_luma_recon16bit;
         EbBool                          spatial_sse_full_loop;
         EbBool                          blk_skip_decision;
         EbBool                          trellis_quant_coeff_optimization;

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -103,6 +103,10 @@ extern "C" {
         NeighborArrayUnit            *cb_recon_neighbor_array;
         NeighborArrayUnit            *cr_recon_neighbor_array;
         NeighborArrayUnit            *tx_search_luma_recon_neighbor_array;
+        NeighborArrayUnit            *luma_recon_neighbor_array16bit;
+        NeighborArrayUnit            *cb_recon_neighbor_array16bit;
+        NeighborArrayUnit            *cr_recon_neighbor_array16bit;
+        NeighborArrayUnit            *tx_search_luma_recon_neighbor_array16bit;
         NeighborArrayUnit            *skip_coeff_neighbor_array;
         NeighborArrayUnit            *luma_dc_sign_level_coeff_neighbor_array; // Stored per 4x4. 8 bit: lower 6 bits (COEFF_CONTEXT_BITS), shows if there is at least one Coef. Top 2 bit store the sign of DC as follow: 0->0,1->-1,2-> 1
         NeighborArrayUnit            *tx_search_luma_dc_sign_level_coeff_neighbor_array; // Stored per 4x4. 8 bit: lower 6 bits (COEFF_CONTEXT_BITS), shows if there is at least one Coef. Top 2 bit store the sign of DC as follow: 0->0,1->-1,2-> 1
@@ -165,6 +169,7 @@ extern "C" {
         EbPfMode                        pf_md_mode;
         uint32_t                        full_recon_search_count;
         EbBool                          cu_use_ref_src_flag;
+        EbBool                          hbd_mode_decision;
         uint16_t                        qp_index;
         uint64_t                        three_quad_energy;
         EbBool                          uv_search_path;
@@ -230,11 +235,11 @@ extern "C" {
         uint8_t                         bipred3x3_injection;
         uint8_t                         interpolation_filter_search_blk_size;
         uint8_t                         redundant_blk;
-        uint8_t                          cfl_temp_luma_recon[128 * 128];
+        uint8_t                         cfl_temp_luma_recon[2 * 128 * 128];
         EbBool                          spatial_sse_full_loop;
         EbBool                          blk_skip_decision;
         EbBool                          trellis_quant_coeff_optimization;
-
+        EbPictureBufferDesc                 *input_sample16bit_buffer;
     } ModeDecisionContext;
 
     typedef void(*EbAv1LambdaAssignFunc)(
@@ -262,7 +267,8 @@ extern "C" {
         ModeDecisionContext       *context_ptr,
         EbColorFormat              color_format,
         EbFifo                    *mode_decision_configuration_input_fifo_ptr,
-        EbFifo                    *mode_decision_output_fifo_ptr);
+        EbFifo                    *mode_decision_output_fifo_ptr,
+        EbBool                     enable_hbd_mode_decision);
 
     extern void reset_mode_decision_neighbor_arrays(
         PictureControlSet *picture_control_set_ptr);

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -249,7 +249,8 @@ extern "C" {
         uint32_t                    *fast_chroma_lambda,
         uint32_t                    *full_chroma_lambda,
         uint8_t                      bit_depth,
-        uint16_t                     qp_index);
+        uint16_t                     qp_index,
+        EbBool                       hbd_mode_decision);
 
     typedef void(*EbLambdaAssignFunc)(
         uint32_t                    *fast_lambda,

--- a/Source/Lib/Common/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimation.c
@@ -4274,9 +4274,11 @@ static void half_pel_refinement_block(
     if (context_ptr->fractional_search_method == SSD_SEARCH) {
         uint32_t integer_sse =
             (uint32_t)spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                    &(context_ptr->sb_src_ptr[src_block_index]),
+                    context_ptr->sb_src_ptr,
+                    src_block_index,
                     context_ptr->sb_src_stride,
-                    &(ref_buffer[search_index_y * ref_stride + search_index_x]),
+                    ref_buffer,
+                    search_index_y * ref_stride + search_index_x,
                     ref_stride,
                     pu_width,
                     pu_height);
@@ -4292,9 +4294,11 @@ static void half_pel_refinement_block(
     distortion_left_position =
         (context_ptr->fractional_search_method == SSD_SEARCH)
             ? spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                      &(context_ptr->sb_src_ptr[src_block_index]),
+                      context_ptr->sb_src_ptr,
+                      src_block_index,
                       context_ptr->sb_src_stride,
-                      &(pos_b_buffer[search_region_index]),
+                      pos_b_buffer,
+                      search_region_index,
                       context_ptr->interpolated_stride,
                       pu_width,
                       pu_height)
@@ -4392,9 +4396,11 @@ static void half_pel_refinement_block(
     distortion_top_position =
         (context_ptr->fractional_search_method == SSD_SEARCH)
             ? spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                      &(context_ptr->sb_src_ptr[src_block_index]),
+                      context_ptr->sb_src_ptr,
+                      src_block_index,
                       context_ptr->sb_src_stride,
-                      &(pos_h_buffer[search_region_index]),
+                      pos_h_buffer,
+                      search_region_index,
                       context_ptr->interpolated_stride,
                       pu_width,
                       pu_height)
@@ -4492,9 +4498,11 @@ static void half_pel_refinement_block(
     distortion_topleft_position =
         (context_ptr->fractional_search_method == SSD_SEARCH)
             ? spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                      &(context_ptr->sb_src_ptr[src_block_index]),
+                      context_ptr->sb_src_ptr,
+                      src_block_index,
                       context_ptr->sb_src_stride,
-                      &(pos_j_buffer[search_region_index]),
+                      pos_j_buffer,
+                      search_region_index,
                       context_ptr->interpolated_stride,
                       pu_width,
                       pu_height)
@@ -4540,9 +4548,11 @@ static void half_pel_refinement_block(
     distortion_topright_position =
         (context_ptr->fractional_search_method == SSD_SEARCH)
             ? spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                      &(context_ptr->sb_src_ptr[src_block_index]),
+                      context_ptr->sb_src_ptr,
+                      src_block_index,
                       context_ptr->sb_src_stride,
-                      &(pos_j_buffer[search_region_index]),
+                      pos_j_buffer,
+                      search_region_index,
                       context_ptr->interpolated_stride,
                       pu_width,
                       pu_height)
@@ -4590,9 +4600,11 @@ static void half_pel_refinement_block(
     distortion_bottomright_position =
         (context_ptr->fractional_search_method == SSD_SEARCH)
             ? spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                      &(context_ptr->sb_src_ptr[src_block_index]),
+                      context_ptr->sb_src_ptr,
+                      src_block_index,
                       context_ptr->sb_src_stride,
-                      &(pos_j_buffer[search_region_index]),
+                      pos_j_buffer,
+                      search_region_index,
                       context_ptr->interpolated_stride,
                       pu_width,
                       pu_height)
@@ -5868,9 +5880,11 @@ static void PU_HalfPelRefinement(
     if (context_ptr->fractional_search_method == SSD_SEARCH) {
         *pBestSsd = (uint32_t)spatial_full_distortion_kernel_func_ptr_array
             [asm_type](
-                &(context_ptr->sb_src_ptr[puLcuBufferIndex]),
+                context_ptr->sb_src_ptr,
+                puLcuBufferIndex,
                 context_ptr->sb_src_stride,
-                &(refBuffer[ySearchIndex * ref_stride + xSearchIndex]),
+                refBuffer,
+                ySearchIndex * ref_stride + xSearchIndex,
                 ref_stride,
                 pu_width,
                 pu_height);
@@ -5887,9 +5901,11 @@ static void PU_HalfPelRefinement(
         distortionLeftPosition =
             (context_ptr->fractional_search_method == SSD_SEARCH)
                 ? spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                          &(context_ptr->sb_src_ptr[puLcuBufferIndex]),
+                          context_ptr->sb_src_ptr,
+                          puLcuBufferIndex,
                           context_ptr->sb_src_stride,
-                          &(pos_b_buffer[searchRegionIndex]),
+                          pos_b_buffer,
+                          searchRegionIndex,
                           context_ptr->interpolated_stride,
                           pu_width,
                           pu_height)
@@ -5935,9 +5951,11 @@ static void PU_HalfPelRefinement(
         distortionRightPosition =
             (context_ptr->fractional_search_method == SSD_SEARCH)
                 ? spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                          &(context_ptr->sb_src_ptr[puLcuBufferIndex]),
+                          context_ptr->sb_src_ptr,
+                          puLcuBufferIndex,
                           context_ptr->sb_src_stride,
-                          &(pos_b_buffer[searchRegionIndex]),
+                          pos_b_buffer,
+                          searchRegionIndex,
                           context_ptr->interpolated_stride,
                           pu_width,
                           pu_height)
@@ -5985,9 +6003,11 @@ static void PU_HalfPelRefinement(
         distortionTopPosition =
             (context_ptr->fractional_search_method == SSD_SEARCH)
                 ? spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                          &(context_ptr->sb_src_ptr[puLcuBufferIndex]),
+                          context_ptr->sb_src_ptr,
+                          puLcuBufferIndex,
                           context_ptr->sb_src_stride,
-                          &(pos_h_buffer[searchRegionIndex]),
+                          pos_h_buffer,
+                          searchRegionIndex,
                           context_ptr->interpolated_stride,
                           pu_width,
                           pu_height)
@@ -6034,9 +6054,11 @@ static void PU_HalfPelRefinement(
         distortionBottomPosition =
             (context_ptr->fractional_search_method == SSD_SEARCH)
                 ? spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                          &(context_ptr->sb_src_ptr[puLcuBufferIndex]),
+                          context_ptr->sb_src_ptr,
+                          puLcuBufferIndex,
                           context_ptr->sb_src_stride,
-                          &(pos_h_buffer[searchRegionIndex]),
+                          pos_h_buffer,
+                          searchRegionIndex,
                           context_ptr->interpolated_stride,
                           pu_width,
                           pu_height)
@@ -6085,9 +6107,11 @@ static void PU_HalfPelRefinement(
         distortionTopLeftPosition =
             (context_ptr->fractional_search_method == SSD_SEARCH)
                 ? spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                          &(context_ptr->sb_src_ptr[puLcuBufferIndex]),
+                          context_ptr->sb_src_ptr,
+                          puLcuBufferIndex,
                           context_ptr->sb_src_stride,
-                          &(pos_j_buffer[searchRegionIndex]),
+                          pos_j_buffer,
+                          searchRegionIndex,
                           context_ptr->interpolated_stride,
                           pu_width,
                           pu_height)
@@ -6134,9 +6158,11 @@ static void PU_HalfPelRefinement(
         distortionTopRightPosition =
             (context_ptr->fractional_search_method == SSD_SEARCH)
                 ? spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                          &(context_ptr->sb_src_ptr[puLcuBufferIndex]),
+                          context_ptr->sb_src_ptr,
+                          puLcuBufferIndex,
                           context_ptr->sb_src_stride,
-                          &(pos_j_buffer[searchRegionIndex]),
+                          pos_j_buffer,
+                          searchRegionIndex,
                           context_ptr->interpolated_stride,
                           pu_width,
                           pu_height)
@@ -6184,9 +6210,11 @@ static void PU_HalfPelRefinement(
         distortionBottomRightPosition =
             (context_ptr->fractional_search_method == SSD_SEARCH)
                 ? spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                          &(context_ptr->sb_src_ptr[puLcuBufferIndex]),
+                          context_ptr->sb_src_ptr,
+                          puLcuBufferIndex,
                           context_ptr->sb_src_stride,
-                          &(pos_j_buffer[searchRegionIndex]),
+                          pos_j_buffer,
+                          searchRegionIndex,
                           context_ptr->interpolated_stride,
                           pu_width,
                           pu_height)
@@ -6233,9 +6261,11 @@ static void PU_HalfPelRefinement(
         distortionBottomLeftPosition =
             (context_ptr->fractional_search_method == SSD_SEARCH)
                 ? spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                          &(context_ptr->sb_src_ptr[puLcuBufferIndex]),
+                          context_ptr->sb_src_ptr,
+                          puLcuBufferIndex,
                           context_ptr->sb_src_stride,
-                          &(pos_j_buffer[searchRegionIndex]),
+                          pos_j_buffer,
+                          searchRegionIndex,
                           context_ptr->interpolated_stride,
                           pu_width,
                           pu_height)

--- a/Source/Lib/Common/Codec/EbNeighborArrays.c
+++ b/Source/Lib/Common/Codec/EbNeighborArrays.c
@@ -241,6 +241,60 @@ void update_recon_neighbor_array(
     return;
 }
 
+void update_recon_neighbor_array16bit(
+    NeighborArrayUnit     *na_unit_ptr,
+    uint16_t              *src_ptr_top,
+    uint16_t              *src_ptr_left,
+    uint32_t               pic_origin_x,
+    uint32_t               pic_origin_y,
+    uint32_t               block_width,
+    uint32_t               block_height)
+{
+    uint16_t *dst_ptr;
+    dst_ptr = (uint16_t *) (na_unit_ptr->top_array +
+        get_neighbor_array_unit_top_index(na_unit_ptr, pic_origin_x) *
+        na_unit_ptr->unit_size);
+    EB_MEMCPY(dst_ptr, src_ptr_top, block_width * sizeof(uint16_t));
+
+    dst_ptr = (uint16_t *) (na_unit_ptr->left_array +
+        get_neighbor_array_unit_left_index(na_unit_ptr, pic_origin_y) *
+        na_unit_ptr->unit_size);
+    EB_MEMCPY(dst_ptr, src_ptr_left, block_height * sizeof(uint16_t));
+
+    //   Top-left Neighbor Array
+    uint32_t idx;
+    uint16_t *readPtr = src_ptr_top;
+    int32_t dstStep;
+    int32_t readStep;
+    uint32_t count;
+
+    // Copy bottom row
+    dst_ptr = (uint16_t *) (na_unit_ptr->top_left_array +
+        get_neighbor_array_unit_top_left_index(na_unit_ptr, pic_origin_x,
+            pic_origin_y + (block_height - 1)) * na_unit_ptr->unit_size);
+    EB_MEMCPY(dst_ptr, readPtr, block_width * sizeof(uint16_t));
+
+    // Reset readPtr to the right-column
+    readPtr = src_ptr_left;
+
+    // Copy right column
+    dst_ptr = (uint16_t *) (na_unit_ptr->top_left_array +
+        get_neighbor_array_unit_top_left_index(
+        na_unit_ptr, pic_origin_x + (block_width - 1), pic_origin_y) *
+        na_unit_ptr->unit_size);
+
+    dstStep = -1;
+    readStep = 1;
+    count = block_height;
+    for (idx = 0; idx < count; ++idx) {
+        *dst_ptr = *readPtr;
+        dst_ptr += dstStep;
+        readPtr += readStep;
+    }
+
+    return;
+}
+
 /*************************************************
  * Neighbor Array Sample Update
  *************************************************/

--- a/Source/Lib/Common/Codec/EbNeighborArrays.h
+++ b/Source/Lib/Common/Codec/EbNeighborArrays.h
@@ -150,6 +150,15 @@ extern "C" {
         uint32_t             block_width,
         uint32_t             block_height);
 
+    void update_recon_neighbor_array16bit(
+        NeighborArrayUnit   *na_unit_ptr,
+        uint16_t            *src_ptr_top,
+        uint16_t            *src_ptr_left,
+        uint32_t             pic_origin_x,
+        uint32_t             pic_origin_y,
+        uint32_t             block_width,
+        uint32_t             block_height);
+
     void copy_neigh_arr(
         NeighborArrayUnit *na_src,
         NeighborArrayUnit *na_dst,

--- a/Source/Lib/Common/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.c
@@ -167,10 +167,17 @@ void picture_control_set_dctor(EbPtr p)
         EB_DELETE(obj->md_mode_type_neighbor_array[depth]);
         EB_DELETE(obj->md_leaf_depth_neighbor_array[depth]);
         EB_DELETE(obj->mdleaf_partition_neighbor_array[depth]);
-        EB_DELETE(obj->md_luma_recon_neighbor_array[depth]);
-        EB_DELETE(obj->md_tx_depth_1_luma_recon_neighbor_array[depth]);
-        EB_DELETE(obj->md_cb_recon_neighbor_array[depth]);
-        EB_DELETE(obj->md_cr_recon_neighbor_array[depth]);
+        if (obj->hbd_mode_decision) {
+            EB_DELETE(obj->md_luma_recon_neighbor_array16bit[depth]);
+            EB_DELETE(obj->md_tx_depth_1_luma_recon_neighbor_array16bit[depth]);
+            EB_DELETE(obj->md_cb_recon_neighbor_array16bit[depth]);
+            EB_DELETE(obj->md_cr_recon_neighbor_array16bit[depth]);
+        } else {
+            EB_DELETE(obj->md_luma_recon_neighbor_array[depth]);
+            EB_DELETE(obj->md_tx_depth_1_luma_recon_neighbor_array[depth]);
+            EB_DELETE(obj->md_cb_recon_neighbor_array[depth]);
+            EB_DELETE(obj->md_cr_recon_neighbor_array[depth]);
+        }
         EB_DELETE(obj->md_skip_coeff_neighbor_array[depth]);
         EB_DELETE(obj->md_luma_dc_sign_level_coeff_neighbor_array[depth]);
         EB_DELETE(obj->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[depth]);
@@ -488,7 +495,7 @@ EbErrorType picture_control_set_ctor(
                 PU_NEIGHBOR_ARRAY_GRANULARITY,
                 PU_NEIGHBOR_ARRAY_GRANULARITY,
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK,
-            }
+            },
             {
                 &object_ptr->md_skip_coeff_neighbor_array[depth],
                 MAX_PICTURE_WIDTH_SIZE,
@@ -571,7 +578,7 @@ EbErrorType picture_control_set_ctor(
             return EB_ErrorInsufficientResources;
 
         if (!initDataPtr->hbd_mode_decision) {
-            InitData data_recon[] = {
+            InitData data[] = {
                 {
                     &object_ptr->md_luma_recon_neighbor_array[depth],
                     MAX_PICTURE_WIDTH_SIZE,
@@ -609,11 +616,11 @@ EbErrorType picture_control_set_ctor(
                     NEIGHBOR_ARRAY_UNIT_FULL_MASK,
                 }
             };
-            return_error = create_neighbor_array_units(data_recon, DIM(data));
+            return_error = create_neighbor_array_units(data, DIM(data));
             if (return_error == EB_ErrorInsufficientResources)
                 return EB_ErrorInsufficientResources;
         } else {
-            InitData data_recon[] = {
+            InitData data[] = {
                 {
                     &object_ptr->md_luma_recon_neighbor_array16bit[depth],
                     MAX_PICTURE_WIDTH_SIZE,
@@ -651,7 +658,7 @@ EbErrorType picture_control_set_ctor(
                     NEIGHBOR_ARRAY_UNIT_FULL_MASK,
                 }
             };
-            return_error = create_neighbor_array_units(data_recon, DIM(data));
+            return_error = create_neighbor_array_units(data, DIM(data));
             if (return_error == EB_ErrorInsufficientResources)
                 return EB_ErrorInsufficientResources;
         }

--- a/Source/Lib/Common/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.c
@@ -420,6 +420,8 @@ EbErrorType picture_control_set_ctor(
 
     // Allocate memory for qp array (used by DLF)
     EB_MALLOC_ARRAY(object_ptr->qp_array, object_ptr->qp_array_size);
+
+    object_ptr->hbd_mode_decision = initDataPtr->hbd_mode_decision;
     // Mode Decision Neighbor Arrays
     uint8_t depth;
     for (depth = 0; depth < NEIGHBOR_ARRAY_TOTAL_COUNT; depth++) {
@@ -486,43 +488,7 @@ EbErrorType picture_control_set_ctor(
                 PU_NEIGHBOR_ARRAY_GRANULARITY,
                 PU_NEIGHBOR_ARRAY_GRANULARITY,
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK,
-            },
-            {
-                &object_ptr->md_luma_recon_neighbor_array[depth],
-                MAX_PICTURE_WIDTH_SIZE,
-                MAX_PICTURE_HEIGHT_SIZE,
-                sizeof(uint8_t),
-                SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
-                SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
-                NEIGHBOR_ARRAY_UNIT_FULL_MASK,
-            },
-            {
-                &object_ptr->md_tx_depth_1_luma_recon_neighbor_array[depth],
-                MAX_PICTURE_WIDTH_SIZE,
-                MAX_PICTURE_HEIGHT_SIZE,
-                sizeof(uint8_t),
-                SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
-                SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
-                NEIGHBOR_ARRAY_UNIT_FULL_MASK,
-            },
-            {
-                &object_ptr->md_cb_recon_neighbor_array[depth],
-                MAX_PICTURE_WIDTH_SIZE >> subsampling_x,
-                MAX_PICTURE_HEIGHT_SIZE >> subsampling_y,
-                sizeof(uint8_t),
-                SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
-                SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
-                NEIGHBOR_ARRAY_UNIT_FULL_MASK,
-            },
-            {
-                &object_ptr->md_cr_recon_neighbor_array[depth],
-                MAX_PICTURE_WIDTH_SIZE >> subsampling_x,
-                MAX_PICTURE_HEIGHT_SIZE >> subsampling_y,
-                sizeof(uint8_t),
-                SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
-                SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
-                NEIGHBOR_ARRAY_UNIT_FULL_MASK,
-            },
+            }
             {
                 &object_ptr->md_skip_coeff_neighbor_array[depth],
                 MAX_PICTURE_WIDTH_SIZE,
@@ -598,11 +564,98 @@ EbErrorType picture_control_set_ctor(
                 PU_NEIGHBOR_ARRAY_GRANULARITY,
                 PU_NEIGHBOR_ARRAY_GRANULARITY,
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK,
-            },
+            }
         };
         return_error = create_neighbor_array_units(data, DIM(data));
         if (return_error == EB_ErrorInsufficientResources)
             return EB_ErrorInsufficientResources;
+
+        if (!initDataPtr->hbd_mode_decision) {
+            InitData data_recon[] = {
+                {
+                    &object_ptr->md_luma_recon_neighbor_array[depth],
+                    MAX_PICTURE_WIDTH_SIZE,
+                    MAX_PICTURE_HEIGHT_SIZE,
+                    sizeof(uint8_t),
+                    SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
+                    SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
+                    NEIGHBOR_ARRAY_UNIT_FULL_MASK,
+                },
+                {
+                    &object_ptr->md_tx_depth_1_luma_recon_neighbor_array[depth],
+                    MAX_PICTURE_WIDTH_SIZE,
+                    MAX_PICTURE_HEIGHT_SIZE,
+                    sizeof(uint8_t),
+                    SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
+                    SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
+                    NEIGHBOR_ARRAY_UNIT_FULL_MASK,
+                },
+                {
+                    &object_ptr->md_cb_recon_neighbor_array[depth],
+                    MAX_PICTURE_WIDTH_SIZE >> subsampling_x,
+                    MAX_PICTURE_HEIGHT_SIZE >> subsampling_y,
+                    sizeof(uint8_t),
+                    SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
+                    SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
+                    NEIGHBOR_ARRAY_UNIT_FULL_MASK,
+                },
+                {
+                    &object_ptr->md_cr_recon_neighbor_array[depth],
+                    MAX_PICTURE_WIDTH_SIZE >> subsampling_x,
+                    MAX_PICTURE_HEIGHT_SIZE >> subsampling_y,
+                    sizeof(uint8_t),
+                    SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
+                    SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
+                    NEIGHBOR_ARRAY_UNIT_FULL_MASK,
+                }
+            };
+            return_error = create_neighbor_array_units(data_recon, DIM(data));
+            if (return_error == EB_ErrorInsufficientResources)
+                return EB_ErrorInsufficientResources;
+        } else {
+            InitData data_recon[] = {
+                {
+                    &object_ptr->md_luma_recon_neighbor_array16bit[depth],
+                    MAX_PICTURE_WIDTH_SIZE,
+                    MAX_PICTURE_HEIGHT_SIZE,
+                    sizeof(uint16_t),
+                    SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
+                    SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
+                    NEIGHBOR_ARRAY_UNIT_FULL_MASK,
+                },
+                {
+                    &object_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[depth],
+                    MAX_PICTURE_WIDTH_SIZE,
+                    MAX_PICTURE_HEIGHT_SIZE,
+                    sizeof(uint16_t),
+                    SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
+                    SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
+                    NEIGHBOR_ARRAY_UNIT_FULL_MASK,
+                },
+                {
+                    &object_ptr->md_cb_recon_neighbor_array16bit[depth],
+                    MAX_PICTURE_WIDTH_SIZE >> subsampling_x,
+                    MAX_PICTURE_HEIGHT_SIZE >> subsampling_y,
+                    sizeof(uint16_t),
+                    SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
+                    SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
+                    NEIGHBOR_ARRAY_UNIT_FULL_MASK,
+                },
+                {
+                    &object_ptr->md_cr_recon_neighbor_array16bit[depth],
+                    MAX_PICTURE_WIDTH_SIZE >> subsampling_x,
+                    MAX_PICTURE_HEIGHT_SIZE >> subsampling_y,
+                    sizeof(uint16_t),
+                    SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
+                    SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
+                    NEIGHBOR_ARRAY_UNIT_FULL_MASK,
+                }
+            };
+            return_error = create_neighbor_array_units(data_recon, DIM(data));
+            if (return_error == EB_ErrorInsufficientResources)
+                return EB_ErrorInsufficientResources;
+        }
+
         EB_NEW(
             object_ptr->md_interpolation_type_neighbor_array[depth],
             neighbor_array_unit_ctor32,

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -13796,6 +13796,11 @@ extern "C" {
         NeighborArrayUnit                  *md_tx_depth_1_luma_recon_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
         NeighborArrayUnit                  *md_cb_recon_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
         NeighborArrayUnit                  *md_cr_recon_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        EbBool                             hbd_mode_decision;
+        NeighborArrayUnit                  *md_luma_recon_neighbor_array16bit[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  *md_tx_depth_1_luma_recon_neighbor_array16bit[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  *md_cb_recon_neighbor_array16bit[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  *md_cr_recon_neighbor_array16bit[NEIGHBOR_ARRAY_TOTAL_COUNT];
         NeighborArrayUnit                  *md_skip_coeff_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
         NeighborArrayUnit                  *md_luma_dc_sign_level_coeff_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
         NeighborArrayUnit                  *md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
@@ -14339,6 +14344,7 @@ extern "C" {
         uint16_t                           enc_dec_segment_row;
         EbEncMode                          enc_mode;
         uint8_t                            speed_control;
+        EbBool                             hbd_mode_decision;
         uint16_t                           film_grain_noise_level;
         EbBool                             ext_block_flag;
         EbBool                             in_loop_me_flag;

--- a/Source/Lib/Common/Codec/EbPictureOperators.h
+++ b/Source/Lib/Common/Codec/EbPictureOperators.h
@@ -29,20 +29,6 @@ extern "C" {
         uint32_t  height,
         EbAsm     asm_type);
 
-    extern EbErrorType picture_copy8_bit(
-        EbPictureBufferDesc  *src,
-        uint32_t                src_luma_origin_index,
-        uint32_t                src_chroma_origin_index,
-        EbPictureBufferDesc  *dst,
-        uint32_t                dst_luma_origin_index,
-        uint32_t                dst_chroma_origin_index,
-        uint32_t                area_width,
-        uint32_t                area_height,
-        uint32_t                chroma_area_width,
-        uint32_t                chroma_area_height,
-        uint32_t                component_mask,
-        EbAsm                   asm_type);
-
     extern EbErrorType picture_full_distortion32_bits(
         EbPictureBufferDesc  *coeff,
         uint32_t                coeff_luma_origin_index,
@@ -246,6 +232,16 @@ extern "C" {
         uint32_t  area_width,
         uint32_t  area_height);
 
+    uint64_t full_distortion_kernel16_bits(
+        uint8_t  *input,
+        uint32_t  input_offset,
+        uint32_t  input_stride,
+        uint8_t  *pred,
+        uint32_t  pred_offset,
+        uint32_t  pred_stride,
+        uint32_t  area_width,
+        uint32_t  area_height);
+
     typedef void(*EbFullDistortionKernelCbfZero32Bits)(
         int32_t  *coeff,
         uint32_t  coeff_stride,
@@ -408,12 +404,14 @@ extern "C" {
     };
 
     typedef uint64_t(*EbSpatialFullDistType)(
-        uint8_t  *input,
-        uint32_t  input_stride,
-        uint8_t  *recon,
-        uint32_t  recon_stride,
-        uint32_t  area_width,
-        uint32_t  area_height);
+        uint8_t   *input,
+        uint32_t   input_offset,
+        uint32_t   input_stride,
+        uint8_t   *recon,
+        uint32_t   recon_offset,
+        uint32_t   recon_stride,
+        uint32_t   area_width,
+        uint32_t   area_height);
 
     static EbSpatialFullDistType FUNC_TABLE spatial_full_distortion_kernel_func_ptr_array[ASM_TYPE_TOTAL] = {
         // NON_AVX2
@@ -432,6 +430,37 @@ extern "C" {
         uint32_t  width,
         uint32_t  height,
         int32_t   bd);
+
+void pic_copy_kernel_8bit(
+    EbByte                     src,
+    uint32_t                   src_stride,
+    EbByte                     dst,
+    uint32_t                   dst_stride,
+    uint32_t                   area_width,
+    uint32_t                   area_height);
+
+void pic_copy_kernel_16bit(
+    uint16_t                  *src,
+    uint32_t                   src_stride,
+    uint16_t                  *dst,
+    uint32_t                   dst_stride,
+    uint32_t                   width,
+    uint32_t                   height);
+
+EbErrorType picture_copy(
+    EbPictureBufferDesc       *src,
+    uint32_t                   src_luma_origin_index,
+    uint32_t                   src_chroma_origin_index,
+    EbPictureBufferDesc       *dst,
+    uint32_t                   dst_luma_origin_index,
+    uint32_t                   dst_chroma_origin_index,
+    uint32_t                   area_width,
+    uint32_t                   area_height,
+    uint32_t                   chroma_area_width,
+    uint32_t                   chroma_area_height,
+    uint32_t                   component_mask,
+    EbBool                     hbd,
+    EbAsm                      asm_type);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -1218,7 +1218,7 @@ void AV1PerformInverseTransformReconLuma(
                     PLANE_TYPE_Y,
                     (uint32_t)candidateBuffer->candidate_ptr->eob[0][txb_itr]);
             else {
-                if (picture_control_set_ptr->hbd_mode_decision)
+                if (picture_control_set_ptr->hbd_mode_decision) {
                     pic_copy_kernel_16bit(
                         ((uint16_t *) candidateBuffer->prediction_ptr->buffer_y) + tu_origin_index,
                         candidateBuffer->prediction_ptr->stride_y,
@@ -1226,7 +1226,7 @@ void AV1PerformInverseTransformReconLuma(
                         candidateBuffer->recon_ptr->stride_y,
                         tu_width,
                         tu_height);
-                else
+                } else {
                     pic_copy_kernel_8bit(
                         &(candidateBuffer->prediction_ptr->buffer_y[tu_origin_index]),
                         candidateBuffer->prediction_ptr->stride_y,
@@ -1234,6 +1234,7 @@ void AV1PerformInverseTransformReconLuma(
                         candidateBuffer->recon_ptr->stride_y,
                         tu_width,
                         tu_height);
+                }
             }
             txb_1d_offset += context_ptr->blk_geom->tx_width[tx_depth][txb_itr] * context_ptr->blk_geom->tx_height[tx_depth][txb_itr];
             ++txb_itr;
@@ -1753,7 +1754,7 @@ void AV1CostCalcCfl(
         assert(chroma_width * CFL_BUF_LINE + chroma_height <=
             CFL_BUF_SQUARE);
 
-        if (!context_ptr->hbd_mode_decision)
+        if (!context_ptr->hbd_mode_decision) {
             cfl_predict_lbd(
                 context_ptr->pred_buf_q3,
                 &(candidateBuffer->prediction_ptr->buffer_cb[cuChromaOriginIndex]),
@@ -1764,7 +1765,7 @@ void AV1CostCalcCfl(
                 8,
                 chroma_width,
                 chroma_height);
-        else
+        } else {
             cfl_predict_hbd(
                 context_ptr->pred_buf_q3,
                 ((uint16_t*)candidateBuffer->prediction_ptr->buffer_cb) + cuChromaOriginIndex,
@@ -1775,6 +1776,7 @@ void AV1CostCalcCfl(
                 10,
                 chroma_width,
                 chroma_height);
+        }
 
         // Cb Residual
         residual_kernel(
@@ -1837,7 +1839,7 @@ void AV1CostCalcCfl(
         assert(chroma_width * CFL_BUF_LINE + chroma_height <=
             CFL_BUF_SQUARE);
 
-        if (!context_ptr->hbd_mode_decision)
+        if (!context_ptr->hbd_mode_decision) {
             cfl_predict_lbd(
                 context_ptr->pred_buf_q3,
                 &(candidateBuffer->prediction_ptr->buffer_cr[cuChromaOriginIndex]),
@@ -1848,7 +1850,7 @@ void AV1CostCalcCfl(
                 8,
                 chroma_width,
                 chroma_height);
-        else
+        } else {
             cfl_predict_hbd(
                 context_ptr->pred_buf_q3,
                 ((uint16_t*)candidateBuffer->prediction_ptr->buffer_cr) + cuChromaOriginIndex,
@@ -1859,6 +1861,7 @@ void AV1CostCalcCfl(
                 10,
                 chroma_width,
                 chroma_height);
+        }
 
         // Cr Residual
         residual_kernel(
@@ -2105,20 +2108,21 @@ static void CflPrediction(
     uint32_t chroma_height = context_ptr->blk_geom->bheight_uv;
 
     // Down sample Luma
-    if (!context_ptr->hbd_mode_decision)
+    if (!context_ptr->hbd_mode_decision) {
         cfl_luma_subsampling_420_lbd_c(
             &(context_ptr->cfl_temp_luma_recon[recLumaOffset]),
             candidateBuffer->recon_ptr->stride_y,
             context_ptr->pred_buf_q3,
             context_ptr->blk_geom->bwidth_uv == context_ptr->blk_geom->bwidth ? (context_ptr->blk_geom->bwidth_uv << 1) : context_ptr->blk_geom->bwidth,
             context_ptr->blk_geom->bheight_uv == context_ptr->blk_geom->bheight ? (context_ptr->blk_geom->bheight_uv << 1) : context_ptr->blk_geom->bheight);
-    else
+    } else {
         cfl_luma_subsampling_420_hbd_c(
             context_ptr->cfl_temp_luma_recon16bit + recLumaOffset,
             candidateBuffer->recon_ptr->stride_y,
             context_ptr->pred_buf_q3,
             context_ptr->blk_geom->bwidth_uv == context_ptr->blk_geom->bwidth ? (context_ptr->blk_geom->bwidth_uv << 1) : context_ptr->blk_geom->bwidth,
             context_ptr->blk_geom->bheight_uv == context_ptr->blk_geom->bheight ? (context_ptr->blk_geom->bheight_uv << 1) : context_ptr->blk_geom->bheight);
+    }
     int32_t round_offset = chroma_width * chroma_height / 2;
 
     subtract_average(
@@ -2613,7 +2617,7 @@ static void tx_search_update_recon_sample_neighbor_array(
     uint32_t               height,
     EbBool                 hbd)
 {
-    if (hbd)
+    if (hbd) {
         neighbor_array_unit16bit_sample_write(
             lumaReconSampleNeighborArray,
             (uint16_t*)recon_buffer->buffer_y,
@@ -2625,7 +2629,7 @@ static void tx_search_update_recon_sample_neighbor_array(
             width,
             height,
             NEIGHBOR_ARRAY_UNIT_FULL_MASK);
-    else
+    } else {
         neighbor_array_unit_sample_write(
             lumaReconSampleNeighborArray,
             recon_buffer->buffer_y,
@@ -2637,6 +2641,7 @@ static void tx_search_update_recon_sample_neighbor_array(
             width,
             height,
             NEIGHBOR_ARRAY_UNIT_FULL_MASK);
+    }
 
     return;
 }
@@ -3092,7 +3097,7 @@ void perform_intra_tx_partitioning(
 
     // Reset depth_1 neighbor arrays
     if (end_tx_depth) {
-        if (!picture_control_set_ptr->hbd_mode_decision)
+        if (!picture_control_set_ptr->hbd_mode_decision) {
             copy_neigh_arr(
                 picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
                 picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
@@ -3101,7 +3106,7 @@ void perform_intra_tx_partitioning(
                 context_ptr->blk_geom->bwidth,
                 context_ptr->blk_geom->bheight,
                 NEIGHBOR_ARRAY_UNIT_FULL_MASK);
-        else
+        } else {
             copy_neigh_arr(
                 picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
                 picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
@@ -3110,6 +3115,7 @@ void perform_intra_tx_partitioning(
                 context_ptr->blk_geom->bwidth,
                 context_ptr->blk_geom->bheight,
                 NEIGHBOR_ARRAY_UNIT_FULL_MASK);
+        }
 
         copy_neigh_arr(
             picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
@@ -3124,18 +3130,17 @@ void perform_intra_tx_partitioning(
     // Transform Depth Loop
     for (context_ptr->tx_depth = 0; context_ptr->tx_depth <= end_tx_depth; context_ptr->tx_depth++) {
         // Set recon neighbor array to be used @ intra compensation
-        if (!context_ptr->hbd_mode_decision)
+        if (!context_ptr->hbd_mode_decision) {
             context_ptr->tx_search_luma_recon_neighbor_array =
                 (context_ptr->tx_depth) ?
                 picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX] :
                 picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
-        else
+        } else {
             context_ptr->tx_search_luma_recon_neighbor_array16bit =
                 (context_ptr->tx_depth) ?
                 picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX] :
                 picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX];
-
-
+        }
 
         // Set luma dc sign level coeff
         context_ptr->tx_search_luma_dc_sign_level_coeff_neighbor_array =

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -259,42 +259,87 @@ void mode_decision_update_neighbor_arrays(
         bheight,
         NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
 
-    if (intraMdOpenLoop == EB_FALSE)
-    {
-        update_recon_neighbor_array(
-            context_ptr->luma_recon_neighbor_array,
-            context_ptr->cu_ptr->neigh_top_recon[0],
-            context_ptr->cu_ptr->neigh_left_recon[0],
-            origin_x,
-            origin_y,
-            context_ptr->blk_geom->bwidth,
-            context_ptr->blk_geom->bheight);
-        if (picture_control_set_ptr->parent_pcs_ptr->atb_mode) {
+    if (!context_ptr->hbd_mode_decision) {
+        if (intraMdOpenLoop == EB_FALSE)
+        {
             update_recon_neighbor_array(
-                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
+                context_ptr->luma_recon_neighbor_array,
                 context_ptr->cu_ptr->neigh_top_recon[0],
                 context_ptr->cu_ptr->neigh_left_recon[0],
                 origin_x,
                 origin_y,
                 context_ptr->blk_geom->bwidth,
                 context_ptr->blk_geom->bheight);
+            if (picture_control_set_ptr->parent_pcs_ptr->atb_mode) {
+                update_recon_neighbor_array(
+                    picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
+                    context_ptr->cu_ptr->neigh_top_recon[0],
+                    context_ptr->cu_ptr->neigh_left_recon[0],
+                    origin_x,
+                    origin_y,
+                    context_ptr->blk_geom->bwidth,
+                    context_ptr->blk_geom->bheight);
+            }
         }
-    }
 
-    if (intraMdOpenLoop == EB_FALSE) {
-        if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
-            update_recon_neighbor_array(
-                context_ptr->cb_recon_neighbor_array,
-                context_ptr->cu_ptr->neigh_top_recon[1],
-                context_ptr->cu_ptr->neigh_left_recon[1],
+        if (intraMdOpenLoop == EB_FALSE) {
+            if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+                update_recon_neighbor_array(
+                    context_ptr->cb_recon_neighbor_array,
+                    context_ptr->cu_ptr->neigh_top_recon[1],
+                    context_ptr->cu_ptr->neigh_left_recon[1],
+                    cu_origin_x_uv,
+                    cu_origin_y_uv,
+                    bwdith_uv,
+                    bwheight_uv);
+                update_recon_neighbor_array(
+                    context_ptr->cr_recon_neighbor_array,
+                    context_ptr->cu_ptr->neigh_top_recon[2],
+                    context_ptr->cu_ptr->neigh_left_recon[2],
+                    cu_origin_x_uv,
+                    cu_origin_y_uv,
+                    bwdith_uv,
+                    bwheight_uv);
+            }
+        }
+    } else {
+        if (intraMdOpenLoop == EB_FALSE)
+            update_recon_neighbor_array16bit(
+                context_ptr->luma_recon_neighbor_array16bit,
+                context_ptr->cu_ptr->neigh_top_recon_16bit[0],
+                context_ptr->cu_ptr->neigh_left_recon_16bit[0],
+                origin_x,
+                origin_y,
+                context_ptr->blk_geom->bwidth,
+                context_ptr->blk_geom->bheight);
+
+            if (picture_control_set_ptr->parent_pcs_ptr->atb_mode) {
+                update_recon_neighbor_array(
+                    picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
+                    context_ptr->cu_ptr->neigh_top_recon[0],
+                    context_ptr->cu_ptr->neigh_left_recon[0],
+                    origin_x,
+                    origin_y,
+                    context_ptr->blk_geom->bwidth,
+                    context_ptr->blk_geom->bheight);
+            }
+
+        if (intraMdOpenLoop == EB_FALSE &&
+            context_ptr->blk_geom->has_uv &&
+            context_ptr->chroma_level <= CHROMA_MODE_1)
+        {
+            update_recon_neighbor_array16bit(
+                context_ptr->cb_recon_neighbor_array16bit,
+                context_ptr->cu_ptr->neigh_top_recon_16bit[1],
+                context_ptr->cu_ptr->neigh_left_recon_16bit[1],
                 cu_origin_x_uv,
                 cu_origin_y_uv,
                 bwdith_uv,
                 bwheight_uv);
-            update_recon_neighbor_array(
-                context_ptr->cr_recon_neighbor_array,
-                context_ptr->cu_ptr->neigh_top_recon[2],
-                context_ptr->cu_ptr->neigh_left_recon[2],
+            update_recon_neighbor_array16bit(
+                context_ptr->cr_recon_neighbor_array16bit,
+                context_ptr->cu_ptr->neigh_top_recon_16bit[2],
+                context_ptr->cu_ptr->neigh_left_recon_16bit[2],
                 cu_origin_x_uv,
                 cu_origin_y_uv,
                 bwdith_uv,
@@ -382,49 +427,86 @@ void copy_neighbour_arrays(
         blk_geom->bheight,
         NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
 
-    //neighbor_array_unit_reset(picture_control_set_ptr->md_luma_recon_neighbor_array[depth]);
-    copy_neigh_arr(
-        picture_control_set_ptr->md_luma_recon_neighbor_array[src_idx],
-        picture_control_set_ptr->md_luma_recon_neighbor_array[dst_idx],
-        blk_org_x,
-        blk_org_y,
-        blk_geom->bwidth,
-        blk_geom->bheight,
-        NEIGHBOR_ARRAY_UNIT_FULL_MASK);
-
-    if (picture_control_set_ptr->parent_pcs_ptr->atb_mode) {
+    if (!context_ptr->hbd_mode_decision) {
         copy_neigh_arr(
-            picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[src_idx],
-            picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[dst_idx],
+            picture_control_set_ptr->md_luma_recon_neighbor_array[src_idx],
+            picture_control_set_ptr->md_luma_recon_neighbor_array[dst_idx],
             blk_org_x,
             blk_org_y,
             blk_geom->bwidth,
             blk_geom->bheight,
             NEIGHBOR_ARRAY_UNIT_FULL_MASK);
-    }
+        if (picture_control_set_ptr->parent_pcs_ptr->atb_mode) {
+            copy_neigh_arr(
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[src_idx],
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[dst_idx],
+                blk_org_x,
+                blk_org_y,
+                blk_geom->bwidth,
+                blk_geom->bheight,
+                NEIGHBOR_ARRAY_UNIT_FULL_MASK);
+        }
+        if (blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+            copy_neigh_arr(
+                picture_control_set_ptr->md_cb_recon_neighbor_array[src_idx],
+                picture_control_set_ptr->md_cb_recon_neighbor_array[dst_idx],
+                blk_org_x_uv,
+                blk_org_y_uv,
+                bwidth_uv,
+                bheight_uv,
+                NEIGHBOR_ARRAY_UNIT_FULL_MASK);
 
-    if (blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
-        //neighbor_array_unit_reset(picture_control_set_ptr->md_cb_recon_neighbor_array[depth]);
-
+            copy_neigh_arr(
+                picture_control_set_ptr->md_cr_recon_neighbor_array[src_idx],
+                picture_control_set_ptr->md_cr_recon_neighbor_array[dst_idx],
+                blk_org_x_uv,
+                blk_org_y_uv,
+                bwidth_uv,
+                bheight_uv,
+                NEIGHBOR_ARRAY_UNIT_FULL_MASK);
+        }
+    } else {
         copy_neigh_arr(
-            picture_control_set_ptr->md_cb_recon_neighbor_array[src_idx],
-            picture_control_set_ptr->md_cb_recon_neighbor_array[dst_idx],
-            blk_org_x_uv,
-            blk_org_y_uv,
-            bwidth_uv,
-            bheight_uv,
+            picture_control_set_ptr->md_luma_recon_neighbor_array16bit[src_idx],
+            picture_control_set_ptr->md_luma_recon_neighbor_array16bit[dst_idx],
+            blk_org_x,
+            blk_org_y,
+            blk_geom->bwidth,
+            blk_geom->bheight,
             NEIGHBOR_ARRAY_UNIT_FULL_MASK);
 
-        //neighbor_array_unit_reset(picture_control_set_ptr->md_cr_recon_neighbor_array[depth]);
-        copy_neigh_arr(
-            picture_control_set_ptr->md_cr_recon_neighbor_array[src_idx],
-            picture_control_set_ptr->md_cr_recon_neighbor_array[dst_idx],
-            blk_org_x_uv,
-            blk_org_y_uv,
-            bwidth_uv,
-            bheight_uv,
-            NEIGHBOR_ARRAY_UNIT_FULL_MASK);
+        if (picture_control_set_ptr->parent_pcs_ptr->atb_mode) {
+            copy_neigh_arr(
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[src_idx],
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[dst_idx],
+                blk_org_x,
+                blk_org_y,
+                blk_geom->bwidth,
+                blk_geom->bheight,
+                NEIGHBOR_ARRAY_UNIT_FULL_MASK);
+        }
+
+        if (blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+            copy_neigh_arr(
+                picture_control_set_ptr->md_cb_recon_neighbor_array16bit[src_idx],
+                picture_control_set_ptr->md_cb_recon_neighbor_array16bit[dst_idx],
+                blk_org_x_uv,
+                blk_org_y_uv,
+                bwidth_uv,
+                bheight_uv,
+                NEIGHBOR_ARRAY_UNIT_FULL_MASK);
+
+            copy_neigh_arr(
+                picture_control_set_ptr->md_cr_recon_neighbor_array16bit[src_idx],
+                picture_control_set_ptr->md_cr_recon_neighbor_array16bit[dst_idx],
+                blk_org_x_uv,
+                blk_org_y_uv,
+                bwidth_uv,
+                bheight_uv,
+                NEIGHBOR_ARRAY_UNIT_FULL_MASK);
+        }
     }
+
     //neighbor_array_unit_reset(picture_control_set_ptr->md_skip_coeff_neighbor_array[depth]);
     copy_neigh_arr(
         picture_control_set_ptr->md_skip_coeff_neighbor_array[src_idx],
@@ -1089,13 +1171,6 @@ void picture_addition_kernel16_bit(
     return;
 }
 
-void pic_copy_kernel(
-    EbByte                     src,
-    uint32_t                   src_stride,
-    EbByte                     dst,
-    uint32_t                   dst_stride,
-    uint32_t                   area_width,
-    uint32_t                   area_height);
 void AV1PerformInverseTransformReconLuma(
     PictureControlSet               *picture_control_set_ptr,
     ModeDecisionContext             *context_ptr,
@@ -1125,33 +1200,40 @@ void AV1PerformInverseTransformReconLuma(
             uint32_t recLumaOffset = txb_origin_x + txb_origin_y * candidateBuffer->recon_ptr->stride_y;
             uint32_t y_has_coeff = (candidateBuffer->candidate_ptr->y_has_coeff & (1 << txb_itr)) > 0;
 
-            if (y_has_coeff) {
-                (void)context_ptr;
-                uint8_t     *predBuffer = &(candidateBuffer->prediction_ptr->buffer_y[tu_origin_index]);
-                uint8_t     *recBuffer = &(context_ptr->cfl_temp_luma_recon[recLumaOffset]);
-
-                uint32_t j;
-
-                for (j = 0; j < tu_height; j++)
-                    memcpy(recBuffer + j * candidateBuffer->recon_ptr->stride_y, predBuffer + j * candidateBuffer->prediction_ptr->stride_y, tu_width);
-
-                av1_inv_transform_recon8bit(
-                    &(((int32_t*)candidateBuffer->recon_coeff_ptr->buffer_y)[txb_1d_offset]),
-                    recBuffer,
+            if (y_has_coeff)
+               inv_transform_recon_copy(
+                    candidateBuffer->prediction_ptr->buffer_y,
+                    tu_origin_index,
+                    candidateBuffer->prediction_ptr->stride_y,
+                    context_ptr->cfl_temp_luma_recon,
+                    recLumaOffset,
                     candidateBuffer->recon_ptr->stride_y,
+                    (int32_t*) candidateBuffer->recon_coeff_ptr->buffer_y,
+                    txb_1d_offset,
+                    tu_width,
+                    tu_height,
+                    picture_control_set_ptr->hbd_mode_decision,
                     context_ptr->blk_geom->txsize[tx_depth][txb_itr],
                     candidateBuffer->candidate_ptr->transform_type[txb_itr],
                     PLANE_TYPE_Y,
-                    (uint16_t)candidateBuffer->candidate_ptr->eob[0][txb_itr]);
-            }
+                    (uint32_t)candidateBuffer->candidate_ptr->eob[0][txb_itr]);
             else {
-                pic_copy_kernel(
-                    &(candidateBuffer->prediction_ptr->buffer_y[tu_origin_index]),
-                    candidateBuffer->prediction_ptr->stride_y,
-                    &(context_ptr->cfl_temp_luma_recon[recLumaOffset]),
-                    candidateBuffer->recon_ptr->stride_y,
-                    tu_width,
-                    tu_height);
+                if (picture_control_set_ptr->hbd_mode_decision)
+                    pic_copy_kernel_16bit(
+                        ((uint16_t *) candidateBuffer->prediction_ptr->buffer_y) + tu_origin_index,
+                        candidateBuffer->prediction_ptr->stride_y,
+                        ((uint16_t *) context_ptr->cfl_temp_luma_recon) + recLumaOffset,
+                        candidateBuffer->recon_ptr->stride_y,
+                        tu_width,
+                        tu_height);
+                else
+                    pic_copy_kernel_8bit(
+                        &(candidateBuffer->prediction_ptr->buffer_y[tu_origin_index]),
+                        candidateBuffer->prediction_ptr->stride_y,
+                        &(context_ptr->cfl_temp_luma_recon[recLumaOffset]),
+                        candidateBuffer->recon_ptr->stride_y,
+                        tu_width,
+                        tu_height);
             }
             txb_1d_offset += context_ptr->blk_geom->tx_width[tx_depth][txb_itr] * context_ptr->blk_geom->tx_height[tx_depth][txb_itr];
             ++txb_itr;
@@ -1164,7 +1246,8 @@ void AV1PerformInverseTransformRecon(
     ModeDecisionCandidateBuffer     *candidateBuffer,
     CodingUnit                      *cu_ptr,
     const BlockGeom                   *blk_geom,
-    EbAsm                              asm_type) {
+    EbAsm                              asm_type)
+{
     uint32_t                           tu_width;
     uint32_t                           tu_height;
     uint32_t                           txb_origin_x;
@@ -1195,25 +1278,25 @@ void AV1PerformInverseTransformRecon(
             recCbOffset = ((((context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr] >> 3) << 3) + ((context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr] >> 3) << 3) * candidateBuffer->recon_ptr->stride_cb) >> 1);
             recCrOffset = ((((context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr] >> 3) << 3) + ((context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr] >> 3) << 3) * candidateBuffer->recon_ptr->stride_cr) >> 1);
             tu_origin_index = txb_origin_x + txb_origin_y * candidateBuffer->prediction_ptr->stride_y;
-            if (txb_ptr->y_has_coeff) {
-                uint8_t     *predBuffer = &(candidateBuffer->prediction_ptr->buffer_y[tu_origin_index]);
-                uint8_t     *recBuffer = &(candidateBuffer->recon_ptr->buffer_y[recLumaOffset]);
-                uint32_t     j;
-
-                for (j = 0; j < tu_height; j++)
-                    memcpy(recBuffer + j * candidateBuffer->recon_ptr->stride_y, predBuffer + j * candidateBuffer->prediction_ptr->stride_y, tu_width);
-
-                av1_inv_transform_recon8bit(
-                    &(((int32_t*)candidateBuffer->recon_coeff_ptr->buffer_y)[txb_1d_offset]),
-                    recBuffer,
+            if (txb_ptr->y_has_coeff)
+                inv_transform_recon_copy(
+                    candidateBuffer->prediction_ptr->buffer_y,
+                    tu_origin_index,
+                    candidateBuffer->prediction_ptr->stride_y,
+                    candidateBuffer->recon_ptr->buffer_y,
+                    recLumaOffset,
                     candidateBuffer->recon_ptr->stride_y,
+                    (int32_t*) candidateBuffer->recon_coeff_ptr->buffer_y,
+                    txb_1d_offset,
+                    tu_width,
+                    tu_height,
+                    picture_control_set_ptr->hbd_mode_decision,
                     context_ptr->blk_geom->txsize[tx_depth][txb_itr],
                     candidateBuffer->candidate_ptr->transform_type[txb_itr],
                     PLANE_TYPE_Y,
-                    (uint16_t)candidateBuffer->candidate_ptr->eob[0][txb_itr]);
-            }
-            else {
-                picture_copy8_bit(
+                    (uint32_t)candidateBuffer->candidate_ptr->eob[0][txb_itr]);
+            else
+                picture_copy(
                     candidateBuffer->prediction_ptr,
                     tu_origin_index,
                     0,//tu_chroma_origin_index,
@@ -1225,82 +1308,86 @@ void AV1PerformInverseTransformRecon(
                     0,//chromaTuSize,
                     0,//chromaTuSize,
                     PICTURE_BUFFER_DESC_Y_FLAG,
+                    picture_control_set_ptr->hbd_mode_decision,
                     asm_type);
-            }
+
+            //CHROMA
             uint8_t tx_depth = candidateBuffer->candidate_ptr->tx_depth;
             if (tx_depth == 0 || txb_itr == 0) {
             if (context_ptr->chroma_level <= CHROMA_MODE_1)
             {
-            //CHROMA
             uint32_t chroma_tu_width = tx_size_wide[context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr]];
             uint32_t chroma_tu_height = tx_size_high[context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr]];
             uint32_t cbTuChromaOriginIndex = ((((txb_origin_x >> 3) << 3) + ((txb_origin_y >> 3) << 3) * candidateBuffer->recon_coeff_ptr->stride_cb) >> 1);
             uint32_t crTuChromaOriginIndex = ((((txb_origin_x >> 3) << 3) + ((txb_origin_y >> 3) << 3) * candidateBuffer->recon_coeff_ptr->stride_cr) >> 1);
 
-            if (context_ptr->blk_geom->has_uv && txb_ptr->u_has_coeff) {
-                uint8_t     *predBuffer = &(candidateBuffer->prediction_ptr->buffer_cb[cbTuChromaOriginIndex]);
-                uint8_t     *recBuffer = &(candidateBuffer->recon_ptr->buffer_cb[recCbOffset]);
-                uint32_t j;
-                for (j = 0; j < chroma_tu_height; j++)
-                    memcpy(recBuffer + j * candidateBuffer->recon_ptr->stride_cb, predBuffer + j * candidateBuffer->prediction_ptr->stride_cb, chroma_tu_width);
+            if (context_ptr->blk_geom->has_uv && txb_ptr->u_has_coeff)
+                    inv_transform_recon_copy(
+                        candidateBuffer->prediction_ptr->buffer_cb,
+                        cbTuChromaOriginIndex,
+                        candidateBuffer->prediction_ptr->stride_cb,
+                        candidateBuffer->recon_ptr->buffer_cb,
+                        recCbOffset,
+                        candidateBuffer->recon_ptr->stride_cb,
+                        (int32_t*) candidateBuffer->recon_coeff_ptr->buffer_cb,
+                        txb_1d_offset_uv,
+                        chroma_tu_width,
+                        chroma_tu_height,
+                        picture_control_set_ptr->hbd_mode_decision,
+                        context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr],
+                        candidateBuffer->candidate_ptr->transform_type_uv,
+                        PLANE_TYPE_UV,
+                        (uint32_t)candidateBuffer->candidate_ptr->eob[1][txb_itr]);
+                else
+                    picture_copy(
+                        candidateBuffer->prediction_ptr,
+                        0,
+                        cbTuChromaOriginIndex,
+                        candidateBuffer->recon_ptr,
+                        0,
+                        recCbOffset,
+                        0,
+                        0,
+                        chroma_tu_width,
+                        chroma_tu_height,
+                        PICTURE_BUFFER_DESC_Cb_FLAG,
+                        picture_control_set_ptr->hbd_mode_decision,
+                        asm_type);
 
-                av1_inv_transform_recon8bit(
-                    &(((int32_t*)candidateBuffer->recon_coeff_ptr->buffer_cb)[txb_1d_offset_uv]),
-                    recBuffer,
-                    candidateBuffer->recon_ptr->stride_cb,
-                    context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr],
-                    candidateBuffer->candidate_ptr->transform_type_uv,
-                    PLANE_TYPE_UV,
-                    (uint16_t)candidateBuffer->candidate_ptr->eob[1][txb_itr]);
-            }
-            else {
-                picture_copy8_bit(
-                    candidateBuffer->prediction_ptr,
-                    0,
-                    cbTuChromaOriginIndex,
-                    candidateBuffer->recon_ptr,
-                    0,
-                    recCbOffset,
-                    0,
-                    0,
-                    chroma_tu_width,
-                    chroma_tu_height,
-                    PICTURE_BUFFER_DESC_Cb_FLAG,
-                    asm_type);
-            }
 
-                if (context_ptr->blk_geom->has_uv && txb_ptr->v_has_coeff) {
-                    uint8_t     *predBuffer = &(candidateBuffer->prediction_ptr->buffer_cr[crTuChromaOriginIndex]);
-                    uint8_t     *recBuffer = &(candidateBuffer->recon_ptr->buffer_cr[recCrOffset]);
-                    uint32_t j;
-                    for (j = 0; j < chroma_tu_height; j++)
-                        memcpy(recBuffer + j * candidateBuffer->recon_ptr->stride_cr, predBuffer + j * candidateBuffer->prediction_ptr->stride_cr, chroma_tu_width);
+            if (context_ptr->blk_geom->has_uv && txb_ptr->v_has_coeff)
+                    inv_transform_recon_copy(
+                        candidateBuffer->prediction_ptr->buffer_cr,
+                        crTuChromaOriginIndex,
+                        candidateBuffer->prediction_ptr->stride_cr,
+                        candidateBuffer->recon_ptr->buffer_cr,
+                        recCrOffset,
+                        candidateBuffer->recon_ptr->stride_cr,
+                        (int32_t*) candidateBuffer->recon_coeff_ptr->buffer_cr,
+                        txb_1d_offset_uv,
+                        chroma_tu_width,
+                        chroma_tu_height,
+                        picture_control_set_ptr->hbd_mode_decision,
+                        context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr],
+                        candidateBuffer->candidate_ptr->transform_type_uv,
+                        PLANE_TYPE_UV,
+                        (uint32_t)candidateBuffer->candidate_ptr->eob[2][txb_itr]);
+                else
+                    picture_copy(
+                        candidateBuffer->prediction_ptr,
+                        0,
+                        crTuChromaOriginIndex,
+                        candidateBuffer->recon_ptr,
+                        0,
+                        recCrOffset,
+                        0,
+                        0,
+                        chroma_tu_width,
+                        chroma_tu_height,
+                        PICTURE_BUFFER_DESC_Cr_FLAG,
+                        picture_control_set_ptr->hbd_mode_decision,
+                        asm_type);
 
-                av1_inv_transform_recon8bit(
-                    &(((int32_t*)candidateBuffer->recon_coeff_ptr->buffer_cr)[txb_1d_offset_uv]),
-                    recBuffer,
-                    candidateBuffer->recon_ptr->stride_cr,
-                    context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr],
-                    candidateBuffer->candidate_ptr->transform_type_uv,
-                    PLANE_TYPE_UV,
-                    (uint16_t)candidateBuffer->candidate_ptr->eob[2][txb_itr]);
-                }
-                else {
-                picture_copy8_bit(
-                    candidateBuffer->prediction_ptr,
-                    0,
-                    crTuChromaOriginIndex,
-                    candidateBuffer->recon_ptr,
-                    0,
-                    recCrOffset,
-                    0,
-                    0,
-                    chroma_tu_width,
-                    chroma_tu_height,
-                    PICTURE_BUFFER_DESC_Cr_FLAG,
-                    asm_type);
-                }
-                //CHROMA END
                 if (context_ptr->blk_geom->has_uv)
                     txb_1d_offset_uv += context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr] * context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr];
             }
@@ -1471,60 +1558,101 @@ void perform_fast_loop(
             // Distortion
             // Y
             if (use_ssd) {
-                candidateBuffer->candidate_ptr->luma_fast_distortion = (uint32_t)(lumaFastDistortion = spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                    input_picture_ptr->buffer_y + inputOriginIndex,
+                EbSpatialFullDistType spatial_full_dist_type_fun = context_ptr->hbd_mode_decision ?
+                        full_distortion_kernel16_bits : spatial_full_distortion_kernel_func_ptr_array[asm_type];
+
+                candidateBuffer->candidate_ptr->luma_fast_distortion = (uint32_t)(lumaFastDistortion = spatial_full_dist_type_fun(
+                    input_picture_ptr->buffer_y,
+                    inputOriginIndex,
                     input_picture_ptr->stride_y,
-                    prediction_ptr->buffer_y + cuOriginIndex,
+                    prediction_ptr->buffer_y,
+                    cuOriginIndex,
                     prediction_ptr->stride_y,
                     context_ptr->blk_geom->bwidth,
                     context_ptr->blk_geom->bheight));
             }
             else {
                 assert((context_ptr->blk_geom->bwidth >> 3) < 17);
-                candidateBuffer->candidate_ptr->luma_fast_distortion = (uint32_t)(lumaFastDistortion = nxm_sad_kernel_sub_sampled_func_ptr_array[asm_type][context_ptr->blk_geom->bwidth >> 3](
-                    input_picture_ptr->buffer_y + inputOriginIndex,
-                    input_picture_ptr->stride_y,
-                    prediction_ptr->buffer_y + cuOriginIndex,
-                    prediction_ptr->stride_y,
-                    context_ptr->blk_geom->bheight,
-                    context_ptr->blk_geom->bwidth));
+                if (!context_ptr->hbd_mode_decision) {
+                    candidateBuffer->candidate_ptr->luma_fast_distortion = (uint32_t)(lumaFastDistortion = nxm_sad_kernel_sub_sampled_func_ptr_array[asm_type][context_ptr->blk_geom->bwidth >> 3](
+                        input_picture_ptr->buffer_y + inputOriginIndex,
+                        input_picture_ptr->stride_y,
+                        prediction_ptr->buffer_y + cuOriginIndex,
+                        prediction_ptr->stride_y,
+                        context_ptr->blk_geom->bheight,
+                        context_ptr->blk_geom->bwidth));
+                } else {
+                    candidateBuffer->candidate_ptr->luma_fast_distortion = (uint32_t)(lumaFastDistortion = sad_16b_kernel(
+                             ((uint16_t *) input_picture_ptr->buffer_y) + inputOriginIndex,
+                             input_picture_ptr->stride_y,
+                             ((uint16_t *) prediction_ptr->buffer_y) + cuOriginIndex,
+                             prediction_ptr->stride_y,
+                             context_ptr->blk_geom->bheight,
+                             context_ptr->blk_geom->bwidth));
+                }
             }
 
             if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
                 if (use_ssd) {
-                    chromaFastDistortion = spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                        input_picture_ptr->buffer_cb + inputCbOriginIndex,
+                    EbSpatialFullDistType spatial_full_dist_type_fun = context_ptr->hbd_mode_decision ?
+                        full_distortion_kernel16_bits : spatial_full_distortion_kernel_func_ptr_array[asm_type];
+
+                    chromaFastDistortion = spatial_full_dist_type_fun(
+                        input_picture_ptr->buffer_cb,
+                        inputCbOriginIndex,
                         input_picture_ptr->stride_cb,
-                        candidateBuffer->prediction_ptr->buffer_cb + cuChromaOriginIndex,
+                        candidateBuffer->prediction_ptr->buffer_cb,
+                        cuChromaOriginIndex,
                         prediction_ptr->stride_cb,
                         context_ptr->blk_geom->bwidth_uv,
                         context_ptr->blk_geom->bheight_uv);
 
-                    chromaFastDistortion += spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                        input_picture_ptr->buffer_cr + inputCrOriginIndex,
+                    chromaFastDistortion += spatial_full_dist_type_fun(
+                        input_picture_ptr->buffer_cr,
+                        inputCrOriginIndex,
                         input_picture_ptr->stride_cb,
-                        candidateBuffer->prediction_ptr->buffer_cr + cuChromaOriginIndex,
+                        candidateBuffer->prediction_ptr->buffer_cr,
+                        cuChromaOriginIndex,
                         prediction_ptr->stride_cr,
                         context_ptr->blk_geom->bwidth_uv,
                         context_ptr->blk_geom->bheight_uv);
                 }
                 else {
                     assert((context_ptr->blk_geom->bwidth_uv >> 3) < 17);
-                    chromaFastDistortion = nxm_sad_kernel_sub_sampled_func_ptr_array[asm_type][context_ptr->blk_geom->bwidth_uv >> 3](
-                        input_picture_ptr->buffer_cb + inputCbOriginIndex,
-                        input_picture_ptr->stride_cb,
-                        candidateBuffer->prediction_ptr->buffer_cb + cuChromaOriginIndex,
-                        prediction_ptr->stride_cb,
-                        context_ptr->blk_geom->bheight_uv,
-                        context_ptr->blk_geom->bwidth_uv);
 
-                    chromaFastDistortion += nxm_sad_kernel_sub_sampled_func_ptr_array[asm_type][context_ptr->blk_geom->bwidth_uv >> 3](
-                        input_picture_ptr->buffer_cr + inputCrOriginIndex,
-                        input_picture_ptr->stride_cb,
-                        candidateBuffer->prediction_ptr->buffer_cr + cuChromaOriginIndex,
-                        prediction_ptr->stride_cr,
-                        context_ptr->blk_geom->bheight_uv,
-                        context_ptr->blk_geom->bwidth_uv);
+                    if (!context_ptr->hbd_mode_decision) {
+                        chromaFastDistortion = nxm_sad_kernel_sub_sampled_func_ptr_array[asm_type][context_ptr->blk_geom->bwidth_uv >> 3](
+                            input_picture_ptr->buffer_cb + inputCbOriginIndex,
+                            input_picture_ptr->stride_cb,
+                            candidateBuffer->prediction_ptr->buffer_cb + cuChromaOriginIndex,
+                            prediction_ptr->stride_cb,
+                            context_ptr->blk_geom->bheight_uv,
+                            context_ptr->blk_geom->bwidth_uv);
+
+                        chromaFastDistortion += nxm_sad_kernel_sub_sampled_func_ptr_array[asm_type][context_ptr->blk_geom->bwidth_uv >> 3](
+                            input_picture_ptr->buffer_cr + inputCrOriginIndex,
+                            input_picture_ptr->stride_cr,
+                            candidateBuffer->prediction_ptr->buffer_cr + cuChromaOriginIndex,
+                            prediction_ptr->stride_cr,
+                            context_ptr->blk_geom->bheight_uv,
+                            context_ptr->blk_geom->bwidth_uv);
+                    } else {
+                        chromaFastDistortion = sad_16b_kernel (
+                            ((uint16_t *) input_picture_ptr->buffer_cb) + inputCbOriginIndex,
+                            input_picture_ptr->stride_cb,
+                            ((uint16_t *) candidateBuffer->prediction_ptr->buffer_cb) + cuChromaOriginIndex,
+                            prediction_ptr->stride_cb,
+                            context_ptr->blk_geom->bheight_uv,
+                            context_ptr->blk_geom->bwidth_uv);
+
+                        chromaFastDistortion += sad_16b_kernel (
+                            ((uint16_t *) input_picture_ptr->buffer_cr) + inputCrOriginIndex,
+                            input_picture_ptr->stride_cr,
+                            ((uint16_t *) candidateBuffer->prediction_ptr->buffer_cr) + cuChromaOriginIndex,
+                            prediction_ptr->stride_cr,
+                            context_ptr->blk_geom->bheight_uv,
+                            context_ptr->blk_geom->bwidth_uv);
+                    }
                 }
             }
             else
@@ -1625,26 +1753,41 @@ void AV1CostCalcCfl(
         assert(chroma_width * CFL_BUF_LINE + chroma_height <=
             CFL_BUF_SQUARE);
 
-        cfl_predict_lbd(
-            context_ptr->pred_buf_q3,
-            &(candidateBuffer->prediction_ptr->buffer_cb[cuChromaOriginIndex]),
-            candidateBuffer->prediction_ptr->stride_cb,
-            //dst_16,
-            &(candidateBuffer->cfl_temp_prediction_ptr->buffer_cb[cuChromaOriginIndex]),
-            candidateBuffer->cfl_temp_prediction_ptr->stride_cb,
-            alpha_q3,
-            8,
-            chroma_width,
-            chroma_height);
-        //Cb Residual
+        if (!context_ptr->hbd_mode_decision)
+            cfl_predict_lbd(
+                context_ptr->pred_buf_q3,
+                &(candidateBuffer->prediction_ptr->buffer_cb[cuChromaOriginIndex]),
+                candidateBuffer->prediction_ptr->stride_cb,
+                &(candidateBuffer->cfl_temp_prediction_ptr->buffer_cb[cuChromaOriginIndex]),
+                candidateBuffer->cfl_temp_prediction_ptr->stride_cb,
+                alpha_q3,
+                8,
+                chroma_width,
+                chroma_height);
+        else
+            cfl_predict_hbd(
+                context_ptr->pred_buf_q3,
+                ((uint16_t*)candidateBuffer->prediction_ptr->buffer_cb) + cuChromaOriginIndex,
+                candidateBuffer->prediction_ptr->stride_cb,
+                ((uint16_t*)candidateBuffer->cfl_temp_prediction_ptr->buffer_cb) + cuChromaOriginIndex,
+                candidateBuffer->cfl_temp_prediction_ptr->stride_cb,
+                alpha_q3,
+                10,
+                chroma_width,
+                chroma_height);
 
-        ResidualKernel(
-            &(input_picture_ptr->buffer_cb[inputCbOriginIndex]),
+        // Cb Residual
+        residual_kernel(
+            input_picture_ptr->buffer_cb,
+            inputCbOriginIndex,
             input_picture_ptr->stride_cb,
-            &(candidateBuffer->cfl_temp_prediction_ptr->buffer_cb[cuChromaOriginIndex]),
+            candidateBuffer->cfl_temp_prediction_ptr->buffer_cb,
+            cuChromaOriginIndex,
             candidateBuffer->cfl_temp_prediction_ptr->stride_cb,
-            &(((int16_t*)candidateBuffer->residual_ptr->buffer_cb)[cuChromaOriginIndex]),
+            (int16_t*)candidateBuffer->residual_ptr->buffer_cb,
+            cuChromaOriginIndex,
             candidateBuffer->residual_ptr->stride_cb,
+            context_ptr->hbd_mode_decision,
             chroma_width,
             chroma_height);
 
@@ -1667,6 +1810,7 @@ void AV1CostCalcCfl(
             context_ptr,
             candidate_ptr,
             picture_control_set_ptr,
+            input_picture_ptr,
             cbFullDistortion,
             crFullDistortion,
             count_non_zero_coeffs,
@@ -1693,26 +1837,41 @@ void AV1CostCalcCfl(
         assert(chroma_width * CFL_BUF_LINE + chroma_height <=
             CFL_BUF_SQUARE);
 
-        cfl_predict_lbd(
-            context_ptr->pred_buf_q3,
-            &(candidateBuffer->prediction_ptr->buffer_cr[cuChromaOriginIndex]),
-            candidateBuffer->prediction_ptr->stride_cr,
-            //dst_16,
-            &(candidateBuffer->cfl_temp_prediction_ptr->buffer_cr[cuChromaOriginIndex]),
-            candidateBuffer->cfl_temp_prediction_ptr->stride_cr,
-            alpha_q3,
-            8,
-            chroma_width,
-            chroma_height);
+        if (!context_ptr->hbd_mode_decision)
+            cfl_predict_lbd(
+                context_ptr->pred_buf_q3,
+                &(candidateBuffer->prediction_ptr->buffer_cr[cuChromaOriginIndex]),
+                candidateBuffer->prediction_ptr->stride_cr,
+                &(candidateBuffer->cfl_temp_prediction_ptr->buffer_cr[cuChromaOriginIndex]),
+                candidateBuffer->cfl_temp_prediction_ptr->stride_cr,
+                alpha_q3,
+                8,
+                chroma_width,
+                chroma_height);
+        else
+            cfl_predict_hbd(
+                context_ptr->pred_buf_q3,
+                ((uint16_t*)candidateBuffer->prediction_ptr->buffer_cr) + cuChromaOriginIndex,
+                candidateBuffer->prediction_ptr->stride_cr,
+                ((uint16_t*)candidateBuffer->cfl_temp_prediction_ptr->buffer_cr) + cuChromaOriginIndex,
+                candidateBuffer->cfl_temp_prediction_ptr->stride_cr,
+                alpha_q3,
+                10,
+                chroma_width,
+                chroma_height);
 
-        //Cr Residual
-        ResidualKernel(
-            &(input_picture_ptr->buffer_cr[inputCbOriginIndex]),
+        // Cr Residual
+        residual_kernel(
+            input_picture_ptr->buffer_cr,
+            inputCbOriginIndex,
             input_picture_ptr->stride_cr,
-            &(candidateBuffer->cfl_temp_prediction_ptr->buffer_cr[cuChromaOriginIndex]),
+            candidateBuffer->cfl_temp_prediction_ptr->buffer_cr,
+            cuChromaOriginIndex,
             candidateBuffer->cfl_temp_prediction_ptr->stride_cr,
-            &(((int16_t*)candidateBuffer->residual_ptr->buffer_cr)[cuChromaOriginIndex]),
+            (int16_t*)candidateBuffer->residual_ptr->buffer_cr,
+            cuChromaOriginIndex,
             candidateBuffer->residual_ptr->stride_cr,
+            context_ptr->hbd_mode_decision,
             chroma_width,
             chroma_height);
 
@@ -1736,6 +1895,7 @@ void AV1CostCalcCfl(
             context_ptr,
             candidate_ptr,
             picture_control_set_ptr,
+            input_picture_ptr,
             cbFullDistortion,
             crFullDistortion,
             count_non_zero_coeffs,
@@ -1945,13 +2105,20 @@ static void CflPrediction(
     uint32_t chroma_height = context_ptr->blk_geom->bheight_uv;
 
     // Down sample Luma
-    cfl_luma_subsampling_420_lbd_c(
-        &(context_ptr->cfl_temp_luma_recon[recLumaOffset]),
-        candidateBuffer->recon_ptr->stride_y,
-        context_ptr->pred_buf_q3,
-        context_ptr->blk_geom->bwidth_uv == context_ptr->blk_geom->bwidth ? (context_ptr->blk_geom->bwidth_uv << 1) : context_ptr->blk_geom->bwidth,
-        context_ptr->blk_geom->bheight_uv == context_ptr->blk_geom->bheight ? (context_ptr->blk_geom->bheight_uv << 1) : context_ptr->blk_geom->bheight);
-
+    if (!context_ptr->hbd_mode_decision)
+        cfl_luma_subsampling_420_lbd_c(
+            &(context_ptr->cfl_temp_luma_recon[recLumaOffset]),
+            candidateBuffer->recon_ptr->stride_y,
+            context_ptr->pred_buf_q3,
+            context_ptr->blk_geom->bwidth_uv == context_ptr->blk_geom->bwidth ? (context_ptr->blk_geom->bwidth_uv << 1) : context_ptr->blk_geom->bwidth,
+            context_ptr->blk_geom->bheight_uv == context_ptr->blk_geom->bheight ? (context_ptr->blk_geom->bheight_uv << 1) : context_ptr->blk_geom->bheight);
+    else
+        cfl_luma_subsampling_420_hbd_c(
+            ((uint16_t*)context_ptr->cfl_temp_luma_recon) + recLumaOffset,
+            candidateBuffer->recon_ptr->stride_y,
+            context_ptr->pred_buf_q3,
+            context_ptr->blk_geom->bwidth_uv == context_ptr->blk_geom->bwidth ? (context_ptr->blk_geom->bwidth_uv << 1) : context_ptr->blk_geom->bwidth,
+            context_ptr->blk_geom->bheight_uv == context_ptr->blk_geom->bheight ? (context_ptr->blk_geom->bheight_uv << 1) : context_ptr->blk_geom->bheight);
     int32_t round_offset = chroma_width * chroma_height / 2;
 
     subtract_average(
@@ -1982,47 +2149,79 @@ static void CflPrediction(
         assert(chroma_height * CFL_BUF_LINE + chroma_width <=
             CFL_BUF_SQUARE);
 
-        cfl_predict_lbd(
-            context_ptr->pred_buf_q3,
-            &(candidateBuffer->prediction_ptr->buffer_cb[cuChromaOriginIndex]),
-            candidateBuffer->prediction_ptr->stride_cb,
-            &(candidateBuffer->prediction_ptr->buffer_cb[cuChromaOriginIndex]),
-            candidateBuffer->prediction_ptr->stride_cb,
-            alpha_q3_cb,
-            8,
-            chroma_width,
-            chroma_height);
+        if (!context_ptr->hbd_mode_decision) {
+            cfl_predict_lbd(
+                context_ptr->pred_buf_q3,
+                &(candidateBuffer->prediction_ptr->buffer_cb[cuChromaOriginIndex]),
+                candidateBuffer->prediction_ptr->stride_cb,
+                &(candidateBuffer->prediction_ptr->buffer_cb[cuChromaOriginIndex]),
+                candidateBuffer->prediction_ptr->stride_cb,
+                alpha_q3_cb,
+                8,
+                chroma_width,
+                chroma_height);
 
-        cfl_predict_lbd(
-            context_ptr->pred_buf_q3,
-            &(candidateBuffer->prediction_ptr->buffer_cr[cuChromaOriginIndex]),
-            candidateBuffer->prediction_ptr->stride_cr,
-            &(candidateBuffer->prediction_ptr->buffer_cr[cuChromaOriginIndex]),
-            candidateBuffer->prediction_ptr->stride_cr,
-            alpha_q3_cr,
-            8,
-            chroma_width,
-            chroma_height);
+            cfl_predict_lbd(
+                context_ptr->pred_buf_q3,
+                &(candidateBuffer->prediction_ptr->buffer_cr[cuChromaOriginIndex]),
+                candidateBuffer->prediction_ptr->stride_cr,
+                &(candidateBuffer->prediction_ptr->buffer_cr[cuChromaOriginIndex]),
+                candidateBuffer->prediction_ptr->stride_cr,
+                alpha_q3_cr,
+                8,
+                chroma_width,
+                chroma_height);
+        } else {
+            cfl_predict_hbd(
+                context_ptr->pred_buf_q3,
+                ((uint16_t*)candidateBuffer->prediction_ptr->buffer_cb) + cuChromaOriginIndex,
+                candidateBuffer->prediction_ptr->stride_cb,
+                ((uint16_t*)candidateBuffer->prediction_ptr->buffer_cb) + cuChromaOriginIndex,
+                candidateBuffer->prediction_ptr->stride_cb,
+                alpha_q3_cb,
+                10,
+                chroma_width,
+                chroma_height);
 
-        //Cb Residual
-        ResidualKernel(
-            &(input_picture_ptr->buffer_cb[inputCbOriginIndex]),
+            cfl_predict_hbd(
+                context_ptr->pred_buf_q3,
+                ((uint16_t*)candidateBuffer->prediction_ptr->buffer_cr) + cuChromaOriginIndex,
+                candidateBuffer->prediction_ptr->stride_cr,
+                ((uint16_t*)candidateBuffer->prediction_ptr->buffer_cr) + cuChromaOriginIndex,
+                candidateBuffer->prediction_ptr->stride_cr,
+                alpha_q3_cr,
+                10,
+                chroma_width,
+                chroma_height);
+        }
+
+        // Cb Residual
+        residual_kernel(
+            input_picture_ptr->buffer_cb,
+            inputCbOriginIndex,
             input_picture_ptr->stride_cb,
-            &(candidateBuffer->prediction_ptr->buffer_cb[cuChromaOriginIndex]),
+            candidateBuffer->prediction_ptr->buffer_cb,
+            cuChromaOriginIndex,
             candidateBuffer->prediction_ptr->stride_cb,
-            &(((int16_t*)candidateBuffer->residual_ptr->buffer_cb)[cuChromaOriginIndex]),
+            (int16_t*)candidateBuffer->residual_ptr->buffer_cb,
+            cuChromaOriginIndex,
             candidateBuffer->residual_ptr->stride_cb,
+            context_ptr->hbd_mode_decision,
             context_ptr->blk_geom->bwidth_uv,
             context_ptr->blk_geom->bheight_uv);
 
-        //Cr Residual
-        ResidualKernel(
-            &(input_picture_ptr->buffer_cr[inputCbOriginIndex]),
+        // Cr Residual
+        residual_kernel(
+            input_picture_ptr->buffer_cr,
+            inputCbOriginIndex,
             input_picture_ptr->stride_cr,
-            &(candidateBuffer->prediction_ptr->buffer_cr[cuChromaOriginIndex]),
+            candidateBuffer->prediction_ptr->buffer_cr,
+            cuChromaOriginIndex,
             candidateBuffer->prediction_ptr->stride_cr,
-            &(((int16_t*)candidateBuffer->residual_ptr->buffer_cr)[cuChromaOriginIndex]),
+            (int16_t*)candidateBuffer->residual_ptr->buffer_cr,
+            cuChromaOriginIndex,
             candidateBuffer->residual_ptr->stride_cr,
+            context_ptr->hbd_mode_decision,
             context_ptr->blk_geom->bwidth_uv,
             context_ptr->blk_geom->bheight_uv);
     }
@@ -2221,23 +2420,33 @@ void check_best_indepedant_cfl(
             candidateBuffer,
             asm_type);
 
-        ResidualKernel(
-            &(input_picture_ptr->buffer_cb[inputCbOriginIndex]),
+        // Cb Residual
+        residual_kernel(
+            input_picture_ptr->buffer_cb,
+            inputCbOriginIndex,
             input_picture_ptr->stride_cb,
-            &(candidateBuffer->prediction_ptr->buffer_cb[cuChromaOriginIndex]),
+            candidateBuffer->prediction_ptr->buffer_cb,
+            cuChromaOriginIndex,
             candidateBuffer->prediction_ptr->stride_cb,
-            &(((int16_t*)candidateBuffer->residual_ptr->buffer_cb)[cuChromaOriginIndex]),
+            (int16_t*)candidateBuffer->residual_ptr->buffer_cb,
+            cuChromaOriginIndex,
             candidateBuffer->residual_ptr->stride_cb,
+            context_ptr->hbd_mode_decision,
             context_ptr->blk_geom->bwidth_uv,
             context_ptr->blk_geom->bheight_uv);
 
-        ResidualKernel(
-            &(input_picture_ptr->buffer_cr[inputCbOriginIndex]),
+        // Cr Residual
+        residual_kernel(
+            input_picture_ptr->buffer_cr,
+            inputCbOriginIndex,
             input_picture_ptr->stride_cr,
-            &(candidateBuffer->prediction_ptr->buffer_cr[cuChromaOriginIndex]),
+            candidateBuffer->prediction_ptr->buffer_cr,
+            cuChromaOriginIndex,
             candidateBuffer->prediction_ptr->stride_cr,
-            &(((int16_t*)candidateBuffer->residual_ptr->buffer_cr)[cuChromaOriginIndex]),
+            (int16_t*)candidateBuffer->residual_ptr->buffer_cr,
+            cuChromaOriginIndex,
             candidateBuffer->residual_ptr->stride_cr,
+            context_ptr->hbd_mode_decision,
             context_ptr->blk_geom->bwidth_uv,
             context_ptr->blk_geom->bheight_uv);
 
@@ -2259,6 +2468,7 @@ void check_best_indepedant_cfl(
             context_ptr,
             candidateBuffer->candidate_ptr,
             picture_control_set_ptr,
+            input_picture_ptr,
             cbFullDistortion,
             crFullDistortion,
             count_non_zero_coeffs,
@@ -2273,32 +2483,7 @@ void check_best_indepedant_cfl(
     }
 }
 
-EbErrorType av1_predict_intra_block(
-    TileInfo                    *tile,
-    STAGE                       stage,
-    const BlockGeom            *blk_geom,
-    const Av1Common *cm,
-    int32_t wpx,
-    int32_t hpx,
-    TxSize tx_size,
-    PredictionMode mode,
-    int32_t angle_delta,
-    int32_t use_palette,
-    FilterIntraMode filter_intra_mode,
-    uint8_t* topNeighArray,
-    uint8_t* leftNeighArray,
-    EbPictureBufferDesc  *recon_buffer,
-    int32_t col_off,
-    int32_t row_off,
-    int32_t plane,
-    BlockSize bsize,
-    uint32_t tu_org_x_pict,
-    uint32_t tu_org_y_pict,
-    uint32_t bl_org_x_pict,
-    uint32_t bl_org_y_pict,
-    uint32_t bl_org_x_mb,
-    uint32_t bl_org_y_mb);
-
+            // double check the usage of tx_search_luma_recon_neighbor_array16bit
 EbErrorType av1_intra_luma_prediction(
     ModeDecisionContext         *md_context_ptr,
     PictureControlSet           *picture_control_set_ptr,
@@ -2335,44 +2520,84 @@ EbErrorType av1_intra_luma_prediction(
 
     TxSize  tx_size = md_context_ptr->blk_geom->txsize[md_context_ptr->tx_depth][md_context_ptr->txb_itr];
 
-    uint8_t    topNeighArray[64 * 2 + 1];
-    uint8_t    leftNeighArray[64 * 2 + 1];
     PredictionMode mode;
+    if (picture_control_set_ptr->hbd_mode_decision) {
+        uint8_t topNeighArray[64 * 2 + 1];
+        uint8_t leftNeighArray[64 * 2 + 1];
 
-    if (txb_origin_y != 0)
-        memcpy(topNeighArray + 1, md_context_ptr->tx_search_luma_recon_neighbor_array->top_array + txb_origin_x, tx_width * 2);
-    if (txb_origin_x != 0)
-        memcpy(leftNeighArray + 1, md_context_ptr->tx_search_luma_recon_neighbor_array->left_array + txb_origin_y, tx_height * 2);
-    if (txb_origin_y != 0 && txb_origin_x != 0)
-        topNeighArray[0] = leftNeighArray[0] = md_context_ptr->tx_search_luma_recon_neighbor_array->top_left_array[MAX_PICTURE_HEIGHT_SIZE + txb_origin_x - txb_origin_y];
+        if (txb_origin_y != 0)
+            memcpy(topNeighArray + 1, md_context_ptr->tx_search_luma_recon_neighbor_array->top_array + txb_origin_x, tx_width * 2);
+        if (txb_origin_x != 0)
+            memcpy(leftNeighArray + 1, md_context_ptr->tx_search_luma_recon_neighbor_array->left_array + txb_origin_y, tx_height * 2);
+        if (txb_origin_y != 0 && txb_origin_x != 0)
+            topNeighArray[0] = leftNeighArray[0] = md_context_ptr->tx_search_luma_recon_neighbor_array->top_left_array[MAX_PICTURE_HEIGHT_SIZE + txb_origin_x - txb_origin_y];
 
-    mode = candidate_buffer_ptr->candidate_ptr->pred_mode;
-    av1_predict_intra_block(
-        &md_context_ptr->sb_ptr->tile_info,
-        MD_STAGE,
-        md_context_ptr->blk_geom,
-        picture_control_set_ptr->parent_pcs_ptr->av1_cm,                                      //const Av1Common *cm,
-        md_context_ptr->blk_geom->bwidth,          //int32_t wpx,
-        md_context_ptr->blk_geom->bheight,          //int32_t hpx,
-        tx_size,                                               //TxSize tx_size,
-        mode,                                                                           //PredictionMode mode,
-        candidate_buffer_ptr->candidate_ptr->angle_delta[PLANE_TYPE_Y],
-        0,                                                                              //int32_t use_palette,
-        FILTER_INTRA_MODES,                                                             //CHKN FilterIntraMode filter_intra_mode,
-        topNeighArray + 1,
-        leftNeighArray + 1,
-        candidate_buffer_ptr->prediction_ptr,                                              //uint8_t *dst,
-        md_context_ptr->blk_geom->tx_boff_x[md_context_ptr->tx_depth][md_context_ptr->txb_itr] >> 2, //int32_t col_off,
-        md_context_ptr->blk_geom->tx_boff_y[md_context_ptr->tx_depth][md_context_ptr->txb_itr] >> 2,                                                                              //int32_t row_off,
-        PLANE_TYPE_Y,                                                                          //int32_t plane,
-        md_context_ptr->blk_geom->bsize,       //uint32_t puSize,
-        md_context_ptr->cu_origin_x,
-        md_context_ptr->cu_origin_y,
-        md_context_ptr->cu_origin_x,                  //uint32_t cuOrgX,
-        md_context_ptr->cu_origin_y,                  //uint32_t cuOrgY
-        md_context_ptr->blk_geom->tx_org_x[md_context_ptr->tx_depth][md_context_ptr->txb_itr],  //uint32_t cuOrgX used only for prediction Ptr
-        md_context_ptr->blk_geom->tx_org_y[md_context_ptr->tx_depth][md_context_ptr->txb_itr]   //uint32_t cuOrgY used only for prediction Ptr
-    );
+        mode = candidate_buffer_ptr->candidate_ptr->pred_mode;
+        av1_predict_intra_block(
+            &md_context_ptr->sb_ptr->tile_info,
+            MD_STAGE,
+            md_context_ptr->blk_geom,
+            picture_control_set_ptr->parent_pcs_ptr->av1_cm,                                      //const Av1Common *cm,
+            md_context_ptr->blk_geom->bwidth,
+            md_context_ptr->blk_geom->bheight,
+            tx_size,
+            mode,                                                                           //PredictionMode mode,
+            candidate_buffer_ptr->candidate_ptr->angle_delta[PLANE_TYPE_Y],
+            0,                                                                              //int32_t use_palette,
+            FILTER_INTRA_MODES,                                                             //CHKN FilterIntraMode filter_intra_mode,
+            topNeighArray + 1,
+            leftNeighArray + 1,
+            candidate_buffer_ptr->prediction_ptr,                                              //uint8_t *dst,
+            md_context_ptr->blk_geom->tx_boff_x[md_context_ptr->tx_depth][md_context_ptr->txb_itr] >> 2, //int32_t col_off,
+            md_context_ptr->blk_geom->tx_boff_y[md_context_ptr->tx_depth][md_context_ptr->txb_itr] >> 2,                                                                              //int32_t row_off,
+            PLANE_TYPE_Y,                                                                          //int32_t plane,
+            md_context_ptr->blk_geom->bsize,
+            md_context_ptr->cu_origin_x,
+            md_context_ptr->cu_origin_y,
+            md_context_ptr->cu_origin_x,
+            md_context_ptr->cu_origin_y,
+            md_context_ptr->blk_geom->tx_org_x[md_context_ptr->tx_depth][md_context_ptr->txb_itr],  //uint32_t cuOrgX used only for prediction Ptr
+            md_context_ptr->blk_geom->tx_org_y[md_context_ptr->tx_depth][md_context_ptr->txb_itr]   //uint32_t cuOrgY used only for prediction Ptr
+        );
+    } else {
+        uint16_t topNeighArray[64 * 2 + 1];
+        uint16_t leftNeighArray[64 * 2 + 1];
+
+        if (txb_origin_y != 0)
+            memcpy(topNeighArray + 1, (uint16_t*)(md_context_ptr->tx_search_luma_recon_neighbor_array16bit->top_array) + txb_origin_x, sizeof(uint16_t) * tx_width * 2);
+        if (txb_origin_x != 0)
+            memcpy(leftNeighArray + 1, (uint16_t*)(md_context_ptr->tx_search_luma_recon_neighbor_array16bit->left_array) + txb_origin_y, sizeof(uint16_t) * tx_height * 2);
+        if (txb_origin_y != 0 && txb_origin_x != 0)
+            topNeighArray[0] = leftNeighArray[0] = ((uint16_t*)(md_context_ptr->tx_search_luma_recon_neighbor_array16bit->top_left_array) + MAX_PICTURE_HEIGHT_SIZE + txb_origin_x - txb_origin_y)[0];
+
+        mode = candidate_buffer_ptr->candidate_ptr->pred_mode;
+        av1_predict_intra_block_16bit(
+            &md_context_ptr->sb_ptr->tile_info,
+            MD_STAGE,
+            md_context_ptr->blk_geom,
+            picture_control_set_ptr->parent_pcs_ptr->av1_cm,
+            md_context_ptr->blk_geom->bwidth,
+            md_context_ptr->blk_geom->bheight,
+            tx_size,
+            mode,
+            candidate_buffer_ptr->candidate_ptr->angle_delta[PLANE_TYPE_Y],
+            0,
+            FILTER_INTRA_MODES,
+            topNeighArray + 1,
+            leftNeighArray + 1,
+            candidate_buffer_ptr->prediction_ptr,
+            md_context_ptr->blk_geom->tx_boff_x[md_context_ptr->tx_depth][md_context_ptr->txb_itr] >> 2,
+            md_context_ptr->blk_geom->tx_boff_y[md_context_ptr->tx_depth][md_context_ptr->txb_itr] >> 2,                                                                              //int32_t row_off,
+            PLANE_TYPE_Y,
+            md_context_ptr->blk_geom->bsize,
+            md_context_ptr->cu_origin_x,
+            md_context_ptr->cu_origin_y,
+            md_context_ptr->cu_origin_x,
+            md_context_ptr->cu_origin_y,
+            md_context_ptr->blk_geom->tx_org_x[md_context_ptr->tx_depth][md_context_ptr->txb_itr],  //uint32_t cuOrgX used only for prediction Ptr
+            md_context_ptr->blk_geom->tx_org_y[md_context_ptr->tx_depth][md_context_ptr->txb_itr]   //uint32_t cuOrgY used only for prediction Ptr
+        );
+    }
 
     return return_error;
 }
@@ -2385,19 +2610,33 @@ static void tx_search_update_recon_sample_neighbor_array(
     uint32_t               input_origin_x,
     uint32_t               input_origin_y,
     uint32_t               width,
-    uint32_t               height)
+    uint32_t               height,
+    EbBool                 hbd)
 {
-    neighbor_array_unit_sample_write(
-        lumaReconSampleNeighborArray,
-        recon_buffer->buffer_y,
-        recon_buffer->stride_y,
-        recon_buffer->origin_x + tu_origin_x,
-        recon_buffer->origin_y + tu_origin_y,
-        input_origin_x,
-        input_origin_y,
-        width,
-        height,
-        NEIGHBOR_ARRAY_UNIT_FULL_MASK);
+    if (hbd)
+        neighbor_array_unit16bit_sample_write(
+            lumaReconSampleNeighborArray,
+            (uint16_t*)recon_buffer->buffer_y,
+            recon_buffer->stride_y,
+            recon_buffer->origin_x + tu_origin_x,
+            recon_buffer->origin_y + tu_origin_y,
+            input_origin_x,
+            input_origin_y,
+            width,
+            height,
+            NEIGHBOR_ARRAY_UNIT_FULL_MASK);
+    else
+        neighbor_array_unit_sample_write(
+            lumaReconSampleNeighborArray,
+            recon_buffer->buffer_y,
+            recon_buffer->stride_y,
+            recon_buffer->origin_x + tu_origin_x,
+            recon_buffer->origin_y + tu_origin_y,
+            input_origin_x,
+            input_origin_y,
+            width,
+            height,
+            NEIGHBOR_ARRAY_UNIT_FULL_MASK);
 
     return;
 }
@@ -2835,7 +3074,8 @@ void perform_intra_tx_partitioning(
     uint64_t                     *y_coeff_bits,
     uint64_t                     *y_full_distortion)
 {
-    EbPictureBufferDesc *input_picture_ptr = picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
+    EbPictureBufferDesc *input_picture_ptr = picture_control_set_ptr->hbd_mode_decision ?
+        picture_control_set_ptr->input_frame16bit : picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
     SequenceControlSet  *sequence_control_set_ptr = (SequenceControlSet*)picture_control_set_ptr->sequence_control_set_wrapper_ptr->object_ptr;
     EbAsm    asm_type = sequence_control_set_ptr->encode_context_ptr->asm_type;
     uint32_t tu_origin_index;
@@ -2852,14 +3092,25 @@ void perform_intra_tx_partitioning(
 
     // Reset depth_1 neighbor arrays
     if (end_tx_depth) {
-        copy_neigh_arr(
-            picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
-            picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
-            context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x,
-            context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y,
-            context_ptr->blk_geom->bwidth,
-            context_ptr->blk_geom->bheight,
-            NEIGHBOR_ARRAY_UNIT_FULL_MASK);
+        if (!picture_control_set_ptr->hbd_mode_decision)
+            copy_neigh_arr(
+                picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
+                context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x,
+                context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y,
+                context_ptr->blk_geom->bwidth,
+                context_ptr->blk_geom->bheight,
+                NEIGHBOR_ARRAY_UNIT_FULL_MASK);
+        else
+            copy_neigh_arr(
+                picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
+                context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x,
+                context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y,
+                context_ptr->blk_geom->bwidth,
+                context_ptr->blk_geom->bheight,
+                NEIGHBOR_ARRAY_UNIT_FULL_MASK);
+
         copy_neigh_arr(
             picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
             picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
@@ -2873,10 +3124,18 @@ void perform_intra_tx_partitioning(
     // Transform Depth Loop
     for (context_ptr->tx_depth = 0; context_ptr->tx_depth <= end_tx_depth; context_ptr->tx_depth++) {
         // Set recon neighbor array to be used @ intra compensation
-        context_ptr->tx_search_luma_recon_neighbor_array =
-            (context_ptr->tx_depth) ?
-            picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX] :
-            picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
+        if (!context_ptr->hbd_mode_decision)
+            context_ptr->tx_search_luma_recon_neighbor_array =
+                (context_ptr->tx_depth) ?
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX] :
+                picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
+        else
+            context_ptr->tx_search_luma_recon_neighbor_array16bit =
+                (context_ptr->tx_depth) ?
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX] :
+                picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX];
+
+
 
         // Set luma dc sign level coeff
         context_ptr->tx_search_luma_dc_sign_level_coeff_neighbor_array =
@@ -2922,13 +3181,17 @@ void perform_intra_tx_partitioning(
                 candidateBuffer);
 
             // Y Residual
-            ResidualKernel(
-                &(input_picture_ptr->buffer_y[input_tu_origin_index]),
+            residual_kernel(
+                input_picture_ptr->buffer_y,
+                input_tu_origin_index,
                 input_picture_ptr->stride_y,
-                &(candidateBuffer->prediction_ptr->buffer_y[tu_origin_index]),
+                candidateBuffer->prediction_ptr->buffer_y,
+                tu_origin_index,
                 candidateBuffer->prediction_ptr->stride_y,
-                &(((int16_t*)candidateBuffer->residual_ptr->buffer_y)[tu_origin_index]),
+                (int16_t*)candidateBuffer->residual_ptr->buffer_y,
+                tu_origin_index,
                 candidateBuffer->residual_ptr->stride_y,
+                context_ptr->hbd_mode_decision,
                 context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
 
@@ -2960,7 +3223,7 @@ void perform_intra_tx_partitioning(
                     context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
                     &context_ptr->three_quad_energy,
                     context_ptr->transform_inner_array_ptr,
-                    0,
+                    picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                     tx_type,
                     asm_type,
                     PLANE_TYPE_Y,
@@ -2982,7 +3245,7 @@ void perform_intra_tx_partitioning(
                     asm_type,
                     &(y_count_non_zero_coeffs[context_ptr->txb_itr]),
                     COMPONENT_LUMA,
-                    BIT_INCREMENT_8BIT,
+                    picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                     tx_type,
                     candidateBuffer,
                     context_ptr->luma_txb_skip_context,
@@ -2998,25 +3261,25 @@ void perform_intra_tx_partitioning(
                 // tx_type not equal to DCT_DCT and no coeff is not an acceptable option in AV1.
                 if (y_has_coeff == 0 && tx_type != DCT_DCT)
                     continue;
-                if (y_has_coeff) {
-                    uint8_t *pred_buffer = &(candidateBuffer->prediction_ptr->buffer_y[tu_origin_index]);
-                    uint8_t *rec_buffer = &(candidateBuffer->recon_ptr->buffer_y[tu_origin_index]);
-
-                    uint32_t j;
-                    for (j = 0; j < context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]; j++)
-                        memcpy(rec_buffer + j * candidateBuffer->recon_ptr->stride_y, pred_buffer + j * candidateBuffer->prediction_ptr->stride_y, context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr]);
-
-                    av1_inv_transform_recon8bit(
-                        &(((int32_t*)candidateBuffer->recon_coeff_ptr->buffer_y)[txb_1d_offset]),
-                        rec_buffer,
+                if (y_has_coeff)
+                    inv_transform_recon_copy(
+                        candidateBuffer->prediction_ptr->buffer_y,
+                        tu_origin_index,
+                        candidateBuffer->prediction_ptr->stride_y,
+                        candidateBuffer->recon_ptr->buffer_y,
+                        tu_origin_index,
                         candidateBuffer->recon_ptr->stride_y,
+                        (int32_t*) candidateBuffer->recon_coeff_ptr->buffer_y,
+                        txb_1d_offset,
+                        context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
+                        context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
+                        picture_control_set_ptr->hbd_mode_decision,
                         context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
                         tx_type,
                         PLANE_TYPE_Y,
                         (uint16_t)candidateBuffer->candidate_ptr->eob[0][context_ptr->txb_itr]);
-                }
-                else {
-                    picture_copy8_bit(
+                else
+                    picture_copy(
                         candidateBuffer->prediction_ptr,
                         tu_origin_index,
                         0,
@@ -3028,21 +3291,28 @@ void perform_intra_tx_partitioning(
                         0,
                         0,
                         PICTURE_BUFFER_DESC_Y_FLAG,
+                        picture_control_set_ptr->hbd_mode_decision,
                         asm_type);
-                }
 
-                tuFullDistortion[0][DIST_CALC_PREDICTION] = spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                    input_picture_ptr->buffer_y + input_tu_origin_index,
+                EbSpatialFullDistType spatial_full_dist_type_fun = context_ptr->hbd_mode_decision ?
+                        full_distortion_kernel16_bits : spatial_full_distortion_kernel_func_ptr_array[asm_type];
+
+                tuFullDistortion[0][DIST_CALC_PREDICTION] = spatial_full_dist_type_fun(
+                    input_picture_ptr->buffer_y,
+                    input_tu_origin_index,
                     input_picture_ptr->stride_y,
-                    candidateBuffer->prediction_ptr->buffer_y + tu_origin_index,
+                    candidateBuffer->prediction_ptr->buffer_y,
+                    tu_origin_index,
                     candidateBuffer->prediction_ptr->stride_y,
                     context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
                     context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
 
-                tuFullDistortion[0][DIST_CALC_RESIDUAL] = spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                    input_picture_ptr->buffer_y + input_tu_origin_index,
+                tuFullDistortion[0][DIST_CALC_RESIDUAL] = spatial_full_dist_type_fun(
+                    input_picture_ptr->buffer_y,
+                    input_tu_origin_index,
                     input_picture_ptr->stride_y,
-                    &(((uint8_t*)candidateBuffer->recon_ptr->buffer_y)[tu_origin_index]),
+                    candidateBuffer->recon_ptr->buffer_y,
+                    tu_origin_index,
                     candidateBuffer->recon_ptr->stride_y,
                     context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
                     context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
@@ -3099,7 +3369,7 @@ void perform_intra_tx_partitioning(
                 context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
                 &context_ptr->three_quad_energy,
                 context_ptr->transform_inner_array_ptr,
-                0,
+                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 candidateBuffer->candidate_ptr->transform_type[context_ptr->txb_itr],
                 asm_type,
                 PLANE_TYPE_Y,
@@ -3124,7 +3394,7 @@ void perform_intra_tx_partitioning(
                 asm_type,
                 &(y_count_non_zero_coeffs[context_ptr->txb_itr]),
                 COMPONENT_LUMA,
-                BIT_INCREMENT_8BIT,
+                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 candidateBuffer->candidate_ptr->transform_type[context_ptr->txb_itr],
                 candidateBuffer,
                 context_ptr->luma_txb_skip_context,
@@ -3134,25 +3404,25 @@ void perform_intra_tx_partitioning(
                 EB_FALSE);
             uint32_t y_has_coeff = y_count_non_zero_coeffs[context_ptr->txb_itr] > 0;
 
-            if (y_has_coeff) {
-                uint8_t *pred_buffer = &(candidateBuffer->prediction_ptr->buffer_y[tu_origin_index]);
-                uint8_t *rec_buffer = &(candidateBuffer->recon_ptr->buffer_y[tu_origin_index]);
-
-                uint32_t j;
-                for (j = 0; j < context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]; j++)
-                    memcpy(rec_buffer + j * candidateBuffer->recon_ptr->stride_y, pred_buffer + j * candidateBuffer->prediction_ptr->stride_y, context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr]);
-
-                av1_inv_transform_recon8bit(
-                    &(((int32_t*)candidateBuffer->recon_coeff_ptr->buffer_y)[txb_1d_offset]),
-                    rec_buffer,
+            if (y_has_coeff)
+                inv_transform_recon_copy(
+                    candidateBuffer->prediction_ptr->buffer_y,
+                    tu_origin_index,
+                    candidateBuffer->prediction_ptr->stride_y,
+                    candidateBuffer->recon_ptr->buffer_y,
+                    tu_origin_index,
                     candidateBuffer->recon_ptr->stride_y,
+                    (int32_t*) candidateBuffer->recon_coeff_ptr->buffer_y,
+                    txb_1d_offset,
+                    context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
+                    context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
+                    picture_control_set_ptr->hbd_mode_decision,
                     context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
                     candidateBuffer->candidate_ptr->transform_type[context_ptr->txb_itr],
                     PLANE_TYPE_Y,
                     (uint16_t)candidateBuffer->candidate_ptr->eob[0][context_ptr->txb_itr]);
-            }
-            else {
-                picture_copy8_bit(
+            else
+                picture_copy(
                     candidateBuffer->prediction_ptr,
                     tu_origin_index,
                     0,
@@ -3164,21 +3434,28 @@ void perform_intra_tx_partitioning(
                     0,
                     0,
                     PICTURE_BUFFER_DESC_Y_FLAG,
+                    picture_control_set_ptr->hbd_mode_decision,
                     asm_type);
-            }
 
-            tuFullDistortion[0][DIST_CALC_PREDICTION] = spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                input_picture_ptr->buffer_y + input_tu_origin_index,
+            EbSpatialFullDistType spatial_full_dist_type_fun = context_ptr->hbd_mode_decision ?
+                full_distortion_kernel16_bits : spatial_full_distortion_kernel_func_ptr_array[asm_type];
+
+            tuFullDistortion[0][DIST_CALC_PREDICTION] = spatial_full_dist_type_fun(
+                input_picture_ptr->buffer_y,
+                input_tu_origin_index,
                 input_picture_ptr->stride_y,
-                candidateBuffer->prediction_ptr->buffer_y + tu_origin_index,
+                candidateBuffer->prediction_ptr->buffer_y,
+                tu_origin_index,
                 candidateBuffer->prediction_ptr->stride_y,
                 context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
 
-            tuFullDistortion[0][DIST_CALC_RESIDUAL] = spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                input_picture_ptr->buffer_y + input_tu_origin_index,
+            tuFullDistortion[0][DIST_CALC_RESIDUAL] = spatial_full_dist_type_fun(
+                input_picture_ptr->buffer_y,
+                input_tu_origin_index,
                 input_picture_ptr->stride_y,
-                &(((uint8_t*)candidateBuffer->recon_ptr->buffer_y)[tu_origin_index]),
+                candidateBuffer->recon_ptr->buffer_y,
+                tu_origin_index,
                 candidateBuffer->recon_ptr->stride_y,
                 context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
@@ -3230,15 +3507,19 @@ void perform_intra_tx_partitioning(
 
             if (context_ptr->tx_depth)
             {
+                NeighborArrayUnit *tx_search_luma_recon =
+                    context_ptr->hbd_mode_decision ? context_ptr->tx_search_luma_recon_neighbor_array16bit : context_ptr->tx_search_luma_recon_neighbor_array;
+
                 tx_search_update_recon_sample_neighbor_array(
-                    context_ptr->tx_search_luma_recon_neighbor_array,
+                    tx_search_luma_recon,
                     candidateBuffer->recon_ptr,
                     context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr],
                     context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr],
                     context_ptr->sb_origin_x + context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr],
                     context_ptr->sb_origin_y + context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr],
                     context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
+                    context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
+                    context_ptr->hbd_mode_decision);
 
                 int8_t dc_sign_level_coeff = candidateBuffer->candidate_ptr->quantized_dc[0][context_ptr->txb_itr];
                 neighbor_array_unit_mode_write(
@@ -3278,7 +3559,10 @@ void perform_intra_tx_partitioning(
 
     if (context_ptr->tx_depth == 0) {
         // Set recon neighbor array to be used @ intra compensation
-        context_ptr->tx_search_luma_recon_neighbor_array = picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
+        if (context_ptr->hbd_mode_decision)
+            context_ptr->tx_search_luma_recon_neighbor_array16bit = picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX];
+        else
+            context_ptr->tx_search_luma_recon_neighbor_array = picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
 
         // Initialize TU Split
         y_full_distortion[DIST_CALC_RESIDUAL] = 0;
@@ -3320,13 +3604,17 @@ void perform_intra_tx_partitioning(
                 candidateBuffer);
 
             // Y Residual
-            ResidualKernel(
-                &(input_picture_ptr->buffer_y[input_tu_origin_index]),
+            residual_kernel(
+                input_picture_ptr->buffer_y,
+                input_tu_origin_index,
                 input_picture_ptr->stride_y,
-                &(candidateBuffer->prediction_ptr->buffer_y[tu_origin_index]),
+                candidateBuffer->prediction_ptr->buffer_y,
+                tu_origin_index,
                 candidateBuffer->prediction_ptr->stride_y,
-                &(((int16_t*)candidateBuffer->residual_ptr->buffer_y)[tu_origin_index]),
+                (int16_t*)candidateBuffer->residual_ptr->buffer_y,
+                tu_origin_index,
                 candidateBuffer->residual_ptr->stride_y,
+                context_ptr->hbd_mode_decision,
                 context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
 
@@ -3344,7 +3632,7 @@ void perform_intra_tx_partitioning(
                 context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
                 &context_ptr->three_quad_energy,
                 context_ptr->transform_inner_array_ptr,
-                0,
+                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 candidateBuffer->candidate_ptr->transform_type[context_ptr->txb_itr],
                 asm_type,
                 PLANE_TYPE_Y,
@@ -3368,7 +3656,7 @@ void perform_intra_tx_partitioning(
                 asm_type,
                 &(y_count_non_zero_coeffs[context_ptr->txb_itr]),
                 COMPONENT_LUMA,
-                BIT_INCREMENT_8BIT,
+                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 candidateBuffer->candidate_ptr->transform_type[context_ptr->txb_itr],
                 candidateBuffer,
                 context_ptr->luma_txb_skip_context,
@@ -3378,25 +3666,26 @@ void perform_intra_tx_partitioning(
                 EB_FALSE);
             uint32_t y_has_coeff = y_count_non_zero_coeffs[context_ptr->txb_itr] > 0;
 
-            if (y_has_coeff) {
-                uint8_t *pred_buffer = &(candidateBuffer->prediction_ptr->buffer_y[tu_origin_index]);
-                uint8_t *rec_buffer = &(candidateBuffer->recon_ptr->buffer_y[tu_origin_index]);
-
-                uint32_t j;
-                for (j = 0; j < context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]; j++)
-                    memcpy(rec_buffer + j * candidateBuffer->recon_ptr->stride_y, pred_buffer + j * candidateBuffer->prediction_ptr->stride_y, context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr]);
-
-                av1_inv_transform_recon8bit(
-                    &(((int32_t*)candidateBuffer->recon_coeff_ptr->buffer_y)[txb_1d_offset]),
-                    rec_buffer,
+            if (y_has_coeff)
+                inv_transform_recon_copy(
+                    candidateBuffer->prediction_ptr->buffer_y,
+                    tu_origin_index,
+                    candidateBuffer->prediction_ptr->stride_y,
+                    candidateBuffer->recon_ptr->buffer_y,
+                    tu_origin_index,
                     candidateBuffer->recon_ptr->stride_y,
+                    (int32_t*) candidateBuffer->recon_coeff_ptr->buffer_y,
+                    txb_1d_offset,
+                    context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
+                    context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
+                    picture_control_set_ptr->hbd_mode_decision,
                     context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
                     candidateBuffer->candidate_ptr->transform_type[context_ptr->txb_itr],
                     PLANE_TYPE_Y,
                     (uint16_t)candidateBuffer->candidate_ptr->eob[0][context_ptr->txb_itr]);
-            }
-            else {
-                picture_copy8_bit(
+
+            else
+                picture_copy(
                     candidateBuffer->prediction_ptr,
                     tu_origin_index,
                     0,
@@ -3408,21 +3697,28 @@ void perform_intra_tx_partitioning(
                     0,
                     0,
                     PICTURE_BUFFER_DESC_Y_FLAG,
+                    picture_control_set_ptr->hbd_mode_decision,
                     asm_type);
-            }
 
-            tuFullDistortion[0][DIST_CALC_PREDICTION] = spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                input_picture_ptr->buffer_y + input_tu_origin_index,
+            EbSpatialFullDistType spatial_full_dist_type_fun = context_ptr->hbd_mode_decision ?
+                full_distortion_kernel16_bits : spatial_full_distortion_kernel_func_ptr_array[asm_type];
+
+            tuFullDistortion[0][DIST_CALC_PREDICTION] = spatial_full_dist_type_fun(
+                input_picture_ptr->buffer_y,
+                input_tu_origin_index,
                 input_picture_ptr->stride_y,
-                candidateBuffer->prediction_ptr->buffer_y + tu_origin_index,
+                candidateBuffer->prediction_ptr->buffer_y,
+                tu_origin_index,
                 candidateBuffer->prediction_ptr->stride_y,
                 context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
 
-            tuFullDistortion[0][DIST_CALC_RESIDUAL] = spatial_full_distortion_kernel_func_ptr_array[asm_type](
-                input_picture_ptr->buffer_y + input_tu_origin_index,
+            tuFullDistortion[0][DIST_CALC_RESIDUAL] = spatial_full_dist_type_fun(
+                input_picture_ptr->buffer_y,
+                input_tu_origin_index,
                 input_picture_ptr->stride_y,
-                &(((uint8_t*)candidateBuffer->recon_ptr->buffer_y)[tu_origin_index]),
+                candidateBuffer->recon_ptr->buffer_y,
+                tu_origin_index,
                 candidateBuffer->recon_ptr->stride_y,
                 context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
@@ -3541,26 +3837,35 @@ void AV1PerformFullLoop(
         candidate_ptr->chroma_distortion_inter_depth = 0;
         // Set Skip Flag
         candidate_ptr->skip_flag = EB_FALSE;
-        //Cb Residual
+
         if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
-            ResidualKernel(
-                &(input_picture_ptr->buffer_cb[inputCbOriginIndex]),
+            //Cb Residual
+            residual_kernel(
+                input_picture_ptr->buffer_cb,
+                inputCbOriginIndex,
                 input_picture_ptr->stride_cb,
-                &(candidateBuffer->prediction_ptr->buffer_cb[cuChromaOriginIndex]),
+                candidateBuffer->prediction_ptr->buffer_cb,
+                cuChromaOriginIndex,
                 candidateBuffer->prediction_ptr->stride_cb,
-                &(((int16_t*)candidateBuffer->residual_ptr->buffer_cb)[cuChromaOriginIndex]),
+                (int16_t*)candidateBuffer->residual_ptr->buffer_cb,
+                cuChromaOriginIndex,
                 candidateBuffer->residual_ptr->stride_cb,
+                picture_control_set_ptr->hbd_mode_decision,
                 context_ptr->blk_geom->bwidth_uv,
                 context_ptr->blk_geom->bheight_uv);
 
             //Cr Residual
-            ResidualKernel(
-                &(input_picture_ptr->buffer_cr[inputCbOriginIndex]),
+            residual_kernel(
+                input_picture_ptr->buffer_cr,
+                inputCbOriginIndex,
                 input_picture_ptr->stride_cr,
-                &(candidateBuffer->prediction_ptr->buffer_cr[cuChromaOriginIndex]),
+                candidateBuffer->prediction_ptr->buffer_cr,
+                cuChromaOriginIndex,
                 candidateBuffer->prediction_ptr->stride_cr,
-                &(((int16_t*)candidateBuffer->residual_ptr->buffer_cr)[cuChromaOriginIndex]),
+                (int16_t*)candidateBuffer->residual_ptr->buffer_cr,
+                cuChromaOriginIndex,
                 candidateBuffer->residual_ptr->stride_cr,
+                picture_control_set_ptr->hbd_mode_decision,
                 context_ptr->blk_geom->bwidth_uv,
                 context_ptr->blk_geom->bheight_uv);
         }
@@ -3614,16 +3919,20 @@ void AV1PerformFullLoop(
                 }
             }
 
-            //Y Residual
-            ResidualKernel(
-                &(input_picture_ptr->buffer_y[inputOriginIndex]),
-                input_picture_ptr->stride_y,
-                &(candidateBuffer->prediction_ptr->buffer_y[cuOriginIndex]),
-                candidateBuffer->prediction_ptr->stride_y/* 64*/,
-                &(((int16_t*)candidateBuffer->residual_ptr->buffer_y)[cuOriginIndex]),
-                candidateBuffer->residual_ptr->stride_y,
-                context_ptr->blk_geom->bwidth,
-                context_ptr->blk_geom->bheight);
+        //Y Residual
+        residual_kernel(
+            input_picture_ptr->buffer_y,
+            inputOriginIndex,
+            input_picture_ptr->stride_y,
+            candidateBuffer->prediction_ptr->buffer_y,
+            cuOriginIndex,
+            candidateBuffer->prediction_ptr->stride_y,
+            (int16_t*)candidateBuffer->residual_ptr->buffer_y,
+            cuOriginIndex,
+            candidateBuffer->residual_ptr->stride_y,
+            picture_control_set_ptr->hbd_mode_decision,
+            context_ptr->blk_geom->bwidth,
+            context_ptr->blk_geom->bheight);
 
             // Transform partitioning free path
             uint8_t  tx_search_skip_fag = picture_control_set_ptr->parent_pcs_ptr->tx_search_level == TX_SEARCH_FULL_LOOP ? get_skip_tx_search_flag(
@@ -3652,6 +3961,7 @@ void AV1PerformFullLoop(
                 candidateBuffer,
                 context_ptr,
                 picture_control_set_ptr,
+                input_picture_ptr,
                 context_ptr->cu_ptr->qp,
                 &(*count_non_zero_coeffs[0]),
                 &y_coeff_bits,
@@ -3711,6 +4021,7 @@ void AV1PerformFullLoop(
                 context_ptr,
                 candidate_ptr,
                 picture_control_set_ptr,
+                input_picture_ptr,
                 cbFullDistortion,
                 crFullDistortion,
                 count_non_zero_coeffs,
@@ -4080,6 +4391,7 @@ void inter_depth_tx_search(
             candidateBuffer,
             context_ptr,
             picture_control_set_ptr,
+            input_picture_ptr,
             context_ptr->cu_ptr->qp,
             &(*count_non_zero_coeffs[0]),
             &y_coeff_bits,
@@ -4119,6 +4431,7 @@ void inter_depth_tx_search(
                 context_ptr,
                 candidate_ptr,
                 picture_control_set_ptr,
+                input_picture_ptr,
                 cbFullDistortion,
                 crFullDistortion,
                 count_non_zero_coeffs,
@@ -4653,23 +4966,33 @@ void search_best_independent_uv_mode(
                 candidateBuffer,
                 asm_type);
 
-            ResidualKernel(
-                &(input_picture_ptr->buffer_cb[inputCbOriginIndex]),
+            //Cb Residual
+            residual_kernel(
+                input_picture_ptr->buffer_cb,
+                inputCbOriginIndex,
                 input_picture_ptr->stride_cb,
-                &(candidateBuffer->prediction_ptr->buffer_cb[cuChromaOriginIndex]),
+                candidateBuffer->prediction_ptr->buffer_cb,
+                cuChromaOriginIndex,
                 candidateBuffer->prediction_ptr->stride_cb,
-                &(((int16_t*)candidateBuffer->residual_ptr->buffer_cb)[cuChromaOriginIndex]),
+                (int16_t*)candidateBuffer->residual_ptr->buffer_cb,
+                cuChromaOriginIndex,
                 candidateBuffer->residual_ptr->stride_cb,
+                picture_control_set_ptr->hbd_mode_decision,
                 context_ptr->blk_geom->bwidth_uv,
                 context_ptr->blk_geom->bheight_uv);
 
-            ResidualKernel(
-                &(input_picture_ptr->buffer_cr[inputCbOriginIndex]),
+            //Cr Residual
+            residual_kernel(
+                input_picture_ptr->buffer_cr,
+                inputCbOriginIndex,
                 input_picture_ptr->stride_cr,
-                &(candidateBuffer->prediction_ptr->buffer_cr[cuChromaOriginIndex]),
+                candidateBuffer->prediction_ptr->buffer_cr,
+                cuChromaOriginIndex,
                 candidateBuffer->prediction_ptr->stride_cr,
-                &(((int16_t*)candidateBuffer->residual_ptr->buffer_cr)[cuChromaOriginIndex]),
+                (int16_t*)candidateBuffer->residual_ptr->buffer_cr,
+                cuChromaOriginIndex,
                 candidateBuffer->residual_ptr->stride_cr,
+                picture_control_set_ptr->hbd_mode_decision,
                 context_ptr->blk_geom->bwidth_uv,
                 context_ptr->blk_geom->bheight_uv);
 
@@ -4691,6 +5014,7 @@ void search_best_independent_uv_mode(
                 context_ptr,
                 candidateBuffer->candidate_ptr,
                 picture_control_set_ptr,
+                input_picture_ptr,
                 cbFullDistortion,
                 crFullDistortion,
                 count_non_zero_coeffs,
@@ -4799,6 +5123,7 @@ void md_encode_block(
     SequenceControlSet             *sequence_control_set_ptr,
     PictureControlSet              *picture_control_set_ptr,
     ModeDecisionContext            *context_ptr,
+    EbPictureBufferDesc            *input_picture_ptr,
     SsMeContext                    *ss_mecontext,
     uint8_t                          *skip_sub_blocks,
     uint32_t                          lcuAddr,
@@ -4813,8 +5138,6 @@ void md_encode_block(
     uint32_t                                  fastCandidateTotalCount;
     EbAsm                                     asm_type = sequence_control_set_ptr->encode_context_ptr->asm_type;
     uint32_t                                  best_intra_mode = EB_INTRA_MODE_INVALID;
-
-    EbPictureBufferDesc                    *input_picture_ptr = picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
     const uint32_t                            inputOriginIndex = (context_ptr->cu_origin_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_y + (context_ptr->cu_origin_x + input_picture_ptr->origin_x);
 
     const uint32_t inputCbOriginIndex = ((context_ptr->round_origin_y >> 1) + (input_picture_ptr->origin_y >> 1)) * input_picture_ptr->stride_cb + ((context_ptr->round_origin_x >> 1) + (input_picture_ptr->origin_x >> 1));
@@ -5066,8 +5389,13 @@ void md_encode_block(
             // Store the luma data for 4x* and *x4 blocks to be used for CFL
             EbPictureBufferDesc  *recon_ptr = candidateBuffer->recon_ptr;
             uint32_t rec_luma_offset = context_ptr->blk_geom->origin_x + context_ptr->blk_geom->origin_y * recon_ptr->stride_y;
-            for (uint32_t j = 0; j < context_ptr->blk_geom->bheight; ++j)
-                memcpy(&context_ptr->cfl_temp_luma_recon[rec_luma_offset + j* recon_ptr->stride_y], recon_ptr->buffer_y + rec_luma_offset + j * recon_ptr->stride_y, context_ptr->blk_geom->bwidth);
+            if (picture_control_set_ptr->hbd_mode_decision) {
+               for (uint32_t j = 0; j < context_ptr->blk_geom->bheight; ++j)
+                    memcpy(((uint16_t *)context_ptr->cfl_temp_luma_recon) + rec_luma_offset + j* recon_ptr->stride_y, ((uint16_t *)recon_ptr->buffer_y) + (rec_luma_offset + j * recon_ptr->stride_y), sizeof(uint16_t) * context_ptr->blk_geom->bwidth);
+            } else {
+                for (uint32_t j = 0; j < context_ptr->blk_geom->bheight; ++j)
+                    memcpy(&context_ptr->cfl_temp_luma_recon[rec_luma_offset + j* recon_ptr->stride_y], recon_ptr->buffer_y + rec_luma_offset + j * recon_ptr->stride_y, context_ptr->blk_geom->bwidth);
+            }
         }
         //copy neigh recon data in cu_ptr
         {
@@ -5078,57 +5406,98 @@ void md_encode_block(
             uint32_t recCbOffset = ((((context_ptr->blk_geom->origin_x >> 3) << 3) + ((context_ptr->blk_geom->origin_y >> 3) << 3) * candidateBuffer->recon_ptr->stride_cb) >> 1);
             uint32_t recCrOffset = ((((context_ptr->blk_geom->origin_x >> 3) << 3) + ((context_ptr->blk_geom->origin_y >> 3) << 3) * candidateBuffer->recon_ptr->stride_cr) >> 1);
 
-            memcpy(cu_ptr->neigh_top_recon[0], recon_ptr->buffer_y + recLumaOffset + (context_ptr->blk_geom->bheight - 1)*recon_ptr->stride_y, context_ptr->blk_geom->bwidth);
-            if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1)
-            {
-                memcpy(cu_ptr->neigh_top_recon[1], recon_ptr->buffer_cb + recCbOffset + (context_ptr->blk_geom->bheight_uv - 1)*recon_ptr->stride_cb, context_ptr->blk_geom->bwidth_uv);
-                memcpy(cu_ptr->neigh_top_recon[2], recon_ptr->buffer_cr + recCrOffset + (context_ptr->blk_geom->bheight_uv - 1)*recon_ptr->stride_cr, context_ptr->blk_geom->bwidth_uv);
-            }
+            if (!context_ptr->hbd_mode_decision) {
+                memcpy(cu_ptr->neigh_top_recon[0], recon_ptr->buffer_y + recLumaOffset + (context_ptr->blk_geom->bheight - 1)*recon_ptr->stride_y, context_ptr->blk_geom->bwidth);
+                if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+                    memcpy(cu_ptr->neigh_top_recon[1], recon_ptr->buffer_cb + recCbOffset + (context_ptr->blk_geom->bheight_uv - 1)*recon_ptr->stride_cb, context_ptr->blk_geom->bwidth_uv);
+                    memcpy(cu_ptr->neigh_top_recon[2], recon_ptr->buffer_cr + recCrOffset + (context_ptr->blk_geom->bheight_uv - 1)*recon_ptr->stride_cr, context_ptr->blk_geom->bwidth_uv);
+                }
 
-            for (j = 0; j < context_ptr->blk_geom->bheight; ++j)
+                for (j = 0; j < context_ptr->blk_geom->bheight; ++j)
+                    cu_ptr->neigh_left_recon[0][j] = recon_ptr->buffer_y[recLumaOffset + context_ptr->blk_geom->bwidth - 1 + j * recon_ptr->stride_y];
 
-                cu_ptr->neigh_left_recon[0][j] = recon_ptr->buffer_y[recLumaOffset + context_ptr->blk_geom->bwidth - 1 + j * recon_ptr->stride_y];
-            if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
-                for (j = 0; j < context_ptr->blk_geom->bheight_uv; ++j) {
-                    cu_ptr->neigh_left_recon[1][j] = recon_ptr->buffer_cb[recCbOffset + context_ptr->blk_geom->bwidth_uv - 1 + j * recon_ptr->stride_cb];
-                    cu_ptr->neigh_left_recon[2][j] = recon_ptr->buffer_cr[recCrOffset + context_ptr->blk_geom->bwidth_uv - 1 + j * recon_ptr->stride_cr];
+                if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+                    for (j = 0; j < context_ptr->blk_geom->bheight_uv; ++j) {
+                        cu_ptr->neigh_left_recon[1][j] = recon_ptr->buffer_cb[recCbOffset + context_ptr->blk_geom->bwidth_uv - 1 + j * recon_ptr->stride_cb];
+                        cu_ptr->neigh_left_recon[2][j] = recon_ptr->buffer_cr[recCrOffset + context_ptr->blk_geom->bwidth_uv - 1 + j * recon_ptr->stride_cr];
+                    }
+                }
+            } else {
+                uint16_t sz = sizeof(uint16_t);
+                memcpy(cu_ptr->neigh_top_recon_16bit[0], recon_ptr->buffer_y + sz * (recLumaOffset + (context_ptr->blk_geom->bheight - 1)*recon_ptr->stride_y), sz * context_ptr->blk_geom->bwidth);
+                if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+                    memcpy(cu_ptr->neigh_top_recon_16bit[1], recon_ptr->buffer_cb + sz * (recCbOffset + (context_ptr->blk_geom->bheight_uv - 1)*recon_ptr->stride_cb), sz * context_ptr->blk_geom->bwidth_uv);
+                    memcpy(cu_ptr->neigh_top_recon_16bit[2], recon_ptr->buffer_cr + sz * (recCrOffset + (context_ptr->blk_geom->bheight_uv - 1)*recon_ptr->stride_cr), sz * context_ptr->blk_geom->bwidth_uv);
+                }
+
+                for (j = 0; j < context_ptr->blk_geom->bheight; ++j)
+                    cu_ptr->neigh_left_recon_16bit[0][j] =  ((uint16_t *) recon_ptr->buffer_y)[recLumaOffset + context_ptr->blk_geom->bwidth - 1 + j * recon_ptr->stride_y];
+
+                if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+                    for (j = 0; j < context_ptr->blk_geom->bheight_uv; ++j) {
+                        cu_ptr->neigh_left_recon_16bit[1][j] = ((uint16_t *) recon_ptr->buffer_cb)[recCbOffset + context_ptr->blk_geom->bwidth_uv - 1 + j * recon_ptr->stride_cb];
+                        cu_ptr->neigh_left_recon_16bit[2][j] = ((uint16_t *) recon_ptr->buffer_cr)[recCrOffset + context_ptr->blk_geom->bwidth_uv - 1 + j * recon_ptr->stride_cr];
+                    }
                 }
             }
         }
 
 #if NO_ENCDEC
         //copy recon
-        {
-            uint32_t  tu_origin_index = context_ptr->blk_geom->origin_x + (context_ptr->blk_geom->origin_y * 128);
-            uint32_t  bwidth = context_ptr->blk_geom->bwidth;
-            uint32_t  bheight = context_ptr->blk_geom->bheight;
+        uint32_t  tu_origin_index = context_ptr->blk_geom->origin_x + (context_ptr->blk_geom->origin_y * 128);
+        uint32_t  bwidth = context_ptr->blk_geom->bwidth;
+        uint32_t  bheight = context_ptr->blk_geom->bheight;
 
+        if (!context_ptr->hbd_mode_decision) {
             uint8_t* src_ptr = &(((uint8_t*)candidateBuffer->recon_ptr->buffer_y)[tu_origin_index]);
             uint8_t* dst_ptr = &(((uint8_t*)context_ptr->cu_ptr->recon_tmp->buffer_y)[0]);
 
             uint32_t j;
             for (j = 0; j < bheight; j++)
                 memcpy(dst_ptr + j * 128, src_ptr + j * 128, bwidth * sizeof(uint8_t));
-            // Cb
+
             if (context_ptr->blk_geom->has_uv)
             {
                 uint32_t tu_origin_index = ((((context_ptr->blk_geom->origin_x >> 3) << 3) + ((context_ptr->blk_geom->origin_y >> 3) << 3) * candidateBuffer->recon_ptr->stride_cb) >> 1);
-
                 bwidth = context_ptr->blk_geom->bwidth_uv;
                 bheight = context_ptr->blk_geom->bheight_uv;
 
+                // Cb
                 src_ptr = &(((uint8_t*)candidateBuffer->recon_ptr->buffer_cb)[tu_origin_index]);
                 dst_ptr = &(((uint8_t*)context_ptr->cu_ptr->recon_tmp->buffer_cb)[0]);
 
                 for (j = 0; j < bheight; j++)
                     memcpy(dst_ptr + j * 64, src_ptr + j * 64, bwidth * sizeof(uint8_t));
-                // Cr
 
+                // Cr
                 src_ptr = &(((uint8_t*)candidateBuffer->recon_ptr->buffer_cr)[tu_origin_index]);
                 dst_ptr = &(((uint8_t*)context_ptr->cu_ptr->recon_tmp->buffer_cr)[0]);
 
                 for (j = 0; j < bheight; j++)
                     memcpy(dst_ptr + j * 64, src_ptr + j * 64, bwidth * sizeof(uint8_t));
+            }
+        } else {
+            uint16_t* src_ptr = ((uint16_t*) candidateBuffer->recon_ptr->buffer_y) + tu_origin_index;
+            uint16_t* dst_ptr = (uint16_t*) context_ptr->cu_ptr->recon_tmp->buffer_y;
+            for (uint32_t j = 0; j < bheight; j++)
+                memcpy(dst_ptr + j * 128, src_ptr + j * 128, bwidth * sizeof(uint16_t));
+
+            if (context_ptr->blk_geom->has_uv) {
+                tu_origin_index = ((((context_ptr->blk_geom->origin_x >> 3) << 3) + ((context_ptr->blk_geom->origin_y >> 3) << 3) * candidateBuffer->recon_ptr->stride_cb) >> 1);
+                bwidth = context_ptr->blk_geom->bwidth_uv;
+                bheight = context_ptr->blk_geom->bheight_uv;
+
+                 // Cb
+                src_ptr = ((uint16_t*) candidateBuffer->recon_ptr->buffer_cb) + tu_origin_index;
+                dst_ptr = (uint16_t*) context_ptr->cu_ptr->recon_tmp->buffer_cb;
+                for (uint32_t j = 0; j < bheight; j++)
+                    memcpy(dst_ptr + j * 64, src_ptr + j * 64, bwidth * sizeof(uint16_t));
+
+                // Cr
+                src_ptr = ((uint16_t*) candidateBuffer->recon_ptr->buffer_cr) + tu_origin_index;
+                dst_ptr = (uint16_t*) context_ptr->cu_ptr->recon_tmp->buffer_cr;
+                for (uint32_t j = 0; j < bheight; j++)
+                    memcpy(dst_ptr + j * 64, src_ptr + j * 64, bwidth * sizeof(uint16_t));
             }
         }
 #endif
@@ -5178,9 +5547,16 @@ EB_EXTERN EbErrorType mode_decision_sb(
     context_ptr->mode_type_neighbor_array = picture_control_set_ptr->md_mode_type_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
     context_ptr->leaf_depth_neighbor_array = picture_control_set_ptr->md_leaf_depth_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
     context_ptr->leaf_partition_neighbor_array = picture_control_set_ptr->mdleaf_partition_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
-    context_ptr->luma_recon_neighbor_array = picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
-    context_ptr->cb_recon_neighbor_array = picture_control_set_ptr->md_cb_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
-    context_ptr->cr_recon_neighbor_array = picture_control_set_ptr->md_cr_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
+
+    if (!context_ptr->hbd_mode_decision) {
+        context_ptr->luma_recon_neighbor_array = picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
+        context_ptr->cb_recon_neighbor_array = picture_control_set_ptr->md_cb_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
+        context_ptr->cr_recon_neighbor_array = picture_control_set_ptr->md_cr_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
+    } else {
+        context_ptr->luma_recon_neighbor_array16bit = picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX];
+        context_ptr->cb_recon_neighbor_array16bit = picture_control_set_ptr->md_cb_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX];
+        context_ptr->cr_recon_neighbor_array16bit = picture_control_set_ptr->md_cr_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX];
+    }
     context_ptr->skip_coeff_neighbor_array = picture_control_set_ptr->md_skip_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
     context_ptr->luma_dc_sign_level_coeff_neighbor_array = picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
     context_ptr->cb_dc_sign_level_coeff_neighbor_array = picture_control_set_ptr->md_cb_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
@@ -5189,6 +5565,57 @@ EB_EXTERN EbErrorType mode_decision_sb(
     context_ptr->inter_pred_dir_neighbor_array = picture_control_set_ptr->md_inter_pred_dir_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
     context_ptr->ref_frame_type_neighbor_array = picture_control_set_ptr->md_ref_frame_type_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
     context_ptr->interpolation_type_neighbor_array = picture_control_set_ptr->md_interpolation_type_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
+
+    EbPictureBufferDesc *input_picture_ptr = picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
+    if (context_ptr->hbd_mode_decision) {
+        const uint32_t input_luma_offset = ((sb_origin_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_y) + (sb_origin_x + input_picture_ptr->origin_x);
+        const uint32_t input_bit_inc_luma_offset = ((sb_origin_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_bit_inc_y) + (sb_origin_x + input_picture_ptr->origin_x);
+        const uint32_t input_cb_offset = (((sb_origin_y + input_picture_ptr->origin_y) >> 1)  * input_picture_ptr->stride_cb) + ((sb_origin_x + input_picture_ptr->origin_x) >> 1);
+        const uint32_t input_bit_inc_cb_offset = (((sb_origin_y + input_picture_ptr->origin_y) >> 1)  * input_picture_ptr->stride_bit_inc_cb) + ((sb_origin_x + input_picture_ptr->origin_x) >> 1);
+        const uint32_t input_cr_offset = (((sb_origin_y + input_picture_ptr->origin_y) >> 1)  * input_picture_ptr->stride_cr) + ((sb_origin_x + input_picture_ptr->origin_x) >> 1);
+        const uint32_t input_bit_inc_cr_offset = (((sb_origin_y + input_picture_ptr->origin_y) >> 1)  * input_picture_ptr->stride_bit_inc_cr) + ((sb_origin_x + input_picture_ptr->origin_x) >> 1);
+
+        uint32_t sb_width  = MIN(sequence_control_set_ptr->sb_size_pix, sequence_control_set_ptr->seq_header.max_frame_width - sb_origin_x);
+        uint32_t sb_height = MIN(sequence_control_set_ptr->sb_size_pix, sequence_control_set_ptr->seq_header.max_frame_height - sb_origin_y);
+        EbAsm asm_type = sequence_control_set_ptr->encode_context_ptr->asm_type;
+
+        pack2d_src(
+            input_picture_ptr->buffer_y + input_luma_offset,
+            input_picture_ptr->stride_y,
+            input_picture_ptr->buffer_bit_inc_y + input_bit_inc_luma_offset,
+            input_picture_ptr->stride_bit_inc_y,
+            (uint16_t *)context_ptr->input_sample16bit_buffer->buffer_y,
+            context_ptr->input_sample16bit_buffer->stride_y,
+            sb_width,
+            sb_height,
+            asm_type);
+
+        pack2d_src(
+            input_picture_ptr->buffer_cb + input_cb_offset,
+            input_picture_ptr->stride_cb,
+            input_picture_ptr->buffer_bit_inc_cb + input_bit_inc_cb_offset,
+            input_picture_ptr->stride_bit_inc_cb,
+            (uint16_t *)context_ptr->input_sample16bit_buffer->buffer_cb,
+            context_ptr->input_sample16bit_buffer->stride_cb,
+            sb_width >> 1,
+            sb_height >> 1,
+            asm_type);
+
+        pack2d_src(
+            input_picture_ptr->buffer_cr + input_cr_offset,
+            input_picture_ptr->stride_cr,
+            input_picture_ptr->buffer_bit_inc_cr + input_bit_inc_cr_offset,
+            input_picture_ptr->stride_bit_inc_cr,
+            (uint16_t *)context_ptr->input_sample16bit_buffer->buffer_cr,
+            context_ptr->input_sample16bit_buffer->stride_cr,
+            sb_width >> 1,
+            sb_height >> 1,
+            asm_type);
+
+        Store16bitInputSrc(context_ptr->input_sample16bit_buffer, picture_control_set_ptr, sb_origin_x, sb_origin_y, sb_width, sb_height);
+        //input_picture_ptr = context_ptr->input_sample16bit_buffer;
+        input_picture_ptr = picture_control_set_ptr->input_frame16bit;
+    }
 
     //CU Loop
     cuIdx = 0;  //index over mdc array
@@ -5267,12 +5694,24 @@ EB_EXTERN EbErrorType mode_decision_sb(
 
             move_cu_data_redund(src_cu, dst_cu);
             memcpy(&context_ptr->md_local_cu_unit[cu_ptr->mds_idx], &context_ptr->md_local_cu_unit[redundant_blk_mds], sizeof(MdCodingUnit));
-            memcpy(dst_cu->neigh_left_recon[0], src_cu->neigh_left_recon[0], 128);
-            memcpy(dst_cu->neigh_left_recon[1], src_cu->neigh_left_recon[1], 128);
-            memcpy(dst_cu->neigh_left_recon[2], src_cu->neigh_left_recon[2], 128);
-            memcpy(dst_cu->neigh_top_recon[0], src_cu->neigh_top_recon[0], 128);
-            memcpy(dst_cu->neigh_top_recon[1], src_cu->neigh_top_recon[1], 128);
-            memcpy(dst_cu->neigh_top_recon[2], src_cu->neigh_top_recon[2], 128);
+
+            if (!context_ptr->hbd_mode_decision) {
+                memcpy(dst_cu->neigh_left_recon[0], src_cu->neigh_left_recon[0], 128);
+                memcpy(dst_cu->neigh_left_recon[1], src_cu->neigh_left_recon[1], 128);
+                memcpy(dst_cu->neigh_left_recon[2], src_cu->neigh_left_recon[2], 128);
+                memcpy(dst_cu->neigh_top_recon[0], src_cu->neigh_top_recon[0], 128);
+                memcpy(dst_cu->neigh_top_recon[1], src_cu->neigh_top_recon[1], 128);
+                memcpy(dst_cu->neigh_top_recon[2], src_cu->neigh_top_recon[2], 128);
+            } else {
+                uint16_t sz = sizeof(uint16_t);
+                memcpy(dst_cu->neigh_left_recon_16bit[0], src_cu->neigh_left_recon_16bit[0], 128 * sz);
+                memcpy(dst_cu->neigh_left_recon_16bit[1], src_cu->neigh_left_recon_16bit[1], 128 * sz);
+                memcpy(dst_cu->neigh_left_recon_16bit[2], src_cu->neigh_left_recon_16bit[2], 128 * sz);
+                memcpy(dst_cu->neigh_top_recon_16bit[0], src_cu->neigh_top_recon_16bit[0], 128 * sz);
+                memcpy(dst_cu->neigh_top_recon_16bit[1], src_cu->neigh_top_recon_16bit[1], 128 * sz);
+                memcpy(dst_cu->neigh_top_recon_16bit[2], src_cu->neigh_top_recon_16bit[2], 128 * sz);
+            }
+
             memcpy(&context_ptr->md_ep_pipe_sb[cu_ptr->mds_idx], &context_ptr->md_ep_pipe_sb[redundant_blk_mds], sizeof(MdEncPassCuData));
             if (context_ptr->blk_geom->shape == PART_N) {
                 uint8_t sq_index = LOG2F(context_ptr->blk_geom->sq_size) - 2;
@@ -5290,6 +5729,7 @@ EB_EXTERN EbErrorType mode_decision_sb(
                 sequence_control_set_ptr,
                 picture_control_set_ptr,
                 context_ptr,
+                input_picture_ptr,
                 ss_mecontext,
                 &skip_sub_blocks,
                 lcuAddr,
@@ -5311,6 +5751,7 @@ EB_EXTERN EbErrorType mode_decision_sb(
             sequence_control_set_ptr,
             picture_control_set_ptr,
             context_ptr,
+            input_picture_ptr,
             ss_mecontext,
             &skip_sub_blocks,
             lcuAddr,

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -1205,7 +1205,7 @@ void AV1PerformInverseTransformReconLuma(
                     candidateBuffer->prediction_ptr->buffer_y,
                     tu_origin_index,
                     candidateBuffer->prediction_ptr->stride_y,
-                    context_ptr->cfl_temp_luma_recon,
+                    picture_control_set_ptr->hbd_mode_decision ? (uint8_t *)context_ptr->cfl_temp_luma_recon16bit : context_ptr->cfl_temp_luma_recon,
                     recLumaOffset,
                     candidateBuffer->recon_ptr->stride_y,
                     (int32_t*) candidateBuffer->recon_coeff_ptr->buffer_y,
@@ -1222,7 +1222,7 @@ void AV1PerformInverseTransformReconLuma(
                     pic_copy_kernel_16bit(
                         ((uint16_t *) candidateBuffer->prediction_ptr->buffer_y) + tu_origin_index,
                         candidateBuffer->prediction_ptr->stride_y,
-                        ((uint16_t *) context_ptr->cfl_temp_luma_recon) + recLumaOffset,
+                        context_ptr->cfl_temp_luma_recon16bit + recLumaOffset,
                         candidateBuffer->recon_ptr->stride_y,
                         tu_width,
                         tu_height);
@@ -2114,7 +2114,7 @@ static void CflPrediction(
             context_ptr->blk_geom->bheight_uv == context_ptr->blk_geom->bheight ? (context_ptr->blk_geom->bheight_uv << 1) : context_ptr->blk_geom->bheight);
     else
         cfl_luma_subsampling_420_hbd_c(
-            ((uint16_t*)context_ptr->cfl_temp_luma_recon) + recLumaOffset,
+            context_ptr->cfl_temp_luma_recon16bit + recLumaOffset,
             candidateBuffer->recon_ptr->stride_y,
             context_ptr->pred_buf_q3,
             context_ptr->blk_geom->bwidth_uv == context_ptr->blk_geom->bwidth ? (context_ptr->blk_geom->bwidth_uv << 1) : context_ptr->blk_geom->bwidth,
@@ -5391,7 +5391,7 @@ void md_encode_block(
             uint32_t rec_luma_offset = context_ptr->blk_geom->origin_x + context_ptr->blk_geom->origin_y * recon_ptr->stride_y;
             if (picture_control_set_ptr->hbd_mode_decision) {
                for (uint32_t j = 0; j < context_ptr->blk_geom->bheight; ++j)
-                    memcpy(((uint16_t *)context_ptr->cfl_temp_luma_recon) + rec_luma_offset + j* recon_ptr->stride_y, ((uint16_t *)recon_ptr->buffer_y) + (rec_luma_offset + j * recon_ptr->stride_y), sizeof(uint16_t) * context_ptr->blk_geom->bwidth);
+                    memcpy(context_ptr->cfl_temp_luma_recon16bit + rec_luma_offset + j* recon_ptr->stride_y, ((uint16_t *)recon_ptr->buffer_y) + (rec_luma_offset + j * recon_ptr->stride_y), sizeof(uint16_t) * context_ptr->blk_geom->bwidth);
             } else {
                 for (uint32_t j = 0; j < context_ptr->blk_geom->bheight; ++j)
                     memcpy(&context_ptr->cfl_temp_luma_recon[rec_luma_offset + j* recon_ptr->stride_y], recon_ptr->buffer_y + rec_luma_offset + j * recon_ptr->stride_y, context_ptr->blk_geom->bwidth);

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -314,10 +314,10 @@ void mode_decision_update_neighbor_arrays(
                 context_ptr->blk_geom->bheight);
 
             if (picture_control_set_ptr->parent_pcs_ptr->atb_mode) {
-                update_recon_neighbor_array(
+                update_recon_neighbor_array16bit(
                     picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
-                    context_ptr->cu_ptr->neigh_top_recon[0],
-                    context_ptr->cu_ptr->neigh_left_recon[0],
+                    context_ptr->cu_ptr->neigh_top_recon_16bit[0],
+                    context_ptr->cu_ptr->neigh_left_recon_16bit[0],
                     origin_x,
                     origin_y,
                     context_ptr->blk_geom->bwidth,
@@ -2525,7 +2525,7 @@ EbErrorType av1_intra_luma_prediction(
     TxSize  tx_size = md_context_ptr->blk_geom->txsize[md_context_ptr->tx_depth][md_context_ptr->txb_itr];
 
     PredictionMode mode;
-    if (picture_control_set_ptr->hbd_mode_decision) {
+    if (!picture_control_set_ptr->hbd_mode_decision) {
         uint8_t topNeighArray[64 * 2 + 1];
         uint8_t leftNeighArray[64 * 2 + 1];
 

--- a/Source/Lib/Decoder/Codec/EbDecHandle.h
+++ b/Source/Lib/Decoder/Codec/EbDecHandle.h
@@ -162,9 +162,9 @@ typedef struct EbDecHandle {
     /** Pointer to Picture manager structure **/
     void   *pv_pic_mgr;
 
-    // * 'remapped_ref_idx[i - 1]' maps reference type ‘i’ (range: LAST_FRAME ...
-    // EXTREF_FRAME) to a remapped index ‘j’ (in range: 0 ... REF_FRAMES - 1)
-    // * Later, 'cm->ref_frame_map[j]' maps the remapped index ‘j’ to a pointer to
+    // * 'remapped_ref_idx[i - 1]' maps reference type i (range: LAST_FRAME ...
+    // EXTREF_FRAME) to a remapped index j (in range: 0 ... REF_FRAMES - 1)
+    // * Later, 'cm->ref_frame_map[j]' maps the remapped index j to a pointer to
     // the reference counted buffer structure RefCntBuffer, taken from the buffer
     // pool cm->buffer_pool->frame_bufs.
     //

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -953,6 +953,7 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         inputData.compressed_ten_bit_format = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->static_config.compressed_ten_bit_format;
         inputData.enc_mode = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->static_config.enc_mode;
         inputData.speed_control = (uint8_t)enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->static_config.speed_control_flag;
+        inputData.hbd_mode_decision = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->static_config.enable_hbd_mode_decision;
         inputData.film_grain_noise_level = enc_handle_ptr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->static_config.film_grain_denoise_strength;
         inputData.bit_depth = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->static_config.encoder_bit_depth;
 
@@ -1009,6 +1010,7 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         inputData.sb_sz = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->sb_sz;
         inputData.sb_size_pix = scs_init.sb_size;
         inputData.max_depth = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_sb_depth;
+        inputData.hbd_mode_decision = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->static_config.enable_hbd_mode_decision;
         inputData.cdf_mode = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->cdf_mode;
         EB_NEW(
             enc_handle_ptr->picture_control_set_pool_ptr_array[instance_index],
@@ -1626,6 +1628,7 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
                     processIndex], // Add port lookup logic here JMJ
             is16bit,
             color_format,
+            enc_handle_ptr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->static_config.enable_hbd_mode_decision,
             enc_handle_ptr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->max_input_luma_width,
             enc_handle_ptr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->max_input_luma_height
         );
@@ -2137,6 +2140,7 @@ void CopyApiFromApp(
     sequence_control_set_ptr->film_grain_denoise_strength = sequence_control_set_ptr->static_config.film_grain_denoise_strength;
 
     // MD Parameters
+    sequence_control_set_ptr->static_config.enable_hbd_mode_decision = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->encoder_bit_depth > 8 ? ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->enable_hbd_mode_decision : 0;
     sequence_control_set_ptr->static_config.constrained_intra = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->constrained_intra;
 
     // Adaptive Loop Filter

--- a/test/SpatialFullDistortionTest.cc
+++ b/test/SpatialFullDistortionTest.cc
@@ -61,15 +61,19 @@ void SpatialFullDistortionTest::RunCheckOutput() {
                  area_height += 4) {
                 const uint64_t dist_org =
                     spatial_full_distortion_kernel_c(input_,
+                                                     0,
                                                      input_stride_,
                                                      recon_,
+                                                     0,
                                                      recon_stride_,
                                                      area_width,
                                                      area_height);
                 const uint64_t dist_opt =
                     spatial_full_distortion_kernel_avx2(input_,
+                                                        0,
                                                         input_stride_,
                                                         recon_,
+                                                        0,
                                                         recon_stride_,
                                                         area_width,
                                                         area_height);
@@ -97,8 +101,10 @@ void SpatialFullDistortionTest::RunSpeedTest() {
 
         for (int i = 0; i < num_loops; ++i) {
             dist_org = spatial_full_distortion_kernel_c(input_,
+                                                        0,
                                                         input_stride_,
                                                         recon_,
+                                                        0,
                                                         recon_stride_,
                                                         area_width,
                                                         area_height);
@@ -108,8 +114,10 @@ void SpatialFullDistortionTest::RunSpeedTest() {
 
         for (int i = 0; i < num_loops; ++i) {
             dist_opt = spatial_full_distortion_kernel_avx2(input_,
+                                                           0,
                                                            input_stride_,
                                                            recon_,
+                                                           0,
                                                            recon_stride_,
                                                            area_width,
                                                            area_height);


### PR DESCRIPTION
Added 10-bit path for the mode decision for intra. Can be enabled by -hbd-md (not fully functional until inter part is added).

Tested using four 10-bit sequences across the 9 encoding modes: BD-rates gains from -2.8% to -10.7%.