### PR TITLE
AVX512: Don't use apt clang and only compile avx512 code if function is defined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ addons:
       - valgrind
       - libgstreamer-plugins-base1.0-dev
       - libgstreamer1.0-dev
-      - llvm
-      - clang
   homebrew:
     packages:
       - yasm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,12 @@ if(COVERAGE AND NOT MSVC)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
 endif()
 
+include(CheckSymbolExists)
+check_symbol_exists("_mm512_extracti64x4_epi64" "immintrin.h" HAS_AVX512)
+if(NOT HAS_AVX512)
+    add_definitions(-DNON_AVX512_SUPPORT)
+endif()
+
 # Add Subdirectories
 add_subdirectory(Source/Lib/Common)
 add_subdirectory(Source/Lib/Encoder)


### PR DESCRIPTION
@lzhangnj, not for master branch

installing the clang and llvm from ubuntu's repo messed up with the clang provided with travis' images

Add CMake code to detect if `_mm512_extracti64x4_epi64` is defined in `immintrin.h` and add the define to not do avx512 stuff. There is a different function for checking functions, types, etc in c files.

For #451