### PR TITLE
Fix saturate issue in hme sad

### DIFF
--- a/Source/Lib/Common/ASM_SSE4_1/EbComputeSAD_Intrinsic_SSE4_1.c
+++ b/Source/Lib/Common/ASM_SSE4_1/EbComputeSAD_Intrinsic_SSE4_1.c
@@ -3730,7 +3730,7 @@ void sad_loop_kernel_sse4_1_hme_l0_intrin(
         break;
 
     case 32:
-        if (height <= 16) {
+        if (height < 16) {
             for (i = 0; i < search_area_height; i++) {
                 for (j = 0; j <= search_area_width - 8; j += 8) {
                     pSrc = src;


### PR DESCRIPTION
1. In sad_loop_kernel_sse4_1_hme_l0_intrin, The sum of 32x16 sad may saturate
   in 16-bit register, although it has subtracted the minimal sum first.