### PR TITLE
Fix different outputs between Windows and Linux

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -425,7 +425,7 @@ static INLINE uint16_t clip_pixel_highbd(int32_t val, int32_t bd) {
 #endif
 #endif /* ATTRIBUTE_PACKED */
 
-typedef enum ATTRIBUTE_PACKED
+typedef enum
 {
     EIGHTTAP_REGULAR,
     EIGHTTAP_SMOOTH,


### PR DESCRIPTION
Windows: sizeof(InterpFilters) is 4, Linux: sizeof(InterpFilters) is 1

Kernel: av1_make_interp_filters() Output value was be casted on uint8.