### PR TITLE
symbols: fix conflicts with aom

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -4903,121 +4903,121 @@ void sad_loop_kernel_avx2_hme_l0_intrin(
     *y_search_center = yBest;
 }
 
-uint32_t aom_sad4x4_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad4x4_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return Compute4xMSadSub_AVX2_INTRIN(src_ptr, src_stride, ref_ptr,
         ref_stride, 4, 4);
 }
 
-uint32_t aom_sad4x8_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad4x8_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return Compute4xMSadSub_AVX2_INTRIN(src_ptr, src_stride, ref_ptr,
         ref_stride, 8, 4);
 }
 
-uint32_t aom_sad4x16_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad4x16_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return Compute4xMSadSub_AVX2_INTRIN(src_ptr, src_stride, ref_ptr,
         ref_stride, 16, 4);
 }
 
-uint32_t aom_sad8x4_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad8x4_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return compute8x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
         ref_stride, 4, 8);
 }
 
-uint32_t aom_sad8x8_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad8x8_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return compute8x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
         ref_stride, 8, 8);
 }
 
-uint32_t aom_sad8x16_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad8x16_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return compute8x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
         ref_stride, 16, 8);
 }
 
-uint32_t aom_sad8x32_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad8x32_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return compute8x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
         ref_stride, 32, 8);
 }
 
-uint32_t aom_sad16x4_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad16x4_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return compute16x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
         ref_stride, 4, 16);
 }
 
-uint32_t aom_sad16x8_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad16x8_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return compute16x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
         ref_stride, 8, 16);
 }
 
-uint32_t aom_sad16x16_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad16x16_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return compute16x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
         ref_stride, 16, 16);
 }
 
-uint32_t aom_sad16x32_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad16x32_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return compute16x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
         ref_stride, 32, 16);
 }
 
-uint32_t aom_sad16x64_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad16x64_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return compute16x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
         ref_stride, 64, 16);
 }
 
-uint32_t aom_sad32x8_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad32x8_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return compute32x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
         ref_stride, 8, 32);
 }
 
-uint32_t aom_sad32x16_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad32x16_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return compute32x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
         ref_stride, 16, 32);
 }
 
-uint32_t aom_sad32x32_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad32x32_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return compute32x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
         ref_stride, 32, 32);
 }
 
-uint32_t aom_sad32x64_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad32x64_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return compute32x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
         ref_stride, 64, 32);
 }
 
-uint32_t aom_sad64x16_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad64x16_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return compute64x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
         ref_stride, 16, 64);
 }
 
-uint32_t aom_sad64x32_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad64x32_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return compute64x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
         ref_stride, 32, 64);
 }
 
-uint32_t aom_sad64x64_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad64x64_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     return compute64x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
         ref_stride, 64, 64);
 }
 
-uint32_t aom_sad128x64_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad128x64_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     unsigned int half_width = 64;
     uint32_t sum = compute64x_m_sad_avx2_intrin(src_ptr, src_stride, ref_ptr,
@@ -5029,17 +5029,17 @@ uint32_t aom_sad128x64_avx2(const uint8_t *src_ptr, int src_stride,
     return sum;
 }
 
-uint32_t aom_sad128x128_avx2(const uint8_t *src_ptr, int src_stride,
+uint32_t eb_aom_sad128x128_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
-    uint32_t sum = aom_sad128x64_avx2(src_ptr, src_stride,
+    uint32_t sum = eb_aom_sad128x64_avx2(src_ptr, src_stride,
         ref_ptr, ref_stride);
     src_ptr += src_stride << 6;
     ref_ptr += ref_stride << 6;
-    sum += aom_sad128x64_avx2(src_ptr, src_stride, ref_ptr, ref_stride);
+    sum += eb_aom_sad128x64_avx2(src_ptr, src_stride, ref_ptr, ref_stride);
     return sum;
 }
 
-static INLINE void aom_sad4xhx4d_calc_avx2(
+static INLINE void eb_aom_sad4xhx4d_calc_avx2(
     const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4], uint32_t height) {
@@ -5123,31 +5123,31 @@ static INLINE void aom_sad4xhx4d_calc_avx2(
         mm256_sad3, 2);
 }
 
-void aom_sad4x4x4d_avx2(
+void eb_aom_sad4x4x4d_avx2(
     const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
-    aom_sad4xhx4d_calc_avx2(src, src_stride,
+    eb_aom_sad4xhx4d_calc_avx2(src, src_stride,
         ref, ref_stride, res, 4);
 }
 
-void aom_sad4x8x4d_avx2(
+void eb_aom_sad4x8x4d_avx2(
     const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
-    aom_sad4xhx4d_calc_avx2(src, src_stride,
+    eb_aom_sad4xhx4d_calc_avx2(src, src_stride,
         ref, ref_stride, res, 8);
 }
 
-void aom_sad4x16x4d_avx2(
+void eb_aom_sad4x16x4d_avx2(
     const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
-    aom_sad4xhx4d_calc_avx2(src, src_stride,
+    eb_aom_sad4xhx4d_calc_avx2(src, src_stride,
         ref, ref_stride, res, 16);
 }
 
-static INLINE void aom_sad8xhx4d_calc_avx2(
+static INLINE void eb_aom_sad8xhx4d_calc_avx2(
     const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4], uint32_t  height) {
@@ -5239,39 +5239,39 @@ static INLINE void aom_sad8xhx4d_calc_avx2(
     res[3] = (uint32_t)_mm_cvtsi128_si32(xmm0);
 }
 
-void aom_sad8x4x4d_avx2(
+void eb_aom_sad8x4x4d_avx2(
     const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
-    aom_sad8xhx4d_calc_avx2(src, src_stride,
+    eb_aom_sad8xhx4d_calc_avx2(src, src_stride,
         ref, ref_stride, res, 4);
 }
 
-void aom_sad8x8x4d_avx2(
+void eb_aom_sad8x8x4d_avx2(
     const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
-    aom_sad8xhx4d_calc_avx2(src, src_stride,
+    eb_aom_sad8xhx4d_calc_avx2(src, src_stride,
         ref, ref_stride, res, 8);
 }
 
-void aom_sad8x16x4d_avx2(
+void eb_aom_sad8x16x4d_avx2(
     const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
-    aom_sad8xhx4d_calc_avx2(src, src_stride,
+    eb_aom_sad8xhx4d_calc_avx2(src, src_stride,
         ref, ref_stride, res, 16);
 }
 
-void aom_sad8x32x4d_avx2(
+void eb_aom_sad8x32x4d_avx2(
     const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
-    aom_sad8xhx4d_calc_avx2(src, src_stride,
+    eb_aom_sad8xhx4d_calc_avx2(src, src_stride,
         ref, ref_stride, res, 32);
 }
 
-static INLINE void aom_sad16xhx4d_calc_avx2(
+static INLINE void eb_aom_sad16xhx4d_calc_avx2(
     const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4], uint32_t  height) {
@@ -5343,47 +5343,47 @@ static INLINE void aom_sad16xhx4d_calc_avx2(
     res[3] = (uint32_t)_mm_cvtsi128_si32(xmm0);
 }
 
-void aom_sad16x4x4d_avx2(
+void eb_aom_sad16x4x4d_avx2(
     const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
-    aom_sad16xhx4d_calc_avx2(src, src_stride,
+    eb_aom_sad16xhx4d_calc_avx2(src, src_stride,
         ref, ref_stride, res, 4);
 }
 
-void aom_sad16x8x4d_avx2(
+void eb_aom_sad16x8x4d_avx2(
     const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
-    aom_sad16xhx4d_calc_avx2(src, src_stride,
+    eb_aom_sad16xhx4d_calc_avx2(src, src_stride,
         ref, ref_stride, res, 8);
 }
 
-void aom_sad16x16x4d_avx2(
+void eb_aom_sad16x16x4d_avx2(
     const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
-    aom_sad16xhx4d_calc_avx2(src, src_stride,
+    eb_aom_sad16xhx4d_calc_avx2(src, src_stride,
         ref, ref_stride, res, 16);
 }
 
-void aom_sad16x32x4d_avx2(
+void eb_aom_sad16x32x4d_avx2(
     const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
-    aom_sad16xhx4d_calc_avx2(src, src_stride,
+    eb_aom_sad16xhx4d_calc_avx2(src, src_stride,
         ref, ref_stride, res, 32);
 }
 
-void aom_sad16x64x4d_avx2(
+void eb_aom_sad16x64x4d_avx2(
     const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
-    aom_sad16xhx4d_calc_avx2(src, src_stride,
+    eb_aom_sad16xhx4d_calc_avx2(src, src_stride,
         ref, ref_stride, res, 64);
 }
 
-void aom_sad32x8x4d_avx2(const uint8_t *src, int src_stride,
+void eb_aom_sad32x8x4d_avx2(const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
     __m256i src_reg, ref0_reg, ref1_reg, ref2_reg, ref3_reg;
@@ -5452,7 +5452,7 @@ void aom_sad32x8x4d_avx2(const uint8_t *src, int src_stride,
     _mm256_zeroupper();
 }
 
-void aom_sad32x16x4d_avx2(const uint8_t *src, int src_stride,
+void eb_aom_sad32x16x4d_avx2(const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
     __m256i src_reg, ref0_reg, ref1_reg, ref2_reg, ref3_reg;
@@ -5521,7 +5521,7 @@ void aom_sad32x16x4d_avx2(const uint8_t *src, int src_stride,
     _mm256_zeroupper();
 }
 
-void aom_sad32x32x4d_avx2(const uint8_t *src, int src_stride,
+void eb_aom_sad32x32x4d_avx2(const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
     __m256i src_reg, ref0_reg, ref1_reg, ref2_reg, ref3_reg;
@@ -5590,7 +5590,7 @@ void aom_sad32x32x4d_avx2(const uint8_t *src, int src_stride,
     _mm256_zeroupper();
 }
 
-void aom_sad64x16x4d_avx2(const uint8_t *src, int src_stride,
+void eb_aom_sad64x16x4d_avx2(const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
     __m256i src_reg, srcnext_reg, ref0_reg, ref0next_reg;
@@ -5675,7 +5675,7 @@ void aom_sad64x16x4d_avx2(const uint8_t *src, int src_stride,
     _mm256_zeroupper();
 }
 
-void aom_sad64x64x4d_avx2(const uint8_t *src, int src_stride,
+void eb_aom_sad64x64x4d_avx2(const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
     __m256i src_reg, srcnext_reg, ref0_reg, ref0next_reg;
@@ -5760,7 +5760,7 @@ void aom_sad64x64x4d_avx2(const uint8_t *src, int src_stride,
     _mm256_zeroupper();
 }
 
-void aom_sad32x64x4d_avx2(const uint8_t *src, int src_stride,
+void eb_aom_sad32x64x4d_avx2(const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
     const uint8_t *rf[4];
@@ -5771,20 +5771,20 @@ void aom_sad32x64x4d_avx2(const uint8_t *src, int src_stride,
     rf[1] = ref[1];
     rf[2] = ref[2];
     rf[3] = ref[3];
-    aom_sad32x32x4d_avx2(src, src_stride, rf, ref_stride, sum0);
+    eb_aom_sad32x32x4d_avx2(src, src_stride, rf, ref_stride, sum0);
     src += src_stride << 5;
     rf[0] += ref_stride << 5;
     rf[1] += ref_stride << 5;
     rf[2] += ref_stride << 5;
     rf[3] += ref_stride << 5;
-    aom_sad32x32x4d_avx2(src, src_stride, rf, ref_stride, sum1);
+    eb_aom_sad32x32x4d_avx2(src, src_stride, rf, ref_stride, sum1);
     res[0] = sum0[0] + sum1[0];
     res[1] = sum0[1] + sum1[1];
     res[2] = sum0[2] + sum1[2];
     res[3] = sum0[3] + sum1[3];
 }
 
-void aom_sad64x32x4d_avx2(const uint8_t *src, int src_stride,
+void eb_aom_sad64x32x4d_avx2(const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
     const uint8_t *rf[4];
@@ -5796,13 +5796,13 @@ void aom_sad64x32x4d_avx2(const uint8_t *src, int src_stride,
     rf[1] = ref[1];
     rf[2] = ref[2];
     rf[3] = ref[3];
-    aom_sad32x32x4d_avx2(src, src_stride, rf, ref_stride, sum0);
+    eb_aom_sad32x32x4d_avx2(src, src_stride, rf, ref_stride, sum0);
     src += half_width;
     rf[0] += half_width;
     rf[1] += half_width;
     rf[2] += half_width;
     rf[3] += half_width;
-    aom_sad32x32x4d_avx2(src, src_stride, rf, ref_stride, sum1);
+    eb_aom_sad32x32x4d_avx2(src, src_stride, rf, ref_stride, sum1);
     res[0] = sum0[0] + sum1[0];
     res[1] = sum0[1] + sum1[1];
     res[2] = sum0[2] + sum1[2];
@@ -5852,7 +5852,7 @@ static unsigned int sad64x64(const uint8_t *src_ptr, int src_stride,
     return sum;
 }
 
-unsigned int aom_sad64x128_avx2(const uint8_t *src_ptr, int src_stride,
+unsigned int eb_aom_sad64x128_avx2(const uint8_t *src_ptr, int src_stride,
     const uint8_t *ref_ptr, int ref_stride) {
     uint32_t sum = sad64x64(src_ptr, src_stride, ref_ptr, ref_stride);
     src_ptr += src_stride << 6;
@@ -5865,11 +5865,11 @@ static void sad64x64x4d(const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     __m128i *res) {
     uint32_t sum[4];
-    aom_sad64x64x4d_avx2(src, src_stride, ref, ref_stride, sum);
+    eb_aom_sad64x64x4d_avx2(src, src_stride, ref, ref_stride, sum);
     *res = _mm_loadu_si128((const __m128i *)sum);
 }
 
-void aom_sad64x128x4d_avx2(const uint8_t *src, int src_stride,
+void eb_aom_sad64x128x4d_avx2(const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
     __m128i sum0, sum1;
@@ -5890,7 +5890,7 @@ void aom_sad64x128x4d_avx2(const uint8_t *src, int src_stride,
     _mm_storeu_si128((__m128i *)res, sum0);
 }
 
-void aom_sad128x64x4d_avx2(const uint8_t *src, int src_stride,
+void eb_aom_sad128x64x4d_avx2(const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
     __m128i sum0, sum1;
@@ -5912,7 +5912,7 @@ void aom_sad128x64x4d_avx2(const uint8_t *src, int src_stride,
     _mm_storeu_si128((__m128i *)res, sum0);
 }
 
-void aom_sad128x128x4d_avx2(const uint8_t *src, int src_stride,
+void eb_aom_sad128x128x4d_avx2(const uint8_t *src, int src_stride,
     const uint8_t *const ref[4], int ref_stride,
     uint32_t res[4]) {
     const uint8_t *rf[4];
@@ -5923,13 +5923,13 @@ void aom_sad128x128x4d_avx2(const uint8_t *src, int src_stride,
     rf[1] = ref[1];
     rf[2] = ref[2];
     rf[3] = ref[3];
-    aom_sad128x64x4d_avx2(src, src_stride, rf, ref_stride, sum0);
+    eb_aom_sad128x64x4d_avx2(src, src_stride, rf, ref_stride, sum0);
     src += src_stride << 6;
     rf[0] += ref_stride << 6;
     rf[1] += ref_stride << 6;
     rf[2] += ref_stride << 6;
     rf[3] += ref_stride << 6;
-    aom_sad128x64x4d_avx2(src, src_stride, rf, ref_stride, sum1);
+    eb_aom_sad128x64x4d_avx2(src, src_stride, rf, ref_stride, sum1);
     res[0] = sum0[0] + sum1[0];
     res[1] = sum0[1] + sum1[1];
     res[2] = sum0[2] + sum1[2];

--- a/Source/Lib/Common/ASM_AVX2/EbHighbdIntraPrediction_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbHighbdIntraPrediction_AVX2.c
@@ -250,7 +250,7 @@ static INLINE void dc_128_predictor_16xh(uint16_t *const dst,
     dc_common_predictor_16xh_kernel(dst, stride, h, dc);
 }
 
-void aom_highbd_dc_128_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -258,7 +258,7 @@ void aom_highbd_dc_128_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_128_predictor_16xh(dst, stride, 4, bd);
 }
 
-void aom_highbd_dc_128_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -266,7 +266,7 @@ void aom_highbd_dc_128_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_128_predictor_16xh(dst, stride, 8, bd);
 }
 
-void aom_highbd_dc_128_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -274,7 +274,7 @@ void aom_highbd_dc_128_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_128_predictor_16xh(dst, stride, 16, bd);
 }
 
-void aom_highbd_dc_128_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -282,7 +282,7 @@ void aom_highbd_dc_128_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_128_predictor_16xh(dst, stride, 32, bd);
 }
 
-void aom_highbd_dc_128_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -299,7 +299,7 @@ static INLINE void dc_128_predictor_32xh(uint16_t *const dst,
     dc_common_predictor_32xh_kernel(dst, stride, h, dc);
 }
 
-void aom_highbd_dc_128_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -307,7 +307,7 @@ void aom_highbd_dc_128_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_128_predictor_32xh(dst, stride, 8, bd);
 }
 
-void aom_highbd_dc_128_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -315,7 +315,7 @@ void aom_highbd_dc_128_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_128_predictor_32xh(dst, stride, 16, bd);
 }
 
-void aom_highbd_dc_128_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -323,7 +323,7 @@ void aom_highbd_dc_128_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_128_predictor_32xh(dst, stride, 32, bd);
 }
 
-void aom_highbd_dc_128_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -340,7 +340,7 @@ static INLINE void dc_128_predictor_64xh(uint16_t *const dst,
     dc_common_predictor_64xh_kernel(dst, stride, h, dc);
 }
 
-void aom_highbd_dc_128_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -348,7 +348,7 @@ void aom_highbd_dc_128_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_128_predictor_64xh(dst, stride, 16, bd);
 }
 
-void aom_highbd_dc_128_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -356,7 +356,7 @@ void aom_highbd_dc_128_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_128_predictor_64xh(dst, stride, 32, bd);
 }
 
-void aom_highbd_dc_128_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -370,7 +370,7 @@ void aom_highbd_dc_128_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16xN
 
-void aom_highbd_dc_left_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     const __m128i round = _mm_cvtsi32_si128(2);
@@ -384,7 +384,7 @@ void aom_highbd_dc_left_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_16xh(dst, stride, 4, sum);
 }
 
-void aom_highbd_dc_left_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     const __m128i round = _mm_cvtsi32_si128(4);
@@ -398,7 +398,7 @@ void aom_highbd_dc_left_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_16xh(dst, stride, 8, sum);
 }
 
-void aom_highbd_dc_left_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     const __m128i round = _mm_cvtsi32_si128(8);
@@ -412,7 +412,7 @@ void aom_highbd_dc_left_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_16xh(dst, stride, 16, sum);
 }
 
-void aom_highbd_dc_left_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     const __m128i round = _mm_cvtsi32_si128(16);
@@ -426,7 +426,7 @@ void aom_highbd_dc_left_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_16xh(dst, stride, 32, sum);
 }
 
-void aom_highbd_dc_left_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     const __m128i round = _mm_cvtsi32_si128(32);
@@ -442,7 +442,7 @@ void aom_highbd_dc_left_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 32xN
 
-void aom_highbd_dc_left_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     const __m128i round = _mm_cvtsi32_si128(4);
@@ -456,7 +456,7 @@ void aom_highbd_dc_left_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_32xh(dst, stride, 8, sum);
 }
 
-void aom_highbd_dc_left_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     const __m128i round = _mm_cvtsi32_si128(8);
@@ -470,7 +470,7 @@ void aom_highbd_dc_left_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_32xh(dst, stride, 16, sum);
 }
 
-void aom_highbd_dc_left_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     const __m128i round = _mm_cvtsi32_si128(16);
@@ -484,7 +484,7 @@ void aom_highbd_dc_left_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_32xh(dst, stride, 32, sum);
 }
 
-void aom_highbd_dc_left_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     const __m128i round = _mm_cvtsi32_si128(32);
@@ -500,7 +500,7 @@ void aom_highbd_dc_left_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 64xN
 
-void aom_highbd_dc_left_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     const __m128i round = _mm_cvtsi32_si128(8);
@@ -514,7 +514,7 @@ void aom_highbd_dc_left_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_64xh(dst, stride, 16, sum);
 }
 
-void aom_highbd_dc_left_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     const __m128i round = _mm_cvtsi32_si128(16);
@@ -528,7 +528,7 @@ void aom_highbd_dc_left_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_64xh(dst, stride, 32, sum);
 }
 
-void aom_highbd_dc_left_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     const __m128i round = _mm_cvtsi32_si128(32);
@@ -562,35 +562,35 @@ static INLINE void dc_top_predictor_16xh(uint16_t *const dst,
     dc_common_predictor_16xh(dst, stride, h, sum);
 }
 
-void aom_highbd_dc_top_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)left;
     dc_top_predictor_16xh(dst, stride, above, 4, bd);
 }
 
-void aom_highbd_dc_top_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)left;
     dc_top_predictor_16xh(dst, stride, above, 8, bd);
 }
 
-void aom_highbd_dc_top_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)left;
     dc_top_predictor_16xh(dst, stride, above, 16, bd);
 }
 
-void aom_highbd_dc_top_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)left;
     dc_top_predictor_16xh(dst, stride, above, 32, bd);
 }
 
-void aom_highbd_dc_top_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)left;
@@ -613,28 +613,28 @@ static INLINE void dc_top_predictor_32xh(uint16_t *const dst,
     dc_common_predictor_32xh(dst, stride, h, sum);
 }
 
-void aom_highbd_dc_top_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)left;
     dc_top_predictor_32xh(dst, stride, above, 8, bd);
 }
 
-void aom_highbd_dc_top_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)left;
     dc_top_predictor_32xh(dst, stride, above, 16, bd);
 }
 
-void aom_highbd_dc_top_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)left;
     dc_top_predictor_32xh(dst, stride, above, 32, bd);
 }
 
-void aom_highbd_dc_top_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)left;
@@ -657,21 +657,21 @@ static INLINE void dc_top_predictor_64xh(uint16_t *const dst,
     dc_common_predictor_64xh(dst, stride, h, sum);
 }
 
-void aom_highbd_dc_top_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)left;
     dc_top_predictor_64xh(dst, stride, above, 16, bd);
 }
 
-void aom_highbd_dc_top_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)left;
     dc_top_predictor_64xh(dst, stride, above, 32, bd);
 }
 
-void aom_highbd_dc_top_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)left;
@@ -684,7 +684,7 @@ void aom_highbd_dc_top_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16xN
 
-void aom_highbd_dc_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd) {
     (void)bd;
     __m128i sum = dc_sum_4_16(left, above);
@@ -696,7 +696,7 @@ void aom_highbd_dc_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_16xh_kernel(dst, stride, 4, dc);
 }
 
-void aom_highbd_dc_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd) {
     (void)bd;
     __m128i sum = dc_sum_8_16(left, above);
@@ -708,7 +708,7 @@ void aom_highbd_dc_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_16xh_kernel(dst, stride, 8, dc);
 }
 
-void aom_highbd_dc_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd) {
     (void)bd;
     __m128i sum = dc_sum_16_16(above, left);
@@ -717,7 +717,7 @@ void aom_highbd_dc_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_16xh(dst, stride, 16, sum);
 }
 
-void aom_highbd_dc_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd) {
     (void)bd;
     __m128i sum = dc_sum_16_32(above, left);
@@ -729,7 +729,7 @@ void aom_highbd_dc_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_16xh_kernel(dst, stride, 32, dc);
 }
 
-void aom_highbd_dc_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd) {
     (void)bd;
     __m128i sum = dc_sum_16_64(above, left);
@@ -743,7 +743,7 @@ void aom_highbd_dc_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 32xN
 
-void aom_highbd_dc_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd) {
     (void)bd;
     __m128i sum = dc_sum_8_32(left, above);
@@ -755,7 +755,7 @@ void aom_highbd_dc_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_32xh_kernel(dst, stride, 8, dc);
 }
 
-void aom_highbd_dc_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd) {
     (void)bd;
     __m128i sum = dc_sum_16_32(left, above);
@@ -767,7 +767,7 @@ void aom_highbd_dc_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_32xh_kernel(dst, stride, 16, dc);
 }
 
-void aom_highbd_dc_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd) {
     (void)bd;
     __m128i sum = dc_sum_32_32(above, left);
@@ -776,7 +776,7 @@ void aom_highbd_dc_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_32xh(dst, stride, 32, sum);
 }
 
-void aom_highbd_dc_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd) {
     (void)bd;
     __m128i sum = dc_sum_32_64(above, left);
@@ -790,7 +790,7 @@ void aom_highbd_dc_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 64xN
 
-void aom_highbd_dc_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd) {
     (void)bd;
     __m128i sum = dc_sum_16_64(left, above);
@@ -802,7 +802,7 @@ void aom_highbd_dc_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_64xh_kernel(dst, stride, 16, dc);
 }
 
-void aom_highbd_dc_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd) {
     (void)bd;
     __m128i sum = dc_sum_32_64(left, above);
@@ -814,7 +814,7 @@ void aom_highbd_dc_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
     dc_common_predictor_64xh_kernel(dst, stride, 32, dc);
 }
 
-void aom_highbd_dc_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd) {
     (void)bd;
     __m128i sum = dc_sum_64_64(above, left);
@@ -861,7 +861,7 @@ static INLINE void h_pred_16x8(uint16_t **dst, const ptrdiff_t stride,
 
 // 16x4
 
-void aom_highbd_h_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -881,7 +881,7 @@ void aom_highbd_h_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x64
 
-void aom_highbd_h_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -928,7 +928,7 @@ static INLINE void h_pred_32x8(uint16_t **dst, const ptrdiff_t stride,
 
 // 32x8
 
-void aom_highbd_h_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -939,7 +939,7 @@ void aom_highbd_h_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 32x64
 
-void aom_highbd_h_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -988,7 +988,7 @@ static INLINE void h_pred_64x8(uint16_t **dst, const ptrdiff_t stride,
 
 // 64x16
 
-void aom_highbd_h_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -1000,7 +1000,7 @@ void aom_highbd_h_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 64x32
 
-void aom_highbd_h_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -1012,7 +1012,7 @@ void aom_highbd_h_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 64x64
 
-void aom_highbd_h_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)above;
@@ -1055,7 +1055,7 @@ static INLINE void v_pred_16x8(uint16_t **const dst, const ptrdiff_t stride,
 
 // 16x4
 
-void aom_highbd_v_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     // Load all 16 pixels in a row into 256-bit registers.
@@ -1076,7 +1076,7 @@ void aom_highbd_v_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x8
 
-void aom_highbd_v_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     // Load all 16 pixels in a row into 256-bit registers.
@@ -1094,7 +1094,7 @@ void aom_highbd_v_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x16
 
-void aom_highbd_v_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     // Load all 16 pixels in a row into 256-bit registers.
@@ -1109,7 +1109,7 @@ void aom_highbd_v_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x32
 
-void aom_highbd_v_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     // Load all 16 pixels in a row into 256-bit registers.
@@ -1124,7 +1124,7 @@ void aom_highbd_v_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x64
 
-void aom_highbd_v_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     // Load all 16 pixels in a row into 256-bit registers.
@@ -1169,7 +1169,7 @@ static INLINE void v_pred_32x8(uint16_t **const dst, const ptrdiff_t stride,
 
 // 32x8
 
-void aom_highbd_v_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     // Load all 32 pixels in a row into 256-bit registers.
@@ -1184,7 +1184,7 @@ void aom_highbd_v_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 32x16
 
-void aom_highbd_v_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     // Load all 32 pixels in a row into 256-bit registers.
@@ -1200,7 +1200,7 @@ void aom_highbd_v_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 32x32
 
-void aom_highbd_v_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     // Load all 32 pixels in a row into 256-bit registers.
@@ -1216,7 +1216,7 @@ void aom_highbd_v_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 32x64
 
-void aom_highbd_v_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     // Load all 32 pixels in a row into 256-bit registers.
@@ -1266,7 +1266,7 @@ static INLINE void v_pred_64x8(uint16_t **const dst, const ptrdiff_t stride,
 
 // 64x16
 
-void aom_highbd_v_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     // Load all 64 pixels in a row into 256-bit registers.
@@ -1284,7 +1284,7 @@ void aom_highbd_v_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 64x32
 
-void aom_highbd_v_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     // Load all 64 pixels in a row into 256-bit registers.
@@ -1302,7 +1302,7 @@ void aom_highbd_v_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 64x64
 
-void aom_highbd_v_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     // Load all 64 pixels in a row into 256-bit registers.
@@ -1568,7 +1568,7 @@ static INLINE void smooth_pred_8x8(const uint16_t *const left,
 
 // 8x4
 
-void aom_highbd_smooth_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], r, lr, weights_w[2], rep[2];
@@ -1581,7 +1581,7 @@ void aom_highbd_smooth_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 8x8
 
-void aom_highbd_smooth_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], r, weights_w[2], rep[2];
@@ -1594,7 +1594,7 @@ void aom_highbd_smooth_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 8x16
 
-void aom_highbd_smooth_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], r, weights_w[2], rep[2];
@@ -1610,7 +1610,7 @@ void aom_highbd_smooth_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 8x32
 
-void aom_highbd_smooth_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], r, weights_w[2], rep[2];
@@ -1695,7 +1695,7 @@ static INLINE void smooth_pred_16x8(const uint16_t *const left,
 
 // 16x4
 
-void aom_highbd_smooth_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], r, lr, weights_w[2], rep[4];
@@ -1708,7 +1708,7 @@ void aom_highbd_smooth_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x8
 
-void aom_highbd_smooth_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], r, weights_w[2], rep[4];
@@ -1721,7 +1721,7 @@ void aom_highbd_smooth_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x16
 
-void aom_highbd_smooth_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], r, weights_w[2], rep[4];
@@ -1737,7 +1737,7 @@ void aom_highbd_smooth_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x32
 
-void aom_highbd_smooth_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], r, weights_w[2], rep[4];
@@ -1753,7 +1753,7 @@ void aom_highbd_smooth_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x64
 
-void aom_highbd_smooth_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], r, weights_w[2], rep[4];
@@ -1842,7 +1842,7 @@ static INLINE void smooth_pred_32x8(const uint16_t *const left,
 
 // 32x8
 
-void aom_highbd_smooth_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[4], r, weights_w[4], rep[4];
@@ -1855,7 +1855,7 @@ void aom_highbd_smooth_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 32x16
 
-void aom_highbd_smooth_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[4], r, weights_w[4], rep[4];
@@ -1871,7 +1871,7 @@ void aom_highbd_smooth_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 32x32
 
-void aom_highbd_smooth_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[4], r, weights_w[4], rep[4];
@@ -1887,7 +1887,7 @@ void aom_highbd_smooth_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 32x64
 
-void aom_highbd_smooth_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[4], r, weights_w[4], rep[4];
@@ -1994,7 +1994,7 @@ static INLINE void smooth_pred_64x8(const uint16_t *const left,
 
 // 64x16
 
-void aom_highbd_smooth_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[8], r, weights_w[8], rep[4];
@@ -2010,7 +2010,7 @@ void aom_highbd_smooth_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 64x32
 
-void aom_highbd_smooth_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[8], r, weights_w[8], rep[4];
@@ -2026,7 +2026,7 @@ void aom_highbd_smooth_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 64x64
 
-void aom_highbd_smooth_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[8], r, weights_w[8], rep[4];
@@ -2106,7 +2106,7 @@ static INLINE void smooth_h_pred_8x8(const uint16_t *const left,
 
 // 8x4
 
-void aom_highbd_smooth_h_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     const __m128i l0 = _mm_loadl_epi64((const __m128i *)left);
@@ -2124,7 +2124,7 @@ void aom_highbd_smooth_h_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 8x8
 
-void aom_highbd_smooth_h_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i r, weights[2];
@@ -2136,7 +2136,7 @@ void aom_highbd_smooth_h_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 8x16
 
-void aom_highbd_smooth_h_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i r, weights[2];
@@ -2149,7 +2149,7 @@ void aom_highbd_smooth_h_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 8x32
 
-void aom_highbd_smooth_h_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i r, weights[2];
@@ -2216,7 +2216,7 @@ static INLINE void smooth_h_predictor_16x16(uint16_t *dst,
 
 // 16x4
 
-void aom_highbd_smooth_h_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i r, lr, weights[2];
@@ -2229,7 +2229,7 @@ void aom_highbd_smooth_h_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x8
 
-void aom_highbd_smooth_h_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i r, weights[2];
@@ -2241,7 +2241,7 @@ void aom_highbd_smooth_h_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x16
 
-void aom_highbd_smooth_h_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)bd;
@@ -2250,7 +2250,7 @@ void aom_highbd_smooth_h_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x32
 
-void aom_highbd_smooth_h_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)bd;
@@ -2259,7 +2259,7 @@ void aom_highbd_smooth_h_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x64
 
-void aom_highbd_smooth_h_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)bd;
@@ -2315,7 +2315,7 @@ static INLINE void smooth_h_pred_32x8(uint16_t *dst,
 
 // 32x8
 
-void aom_highbd_smooth_h_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)bd;
@@ -2324,7 +2324,7 @@ void aom_highbd_smooth_h_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 32x16
 
-void aom_highbd_smooth_h_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)bd;
@@ -2333,7 +2333,7 @@ void aom_highbd_smooth_h_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 32x32
 
-void aom_highbd_smooth_h_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)bd;
@@ -2342,7 +2342,7 @@ void aom_highbd_smooth_h_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 32x64
 
-void aom_highbd_smooth_h_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)bd;
@@ -2406,7 +2406,7 @@ static INLINE void smooth_h_pred_64x8(uint16_t *dst,
 
 // 64x16
 
-void aom_highbd_smooth_h_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)bd;
@@ -2415,7 +2415,7 @@ void aom_highbd_smooth_h_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 64x32
 
-void aom_highbd_smooth_h_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)bd;
@@ -2424,7 +2424,7 @@ void aom_highbd_smooth_h_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 64x64
 
-void aom_highbd_smooth_h_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)bd;
@@ -2506,7 +2506,7 @@ static INLINE void smooth_v_pred_8x8(const uint16_t *const sm_weights_h,
 
 // 8x4
 
-void aom_highbd_smooth_v_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], rep[2];
@@ -2518,7 +2518,7 @@ void aom_highbd_smooth_v_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 8x8
 
-void aom_highbd_smooth_v_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], rep[2];
@@ -2531,7 +2531,7 @@ void aom_highbd_smooth_v_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 8x16
 
-void aom_highbd_smooth_v_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], rep[2];
@@ -2545,7 +2545,7 @@ void aom_highbd_smooth_v_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 8x32
 
-void aom_highbd_smooth_v_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], rep[2];
@@ -2610,7 +2610,7 @@ static INLINE void smooth_v_pred_16x8(const uint16_t *const sm_weights_h,
 
 // 16x4
 
-void aom_highbd_smooth_v_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], rep[4];
@@ -2622,7 +2622,7 @@ void aom_highbd_smooth_v_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x8
 
-void aom_highbd_smooth_v_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], rep[4];
@@ -2635,7 +2635,7 @@ void aom_highbd_smooth_v_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x16
 
-void aom_highbd_smooth_v_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], rep[4];
@@ -2649,7 +2649,7 @@ void aom_highbd_smooth_v_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x32
 
-void aom_highbd_smooth_v_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], rep[4];
@@ -2663,7 +2663,7 @@ void aom_highbd_smooth_v_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 16x64
 
-void aom_highbd_smooth_v_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[2], rep[4];
@@ -2728,7 +2728,7 @@ static INLINE void smooth_v_pred_32x8(const uint16_t *const sm_weights_h,
 
 // 32x8
 
-void aom_highbd_smooth_v_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[4], rep[4];
@@ -2741,7 +2741,7 @@ void aom_highbd_smooth_v_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 32x16
 
-void aom_highbd_smooth_v_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[4], rep[4];
@@ -2755,7 +2755,7 @@ void aom_highbd_smooth_v_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 32x32
 
-void aom_highbd_smooth_v_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[4], rep[4];
@@ -2769,7 +2769,7 @@ void aom_highbd_smooth_v_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 32x64
 
-void aom_highbd_smooth_v_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[4], rep[4];
@@ -2844,7 +2844,7 @@ static INLINE void smooth_v_pred_64x8(const uint16_t *const sm_weights_h,
 
 // 64x16
 
-void aom_highbd_smooth_v_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[8], rep[4];
@@ -2858,7 +2858,7 @@ void aom_highbd_smooth_v_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 64x32
 
-void aom_highbd_smooth_v_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[8], rep[4];
@@ -2872,7 +2872,7 @@ void aom_highbd_smooth_v_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
 
 // 64x64
 
-void aom_highbd_smooth_v_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m256i ab[8], rep[4];

--- a/Source/Lib/Common/ASM_AVX2/EbIntraPrediction_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbIntraPrediction_Intrinsic_AVX2.c
@@ -1660,7 +1660,7 @@ static INLINE __m256i dc_sum_64(const uint8_t *ref) {
     u0 = _mm256_unpackhi_epi64(y0, y0);
     return _mm256_add_epi16(y0, u0);
 }
-void aom_dc_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m256i sum_above = dc_sum_64(above);
     __m256i sum_left = dc_sum_64(left);
@@ -1672,7 +1672,7 @@ void aom_dc_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
     row_store_64xh(&row, 64, dst, stride);
 }
 
-void aom_dc_left_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_left_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m256i sum = dc_sum_64(left);
@@ -1685,7 +1685,7 @@ void aom_dc_left_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
     __m256i row = _mm256_shuffle_epi8(sum, zero);
     row_store_64xh(&row, 64, dst, stride);
 }
-void aom_dc_top_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_top_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m256i sum = dc_sum_64(above);
@@ -1698,7 +1698,7 @@ void aom_dc_top_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
     __m256i row = _mm256_shuffle_epi8(sum, zero);
     row_store_64xh(&row, 64, dst, stride);
 }
-void aom_dc_top_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_top_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m256i sum = dc_sum_32(above);
@@ -1711,7 +1711,7 @@ void aom_dc_top_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
     __m256i row = _mm256_shuffle_epi8(sum, zero);
     row_store_32xh(&row, 32, dst, stride);
 }
-void aom_dc_left_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_left_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m256i sum = dc_sum_32(left);
@@ -1724,7 +1724,7 @@ void aom_dc_left_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
     __m256i row = _mm256_shuffle_epi8(sum, zero);
     row_store_32xh(&row, 32, dst, stride);
 }
-void aom_dc_128_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_128_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)above;
@@ -1732,7 +1732,7 @@ void aom_dc_128_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
     const __m256i row = _mm256_set1_epi8((uint8_t)0x80);
     row_store_64xh(&row, 64, dst, stride);
 }
-void aom_dc_128_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_128_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)above;
@@ -1741,7 +1741,7 @@ void aom_dc_128_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
     row_store_32xh(&row, 32, dst, stride);
 }
 
-void aom_dc_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i top_sum = dc_sum_32_sse2(above);
     __m128i left_sum = dc_sum_16_sse2(left);
@@ -1753,7 +1753,7 @@ void aom_dc_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
     row_store_32xh(&row, 16, dst, stride);
 }
 
-void aom_dc_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m256i sum_above = dc_sum_32(above);
     __m256i sum_left = dc_sum_64(left);
@@ -1765,7 +1765,7 @@ void aom_dc_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
     row_store_32xh(&row, 64, dst, stride);
 }
 
-void aom_dc_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m256i sum_above = dc_sum_64(above);
     __m256i sum_left = dc_sum_32(left);
@@ -1777,7 +1777,7 @@ void aom_dc_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
     row_store_64xh(&row, 32, dst, stride);
 }
 
-void aom_dc_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m256i sum_above = dc_sum_64(above);
     __m256i sum_left = _mm256_castsi128_si256(dc_sum_16_sse2(left));
@@ -1789,7 +1789,7 @@ void aom_dc_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
     row_store_64xh(&row, 16, dst, stride);
 }
 
-void aom_dc_left_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_left_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i sum = dc_sum_16_sse2(left);
@@ -1804,7 +1804,7 @@ void aom_dc_left_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
     row_store_32xh(&row, 16, dst, stride);
 }
 
-void aom_dc_left_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_left_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m256i sum = dc_sum_64(left);
@@ -1818,7 +1818,7 @@ void aom_dc_left_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
     row_store_32xh(&row, 64, dst, stride);
 }
 
-void aom_dc_left_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_left_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m256i sum = dc_sum_32(left);
@@ -1832,7 +1832,7 @@ void aom_dc_left_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
     row_store_64xh(&row, 32, dst, stride);
 }
 
-void aom_dc_left_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_left_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i sum = dc_sum_16_sse2(left);
@@ -1847,7 +1847,7 @@ void aom_dc_left_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
     row_store_64xh(&row, 16, dst, stride);
 }
 
-void aom_dc_top_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_top_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m256i sum = dc_sum_32(above);
@@ -1861,7 +1861,7 @@ void aom_dc_top_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
     row_store_32xh(&row, 16, dst, stride);
 }
 
-void aom_dc_top_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_top_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m256i sum = dc_sum_32(above);
@@ -1875,7 +1875,7 @@ void aom_dc_top_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
     row_store_32xh(&row, 64, dst, stride);
 }
 
-void aom_dc_top_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_top_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m256i sum = dc_sum_64(above);
@@ -1889,7 +1889,7 @@ void aom_dc_top_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
     row_store_64xh(&row, 32, dst, stride);
 }
 
-void aom_dc_top_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_top_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m256i sum = dc_sum_64(above);
@@ -1903,7 +1903,7 @@ void aom_dc_top_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
     row_store_64xh(&row, 16, dst, stride);
 }
 
-void aom_dc_128_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_128_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)above;
@@ -1911,7 +1911,7 @@ void aom_dc_128_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
     const __m256i row = _mm256_set1_epi8((uint8_t)0x80);
     row_store_32xh(&row, 16, dst, stride);
 }
-void aom_dc_128_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_128_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)above;
@@ -1919,7 +1919,7 @@ void aom_dc_128_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
     const __m256i row = _mm256_set1_epi8((uint8_t)0x80);
     row_store_32xh(&row, 64, dst, stride);
 }
-void aom_dc_128_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_128_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)above;
@@ -1927,7 +1927,7 @@ void aom_dc_128_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
     const __m256i row = _mm256_set1_epi8((uint8_t)0x80);
     row_store_64xh(&row, 16, dst, stride);
 }
-void aom_dc_128_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_128_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)above;
@@ -1958,7 +1958,7 @@ static INLINE void h_predictor_32x8line(const __m256i *row, uint8_t *dst,
     }
 }
 
-void aom_h_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_h_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     const __m256i left_col = _mm256_loadu_si256((__m256i const *)left);
@@ -1991,40 +1991,40 @@ static INLINE void row_store_32x2xh(const __m256i *r0, const __m256i *r1,
         dst += stride;
     }
 }
-void aom_v_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_v_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m256i row0 = _mm256_loadu_si256((const __m256i *)above);
     const __m256i row1 = _mm256_loadu_si256((const __m256i *)(above + 32));
     (void)left;
     row_store_32x2xh(&row0, &row1, 64, dst, stride);
 }
-void aom_v_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_v_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m256i row = _mm256_loadu_si256((const __m256i *)above);
     (void)left;
     row_store_32xh(&row, 32, dst, stride);
 }
 
-void aom_v_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_v_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m256i row = _mm256_loadu_si256((const __m256i *)above);
     (void)left;
     row_store_32xh(&row, 16, dst, stride);
 }
-void aom_v_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_v_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m256i row = _mm256_loadu_si256((const __m256i *)above);
     (void)left;
     row_store_32xh(&row, 64, dst, stride);
 }
-void aom_v_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_v_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m256i row0 = _mm256_loadu_si256((const __m256i *)above);
     const __m256i row1 = _mm256_loadu_si256((const __m256i *)(above + 32));
     (void)left;
     row_store_32x2xh(&row0, &row1, 16, dst, stride);
 }
-void aom_v_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_v_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m256i row0 = _mm256_loadu_si256((const __m256i *)above);
     const __m256i row1 = _mm256_loadu_si256((const __m256i *)(above + 32));
@@ -2049,22 +2049,22 @@ void intra_mode_dc_64x64_av1_avx2_intrin(
     //uint32_t rowStride = skip ? 2 : 1;
 
     if (isLeftAvailble && !isAboveAvailble) {
-        aom_dc_left_predictor_64x64_avx2(
+        eb_aom_dc_left_predictor_64x64_avx2(
             dst, prediction_buffer_stride,
             ref_samples + topOffset, ref_samples + leftOffset);
     }
     else if (isAboveAvailble && !isLeftAvailble) {
-        aom_dc_top_predictor_64x64_avx2(
+        eb_aom_dc_top_predictor_64x64_avx2(
             dst, prediction_buffer_stride,
             ref_samples + topOffset, ref_samples + leftOffset);
     }
     else {
-        aom_dc_predictor_64x64_avx2(
+        eb_aom_dc_predictor_64x64_avx2(
             dst, prediction_buffer_stride,
             ref_samples + topOffset, ref_samples + leftOffset);
     }
 }
-void aom_dc_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m256i sum_above = dc_sum_32(above);
     __m256i sum_left = dc_sum_32(left);
@@ -5660,7 +5660,7 @@ static void dr_prediction_z1_64xN_avx2(int32_t N, uint8_t *dst, ptrdiff_t stride
 }
 
 // Directional prediction, zone 1: 0 < angle < 90
-void av1_dr_prediction_z1_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh,
+void eb_av1_dr_prediction_z1_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh,
     const uint8_t *above, const uint8_t *left,
     int32_t upsample_above, int32_t dx, int32_t dy) {
     (void)left;
@@ -6165,7 +6165,7 @@ static void highbd_dr_prediction_z1_64xN_avx2(int32_t N, uint16_t *dst,
 }
 
 // Directional prediction, zone 1: 0 < angle < 90
-void av1_highbd_dr_prediction_z1_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw,
+void eb_av1_highbd_dr_prediction_z1_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw,
     int32_t bh, const uint16_t *above,
     const uint16_t *left, int32_t upsample_above,
     int32_t dx, int32_t dy, int32_t bd) {
@@ -6702,7 +6702,7 @@ static void dr_prediction_z2_HxW_avx2(int32_t H, int32_t W, uint8_t *dst,
 }
 
 // Directional prediction, zone 2: 90 < angle < 180
-void av1_dr_prediction_z2_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh,
+void eb_av1_dr_prediction_z2_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh,
     const uint8_t *above, const uint8_t *left,
     int32_t upsample_above, int32_t upsample_left, int32_t dx,
     int32_t dy) {
@@ -7168,7 +7168,7 @@ static void dr_prediction_z3_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
     }
 }
 
-void av1_dr_prediction_z3_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh,
+void eb_av1_dr_prediction_z3_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh,
     const uint8_t *above, const uint8_t *left,
     int32_t upsample_left, int32_t dx, int32_t dy) {
     (void)above;
@@ -9553,7 +9553,7 @@ static void highbd_dr_prediction_z2_HxW_avx2(
 }
 
 // Directional prediction, zone 2: 90 < angle < 180
-void av1_highbd_dr_prediction_z2_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw,
+void eb_av1_highbd_dr_prediction_z2_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw,
     int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above,
     int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd) {
     (void)bd;
@@ -9892,7 +9892,7 @@ static void highbd_dr_prediction_z3_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void av1_highbd_dr_prediction_z3_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw,
+void eb_av1_highbd_dr_prediction_z3_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw,
     int32_t bh, const uint16_t *above,
     const uint16_t *left, int32_t upsample_left,
     int32_t dx, int32_t dy, int32_t bd) {
@@ -10043,7 +10043,7 @@ static INLINE __m256i get_top_vector(const uint8_t *above) {
   return _mm256_inserti128_si256(_mm256_castsi128_si256(t0), t1, 1);
 }
 
-void aom_paeth_predictor_16x8_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_16x8_avx2(uint8_t *dst, ptrdiff_t stride,
                                    const uint8_t *above, const uint8_t *left) {
   __m128i x = _mm_loadl_epi64((const __m128i *)left);
   const __m256i l = _mm256_inserti128_si256(_mm256_castsi128_si256(x), x, 1);
@@ -10068,7 +10068,7 @@ static INLINE __m256i get_left_vector(const uint8_t *left) {
   return _mm256_inserti128_si256(_mm256_castsi128_si256(x), x, 1);
 }
 
-void aom_paeth_predictor_16x16_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_16x16_avx2(uint8_t *dst, ptrdiff_t stride,
                                     const uint8_t *above, const uint8_t *left) {
   const __m256i l = get_left_vector(left);
   const __m256i tl16 = _mm256_set1_epi16((uint16_t)above[-1]);
@@ -10087,7 +10087,7 @@ void aom_paeth_predictor_16x16_avx2(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_16x32_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_16x32_avx2(uint8_t *dst, ptrdiff_t stride,
                                     const uint8_t *above, const uint8_t *left) {
   __m256i l = get_left_vector(left);
   const __m256i tl16 = _mm256_set1_epi16((uint16_t)above[-1]);
@@ -10117,7 +10117,7 @@ void aom_paeth_predictor_16x32_avx2(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_16x64_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_16x64_avx2(uint8_t *dst, ptrdiff_t stride,
                                     const uint8_t *above, const uint8_t *left) {
   const __m256i tl16 = _mm256_set1_epi16((uint16_t)above[-1]);
   const __m256i one = _mm256_set1_epi16(1);
@@ -10152,7 +10152,7 @@ static INLINE __m256i paeth_32x1_pred(const __m256i *left, const __m256i *top0,
   return _mm256_permute2x128_si256(x0, x1, 0x20);
 }
 
-void aom_paeth_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
                                     const uint8_t *above, const uint8_t *left) {
   const __m256i l = get_left_vector(left);
   const __m256i t0 = get_top_vector(above);
@@ -10174,7 +10174,7 @@ void aom_paeth_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
                                     const uint8_t *above, const uint8_t *left) {
   __m256i l = get_left_vector(left);
   const __m256i t0 = get_top_vector(above);
@@ -10213,7 +10213,7 @@ void aom_paeth_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
                                     const uint8_t *above, const uint8_t *left) {
   const __m256i t0 = get_top_vector(above);
   const __m256i t1 = get_top_vector(above + 16);
@@ -10239,7 +10239,7 @@ void aom_paeth_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
                                     const uint8_t *above, const uint8_t *left) {
   const __m256i t0 = get_top_vector(above);
   const __m256i t1 = get_top_vector(above + 16);
@@ -10271,7 +10271,7 @@ void aom_paeth_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
                                     const uint8_t *above, const uint8_t *left) {
   const __m256i t0 = get_top_vector(above);
   const __m256i t1 = get_top_vector(above + 16);
@@ -10303,7 +10303,7 @@ void aom_paeth_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
                                     const uint8_t *above, const uint8_t *left) {
   const __m256i t0 = get_top_vector(above);
   const __m256i t1 = get_top_vector(above + 16);
@@ -10333,7 +10333,7 @@ void aom_paeth_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_highbd_paeth_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     (void) bd;
     const __m256i tl16 = _mm256_set1_epi16(above[-1]);
@@ -10349,7 +10349,7 @@ void aom_highbd_paeth_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m256i tl16 = _mm256_set1_epi16(above[-1]);
     const __m256i top = _mm256_loadu_si256((const __m256i *)above);
@@ -10365,7 +10365,7 @@ void aom_highbd_paeth_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m256i tl16 = _mm256_set1_epi16(above[-1]);
     const __m256i top = _mm256_loadu_si256((const __m256i *)above);
@@ -10381,7 +10381,7 @@ void aom_highbd_paeth_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m256i tl16 = _mm256_set1_epi16(above[-1]);
     const __m256i top = _mm256_loadu_si256((const __m256i *)above);
@@ -10397,7 +10397,7 @@ void aom_highbd_paeth_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m256i tl16 = _mm256_set1_epi16(above[-1]);
     const __m256i top = _mm256_loadu_si256((const __m256i *)above);
@@ -10413,7 +10413,7 @@ void aom_highbd_paeth_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m256i t0 = _mm256_loadu_si256((const __m256i *)above);
     const __m256i t1 = _mm256_loadu_si256((const __m256i *)(above + 16));
@@ -10435,7 +10435,7 @@ void aom_highbd_paeth_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m256i t0 = _mm256_loadu_si256((const __m256i *)above);
     const __m256i t1 = _mm256_loadu_si256((const __m256i *)(above + 16));
@@ -10457,7 +10457,7 @@ void aom_highbd_paeth_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m256i t0 = _mm256_loadu_si256((const __m256i *)above);
     const __m256i t1 = _mm256_loadu_si256((const __m256i *)(above + 16));
@@ -10479,7 +10479,7 @@ void aom_highbd_paeth_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m256i t0 = _mm256_loadu_si256((const __m256i *)above);
     const __m256i t1 = _mm256_loadu_si256((const __m256i *)(above + 16));
@@ -10501,7 +10501,7 @@ void aom_highbd_paeth_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m256i t0 = _mm256_loadu_si256((const __m256i *)above);
     const __m256i t1 = _mm256_loadu_si256((const __m256i *)(above + 16));
@@ -10531,7 +10531,7 @@ void aom_highbd_paeth_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m256i t0 = _mm256_loadu_si256((const __m256i *)above);
     const __m256i t1 = _mm256_loadu_si256((const __m256i *)(above + 16));
@@ -10561,7 +10561,7 @@ void aom_highbd_paeth_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m256i t0 = _mm256_loadu_si256((const __m256i *)above);
     const __m256i t1 = _mm256_loadu_si256((const __m256i *)(above + 16));
@@ -10591,7 +10591,7 @@ void aom_highbd_paeth_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m128i t = _mm_loadu_si128((const __m128i *)above);
     const __m256i t0 = _mm256_setr_m128i(t, t);
@@ -10612,7 +10612,7 @@ void aom_highbd_paeth_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m128i t = _mm_loadu_si128((const __m128i *)above);
     const __m256i t0 = _mm256_setr_m128i(t, t);
@@ -10633,7 +10633,7 @@ void aom_highbd_paeth_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m128i t = _mm_loadu_si128((const __m128i *)above);
     const __m256i t0 = _mm256_setr_m128i(t, t);
@@ -10654,7 +10654,7 @@ void aom_highbd_paeth_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m128i t = _mm_loadu_si128((const __m128i *)above);
     const __m256i t0 = _mm256_setr_m128i(t, t);
@@ -10675,7 +10675,7 @@ void aom_highbd_paeth_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_4x4_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_4x4_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m256i t0 = _mm256_set1_epi64x(((uint64_t*)above)[0]);
     const __m256i tl = _mm256_set1_epi16(above[-1]);
@@ -10698,7 +10698,7 @@ void aom_highbd_paeth_predictor_4x4_avx2(uint16_t *dst, ptrdiff_t stride,
     *(uint64_t*)&dst[3 * stride] = _mm256_extract_epi64(row, 3);
 }
 
-void aom_highbd_paeth_predictor_4x8_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_4x8_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m256i t0 = _mm256_set1_epi64x(((uint64_t*)above)[0]);
     const __m256i tl = _mm256_set1_epi16(above[-1]);
@@ -10725,7 +10725,7 @@ void aom_highbd_paeth_predictor_4x8_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_4x16_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_4x16_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     const __m256i t0 = _mm256_set1_epi64x(((uint64_t*)above)[0]);
     const __m256i tl = _mm256_set1_epi16(above[-1]);
@@ -10752,7 +10752,7 @@ void aom_highbd_paeth_predictor_4x16_avx2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_paeth_predictor_2x2_avx2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_paeth_predictor_2x2_avx2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int bd) {
     (void) bd;
     __m256i tl = _mm256_set1_epi16(above[-1]);

--- a/Source/Lib/Common/ASM_AVX2/av1_inv_txfm_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/av1_inv_txfm_avx2.c
@@ -1613,7 +1613,7 @@ static INLINE void lowbd_inv_txfm2d_add_no_identity_avx2(
     __m256i buf1[64 * 16];
     int eobx, eoby;
     get_eobx_eoby_scan_default(&eobx, &eoby, tx_size, eob);
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int txw_idx = get_txw_idx(tx_size);
     const int txh_idx = get_txh_idx(tx_size);
     const int cos_bit_col = inv_cos_bit_col[txw_idx][txh_idx];
@@ -1746,7 +1746,7 @@ static INLINE void iidentity_col_16xn_avx2(uint8_t *output, int stride,
 static INLINE void lowbd_inv_txfm2d_add_idtx_avx2(const int32_t *input,
     uint8_t *output, int stride, TxSize tx_size, int32_t eob) {
     (void)eob;
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int txw_idx = get_txw_idx(tx_size);
     const int txh_idx = get_txh_idx(tx_size);
     const int txfm_size_col = tx_size_wide[tx_size];
@@ -1768,7 +1768,7 @@ static INLINE void lowbd_inv_txfm2d_add_h_identity_avx2(
     TxSize tx_size, int eob) {
     int eobx, eoby;
     get_eobx_eoby_scan_h_identity(&eobx, &eoby, tx_size, eob);
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int txw_idx = get_txw_idx(tx_size);
     const int txh_idx = get_txh_idx(tx_size);
     const int cos_bit_col = inv_cos_bit_col[txw_idx][txh_idx];
@@ -1808,7 +1808,7 @@ static INLINE void lowbd_inv_txfm2d_add_v_identity_avx2(
     __m256i buf1[64];
     int eobx, eoby;
     get_eobx_eoby_scan_v_identity(&eobx, &eoby, tx_size, eob);
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int txw_idx = get_txw_idx(tx_size);
     const int txh_idx = get_txh_idx(tx_size);
     const int cos_bit_row = inv_cos_bit_row[txw_idx][txh_idx];
@@ -1893,13 +1893,13 @@ static INLINE void lowbd_inv_txfm2d_add_universe_avx2(
             tx_size, eob);
         break;
     default:
-        av1_lowbd_inv_txfm2d_add_ssse3(input, output, stride, tx_type, tx_size,
+        eb_av1_lowbd_inv_txfm2d_add_ssse3(input, output, stride, tx_type, tx_size,
             eob);
         break;
     }
 }
 
-void av1_lowbd_inv_txfm2d_add_avx2(const int32_t *input, uint8_t *output,
+void eb_av1_lowbd_inv_txfm2d_add_avx2(const int32_t *input, uint8_t *output,
     int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob) {
     switch (tx_size) {
     case TX_4X4:
@@ -1912,7 +1912,7 @@ void av1_lowbd_inv_txfm2d_add_avx2(const int32_t *input, uint8_t *output,
     case TX_16X4:
     case TX_8X32:
     case TX_32X8:
-        av1_lowbd_inv_txfm2d_add_ssse3(input, output, stride, tx_type, tx_size,
+        eb_av1_lowbd_inv_txfm2d_add_ssse3(input, output, stride, tx_type, tx_size,
             eob);
         break;
     case TX_16X16:
@@ -1931,12 +1931,12 @@ void av1_lowbd_inv_txfm2d_add_avx2(const int32_t *input, uint8_t *output,
     }
 }
 
-void av1_inv_txfm_add_avx2(const TranLow *dqcoeff, uint8_t *dst, int32_t stride,
+void eb_av1_inv_txfm_add_avx2(const TranLow *dqcoeff, uint8_t *dst, int32_t stride,
     const TxfmParam *txfm_param) {
     const TxType tx_type = txfm_param->tx_type;
     if (!txfm_param->lossless)
-        av1_lowbd_inv_txfm2d_add_avx2(dqcoeff, dst, stride, tx_type,
+        eb_av1_lowbd_inv_txfm2d_add_avx2(dqcoeff, dst, stride, tx_type,
             txfm_param->tx_size, txfm_param->eob);
     else
-        av1_inv_txfm_add_c(dqcoeff, dst, stride, txfm_param);
+        eb_av1_inv_txfm_add_c(dqcoeff, dst, stride, txfm_param);
 }

--- a/Source/Lib/Common/ASM_AVX2/av1_quantize_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/av1_quantize_avx2.c
@@ -129,7 +129,7 @@ static INLINE void quantize(const __m256i *thr, const __m256i *qp, __m256i *c,
     }
 }
 
-void av1_quantize_fp_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs,
+void eb_av1_quantize_fp_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs,
     const int16_t *zbin_ptr, const int16_t *round_ptr,
     const int16_t *quant_ptr,
     const int16_t *quant_shift_ptr,
@@ -206,7 +206,7 @@ static INLINE void quantize_32x32(const __m256i *thr, const __m256i *qp,
     }
 }
 
-void av1_quantize_fp_32x32_avx2(
+void eb_av1_quantize_fp_32x32_avx2(
     const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr,
     const int16_t *round_ptr, const int16_t *quant_ptr,
     const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr,
@@ -287,7 +287,7 @@ static INLINE void quantize_64x64(const __m256i *thr, const __m256i *qp,
     }
 }
 
-void av1_quantize_fp_64x64_avx2(
+void eb_av1_quantize_fp_64x64_avx2(
     const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr,
     const int16_t *round_ptr, const int16_t *quant_ptr,
     const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr,

--- a/Source/Lib/Common/ASM_AVX2/cdef_block_simd.c
+++ b/Source/Lib/Common/ASM_AVX2/cdef_block_simd.c
@@ -21,7 +21,7 @@
 
 #include "aom_dsp_rtcd.h"
 
-#define SIMD_FUNC(name) name##_avx2
+#define SIMD_FUNC(name) eb_##name##_avx2
 
 #if defined(__SSE4_1__)
 #undef CDEF_AVX_OPT
@@ -393,15 +393,15 @@ void SIMD_FUNC(cdef_filter_block_4x4_8)(uint8_t *dst, int32_t dstride,
     v128 p0, p1, p2, p3;
     v256 sum, row, tap, res;
     v256 max, min, large = v256_dup_16(CDEF_VERY_LARGE);
-    int32_t po1 = cdef_directions[dir][0];
-    int32_t po2 = cdef_directions[dir][1];
-    int32_t s1o1 = cdef_directions[(dir + 2) & 7][0];
-    int32_t s1o2 = cdef_directions[(dir + 2) & 7][1];
-    int32_t s2o1 = cdef_directions[(dir + 6) & 7][0];
-    int32_t s2o2 = cdef_directions[(dir + 6) & 7][1];
+    int32_t po1 = eb_cdef_directions[dir][0];
+    int32_t po2 = eb_cdef_directions[dir][1];
+    int32_t s1o1 = eb_cdef_directions[(dir + 2) & 7][0];
+    int32_t s1o2 = eb_cdef_directions[(dir + 2) & 7][1];
+    int32_t s2o1 = eb_cdef_directions[(dir + 6) & 7][0];
+    int32_t s2o2 = eb_cdef_directions[(dir + 6) & 7][1];
 
-    const int32_t *pri_taps = cdef_pri_taps[(pri_strength >> coeff_shift) & 1];
-    const int32_t *sec_taps = cdef_sec_taps[(pri_strength >> coeff_shift) & 1];
+    const int32_t *pri_taps = eb_cdef_pri_taps[(pri_strength >> coeff_shift) & 1];
+    const int32_t *sec_taps = eb_cdef_sec_taps[(pri_strength >> coeff_shift) & 1];
 
     if (pri_strength)
         pri_damping = AOMMAX(0, pri_damping - get_msb(pri_strength));
@@ -656,15 +656,15 @@ void SIMD_FUNC(cdef_filter_block_8x8_8)(uint8_t *dst, int32_t dstride,
     v128 p0, p1, p2, p3;
     v256 sum, row, res, tap;
     v256 max, min, large = v256_dup_16(CDEF_VERY_LARGE);
-    int32_t po1 = cdef_directions[dir][0];
-    int32_t po2 = cdef_directions[dir][1];
-    int32_t s1o1 = cdef_directions[(dir + 2) & 7][0];
-    int32_t s1o2 = cdef_directions[(dir + 2) & 7][1];
-    int32_t s2o1 = cdef_directions[(dir + 6) & 7][0];
-    int32_t s2o2 = cdef_directions[(dir + 6) & 7][1];
+    int32_t po1 = eb_cdef_directions[dir][0];
+    int32_t po2 = eb_cdef_directions[dir][1];
+    int32_t s1o1 = eb_cdef_directions[(dir + 2) & 7][0];
+    int32_t s1o2 = eb_cdef_directions[(dir + 2) & 7][1];
+    int32_t s2o1 = eb_cdef_directions[(dir + 6) & 7][0];
+    int32_t s2o2 = eb_cdef_directions[(dir + 6) & 7][1];
 
-    const int32_t *pri_taps = cdef_pri_taps[(pri_strength >> coeff_shift) & 1];
-    const int32_t *sec_taps = cdef_sec_taps[(pri_strength >> coeff_shift) & 1];
+    const int32_t *pri_taps = eb_cdef_pri_taps[(pri_strength >> coeff_shift) & 1];
+    const int32_t *sec_taps = eb_cdef_sec_taps[(pri_strength >> coeff_shift) & 1];
 #if CDEF_AVX_OPT
     v256 pri_taps_0 = v256_dup_8(pri_taps[0]);
     v256 pri_taps_1 = v256_dup_8(pri_taps[1]);
@@ -931,15 +931,15 @@ void SIMD_FUNC(cdef_filter_block_4x4_16)(uint16_t *dst, int32_t dstride,
 #endif
     v256 p0, p1, p2, p3, sum, row, res;
     v256 max, min, large = v256_dup_16(CDEF_VERY_LARGE);
-    int32_t po1 = cdef_directions[dir][0];
-    int32_t po2 = cdef_directions[dir][1];
-    int32_t s1o1 = cdef_directions[(dir + 2) & 7][0];
-    int32_t s1o2 = cdef_directions[(dir + 2) & 7][1];
-    int32_t s2o1 = cdef_directions[(dir + 6) & 7][0];
-    int32_t s2o2 = cdef_directions[(dir + 6) & 7][1];
+    int32_t po1 = eb_cdef_directions[dir][0];
+    int32_t po2 = eb_cdef_directions[dir][1];
+    int32_t s1o1 = eb_cdef_directions[(dir + 2) & 7][0];
+    int32_t s1o2 = eb_cdef_directions[(dir + 2) & 7][1];
+    int32_t s2o1 = eb_cdef_directions[(dir + 6) & 7][0];
+    int32_t s2o2 = eb_cdef_directions[(dir + 6) & 7][1];
 
-    const int32_t *pri_taps = cdef_pri_taps[(pri_strength >> coeff_shift) & 1];
-    const int32_t *sec_taps = cdef_sec_taps[(pri_strength >> coeff_shift) & 1];
+    const int32_t *pri_taps = eb_cdef_pri_taps[(pri_strength >> coeff_shift) & 1];
+    const int32_t *sec_taps = eb_cdef_sec_taps[(pri_strength >> coeff_shift) & 1];
 #if  CDEF_AVX_OPT
     v256 pri_strength_256 = v256_dup_16(pri_strength);
     v256 sec_strength_256 = v256_dup_16(sec_strength);
@@ -1228,15 +1228,15 @@ void SIMD_FUNC(cdef_filter_block_8x8_16)(uint16_t *dst, int32_t dstride,
     int32_t i;
     v256 sum, p0, p1, p2, p3, row, res;
     v256 max, min, large = v256_dup_16(CDEF_VERY_LARGE);
-    int32_t po1 = cdef_directions[dir][0];
-    int32_t po2 = cdef_directions[dir][1];
-    int32_t s1o1 = cdef_directions[(dir + 2) & 7][0];
-    int32_t s1o2 = cdef_directions[(dir + 2) & 7][1];
-    int32_t s2o1 = cdef_directions[(dir + 6) & 7][0];
-    int32_t s2o2 = cdef_directions[(dir + 6) & 7][1];
+    int32_t po1 = eb_cdef_directions[dir][0];
+    int32_t po2 = eb_cdef_directions[dir][1];
+    int32_t s1o1 = eb_cdef_directions[(dir + 2) & 7][0];
+    int32_t s1o2 = eb_cdef_directions[(dir + 2) & 7][1];
+    int32_t s2o1 = eb_cdef_directions[(dir + 6) & 7][0];
+    int32_t s2o2 = eb_cdef_directions[(dir + 6) & 7][1];
     //SSE CHKN
-    const int32_t *pri_taps = cdef_pri_taps[(pri_strength >> coeff_shift) & 1];
-    const int32_t *sec_taps = cdef_sec_taps[(pri_strength >> coeff_shift) & 1];
+    const int32_t *pri_taps = eb_cdef_pri_taps[(pri_strength >> coeff_shift) & 1];
+    const int32_t *sec_taps = eb_cdef_sec_taps[(pri_strength >> coeff_shift) & 1];
 #if CDEF_AVX_OPT
     v256 pri_taps_0 = v256_dup_16(pri_taps[0]);
     v256 pri_taps_1 = v256_dup_16(pri_taps[1]);

--- a/Source/Lib/Common/ASM_AVX2/cfl_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/cfl_avx2.c
@@ -37,7 +37,7 @@ static INLINE void _mm_storeh_epi32(__m128i const *mem_addr, __m128i a) {
     *((int32_t *)mem_addr) = _mm_cvtsi128_si32(a);
 }
 
-void cfl_predict_lbd_avx2(const int16_t *pred_buf_q3,
+void eb_cfl_predict_lbd_avx2(const int16_t *pred_buf_q3,
         uint8_t *pred,
         int32_t pred_stride,
         uint8_t *dst,
@@ -111,7 +111,7 @@ static INLINE __m128i highbd_clamp_epi16_ssse3(__m128i u, __m128i zero, __m128i 
     return _mm_max_epi16(_mm_min_epi16(u, max), zero);
 }
 
-void cfl_predict_hbd_avx2(
+void eb_cfl_predict_hbd_avx2(
     const int16_t *pred_buf_q3,
     uint16_t *pred,// AMIR ADDED
     int32_t pred_stride,
@@ -193,7 +193,7 @@ static INLINE __m256i _mm256_addl_epi16(__m256i a) {
                           _mm256_unpackhi_epi16(a, _mm256_setzero_si256()));
 }
 
-/*staticINLINE*/  void subtract_average_avx2(int16_t *pred_buf_q3, int32_t width,
+/*staticINLINE*/  void eb_subtract_average_avx2(int16_t *pred_buf_q3, int32_t width,
     int32_t height, int32_t round_offset,
     int32_t num_pel_log2) {
     // Use SSE2 version for smaller widths

--- a/Source/Lib/Common/ASM_AVX2/convolve_2d_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/convolve_2d_avx2.c
@@ -16,7 +16,7 @@
 #include "convolve_avx2.h"
 #include "synonyms.h"
 
-void av1_convolve_2d_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst,
+void eb_av1_convolve_2d_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst,
     int32_t dst_stride, int32_t w, int32_t h,
     InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y,
@@ -174,7 +174,7 @@ static INLINE void copy_128(const uint8_t *src, uint8_t *dst) {
     _mm256_storeu_si256((__m256i *)(dst + 3 * 32), s[3]);
 }
 
-void av1_convolve_2d_copy_sr_avx2(const uint8_t *src, int32_t src_stride,
+void eb_av1_convolve_2d_copy_sr_avx2(const uint8_t *src, int32_t src_stride,
     uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h,
     InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y,

--- a/Source/Lib/Common/ASM_AVX2/convolve_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/convolve_avx2.c
@@ -16,7 +16,7 @@
 #include "convolve_avx2.h"
 #include "synonyms.h"
 
-void av1_convolve_y_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst,
+void eb_av1_convolve_y_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst,
     int32_t dst_stride, int32_t w, int32_t h,
     InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y,
@@ -176,7 +176,7 @@ void av1_convolve_y_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst
     }
 }
 
-void av1_convolve_x_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst,
+void eb_av1_convolve_x_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst,
     int32_t dst_stride, int32_t w, int32_t h,
     InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y,

--- a/Source/Lib/Common/ASM_AVX2/encodetxb_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/encodetxb_avx2.c
@@ -18,7 +18,7 @@
 #include "synonyms.h"
 #include "synonyms_avx2.h"
 
-void av1_txb_init_levels_avx2(const TranLow *const coeff, const int32_t width,
+void eb_av1_txb_init_levels_avx2(const TranLow *const coeff, const int32_t width,
     const int32_t height, uint8_t *const levels) {
     const int32_t stride = width + TX_PAD_HOR;
   const __m256i y_zeros = _mm256_setzero_si256();

--- a/Source/Lib/Common/ASM_AVX2/fft_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/fft_avx2.c
@@ -14,8 +14,8 @@
 #include "EbDefinitions.h"
 #include "fft_common.h"
 
-extern void aom_transpose_float_sse2(const float *A, float *B, int32_t n);
-extern void aom_fft_unpack_2d_output_sse2(const float *col_fft, float *output,
+extern void eb_aom_transpose_float_sse2(const float *A, float *B, int32_t n);
+extern void eb_aom_fft_unpack_2d_output_sse2(const float *col_fft, float *output,
     int32_t n);
 
 // Generate the 1d forward transforms for float using _mm256
@@ -29,19 +29,19 @@ GEN_FFT_32(static INLINE void, avx2, float, __m256, _mm256_load_ps,
     _mm256_store_ps, _mm256_set1_ps, _mm256_add_ps, _mm256_sub_ps,
     _mm256_mul_ps);
 
-void aom_fft8x8_float_avx2(const float *input, float *temp, float *output) {
-    aom_fft_2d_gen(input, temp, output, 8, aom_fft1d_8_avx2,
-        aom_transpose_float_sse2, aom_fft_unpack_2d_output_sse2, 8);
+void eb_aom_fft8x8_float_avx2(const float *input, float *temp, float *output) {
+    eb_aom_fft_2d_gen(input, temp, output, 8, eb_aom_fft1d_8_avx2,
+        eb_aom_transpose_float_sse2, eb_aom_fft_unpack_2d_output_sse2, 8);
 }
 
-void aom_fft16x16_float_avx2(const float *input, float *temp, float *output) {
-    aom_fft_2d_gen(input, temp, output, 16, aom_fft1d_16_avx2,
-        aom_transpose_float_sse2, aom_fft_unpack_2d_output_sse2, 8);
+void eb_aom_fft16x16_float_avx2(const float *input, float *temp, float *output) {
+    eb_aom_fft_2d_gen(input, temp, output, 16, eb_aom_fft1d_16_avx2,
+        eb_aom_transpose_float_sse2, eb_aom_fft_unpack_2d_output_sse2, 8);
 }
 
-void aom_fft32x32_float_avx2(const float *input, float *temp, float *output) {
-    aom_fft_2d_gen(input, temp, output, 32, aom_fft1d_32_avx2,
-        aom_transpose_float_sse2, aom_fft_unpack_2d_output_sse2, 8);
+void eb_aom_fft32x32_float_avx2(const float *input, float *temp, float *output) {
+    eb_aom_fft_2d_gen(input, temp, output, 32, eb_aom_fft1d_32_avx2,
+        eb_aom_transpose_float_sse2, eb_aom_fft_unpack_2d_output_sse2, 8);
 }
 
 // Generate the 1d inverse transforms for float using _mm256
@@ -55,19 +55,19 @@ GEN_IFFT_32(static INLINE void, avx2, float, __m256, _mm256_load_ps,
     _mm256_store_ps, _mm256_set1_ps, _mm256_add_ps, _mm256_sub_ps,
     _mm256_mul_ps);
 
-void aom_ifft8x8_float_avx2(const float *input, float *temp, float *output) {
-    aom_ifft_2d_gen(input, temp, output, 8, aom_fft1d_8_float, aom_fft1d_8_avx2,
-        aom_ifft1d_8_avx2, aom_transpose_float_sse2, 8);
+void eb_aom_ifft8x8_float_avx2(const float *input, float *temp, float *output) {
+    eb_aom_ifft_2d_gen(input, temp, output, 8, eb_aom_fft1d_8_float, eb_aom_fft1d_8_avx2,
+        eb_aom_ifft1d_8_avx2, eb_aom_transpose_float_sse2, 8);
 }
 
-void aom_ifft16x16_float_avx2(const float *input, float *temp, float *output) {
-    aom_ifft_2d_gen(input, temp, output, 16, aom_fft1d_16_float,
-        aom_fft1d_16_avx2, aom_ifft1d_16_avx2,
-        aom_transpose_float_sse2, 8);
+void eb_aom_ifft16x16_float_avx2(const float *input, float *temp, float *output) {
+    eb_aom_ifft_2d_gen(input, temp, output, 16, eb_aom_fft1d_16_float,
+        eb_aom_fft1d_16_avx2, eb_aom_ifft1d_16_avx2,
+        eb_aom_transpose_float_sse2, 8);
 }
 
-void aom_ifft32x32_float_avx2(const float *input, float *temp, float *output) {
-    aom_ifft_2d_gen(input, temp, output, 32, aom_fft1d_32_float,
-        aom_fft1d_32_avx2, aom_ifft1d_32_avx2,
-        aom_transpose_float_sse2, 8);
+void eb_aom_ifft32x32_float_avx2(const float *input, float *temp, float *output) {
+    eb_aom_ifft_2d_gen(input, temp, output, 32, eb_aom_fft1d_32_float,
+        eb_aom_fft1d_32_avx2, eb_aom_ifft1d_32_avx2,
+        eb_aom_transpose_float_sse2, 8);
 }

--- a/Source/Lib/Common/ASM_AVX2/highbd_convolve_2d_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/highbd_convolve_2d_avx2.c
@@ -19,7 +19,7 @@
 #include "synonyms.h"
 #include "convolve.h"
 
-void av1_highbd_convolve_2d_sr_avx2(const uint16_t *src, int32_t src_stride,
+void eb_av1_highbd_convolve_2d_sr_avx2(const uint16_t *src, int32_t src_stride,
     uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h,
     const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y,
@@ -220,7 +220,7 @@ static INLINE void copy_128(const uint16_t *src, uint16_t *dst) {
     _mm256_storeu_si256((__m256i *)(dst + 7 * 16), s[7]);
 }
 
-void av1_highbd_convolve_2d_copy_sr_avx2(
+void eb_av1_highbd_convolve_2d_copy_sr_avx2(
     const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w,
     int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,

--- a/Source/Lib/Common/ASM_AVX2/highbd_convolve_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/highbd_convolve_avx2.c
@@ -20,7 +20,7 @@
  // -----------------------------------------------------------------------------
  // Copy and average
 
-void av1_highbd_convolve_y_sr_avx2(const uint16_t *src, int32_t src_stride,
+void eb_av1_highbd_convolve_y_sr_avx2(const uint16_t *src, int32_t src_stride,
     uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h,
     const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y,
@@ -171,7 +171,7 @@ void av1_highbd_convolve_y_sr_avx2(const uint16_t *src, int32_t src_stride,
     }
 }
 
-void av1_highbd_convolve_x_sr_avx2(const uint16_t *src, int32_t src_stride,
+void eb_av1_highbd_convolve_x_sr_avx2(const uint16_t *src, int32_t src_stride,
     uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h,
     const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y,

--- a/Source/Lib/Common/ASM_AVX2/highbd_fwd_txfm_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/highbd_fwd_txfm_avx2.c
@@ -775,7 +775,7 @@ static void fadst8x8_avx2(const __m256i *in, __m256i *out, int8_t bit, const int
     out[7 * col_num] = v0;
 }
 
-void av1_fwd_txfm2d_8x8_avx2(int16_t *input, int32_t *coeff, uint32_t stride, TxType tx_type, uint8_t  bd)
+void eb_av1_fwd_txfm2d_8x8_avx2(int16_t *input, int32_t *coeff, uint32_t stride, TxType tx_type, uint8_t  bd)
 {
     __m256i in[8], out[8];
     const int8_t *shift = fwd_txfm_shift_ls[TX_8X8];
@@ -2552,7 +2552,7 @@ static void fadst16x16_avx2(const __m256i *in, __m256i *out, int8_t bit, const i
     }
 }
 
-void av1_fwd_txfm2d_16x16_avx2(int16_t *input, int32_t *coeff, uint32_t stride, TxType tx_type, uint8_t  bd)
+void eb_av1_fwd_txfm2d_16x16_avx2(int16_t *input, int32_t *coeff, uint32_t stride, TxType tx_type, uint8_t  bd)
 {
     __m256i in[32], out[32];
     const int8_t *shift = fwd_txfm_shift_ls[TX_16X16];
@@ -4064,7 +4064,7 @@ static INLINE void fwd_txfm2d_32x32_avx2(const int16_t *input, int32_t *output,
     transpose_32_avx2(txfm_size, buf_256, out_256);
 }
 
-void av1_fwd_txfm2d_32x32_avx2(int16_t *input, int32_t *output,
+void eb_av1_fwd_txfm2d_32x32_avx2(int16_t *input, int32_t *output,
     uint32_t stride, TxType tx_type, uint8_t  bd)
 {
     DECLARE_ALIGNED(32, int32_t, txfm_buf[1024]);
@@ -4113,7 +4113,7 @@ static INLINE void load_buffer_64x64_avx2(const int16_t *input,
     }
 }
 
-void av1_fwd_txfm2d_64x64_avx2(int16_t *input, int32_t *output,
+void eb_av1_fwd_txfm2d_64x64_avx2(int16_t *input, int32_t *output,
     uint32_t stride, TxType tx_type, uint8_t  bd) {
     (void)bd;
     __m256i in[512];
@@ -4270,7 +4270,7 @@ static INLINE void write_buffer_16x8_avx2(const __m256i *res, int32_t *output,
     _mm256_storeu_si256((__m256i *)(output + (stride * 7)), res[7]);
 }
 
-void av1_fwd_txfm2d_32x64_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
+void eb_av1_fwd_txfm2d_32x64_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
 {
     (void)tx_type;
     __m256i in[256];
@@ -4301,7 +4301,7 @@ void av1_fwd_txfm2d_32x64_avx2(int16_t *input, int32_t *output, uint32_t stride,
     (void)bd;
 }
 
-void av1_fwd_txfm2d_64x32_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
+void eb_av1_fwd_txfm2d_64x32_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
 {
     (void)tx_type;
     __m256i in[256];
@@ -4336,7 +4336,7 @@ void av1_fwd_txfm2d_64x32_avx2(int16_t *input, int32_t *output, uint32_t stride,
     (void)bd;
 }
 
-void av1_fwd_txfm2d_16x64_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
+void eb_av1_fwd_txfm2d_16x64_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
 {
     __m256i in[128];
     __m256i *outcoeff256 = (__m256i *)output;
@@ -4372,7 +4372,7 @@ void av1_fwd_txfm2d_16x64_avx2(int16_t *input, int32_t *output, uint32_t stride,
     (void)bd;
 }
 
-void av1_fwd_txfm2d_64x16_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
+void eb_av1_fwd_txfm2d_64x16_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
 {
     __m256i in[128];
     __m256i *outcoeff256 = (__m256i *)output;
@@ -4545,7 +4545,7 @@ static const fwd_transform_1d_avx2 row_fwdtxfm_8x16_arr[TX_TYPES] = {
 };
 
 /* call this function only for DCT_DCT, IDTX */
-void av1_fwd_txfm2d_16x32_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
+void eb_av1_fwd_txfm2d_16x32_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
 {
     __m256i in[64];
     __m256i *outcoef256 = (__m256i *)output;
@@ -4580,7 +4580,7 @@ void av1_fwd_txfm2d_16x32_avx2(int16_t *input, int32_t *output, uint32_t stride,
 }
 
 /* call this function only for IDTX */
-void av1_fwd_txfm2d_32x16_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
+void eb_av1_fwd_txfm2d_32x16_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
 {
     __m256i in[64];
     __m256i *outcoef256 = (__m256i *)output;
@@ -4613,7 +4613,7 @@ void av1_fwd_txfm2d_32x16_avx2(int16_t *input, int32_t *output, uint32_t stride,
 }
 
 /* call this function only for DCT_DCT, IDTX */
-void av1_fwd_txfm2d_8x32_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
+void eb_av1_fwd_txfm2d_8x32_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
 {
     __m256i in[32];
     __m256i *outcoef256 = (__m256i *)output;
@@ -4647,7 +4647,7 @@ void av1_fwd_txfm2d_8x32_avx2(int16_t *input, int32_t *output, uint32_t stride, 
 }
 
 /* call this function only for DCT_DCT, IDTX */
-void av1_fwd_txfm2d_32x8_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
+void eb_av1_fwd_txfm2d_32x8_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
 {
     __m256i in[32];
     __m256i *outcoef256 = (__m256i *)output;
@@ -4679,7 +4679,7 @@ void av1_fwd_txfm2d_32x8_avx2(int16_t *input, int32_t *output, uint32_t stride, 
 }
 
 /* call this function for all 16 transform types */
-void av1_fwd_txfm2d_8x16_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
+void eb_av1_fwd_txfm2d_8x16_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
 {
     __m256i in[16], out[16];
     const int8_t *shift = fwd_txfm_shift_ls[TX_8X16];
@@ -4714,7 +4714,7 @@ void av1_fwd_txfm2d_8x16_avx2(int16_t *input, int32_t *output, uint32_t stride, 
 }
 
 /* call this function for all 16 transform types */
-void av1_fwd_txfm2d_16x8_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
+void eb_av1_fwd_txfm2d_16x8_avx2(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
 {
     __m256i in[16], out[16]={0};
     const int8_t *shift = fwd_txfm_shift_ls[TX_16X8];
@@ -4756,7 +4756,7 @@ void av1_fwd_txfm2d_16x8_avx2(int16_t *input, int32_t *output, uint32_t stride, 
     (void)bd;
 }
 
-void av1_fwd_txfm2d_4x8_avx2(int16_t *input, int32_t *output, uint32_t stride,
+void eb_av1_fwd_txfm2d_4x8_avx2(int16_t *input, int32_t *output, uint32_t stride,
     TxType tx_type, uint8_t  bd)
 {
     __m256i in[4];
@@ -4918,7 +4918,7 @@ void av1_fwd_txfm2d_4x8_avx2(int16_t *input, int32_t *output, uint32_t stride,
     (void)bd;
 }
 
-void av1_fwd_txfm2d_8x4_avx2(int16_t *input, int32_t *output, uint32_t stride,
+void eb_av1_fwd_txfm2d_8x4_avx2(int16_t *input, int32_t *output, uint32_t stride,
     TxType tx_type, uint8_t  bd)
 {
     __m256i in[4];
@@ -5079,7 +5079,7 @@ void av1_fwd_txfm2d_8x4_avx2(int16_t *input, int32_t *output, uint32_t stride,
     (void)bd;
 }
 
-void av1_fwd_txfm2d_4x16_avx2(int16_t *input, int32_t *output, uint32_t stride,
+void eb_av1_fwd_txfm2d_4x16_avx2(int16_t *input, int32_t *output, uint32_t stride,
     TxType tx_type, uint8_t  bd)
 {
     __m256i in[8];
@@ -5240,7 +5240,7 @@ void av1_fwd_txfm2d_4x16_avx2(int16_t *input, int32_t *output, uint32_t stride,
     (void)bd;
 }
 
-void av1_fwd_txfm2d_16x4_avx2(int16_t *input, int32_t *output, uint32_t stride,
+void eb_av1_fwd_txfm2d_16x4_avx2(int16_t *input, int32_t *output, uint32_t stride,
     TxType tx_type, uint8_t  bd) {
     __m256i in[8];
     __m256i *outcoeff256 = (__m256i *)output;

--- a/Source/Lib/Common/ASM_AVX2/highbd_inv_txfm_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/highbd_inv_txfm_avx2.c
@@ -820,10 +820,10 @@ static INLINE void iadst4_col_avx2(__m256i *in, int8_t cos_bit) {
     in[1] = _mm256_srai_epi32(y0, bit);
 }
 
-void av1_inv_txfm2d_add_4x4_avx2(const int32_t *coeff, uint16_t *output,
+void eb_av1_inv_txfm2d_add_4x4_avx2(const int32_t *coeff, uint16_t *output,
     int32_t stride, TxType tx_type, int32_t bd) {
     __m256i in[2];
-    const int8_t *shift = inv_txfm_shift_ls[TX_4X4];
+    const int8_t *shift = eb_inv_txfm_shift_ls[TX_4X4];
     const int32_t txw_idx = get_txw_idx(TX_4X4);
     const int32_t txh_idx = get_txh_idx(TX_4X4);
 
@@ -874,7 +874,7 @@ void av1_inv_txfm2d_add_4x4_avx2(const int32_t *coeff, uint16_t *output,
         write_buffer_4x4(in, output, stride, 1, 0, bd);
         break;
     default:
-        av1_inv_txfm2d_add_4x4_sse4_1(coeff, output, stride, tx_type, bd);
+        eb_av1_inv_txfm2d_add_4x4_sse4_1(coeff, output, stride, tx_type, bd);
         break;
     }
 }
@@ -1194,10 +1194,10 @@ static INLINE void iadst8_col_avx2(__m256i *in, __m256i *out, int8_t cos_bit) {
     out[7] = _mm256_sign_epi32(tmp[1], negative);
 }
 
-void av1_inv_txfm2d_add_8x8_avx2(const int32_t *coeff, uint16_t *output,
+void eb_av1_inv_txfm2d_add_8x8_avx2(const int32_t *coeff, uint16_t *output,
     int32_t stride, TxType tx_type, int32_t bd) {
     __m256i in[8], out[8];
-    const int8_t *shift = inv_txfm_shift_ls[TX_8X8];
+    const int8_t *shift = eb_inv_txfm_shift_ls[TX_8X8];
     const int32_t txw_idx = get_txw_idx(TX_8X8);
     const int32_t txh_idx = get_txh_idx(TX_8X8);
 
@@ -1205,16 +1205,16 @@ void av1_inv_txfm2d_add_8x8_avx2(const int32_t *coeff, uint16_t *output,
     case IDTX:
         load_buffer_8x8(coeff, in);
         // Operations can be joined together without losing precision
-        // av1_iidentity8_c() shift left 1 bits
+        // eb_av1_iidentity8_c() shift left 1 bits
         // round_shift_8x8(, -shift[0]) shift right 1 bits
-        // av1_iidentity8_c() shift left 1 bits
+        // eb_av1_iidentity8_c() shift left 1 bits
         // round_shift_8x8(, -shift[1]) shift right 4 bits with complement
         round_shift_8x8(in, -shift[0] - shift[1] - 2);
         write_buffer_8x8(in, output, stride, 0, 0, bd);
         break;
     case V_DCT:
         load_buffer_8x8(coeff, in);
-        // av1_iidentity8_c() shift left 1 bits
+        // eb_av1_iidentity8_c() shift left 1 bits
         // round_shift_8x8(, -shift[0]) shift right 1 bits
         idct8_col_avx2(in, out, inv_cos_bit_col[txw_idx][txh_idx]);
         round_shift_8x8(out, -shift[1]);
@@ -1225,14 +1225,14 @@ void av1_inv_txfm2d_add_8x8_avx2(const int32_t *coeff, uint16_t *output,
         transpose_8x8_avx2(in, out);
         idct8_col_avx2(out, in, inv_cos_bit_row[txw_idx][txh_idx]);
         transpose_8x8_avx2(in, out);
-        // av1_iidentity8_c() shift left 1 bits
+        // eb_av1_iidentity8_c() shift left 1 bits
         // round_shift_8x8(, -shift[1]) shift right 4 bits with complement
         round_shift_8x8_double(out, -shift[0], -shift[1] - 1);
         write_buffer_8x8(out, output, stride, 0, 0, bd);
         break;
     case V_ADST:
         load_buffer_8x8(coeff, in);
-        // av1_iidentity8_c() shift left 1 bits
+        // eb_av1_iidentity8_c() shift left 1 bits
         // round_shift_8x8(, -shift[0]) shift right 1 bits
         iadst8_col_avx2(in, out, inv_cos_bit_col[txw_idx][txh_idx]);
         round_shift_8x8(out, -shift[1]);
@@ -1243,14 +1243,14 @@ void av1_inv_txfm2d_add_8x8_avx2(const int32_t *coeff, uint16_t *output,
         transpose_8x8_avx2(in, out);
         iadst8_col_avx2(out, in, inv_cos_bit_row[txw_idx][txh_idx]);
         transpose_8x8_avx2(in, out);
-        // av1_iidentity8_c() shift left 1 bits
+        // eb_av1_iidentity8_c() shift left 1 bits
         // round_shift_8x8(, -shift[1]) shift right 4 bits with complement
         round_shift_8x8_double(out, -shift[0], -shift[1] - 1);
         write_buffer_8x8(out, output, stride, 0, 0, bd);
         break;
     case V_FLIPADST:
         load_buffer_8x8(coeff, in);
-        // av1_iidentity8_c() shift left 1 bits
+        // eb_av1_iidentity8_c() shift left 1 bits
         // round_shift_8x8(, -shift[0]) shift right 1 bits
         iadst8_col_avx2(in, out, inv_cos_bit_col[txw_idx][txh_idx]);
         round_shift_8x8(out, -shift[1]);
@@ -1261,13 +1261,13 @@ void av1_inv_txfm2d_add_8x8_avx2(const int32_t *coeff, uint16_t *output,
         transpose_8x8_avx2(in, out);
         iadst8_col_avx2(out, in, inv_cos_bit_row[txw_idx][txh_idx]);
         transpose_8x8_avx2(in, out);
-        // av1_iidentity8_c() shift left 1 bits
+        // eb_av1_iidentity8_c() shift left 1 bits
         // round_shift_8x8(, -shift[1]) shift right 4 bits with complement
         round_shift_8x8_double(out, -shift[0], -shift[1] - 1);
         write_buffer_8x8(out, output, stride, 1, 0, bd);
         break;
     default:
-        av1_inv_txfm2d_add_8x8_sse4_1(coeff, output, stride, tx_type, bd);
+        eb_av1_inv_txfm2d_add_8x8_sse4_1(coeff, output, stride, tx_type, bd);
         break;
     }
 }
@@ -1710,10 +1710,10 @@ static INLINE void iadst16_col_avx2(__m256i *in, __m256i *out,
     }
 }
 
-void av1_inv_txfm2d_add_16x16_avx2(const int32_t *coeff, uint16_t *output,
+void eb_av1_inv_txfm2d_add_16x16_avx2(const int32_t *coeff, uint16_t *output,
     int32_t stride, TxType tx_type, int32_t bd) {
     __m256i in[32], out[32];
-    const int8_t *shift = inv_txfm_shift_ls[TX_16X16];
+    const int8_t *shift = eb_inv_txfm_shift_ls[TX_16X16];
     const int32_t txw_idx = get_txw_idx(TX_16X16);
     const int32_t txh_idx = get_txh_idx(TX_16X16);
 
@@ -1773,7 +1773,7 @@ void av1_inv_txfm2d_add_16x16_avx2(const int32_t *coeff, uint16_t *output,
         write_buffer_16x16(out, output, stride, 1, 0, bd);
         break;
     default:
-        av1_inv_txfm2d_add_16x16_sse4_1(coeff, output, stride, tx_type, bd);
+        eb_av1_inv_txfm2d_add_16x16_sse4_1(coeff, output, stride, tx_type, bd);
         break;
     }
 }
@@ -2348,10 +2348,10 @@ static void idct32_avx2(__m256i *in, __m256i *out, int32_t bit) {
     }
 }
 
-void av1_inv_txfm2d_add_32x32_avx2(const int32_t *coeff, uint16_t *output,
+void eb_av1_inv_txfm2d_add_32x32_avx2(const int32_t *coeff, uint16_t *output,
     int32_t stride, TxType tx_type, int32_t bd) {
     __m256i in[128], out[128];
-    const int8_t *shift = inv_txfm_shift_ls[TX_32X32];
+    const int8_t *shift = eb_inv_txfm_shift_ls[TX_32X32];
     const int32_t txw_idx = get_txw_idx(TX_32X32);
     const int32_t txh_idx = get_txh_idx(TX_32X32);
 
@@ -2369,9 +2369,9 @@ void av1_inv_txfm2d_add_32x32_avx2(const int32_t *coeff, uint16_t *output,
     case IDTX:
         load_buffer_32x32(coeff, in);
         // Operations can be joined together without losing precision
-        // av1_iidentity32_c() shift left 2 bits
+        // eb_av1_iidentity32_c() shift left 2 bits
         // round_shift_32x32(, -shift[0]) shift right 2 bits
-        // av1_iidentity32_c() shift left 2 bits
+        // eb_av1_iidentity32_c() shift left 2 bits
         // round_shift_32x32(, -shift[1]) shift right 4 bits with complement
         round_shift_32x32(in, -shift[0] - shift[1] - 4);
         write_buffer_32x32(in, output, stride, 0, 0, bd);
@@ -6170,7 +6170,7 @@ static void highbd_inv_txfm2d_add_no_identity_avx2(const int32_t *input,
     __m256i buf1[64 * 8];
     int32_t eobx, eoby;
     get_eobx_eoby_scan_default(&eobx, &eoby, tx_size, eob);
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     const int32_t txfm_size_col = tx_size_wide[tx_size];
@@ -6253,7 +6253,7 @@ static void highbd_inv_txfm2d_add_idtx_avx2(const int32_t *input,
     (void)eob;
     __m256i buf1[64 * 2];
 
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     const int32_t txfm_size_col = tx_size_wide[tx_size];
@@ -6328,7 +6328,7 @@ static void highbd_inv_txfm2d_add_v_identity_avx2(const int32_t *input,
     __m256i buf1[64];
     int32_t eobx, eoby;
     get_eobx_eoby_scan_v_identity(&eobx, &eoby, tx_size, eob);
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     const int32_t txfm_size_col = tx_size_wide[tx_size];
@@ -6401,7 +6401,7 @@ static void highbd_inv_txfm2d_add_h_identity_avx2(const int32_t *input,
     __m256i buf1[32];
     int32_t eobx, eoby;
     get_eobx_eoby_scan_h_identity(&eobx, &eoby, tx_size, eob);
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     const int32_t txfm_size_col = tx_size_wide[tx_size];
@@ -6468,7 +6468,7 @@ static void highbd_inv_txfm2d_add_h_identity_avx2(const int32_t *input,
             bd);
     }
 }
-void av1_highbd_inv_txfm2d_add_universe_avx2(const int32_t *input,
+void eb_av1_highbd_inv_txfm2d_add_universe_avx2(const int32_t *input,
     uint16_t *output, int32_t stride,
     TxType tx_type, TxSize tx_size,
     int32_t eob, const int32_t bd) {
@@ -6505,11 +6505,11 @@ void av1_highbd_inv_txfm2d_add_universe_avx2(const int32_t *input,
     default: break;
     }
 }
-void av1_highbd_inv_txfm_add_avx2(const int32_t *input, uint16_t *dest,
+void eb_av1_highbd_inv_txfm_add_avx2(const int32_t *input, uint16_t *dest,
     int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd) {
     //assert(av1_ext_tx_used[txfm_param->tx_set_type][txfm_param->tx_type]);
 
-    av1_highbd_inv_txfm2d_add_universe_avx2(
+    eb_av1_highbd_inv_txfm2d_add_universe_avx2(
         input, dest, stride, tx_type, tx_size,
         eob, bd);
 }

--- a/Source/Lib/Common/ASM_AVX2/highbd_jnt_convolve_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/highbd_jnt_convolve_avx2.c
@@ -22,7 +22,7 @@
 #include "convolve_avx2.h"
 #include "convolve.h"
 
-void av1_highbd_jnt_convolve_2d_copy_avx2(
+void eb_av1_highbd_jnt_convolve_2d_copy_avx2(
     const uint16_t *src, int32_t src_stride, uint16_t *dst0, int32_t dst_stride0, int32_t w,
     int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
@@ -228,7 +228,7 @@ void av1_highbd_jnt_convolve_2d_copy_avx2(
     }
 }
 
-void av1_highbd_jnt_convolve_2d_avx2(
+void eb_av1_highbd_jnt_convolve_2d_avx2(
     const uint16_t *src, int32_t src_stride, uint16_t *dst0, int32_t dst_stride0, int32_t w,
     int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
@@ -464,7 +464,7 @@ void av1_highbd_jnt_convolve_2d_avx2(
     }
 }
 
-void av1_highbd_jnt_convolve_x_avx2(
+void eb_av1_highbd_jnt_convolve_x_avx2(
     const uint16_t *src, int32_t src_stride, uint16_t *dst0, int32_t dst_stride0, int32_t w,
     int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
@@ -634,7 +634,7 @@ void av1_highbd_jnt_convolve_x_avx2(
     }
 }
 
-void av1_highbd_jnt_convolve_y_avx2(
+void eb_av1_highbd_jnt_convolve_y_avx2(
     const uint16_t *src, int32_t src_stride, uint16_t *dst0, int32_t dst_stride0, int32_t w,
     int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,

--- a/Source/Lib/Common/ASM_AVX2/highbd_quantize_intrin_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/highbd_quantize_intrin_avx2.c
@@ -119,7 +119,7 @@ static INLINE void quantize(const __m256i *qp, __m256i *c,
     }
 }
 
-void aom_highbd_quantize_b_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs,
+void eb_aom_highbd_quantize_b_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs,
     int32_t skip_block, const int16_t *zbin_ptr,
     const int16_t *round_ptr,
     const int16_t *quant_ptr,
@@ -266,7 +266,7 @@ static INLINE void quantize_64X64(const __m256i *qp, __m256i *c,
     }
 }
 
-void aom_highbd_quantize_b_64x64_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs,
+void eb_aom_highbd_quantize_b_64x64_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs,
     int32_t skip_block, const int16_t *zbin_ptr,
     const int16_t *round_ptr,
     const int16_t *quant_ptr,
@@ -412,7 +412,7 @@ static INLINE void quantize_32x32(const __m256i *qp, __m256i *c,
     }
 }
 
-void aom_highbd_quantize_b_32x32_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs,
+void eb_aom_highbd_quantize_b_32x32_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs,
     int skip_block, const int16_t *zbin_ptr,
     const int16_t *round_ptr,
     const int16_t *quant_ptr,

--- a/Source/Lib/Common/ASM_AVX2/jnt_convolve_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/jnt_convolve_avx2.c
@@ -30,7 +30,7 @@ static INLINE __m256i load_line2_avx2(const void *a, const void *b) {
         _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)b)), 0x20);
 }
 
-void av1_jnt_convolve_x_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst0,
+void eb_av1_jnt_convolve_x_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst0,
     int32_t dst_stride0, int32_t w, int32_t h,
     InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y,
@@ -125,7 +125,7 @@ void av1_jnt_convolve_x_avx2(const uint8_t *src, int32_t src_stride, uint8_t *ds
     }
 }
 
-void av1_jnt_convolve_y_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst0,
+void eb_av1_jnt_convolve_y_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst0,
     int32_t dst_stride0, int32_t w, int32_t h,
     InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y,
@@ -340,7 +340,7 @@ void av1_jnt_convolve_y_avx2(const uint8_t *src, int32_t src_stride, uint8_t *ds
     }
 }
 
-void av1_jnt_convolve_2d_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst0,
+void eb_av1_jnt_convolve_2d_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst0,
     int32_t dst_stride0, int32_t w, int32_t h,
     InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y,
@@ -523,7 +523,7 @@ void av1_jnt_convolve_2d_avx2(const uint8_t *src, int32_t src_stride, uint8_t *d
     }
 }
 
-void av1_jnt_convolve_2d_copy_avx2(const uint8_t *src, int32_t src_stride,
+void eb_av1_jnt_convolve_2d_copy_avx2(const uint8_t *src, int32_t src_stride,
     uint8_t *dst0, int32_t dst_stride0, int32_t w, int32_t h,
     InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y,

--- a/Source/Lib/Common/ASM_AVX2/pickrst_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/pickrst_avx2.c
@@ -3341,10 +3341,10 @@ static INLINE void compute_stats_win7_avx2(
     } while (++i < wiener_win);
 }
 
-void *aom_memalign(size_t align, size_t size);
-void aom_free(void *memblk);
+void *eb_aom_memalign(size_t align, size_t size);
+void eb_aom_free(void *memblk);
 
-void av1_compute_stats_avx2(int32_t wiener_win, const uint8_t *dgd,
+void eb_av1_compute_stats_avx2(int32_t wiener_win, const uint8_t *dgd,
                             const uint8_t *src, int32_t h_start, int32_t h_end,
                             int32_t v_start, int32_t v_end, int32_t dgd_stride,
                             int32_t src_stride, int64_t *M, int64_t *H) {
@@ -3362,7 +3362,7 @@ void av1_compute_stats_avx2(int32_t wiener_win, const uint8_t *dgd,
     // (9 / 4) * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX. Enlarge to
     // 3 * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX considering
     // paddings.
-    d = aom_memalign(32,
+    d = eb_aom_memalign(32,
             sizeof(*d) * 6 * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX);
     s = d + 3 * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX;
 
@@ -3400,10 +3400,10 @@ void av1_compute_stats_avx2(int32_t wiener_win, const uint8_t *dgd,
     // We can copy it down to the lower triangle outside the (i, j) loops.
     diagonal_copy_stats_avx2(wiener_win2, H);
 
-    aom_free(d);
+    eb_aom_free(d);
 }
 
-void av1_compute_stats_highbd_avx2(int32_t wiener_win, const uint8_t *dgd8,
+void eb_av1_compute_stats_highbd_avx2(int32_t wiener_win, const uint8_t *dgd8,
                                    const uint8_t *src8, int32_t h_start,
                                    int32_t h_end, int32_t v_start,
                                    int32_t v_end, int32_t dgd_stride,
@@ -3428,7 +3428,7 @@ void av1_compute_stats_highbd_avx2(int32_t wiener_win, const uint8_t *dgd8,
     // (9 / 4) * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX. Enlarge to
     // 3 * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX considering
     // paddings.
-    d = aom_memalign(32,
+    d = eb_aom_memalign(32,
             sizeof(*d) * 6 * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX);
     s = d + 3 * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX;
 
@@ -3504,7 +3504,7 @@ void av1_compute_stats_highbd_avx2(int32_t wiener_win, const uint8_t *dgd8,
         div16_diagonal_copy_stats_avx2(wiener_win2, H);
     }
 
-    aom_free(d);
+    eb_aom_free(d);
 }
 
 static INLINE __m256i pair_set_epi16(uint16_t a, uint16_t b) {
@@ -3512,7 +3512,7 @@ static INLINE __m256i pair_set_epi16(uint16_t a, uint16_t b) {
         (int32_t)(((uint16_t)(a)) | (((uint32_t)(b)) << 16)));
 }
 
-int64_t av1_lowbd_pixel_proj_error_avx2(
+int64_t eb_av1_lowbd_pixel_proj_error_avx2(
     const uint8_t *src8, int32_t width, int32_t height, int32_t src_stride,
     const uint8_t *dat8, int32_t dat_stride, int32_t *flt0, int32_t flt0_stride,
     int32_t *flt1, int32_t flt1_stride, int32_t xq[2], const SgrParamsType *params) {
@@ -3647,7 +3647,7 @@ int64_t av1_lowbd_pixel_proj_error_avx2(
     return err;
 }
 
-int64_t av1_highbd_pixel_proj_error_avx2(
+int64_t eb_av1_highbd_pixel_proj_error_avx2(
     const uint8_t *src8, int32_t width, int32_t height, int32_t src_stride,
     const uint8_t *dat8, int32_t dat_stride, int32_t *flt0, int32_t flt0_stride,
     int32_t *flt1, int32_t flt1_stride, int32_t xq[2], const SgrParamsType *params) {

--- a/Source/Lib/Common/ASM_AVX2/selfguided_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/selfguided_avx2.c
@@ -270,12 +270,12 @@ static INLINE __m256i compute_p_highbd(__m256i sum1, __m256i sum2,
 static AOM_FORCE_INLINE void calc_ab(int32_t *A, int32_t *B, const int32_t *C,
     const int32_t *D, int32_t width, int32_t height, int32_t buf_stride,
     int32_t bit_depth, int32_t sgr_params_idx, int32_t radius_idx) {
-    const SgrParamsType *const params = &sgr_params[sgr_params_idx];
+    const SgrParamsType *const params = &eb_sgr_params[sgr_params_idx];
     const int32_t r = params->r[radius_idx];
     const int32_t n = (2 * r + 1) * (2 * r + 1);
     const __m256i s = _mm256_set1_epi32(params->s[radius_idx]);
     // one_over_n[n-1] is 2^12/n, so easily fits in an int16
-    const __m256i one_over_n = _mm256_set1_epi32(one_by_x[n - 1]);
+    const __m256i one_over_n = _mm256_set1_epi32(eb_one_by_x[n - 1]);
     const __m256i rnd_z = round_for_shift(SGRPROJ_MTABLE_BITS);
     const __m256i rnd_res = round_for_shift(SGRPROJ_RECIP_BITS);
 
@@ -297,7 +297,7 @@ static AOM_FORCE_INLINE void calc_ab(int32_t *A, int32_t *B, const int32_t *C,
                     _mm256_srli_epi32(_mm256_add_epi32(_mm256_mullo_epi32(p, s), rnd_z),
                         SGRPROJ_MTABLE_BITS),
                     _mm256_set1_epi32(255));
-                const __m256i a_res = _mm256_i32gather_epi32(x_by_xplus1, z, 4);
+                const __m256i a_res = _mm256_i32gather_epi32(eb_x_by_xplus1, z, 4);
                 yy_storeu_256(A + j, a_res);
 
                 const __m256i a_complement =
@@ -331,7 +331,7 @@ static AOM_FORCE_INLINE void calc_ab(int32_t *A, int32_t *B, const int32_t *C,
                     _mm256_srli_epi32(_mm256_add_epi32(_mm256_mullo_epi32(p, s), rnd_z),
                         SGRPROJ_MTABLE_BITS),
                     _mm256_set1_epi32(255));
-                const __m256i a_res = _mm256_i32gather_epi32(x_by_xplus1, z, 4);
+                const __m256i a_res = _mm256_i32gather_epi32(eb_x_by_xplus1, z, 4);
                 yy_storeu_256(A + j, a_res);
 
                 const __m256i a_complement =
@@ -455,12 +455,12 @@ static AOM_FORCE_INLINE void calc_ab_fast(int32_t *A, int32_t *B,
     const int32_t *C, const int32_t *D, int32_t width, int32_t height,
     int32_t buf_stride, int32_t bit_depth, int32_t sgr_params_idx,
     int32_t radius_idx) {
-    const SgrParamsType *const params = &sgr_params[sgr_params_idx];
+    const SgrParamsType *const params = &eb_sgr_params[sgr_params_idx];
     const int32_t r = params->r[radius_idx];
     const int32_t n = (2 * r + 1) * (2 * r + 1);
     const __m256i s = _mm256_set1_epi32(params->s[radius_idx]);
     // one_over_n[n-1] is 2^12/n, so easily fits in an int16
-    const __m256i one_over_n = _mm256_set1_epi32(one_by_x[n - 1]);
+    const __m256i one_over_n = _mm256_set1_epi32(eb_one_by_x[n - 1]);
     const __m256i rnd_z = round_for_shift(SGRPROJ_MTABLE_BITS);
     const __m256i rnd_res = round_for_shift(SGRPROJ_RECIP_BITS);
 
@@ -481,7 +481,7 @@ static AOM_FORCE_INLINE void calc_ab_fast(int32_t *A, int32_t *B,
                     _mm256_srli_epi32(_mm256_add_epi32(_mm256_mullo_epi32(p, s), rnd_z),
                         SGRPROJ_MTABLE_BITS),
                     _mm256_set1_epi32(255));
-                const __m256i a_res = _mm256_i32gather_epi32(x_by_xplus1, z, 4);
+                const __m256i a_res = _mm256_i32gather_epi32(eb_x_by_xplus1, z, 4);
                 yy_storeu_256(A + j, a_res);
 
                 const __m256i a_complement =
@@ -516,7 +516,7 @@ static AOM_FORCE_INLINE void calc_ab_fast(int32_t *A, int32_t *B,
                     _mm256_srli_epi32(_mm256_add_epi32(_mm256_mullo_epi32(p, s), rnd_z),
                         SGRPROJ_MTABLE_BITS),
                     _mm256_set1_epi32(255));
-                const __m256i a_res = _mm256_i32gather_epi32(x_by_xplus1, z, 4);
+                const __m256i a_res = _mm256_i32gather_epi32(eb_x_by_xplus1, z, 4);
                 yy_storeu_256(A + j, a_res);
 
                 const __m256i a_complement =
@@ -710,7 +710,7 @@ static AOM_FORCE_INLINE void final_filter_fast(int32_t *dst, int32_t dst_stride,
     }
 }
 
-void av1_selfguided_restoration_avx2(const uint8_t *dgd8, int32_t width,
+void eb_av1_selfguided_restoration_avx2(const uint8_t *dgd8, int32_t width,
     int32_t height, int32_t dgd_stride, int32_t *flt0, int32_t *flt1,
     int32_t flt_stride, int32_t sgr_params_idx, int32_t bit_depth,
     int32_t highbd) {
@@ -766,7 +766,7 @@ void av1_selfguided_restoration_avx2(const uint8_t *dgd8, int32_t width,
         integral_images(dgd0, dgd_stride, width_ext, height_ext, Ctl, Dtl,
             buf_stride);
 
-    const SgrParamsType *const params = &sgr_params[sgr_params_idx];
+    const SgrParamsType *const params = &eb_sgr_params[sgr_params_idx];
     // Write to flt0 and flt1
     // If params->r == 0 we skip the corresponding filter. We only allow one of
     // the radii to be 0, as having both equal to 0 would be equivalent to
@@ -790,18 +790,18 @@ void av1_selfguided_restoration_avx2(const uint8_t *dgd8, int32_t width,
     }
 }
 
-void apply_selfguided_restoration_avx2(const uint8_t *dat8, int32_t width,
+void eb_apply_selfguided_restoration_avx2(const uint8_t *dat8, int32_t width,
     int32_t height, int32_t stride, int32_t eps, const int32_t *xqd,
     uint8_t *dst8, int32_t dst_stride, int32_t *tmpbuf, int32_t bit_depth,
     int32_t highbd) {
     int32_t *flt0 = tmpbuf;
     int32_t *flt1 = flt0 + RESTORATION_UNITPELS_MAX;
     assert(width * height <= RESTORATION_UNITPELS_MAX);
-    av1_selfguided_restoration_avx2(dat8, width, height, stride, flt0, flt1,
+    eb_av1_selfguided_restoration_avx2(dat8, width, height, stride, flt0, flt1,
         width, eps, bit_depth, highbd);
-    const SgrParamsType *const params = &sgr_params[eps];
+    const SgrParamsType *const params = &eb_sgr_params[eps];
     int32_t xq[2];
-    decode_xq(xqd, xq, params);
+    eb_decode_xq(xqd, xq, params);
 
     const __m256i xq0 = _mm256_set1_epi32(xq[0]);
     const __m256i xq1 = _mm256_set1_epi32(xq[1]);

--- a/Source/Lib/Common/ASM_AVX2/variance_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/variance_avx2.c
@@ -172,7 +172,7 @@ static INLINE void variance128_no_sum_avx2(const uint8_t *src, const int32_t src
 }
 
 #define AOM_VAR_NO_LOOP_NO_SUM_AVX2(bw, bh, bits, max_pixel)                         \
-  void aom_variance##bw##x##bh##_no_sum_avx2(                                \
+  void eb_aom_variance##bw##x##bh##_no_sum_avx2(                                \
       const uint8_t *src, int32_t src_stride, const uint8_t *ref, int32_t ref_stride, \
       uint32_t *sse) {                                                    \
     __m256i vsse = _mm256_setzero_si256();                                    \
@@ -182,10 +182,10 @@ static INLINE void variance128_no_sum_avx2(const uint8_t *src, const int32_t src
 
 AOM_VAR_NO_LOOP_NO_SUM_AVX2(16, 16, 8, 512);
 
-uint32_t aom_mse16x16_avx2(const uint8_t *src, int32_t src_stride,
+uint32_t eb_aom_mse16x16_avx2(const uint8_t *src, int32_t src_stride,
     const uint8_t *ref, int32_t ref_stride,
     uint32_t *sse) {
-    aom_variance16x16_no_sum_avx2(src, src_stride, ref, ref_stride, sse);
+    eb_aom_variance16x16_no_sum_avx2(src, src_stride, ref, ref_stride, sse);
     return *sse;
 }
 
@@ -424,7 +424,7 @@ static INLINE void variance128_avx2(const uint8_t *src, const int src_stride,
 }
 
 #define AOM_VAR_NO_LOOP_AVX2(bw, bh, bits, max_pixel)                         \
-  unsigned int aom_variance##bw##x##bh##_avx2(                                \
+  unsigned int eb_aom_variance##bw##x##bh##_avx2(                                \
       const uint8_t *src, int src_stride, const uint8_t *ref, int ref_stride, \
       unsigned int *sse) {                                                    \
     __m256i vsse = _mm256_setzero_si256();                                    \
@@ -449,7 +449,7 @@ AOM_VAR_NO_LOOP_AVX2(64, 16, 10, 1024);
 AOM_VAR_NO_LOOP_AVX2(64, 32, 11, 2048);
 
 #define AOM_VAR_LOOP_AVX2(bw, bh, bits, uh)                                   \
-  unsigned int aom_variance##bw##x##bh##_avx2(                                \
+  unsigned int eb_aom_variance##bw##x##bh##_avx2(                                \
       const uint8_t *src, int src_stride, const uint8_t *ref, int ref_stride, \
       unsigned int *sse) {                                                    \
     __m256i vsse = _mm256_setzero_si256();                                    \

--- a/Source/Lib/Common/ASM_AVX2/warp_plane_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/warp_plane_avx2.c
@@ -13,7 +13,7 @@
 #include "aom_dsp_rtcd.h"
 #include "EbWarpedMotion.h"
 
- /* This is a modified version of 'warped_filter' from warped_motion.c:
+ /* This is a modified version of 'eb_warped_filter' from warped_motion.c:
     * Each coefficient is stored in 8 bits instead of 16 bits
     * The coefficients are rearranged in the column order 0, 2, 4, 6, 1, 3, 5, 7
 
@@ -29,7 +29,7 @@
  */
  /* clang-format off */
 DECLARE_ALIGNED(8, const int8_t,
-av1_filter_8bit[WARPEDPIXEL_PREC_SHIFTS * 3 + 1][8]) = {
+eb_av1_filter_8bit[WARPEDPIXEL_PREC_SHIFTS * 3 + 1][8]) = {
 #if WARPEDPIXEL_PREC_BITS == 6
         // [-1, 0)
         { 0, 127,   0, 0,   0,   1, 0, 0}, { 0, 127,   0, 0,  -1,   2, 0, 0},
@@ -277,21 +277,21 @@ static INLINE void prepare_horizontal_filter_coeff_avx2(int alpha, int beta,
     int sx,
     __m256i *coeff) {
     __m128i tmp_0 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 0 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 0 * alpha) >> WARPEDDIFF_PREC_BITS]);
     __m128i tmp_1 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 1 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 1 * alpha) >> WARPEDDIFF_PREC_BITS]);
     __m128i tmp_2 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 2 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 2 * alpha) >> WARPEDDIFF_PREC_BITS]);
     __m128i tmp_3 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 3 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 3 * alpha) >> WARPEDDIFF_PREC_BITS]);
     __m128i tmp_4 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 4 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 4 * alpha) >> WARPEDDIFF_PREC_BITS]);
     __m128i tmp_5 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 5 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 5 * alpha) >> WARPEDDIFF_PREC_BITS]);
     __m128i tmp_6 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 6 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 6 * alpha) >> WARPEDDIFF_PREC_BITS]);
     __m128i tmp_7 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 7 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 7 * alpha) >> WARPEDDIFF_PREC_BITS]);
 
     tmp_0 = _mm_unpacklo_epi16(tmp_0, tmp_2);
     tmp_1 = _mm_unpacklo_epi16(tmp_1, tmp_3);
@@ -299,28 +299,28 @@ static INLINE void prepare_horizontal_filter_coeff_avx2(int alpha, int beta,
     tmp_5 = _mm_unpacklo_epi16(tmp_5, tmp_7);
 
     __m128i tmp_8 =
-        _mm_loadl_epi64((__m128i *)&av1_filter_8bit[((sx + beta) + 0 * alpha) >>
+        _mm_loadl_epi64((__m128i *)&eb_av1_filter_8bit[((sx + beta) + 0 * alpha) >>
             WARPEDDIFF_PREC_BITS]);
     __m128i tmp_9 =
-        _mm_loadl_epi64((__m128i *)&av1_filter_8bit[((sx + beta) + 1 * alpha) >>
+        _mm_loadl_epi64((__m128i *)&eb_av1_filter_8bit[((sx + beta) + 1 * alpha) >>
             WARPEDDIFF_PREC_BITS]);
     __m128i tmp_10 =
-        _mm_loadl_epi64((__m128i *)&av1_filter_8bit[((sx + beta) + 2 * alpha) >>
+        _mm_loadl_epi64((__m128i *)&eb_av1_filter_8bit[((sx + beta) + 2 * alpha) >>
             WARPEDDIFF_PREC_BITS]);
     __m128i tmp_11 =
-        _mm_loadl_epi64((__m128i *)&av1_filter_8bit[((sx + beta) + 3 * alpha) >>
+        _mm_loadl_epi64((__m128i *)&eb_av1_filter_8bit[((sx + beta) + 3 * alpha) >>
             WARPEDDIFF_PREC_BITS]);
     tmp_2 =
-        _mm_loadl_epi64((__m128i *)&av1_filter_8bit[((sx + beta) + 4 * alpha) >>
+        _mm_loadl_epi64((__m128i *)&eb_av1_filter_8bit[((sx + beta) + 4 * alpha) >>
             WARPEDDIFF_PREC_BITS]);
     tmp_3 =
-        _mm_loadl_epi64((__m128i *)&av1_filter_8bit[((sx + beta) + 5 * alpha) >>
+        _mm_loadl_epi64((__m128i *)&eb_av1_filter_8bit[((sx + beta) + 5 * alpha) >>
             WARPEDDIFF_PREC_BITS]);
     tmp_6 =
-        _mm_loadl_epi64((__m128i *)&av1_filter_8bit[((sx + beta) + 6 * alpha) >>
+        _mm_loadl_epi64((__m128i *)&eb_av1_filter_8bit[((sx + beta) + 6 * alpha) >>
             WARPEDDIFF_PREC_BITS]);
     tmp_7 =
-        _mm_loadl_epi64((__m128i *)&av1_filter_8bit[((sx + beta) + 7 * alpha) >>
+        _mm_loadl_epi64((__m128i *)&eb_av1_filter_8bit[((sx + beta) + 7 * alpha) >>
             WARPEDDIFF_PREC_BITS]);
 
     tmp_8 = _mm_unpacklo_epi16(tmp_8, tmp_10);
@@ -351,21 +351,21 @@ static INLINE void prepare_horizontal_filter_coeff_avx2(int alpha, int beta,
 static INLINE void prepare_horizontal_filter_coeff_beta0_avx2(int alpha, int sx,
     __m256i *coeff) {
     __m128i tmp_0 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 0 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 0 * alpha) >> WARPEDDIFF_PREC_BITS]);
     __m128i tmp_1 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 1 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 1 * alpha) >> WARPEDDIFF_PREC_BITS]);
     __m128i tmp_2 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 2 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 2 * alpha) >> WARPEDDIFF_PREC_BITS]);
     __m128i tmp_3 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 3 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 3 * alpha) >> WARPEDDIFF_PREC_BITS]);
     __m128i tmp_4 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 4 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 4 * alpha) >> WARPEDDIFF_PREC_BITS]);
     __m128i tmp_5 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 5 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 5 * alpha) >> WARPEDDIFF_PREC_BITS]);
     __m128i tmp_6 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 6 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 6 * alpha) >> WARPEDDIFF_PREC_BITS]);
     __m128i tmp_7 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 7 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 7 * alpha) >> WARPEDDIFF_PREC_BITS]);
 
     tmp_0 = _mm_unpacklo_epi16(tmp_0, tmp_2);
     tmp_1 = _mm_unpacklo_epi16(tmp_1, tmp_3);
@@ -391,9 +391,9 @@ static INLINE void prepare_horizontal_filter_coeff_beta0_avx2(int alpha, int sx,
 static INLINE void prepare_horizontal_filter_coeff_alpha0_avx2(int beta, int sx,
     __m256i *coeff) {
     const __m128i tmp_0 =
-        _mm_loadl_epi64((__m128i *)&av1_filter_8bit[sx >> WARPEDDIFF_PREC_BITS]);
+        _mm_loadl_epi64((__m128i *)&eb_av1_filter_8bit[sx >> WARPEDDIFF_PREC_BITS]);
     const __m128i tmp_1 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + beta) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + beta) >> WARPEDDIFF_PREC_BITS]);
 
     const __m256i res_0 =
         _mm256_inserti128_si256(_mm256_castsi128_si256(tmp_0), tmp_1, 0x1);
@@ -421,21 +421,21 @@ static INLINE void horizontal_filter_avx2(const __m256i src, __m256i *horz_out,
 static INLINE void prepare_horizontal_filter_coeff(int alpha, int sx,
     __m256i *coeff) {
     const __m128i tmp_0 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 0 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 0 * alpha) >> WARPEDDIFF_PREC_BITS]);
     const __m128i tmp_1 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 1 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 1 * alpha) >> WARPEDDIFF_PREC_BITS]);
     const __m128i tmp_2 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 2 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 2 * alpha) >> WARPEDDIFF_PREC_BITS]);
     const __m128i tmp_3 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 3 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 3 * alpha) >> WARPEDDIFF_PREC_BITS]);
     const __m128i tmp_4 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 4 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 4 * alpha) >> WARPEDDIFF_PREC_BITS]);
     const __m128i tmp_5 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 5 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 5 * alpha) >> WARPEDDIFF_PREC_BITS]);
     const __m128i tmp_6 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 6 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 6 * alpha) >> WARPEDDIFF_PREC_BITS]);
     const __m128i tmp_7 = _mm_loadl_epi64(
-        (__m128i *)&av1_filter_8bit[(sx + 7 * alpha) >> WARPEDDIFF_PREC_BITS]);
+        (__m128i *)&eb_av1_filter_8bit[(sx + 7 * alpha) >> WARPEDDIFF_PREC_BITS]);
 
     const __m128i tmp_8 = _mm_unpacklo_epi16(tmp_0, tmp_2);
     const __m128i tmp_9 = _mm_unpacklo_epi16(tmp_1, tmp_3);
@@ -604,29 +604,29 @@ static INLINE void prepare_vertical_filter_coeffs_avx2(int gamma, int delta,
     int sy,
     __m256i *coeffs) {
     __m128i filt_00 =
-        _mm_loadu_si128((__m128i *)(warped_filter +
+        _mm_loadu_si128((__m128i *)(eb_warped_filter +
         ((sy + 0 * gamma) >> WARPEDDIFF_PREC_BITS)));
     __m128i filt_01 =
-        _mm_loadu_si128((__m128i *)(warped_filter +
+        _mm_loadu_si128((__m128i *)(eb_warped_filter +
         ((sy + 2 * gamma) >> WARPEDDIFF_PREC_BITS)));
     __m128i filt_02 =
-        _mm_loadu_si128((__m128i *)(warped_filter +
+        _mm_loadu_si128((__m128i *)(eb_warped_filter +
         ((sy + 4 * gamma) >> WARPEDDIFF_PREC_BITS)));
     __m128i filt_03 =
-        _mm_loadu_si128((__m128i *)(warped_filter +
+        _mm_loadu_si128((__m128i *)(eb_warped_filter +
         ((sy + 6 * gamma) >> WARPEDDIFF_PREC_BITS)));
 
     __m128i filt_10 = _mm_loadu_si128(
-        (__m128i *)(warped_filter +
+        (__m128i *)(eb_warped_filter +
         (((sy + delta) + 0 * gamma) >> WARPEDDIFF_PREC_BITS)));
     __m128i filt_11 = _mm_loadu_si128(
-        (__m128i *)(warped_filter +
+        (__m128i *)(eb_warped_filter +
         (((sy + delta) + 2 * gamma) >> WARPEDDIFF_PREC_BITS)));
     __m128i filt_12 = _mm_loadu_si128(
-        (__m128i *)(warped_filter +
+        (__m128i *)(eb_warped_filter +
         (((sy + delta) + 4 * gamma) >> WARPEDDIFF_PREC_BITS)));
     __m128i filt_13 = _mm_loadu_si128(
-        (__m128i *)(warped_filter +
+        (__m128i *)(eb_warped_filter +
         (((sy + delta) + 6 * gamma) >> WARPEDDIFF_PREC_BITS)));
 
     __m256i filt_0 =
@@ -649,29 +649,29 @@ static INLINE void prepare_vertical_filter_coeffs_avx2(int gamma, int delta,
     coeffs[3] = _mm256_unpackhi_epi64(res_2, res_3);
 
     filt_00 =
-        _mm_loadu_si128((__m128i *)(warped_filter +
+        _mm_loadu_si128((__m128i *)(eb_warped_filter +
         ((sy + 1 * gamma) >> WARPEDDIFF_PREC_BITS)));
     filt_01 =
-        _mm_loadu_si128((__m128i *)(warped_filter +
+        _mm_loadu_si128((__m128i *)(eb_warped_filter +
         ((sy + 3 * gamma) >> WARPEDDIFF_PREC_BITS)));
     filt_02 =
-        _mm_loadu_si128((__m128i *)(warped_filter +
+        _mm_loadu_si128((__m128i *)(eb_warped_filter +
         ((sy + 5 * gamma) >> WARPEDDIFF_PREC_BITS)));
     filt_03 =
-        _mm_loadu_si128((__m128i *)(warped_filter +
+        _mm_loadu_si128((__m128i *)(eb_warped_filter +
         ((sy + 7 * gamma) >> WARPEDDIFF_PREC_BITS)));
 
     filt_10 = _mm_loadu_si128(
-        (__m128i *)(warped_filter +
+        (__m128i *)(eb_warped_filter +
         (((sy + delta) + 1 * gamma) >> WARPEDDIFF_PREC_BITS)));
     filt_11 = _mm_loadu_si128(
-        (__m128i *)(warped_filter +
+        (__m128i *)(eb_warped_filter +
         (((sy + delta) + 3 * gamma) >> WARPEDDIFF_PREC_BITS)));
     filt_12 = _mm_loadu_si128(
-        (__m128i *)(warped_filter +
+        (__m128i *)(eb_warped_filter +
         (((sy + delta) + 5 * gamma) >> WARPEDDIFF_PREC_BITS)));
     filt_13 = _mm_loadu_si128(
-        (__m128i *)(warped_filter +
+        (__m128i *)(eb_warped_filter +
         (((sy + delta) + 7 * gamma) >> WARPEDDIFF_PREC_BITS)));
 
     filt_0 =
@@ -697,16 +697,16 @@ static INLINE void prepare_vertical_filter_coeffs_avx2(int gamma, int delta,
 static INLINE void prepare_vertical_filter_coeffs_delta0_avx2(int gamma, int sy,
     __m256i *coeffs) {
     __m128i filt_00 =
-        _mm_loadu_si128((__m128i *)(warped_filter +
+        _mm_loadu_si128((__m128i *)(eb_warped_filter +
         ((sy + 0 * gamma) >> WARPEDDIFF_PREC_BITS)));
     __m128i filt_01 =
-        _mm_loadu_si128((__m128i *)(warped_filter +
+        _mm_loadu_si128((__m128i *)(eb_warped_filter +
         ((sy + 2 * gamma) >> WARPEDDIFF_PREC_BITS)));
     __m128i filt_02 =
-        _mm_loadu_si128((__m128i *)(warped_filter +
+        _mm_loadu_si128((__m128i *)(eb_warped_filter +
         ((sy + 4 * gamma) >> WARPEDDIFF_PREC_BITS)));
     __m128i filt_03 =
-        _mm_loadu_si128((__m128i *)(warped_filter +
+        _mm_loadu_si128((__m128i *)(eb_warped_filter +
         ((sy + 6 * gamma) >> WARPEDDIFF_PREC_BITS)));
 
     __m256i filt_0 = _mm256_broadcastsi128_si256(filt_00);
@@ -725,16 +725,16 @@ static INLINE void prepare_vertical_filter_coeffs_delta0_avx2(int gamma, int sy,
     coeffs[3] = _mm256_unpackhi_epi64(res_2, res_3);
 
     filt_00 =
-        _mm_loadu_si128((__m128i *)(warped_filter +
+        _mm_loadu_si128((__m128i *)(eb_warped_filter +
         ((sy + 1 * gamma) >> WARPEDDIFF_PREC_BITS)));
     filt_01 =
-        _mm_loadu_si128((__m128i *)(warped_filter +
+        _mm_loadu_si128((__m128i *)(eb_warped_filter +
         ((sy + 3 * gamma) >> WARPEDDIFF_PREC_BITS)));
     filt_02 =
-        _mm_loadu_si128((__m128i *)(warped_filter +
+        _mm_loadu_si128((__m128i *)(eb_warped_filter +
         ((sy + 5 * gamma) >> WARPEDDIFF_PREC_BITS)));
     filt_03 =
-        _mm_loadu_si128((__m128i *)(warped_filter +
+        _mm_loadu_si128((__m128i *)(eb_warped_filter +
         ((sy + 7 * gamma) >> WARPEDDIFF_PREC_BITS)));
 
     filt_0 = _mm256_broadcastsi128_si256(filt_00);
@@ -756,9 +756,9 @@ static INLINE void prepare_vertical_filter_coeffs_delta0_avx2(int gamma, int sy,
 static INLINE void prepare_vertical_filter_coeffs_gamma0_avx2(int delta, int sy,
     __m256i *coeffs) {
     const __m128i filt_0 = _mm_loadu_si128(
-        (__m128i *)(warped_filter + (sy >> WARPEDDIFF_PREC_BITS)));
+        (__m128i *)(eb_warped_filter + (sy >> WARPEDDIFF_PREC_BITS)));
     const __m128i filt_1 = _mm_loadu_si128(
-        (__m128i *)(warped_filter + ((sy + delta) >> WARPEDDIFF_PREC_BITS)));
+        (__m128i *)(eb_warped_filter + ((sy + delta) >> WARPEDDIFF_PREC_BITS)));
 
     __m256i res_0 =
         _mm256_inserti128_si256(_mm256_castsi128_si256(filt_0), filt_1, 0x1);
@@ -1183,7 +1183,7 @@ static INLINE void prepare_warp_horizontal_filter_avx2(
             shuffle_src);
 }
 
-int64_t av1_calc_frame_error_avx2(const uint8_t *const ref, int ref_stride,
+int64_t eb_av1_calc_frame_error_avx2(const uint8_t *const ref, int ref_stride,
     const uint8_t *const dst, int p_width,
     int p_height, int dst_stride) {
     int64_t sum_error = 0;
@@ -1291,7 +1291,7 @@ int64_t av1_calc_frame_error_avx2(const uint8_t *const ref, int ref_stride,
     return sum_error;
 }
 
-void av1_warp_affine_avx2(const int32_t *mat, const uint8_t *ref, int width,
+void eb_av1_warp_affine_avx2(const int32_t *mat, const uint8_t *ref, int width,
     int height, int stride, uint8_t *pred, int p_col,
     int p_row, int p_width, int p_height, int p_stride,
     int subsampling_x, int subsampling_y,

--- a/Source/Lib/Common/ASM_AVX2/wiener_convolve_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/wiener_convolve_avx2.c
@@ -102,7 +102,7 @@ static INLINE __m256i convolve(const __m256i *const s,
 // the centre pixel by 2^(FILTER_BITS - round_0) and add it to get the
 // horizontal filter output.
 
-void av1_wiener_convolve_add_src_avx2(const uint8_t *src, ptrdiff_t src_stride,
+void eb_av1_wiener_convolve_add_src_avx2(const uint8_t *src, ptrdiff_t src_stride,
     uint8_t *dst, ptrdiff_t dst_stride,
     const int16_t *filter_x, int32_t x_step_q4,
     const int16_t *filter_y, int32_t y_step_q4,
@@ -298,7 +298,7 @@ void av1_wiener_convolve_add_src_avx2(const uint8_t *src, ptrdiff_t src_stride,
 // on the left.
 // A row of, say, 16-bit pixels with values p0, p1, p2, ..., p14, p15 will be
 // loaded and stored as [ p15 ... p9 p8 ][ p7 ... p1 p0 ].
-void av1_highbd_wiener_convolve_add_src_avx2(
+void eb_av1_highbd_wiener_convolve_add_src_avx2(
     const uint8_t *src8, ptrdiff_t src_stride, uint8_t *dst8,
     ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4,
     const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h,

--- a/Source/Lib/Common/ASM_SSE2/EbIntraPrediction_AV1_Intrinsic_SSE2.c
+++ b/Source/Lib/Common/ASM_SSE2/EbIntraPrediction_AV1_Intrinsic_SSE2.c
@@ -483,43 +483,43 @@ static INLINE void h_predictor_64xh(uint8_t *dst, ptrdiff_t stride,
     } while (--i);
 }
 
-void aom_h_predictor_64x64_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_h_predictor_64x64_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     h_predictor_64xh(dst, stride, left, 64);
 }
 
-void aom_h_predictor_64x32_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_h_predictor_64x32_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     h_predictor_64xh(dst, stride, left, 32);
 }
 
-void aom_h_predictor_32x64_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_h_predictor_32x64_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     h_predictor_32xh(dst, stride, left, 64);
 }
 
-void aom_h_predictor_64x16_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_h_predictor_64x16_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     h_predictor_64xh(dst, stride, left, 16);
 }
 
-void aom_h_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_h_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     h_predictor_16xh(dst, stride, left, 4);
 }
 
-void aom_h_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_h_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     h_predictor_16xh(dst, stride, left, 2);
 }
 
-void aom_h_predictor_32x16_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_h_predictor_32x16_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     __m128i left_col, left_col_8p;
     (void)above;
@@ -538,7 +538,7 @@ void aom_h_predictor_32x16_sse2(uint8_t *dst, ptrdiff_t stride,
     h_prediction_32x8_2(&left_col_8p, dst, stride);
 }
 
-void aom_h_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_h_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     const __m128i left_col = _mm_loadl_epi64((const __m128i *)left);
@@ -546,7 +546,7 @@ void aom_h_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
     h_prediction_16x8_1(&left_col_8p, dst, stride);
 }
 
-void aom_h_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_h_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     const __m128i left_col = _mm_loadl_epi64((const __m128i *)left);
@@ -556,7 +556,7 @@ void aom_h_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
     h_prediction_16x8_2(&left_col_8p, dst, stride);
 }
 
-void aom_h_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_h_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     __m128i left_col, left_col_8p;
     (void)above;
@@ -569,7 +569,7 @@ void aom_h_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride,
     h_prediction_32x8_2(&left_col_8p, dst, stride);
 }
 
-void aom_h_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_h_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     const __m128i left_col = _mm_load_si128((__m128i const *)left);
@@ -630,7 +630,7 @@ void aom_h_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
     *(uint32_t *)dst = _mm_cvtsi128_si32(row3);
 }
 
-void aom_h_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_h_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     __m128i left_col = _mm_loadl_epi64((__m128i const *)left);
@@ -661,15 +661,15 @@ void aom_h_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
     *(uint32_t *)dst = _mm_cvtsi128_si32(row3);
 }
 
-void aom_h_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_h_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     h_predictor_8x16xc(dst, stride, above, left, 1);
 }
-void aom_h_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_h_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     h_predictor_8x16xc(dst, stride, above, left, 2);
 }
-void aom_h_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_h_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     __m128i left_col = _mm_loadl_epi64((__m128i const *)left);
@@ -687,63 +687,63 @@ void aom_h_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
     _mm_storel_epi64((__m128i *)dst, row3);
 }
 
-void aom_v_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_v_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i row = _mm_load_si128((__m128i const *)above);
     (void)left;
     dc_store_16xh(&row, 32, dst, stride);
 }
 
-void aom_v_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_v_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i row = _mm_load_si128((__m128i const *)above);
     (void)left;
     dc_store_16xh(&row, 4, dst, stride);
 }
 
-void aom_v_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_v_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i row = _mm_load_si128((__m128i const *)above);
     (void)left;
     dc_store_16xh(&row, 64, dst, stride);
 }
-void aom_v_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_v_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i row = _mm_load_si128((__m128i const *)above);
     (void)left;
     dc_store_16xh(&row, 8, dst, stride);
 }
 
-void aom_v_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_v_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)left;
     v_predictor_32xh(dst, stride, above, 8);
 }
-void aom_v_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_v_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const uint32_t pred = *(uint32_t *)above;
     (void)left;
     dc_store_4xh(pred, 16, dst, stride);
 }
-void aom_v_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_v_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const uint32_t pred = *(uint32_t *)above;
     (void)left;
     dc_store_4xh(pred, 8, dst, stride);
 }
-void aom_v_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_v_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i row = _mm_loadl_epi64((__m128i const *)above);
     (void)left;
     dc_store_8xh(&row, 16, dst, stride);
 }
-void aom_v_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_v_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i row = _mm_loadl_epi64((__m128i const *)above);
     (void)left;
     dc_store_8xh(&row, 32, dst, stride);
 }
-void aom_v_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_v_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i row = _mm_loadl_epi64((__m128i const *)above);
     (void)left;
@@ -752,7 +752,7 @@ void aom_v_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
 // -----------------------------------------------------------------------------
 // DC_128
 
-void aom_dc_128_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_128_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     (void)left;
@@ -760,7 +760,7 @@ void aom_dc_128_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_4xh(pred, 8, dst, stride);
 }
 
-void aom_dc_128_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_128_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     (void)left;
@@ -768,7 +768,7 @@ void aom_dc_128_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_4xh(pred, 16, dst, stride);
 }
 
-void aom_dc_128_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_128_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     (void)left;
@@ -776,7 +776,7 @@ void aom_dc_128_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_8xh(&row, 4, dst, stride);
 }
 
-void aom_dc_128_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_128_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     (void)left;
@@ -784,7 +784,7 @@ void aom_dc_128_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_8xh(&row, 16, dst, stride);
 }
 
-void aom_dc_128_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_128_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     (void)left;
@@ -792,7 +792,7 @@ void aom_dc_128_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_8xh(&row, 32, dst, stride);
 }
 
-void aom_dc_128_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_128_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     (void)left;
@@ -800,7 +800,7 @@ void aom_dc_128_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_16xh(&row, 4, dst, stride);
 }
 
-void aom_dc_128_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_128_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     (void)left;
@@ -808,7 +808,7 @@ void aom_dc_128_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_16xh(&row, 8, dst, stride);
 }
 
-void aom_dc_128_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_128_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)above;
@@ -817,7 +817,7 @@ void aom_dc_128_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_16xh(&row, 32, dst, stride);
 }
 
-void aom_dc_128_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_128_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)above;
@@ -826,7 +826,7 @@ void aom_dc_128_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_16xh(&row, 64, dst, stride);
 }
 
-void aom_dc_128_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_128_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     (void)left;
@@ -837,7 +837,7 @@ void aom_dc_128_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride,
 // -----------------------------------------------------------------------------
 // DC_TOP
 
-void aom_dc_top_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_top_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)left;
     __m128i sum_above = dc_sum_4(above);
@@ -851,7 +851,7 @@ void aom_dc_top_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_4xh(pred, 8, dst, stride);
 }
 
-void aom_dc_top_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_top_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)left;
     __m128i sum_above = dc_sum_4(above);
@@ -865,7 +865,7 @@ void aom_dc_top_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_4xh(pred, 16, dst, stride);
 }
 
-void aom_dc_top_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_top_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)left;
     __m128i sum_above = dc_sum_8(above);
@@ -877,7 +877,7 @@ void aom_dc_top_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_8xh(&row, 4, dst, stride);
 }
 
-void aom_dc_top_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_top_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)left;
     __m128i sum_above = dc_sum_8(above);
@@ -889,7 +889,7 @@ void aom_dc_top_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_8xh(&row, 16, dst, stride);
 }
 
-void aom_dc_top_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_top_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)left;
     __m128i sum_above = dc_sum_8(above);
@@ -901,7 +901,7 @@ void aom_dc_top_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_8xh(&row, 32, dst, stride);
 }
 
-void aom_dc_top_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_top_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)left;
     __m128i sum_above = dc_sum_16(above);
@@ -914,7 +914,7 @@ void aom_dc_top_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_16xh(&row, 4, dst, stride);
 }
 
-void aom_dc_top_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_top_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)left;
     __m128i sum_above = dc_sum_16(above);
@@ -927,7 +927,7 @@ void aom_dc_top_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_16xh(&row, 8, dst, stride);
 }
 
-void aom_dc_top_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_top_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)left;
@@ -941,7 +941,7 @@ void aom_dc_top_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_16xh(&row, 32, dst, stride);
 }
 
-void aom_dc_top_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_top_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)left;
@@ -955,7 +955,7 @@ void aom_dc_top_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_16xh(&row, 64, dst, stride);
 }
 
-void aom_dc_top_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_top_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)left;
     __m128i sum_above = dc_sum_32(above);
@@ -971,7 +971,7 @@ void aom_dc_top_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride,
 // -----------------------------------------------------------------------------
 // DC_LEFT
 
-void aom_dc_left_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_left_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     __m128i sum_left = dc_sum_8(left);
@@ -985,7 +985,7 @@ void aom_dc_left_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_4xh(pred, 8, dst, stride);
 }
 
-void aom_dc_left_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_left_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)above;
@@ -1000,7 +1000,7 @@ void aom_dc_left_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_4xh(pred, 16, dst, stride);
 }
 
-void aom_dc_left_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_left_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     (void)above;
     __m128i sum_left = dc_sum_4(left);
@@ -1012,7 +1012,7 @@ void aom_dc_left_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_8xh(&row, 4, dst, stride);
 }
 
-void aom_dc_left_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_left_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)above;
@@ -1025,7 +1025,7 @@ void aom_dc_left_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_8xh(&row, 16, dst, stride);
 }
 
-void aom_dc_left_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_left_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)above;
@@ -1038,7 +1038,7 @@ void aom_dc_left_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_8xh(&row, 32, dst, stride);
 }
 
-void aom_dc_left_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_left_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)above;
@@ -1052,7 +1052,7 @@ void aom_dc_left_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_16xh(&row, 4, dst, stride);
 }
 
-void aom_dc_left_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_left_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)above;
@@ -1066,7 +1066,7 @@ void aom_dc_left_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_16xh(&row, 8, dst, stride);
 }
 
-void aom_dc_left_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_left_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)above;
@@ -1080,7 +1080,7 @@ void aom_dc_left_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_16xh(&row, 32, dst, stride);
 }
 
-void aom_dc_left_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_left_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)above;
@@ -1094,7 +1094,7 @@ void aom_dc_left_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_16xh(&row, 64, dst, stride);
 }
 
-void aom_dc_left_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_left_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     (void)above;
@@ -1111,7 +1111,7 @@ void aom_dc_left_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride,
 // -----------------------------------------------------------------------------
 // DC_PRED
 
-void aom_dc_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i sum_left = dc_sum_8(left);
     __m128i sum_above = dc_sum_4(above);
@@ -1126,7 +1126,7 @@ void aom_dc_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_4xh(pred, 8, dst, stride);
 }
 
-void aom_dc_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i sum_left = dc_sum_16(left);
     __m128i sum_above = dc_sum_4(above);
@@ -1141,7 +1141,7 @@ void aom_dc_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_4xh(pred, 16, dst, stride);
 }
 
-void aom_dc_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i sum_left = dc_sum_4(left);
     __m128i sum_above = dc_sum_8(above);
@@ -1155,7 +1155,7 @@ void aom_dc_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_8xh(&row, 4, dst, stride);
 }
 
-void aom_dc_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i sum_left = dc_sum_16(left);
     __m128i sum_above = dc_sum_8(above);
@@ -1168,7 +1168,7 @@ void aom_dc_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_8xh(&row, 16, dst, stride);
 }
 
-void aom_dc_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i sum_left = dc_sum_32(left);
     __m128i sum_above = dc_sum_8(above);
@@ -1181,7 +1181,7 @@ void aom_dc_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_8xh(&row, 32, dst, stride);
 }
 
-void aom_dc_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i sum_left = dc_sum_4(left);
     __m128i sum_above = dc_sum_16(above);
@@ -1194,7 +1194,7 @@ void aom_dc_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_16xh(&row, 4, dst, stride);
 }
 
-void aom_dc_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i sum_left = dc_sum_8(left);
     __m128i sum_above = dc_sum_16(above);
@@ -1207,7 +1207,7 @@ void aom_dc_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_16xh(&row, 8, dst, stride);
 }
 
-void aom_dc_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i sum_left = dc_sum_32(left);
     __m128i sum_above = dc_sum_16(above);
@@ -1220,7 +1220,7 @@ void aom_dc_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_16xh(&row, 32, dst, stride);
 }
 
-void aom_dc_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     const __m128i sum_left = dc_sum_64(left);
     __m128i sum_above = dc_sum_16(above);
@@ -1233,7 +1233,7 @@ void aom_dc_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride,
     dc_store_16xh(&row, 64, dst, stride);
 }
 
-void aom_dc_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_dc_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     __m128i sum_above = dc_sum_32(above);
     const __m128i sum_left = dc_sum_8(left);

--- a/Source/Lib/Common/ASM_SSE2/encodetxb_sse2.c
+++ b/Source/Lib/Common/ASM_SSE2/encodetxb_sse2.c
@@ -466,7 +466,7 @@ static INLINE int32_t get_txb_bwl(TxSize tx_size) {
     return tx_size_wide_log2[tx_size];
 }
 
-void av1_get_nz_map_contexts_sse2(
+void eb_av1_get_nz_map_contexts_sse2(
     const uint8_t *const levels,
     const int16_t *const scan,
     const uint16_t eob,

--- a/Source/Lib/Common/ASM_SSE2/fft_sse2.c
+++ b/Source/Lib/Common/ASM_SSE2/fft_sse2.c
@@ -27,14 +27,14 @@ static INLINE void transpose4x4(const float *A, float *B, const int32_t lda,
     _mm_store_ps(&B[3 * ldb], row4);
 }
 
-void aom_transpose_float_sse2(const float *A, float *B, int32_t n) {
+void eb_aom_transpose_float_sse2(const float *A, float *B, int32_t n) {
     for (int32_t y = 0; y < n; y += 4) {
         for (int32_t x = 0; x < n; x += 4)
             transpose4x4(A + y * n + x, B + x * n + y, n, n);
     }
 }
 
-void aom_fft_unpack_2d_output_sse2(const float *packed, float *output, int32_t n) {
+void eb_aom_fft_unpack_2d_output_sse2(const float *packed, float *output, int32_t n) {
     const int32_t n2 = n / 2;
     output[0] = packed[0];
     output[1] = 0;
@@ -106,16 +106,16 @@ void aom_fft_unpack_2d_output_sse2(const float *packed, float *output, int32_t n
 GEN_FFT_4(static INLINE void, sse2, float, __m128, _mm_load_ps, _mm_store_ps,
     _mm_set1_ps, _mm_add_ps, _mm_sub_ps);
 
-void aom_fft4x4_float_sse2(const float *input, float *temp, float *output) {
-    aom_fft_2d_gen(input, temp, output, 4, aom_fft1d_4_sse2,
-        aom_transpose_float_sse2, aom_fft_unpack_2d_output_sse2, 4);
+void eb_aom_fft4x4_float_sse2(const float *input, float *temp, float *output) {
+    eb_aom_fft_2d_gen(input, temp, output, 4, eb_aom_fft1d_4_sse2,
+        eb_aom_transpose_float_sse2, eb_aom_fft_unpack_2d_output_sse2, 4);
 }
 
 // Generate definitions for 1d inverse transforms using float and mm128
 GEN_IFFT_4(static INLINE void, sse2, float, __m128, _mm_load_ps, _mm_store_ps,
     _mm_set1_ps, _mm_add_ps, _mm_sub_ps);
 
-void aom_ifft4x4_float_sse2(const float *input, float *temp, float *output) {
-    aom_ifft_2d_gen(input, temp, output, 4, aom_fft1d_4_float, aom_fft1d_4_sse2,
-        aom_ifft1d_4_sse2, aom_transpose_float_sse2, 4);
+void eb_aom_ifft4x4_float_sse2(const float *input, float *temp, float *output) {
+    eb_aom_ifft_2d_gen(input, temp, output, 4, eb_aom_fft1d_4_float, eb_aom_fft1d_4_sse2,
+        eb_aom_ifft1d_4_sse2, eb_aom_transpose_float_sse2, 4);
 }

--- a/Source/Lib/Common/ASM_SSE2/highbd_intrapred_sse2.c
+++ b/Source/Lib/Common/ASM_SSE2/highbd_intrapred_sse2.c
@@ -17,7 +17,7 @@
  // -----------------------------------------------------------------------------
  // H_PRED
 
-void aom_highbd_h_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     const __m128i left_u16 = _mm_loadl_epi64((const __m128i *)left);
@@ -36,31 +36,31 @@ void aom_highbd_h_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t stride,
     _mm_storel_epi64((__m128i *)dst, row3);
 }
 
-void aom_highbd_h_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
-    aom_highbd_h_predictor_4x4_sse2(dst, stride, above, left, bd);
+    eb_aom_highbd_h_predictor_4x4_sse2(dst, stride, above, left, bd);
     dst += stride << 2;
     left += 4;
-    aom_highbd_h_predictor_4x4_sse2(dst, stride, above, left, bd);
+    eb_aom_highbd_h_predictor_4x4_sse2(dst, stride, above, left, bd);
 }
 
-void aom_highbd_h_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
-    aom_highbd_h_predictor_4x4_sse2(dst, stride, above, left, bd);
+    eb_aom_highbd_h_predictor_4x4_sse2(dst, stride, above, left, bd);
     dst += stride << 2;
     left += 4;
-    aom_highbd_h_predictor_4x4_sse2(dst, stride, above, left, bd);
+    eb_aom_highbd_h_predictor_4x4_sse2(dst, stride, above, left, bd);
     dst += stride << 2;
     left += 4;
-    aom_highbd_h_predictor_4x4_sse2(dst, stride, above, left, bd);
+    eb_aom_highbd_h_predictor_4x4_sse2(dst, stride, above, left, bd);
     dst += stride << 2;
     left += 4;
-    aom_highbd_h_predictor_4x4_sse2(dst, stride, above, left, bd);
+    eb_aom_highbd_h_predictor_4x4_sse2(dst, stride, above, left, bd);
 }
 
-void aom_highbd_h_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     const __m128i left_u16 = _mm_load_si128((const __m128i *)left);
@@ -79,7 +79,7 @@ void aom_highbd_h_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
     _mm_store_si128((__m128i *)dst, _mm_unpacklo_epi64(row3, row3));
 }
 
-void aom_highbd_h_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     const __m128i left_u16 = _mm_load_si128((const __m128i *)left);
@@ -110,28 +110,28 @@ void aom_highbd_h_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t stride,
     _mm_store_si128((__m128i *)dst, _mm_unpackhi_epi64(row7, row7));
 }
 
-void aom_highbd_h_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
-    aom_highbd_h_predictor_8x8_sse2(dst, stride, above, left, bd);
+    eb_aom_highbd_h_predictor_8x8_sse2(dst, stride, above, left, bd);
     dst += stride << 3;
     left += 8;
-    aom_highbd_h_predictor_8x8_sse2(dst, stride, above, left, bd);
+    eb_aom_highbd_h_predictor_8x8_sse2(dst, stride, above, left, bd);
 }
 
-void aom_highbd_h_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
-    aom_highbd_h_predictor_8x8_sse2(dst, stride, above, left, bd);
+    eb_aom_highbd_h_predictor_8x8_sse2(dst, stride, above, left, bd);
     dst += stride << 3;
     left += 8;
-    aom_highbd_h_predictor_8x8_sse2(dst, stride, above, left, bd);
+    eb_aom_highbd_h_predictor_8x8_sse2(dst, stride, above, left, bd);
     dst += stride << 3;
     left += 8;
-    aom_highbd_h_predictor_8x8_sse2(dst, stride, above, left, bd);
+    eb_aom_highbd_h_predictor_8x8_sse2(dst, stride, above, left, bd);
     dst += stride << 3;
     left += 8;
-    aom_highbd_h_predictor_8x8_sse2(dst, stride, above, left, bd);
+    eb_aom_highbd_h_predictor_8x8_sse2(dst, stride, above, left, bd);
 }
 
 static INLINE void h_store_16_unpacklo(uint16_t **dst, const ptrdiff_t stride,
@@ -171,7 +171,7 @@ static INLINE void h_predictor_16x8(uint16_t *dst, ptrdiff_t stride,
     h_store_16_unpackhi(&dst, stride, &row7);
 }
 
-void aom_highbd_h_predictor_16x8_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_16x8_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)above;
@@ -179,7 +179,7 @@ void aom_highbd_h_predictor_16x8_sse2(uint16_t *dst, ptrdiff_t stride,
     h_predictor_16x8(dst, stride, left);
 }
 
-void aom_highbd_h_predictor_16x16_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_16x16_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     int32_t i;
@@ -192,7 +192,7 @@ void aom_highbd_h_predictor_16x16_sse2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_h_predictor_16x32_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_16x32_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     int32_t i;
@@ -246,7 +246,7 @@ static INLINE void h_predictor_32x8(uint16_t *dst, ptrdiff_t stride,
     h_store_32_unpackhi(&dst, stride, &row7);
 }
 
-void aom_highbd_h_predictor_32x16_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_32x16_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     int32_t i;
@@ -259,7 +259,7 @@ void aom_highbd_h_predictor_32x16_sse2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_h_predictor_32x32_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_h_predictor_32x32_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     int32_t i;
@@ -285,7 +285,7 @@ static INLINE void dc_store_4xh(uint16_t *dst, ptrdiff_t stride, int32_t height,
         _mm_storel_epi64((__m128i *)dst, dc_dup);
 }
 
-void aom_highbd_dc_left_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     const __m128i two = _mm_cvtsi32_si128(2);
@@ -296,7 +296,7 @@ void aom_highbd_dc_left_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t stride,
     dc_store_4xh(dst, stride, 4, &dc);
 }
 
-void aom_highbd_dc_top_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     const __m128i two = _mm_cvtsi32_si128(2);
@@ -307,7 +307,7 @@ void aom_highbd_dc_top_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t stride,
     dc_store_4xh(dst, stride, 4, &dc);
 }
 
-void aom_highbd_dc_128_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     const __m128i dc = _mm_cvtsi32_si128(1 << (bd - 1));
@@ -319,7 +319,7 @@ void aom_highbd_dc_128_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t stride,
 // -----------------------------------------------------------------------------
 // 4x8
 
-void aom_highbd_dc_left_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     const __m128i sum = dc_sum_8(left);
@@ -330,7 +330,7 @@ void aom_highbd_dc_left_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride,
     dc_store_4xh(dst, stride, 8, &dc);
 }
 
-void aom_highbd_dc_top_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     const __m128i two = _mm_cvtsi32_si128(2);
@@ -341,7 +341,7 @@ void aom_highbd_dc_top_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride,
     dc_store_4xh(dst, stride, 8, &dc);
 }
 
-void aom_highbd_dc_128_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     const __m128i dc = _mm_cvtsi32_si128(1 << (bd - 1));
@@ -367,7 +367,7 @@ static INLINE __m128i dc_sum_16(const uint16_t *const src) {
     return sum;
 }
 
-void aom_highbd_dc_left_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     const __m128i sum = dc_sum_16(left);
@@ -378,7 +378,7 @@ void aom_highbd_dc_left_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride,
     dc_store_4xh(dst, stride, 16, &dc);
 }
 
-void aom_highbd_dc_top_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     const __m128i two = _mm_cvtsi32_si128(2);
@@ -389,7 +389,7 @@ void aom_highbd_dc_top_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride,
     dc_store_4xh(dst, stride, 16, &dc);
 }
 
-void aom_highbd_dc_128_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     const __m128i dc = _mm_cvtsi32_si128(1 << (bd - 1));
@@ -421,7 +421,7 @@ static INLINE void dc_top_predictor_8xh(uint16_t *dst, ptrdiff_t stride,
     dc_store_8xh(dst, stride, height, &dc);
 }
 
-void aom_highbd_dc_top_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)left;
@@ -429,7 +429,7 @@ void aom_highbd_dc_top_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
     dc_top_predictor_8xh(dst, stride, 4, above);
 }
 
-void aom_highbd_dc_top_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)left;
@@ -437,7 +437,7 @@ void aom_highbd_dc_top_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t stride,
     dc_top_predictor_8xh(dst, stride, 8, above);
 }
 
-void aom_highbd_dc_top_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_top_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)left;
@@ -457,7 +457,7 @@ static INLINE __m128i dc_sum_32(const uint16_t *ref) {
         _mm_unpacklo_epi16(sum_b, zero));
 }
 
-void aom_highbd_dc_left_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     const __m128i two = _mm_cvtsi32_si128(2);
@@ -468,7 +468,7 @@ void aom_highbd_dc_left_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
     dc_store_8xh(dst, stride, 4, &dc);
 }
 
-void aom_highbd_dc_left_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     const __m128i four = _mm_cvtsi32_si128(4);
@@ -479,7 +479,7 @@ void aom_highbd_dc_left_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t stride,
     dc_store_8xh(dst, stride, 8, &dc);
 }
 
-void aom_highbd_dc_left_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     const __m128i eight = _mm_cvtsi32_si128(8);
@@ -490,7 +490,7 @@ void aom_highbd_dc_left_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride,
     dc_store_8xh(dst, stride, 16, &dc);
 }
 
-void aom_highbd_dc_left_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_left_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     const __m128i sixteen = _mm_cvtsi32_si128(16);
@@ -510,7 +510,7 @@ static INLINE void dc_128_predictor_8xh(uint16_t *dst, ptrdiff_t stride,
     dc_store_8xh(dst, stride, height, &dc);
 }
 
-void aom_highbd_dc_128_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)above;
@@ -518,7 +518,7 @@ void aom_highbd_dc_128_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
     dc_128_predictor_8xh(dst, stride, 4, bd);
 }
 
-void aom_highbd_dc_128_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)above;
@@ -526,7 +526,7 @@ void aom_highbd_dc_128_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t stride,
     dc_128_predictor_8xh(dst, stride, 8, bd);
 }
 
-void aom_highbd_dc_128_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)above;
@@ -534,7 +534,7 @@ void aom_highbd_dc_128_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride,
     dc_128_predictor_8xh(dst, stride, 16, bd);
 }
 
-void aom_highbd_dc_128_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_128_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)above;
@@ -545,7 +545,7 @@ void aom_highbd_dc_128_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t stride,
 // -----------------------------------------------------------------------------
 // V_PRED
 
-void aom_highbd_v_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)left;
@@ -561,7 +561,7 @@ void aom_highbd_v_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_v_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)left;
@@ -577,7 +577,7 @@ void aom_highbd_v_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_v_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)left;
@@ -589,7 +589,7 @@ void aom_highbd_v_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
     _mm_store_si128((__m128i *)(dst + 3 * stride), above_u16);
 }
 
-void aom_highbd_v_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)left;
@@ -605,7 +605,7 @@ void aom_highbd_v_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_v_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_v_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)left;
@@ -638,7 +638,7 @@ static INLINE __m128i dc_sum_8_32(const uint16_t *const src_8,
     return dc_sum_8x16bit_large(sum);
 }
 
-void aom_highbd_dc_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)bd;
@@ -658,7 +658,7 @@ void aom_highbd_dc_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_dc_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)bd;
@@ -681,7 +681,7 @@ void aom_highbd_dc_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_dc_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)bd;
@@ -702,7 +702,7 @@ void aom_highbd_dc_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride,
     _mm_store_si128((__m128i *)dst, row);
 }
 
-void aom_highbd_dc_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)bd;
@@ -729,7 +729,7 @@ void aom_highbd_dc_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_highbd_dc_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)bd;
@@ -750,7 +750,7 @@ void aom_highbd_dc_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t stride,
         dst += stride;
     }
 }
-void aom_highbd_dc_predictor_32x16_sse2(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_dc_predictor_32x16_sse2(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above,
     const uint16_t *left, int32_t bd) {
     (void)bd;

--- a/Source/Lib/Common/ASM_SSE2/highbd_variance_sse2.c
+++ b/Source/Lib/Common/ASM_SSE2/highbd_variance_sse2.c
@@ -96,7 +96,7 @@ static void highbd_12_variance_sse2(const uint16_t *src, int32_t src_stride,
 }
 
 #define HIGH_GET_VAR(S)                                                       \
-  void aom_highbd_get##S##x##S##var_sse2(const uint8_t *src8, int32_t src_stride, \
+  void eb_aom_highbd_get##S##x##S##var_sse2(const uint8_t *src8, int32_t src_stride, \
                                          const uint8_t *ref8, int32_t ref_stride, \
                                          uint32_t *sse, int32_t *sum) {           \
     uint16_t *src = CONVERT_TO_SHORTPTR(src8);                                \
@@ -105,7 +105,7 @@ static void highbd_12_variance_sse2(const uint16_t *src, int32_t src_stride,
                                        sum);                                  \
   }                                                                           \
                                                                               \
-  void aom_highbd_10_get##S##x##S##var_sse2(                                  \
+  void eb_aom_highbd_10_get##S##x##S##var_sse2(                                  \
       const uint8_t *src8, int32_t src_stride, const uint8_t *ref8,               \
       int32_t ref_stride, uint32_t *sse, int32_t *sum) {                              \
     uint16_t *src = CONVERT_TO_SHORTPTR(src8);                                \
@@ -116,7 +116,7 @@ static void highbd_12_variance_sse2(const uint16_t *src, int32_t src_stride,
     *sse = ROUND_POWER_OF_TWO(*sse, 4);                                       \
   }                                                                           \
                                                                               \
-  void aom_highbd_12_get##S##x##S##var_sse2(                                  \
+  void eb_aom_highbd_12_get##S##x##S##var_sse2(                                  \
       const uint8_t *src8, int32_t src_stride, const uint8_t *ref8,               \
       int32_t ref_stride, uint32_t *sse, int32_t *sum) {                              \
     uint16_t *src = CONVERT_TO_SHORTPTR(src8);                                \
@@ -133,7 +133,7 @@ HIGH_GET_VAR(8);
 #undef HIGH_GET_VAR
 
 #define VAR_FN(w, h, block_size, shift)                                    \
-  uint32_t aom_highbd_8_variance##w##x##h##_sse2(                          \
+  uint32_t eb_aom_highbd_8_variance##w##x##h##_sse2(                          \
       const uint8_t *src8, int32_t src_stride, const uint8_t *ref8,            \
       int32_t ref_stride, uint32_t *sse) {                                     \
     int32_t sum;                                                               \
@@ -145,7 +145,7 @@ HIGH_GET_VAR(8);
     return *sse - (uint32_t)(((int64_t)sum * sum) >> shift);               \
   }                                                                        \
                                                                            \
-  uint32_t aom_highbd_10_variance##w##x##h##_sse2(                         \
+  uint32_t eb_aom_highbd_10_variance##w##x##h##_sse2(                         \
       const uint8_t *src8, int32_t src_stride, const uint8_t *ref8,            \
       int32_t ref_stride, uint32_t *sse) {                                     \
     int32_t sum;                                                               \
@@ -159,7 +159,7 @@ HIGH_GET_VAR(8);
     return (var >= 0) ? (uint32_t)var : 0;                                 \
   }                                                                        \
                                                                            \
-  uint32_t aom_highbd_12_variance##w##x##h##_sse2(                         \
+  uint32_t eb_aom_highbd_12_variance##w##x##h##_sse2(                         \
       const uint8_t *src8, int32_t src_stride, const uint8_t *ref8,            \
       int32_t ref_stride, uint32_t *sse) {                                     \
     int32_t sum;                                                               \
@@ -191,7 +191,7 @@ VAR_FN(64, 16, 16, 10);
 
 #undef VAR_FN
 
-void aom_highbd_8_mse16x16_sse2(const uint8_t *src8, int32_t src_stride,
+void eb_aom_highbd_8_mse16x16_sse2(const uint8_t *src8, int32_t src_stride,
     const uint8_t *ref8, int32_t ref_stride,
     uint32_t *sse) {
     int32_t sum;

--- a/Source/Lib/Common/ASM_SSE2/variance_sse2.c
+++ b/Source/Lib/Common/ASM_SSE2/variance_sse2.c
@@ -23,7 +23,7 @@ extern "C" {
 }
 #endif
 
-uint32_t aom_get_mb_ss_sse2(const int16_t *src) {
+uint32_t eb_aom_get_mb_ss_sse2(const int16_t *src) {
     __m128i vsum = _mm_setzero_si128();
     int32_t i;
 
@@ -106,7 +106,7 @@ static INLINE void variance8_sse2(const uint8_t *src, const int src_stride,
 }
 
 #define AOM_VAR_NO_LOOP_SSE2(bw, bh, bits, max_pixels)                        \
-  unsigned int aom_variance##bw##x##bh##_sse2(                                \
+  unsigned int eb_aom_variance##bw##x##bh##_sse2(                                \
       const uint8_t *src, int src_stride, const uint8_t *ref, int ref_stride, \
       unsigned int *sse) {                                                    \
     __m128i vsse = _mm_setzero_si128();                                       \

--- a/Source/Lib/Common/ASM_SSE2/x86inc.asm
+++ b/Source/Lib/Common/ASM_SSE2/x86inc.asm
@@ -106,7 +106,7 @@ HAVE_WXWIDGETS equ 0
 
 
 %ifndef private_prefix
-    %define private_prefix aom
+    %define private_prefix eb_aom
 %endif
 
 %ifndef public_prefix

--- a/Source/Lib/Common/ASM_SSE4_1/EbIntraPrediction16bit_Intrinsic_SSE4_1.c
+++ b/Source/Lib/Common/ASM_SSE4_1/EbIntraPrediction16bit_Intrinsic_SSE4_1.c
@@ -329,7 +329,7 @@ EB_EXTERN void intra_mode_dc_luma16bit_sse4_1_intrin(
     }
 }
 
-void av1_filter_intra_edge_sse4_1(uint8_t *p, int32_t sz, int32_t strength) {
+void eb_av1_filter_intra_edge_sse4_1(uint8_t *p, int32_t sz, int32_t strength) {
     if (!strength) return;
 
     DECLARE_ALIGNED(16, static const int8_t, kern[3][16]) = {
@@ -428,7 +428,7 @@ void av1_filter_intra_edge_sse4_1(uint8_t *p, int32_t sz, int32_t strength) {
     }
 }
 
-void av1_filter_intra_edge_high_sse4_1(uint16_t *p, int32_t sz, int32_t strength) {
+void eb_av1_filter_intra_edge_high_sse4_1(uint16_t *p, int32_t sz, int32_t strength) {
     if (!strength) return;
 
     DECLARE_ALIGNED(16, static const int16_t, kern[3][8]) = {
@@ -520,7 +520,7 @@ void av1_filter_intra_edge_high_sse4_1(uint16_t *p, int32_t sz, int32_t strength
     }
 }
 
-void av1_upsample_intra_edge_sse4_1(uint8_t *p, int32_t sz) {
+void eb_av1_upsample_intra_edge_sse4_1(uint8_t *p, int32_t sz) {
     // interpolate half-sample positions
     assert(sz <= 24);
 

--- a/Source/Lib/Common/ASM_SSE4_1/highbd_fwd_txfm_sse4.c
+++ b/Source/Lib/Common/ASM_SSE4_1/highbd_fwd_txfm_sse4.c
@@ -230,7 +230,7 @@ static void fadst4x4_sse4_1(__m128i *in, __m128i *out, int32_t bit,
     out[3] = _mm_unpackhi_epi64(v1, v3);
 }
 
-void av1_fwd_txfm2d_4x4_sse4_1(int16_t *input, int32_t *coeff, uint32_t stride, TxType tx_type, uint8_t  bd)
+void eb_av1_fwd_txfm2d_4x4_sse4_1(int16_t *input, int32_t *coeff, uint32_t stride, TxType tx_type, uint8_t  bd)
 {
     __m128i in[4];
     const int8_t *shift = fwd_txfm_shift_ls[TX_4X4];

--- a/Source/Lib/Common/ASM_SSE4_1/highbd_inv_txfm_sse4.c
+++ b/Source/Lib/Common/ASM_SSE4_1/highbd_inv_txfm_sse4.c
@@ -298,10 +298,10 @@ static void write_buffer_4x4(__m128i *in, uint16_t *output, int32_t stride,
     _mm_storel_epi64((__m128i *)(output + 3 * stride), v3);
 }
 
-void av1_inv_txfm2d_add_4x4_sse4_1(const int32_t *coeff, uint16_t *output,
+void eb_av1_inv_txfm2d_add_4x4_sse4_1(const int32_t *coeff, uint16_t *output,
     int32_t stride, TxType tx_type, int32_t bd) {
     __m128i in[4];
-    const int8_t *shift = inv_txfm_shift_ls[TX_4X4];
+    const int8_t *shift = eb_inv_txfm_shift_ls[TX_4X4];
     const int32_t txw_idx = get_txw_idx(TX_4X4);
     const int32_t txh_idx = get_txh_idx(TX_4X4);
 
@@ -878,10 +878,10 @@ static void write_buffer_8x8(__m128i *in, uint16_t *output, int32_t stride,
     _mm_store_si128((__m128i *)(output + 7 * stride), u7);
 }
 
-void av1_inv_txfm2d_add_8x8_sse4_1(const int32_t *coeff, uint16_t *output,
+void eb_av1_inv_txfm2d_add_8x8_sse4_1(const int32_t *coeff, uint16_t *output,
     int32_t stride, TxType tx_type, int32_t bd) {
     __m128i in[16], out[16];
-    const int8_t *shift = inv_txfm_shift_ls[TX_8X8];
+    const int8_t *shift = eb_inv_txfm_shift_ls[TX_8X8];
     const int32_t txw_idx = get_txw_idx(TX_8X8);
     const int32_t txh_idx = get_txh_idx(TX_8X8);
 
@@ -1609,10 +1609,10 @@ static void round_shift_16x16(__m128i *in, int32_t shift) {
     round_shift_8x8(&in[48], shift);
 }
 
-void av1_inv_txfm2d_add_16x16_sse4_1(const int32_t *coeff, uint16_t *output,
+void eb_av1_inv_txfm2d_add_16x16_sse4_1(const int32_t *coeff, uint16_t *output,
     int32_t stride, TxType tx_type, int32_t bd) {
     __m128i in[64], out[64];
-    const int8_t *shift = inv_txfm_shift_ls[TX_16X16];
+    const int8_t *shift = eb_inv_txfm_shift_ls[TX_16X16];
     const int32_t txw_idx = get_txw_idx(TX_16X16);
     const int32_t txh_idx = get_txh_idx(TX_16X16);
 
@@ -2297,10 +2297,10 @@ static void idct64x64_sse4_1(__m128i *in, __m128i *out, int32_t bit, int32_t do_
     }
 }
 
-void av1_inv_txfm2d_add_64x64_sse4_1(const int32_t *coeff, uint16_t *output,
+void eb_av1_inv_txfm2d_add_64x64_sse4_1(const int32_t *coeff, uint16_t *output,
     int32_t stride, TxType tx_type, int32_t bd) {
     __m128i in[64 * 64 / 4], out[64 * 64 / 4];
-    const int8_t *shift = inv_txfm_shift_ls[TX_64X64];
+    const int8_t *shift = eb_inv_txfm_shift_ls[TX_64X64];
     const int32_t txw_idx = tx_size_wide_log2[TX_64X64] - tx_size_wide_log2[0];
     const int32_t txh_idx = tx_size_high_log2[TX_64X64] - tx_size_high_log2[0];
 
@@ -2317,7 +2317,7 @@ void av1_inv_txfm2d_add_64x64_sse4_1(const int32_t *coeff, uint16_t *output,
         break;
 
     default:
-        av1_inv_txfm2d_add_64x64_c(coeff, output, stride, tx_type, bd);
+        eb_av1_inv_txfm2d_add_64x64_c(coeff, output, stride, tx_type, bd);
         break;
     }
 }
@@ -4363,11 +4363,11 @@ highbd_txfm_all_1d_zeros_w8_arr[TX_SIZES][ITX_TYPES_1D][4] = {
     { NULL, NULL, NULL, NULL } }
 };
 
-void av1_inv_txfm2d_add_4x8_sse4_1(const int32_t *input,
+void eb_av1_inv_txfm2d_add_4x8_sse4_1(const int32_t *input,
     uint16_t *output, int32_t stride,
     TxType tx_type, TxSize tx_size, int32_t bd) {
     __m128i buf1[8];
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     const int32_t txfm_size_col = tx_size_wide[tx_size];
@@ -4450,11 +4450,11 @@ static INLINE void highbd_write_buffer_8xn_sse4_1(__m128i *in, uint16_t *output,
         _mm_storeu_si128((__m128i *)(output + i * stride), u);
     }
 }
-void av1_inv_txfm2d_add_8x4_sse4_1(const int32_t *input,
+void eb_av1_inv_txfm2d_add_8x4_sse4_1(const int32_t *input,
     uint16_t *output, int32_t stride,
     TxType tx_type, TxSize tx_size, int32_t bd) {
     __m128i buf1[8];
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     const int32_t txfm_size_col = tx_size_wide[tx_size];
@@ -4502,11 +4502,11 @@ void av1_inv_txfm2d_add_8x4_sse4_1(const int32_t *input,
 }
 
 //4x16
-void av1_inv_txfm2d_add_4x16_sse4_1(const int32_t *input,
+void eb_av1_inv_txfm2d_add_4x16_sse4_1(const int32_t *input,
     uint16_t *output, int32_t stride,
     TxType tx_type, TxSize tx_size,int32_t bd) {
     __m128i buf1[16];
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     const int32_t txfm_size_col = tx_size_wide[tx_size];
@@ -4561,11 +4561,11 @@ void av1_inv_txfm2d_add_4x16_sse4_1(const int32_t *input,
 }
 
 //16x4
-void av1_inv_txfm2d_add_16x4_sse4_1(const int32_t *input,
+void eb_av1_inv_txfm2d_add_16x4_sse4_1(const int32_t *input,
     uint16_t *output, int32_t stride,
     TxType tx_type, TxSize tx_size, int32_t bd) {
     __m128i buf1[16];
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     const int32_t txfm_size_col = tx_size_wide[tx_size];

--- a/Source/Lib/Common/ASM_SSSE3/EbHighbdIntraPrediction_Intrinsic_SSSE3.c
+++ b/Source/Lib/Common/ASM_SSSE3/EbHighbdIntraPrediction_Intrinsic_SSSE3.c
@@ -103,7 +103,7 @@ static INLINE void smooth_pred_4x4(const __m128i weights_w,
 
 // 4x4
 
-void aom_highbd_smooth_predictor_4x4_ssse3(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_4x4_ssse3(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     const __m128i l = _mm_loadl_epi64((const __m128i *)left);
@@ -117,7 +117,7 @@ void aom_highbd_smooth_predictor_4x4_ssse3(uint16_t *dst, ptrdiff_t stride,
 
 // 4x8
 
-void aom_highbd_smooth_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m128i ab, r, lr[2], weights_w, weights_h, rep[4];
@@ -133,7 +133,7 @@ void aom_highbd_smooth_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t stride,
 
 // 4x16
 
-void aom_highbd_smooth_predictor_4x16_ssse3(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_predictor_4x16_ssse3(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m128i ab, r, lr[2], weights_w, weights_h, rep[4];
@@ -194,7 +194,7 @@ static INLINE void smooth_h_pred_4x4(const __m128i weights, __m128i *const lr,
 
 // 4x4
 
-void aom_highbd_smooth_h_predictor_4x4_ssse3(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_4x4_ssse3(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     const __m128i l = _mm_loadl_epi64((const __m128i *)left);
@@ -208,7 +208,7 @@ void aom_highbd_smooth_h_predictor_4x4_ssse3(uint16_t *dst, ptrdiff_t stride,
 
 // 4x8
 
-void aom_highbd_smooth_h_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m128i r, lr[2], weights;
@@ -222,7 +222,7 @@ void aom_highbd_smooth_h_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t stride,
 
 // 4x16
 
-void aom_highbd_smooth_h_predictor_4x16_ssse3(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_h_predictor_4x16_ssse3(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m128i r, lr[2], weights;
@@ -293,7 +293,7 @@ static INLINE void smooth_v_pred_4x4(const __m128i weights,
 
 // 4x4
 
-void aom_highbd_smooth_v_predictor_4x4_ssse3(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_4x4_ssse3(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m128i ab, rep[4];
@@ -306,7 +306,7 @@ void aom_highbd_smooth_v_predictor_4x4_ssse3(uint16_t *dst, ptrdiff_t stride,
 
 // 4x8
 
-void aom_highbd_smooth_v_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m128i ab, weights, rep[4];
@@ -321,7 +321,7 @@ void aom_highbd_smooth_v_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t stride,
 
 // 4x16
 
-void aom_highbd_smooth_v_predictor_4x16_ssse3(uint16_t *dst, ptrdiff_t stride,
+void eb_aom_highbd_smooth_v_predictor_4x16_ssse3(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     __m128i ab, weights, rep[4];
@@ -363,7 +363,7 @@ static INLINE __m128i paeth_8x1_pred(const __m128i *left, const __m128i *top,
   return _mm_or_si128(pl, pt);
 }
 
-void aom_paeth_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t stride,
                                    const uint8_t *above, const uint8_t *left) {
   __m128i l = _mm_loadl_epi64((const __m128i *)left);
   const __m128i t = _mm_loadl_epi64((const __m128i *)above);
@@ -384,7 +384,7 @@ void aom_paeth_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t stride,
                                    const uint8_t *above, const uint8_t *left) {
   __m128i l = _mm_loadl_epi64((const __m128i *)left);
   const __m128i t = _mm_loadl_epi64((const __m128i *)above);
@@ -405,7 +405,7 @@ void aom_paeth_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t stride,
                                     const uint8_t *above, const uint8_t *left) {
   __m128i l = _mm_load_si128((const __m128i *)left);
   const __m128i t = _mm_cvtsi32_si128(((const uint32_t *)above)[0]);
@@ -425,7 +425,7 @@ void aom_paeth_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t stride,
                                    const uint8_t *above, const uint8_t *left) {
   __m128i l = _mm_loadl_epi64((const __m128i *)left);
   const __m128i t = _mm_loadl_epi64((const __m128i *)above);
@@ -446,7 +446,7 @@ void aom_paeth_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t stride,
                                    const uint8_t *above, const uint8_t *left) {
   __m128i l = _mm_loadl_epi64((const __m128i *)left);
   const __m128i t = _mm_loadl_epi64((const __m128i *)above);
@@ -467,7 +467,7 @@ void aom_paeth_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t stride,
                                     const uint8_t *above, const uint8_t *left) {
   __m128i l = _mm_load_si128((const __m128i *)left);
   const __m128i t = _mm_loadl_epi64((const __m128i *)above);
@@ -488,7 +488,7 @@ void aom_paeth_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t stride,
                                     const uint8_t *above, const uint8_t *left) {
   const __m128i t = _mm_loadl_epi64((const __m128i *)above);
   const __m128i zero = _mm_setzero_si128();
@@ -519,7 +519,7 @@ static INLINE __m128i paeth_16x1_pred(const __m128i *left, const __m128i *top0,
   return _mm_packus_epi16(p0, p1);
 }
 
-void aom_paeth_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t stride,
                                     const uint8_t *above, const uint8_t *left) {
   __m128i l = _mm_cvtsi32_si128(((const uint32_t *)left)[0]);
   const __m128i t = _mm_load_si128((const __m128i *)above);
@@ -540,7 +540,7 @@ void aom_paeth_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t stride,
                                     const uint8_t *above, const uint8_t *left) {
   __m128i l = _mm_loadl_epi64((const __m128i *)left);
   const __m128i t = _mm_load_si128((const __m128i *)above);
@@ -562,7 +562,7 @@ void aom_paeth_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t stride,
                                      const uint8_t *above,
                                      const uint8_t *left) {
   __m128i l = _mm_load_si128((const __m128i *)left);
@@ -585,7 +585,7 @@ void aom_paeth_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t stride,
                                      const uint8_t *above,
                                      const uint8_t *left) {
   __m128i l = _mm_load_si128((const __m128i *)left);
@@ -620,7 +620,7 @@ void aom_paeth_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t stride,
                                      const uint8_t *above,
                                      const uint8_t *left) {
   const __m128i t = _mm_load_si128((const __m128i *)above);
@@ -643,7 +643,7 @@ void aom_paeth_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t stride,
                                     const uint8_t *above, const uint8_t *left) {
   const __m128i a = _mm_load_si128((const __m128i *)above);
   const __m128i b = _mm_load_si128((const __m128i *)(above + 16));
@@ -671,7 +671,7 @@ void aom_paeth_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t stride,
                                      const uint8_t *above,
                                      const uint8_t *left) {
   const __m128i a = _mm_load_si128((const __m128i *)above);
@@ -701,7 +701,7 @@ void aom_paeth_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t stride,
                                      const uint8_t *above,
                                      const uint8_t *left) {
   const __m128i a = _mm_load_si128((const __m128i *)above);
@@ -744,7 +744,7 @@ void aom_paeth_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t stride,
                                      const uint8_t *above,
                                      const uint8_t *left) {
   const __m128i a = _mm_load_si128((const __m128i *)above);
@@ -776,7 +776,7 @@ void aom_paeth_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t stride,
                                      const uint8_t *above,
                                      const uint8_t *left) {
   const __m128i a = _mm_load_si128((const __m128i *)above);
@@ -818,7 +818,7 @@ void aom_paeth_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t stride,
                                      const uint8_t *above,
                                      const uint8_t *left) {
   const __m128i a = _mm_load_si128((const __m128i *)above);
@@ -860,7 +860,7 @@ void aom_paeth_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t stride,
   }
 }
 
-void aom_paeth_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_paeth_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t stride,
                                      const uint8_t *above,
                                      const uint8_t *left) {
   const __m128i a = _mm_load_si128((const __m128i *)above);

--- a/Source/Lib/Common/ASM_SSSE3/av1_inv_txfm_ssse3.c
+++ b/Source/Lib/Common/ASM_SSSE3/av1_inv_txfm_ssse3.c
@@ -2433,7 +2433,7 @@ static INLINE void iidentity_col_8xn_ssse3(uint8_t *output, int32_t stride,
 static INLINE void lowbd_inv_txfm2d_add_idtx_ssse3(const int32_t *input,
     uint8_t *output, int32_t stride,
     TxSize tx_size) {
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     const int32_t txfm_size_col = tx_size_wide[tx_size];
@@ -2458,7 +2458,7 @@ static void lowbd_inv_txfm2d_add_4x4_ssse3(const int32_t *input,
     (void)eob;
     __m128i buf[4];
     const TxSize tx_size = TX_4X4;
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     const int32_t cos_bit_row = inv_cos_bit_row[txw_idx][txh_idx];
@@ -2523,7 +2523,7 @@ static INLINE void lowbd_inv_txfm2d_add_no_identity_ssse3(
     __m128i buf1[64 * 8];
     int32_t eobx, eoby;
     get_eobx_eoby_scan_default(&eobx, &eoby, tx_size, eob);
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     const int32_t cos_bit_col = inv_cos_bit_col[txw_idx][txh_idx];
@@ -2593,7 +2593,7 @@ static INLINE void lowbd_inv_txfm2d_add_no_identity_ssse3(
 static INLINE void lowbd_inv_txfm2d_add_h_identity_ssse3(
     const int32_t *input, uint8_t *output, int32_t stride, TxType tx_type,
     TxSize tx_size, int32_t eob) {
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     int32_t eobx, eoby;
     get_eobx_eoby_scan_h_identity(&eobx, &eoby, tx_size, eob);
     const int32_t txw_idx = get_txw_idx(tx_size);
@@ -2640,7 +2640,7 @@ static INLINE void lowbd_inv_txfm2d_add_v_identity_ssse3(
     __m128i buf1[64];
     int32_t eobx, eoby;
     get_eobx_eoby_scan_v_identity(&eobx, &eoby, tx_size, eob);
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     const int32_t cos_bit_row = inv_cos_bit_row[txw_idx][txh_idx];
@@ -2728,7 +2728,7 @@ static void lowbd_inv_txfm2d_add_4x8_ssse3(const int32_t *input,
     (void)eob;
     __m128i buf[8];
     const TxSize tx_size = TX_4X8;
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     const int32_t cos_bit_row = inv_cos_bit_row[txw_idx][txh_idx];
@@ -2767,7 +2767,7 @@ static void lowbd_inv_txfm2d_add_8x4_ssse3(const int32_t *input,
     (void)eob;
     __m128i buf[8];
     const TxSize tx_size = TX_8X4;
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     const int32_t cos_bit_row = inv_cos_bit_row[txw_idx][txh_idx];
@@ -2806,7 +2806,7 @@ static void lowbd_inv_txfm2d_add_4x16_ssse3(const int32_t *input,
     (void)eob;
     __m128i buf[16];
     const TxSize tx_size = TX_4X16;
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     const int32_t cos_bit_row = inv_cos_bit_row[txw_idx][txh_idx];
@@ -2851,7 +2851,7 @@ static void lowbd_inv_txfm2d_add_16x4_ssse3(const int32_t *input,
     (void)eob;
     __m128i buf[16];
     const TxSize tx_size = TX_16X4;
-    const int8_t *shift = inv_txfm_shift_ls[tx_size];
+    const int8_t *shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     const int32_t cos_bit_row = inv_cos_bit_row[txw_idx][txh_idx];
@@ -2895,7 +2895,7 @@ static void lowbd_inv_txfm2d_add_16x4_ssse3(const int32_t *input,
     lowbd_write_buffer_8xn_sse2(buf + 8, output + 8, stride, ud_flip, 4);
 }
 
-void av1_lowbd_inv_txfm2d_add_ssse3(const int32_t *input, uint8_t *output,
+void eb_av1_lowbd_inv_txfm2d_add_ssse3(const int32_t *input, uint8_t *output,
     int32_t stride, TxType tx_type,
     TxSize tx_size, int32_t eob) {
     switch (tx_size) {
@@ -2926,13 +2926,13 @@ void av1_lowbd_inv_txfm2d_add_ssse3(const int32_t *input, uint8_t *output,
     }
 }
 
-void av1_inv_txfm_add_ssse3(const TranLow *dqcoeff, uint8_t *dst, int32_t stride,
+void eb_av1_inv_txfm_add_ssse3(const TranLow *dqcoeff, uint8_t *dst, int32_t stride,
     const TxfmParam *txfm_param) {
     const TxType tx_type = txfm_param->tx_type;
     //f (!txfm_param->lossless) {
-    av1_lowbd_inv_txfm2d_add_ssse3(dqcoeff, dst, stride, tx_type,
+    eb_av1_lowbd_inv_txfm2d_add_ssse3(dqcoeff, dst, stride, tx_type,
         txfm_param->tx_size, txfm_param->eob);
     //else {
-   // av1_inv_txfm_add_c(dqcoeff, dst, stride, txfm_param);
+   // eb_av1_inv_txfm_add_c(dqcoeff, dst, stride, txfm_param);
    // }
 }

--- a/Source/Lib/Common/ASM_SSSE3/av1_inv_txfm_ssse3.h
+++ b/Source/Lib/Common/ASM_SSSE3/av1_inv_txfm_ssse3.h
@@ -214,7 +214,7 @@ av1_eob_to_eobxy_32x16_default,
     typedef void(*transform_1d_ssse3)(const __m128i *input, __m128i *output,
         int8_t cos_bit);
 
-    void av1_lowbd_inv_txfm2d_add_ssse3(const int32_t *input, uint8_t *output,
+    void eb_av1_lowbd_inv_txfm2d_add_ssse3(const int32_t *input, uint8_t *output,
         int32_t stride, TxType tx_type,
         TxSize tx_size, int32_t eob);
 #ifdef __cplusplus

--- a/Source/Lib/Common/ASM_SSSE3/intrapred_ssse3.c
+++ b/Source/Lib/Common/ASM_SSSE3/intrapred_ssse3.c
@@ -130,7 +130,7 @@ static INLINE void smooth_pred_4xh(const __m128i *pixel, const __m128i *wh,
     }
 }
 
-void aom_smooth_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     __m128i pixels[3];
     load_pixel_w4(above, left, 4, pixels);
@@ -141,7 +141,7 @@ void aom_smooth_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t stride,
     smooth_pred_4xh(pixels, wh, ww, 4, dst, stride, 0);
 }
 
-void aom_smooth_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     __m128i pixels[3];
     load_pixel_w4(above, left, 8, pixels);
@@ -152,7 +152,7 @@ void aom_smooth_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     smooth_pred_4xh(pixels, wh, ww, 8, dst, stride, 0);
 }
 
-void aom_smooth_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels[3];
@@ -296,7 +296,7 @@ static INLINE void smooth_pred_8xh(const __m128i *pixels, const __m128i *wh,
     }
 }
 
-void aom_smooth_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     __m128i pixels[4];
     load_pixel_w8(above, left, 4, pixels);
@@ -307,7 +307,7 @@ void aom_smooth_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t stride,
     smooth_pred_8xh(pixels, wh, ww, 4, dst, stride, 0);
 }
 
-void aom_smooth_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above, const uint8_t *left) {
     __m128i pixels[4];
     load_pixel_w8(above, left, 8, pixels);
@@ -318,7 +318,7 @@ void aom_smooth_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     smooth_pred_8xh(pixels, wh, ww, 8, dst, stride, 0);
 }
 
-void aom_smooth_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels[4];
@@ -332,7 +332,7 @@ void aom_smooth_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     smooth_pred_8xh(pixels, &wh[2], ww, 8, dst, stride, 1);
 }
 
-void aom_smooth_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels[8];
@@ -410,73 +410,73 @@ static INLINE void smooth_predictor_wxh(uint8_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_smooth_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_predictor_wxh(dst, stride, above, left, 16, 4);
 }
 
-void aom_smooth_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_predictor_wxh(dst, stride, above, left, 16, 8);
 }
 
-void aom_smooth_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_predictor_wxh(dst, stride, above, left, 16, 16);
 }
 
-void aom_smooth_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_predictor_wxh(dst, stride, above, left, 16, 32);
 }
 
-void aom_smooth_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_predictor_wxh(dst, stride, above, left, 32, 8);
 }
 
-void aom_smooth_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_predictor_wxh(dst, stride, above, left, 32, 16);
 }
 
-void aom_smooth_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_predictor_wxh(dst, stride, above, left, 32, 32);
 }
 
-void aom_smooth_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_predictor_wxh(dst, stride, above, left, 32, 64);
 }
 
-void aom_smooth_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_predictor_wxh(dst, stride, above, left, 64, 64);
 }
 
-void aom_smooth_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_predictor_wxh(dst, stride, above, left, 64, 32);
 }
 
-void aom_smooth_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_predictor_wxh(dst, stride, above, left, 64, 16);
 }
 
-void aom_smooth_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_predictor_wxh(dst, stride, above, left, 16, 64);
@@ -544,7 +544,7 @@ static INLINE void smooth_v_pred_4xh(const __m128i *pixel,
     }
 }
 
-void aom_smooth_v_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels;
@@ -556,7 +556,7 @@ void aom_smooth_v_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t stride,
     smooth_v_pred_4xh(&pixels, weights, 4, dst, stride);
 }
 
-void aom_smooth_v_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels;
@@ -568,7 +568,7 @@ void aom_smooth_v_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     smooth_v_pred_4xh(&pixels, weights, 8, dst, stride);
 }
 
-void aom_smooth_v_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels;
@@ -666,7 +666,7 @@ static INLINE void smooth_v_pred_8xh(const __m128i *pixels, const __m128i *wh,
     }
 }
 
-void aom_smooth_v_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels[2];
@@ -678,7 +678,7 @@ void aom_smooth_v_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t stride,
     smooth_v_pred_8xh(pixels, wh, 4, dst, stride);
 }
 
-void aom_smooth_v_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels[2];
@@ -690,7 +690,7 @@ void aom_smooth_v_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     smooth_v_pred_8xh(pixels, wh, 8, dst, stride);
 }
 
-void aom_smooth_v_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels[2];
@@ -704,7 +704,7 @@ void aom_smooth_v_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     smooth_v_pred_8xh(pixels, &wh[2], 8, dst, stride);
 }
 
-void aom_smooth_v_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels[2];
@@ -767,73 +767,73 @@ static INLINE void smooth_v_predictor_wxh(uint8_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_smooth_v_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_v_predictor_wxh(dst, stride, above, left, 16, 4);
 }
 
-void aom_smooth_v_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_v_predictor_wxh(dst, stride, above, left, 16, 8);
 }
 
-void aom_smooth_v_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_v_predictor_wxh(dst, stride, above, left, 16, 16);
 }
 
-void aom_smooth_v_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_v_predictor_wxh(dst, stride, above, left, 16, 32);
 }
 
-void aom_smooth_v_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_v_predictor_wxh(dst, stride, above, left, 32, 8);
 }
 
-void aom_smooth_v_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_v_predictor_wxh(dst, stride, above, left, 32, 16);
 }
 
-void aom_smooth_v_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_v_predictor_wxh(dst, stride, above, left, 32, 32);
 }
 
-void aom_smooth_v_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_v_predictor_wxh(dst, stride, above, left, 32, 64);
 }
 
-void aom_smooth_v_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_v_predictor_wxh(dst, stride, above, left, 64, 64);
 }
 
-void aom_smooth_v_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_v_predictor_wxh(dst, stride, above, left, 64, 32);
 }
 
-void aom_smooth_v_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_v_predictor_wxh(dst, stride, above, left, 64, 16);
 }
 
-void aom_smooth_v_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_v_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_v_predictor_wxh(dst, stride, above, left, 16, 64);
@@ -892,7 +892,7 @@ static INLINE void smooth_h_pred_4xh(const __m128i *pixel,
     }
 }
 
-void aom_smooth_h_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels[2];
@@ -904,7 +904,7 @@ void aom_smooth_h_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t stride,
     smooth_h_pred_4xh(pixels, &weights, 4, dst, stride);
 }
 
-void aom_smooth_h_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels[2];
@@ -916,7 +916,7 @@ void aom_smooth_h_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     smooth_h_pred_4xh(pixels, &weights, 8, dst, stride);
 }
 
-void aom_smooth_h_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels[2];
@@ -996,7 +996,7 @@ static INLINE void smooth_h_pred_8xh(const __m128i *pixels, const __m128i *ww,
     }
 }
 
-void aom_smooth_h_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels[2];
@@ -1008,7 +1008,7 @@ void aom_smooth_h_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t stride,
     smooth_h_pred_8xh(pixels, ww, 4, dst, stride, 0);
 }
 
-void aom_smooth_h_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels[2];
@@ -1020,7 +1020,7 @@ void aom_smooth_h_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     smooth_h_pred_8xh(pixels, ww, 8, dst, stride, 0);
 }
 
-void aom_smooth_h_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels[2];
@@ -1034,7 +1034,7 @@ void aom_smooth_h_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     smooth_h_pred_8xh(pixels, ww, 8, dst, stride, 1);
 }
 
-void aom_smooth_h_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     __m128i pixels[4];
@@ -1093,73 +1093,73 @@ static INLINE void smooth_h_predictor_wxh(uint8_t *dst, ptrdiff_t stride,
     }
 }
 
-void aom_smooth_h_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_h_predictor_wxh(dst, stride, above, left, 16, 4);
 }
 
-void aom_smooth_h_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_h_predictor_wxh(dst, stride, above, left, 16, 8);
 }
 
-void aom_smooth_h_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_h_predictor_wxh(dst, stride, above, left, 16, 16);
 }
 
-void aom_smooth_h_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_h_predictor_wxh(dst, stride, above, left, 16, 32);
 }
 
-void aom_smooth_h_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_h_predictor_wxh(dst, stride, above, left, 16, 64);
 }
 
-void aom_smooth_h_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_h_predictor_wxh(dst, stride, above, left, 32, 8);
 }
 
-void aom_smooth_h_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_h_predictor_wxh(dst, stride, above, left, 32, 16);
 }
 
-void aom_smooth_h_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_h_predictor_wxh(dst, stride, above, left, 32, 32);
 }
 
-void aom_smooth_h_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_h_predictor_wxh(dst, stride, above, left, 32, 64);
 }
 
-void aom_smooth_h_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_h_predictor_wxh(dst, stride, above, left, 64, 64);
 }
 
-void aom_smooth_h_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_h_predictor_wxh(dst, stride, above, left, 64, 32);
 }
 
-void aom_smooth_h_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t stride,
+void eb_aom_smooth_h_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t stride,
     const uint8_t *above,
     const uint8_t *left) {
     smooth_h_predictor_wxh(dst, stride, above, left, 64, 16);
@@ -1172,7 +1172,7 @@ void eb_smooth_v_predictor_all_ssse3(uint8_t *dst, ptrdiff_t stride, int32_t bw,
 
     switch (bw) {
     case 4:
-        aom_smooth_v_predictor_4x4_ssse3(
+        eb_aom_smooth_v_predictor_4x4_ssse3(
             dst,
             stride,
             above,
@@ -1180,7 +1180,7 @@ void eb_smooth_v_predictor_all_ssse3(uint8_t *dst, ptrdiff_t stride, int32_t bw,
         );
         break;
     case 8:
-        aom_smooth_v_predictor_8x8_ssse3(
+        eb_aom_smooth_v_predictor_8x8_ssse3(
             dst,
             stride,
             above,
@@ -1188,7 +1188,7 @@ void eb_smooth_v_predictor_all_ssse3(uint8_t *dst, ptrdiff_t stride, int32_t bw,
         );
         break;
     case 16:
-        aom_smooth_v_predictor_16x16_ssse3(
+        eb_aom_smooth_v_predictor_16x16_ssse3(
             dst,
             stride,
             above,
@@ -1196,7 +1196,7 @@ void eb_smooth_v_predictor_all_ssse3(uint8_t *dst, ptrdiff_t stride, int32_t bw,
         );
         break;
     case 32:
-        aom_smooth_v_predictor_32x32_ssse3(
+        eb_aom_smooth_v_predictor_32x32_ssse3(
             dst,
             stride,
             above,
@@ -1204,7 +1204,7 @@ void eb_smooth_v_predictor_all_ssse3(uint8_t *dst, ptrdiff_t stride, int32_t bw,
         );
         break;
     case 64:
-        aom_smooth_v_predictor_64x64_ssse3(
+        eb_aom_smooth_v_predictor_64x64_ssse3(
             dst,
             stride,
             above,
@@ -1223,7 +1223,7 @@ void eb_smooth_h_predictor_all_ssse3(uint8_t *dst, ptrdiff_t stride, int32_t bw,
     //printf("here");
     switch (bw) {
     case 4:
-        aom_smooth_h_predictor_4x4_ssse3(
+        eb_aom_smooth_h_predictor_4x4_ssse3(
             dst,
             stride,
             above,
@@ -1231,7 +1231,7 @@ void eb_smooth_h_predictor_all_ssse3(uint8_t *dst, ptrdiff_t stride, int32_t bw,
         );
         break;
     case 8:
-        aom_smooth_h_predictor_8x8_ssse3(
+        eb_aom_smooth_h_predictor_8x8_ssse3(
             dst,
             stride,
             above,
@@ -1239,7 +1239,7 @@ void eb_smooth_h_predictor_all_ssse3(uint8_t *dst, ptrdiff_t stride, int32_t bw,
         );
         break;
     case 16:
-        aom_smooth_h_predictor_16x16_ssse3(
+        eb_aom_smooth_h_predictor_16x16_ssse3(
             dst,
             stride,
             above,
@@ -1247,7 +1247,7 @@ void eb_smooth_h_predictor_all_ssse3(uint8_t *dst, ptrdiff_t stride, int32_t bw,
         );
         break;
     case 32:
-        aom_smooth_h_predictor_32x32_ssse3(
+        eb_aom_smooth_h_predictor_32x32_ssse3(
             dst,
             stride,
             above,
@@ -1255,7 +1255,7 @@ void eb_smooth_h_predictor_all_ssse3(uint8_t *dst, ptrdiff_t stride, int32_t bw,
         );
         break;
     case 64:
-        aom_smooth_h_predictor_64x64_ssse3(
+        eb_aom_smooth_h_predictor_64x64_ssse3(
             dst,
             stride,
             above,

--- a/Source/Lib/Common/C_DEFAULT/EbComputeSAD_C.c
+++ b/Source/Lib/Common/C_DEFAULT/EbComputeSAD_C.c
@@ -201,20 +201,20 @@ static INLINE uint32_t sad_inline_c(const uint8_t *a, int a_stride,
 }
 
 #define sadMxN(m, n)                                                          \
-  uint32_t aom_sad##m##x##n##_c(const uint8_t *src, int src_stride,       \
+  uint32_t eb_aom_sad##m##x##n##_c(const uint8_t *src, int src_stride,       \
                                     const uint8_t *ref, int ref_stride) {     \
     return sad_inline_c(src, src_stride, ref, ref_stride, m, n);              \
   }
 
 // Calculate sad against 4 reference locations and store each in sad_array
 #define sadMxNx4D(m, n)                                                    \
-  void aom_sad##m##x##n##x4d_c(const uint8_t *src, int src_stride,         \
+  void eb_aom_sad##m##x##n##x4d_c(const uint8_t *src, int src_stride,         \
                                const uint8_t *const ref_array[],           \
                                int ref_stride, uint32_t *sad_array) {      \
     int i;                                                                 \
     for (i = 0; i < 4; ++i) {                                              \
       sad_array[i] =                                                       \
-          aom_sad##m##x##n##_c(src, src_stride, ref_array[i], ref_stride); \
+          eb_aom_sad##m##x##n##_c(src, src_stride, ref_array[i], ref_stride); \
     }                                                                      \
   }
 

--- a/Source/Lib/Common/C_DEFAULT/EbComputeVariance_C.c
+++ b/Source/Lib/Common/C_DEFAULT/EbComputeVariance_C.c
@@ -25,7 +25,7 @@ static void variance_c(const uint8_t *a, int a_stride, const uint8_t *b,
 }
 
 #define VAR(W, H)                                                    \
-  uint32_t aom_variance##W##x##H##_c(const uint8_t *a, int a_stride, \
+  uint32_t eb_aom_variance##W##x##H##_c(const uint8_t *a, int a_stride, \
                                      const uint8_t *b, int b_stride, \
                                      uint32_t *sse) {                \
     int sum;                                                         \

--- a/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
+++ b/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
@@ -1874,7 +1874,7 @@ EbBool warped_motion_parameters(
         nsamples = select_samples(&mv, pts, pts_inref, nsamples, bsize);
     *num_samples = nsamples;
 
-    apply_wm = !find_projection(
+    apply_wm = !eb_find_projection(
         (int) nsamples,
         pts,
         pts_inref,
@@ -1962,7 +1962,7 @@ int count_overlappable_nb_left(
     return nb_count;
 }
 
-void av1_count_overlappable_neighbors(
+void eb_av1_count_overlappable_neighbors(
     const PictureControlSet        *picture_control_set_ptr,
     CodingUnit                     *cu_ptr,
     const BlockSize                   bsize,
@@ -2085,7 +2085,7 @@ int av1_is_dv_valid(const MV dv,
     return 1;
 }
 
-IntMv av1_get_ref_mv_from_stack(int ref_idx,
+IntMv eb_av1_get_ref_mv_from_stack(int ref_idx,
     const MvReferenceFrame *ref_frame,
     int ref_mv_idx,
     CandidateMv ref_mv_stack[][MAX_REF_MV_STACK_SIZE],
@@ -2127,7 +2127,7 @@ static INLINE void lower_mv_precision(MV *mv, int allow_hp, int is_integer) {
         }
     }
 }
-void av1_find_best_ref_mvs_from_stack(int allow_hp,
+void eb_av1_find_best_ref_mvs_from_stack(int allow_hp,
     //const MB_MODE_INFO_EXT *mbmi_ext,
     CandidateMv ref_mv_stack[][MAX_REF_MV_STACK_SIZE],
     MacroBlockD * xd,
@@ -2137,8 +2137,8 @@ void av1_find_best_ref_mvs_from_stack(int allow_hp,
 {
     const int ref_idx = 0;
     MvReferenceFrame ref_frames[2] = { ref_frame, NONE_FRAME };
-    *nearest_mv = av1_get_ref_mv_from_stack(ref_idx, ref_frames, 0, ref_mv_stack/*mbmi_ext*/, xd);
+    *nearest_mv = eb_av1_get_ref_mv_from_stack(ref_idx, ref_frames, 0, ref_mv_stack/*mbmi_ext*/, xd);
     lower_mv_precision(&nearest_mv->as_mv, allow_hp, is_integer);
-    *near_mv = av1_get_ref_mv_from_stack(ref_idx, ref_frames, 1, ref_mv_stack/*mbmi_ext*/, xd);
+    *near_mv = eb_av1_get_ref_mv_from_stack(ref_idx, ref_frames, 1, ref_mv_stack/*mbmi_ext*/, xd);
     lower_mv_precision(&near_mv->as_mv, allow_hp, is_integer);
 }

--- a/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.h
+++ b/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.h
@@ -137,14 +137,14 @@ extern "C" {
              || cu_ptr->prediction_unit_array[0].overlappable_neighbors[1] != 0);
     }
 
-    void av1_count_overlappable_neighbors(
+    void eb_av1_count_overlappable_neighbors(
         const PictureControlSet        *picture_control_set_ptr,
         CodingUnit                     *cu_ptr,
         const BlockSize                   bsize,
         int32_t                           mi_row,
         int32_t                           mi_col);
 
-    void av1_find_best_ref_mvs_from_stack(int allow_hp,
+    void eb_av1_find_best_ref_mvs_from_stack(int allow_hp,
         CandidateMv ref_mv_stack[][MAX_REF_MV_STACK_SIZE],
         MacroBlockD * xd,
         MvReferenceFrame ref_frame,

--- a/Source/Lib/Common/Codec/EbBitstreamUnit.h
+++ b/Source/Lib/Common/Codec/EbBitstreamUnit.h
@@ -176,7 +176,7 @@ on a larger type, you can speed up the decoder by using it here.*/
 
     /*See entcode.c for further documentation.*/
 
-    OD_WARN_UNUSED_RESULT uint32_t od_ec_tell_frac(uint32_t nbits_total,
+    OD_WARN_UNUSED_RESULT uint32_t eb_od_ec_tell_frac(uint32_t nbits_total,
         uint32_t rng);
 
     /********************************************************************************************************************************/
@@ -189,7 +189,7 @@ on a larger type, you can speed up the decoder by using it here.*/
     struct OdEcEnc
     {
         /*Buffered output.
-        This contains only the raw bits until the final call to od_ec_enc_done(),
+        This contains only the raw bits until the final call to eb_od_ec_enc_done(),
         where all the arithmetic-coded data gets prepended to it.*/
         uint8_t *buf;
         /*The size of the buffer.*/
@@ -218,27 +218,27 @@ on a larger type, you can speed up the decoder by using it here.*/
 
     /*See entenc.c for further documentation.*/
 
-    void od_ec_enc_init(OdEcEnc *enc, uint32_t size) OD_ARG_NONNULL(1);
-    void od_ec_enc_reset(OdEcEnc *enc) OD_ARG_NONNULL(1);
-    void od_ec_enc_clear(OdEcEnc *enc) OD_ARG_NONNULL(1);
+    void eb_od_ec_enc_init(OdEcEnc *enc, uint32_t size) OD_ARG_NONNULL(1);
+    void eb_od_ec_enc_reset(OdEcEnc *enc) OD_ARG_NONNULL(1);
+    void eb_od_ec_enc_clear(OdEcEnc *enc) OD_ARG_NONNULL(1);
 
-    void od_ec_encode_bool_q15(OdEcEnc *enc, int32_t val, unsigned f_q15)
+    void eb_od_ec_encode_bool_q15(OdEcEnc *enc, int32_t val, unsigned f_q15)
         OD_ARG_NONNULL(1);
-    void od_ec_encode_cdf_q15(OdEcEnc *enc, int32_t s, const uint16_t *cdf, int32_t nsyms)
+    void eb_od_ec_encode_cdf_q15(OdEcEnc *enc, int32_t s, const uint16_t *cdf, int32_t nsyms)
         OD_ARG_NONNULL(1) OD_ARG_NONNULL(3);
 
     void od_ec_enc_bits(OdEcEnc *enc, uint32_t fl, unsigned ftb)
         OD_ARG_NONNULL(1);
 
-    OD_WARN_UNUSED_RESULT uint8_t *od_ec_enc_done(OdEcEnc *enc,
+    OD_WARN_UNUSED_RESULT uint8_t *eb_od_ec_enc_done(OdEcEnc *enc,
         uint32_t *nbytes)
         OD_ARG_NONNULL(1) OD_ARG_NONNULL(2);
 
-    OD_WARN_UNUSED_RESULT int32_t od_ec_enc_tell(const OdEcEnc *enc)
+    OD_WARN_UNUSED_RESULT int32_t eb_od_ec_enc_tell(const OdEcEnc *enc)
         OD_ARG_NONNULL(1);
 
-    void od_ec_enc_checkpoint(OdEcEnc *dst, const OdEcEnc *src);
-    void od_ec_enc_rollback(OdEcEnc *dst, const OdEcEnc *src);
+    void eb_od_ec_enc_checkpoint(OdEcEnc *dst, const OdEcEnc *src);
+    void eb_od_ec_enc_rollback(OdEcEnc *dst, const OdEcEnc *src);
 
     /********************************************************************************************************************************/
     //daalaboolwriter.h
@@ -251,8 +251,8 @@ on a larger type, you can speed up the decoder by using it here.*/
 
     typedef struct DaalaWriter DaalaWriter;
 
-    void aom_daala_start_encode(DaalaWriter *w, uint8_t *buffer);
-    int32_t aom_daala_stop_encode(DaalaWriter *w);
+    void eb_aom_daala_start_encode(DaalaWriter *w, uint8_t *buffer);
+    int32_t eb_aom_daala_stop_encode(DaalaWriter *w);
 
     static INLINE void aom_daala_write(DaalaWriter *w, int32_t bit, int32_t prob) {
         int32_t p = (0x7FFFFF - (prob << 15) + prob) >> 8;
@@ -260,7 +260,7 @@ on a larger type, you can speed up the decoder by using it here.*/
         AomCdfProb cdf[2] = { (AomCdfProb)p, 32767 };
         bitstream_queue_push(bit, cdf, 2);
 #endif
-        od_ec_encode_bool_q15(&w->ec, bit, p);
+        eb_od_ec_encode_bool_q15(&w->ec, bit, p);
     }
 
     static INLINE void daala_write_symbol(DaalaWriter *w, int32_t symb,
@@ -268,7 +268,7 @@ on a larger type, you can speed up the decoder by using it here.*/
 #if CONFIG_BITSTREAM_DEBUG
         bitstream_queue_push(symb, cdf, nsymbs);
 #endif
-        od_ec_encode_cdf_q15(&w->ec, symb, cdf, nsymbs);
+        eb_od_ec_encode_cdf_q15(&w->ec, symb, cdf, nsymbs);
     }
 
     /********************************************************************************************************************************/
@@ -295,11 +295,11 @@ on a larger type, you can speed up the decoder by using it here.*/
     }
 
     static INLINE void aom_start_encode(AomWriter *bc, uint8_t *buffer) {
-        aom_daala_start_encode(bc, buffer);
+        eb_aom_daala_start_encode(bc, buffer);
     }
 
     static INLINE int32_t aom_stop_encode(AomWriter *bc) {
-        return aom_daala_stop_encode(bc);
+        return eb_aom_daala_stop_encode(bc);
     }
 
     static INLINE void aom_write(AomWriter *br, int32_t bit, int32_t probability) {

--- a/Source/Lib/Common/Codec/EbCabacContextModel.c
+++ b/Source/Lib/Common/Codec/EbCabacContextModel.c
@@ -4443,7 +4443,7 @@ static int32_t get_q_ctx(int32_t q) {
     return 3;
 }
 
-void av1_default_coef_probs(FRAME_CONTEXT *fc, int32_t base_qindex) {
+void eb_av1_default_coef_probs(FRAME_CONTEXT *fc, int32_t base_qindex) {
     const int32_t index = get_q_ctx(base_qindex);
 
 #if CONFIG_ENTROPY_STATS
@@ -4497,7 +4497,7 @@ static void reset_nmv_counter(NmvContext *nmv) {
     }
 }
 
-void av1_reset_cdf_symbol_counters(FRAME_CONTEXT *fc) {
+void eb_av1_reset_cdf_symbol_counters(FRAME_CONTEXT *fc) {
     RESET_CDF_COUNTER(fc->txb_skip_cdf, 2);
     RESET_CDF_COUNTER(fc->eob_extra_cdf, 2);
     RESET_CDF_COUNTER(fc->dc_sign_cdf, 2);

--- a/Source/Lib/Common/Codec/EbCabacContextModel.h
+++ b/Source/Lib/Common/Codec/EbCabacContextModel.h
@@ -715,8 +715,8 @@ extern "C" {
 
     struct AV1Common;
     struct FrameContexts;
-    void av1_reset_cdf_symbol_counters(struct FrameContexts *fc);
-    void av1_default_coef_probs(struct FrameContexts *fc, int32_t base_qindex);
+    void eb_av1_reset_cdf_symbol_counters(struct FrameContexts *fc);
+    void eb_av1_default_coef_probs(struct FrameContexts *fc, int32_t base_qindex);
     void init_mode_probs(struct FrameContexts *fc);
 
     struct FrameContexts;

--- a/Source/Lib/Common/Codec/EbCdef.c
+++ b/Source/Lib/Common/Codec/EbCdef.c
@@ -23,7 +23,7 @@
     int32_t src_voffset, int32_t src_hoffset, int32_t sstride,
     int32_t vsize, int32_t hsize);
 
-extern int16_t av1_ac_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth);
+extern int16_t eb_av1_ac_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth);
 
 //-------memory stuff
 
@@ -62,7 +62,7 @@ static void *GetActualMallocAddress(void *const mem) {
     return (void *)(*malloc_addr_location);
 }
 
-void *aom_memalign(size_t align, size_t size) {
+void *eb_aom_memalign(size_t align, size_t size) {
     void *x = NULL;
     const size_t aligned_size = GetAlignedMallocSize(size, align);
 #if defined(AOM_MAX_ALLOCABLE_MEMORY)
@@ -76,16 +76,16 @@ void *aom_memalign(size_t align, size_t size) {
     return x;
 }
 
-void *aom_malloc(size_t size) { return aom_memalign(DEFAULT_ALIGNMENT, size); }
+void *eb_aom_malloc(size_t size) { return eb_aom_memalign(DEFAULT_ALIGNMENT, size); }
 
-void aom_free(void *memblk) {
+void eb_aom_free(void *memblk) {
     if (memblk) {
         void *addr = GetActualMallocAddress(memblk);
         free(addr);
     }
 }
 
-void *aom_memset16(void *dest, int32_t val, size_t length) {
+void *eb_aom_memset16(void *dest, int32_t val, size_t length) {
     size_t i;
     uint16_t *dest16 = (uint16_t *)dest;
     for (i = 0; i < length; i++) *dest16++ = (uint16_t)val;
@@ -105,7 +105,7 @@ static INLINE int32_t constrain(int32_t diff, int32_t threshold, int32_t damping
 }
 
 /* Generated from gen_filter_tables.c. */
-DECLARE_ALIGNED(16, const int32_t, cdef_directions[8][2]) = {
+DECLARE_ALIGNED(16, const int32_t, eb_cdef_directions[8][2]) = {
     { -1 * CDEF_BSTRIDE + 1, -2 * CDEF_BSTRIDE + 2 },
     { 0 * CDEF_BSTRIDE + 1, -1 * CDEF_BSTRIDE + 2 },
     { 0 * CDEF_BSTRIDE + 1, 0 * CDEF_BSTRIDE + 2 },
@@ -123,7 +123,7 @@ particular direction, i.e. the squared error between the input and a
 in a particular direction. Since each direction have the same sum(x^2) term,
 that term is never computed. See Section 2, step 2, of:
 http://jmvalin.ca/notes/intra_paint.pdf */
-int32_t cdef_find_dir_c(const uint16_t *img, int32_t stride, int32_t *var,
+int32_t eb_cdef_find_dir_c(const uint16_t *img, int32_t stride, int32_t *var,
     int32_t coeff_shift) {
     int32_t i;
     int32_t cost[8] = { 0 };
@@ -193,19 +193,19 @@ int32_t cdef_find_dir_c(const uint16_t *img, int32_t stride, int32_t *var,
     return best_dir;
 }
 
-const int32_t cdef_pri_taps[2][2] = { { 4, 2 }, { 3, 3 } };
-const int32_t cdef_sec_taps[2][2] = { { 2, 1 }, { 2, 1 } };
+const int32_t eb_cdef_pri_taps[2][2] = { { 4, 2 }, { 3, 3 } };
+const int32_t eb_cdef_sec_taps[2][2] = { { 2, 1 }, { 2, 1 } };
 
 /* Smooth in the direction detected. */
-void cdef_filter_block_c(uint8_t *dst8, uint16_t *dst16, int32_t dstride,
+void eb_cdef_filter_block_c(uint8_t *dst8, uint16_t *dst16, int32_t dstride,
     const uint16_t *in, int32_t pri_strength, int32_t sec_strength,
     int32_t dir, int32_t pri_damping, int32_t sec_damping, int32_t bsize,
     /*AOM_UNUSED*/ int32_t max_unused, int32_t coeff_shift) {
     (void)max_unused;
     int32_t i, j, k;
     const int32_t s = CDEF_BSTRIDE;
-    const int32_t *pri_taps = cdef_pri_taps[(pri_strength >> coeff_shift) & 1];
-    const int32_t *sec_taps = cdef_sec_taps[(pri_strength >> coeff_shift) & 1];
+    const int32_t *pri_taps = eb_cdef_pri_taps[(pri_strength >> coeff_shift) & 1];
+    const int32_t *sec_taps = eb_cdef_sec_taps[(pri_strength >> coeff_shift) & 1];
 
     for (i = 0; i < (4 << (int32_t)(bsize == BLOCK_8X8 || bsize == BLOCK_4X8)); i++) {
         for (j = 0; j < (4 << (int32_t)(bsize == BLOCK_8X8 || bsize == BLOCK_8X4)); j++) {
@@ -215,18 +215,18 @@ void cdef_filter_block_c(uint8_t *dst8, uint16_t *dst16, int32_t dstride,
             int32_t max = x;
             int32_t min = x;
             for (k = 0; k < 2; k++) {
-                int16_t p0 = in[i * s + j + cdef_directions[dir][k]];
-                int16_t p1 = in[i * s + j - cdef_directions[dir][k]];
+                int16_t p0 = in[i * s + j + eb_cdef_directions[dir][k]];
+                int16_t p1 = in[i * s + j - eb_cdef_directions[dir][k]];
                 sum += (int16_t)(pri_taps[k] * constrain(p0 - x, pri_strength, pri_damping));
                 sum += (int16_t)(pri_taps[k] * constrain(p1 - x, pri_strength, pri_damping));
                 if (p0 != CDEF_VERY_LARGE) max = AOMMAX(p0, max);
                 if (p1 != CDEF_VERY_LARGE) max = AOMMAX(p1, max);
                 min = AOMMIN(p0, min);
                 min = AOMMIN(p1, min);
-                int16_t s0 = in[i * s + j + cdef_directions[(dir + 2) & 7][k]];
-                int16_t s1 = in[i * s + j - cdef_directions[(dir + 2) & 7][k]];
-                int16_t s2 = in[i * s + j + cdef_directions[(dir + 6) & 7][k]];
-                int16_t s3 = in[i * s + j - cdef_directions[(dir + 6) & 7][k]];
+                int16_t s0 = in[i * s + j + eb_cdef_directions[(dir + 2) & 7][k]];
+                int16_t s1 = in[i * s + j - eb_cdef_directions[(dir + 2) & 7][k]];
+                int16_t s2 = in[i * s + j + eb_cdef_directions[(dir + 6) & 7][k]];
+                int16_t s3 = in[i * s + j - eb_cdef_directions[(dir + 6) & 7][k]];
                 if (s0 != CDEF_VERY_LARGE) max = AOMMAX(s0, max);
                 if (s1 != CDEF_VERY_LARGE) max = AOMMAX(s1, max);
                 if (s2 != CDEF_VERY_LARGE) max = AOMMAX(s2, max);
@@ -265,7 +265,7 @@ static INLINE int32_t adjust_strength(int32_t strength, int32_t var) {
     return var ? (strength * (4 + i) + 8) >> 4 : 0;
 }
 
-void cdef_filter_fb(uint8_t *dst8, uint16_t *dst16, int32_t dstride, uint16_t *in,
+void eb_cdef_filter_fb(uint8_t *dst8, uint16_t *dst16, int32_t dstride, uint16_t *in,
     int32_t xdec, int32_t ydec, int32_t dir[CDEF_NBLOCKS][CDEF_NBLOCKS],
     int32_t *dirinit, int32_t var[CDEF_NBLOCKS][CDEF_NBLOCKS], int32_t pli,
     cdef_list *dlist, int32_t cdef_count, int32_t level,
@@ -287,8 +287,8 @@ void cdef_filter_fb(uint8_t *dst8, uint16_t *dst16, int32_t dstride, uint16_t *i
     if (dirinit && pri_strength == 0 && sec_strength == 0) {
         // If we're here, both primary and secondary strengths are 0, and
         // we still haven't written anything to y[] yet, so we just copy
-        // the input to y[]. This is necessary only for av1_cdef_search()
-        // and only av1_cdef_search() sets dirinit.
+        // the input to y[]. This is necessary only for eb_av1_cdef_search()
+        // and only eb_av1_cdef_search() sets dirinit.
         for (bi = 0; bi < cdef_count; bi++) {
             by = dlist[bi].by;
             bx = dlist[bi].bx;
@@ -308,7 +308,7 @@ void cdef_filter_fb(uint8_t *dst8, uint16_t *dst16, int32_t dstride, uint16_t *i
                 by = dlist[bi].by;
                 bx = dlist[bi].bx;
 
-                dir[by][bx] = cdef_find_dir(&in[8 * by * CDEF_BSTRIDE + 8 * bx],
+                dir[by][bx] = eb_cdef_find_dir(&in[8 * by * CDEF_BSTRIDE + 8 * bx],
                     CDEF_BSTRIDE, &var[by][bx], coeff_shift);
             }
             if (dirinit) *dirinit = 1;
@@ -330,14 +330,14 @@ void cdef_filter_fb(uint8_t *dst8, uint16_t *dst16, int32_t dstride, uint16_t *i
         by = dlist[bi].by;
         bx = dlist[bi].bx;
         if (dst8)
-            cdef_filter_block(&dst8[(by << bsizey) * dstride + (bx << bsizex)], NULL,
+            eb_cdef_filter_block(&dst8[(by << bsizey) * dstride + (bx << bsizex)], NULL,
                 dstride,
                 &in[(by * CDEF_BSTRIDE << bsizey) + (bx << bsizex)],
                 (pli ? t : adjust_strength(t, var[by][bx])), s,
                 t ? dir[by][bx] : 0, pri_damping, sec_damping, bsize,
                 (256 << coeff_shift) - 1, coeff_shift);
         else
-            cdef_filter_block(
+            eb_cdef_filter_block(
                 NULL,
                 &dst16[dirinit ? bi << (bsizex + bsizey)
                 : (by << bsizey) * dstride + (bx << bsizex)],
@@ -349,7 +349,7 @@ void cdef_filter_fb(uint8_t *dst8, uint16_t *dst16, int32_t dstride, uint16_t *i
     }
 }
 
-int32_t sb_all_skip(PictureControlSet   *picture_control_set_ptr, const Av1Common *const cm, int32_t mi_row, int32_t mi_col) {
+int32_t eb_sb_all_skip(PictureControlSet   *picture_control_set_ptr, const Av1Common *const cm, int32_t mi_row, int32_t mi_col) {
     int32_t maxc, maxr;
     int32_t skip = 1;
     maxc = cm->mi_cols - mi_col;
@@ -379,7 +379,7 @@ static int32_t is_8x8_block_skip(ModeInfo **grid, int32_t mi_row, int32_t mi_col
     return is_skip;
 }
 
-int32_t sb_compute_cdef_list(PictureControlSet            *picture_control_set_ptr, const Av1Common *const cm, int32_t mi_row, int32_t mi_col,
+int32_t eb_sb_compute_cdef_list(PictureControlSet            *picture_control_set_ptr, const Av1Common *const cm, int32_t mi_row, int32_t mi_col,
     cdef_list *dlist, BlockSize bs)
 {
     //MbModeInfo **grid = cm->mi_grid_visible;
@@ -419,7 +419,7 @@ int32_t sb_compute_cdef_list(PictureControlSet            *picture_control_set_p
     }
     return count;
 }
-void copy_rect8_8bit_to_16bit_c(uint16_t *dst, int32_t dstride, const uint8_t *src,
+void eb_copy_rect8_8bit_to_16bit_c(uint16_t *dst, int32_t dstride, const uint8_t *src,
     int32_t sstride, int32_t v, int32_t h) {
     for (int32_t i = 0; i < v; i++) {
         for (int32_t j = 0; j < h; j++)
@@ -433,7 +433,7 @@ static void copy_sb8_16(uint16_t *dst, int32_t dstride,
         {
             const uint8_t *base = &src[src_voffset * sstride + src_hoffset];
 
-            copy_rect8_8bit_to_16bit(dst, dstride, base, sstride, vsize, hsize);
+            eb_copy_rect8_8bit_to_16bit(dst, dstride, base, sstride, vsize, hsize);
         }
 }
 
@@ -453,7 +453,7 @@ static INLINE void copy_rect(uint16_t *dst, int32_t dstride, const uint16_t *src
     }
 }
 
-void av1_cdef_frame(
+void eb_av1_cdef_frame(
     EncDecContext                *context_ptr,
     SequenceControlSet           *sequence_control_set_ptr,
     PictureControlSet            *pCs){
@@ -490,8 +490,8 @@ void av1_cdef_frame(
     int32_t coeff_shift = AOMMAX(sequence_control_set_ptr->static_config.encoder_bit_depth/*cm->bit_depth*/ - 8, 0);
     const int32_t nvfb = (cm->mi_rows + MI_SIZE_64X64 - 1) / MI_SIZE_64X64;
     const int32_t nhfb = (cm->mi_cols + MI_SIZE_64X64 - 1) / MI_SIZE_64X64;
-    //av1_setup_dst_planes(xd->plane, cm->seq_params.sb_size, frame, 0, 0, 0, num_planes);
-    row_cdef = (uint8_t *)aom_malloc(sizeof(*row_cdef) * (nhfb + 2) * 2);
+    //eb_av1_setup_dst_planes(xd->plane, cm->seq_params.sb_size, frame, 0, 0, 0, num_planes);
+    row_cdef = (uint8_t *)eb_aom_malloc(sizeof(*row_cdef) * (nhfb + 2) * 2);
     assert(row_cdef != NULL);
     memset(row_cdef, 1, sizeof(*row_cdef) * (nhfb + 2) * 2);
     prev_row_cdef = row_cdef + 1;
@@ -508,8 +508,8 @@ void av1_cdef_frame(
 
     const int32_t stride = (cm->mi_cols << MI_SIZE_LOG2) + 2 * CDEF_HBORDER;
     for (int32_t pli = 0; pli < num_planes; pli++) {
-        linebuf[pli] = (uint16_t *)aom_malloc(sizeof(*linebuf) * CDEF_VBORDER * stride);
-        colbuf[pli] = (uint16_t *)aom_malloc(sizeof(*colbuf)  * ((CDEF_BLOCKSIZE << mi_high_l2[pli]) + 2 * CDEF_VBORDER) * CDEF_HBORDER);
+        linebuf[pli] = (uint16_t *)eb_aom_malloc(sizeof(*linebuf) * CDEF_VBORDER * stride);
+        colbuf[pli] = (uint16_t *)eb_aom_malloc(sizeof(*colbuf)  * ((CDEF_BLOCKSIZE << mi_high_l2[pli]) + 2 * CDEF_VBORDER) * CDEF_HBORDER);
     }
 
     for (int32_t fbr = 0; fbr < nvfb; fbr++) {
@@ -574,7 +574,7 @@ void av1_cdef_frame(
             uv_sec_strength = frm_hdr->CDEF_params.cdef_uv_strength[mbmi_cdef_strength] % CDEF_SEC_STRENGTHS;
             uv_sec_strength += uv_sec_strength == 3;
             if ((level == 0 && sec_strength == 0 && uv_level == 0 && uv_sec_strength == 0) ||
-                (cdef_count = sb_compute_cdef_list(pCs, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64, dlist, BLOCK_64X64)) == 0) {
+                (cdef_count = eb_sb_compute_cdef_list(pCs, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64, dlist, BLOCK_64X64)) == 0) {
                 cdef_left = 0;
                 continue;
             }
@@ -732,7 +732,7 @@ void av1_cdef_frame(
                 }
 
                 //if (cm->use_highbitdepth) {
-                //  cdef_filter_fb(
+                //  eb_cdef_filter_fb(
                 //      NULL,
                 //      &CONVERT_TO_SHORTPTR(
                 //          xd->plane[pli]
@@ -745,7 +745,7 @@ void av1_cdef_frame(
                 //      sec_strength, pri_damping, sec_damping, coeff_shift);
                 //} else
                 {
-                    cdef_filter_fb(
+                    eb_cdef_filter_fb(
                         &recBuff[recStride *(MI_SIZE_64X64 * fbr << mi_high_l2[pli]) + (fbc * MI_SIZE_64X64 << mi_wide_l2[pli])],
                         //&xd->plane[pli].dst.buf[xd->plane[pli].dst.stride *(MI_SIZE_64X64 * fbr << mi_high_l2[pli]) +(fbc * MI_SIZE_64X64 << mi_wide_l2[pli])],
                         NULL, recStride/*xd->plane[pli].dst.stride*/,
@@ -762,10 +762,10 @@ void av1_cdef_frame(
             curr_row_cdef = tmp;
         }
     }
-    aom_free(row_cdef);
+    eb_aom_free(row_cdef);
     for (int32_t pli = 0; pli < num_planes; pli++) {
-        aom_free(linebuf[pli]);
-        aom_free(colbuf[pli]);
+        eb_aom_free(linebuf[pli]);
+        eb_aom_free(colbuf[pli]);
     }
 }
 
@@ -806,8 +806,8 @@ void av1_cdef_frame16bit(
     int32_t coeff_shift = AOMMAX(sequence_control_set_ptr->static_config.encoder_bit_depth/*cm->bit_depth*/ - 8, 0);
     const int32_t nvfb = (cm->mi_rows + MI_SIZE_64X64 - 1) / MI_SIZE_64X64;
     const int32_t nhfb = (cm->mi_cols + MI_SIZE_64X64 - 1) / MI_SIZE_64X64;
-    //av1_setup_dst_planes(xd->plane, cm->seq_params.sb_size, frame, 0, 0, 0, num_planes);
-    row_cdef = (uint8_t *)aom_malloc(sizeof(*row_cdef) * (nhfb + 2) * 2);
+    //eb_av1_setup_dst_planes(xd->plane, cm->seq_params.sb_size, frame, 0, 0, 0, num_planes);
+    row_cdef = (uint8_t *)eb_aom_malloc(sizeof(*row_cdef) * (nhfb + 2) * 2);
     assert(row_cdef);
     memset(row_cdef, 1, sizeof(*row_cdef) * (nhfb + 2) * 2);
     prev_row_cdef = row_cdef + 1;
@@ -824,8 +824,8 @@ void av1_cdef_frame16bit(
 
     const int32_t stride = (cm->mi_cols << MI_SIZE_LOG2) + 2 * CDEF_HBORDER;
     for (int32_t pli = 0; pli < num_planes; pli++) {
-        linebuf[pli] = (uint16_t *)aom_malloc(sizeof(*linebuf) * CDEF_VBORDER * stride);
-        colbuf[pli] = (uint16_t *)aom_malloc(sizeof(*colbuf)  * ((CDEF_BLOCKSIZE << mi_high_l2[pli]) + 2 * CDEF_VBORDER) * CDEF_HBORDER);
+        linebuf[pli] = (uint16_t *)eb_aom_malloc(sizeof(*linebuf) * CDEF_VBORDER * stride);
+        colbuf[pli] = (uint16_t *)eb_aom_malloc(sizeof(*colbuf)  * ((CDEF_BLOCKSIZE << mi_high_l2[pli]) + 2 * CDEF_VBORDER) * CDEF_HBORDER);
     }
 
     for (int32_t fbr = 0; fbr < nvfb; fbr++) {
@@ -890,7 +890,7 @@ void av1_cdef_frame16bit(
             uv_sec_strength = frm_hdr->CDEF_params.cdef_uv_strength[mbmi_cdef_strength] % CDEF_SEC_STRENGTHS;
             uv_sec_strength += uv_sec_strength == 3;
             if ((level == 0 && sec_strength == 0 && uv_level == 0 && uv_sec_strength == 0) ||
-                (cdef_count = sb_compute_cdef_list(pCs, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64, dlist, BLOCK_64X64)) == 0) {
+                (cdef_count = eb_sb_compute_cdef_list(pCs, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64, dlist, BLOCK_64X64)) == 0) {
                 cdef_left = 0;
                 continue;
             }
@@ -1049,7 +1049,7 @@ void av1_cdef_frame16bit(
                 }
 
                 //if (cm->use_highbitdepth) {
-                //  cdef_filter_fb(
+                //  eb_cdef_filter_fb(
                 //      NULL,
                 //      &CONVERT_TO_SHORTPTR(
                 //          xd->plane[pli]
@@ -1062,7 +1062,7 @@ void av1_cdef_frame16bit(
                 //      sec_strength, pri_damping, sec_damping, coeff_shift);
                 //} else
                 {
-                    cdef_filter_fb(
+                    eb_cdef_filter_fb(
                         NULL,
                         &recBuff[recStride *(MI_SIZE_64X64 * fbr << mi_high_l2[pli]) + (fbc * MI_SIZE_64X64 << mi_wide_l2[pli])],
                         //&xd->plane[pli].dst.buf[xd->plane[pli].dst.stride *(MI_SIZE_64X64 * fbr << mi_high_l2[pli]) +(fbc * MI_SIZE_64X64 << mi_wide_l2[pli])],
@@ -1080,10 +1080,10 @@ void av1_cdef_frame16bit(
             curr_row_cdef = tmp;
         }
     }
-    aom_free(row_cdef);
+    eb_aom_free(row_cdef);
     for (int32_t pli = 0; pli < num_planes; pli++) {
-        aom_free(linebuf[pli]);
-        aom_free(colbuf[pli]);
+        eb_aom_free(linebuf[pli]);
+        eb_aom_free(colbuf[pli]);
     }
 }
 
@@ -1385,7 +1385,7 @@ void finish_cdef_search(
     const int32_t num_planes = 3;
 
     quantizer =
-        av1_ac_quant_Q3(frm_hdr->quantization_params.base_q_idx, 0, (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth) >> (sequence_control_set_ptr->static_config.encoder_bit_depth - 8);
+        eb_av1_ac_quant_Q3(frm_hdr->quantization_params.base_q_idx, 0, (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth) >> (sequence_control_set_ptr->static_config.encoder_bit_depth - 8);
     lambda = .12 * quantizer * quantizer / 256.;
 
     mse[0] = (uint64_t(*)[64])malloc(sizeof(**mse) * nvfb * nhfb);
@@ -1406,7 +1406,7 @@ void finish_cdef_search(
             }
 
             // No filtering if the entire filter block is skipped
-            if (sb_all_skip(picture_control_set_ptr, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64))
+            if (eb_sb_all_skip(picture_control_set_ptr, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64))
                 continue;
 
             for (pli = 0; pli < num_planes; pli++) {
@@ -1507,7 +1507,7 @@ void finish_cdef_search(
     free(selected_strength);
 }
 
-void av1_cdef_search(
+void eb_av1_cdef_search(
     EncDecContext                *context_ptr,
     SequenceControlSet           *sequence_control_set_ptr,
     PictureControlSet            *picture_control_set_ptr
@@ -1567,8 +1567,8 @@ void av1_cdef_search(
     int32_t nvfb = (mi_rows /*cm->mi_rows*/ + MI_SIZE_64X64 - 1) / MI_SIZE_64X64;
     int32_t nhfb = (mi_cols/*cm->mi_cols*/ + MI_SIZE_64X64 - 1) / MI_SIZE_64X64;
 
-    int32_t *sb_index = (int32_t *)aom_malloc(nvfb * nhfb * sizeof(*sb_index));       //CHKN add cast
-    int32_t *selected_strength = (int32_t *)aom_malloc(nvfb * nhfb * sizeof(*sb_index));
+    int32_t *sb_index = (int32_t *)eb_aom_malloc(nvfb * nhfb * sizeof(*sb_index));       //CHKN add cast
+    int32_t *selected_strength = (int32_t *)eb_aom_malloc(nvfb * nhfb * sizeof(*sb_index));
 
     assert(sb_index != NULL);
     assert(selected_strength != NULL);
@@ -1596,13 +1596,13 @@ void av1_cdef_search(
 
     quantizer =
         //CHKN av1_ac_quant_Q3(cm->quant_param.base_q_idx, 0, cm->bit_depth) >> (cm->bit_depth - 8);
-        av1_ac_quant_Q3(frm_hdr->quantization_params.base_q_idx, 0, (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth) >> (sequence_control_set_ptr->static_config.encoder_bit_depth - 8);
+        eb_av1_ac_quant_Q3(frm_hdr->quantization_params.base_q_idx, 0, (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth) >> (sequence_control_set_ptr->static_config.encoder_bit_depth - 8);
     lambda = .12 * quantizer * quantizer / 256.;
 
-    //av1_setup_dst_planes(xd->plane, cm->seq_params.sb_size, frame, 0, 0, 0,    num_planes);
+    //eb_av1_setup_dst_planes(xd->plane, cm->seq_params.sb_size, frame, 0, 0, 0,    num_planes);
 
-    mse[0] = (uint64_t(*)[64])aom_malloc(sizeof(**mse) * nvfb * nhfb);
-    mse[1] = (uint64_t(*)[64])aom_malloc(sizeof(**mse) * nvfb * nhfb);
+    mse[0] = (uint64_t(*)[64])eb_aom_malloc(sizeof(**mse) * nvfb * nhfb);
+    mse[1] = (uint64_t(*)[64])eb_aom_malloc(sizeof(**mse) * nvfb * nhfb);
 
     for (pli = 0; pli < num_planes; pli++) {
         uint8_t *in_buffer = 0;
@@ -1632,8 +1632,8 @@ void av1_cdef_search(
         }
 
         ///CHKN: allocate one frame 16bit for src and recon!!
-        src[pli] = (uint16_t*)aom_memalign(32, sizeof(*src)       * mi_rows * mi_cols * MI_SIZE * MI_SIZE);
-        ref_coeff[pli] = (uint16_t*)aom_memalign(32, sizeof(*ref_coeff) * mi_rows * mi_cols * MI_SIZE * MI_SIZE);
+        src[pli] = (uint16_t*)eb_aom_memalign(32, sizeof(*src)       * mi_rows * mi_cols * MI_SIZE * MI_SIZE);
+        ref_coeff[pli] = (uint16_t*)eb_aom_memalign(32, sizeof(*ref_coeff) * mi_rows * mi_cols * MI_SIZE * MI_SIZE);
 
         int32_t subsampling_x = (pli == 0) ? 0 : 1;
         int32_t subsampling_y = (pli == 0) ? 0 : 1;
@@ -1704,10 +1704,10 @@ void av1_cdef_search(
             }
 
             // No filtering if the entire filter block is skipped
-            if (sb_all_skip(picture_control_set_ptr, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64))
+            if (eb_sb_all_skip(picture_control_set_ptr, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64))
                 continue;
 
-            cdef_count = sb_compute_cdef_list(picture_control_set_ptr, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64, dlist, bs);
+            cdef_count = eb_sb_compute_cdef_list(picture_control_set_ptr, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64, dlist, bs);
 
             for (pli = 0; pli < num_planes; pli++) {
                 for (i = 0; i < CDEF_INBUF_SIZE; i++)
@@ -1733,12 +1733,12 @@ void av1_cdef_search(
                     /* We avoid filtering the pixels for which some of the pixels to
                     average are outside the frame. We could change the filter instead, but it would add special cases for any future vectorization. */
                     sec_strength = gi % CDEF_SEC_STRENGTHS;
-                    cdef_filter_fb(NULL, tmp_dst, CDEF_BSTRIDE, in, xdec[pli], ydec[pli],
+                    eb_cdef_filter_fb(NULL, tmp_dst, CDEF_BSTRIDE, in, xdec[pli], ydec[pli],
                         dir, &dirinit, var, pli, dlist, cdef_count, threshold,
                         sec_strength + (sec_strength == 3), pri_damping,
                         sec_damping, coeff_shift);
 
-                    curr_mse = compute_cdef_dist(
+                    curr_mse = eb_compute_cdef_dist(
                         ref_coeff[pli] +
                         (fbr * MI_SIZE_64X64 << mi_high_l2[pli]) * stride[pli] +
                         (fbc * MI_SIZE_64X64 << mi_wide_l2[pli]),
@@ -1834,14 +1834,14 @@ void av1_cdef_search(
     //pPcs->cdef_pri_damping = pri_damping;
     //pPcs->cdef_sec_damping = sec_damping;
 
-    aom_free(mse[0]);
-    aom_free(mse[1]);
+    eb_aom_free(mse[0]);
+    eb_aom_free(mse[1]);
     for (pli = 0; pli < num_planes; pli++) {
-        aom_free(src[pli]);
-        aom_free(ref_coeff[pli]);
+        eb_aom_free(src[pli]);
+        eb_aom_free(ref_coeff[pli]);
     }
-    aom_free(sb_index);
-    aom_free(selected_strength);
+    eb_aom_free(sb_index);
+    eb_aom_free(selected_strength);
 }
 
 void av1_cdef_search16bit(
@@ -1904,8 +1904,8 @@ void av1_cdef_search16bit(
     int32_t nvfb = (mi_rows /*cm->mi_rows*/ + MI_SIZE_64X64 - 1) / MI_SIZE_64X64;
     int32_t nhfb = (mi_cols/*cm->mi_cols*/ + MI_SIZE_64X64 - 1) / MI_SIZE_64X64;
 
-    int32_t *sb_index = (int32_t *)aom_malloc(nvfb * nhfb * sizeof(*sb_index));       //CHKN add cast
-    int32_t *selected_strength = (int32_t *)aom_malloc(nvfb * nhfb * sizeof(*sb_index));
+    int32_t *sb_index = (int32_t *)eb_aom_malloc(nvfb * nhfb * sizeof(*sb_index));       //CHKN add cast
+    int32_t *selected_strength = (int32_t *)eb_aom_malloc(nvfb * nhfb * sizeof(*sb_index));
 
     assert(sb_index);
     assert(selected_strength);
@@ -1934,13 +1934,13 @@ void av1_cdef_search16bit(
 
     quantizer =
         //CHKN av1_ac_quant_Q3(cm->quant_param.base_q_idx, 0, cm->bit_depth) >> (cm->bit_depth - 8);
-        av1_ac_quant_Q3(frm_hdr->quantization_params.base_q_idx, 0, (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth) >> (sequence_control_set_ptr->static_config.encoder_bit_depth - 8);
+        eb_av1_ac_quant_Q3(frm_hdr->quantization_params.base_q_idx, 0, (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth) >> (sequence_control_set_ptr->static_config.encoder_bit_depth - 8);
     lambda = .12 * quantizer * quantizer / 256.;
 
-    //av1_setup_dst_planes(xd->plane, cm->seq_params.sb_size, frame, 0, 0, 0,    num_planes);
+    //eb_av1_setup_dst_planes(xd->plane, cm->seq_params.sb_size, frame, 0, 0, 0,    num_planes);
 
-    mse[0] = (uint64_t(*)[64])aom_malloc(sizeof(**mse) * nvfb * nhfb);
-    mse[1] = (uint64_t(*)[64])aom_malloc(sizeof(**mse) * nvfb * nhfb);
+    mse[0] = (uint64_t(*)[64])eb_aom_malloc(sizeof(**mse) * nvfb * nhfb);
+    mse[1] = (uint64_t(*)[64])eb_aom_malloc(sizeof(**mse) * nvfb * nhfb);
 
     for (pli = 0; pli < num_planes; pli++) {
         uint16_t *in_buffer = 0;
@@ -1970,8 +1970,8 @@ void av1_cdef_search16bit(
         }
 
         ///CHKN: allocate one frame 16bit for src and recon!!
-        src[pli] = (uint16_t*)aom_memalign(32, sizeof(*src)       * mi_rows * mi_cols * MI_SIZE * MI_SIZE);
-        ref_coeff[pli] = (uint16_t*)aom_memalign(32, sizeof(*ref_coeff) * mi_rows * mi_cols * MI_SIZE * MI_SIZE);
+        src[pli] = (uint16_t*)eb_aom_memalign(32, sizeof(*src)       * mi_rows * mi_cols * MI_SIZE * MI_SIZE);
+        ref_coeff[pli] = (uint16_t*)eb_aom_memalign(32, sizeof(*ref_coeff) * mi_rows * mi_cols * MI_SIZE * MI_SIZE);
 
         int32_t subsampling_x = (pli == 0) ? 0 : 1;
         int32_t subsampling_y = (pli == 0) ? 0 : 1;
@@ -2042,10 +2042,10 @@ void av1_cdef_search16bit(
             }
 
             // No filtering if the entire filter block is skipped
-            if (sb_all_skip(picture_control_set_ptr, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64))
+            if (eb_sb_all_skip(picture_control_set_ptr, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64))
                 continue;
 
-            cdef_count = sb_compute_cdef_list(picture_control_set_ptr, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64, dlist, bs);
+            cdef_count = eb_sb_compute_cdef_list(picture_control_set_ptr, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64, dlist, bs);
 
             for (pli = 0; pli < num_planes; pli++) {
                 for (i = 0; i < CDEF_INBUF_SIZE; i++)
@@ -2071,12 +2071,12 @@ void av1_cdef_search16bit(
                         (fbc * MI_SIZE_64X64 << mi_wide_l2[pli]) - xoff,
                         stride[pli], ysize, xsize);
 
-                    cdef_filter_fb(NULL, tmp_dst, CDEF_BSTRIDE, in, xdec[pli], ydec[pli],
+                    eb_cdef_filter_fb(NULL, tmp_dst, CDEF_BSTRIDE, in, xdec[pli], ydec[pli],
                         dir, &dirinit, var, pli, dlist, cdef_count, threshold,
                         sec_strength + (sec_strength == 3), pri_damping,
                         sec_damping, coeff_shift);
 
-                    curr_mse = compute_cdef_dist(
+                    curr_mse = eb_compute_cdef_dist(
                         ref_coeff[pli] +
                         (fbr * MI_SIZE_64X64 << mi_high_l2[pli]) * stride[pli] +
                         (fbc * MI_SIZE_64X64 << mi_wide_l2[pli]),
@@ -2177,12 +2177,12 @@ void av1_cdef_search16bit(
         best_frame_gi_cnt += selected_strength_cnt[i] > best_frame_gi_cnt ? 1 : 0;
     pPcs->cdef_frame_strength = ((best_frame_gi_cnt + 4) / 4) * 4;
 
-    aom_free(mse[0]);
-    aom_free(mse[1]);
+    eb_aom_free(mse[0]);
+    eb_aom_free(mse[1]);
     for (pli = 0; pli < num_planes; pli++) {
-        aom_free(src[pli]);
-        aom_free(ref_coeff[pli]);
+        eb_aom_free(src[pli]);
+        eb_aom_free(ref_coeff[pli]);
     }
-    aom_free(sb_index);
-    aom_free(selected_strength);
+    eb_aom_free(sb_index);
+    eb_aom_free(selected_strength);
 }

--- a/Source/Lib/Common/Codec/EbCdef.h
+++ b/Source/Lib/Common/Codec/EbCdef.h
@@ -40,9 +40,9 @@ extern "C" {
 #define CDEF_INBUF_SIZE \
   (CDEF_BSTRIDE * ((1 << MAX_SB_SIZE_LOG2) + 2 * CDEF_VBORDER))
 
-    extern const int32_t cdef_pri_taps[2][2];
-    extern const int32_t cdef_sec_taps[2][2];
-    DECLARE_ALIGNED(16, extern const int32_t, cdef_directions[8][2]);
+    extern const int32_t eb_cdef_pri_taps[2][2];
+    extern const int32_t eb_cdef_sec_taps[2][2];
+    DECLARE_ALIGNED(16, extern const int32_t, eb_cdef_directions[8][2]);
 
 #define REDUCED_PRI_STRENGTHS 8
 #define REDUCED_TOTAL_STRENGTHS (REDUCED_PRI_STRENGTHS * CDEF_SEC_STRENGTHS)
@@ -57,7 +57,7 @@ extern "C" {
     void copy_cdef_16bit_to_16bit(uint16_t *dst, int32_t dstride, uint16_t *src,
         cdef_list *dlist, int32_t cdef_count, int32_t bsize);
 
-    void cdef_filter_fb(uint8_t *dst8, uint16_t *dst16, int32_t dstride, uint16_t *in,
+    void eb_cdef_filter_fb(uint8_t *dst8, uint16_t *dst16, int32_t dstride, uint16_t *in,
         int32_t xdec, int32_t ydec, int32_t dir[CDEF_NBLOCKS][CDEF_NBLOCKS],
         int32_t *dirinit, int32_t var[CDEF_NBLOCKS][CDEF_NBLOCKS], int32_t pli,
         cdef_list *dlist, int32_t cdef_count, int32_t level,
@@ -67,13 +67,13 @@ extern "C" {
     int32_t get_cdef_gi_step(
         int8_t   cdef_filter_mode);
 
-    //int32_t sb_all_skip(const Av1Common *const cm, int32_t mi_row, int32_t mi_col);
-    //int32_t sb_compute_cdef_list(const Av1Common *const cm, int32_t mi_row, int32_t mi_col,
+    //int32_t eb_sb_all_skip(const Av1Common *const cm, int32_t mi_row, int32_t mi_col);
+    //int32_t eb_sb_compute_cdef_list(const Av1Common *const cm, int32_t mi_row, int32_t mi_col,
     //                         cdef_list *dlist, BlockSize bsize);
 
-    //void av1_cdef_frame(Yv12BufferConfig *frame, Av1Common *cm, MacroBlockD *xd);
+    //void eb_av1_cdef_frame(Yv12BufferConfig *frame, Av1Common *cm, MacroBlockD *xd);
     //
-    //void av1_cdef_search(Yv12BufferConfig *frame, const Yv12BufferConfig *ref,
+    //void eb_av1_cdef_search(Yv12BufferConfig *frame, const Yv12BufferConfig *ref,
     //                     Av1Common *cm, MacroBlockD *xd, int32_t fast);
 
 #ifdef __cplusplus

--- a/Source/Lib/Common/Codec/EbCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbCodingLoop.c
@@ -609,7 +609,7 @@ static void Av1EncodeLoop(
                 context_ptr->blk_geom->bheight_uv == context_ptr->blk_geom->bheight ? (context_ptr->blk_geom->bheight_uv << 1) : context_ptr->blk_geom->bheight);
             int32_t round_offset = ((context_ptr->blk_geom->tx_width_uv[cu_ptr->tx_depth][context_ptr->txb_itr])*(context_ptr->blk_geom->tx_height_uv[cu_ptr->tx_depth][context_ptr->txb_itr])) / 2;
 
-            subtract_average(
+            eb_subtract_average(
                 context_ptr->md_context->pred_buf_q3,
                 context_ptr->blk_geom->tx_width_uv[cu_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height_uv[cu_ptr->tx_depth][context_ptr->txb_itr],
@@ -676,7 +676,7 @@ static void Av1EncodeLoop(
                 //TOCHANGE
                 //assert(chroma_size * CFL_BUF_LINE + chroma_size <= CFL_BUF_SQUARE);
 
-                cfl_predict_lbd(
+                eb_cfl_predict_lbd(
                     context_ptr->md_context->pred_buf_q3,
                     predSamples->buffer_cb + pred_cb_offset,
                     predSamples->stride_cb,
@@ -692,7 +692,7 @@ static void Av1EncodeLoop(
                 //TOCHANGE
                 //assert(chroma_size * CFL_BUF_LINE + chroma_size <= CFL_BUF_SQUARE);
 
-                cfl_predict_lbd(
+                eb_cfl_predict_lbd(
                     context_ptr->md_context->pred_buf_q3,
                     predSamples->buffer_cr + pred_cr_offset,
                     predSamples->stride_cr,
@@ -1043,7 +1043,7 @@ static void Av1EncodeLoop16bit(
                 context_ptr->blk_geom->bheight_uv == context_ptr->blk_geom->bheight ? (context_ptr->blk_geom->bheight_uv << 1) : context_ptr->blk_geom->bheight);
             int32_t round_offset = ((context_ptr->blk_geom->tx_width_uv[cu_ptr->tx_depth][context_ptr->txb_itr])*(context_ptr->blk_geom->tx_height_uv[cu_ptr->tx_depth][context_ptr->txb_itr])) / 2;
 
-            subtract_average(
+            eb_subtract_average(
                 context_ptr->md_context->pred_buf_q3,
                 context_ptr->blk_geom->tx_width_uv[cu_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height_uv[cu_ptr->tx_depth][context_ptr->txb_itr],
@@ -1055,7 +1055,7 @@ static void Av1EncodeLoop16bit(
             // TOCHANGE
             // assert(chroma_size * CFL_BUF_LINE + chroma_size <=                CFL_BUF_SQUARE);
 
-            cfl_predict_hbd(
+            eb_cfl_predict_hbd(
                 context_ptr->md_context->pred_buf_q3,
                 ((uint16_t*)predSamples16bit->buffer_cb) + pred_cb_offset,
                 predSamples16bit->stride_cb,
@@ -1071,7 +1071,7 @@ static void Av1EncodeLoop16bit(
             // TOCHANGE
             //assert(chroma_size * CFL_BUF_LINE + chroma_size <=                CFL_BUF_SQUARE);
 
-            cfl_predict_hbd(
+            eb_cfl_predict_hbd(
                 context_ptr->md_context->pred_buf_q3,
                 ((uint16_t*)predSamples16bit->buffer_cr) + pred_cr_offset,
                 predSamples16bit->stride_cr,
@@ -1702,7 +1702,7 @@ void perform_intra_coding_loop(
 
             mode = cu_ptr->pred_mode;
 
-            av1_predict_intra_block_16bit(
+            eb_av1_predict_intra_block_16bit(
                 &sb_ptr->tile_info,
                 ED_STAGE,
                 context_ptr->blk_geom,
@@ -1748,7 +1748,7 @@ void perform_intra_coding_loop(
 
             // Hsan: if CHROMA_MODE_2, then CFL will be evaluated @ EP as no CHROMA @ MD
             // If that's the case then you should ensure than the 1st chroma prediction uses UV_DC_PRED (that's the default configuration for CHROMA_MODE_2 if CFL applicable (set @ fast loop candidates injection) then MD assumes chroma mode always UV_DC_PRED)
-            av1_predict_intra_block(
+            eb_av1_predict_intra_block(
                 &sb_ptr->tile_info,
                 ED_STAGE,
                 context_ptr->blk_geom,
@@ -1953,7 +1953,7 @@ void perform_intra_coding_loop(
 
                 mode = (pu_ptr->intra_chroma_mode == UV_CFL_PRED) ? (PredictionMode)UV_DC_PRED : (PredictionMode)pu_ptr->intra_chroma_mode;
 
-                av1_predict_intra_block_16bit(
+                eb_av1_predict_intra_block_16bit(
                     &sb_ptr->tile_info,
                     ED_STAGE,
                     context_ptr->blk_geom,
@@ -2017,7 +2017,7 @@ void perform_intra_coding_loop(
 
                 // Hsan: if CHROMA_MODE_2, then CFL will be evaluated @ EP as no CHROMA @ MD
                 // If that's the case then you should ensure than the 1st chroma prediction uses UV_DC_PRED (that's the default configuration for CHROMA_MODE_2 if CFL applicable (set @ fast loop candidates injection) then MD assumes chroma mode always UV_DC_PRED)
-                av1_predict_intra_block(
+                eb_av1_predict_intra_block(
                     &sb_ptr->tile_info,
                     ED_STAGE,
                     context_ptr->blk_geom,
@@ -2402,15 +2402,15 @@ EB_EXTERN void av1_encode_pass(
 #if AV1_LF
     if (dlfEnableFlag && picture_control_set_ptr->parent_pcs_ptr->loop_filter_mode == 1){
         if (tbAddr == 0) {
-            av1_loop_filter_init(picture_control_set_ptr);
+            eb_av1_loop_filter_init(picture_control_set_ptr);
 
-            av1_pick_filter_level(
+            eb_av1_pick_filter_level(
                 0,
                 (EbPictureBufferDesc*)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr,
                 picture_control_set_ptr,
                 LPF_PICK_FROM_Q);
 
-            av1_loop_filter_frame_init(picture_control_set_ptr, 0, 3);
+            eb_av1_loop_filter_frame_init(picture_control_set_ptr, 0, 3);
         }
     }
 #endif
@@ -2644,7 +2644,7 @@ EB_EXTERN void av1_encode_pass(
                                     picture_control_set_ptr);
 
                                 IntMv nearestmv, nearmv;
-                                av1_find_best_ref_mvs_from_stack(0, context_ptr->md_context->md_local_cu_unit[blk_geom->blkidx_mds].ed_ref_mv_stack, cu_ptr->av1xd, ref_frame, &nearestmv, &nearmv,
+                                eb_av1_find_best_ref_mvs_from_stack(0, context_ptr->md_context->md_local_cu_unit[blk_geom->blkidx_mds].ed_ref_mv_stack, cu_ptr->av1xd, ref_frame, &nearestmv, &nearmv,
                                     0);
 
                                 if (nearestmv.as_int == INVALID_MV)
@@ -2755,7 +2755,7 @@ EB_EXTERN void av1_encode_pass(
                                         mode = (pu_ptr->intra_chroma_mode == UV_CFL_PRED) ? (PredictionMode)UV_DC_PRED : (PredictionMode)pu_ptr->intra_chroma_mode;
                                     else
                                         mode = cu_ptr->pred_mode; //PredictionMode mode,
-                                    av1_predict_intra_block_16bit(
+                                    eb_av1_predict_intra_block_16bit(
                                         &sb_ptr->tile_info,
                                         ED_STAGE,
                                         context_ptr->blk_geom,
@@ -2830,7 +2830,7 @@ EB_EXTERN void av1_encode_pass(
                                         mode = cu_ptr->pred_mode; //PredictionMode mode,
                                     // Hsan: if CHROMA_MODE_2, then CFL will be evaluated @ EP as no CHROMA @ MD
                                     // If that's the case then you should ensure than the 1st chroma prediction uses UV_DC_PRED (that's the default configuration for CHROMA_MODE_2 if CFL applicable (set @ fast loop candidates injection) then MD assumes chroma mode always UV_DC_PRED)
-                                    av1_predict_intra_block(
+                                    eb_av1_predict_intra_block(
                                         &sb_ptr->tile_info,
                                         ED_STAGE,
                                         context_ptr->blk_geom,

--- a/Source/Lib/Common/Codec/EbDeblockingFilter.c
+++ b/Source/Lib/Common/Codec/EbDeblockingFilter.c
@@ -663,7 +663,7 @@ static uint8_t get_filter_level(
     }
 }
 
-void av1_loop_filter_init(PictureControlSet *pcs_ptr) {
+void eb_av1_loop_filter_init(PictureControlSet *pcs_ptr) {
     //assert(MB_MODE_COUNT == n_elements(mode_lf_lut));
     LoopFilterInfoN *lfi = &pcs_ptr->parent_pcs_ptr->lf_info;
     struct LoopFilter *lf = &pcs_ptr->parent_pcs_ptr->frm_hdr.loop_filter_params;
@@ -681,8 +681,8 @@ void av1_loop_filter_init(PictureControlSet *pcs_ptr) {
 
 // Update the loop filter for the current frame.
 // This should be called before loop_filter_rows(),
-// av1_loop_filter_frame() calls this function directly.
-void av1_loop_filter_frame_init(PictureControlSet *pcs_ptr, int32_t plane_start,
+// eb_av1_loop_filter_frame() calls this function directly.
+void eb_av1_loop_filter_frame_init(PictureControlSet *pcs_ptr, int32_t plane_start,
     int32_t plane_end) {
     int32_t filt_lvl[MAX_MB_PLANE], filt_lvl_r[MAX_MB_PLANE];
     int32_t plane;
@@ -783,7 +783,7 @@ static INLINE void setup_pred_plane(struct Buf2d *dst, BlockSize bsize,
     dst->height = height;
     dst->stride = stride;
 }
-void av1_setup_dst_planes(struct MacroblockdPlane *planes, BlockSize bsize,
+void eb_av1_setup_dst_planes(struct MacroblockdPlane *planes, BlockSize bsize,
     //const Yv12BufferConfig *src,
     const EbPictureBufferDesc *src,
     int32_t mi_row, int32_t mi_col,
@@ -996,7 +996,7 @@ static TxSize set_lpf_parameters(
     return ts;
 }
 
-void av1_filter_block_plane_vert(
+void eb_av1_filter_block_plane_vert(
     const PictureControlSet *const  pcs_ptr,
     const MacroBlockD *const xd, const int32_t plane,
     const MacroblockdPlane *const plane_ptr,
@@ -1117,7 +1117,7 @@ void av1_filter_block_plane_vert(
     }
 }
 
-void av1_filter_block_plane_horz(
+void eb_av1_filter_block_plane_horz(
     const PictureControlSet *const  pcs_ptr,
     const MacroBlockD *const xd, const int32_t plane,
     const MacroblockdPlane *const plane_ptr,
@@ -1290,47 +1290,47 @@ void loop_filter_sb(
         if (frm_hdr->loop_filter_params.combine_vert_horz_lf) {
             // filter all vertical and horizontal edges in every 64x64 super block
             // filter vertical edges
-            av1_setup_dst_planes(pd, pcs_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.sb_size, frame_buffer, mi_row,
+            eb_av1_setup_dst_planes(pd, pcs_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.sb_size, frame_buffer, mi_row,
                 mi_col, plane, plane + 1);
-            av1_filter_block_plane_vert(pcs_ptr, xd, plane, &pd[plane], mi_row,
+            eb_av1_filter_block_plane_vert(pcs_ptr, xd, plane, &pd[plane], mi_row,
                 mi_col);
             // filter horizontal edges
             int32_t max_mib_size = pcs_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128 ? MAX_MIB_SIZE : SB64_MIB_SIZE;
 
             if (mi_col - max_mib_size >= 0) {
-                av1_setup_dst_planes(pd, pcs_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.sb_size, frame_buffer,
+                eb_av1_setup_dst_planes(pd, pcs_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.sb_size, frame_buffer,
                     mi_row, mi_col - max_mib_size, plane,
                     plane + 1);
-                av1_filter_block_plane_horz(pcs_ptr, xd, plane, &pd[plane], mi_row,
+                eb_av1_filter_block_plane_horz(pcs_ptr, xd, plane, &pd[plane], mi_row,
                     mi_col - max_mib_size);
             }
             // Filter the horizontal edges of the last lcu in each row
             if (LastCol) {
-                av1_setup_dst_planes(pd, pcs_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.sb_size, frame_buffer,
+                eb_av1_setup_dst_planes(pd, pcs_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.sb_size, frame_buffer,
                     mi_row, mi_col, plane,
                     plane + 1);
-                av1_filter_block_plane_horz(pcs_ptr, xd, plane, &pd[plane], mi_row,
+                eb_av1_filter_block_plane_horz(pcs_ptr, xd, plane, &pd[plane], mi_row,
                     mi_col);
             }
         }
         else {
             // filter all vertical edges in every 64x64 super block
-            av1_setup_dst_planes(pd, pcs_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.sb_size, frame_buffer, mi_row,
+            eb_av1_setup_dst_planes(pd, pcs_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.sb_size, frame_buffer, mi_row,
                 mi_col, plane, plane + 1);
 
-            av1_filter_block_plane_vert(pcs_ptr, xd, plane, &pd[plane], mi_row,
+            eb_av1_filter_block_plane_vert(pcs_ptr, xd, plane, &pd[plane], mi_row,
                 mi_col);
 
             // filter all horizontal edges in every 64x64 super block
-            av1_setup_dst_planes(pd, pcs_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.sb_size, frame_buffer, mi_row,
+            eb_av1_setup_dst_planes(pd, pcs_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.sb_size, frame_buffer, mi_row,
                 mi_col, plane, plane + 1);
-            av1_filter_block_plane_horz(pcs_ptr, xd, plane, &pd[plane], mi_row,
+            eb_av1_filter_block_plane_horz(pcs_ptr, xd, plane, &pd[plane], mi_row,
                 mi_col);
         }
     }
 }
 
-void av1_loop_filter_frame(
+void eb_av1_loop_filter_frame(
     EbPictureBufferDesc *frame_buffer,
     PictureControlSet *picture_control_set_ptr,
     int32_t plane_start, int32_t plane_end) {
@@ -1346,7 +1346,7 @@ void av1_loop_filter_frame(
 
     uint32_t picture_width_in_sb = (scs_ptr->seq_header.max_frame_width + scs_ptr->sb_size_pix - 1) / scs_ptr->sb_size_pix;
     uint32_t picture_height_in_sb = (scs_ptr->seq_header.max_frame_height + scs_ptr->sb_size_pix - 1) / scs_ptr->sb_size_pix;
-    av1_loop_filter_frame_init(picture_control_set_ptr, plane_start, plane_end);
+    eb_av1_loop_filter_frame_init(picture_control_set_ptr, plane_start, plane_end);
 
     for (y_lcu_index = 0; y_lcu_index < picture_height_in_sb; ++y_lcu_index) {
         for (x_lcu_index = 0; x_lcu_index < picture_width_in_sb; ++x_lcu_index) {
@@ -1368,7 +1368,7 @@ void av1_loop_filter_frame(
         }
     }
 }
-extern int16_t av1_ac_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth);
+extern int16_t eb_av1_ac_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth);
 
 void EbCopyBuffer(
     EbPictureBufferDesc  *srcBuffer,
@@ -1636,7 +1636,7 @@ static int64_t try_filter_frame(
     case 2: frm_hdr->loop_filter_params.filter_level_v = filter_level[0]; break;
     }
 
-    av1_loop_filter_frame(recon_buffer, pcs_ptr, plane, plane + 1);
+    eb_av1_loop_filter_frame(recon_buffer, pcs_ptr, plane, plane + 1);
 
     filt_err = PictureSseCalculations(pcs_ptr, recon_buffer, plane);
 
@@ -1804,7 +1804,7 @@ static int32_t search_filter_level(
     return filt_best;
 }
 
-void av1_pick_filter_level(
+void eb_av1_pick_filter_level(
     DlfContext            *context_ptr,
     EbPictureBufferDesc   *srcBuffer, // source input
     PictureControlSet     *pcs_ptr,
@@ -1824,7 +1824,7 @@ void av1_pick_filter_level(
     else if (method >= LPF_PICK_FROM_Q) {
         const int32_t min_filter_level = 0;
         const int32_t max_filter_level = MAX_LOOP_FILTER;// av1_get_max_filter_level(cpi);
-        const int32_t q = av1_ac_quant_Q3(frm_hdr->quantization_params.base_q_idx, 0, (AomBitDepth)scs_ptr->static_config.encoder_bit_depth);
+        const int32_t q = eb_av1_ac_quant_Q3(frm_hdr->quantization_params.base_q_idx, 0, (AomBitDepth)scs_ptr->static_config.encoder_bit_depth);
         // These values were determined by linear fitting the result of the
         // searched level for 8 bit depth:
         // Keyframes: filt_guess = q * 0.06699 - 1.60817

--- a/Source/Lib/Common/Codec/EbDeblockingFilter.h
+++ b/Source/Lib/Common/Codec/EbDeblockingFilter.h
@@ -74,9 +74,9 @@ extern "C" {
     struct macroblockd;
     struct AV1LfSyncData;
 
-    void av1_loop_filter_init(PictureControlSet *pcs_ptr);
+    void eb_av1_loop_filter_init(PictureControlSet *pcs_ptr);
 
-    void av1_loop_filter_frame_init(PictureControlSet *pcs_ptr, int32_t plane_start,
+    void eb_av1_loop_filter_frame_init(PictureControlSet *pcs_ptr, int32_t plane_start,
         int32_t plane_end);
 
     void loop_filter_sb(
@@ -87,27 +87,27 @@ extern "C" {
         int32_t plane_start, int32_t plane_end,
         uint8_t LastCol);
 
-    void av1_loop_filter_frame(
+    void eb_av1_loop_filter_frame(
         EbPictureBufferDesc *frame_buffer,//reconpicture,
         //Yv12BufferConfig *frame_buffer,
         PictureControlSet *pcs_ptr,
         /*MacroBlockD *xd,*/ int32_t plane_start, int32_t plane_end/*,
         int32_t partial_frame*/);
 
-    void av1_pick_filter_level(
+    void eb_av1_pick_filter_level(
         DlfContext            *context_ptr,
         EbPictureBufferDesc   *srcBuffer, // source input
         PictureControlSet     *pcs_ptr,
         LpfPickMethod          method);
 
-    void av1_filter_block_plane_vert(
+    void eb_av1_filter_block_plane_vert(
         const PictureControlSet *const  pcs_ptr,
         const MacroBlockD *const xd,
         const int32_t plane,
         const MacroblockdPlane *const plane_ptr,
         const uint32_t mi_row, const uint32_t mi_col);
 
-    void av1_filter_block_plane_horz(
+    void eb_av1_filter_block_plane_horz(
         const PictureControlSet *const  pcs_ptr,
         const MacroBlockD *const xd, const int32_t plane,
         const MacroblockdPlane *const plane_ptr,

--- a/Source/Lib/Common/Codec/EbDlfProcess.c
+++ b/Source/Lib/Common/Codec/EbDlfProcess.c
@@ -23,7 +23,7 @@
 
 #include "EbDeblockingFilter.h"
 
-void av1_loop_restoration_save_boundary_lines(const Yv12BufferConfig *frame, Av1Common *cm, int32_t after_cdef);
+void eb_av1_loop_restoration_save_boundary_lines(const Yv12BufferConfig *frame, Av1Common *cm, int32_t after_cdef);
 
 static void dlf_context_dctor(EbPtr p)
 {
@@ -128,17 +128,17 @@ void* dlf_kernel(void *input_ptr)
             else  // non ref pictures
                 recon_buffer = is16bit ? picture_control_set_ptr->recon_picture16bit_ptr : picture_control_set_ptr->recon_picture_ptr;
 
-            av1_loop_filter_init(picture_control_set_ptr);
+            eb_av1_loop_filter_init(picture_control_set_ptr);
 
             if (picture_control_set_ptr->parent_pcs_ptr->loop_filter_mode == 2) {
-                av1_pick_filter_level(
+                eb_av1_pick_filter_level(
                     context_ptr,
                     (EbPictureBufferDesc*)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr,
                     picture_control_set_ptr,
                     LPF_PICK_FROM_Q);
             }
 
-            av1_pick_filter_level(
+            eb_av1_pick_filter_level(
                 context_ptr,
                 (EbPictureBufferDesc*)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr,
                 picture_control_set_ptr,
@@ -151,7 +151,7 @@ void* dlf_kernel(void *input_ptr)
             picture_control_set_ptr->parent_pcs_ptr->lf.filter_level_u = 0;
             picture_control_set_ptr->parent_pcs_ptr->lf.filter_level_v = 0;
 #endif
-                av1_loop_filter_frame(
+                eb_av1_loop_filter_frame(
                     recon_buffer,
                     picture_control_set_ptr,
                     0,
@@ -180,7 +180,7 @@ void* dlf_kernel(void *input_ptr)
                 cm->frame_to_show);
 
             if (sequence_control_set_ptr->seq_header.enable_restoration)
-                av1_loop_restoration_save_boundary_lines(cm->frame_to_show, cm, 0);
+                eb_av1_loop_restoration_save_boundary_lines(cm->frame_to_show, cm, 0);
             if (sequence_control_set_ptr->seq_header.enable_cdef && picture_control_set_ptr->parent_pcs_ptr->cdef_filter_mode)
             {
                 if (is16bit)

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -24,13 +24,13 @@
 #include "EbUtility.h"
 #include "grainSynthesis.h"
 
-void av1_cdef_search(
+void eb_av1_cdef_search(
     EncDecContext                *context_ptr,
     SequenceControlSet           *sequence_control_set_ptr,
     PictureControlSet            *picture_control_set_ptr
 );
 
-void av1_cdef_frame(
+void eb_av1_cdef_frame(
     EncDecContext                *context_ptr,
     SequenceControlSet           *sequence_control_set_ptr,
     PictureControlSet            *pCs
@@ -47,13 +47,13 @@ void av1_cdef_frame16bit(
     PictureControlSet            *pCs
 );
 
-void av1_add_film_grain(EbPictureBufferDesc *src,
+void eb_av1_add_film_grain(EbPictureBufferDesc *src,
     EbPictureBufferDesc *dst,
     aom_film_grain_t *film_grain_ptr);
 
-void av1_loop_restoration_save_boundary_lines(const Yv12BufferConfig *frame, Av1Common *cm, int32_t after_cdef);
-void av1_pick_filter_restoration(const Yv12BufferConfig *src, Yv12BufferConfig * trial_frame_rst /*Av1Comp *cpi*/, Macroblock *x, Av1Common *const cm);
-void av1_loop_restoration_filter_frame(Yv12BufferConfig *frame, Av1Common *cm, int32_t optimized_lr);
+void eb_av1_loop_restoration_save_boundary_lines(const Yv12BufferConfig *frame, Av1Common *cm, int32_t after_cdef);
+void eb_av1_pick_filter_restoration(const Yv12BufferConfig *src, Yv12BufferConfig * trial_frame_rst /*Av1Comp *cpi*/, Macroblock *x, Av1Common *const cm);
+void eb_av1_loop_restoration_filter_frame(Yv12BufferConfig *frame, Av1Common *cm, int32_t optimized_lr);
 
 const int16_t encMinDeltaQpWeightTab[MAX_TEMPORAL_LAYERS] = { 100, 100, 100, 100, 100, 100 };
 const int16_t encMaxDeltaQpWeightTab[MAX_TEMPORAL_LAYERS] = { 100, 100, 100, 100, 100, 100 };
@@ -589,7 +589,7 @@ void ReconOutput(
                 else
                     film_grain_ptr = &picture_control_set_ptr->parent_pcs_ptr->frm_hdr.film_grain_params;
 
-                av1_add_film_grain(recon_ptr, intermediateBufferPtr, film_grain_ptr);
+                eb_av1_add_film_grain(recon_ptr, intermediateBufferPtr, film_grain_ptr);
                 recon_ptr = intermediateBufferPtr;
             }
 
@@ -1703,7 +1703,7 @@ void* enc_dec_kernel(void *input_ptr)
     return EB_NULL;
 }
 
-void av1_add_film_grain(EbPictureBufferDesc *src,
+void eb_av1_add_film_grain(EbPictureBufferDesc *src,
     EbPictureBufferDesc *dst,
     aom_film_grain_t *film_grain_ptr) {
     uint8_t *luma, *cb, *cr;
@@ -1767,7 +1767,7 @@ void av1_add_film_grain(EbPictureBufferDesc *src,
     width = dst->width;
     height = dst->height;
 
-    av1_add_film_grain_run(&params, luma, cb, cr, height, width, luma_stride,
+    eb_av1_add_film_grain_run(&params, luma, cb, cr, height, width, luma_stride,
         chroma_stride, use_high_bit_depth, chroma_subsamp_y,
         chroma_subsamp_x);
     return;

--- a/Source/Lib/Common/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Common/Codec/EbEntropyCoding.c
@@ -33,7 +33,7 @@
 #define S8  8*8
 #define S4  4*4
 
-int32_t av1_loop_restoration_corners_in_sb(Av1Common *cm, int32_t plane,
+int32_t eb_av1_loop_restoration_corners_in_sb(Av1Common *cm, int32_t plane,
     int32_t mi_row, int32_t mi_col, BlockSize bsize,
     int32_t *rcol0, int32_t *rcol1, int32_t *rrow0,
     int32_t *rrow1, int32_t *tile_tl_idx);
@@ -57,7 +57,7 @@ int32_t is_inter_block(const MbModeInfo *mbmi);
 static INLINE int32_t is_comp_ref_allowed(BlockSize bsize) {
     return AOMMIN(block_size_wide[bsize], block_size_high[bsize]) >= 8;
 }
-int32_t av1_loop_restoration_corners_in_sb(Av1Common *cm, int32_t plane,
+int32_t eb_av1_loop_restoration_corners_in_sb(Av1Common *cm, int32_t plane,
     int32_t mi_row, int32_t mi_col, BlockSize bsize,
     int32_t *rcol0, int32_t *rcol1, int32_t *rrow0,
     int32_t *rrow1, int32_t *tile_tl_idx);
@@ -620,7 +620,7 @@ int32_t  Av1WriteCoeffsTxb1D(
         }
     }
 
-    av1_get_nz_map_contexts(levels, scan, eob, txSize, tx_type_to_class[txType], coeffContexts);
+    eb_av1_get_nz_map_contexts(levels, scan, eob, txSize, tx_type_to_class[txType], coeffContexts);
 
     for (c = eob - 1; c >= 0; --c) {
         const int16_t pos = scan[c];
@@ -1672,7 +1672,7 @@ EbErrorType reset_entropy_coder(
 
     (void)encode_context_ptr;
     (void)slice_type;
-    av1_default_coef_probs(entropy_coder_ptr->fc, qp);
+    eb_av1_default_coef_probs(entropy_coder_ptr->fc, qp);
     init_mode_probs(entropy_coder_ptr->fc);
 
     return return_error;
@@ -1788,7 +1788,7 @@ EbPtr entropy_coder_get_bitstream_ptr(
 static const size_t kMaximumLeb128Size = 8;
 static const uint64_t kMaximumLeb128Value = 0xFFFFFFFFFFFFFF;  // 2 ^ 56 - 1
 
-size_t aom_uleb_size_in_bytes(uint64_t value) {
+size_t eb_aom_uleb_size_in_bytes(uint64_t value) {
     size_t size = 0;
     do {
         ++size;
@@ -1796,9 +1796,9 @@ size_t aom_uleb_size_in_bytes(uint64_t value) {
     return size;
 }
 
-int32_t aom_uleb_encode(uint64_t value, size_t available, uint8_t *coded_value,
+int32_t eb_aom_uleb_encode(uint64_t value, size_t available, uint8_t *coded_value,
     size_t *coded_size) {
-    const size_t leb_size = aom_uleb_size_in_bytes(value);
+    const size_t leb_size = eb_aom_uleb_size_in_bytes(value);
     if (value > kMaximumLeb128Value || leb_size > kMaximumLeb128Size ||
         leb_size > available || !coded_value || !coded_size) {
         return -1;
@@ -1817,15 +1817,15 @@ int32_t aom_uleb_encode(uint64_t value, size_t available, uint8_t *coded_value,
     return 0;
 }
 
-int32_t aom_wb_is_byte_aligned(const struct AomWriteBitBuffer *wb) {
+int32_t eb_aom_wb_is_byte_aligned(const struct AomWriteBitBuffer *wb) {
     return (wb->bit_offset % CHAR_BIT == 0);
 }
 
-uint32_t aom_wb_bytes_written(const struct AomWriteBitBuffer *wb) {
+uint32_t eb_aom_wb_bytes_written(const struct AomWriteBitBuffer *wb) {
     return wb->bit_offset / CHAR_BIT + (wb->bit_offset % CHAR_BIT > 0);
 }
 
-void aom_wb_write_bit(struct AomWriteBitBuffer *wb, int32_t bit) {
+void eb_aom_wb_write_bit(struct AomWriteBitBuffer *wb, int32_t bit) {
     const int32_t off = (int32_t)wb->bit_offset;
     const int32_t p = off / CHAR_BIT;
     const int32_t q = CHAR_BIT - 1 - off % CHAR_BIT;
@@ -1840,7 +1840,7 @@ void aom_wb_write_bit(struct AomWriteBitBuffer *wb, int32_t bit) {
     wb->bit_offset = off + 1;
 }
 
-void aom_wb_overwrite_bit(struct AomWriteBitBuffer *wb, int32_t bit) {
+void eb_aom_wb_overwrite_bit(struct AomWriteBitBuffer *wb, int32_t bit) {
     // Do not zero bytes but overwrite exisiting values
     const int32_t off = (int32_t)wb->bit_offset;
     const int32_t p = off / CHAR_BIT;
@@ -1850,14 +1850,14 @@ void aom_wb_overwrite_bit(struct AomWriteBitBuffer *wb, int32_t bit) {
     wb->bit_offset = off + 1;
 }
 
-void aom_wb_write_literal(struct AomWriteBitBuffer *wb, int32_t data, int32_t bits) {
+void eb_aom_wb_write_literal(struct AomWriteBitBuffer *wb, int32_t data, int32_t bits) {
     int32_t bit;
-    for (bit = bits - 1; bit >= 0; bit--) aom_wb_write_bit(wb, (data >> bit) & 1);
+    for (bit = bits - 1; bit >= 0; bit--) eb_aom_wb_write_bit(wb, (data >> bit) & 1);
 }
 
-void aom_wb_write_inv_signed_literal(struct AomWriteBitBuffer *wb, int32_t data,
+void eb_aom_wb_write_inv_signed_literal(struct AomWriteBitBuffer *wb, int32_t data,
     int32_t bits) {
-    aom_wb_write_literal(wb, data, bits + 1);
+    eb_aom_wb_write_literal(wb, data, bits + 1);
 }
 
 //*******************************************************************************************//
@@ -1993,7 +1993,7 @@ static INLINE int32_t is_mv_valid(const MV *mv) {
         mv->col < MV_UPP;
 }
 
-void av1_encode_mv(
+void eb_av1_encode_mv(
     PictureParentControlSet   *pcs_ptr,
     AomWriter                  *ec_writer,
     const MV *mv,
@@ -2030,7 +2030,7 @@ void av1_encode_mv(
 #define INTER_FILTER_COMP_OFFSET (SWITCHABLE_FILTERS + 1)
 #define INTER_FILTER_DIR_OFFSET ((SWITCHABLE_FILTERS + 1) * 2)
 
-int32_t av1_get_pred_context_switchable_interp(
+int32_t eb_av1_get_pred_context_switchable_interp(
     NeighborArrayUnit     *ref_frame_type_neighbor_array,
     MvReferenceFrame rf0,
     MvReferenceFrame rf1,
@@ -2169,7 +2169,7 @@ void write_mb_interp_filter(
         int32_t dir;
         for (dir = 0; dir < 2; ++dir) {
             // printf("\nP:%d\tX: %d\tY:%d\t %d",(pcs_ptr)->picture_number,blkOriginX,blkOriginY ,((ec_writer)->ec).rng);
-            const int32_t ctx = av1_get_pred_context_switchable_interp(
+            const int32_t ctx = eb_av1_get_pred_context_switchable_interp(
                 ref_frame_type_neighbor_array,
                 rf0,
                 rf1,
@@ -2202,7 +2202,7 @@ static void WriteInterCompoundMode(
         INTER_COMPOUND_MODES);
 }
 
-int32_t av1_get_reference_mode_context(
+int32_t eb_av1_get_reference_mode_context(
     uint32_t                  cu_origin_x,
     uint32_t                  cu_origin_y,
     NeighborArrayUnit    *mode_type_neighbor_array,
@@ -2285,11 +2285,11 @@ int av1_get_comp_reference_type_context_new(const MacroBlockD *xd);
 
 // == Uni-directional contexts ==
 
-int av1_get_pred_context_uni_comp_ref_p(const MacroBlockD *xd);
+int eb_av1_get_pred_context_uni_comp_ref_p(const MacroBlockD *xd);
 
-int av1_get_pred_context_uni_comp_ref_p1(const MacroBlockD *xd);
+int eb_av1_get_pred_context_uni_comp_ref_p1(const MacroBlockD *xd);
 
-int av1_get_pred_context_uni_comp_ref_p2(const MacroBlockD *xd);
+int eb_av1_get_pred_context_uni_comp_ref_p2(const MacroBlockD *xd);
 
 static INLINE AomCdfProb *av1_get_comp_reference_type_cdf(
     const MacroBlockD *xd) {
@@ -2299,48 +2299,48 @@ static INLINE AomCdfProb *av1_get_comp_reference_type_cdf(
 
 static INLINE AomCdfProb *av1_get_pred_cdf_uni_comp_ref_p(
     const MacroBlockD *xd) {
-    const int pred_context = av1_get_pred_context_uni_comp_ref_p(xd);
+    const int pred_context = eb_av1_get_pred_context_uni_comp_ref_p(xd);
     return xd->tile_ctx->uni_comp_ref_cdf[pred_context][0];
 }
 
 static INLINE AomCdfProb *av1_get_pred_cdf_uni_comp_ref_p1(
     const MacroBlockD *xd) {
-    const int pred_context = av1_get_pred_context_uni_comp_ref_p1(xd);
+    const int pred_context = eb_av1_get_pred_context_uni_comp_ref_p1(xd);
     return xd->tile_ctx->uni_comp_ref_cdf[pred_context][1];
 }
 
 static INLINE AomCdfProb *av1_get_pred_cdf_uni_comp_ref_p2(
     const MacroBlockD *xd) {
-    const int pred_context = av1_get_pred_context_uni_comp_ref_p2(xd);
+    const int pred_context = eb_av1_get_pred_context_uni_comp_ref_p2(xd);
     return xd->tile_ctx->uni_comp_ref_cdf[pred_context][2];
 }
 
 static INLINE AomCdfProb *av1_get_pred_cdf_comp_ref_p(const MacroBlockD *xd) {
-    const int pred_context = av1_get_pred_context_comp_ref_p(xd);
+    const int pred_context = eb_av1_get_pred_context_comp_ref_p(xd);
     return xd->tile_ctx->comp_ref_cdf[pred_context][0];
 }
 
 static INLINE AomCdfProb *av1_get_pred_cdf_comp_ref_p1(
     const MacroBlockD *xd) {
-    const int pred_context = av1_get_pred_context_comp_ref_p1(xd);
+    const int pred_context = eb_av1_get_pred_context_comp_ref_p1(xd);
     return xd->tile_ctx->comp_ref_cdf[pred_context][1];
 }
 
 static INLINE AomCdfProb *av1_get_pred_cdf_comp_ref_p2(
     const MacroBlockD *xd) {
-    const int pred_context = av1_get_pred_context_comp_ref_p2(xd);
+    const int pred_context = eb_av1_get_pred_context_comp_ref_p2(xd);
     return xd->tile_ctx->comp_ref_cdf[pred_context][2];
 }
 
 static INLINE AomCdfProb *av1_get_pred_cdf_comp_bwdref_p(
     const MacroBlockD *xd) {
-    const int pred_context = av1_get_pred_context_comp_bwdref_p(xd);
+    const int pred_context = eb_av1_get_pred_context_comp_bwdref_p(xd);
     return xd->tile_ctx->comp_bwdref_cdf[pred_context][0];
 }
 
 static INLINE AomCdfProb *av1_get_pred_cdf_comp_bwdref_p1(
     const MacroBlockD *xd) {
-    const int pred_context = av1_get_pred_context_comp_bwdref_p1(xd);
+    const int pred_context = eb_av1_get_pred_context_comp_bwdref_p1(xd);
     return xd->tile_ctx->comp_bwdref_cdf[pred_context][1];
 }
 
@@ -2433,7 +2433,7 @@ int av1_get_comp_reference_type_context_new(const MacroBlockD *xd) {
 //
 // 3 contexts: Voting is used to compare the count of forward references with
 //             that of backward references from the spatial neighbors.
-int av1_get_pred_context_uni_comp_ref_p(const MacroBlockD *xd) {
+int eb_av1_get_pred_context_uni_comp_ref_p(const MacroBlockD *xd) {
     const uint8_t *const ref_counts = &xd->neighbors_ref_counts[0];
 
     // Count of forward references (L, L2, L3, or G)
@@ -2458,7 +2458,7 @@ int av1_get_pred_context_uni_comp_ref_p(const MacroBlockD *xd) {
 //
 // 3 contexts: Voting is used to compare the count of LAST2_FRAME with the
 //             total count of LAST3/GOLDEN from the spatial neighbors.
-int av1_get_pred_context_uni_comp_ref_p1(const MacroBlockD *xd) {
+int eb_av1_get_pred_context_uni_comp_ref_p1(const MacroBlockD *xd) {
     const uint8_t *const ref_counts = &xd->neighbors_ref_counts[0];
 
     // Count of LAST2
@@ -2483,7 +2483,7 @@ int av1_get_pred_context_uni_comp_ref_p1(const MacroBlockD *xd) {
 //
 // 3 contexts: Voting is used to compare the count of LAST3_FRAME with the
 //             total count of GOLDEN_FRAME from the spatial neighbors.
-int av1_get_pred_context_uni_comp_ref_p2(const MacroBlockD *xd) {
+int eb_av1_get_pred_context_uni_comp_ref_p2(const MacroBlockD *xd) {
     const uint8_t *const ref_counts = &xd->neighbors_ref_counts[0];
 
     // Count of LAST3
@@ -2566,7 +2566,7 @@ INLINE void av1_collect_neighbors_ref_counts_new(MacroBlockD *const xd) {
     }
 }
 
-int32_t av1_get_comp_reference_type_context(
+int32_t eb_av1_get_comp_reference_type_context(
     uint32_t                  cu_origin_x,
     uint32_t                  cu_origin_y,
     NeighborArrayUnit    *mode_type_neighbor_array,
@@ -2834,33 +2834,33 @@ static int32_t get_pred_context_brf_or_arf2(const MacroBlockD *xd) {
 // Returns a context number for the given MB prediction signal
 // Signal the first reference frame for a compound mode be either
 // GOLDEN/LAST3, or LAST/LAST2.
-int32_t av1_get_pred_context_comp_ref_p(const MacroBlockD *xd) {
+int32_t eb_av1_get_pred_context_comp_ref_p(const MacroBlockD *xd) {
     return get_pred_context_ll2_or_l3gld(xd);
 }
 
 // Returns a context number for the given MB prediction signal
 // Signal the first reference frame for a compound mode be LAST,
 // conditioning on that it is known either LAST/LAST2.
-int32_t av1_get_pred_context_comp_ref_p1(const MacroBlockD *xd) {
+int32_t eb_av1_get_pred_context_comp_ref_p1(const MacroBlockD *xd) {
     return get_pred_context_last_or_last2(xd);
 }
 
 // Returns a context number for the given MB prediction signal
 // Signal the first reference frame for a compound mode be GOLDEN,
 // conditioning on that it is known either GOLDEN or LAST3.
-int32_t av1_get_pred_context_comp_ref_p2(const MacroBlockD *xd) {
+int32_t eb_av1_get_pred_context_comp_ref_p2(const MacroBlockD *xd) {
     return get_pred_context_last3_or_gld(xd);
 }
 
 // Signal the 2nd reference frame for a compound mode be either
 // ALTREF, or ALTREF2/BWDREF.
-int32_t av1_get_pred_context_comp_bwdref_p(const MacroBlockD *xd) {
+int32_t eb_av1_get_pred_context_comp_bwdref_p(const MacroBlockD *xd) {
     return get_pred_context_brfarf2_or_arf(xd);
 }
 
 // Signal the 2nd reference frame for a compound mode be either
 // ALTREF2 or BWDREF.
-int32_t av1_get_pred_context_comp_bwdref_p1(const MacroBlockD *xd) {
+int32_t eb_av1_get_pred_context_comp_bwdref_p1(const MacroBlockD *xd) {
     return get_pred_context_brf_or_arf2(xd);
 }
 
@@ -2868,7 +2868,7 @@ int32_t av1_get_pred_context_comp_bwdref_p1(const MacroBlockD *xd) {
 //
 // For the bit to signal whether the single reference is a forward reference
 // frame or a backward reference frame.
-int32_t av1_get_pred_context_single_ref_p1(const MacroBlockD *xd) {
+int32_t eb_av1_get_pred_context_single_ref_p1(const MacroBlockD *xd) {
     const uint8_t *const ref_counts = &xd->neighbors_ref_counts[0];
 
     // Count of forward reference frames
@@ -2887,62 +2887,62 @@ int32_t av1_get_pred_context_single_ref_p1(const MacroBlockD *xd) {
 static INLINE AomCdfProb *av1_get_pred_cdf_single_ref_p1(
     const MacroBlockD *xd) {
     return xd->tile_ctx
-        ->single_ref_cdf[av1_get_pred_context_single_ref_p1(xd)][0];
+        ->single_ref_cdf[eb_av1_get_pred_context_single_ref_p1(xd)][0];
 }
 static INLINE AomCdfProb *av1_get_pred_cdf_single_ref_p2(
     const MacroBlockD *xd) {
     return xd->tile_ctx
-        ->single_ref_cdf[av1_get_pred_context_single_ref_p2(xd)][1];
+        ->single_ref_cdf[eb_av1_get_pred_context_single_ref_p2(xd)][1];
 }
 static INLINE AomCdfProb *av1_get_pred_cdf_single_ref_p3(
     const MacroBlockD *xd) {
     return xd->tile_ctx
-        ->single_ref_cdf[av1_get_pred_context_single_ref_p3(xd)][2];
+        ->single_ref_cdf[eb_av1_get_pred_context_single_ref_p3(xd)][2];
 }
 static INLINE AomCdfProb *av1_get_pred_cdf_single_ref_p4(
     const MacroBlockD *xd) {
     return xd->tile_ctx
-        ->single_ref_cdf[av1_get_pred_context_single_ref_p4(xd)][3];
+        ->single_ref_cdf[eb_av1_get_pred_context_single_ref_p4(xd)][3];
 }
 static INLINE AomCdfProb *av1_get_pred_cdf_single_ref_p5(
     const MacroBlockD *xd) {
     return xd->tile_ctx
-        ->single_ref_cdf[av1_get_pred_context_single_ref_p5(xd)][4];
+        ->single_ref_cdf[eb_av1_get_pred_context_single_ref_p5(xd)][4];
 }
 static INLINE AomCdfProb *av1_get_pred_cdf_single_ref_p6(
     const MacroBlockD *xd) {
     return xd->tile_ctx
-        ->single_ref_cdf[av1_get_pred_context_single_ref_p6(xd)][5];
+        ->single_ref_cdf[eb_av1_get_pred_context_single_ref_p6(xd)][5];
 }
 
 // For the bit to signal whether the single reference is ALTREF_FRAME or
 // non-ALTREF backward reference frame, knowing that it shall be either of
 // these 2 choices.
-int32_t av1_get_pred_context_single_ref_p2(const MacroBlockD *xd) {
+int32_t eb_av1_get_pred_context_single_ref_p2(const MacroBlockD *xd) {
     return get_pred_context_brfarf2_or_arf(xd);
 }
 
 // For the bit to signal whether the single reference is LAST3/GOLDEN or
 // LAST2/LAST, knowing that it shall be either of these 2 choices.
-int32_t av1_get_pred_context_single_ref_p3(const MacroBlockD *xd) {
+int32_t eb_av1_get_pred_context_single_ref_p3(const MacroBlockD *xd) {
     return get_pred_context_ll2_or_l3gld(xd);
 }
 
 // For the bit to signal whether the single reference is LAST2_FRAME or
 // LAST_FRAME, knowing that it shall be either of these 2 choices.
-int32_t av1_get_pred_context_single_ref_p4(const MacroBlockD *xd) {
+int32_t eb_av1_get_pred_context_single_ref_p4(const MacroBlockD *xd) {
     return get_pred_context_last_or_last2(xd);
 }
 
 // For the bit to signal whether the single reference is GOLDEN_FRAME or
 // LAST3_FRAME, knowing that it shall be either of these 2 choices.
-int32_t av1_get_pred_context_single_ref_p5(const MacroBlockD *xd) {
+int32_t eb_av1_get_pred_context_single_ref_p5(const MacroBlockD *xd) {
     return get_pred_context_last3_or_gld(xd);
 }
 
 // For the bit to signal whether the single reference is ALTREF2_FRAME or
 // BWDREF_FRAME, knowing that it shall be either of these 2 choices.
-int32_t av1_get_pred_context_single_ref_p6(const MacroBlockD *xd) {
+int32_t eb_av1_get_pred_context_single_ref_p6(const MacroBlockD *xd) {
     return get_pred_context_brf_or_arf2(xd);
 }
 /***************************************************************************************/
@@ -3056,8 +3056,8 @@ static void encode_restoration_mode(PictureParentControlSet *pcs_ptr,
     const int32_t num_planes = 3;// av1_num_planes(cm);
     int32_t all_none = 1, chroma_none = 1;
     for (int32_t p = 0; p < num_planes; ++p) {
-        //   aom_wb_write_bit(wb, 0);
-        //   aom_wb_write_bit(wb, 0);
+        //   eb_aom_wb_write_bit(wb, 0);
+        //   eb_aom_wb_write_bit(wb, 0);
 
         RestorationInfo *rsi = &pcs_ptr->av1_cm->rst_info[p];
 
@@ -3074,20 +3074,20 @@ static void encode_restoration_mode(PictureParentControlSet *pcs_ptr,
         }
         switch (rsi->frame_restoration_type) {
         case RESTORE_NONE:
-            aom_wb_write_bit(wb, 0);
-            aom_wb_write_bit(wb, 0);
+            eb_aom_wb_write_bit(wb, 0);
+            eb_aom_wb_write_bit(wb, 0);
             break;
         case RESTORE_WIENER:
-            aom_wb_write_bit(wb, 1);
-            aom_wb_write_bit(wb, 0);
+            eb_aom_wb_write_bit(wb, 1);
+            eb_aom_wb_write_bit(wb, 0);
             break;
         case RESTORE_SGRPROJ:
-            aom_wb_write_bit(wb, 1);
-            aom_wb_write_bit(wb, 1);
+            eb_aom_wb_write_bit(wb, 1);
+            eb_aom_wb_write_bit(wb, 1);
             break;
         case RESTORE_SWITCHABLE:
-            aom_wb_write_bit(wb, 0);
-            aom_wb_write_bit(wb, 1);
+            eb_aom_wb_write_bit(wb, 0);
+            eb_aom_wb_write_bit(wb, 1);
             break;
         default: assert(0);
         }
@@ -3102,15 +3102,15 @@ static void encode_restoration_mode(PictureParentControlSet *pcs_ptr,
         assert(RESTORATION_UNITSIZE_MAX == 256);
 
         if (sb_size == 64)
-            aom_wb_write_bit(wb, rsi->restoration_unit_size > 64);
+            eb_aom_wb_write_bit(wb, rsi->restoration_unit_size > 64);
         if (rsi->restoration_unit_size > 64)
-            aom_wb_write_bit(wb, rsi->restoration_unit_size > 128);
+            eb_aom_wb_write_bit(wb, rsi->restoration_unit_size > 128);
     }
 
     if (num_planes > 1) {
         int32_t s = 1;// AOMMIN(cm->subsampling_x, cm->subsampling_y);
         if (s && !chroma_none) {
-            aom_wb_write_bit(wb, cm->rst_info[1].restoration_unit_size !=
+            eb_aom_wb_write_bit(wb, cm->rst_info[1].restoration_unit_size !=
                 cm->rst_info[0].restoration_unit_size);
             assert(cm->rst_info[1].restoration_unit_size ==
                 cm->rst_info[0].restoration_unit_size ||
@@ -3131,26 +3131,26 @@ static void encode_restoration_mode(PictureParentControlSet *pcs_ptr,
 
 static void encode_segmentation(PictureParentControlSet *pcsPtr, struct AomWriteBitBuffer *wb) {
     SegmentationParams *segmentation_params = &pcsPtr->frm_hdr.segmentation_params;
-    aom_wb_write_bit(wb, segmentation_params->segmentation_enabled);
+    eb_aom_wb_write_bit(wb, segmentation_params->segmentation_enabled);
     if (segmentation_params->segmentation_enabled) {
         if (!(pcsPtr->frm_hdr.primary_ref_frame==PRIMARY_REF_NONE)) {
-            aom_wb_write_bit(wb, segmentation_params->segmentation_update_map);
+            eb_aom_wb_write_bit(wb, segmentation_params->segmentation_update_map);
             if (segmentation_params->segmentation_update_map) {
-                aom_wb_write_bit(wb, segmentation_params->segmentation_temporal_update);
+                eb_aom_wb_write_bit(wb, segmentation_params->segmentation_temporal_update);
             }
-            aom_wb_write_bit(wb, segmentation_params->segmentation_update_map);
+            eb_aom_wb_write_bit(wb, segmentation_params->segmentation_update_map);
         }
         if (segmentation_params->segmentation_update_map) {
             for (int i = 0; i < MAX_SEGMENTS; i++) {
                 for (int j = 0; j < SEG_LVL_MAX; j++) {
-                    aom_wb_write_bit(wb, segmentation_params->feature_enabled[i][j]);
+                    eb_aom_wb_write_bit(wb, segmentation_params->feature_enabled[i][j]);
                     if (segmentation_params->feature_enabled[i][j]) {
                         //TODO: add clamping
                         if (segmentation_feature_signed[j]) {
-                            aom_wb_write_inv_signed_literal(wb, segmentation_params->feature_data[i][j],
+                            eb_aom_wb_write_inv_signed_literal(wb, segmentation_params->feature_data[i][j],
                                                             segmentation_feature_bits[j]);
                         } else {
-                            aom_wb_write_literal(wb, segmentation_params->feature_data[i][j],
+                            eb_aom_wb_write_literal(wb, segmentation_params->feature_data[i][j],
                                                  segmentation_feature_bits[j]);
                         }
                     }
@@ -3172,22 +3172,22 @@ static void encode_loopfilter(PictureParentControlSet *pcs_ptr, struct AomWriteB
     struct LoopFilter *lf = &frm_hdr->loop_filter_params;
 
     // Encode the loop filter level and type
-    aom_wb_write_literal(wb, lf->filter_level[0], 6);
-    aom_wb_write_literal(wb, lf->filter_level[1], 6);
+    eb_aom_wb_write_literal(wb, lf->filter_level[0], 6);
+    eb_aom_wb_write_literal(wb, lf->filter_level[1], 6);
     if (num_planes > 1) {
         if (lf->filter_level[0] || lf->filter_level[1]) {
-            aom_wb_write_literal(wb, lf->filter_level_u, 6);
-            aom_wb_write_literal(wb, lf->filter_level_v, 6);
+            eb_aom_wb_write_literal(wb, lf->filter_level_u, 6);
+            eb_aom_wb_write_literal(wb, lf->filter_level_v, 6);
         }
     }
-    aom_wb_write_literal(wb, lf->sharpness_level, 3);
+    eb_aom_wb_write_literal(wb, lf->sharpness_level, 3);
 
     // Write out loop filter deltas applied at the MB level based on mode or
     // ref frame (if they are enabled).
-    aom_wb_write_bit(wb, lf->mode_ref_delta_enabled);
+    eb_aom_wb_write_bit(wb, lf->mode_ref_delta_enabled);
     if (lf->mode_ref_delta_enabled) {
         printf("ERROR[AN]: Loop Filter is not supported yet \n");
-        /* aom_wb_write_bit(wb, lf->mode_ref_delta_update);
+        /* eb_aom_wb_write_bit(wb, lf->mode_ref_delta_update);
         if (lf->mode_ref_delta_update) {
         const int32_t prime_idx = pcs_ptr->primary_ref_frame;
         const int32_t buf_idx =
@@ -3202,8 +3202,8 @@ static void encode_loopfilter(PictureParentControlSet *pcs_ptr, struct AomWriteB
         for (i = 0; i < TOTAL_REFS_PER_FRAME; i++) {
         const int32_t delta = lf->ref_deltas[i];
         const int32_t changed = delta != last_ref_deltas[i];
-        aom_wb_write_bit(wb, changed);
-        if (changed) aom_wb_write_inv_signed_literal(wb, delta, 6);
+        eb_aom_wb_write_bit(wb, changed);
+        if (changed) eb_aom_wb_write_inv_signed_literal(wb, delta, 6);
         }
         int8_t last_mode_deltas[MAX_MODE_LF_DELTAS];
         if (prime_idx == PRIMARY_REF_NONE || buf_idx < 0) {
@@ -3217,8 +3217,8 @@ static void encode_loopfilter(PictureParentControlSet *pcs_ptr, struct AomWriteB
         for (i = 0; i < MAX_MODE_LF_DELTAS; i++) {
         const int32_t delta = lf->mode_deltas[i];
         const int32_t changed = delta != last_mode_deltas[i];
-        aom_wb_write_bit(wb, changed);
-        if (changed) aom_wb_write_inv_signed_literal(wb, delta, 6);
+        eb_aom_wb_write_bit(wb, changed);
+        if (changed) eb_aom_wb_write_inv_signed_literal(wb, delta, 6);
         }
         }*/
     }
@@ -3235,24 +3235,24 @@ static void encode_cdef(const PictureParentControlSet *pcs_ptr, struct AomWriteB
 
     const int32_t num_planes = 3;// av1_num_planes(pcs_ptr);
     int32_t i;
-    aom_wb_write_literal(wb, frm_hdr->CDEF_params.cdef_damping - 3, 2);
+    eb_aom_wb_write_literal(wb, frm_hdr->CDEF_params.cdef_damping - 3, 2);
     //cdef_pri_damping & cdef_sec_damping consolidated to cdef_damping
     //assert(pcs_ptr->cdef_pri_damping == pcs_ptr->cdef_sec_damping);
-    aom_wb_write_literal(wb, frm_hdr->CDEF_params.cdef_bits, 2);
+    eb_aom_wb_write_literal(wb, frm_hdr->CDEF_params.cdef_bits, 2);
     for (i = 0; i < pcs_ptr->nb_cdef_strengths; i++) {
-        aom_wb_write_literal(wb, frm_hdr->CDEF_params.cdef_y_strength[i], CDEF_STRENGTH_BITS);
+        eb_aom_wb_write_literal(wb, frm_hdr->CDEF_params.cdef_y_strength[i], CDEF_STRENGTH_BITS);
         if (num_planes > 1)
-            aom_wb_write_literal(wb, frm_hdr->CDEF_params.cdef_uv_strength[i], CDEF_STRENGTH_BITS);
+            eb_aom_wb_write_literal(wb, frm_hdr->CDEF_params.cdef_uv_strength[i], CDEF_STRENGTH_BITS);
     }
 }
 
 static void write_delta_q(struct AomWriteBitBuffer *wb, int32_t delta_q) {
     if (delta_q != 0) {
-        aom_wb_write_bit(wb, 1);
-        aom_wb_write_inv_signed_literal(wb, delta_q, 6);
+        eb_aom_wb_write_bit(wb, 1);
+        eb_aom_wb_write_inv_signed_literal(wb, delta_q, 6);
     }
     else
-        aom_wb_write_bit(wb, 0);
+        eb_aom_wb_write_bit(wb, 0);
 }
 
 static void encode_quantization(const PictureParentControlSet *const pcs_ptr,
@@ -3260,12 +3260,12 @@ static void encode_quantization(const PictureParentControlSet *const pcs_ptr,
     const int32_t num_planes = 3;//av1_num_planes(cm);
 
     const FrameHeader *frm_hdr = &pcs_ptr->frm_hdr;
-    aom_wb_write_literal(wb, frm_hdr->quantization_params.base_q_idx, QINDEX_BITS);
+    eb_aom_wb_write_literal(wb, frm_hdr->quantization_params.base_q_idx, QINDEX_BITS);
     write_delta_q(wb, frm_hdr->quantization_params.delta_q_y_dc);
     if (num_planes > 1) {
         int32_t diff_uv_delta = (frm_hdr->quantization_params.delta_q_u_dc != frm_hdr->quantization_params.delta_q_v_dc) ||
             (frm_hdr->quantization_params.delta_q_u_ac != frm_hdr->quantization_params.delta_q_v_ac);
-        if (pcs_ptr->separate_uv_delta_q) aom_wb_write_bit(wb, diff_uv_delta);
+        if (pcs_ptr->separate_uv_delta_q) eb_aom_wb_write_bit(wb, diff_uv_delta);
         write_delta_q(wb, frm_hdr->quantization_params.delta_q_u_dc);
         write_delta_q(wb, frm_hdr->quantization_params.delta_q_u_ac);
         if (diff_uv_delta) {
@@ -3273,36 +3273,36 @@ static void encode_quantization(const PictureParentControlSet *const pcs_ptr,
             write_delta_q(wb, frm_hdr->quantization_params.delta_q_v_ac);
         }
     }
-    aom_wb_write_bit(wb, frm_hdr->quantization_params.using_qmatrix);
+    eb_aom_wb_write_bit(wb, frm_hdr->quantization_params.using_qmatrix);
     if (frm_hdr->quantization_params.using_qmatrix) {
-        aom_wb_write_literal(wb, frm_hdr->quantization_params.qm_y, QM_LEVEL_BITS);
-        aom_wb_write_literal(wb, frm_hdr->quantization_params.qm_u, QM_LEVEL_BITS);
+        eb_aom_wb_write_literal(wb, frm_hdr->quantization_params.qm_y, QM_LEVEL_BITS);
+        eb_aom_wb_write_literal(wb, frm_hdr->quantization_params.qm_u, QM_LEVEL_BITS);
         if (!pcs_ptr->separate_uv_delta_q)
             assert(frm_hdr->quantization_params.qm_u == frm_hdr->quantization_params.qm_v);
         else
-            aom_wb_write_literal(wb, frm_hdr->quantization_params.qm_v, QM_LEVEL_BITS);
+            eb_aom_wb_write_literal(wb, frm_hdr->quantization_params.qm_v, QM_LEVEL_BITS);
     }
 }
 
 static void write_tile_info_max_tile(const PictureParentControlSet *const pcs_ptr,
     struct AomWriteBitBuffer *wb) {
     Av1Common * cm = pcs_ptr->av1_cm;
-    aom_wb_write_bit(wb, cm->tiles_info.uniform_tile_spacing_flag);
+    eb_aom_wb_write_bit(wb, cm->tiles_info.uniform_tile_spacing_flag);
 
     if (cm->tiles_info.uniform_tile_spacing_flag) {
         // Uniform spaced tiles with power-of-two number of rows and columns
         // tile columns
         int32_t ones = cm->log2_tile_cols - cm->tiles_info.min_log2_tile_cols;
         while (ones--)
-            aom_wb_write_bit(wb, 1);
+            eb_aom_wb_write_bit(wb, 1);
         if (cm->log2_tile_cols < cm->tiles_info.max_log2_tile_cols)
-            aom_wb_write_bit(wb, 0);
+            eb_aom_wb_write_bit(wb, 0);
         // rows
         ones = cm->log2_tile_rows - cm->tiles_info.min_log2_tile_rows;
         while (ones--)
-            aom_wb_write_bit(wb, 1);
+            eb_aom_wb_write_bit(wb, 1);
         if (cm->log2_tile_rows < cm->tiles_info.max_log2_tile_rows)
-            aom_wb_write_bit(wb, 0);
+            eb_aom_wb_write_bit(wb, 0);
     }
     else {
         // Explicit tiles with configurable tile widths and heights
@@ -3334,7 +3334,7 @@ static int32_t tile_log2(int32_t blk_size, int32_t target) {
     return k;
 }
 
-void av1_get_tile_limits(PictureParentControlSet * pcs_ptr) {
+void eb_av1_get_tile_limits(PictureParentControlSet * pcs_ptr) {
     Av1Common * cm = pcs_ptr->av1_cm;
 
     int32_t mi_cols = ALIGN_POWER_OF_TWO(cm->mi_cols, pcs_ptr->sequence_control_set_ptr->seq_header.sb_size_log2);
@@ -3354,7 +3354,7 @@ void av1_get_tile_limits(PictureParentControlSet * pcs_ptr) {
     cm->tiles_info.min_log2_tiles = AOMMAX(cm->tiles_info.min_log2_tiles, cm->tiles_info.min_log2_tile_cols);
 }
 
-void av1_calculate_tile_cols(PictureParentControlSet * pcs_ptr) {
+void eb_av1_calculate_tile_cols(PictureParentControlSet * pcs_ptr) {
     Av1Common *const cm = pcs_ptr->av1_cm;
 
     int mi_cols = ALIGN_POWER_OF_TWO(cm->mi_cols, pcs_ptr->sequence_control_set_ptr->seq_header.sb_size_log2);
@@ -3395,7 +3395,7 @@ void av1_calculate_tile_cols(PictureParentControlSet * pcs_ptr) {
     }
 }
 
-void av1_calculate_tile_rows(PictureParentControlSet * pcs_ptr)
+void eb_av1_calculate_tile_rows(PictureParentControlSet * pcs_ptr)
 {
     Av1Common *const cm = pcs_ptr->av1_cm;
 
@@ -3443,7 +3443,7 @@ void av1_calculate_tile_rows(PictureParentControlSet * pcs_ptr)
     int tile_widths[MAX_TILE_COLS] = {0};
     int tile_heights[MAX_TILE_ROWS] = { 0 };
 
-    av1_get_tile_limits(pcs_ptr);
+    eb_av1_get_tile_limits(pcs_ptr);
 
     // configure tile columns
     if (tile_width_count == 0 || tile_height_count == 0)
@@ -3466,7 +3466,7 @@ void av1_calculate_tile_rows(PictureParentControlSet * pcs_ptr)
         cm->tiles_info.tile_cols = i;
         cm->tiles_info.tile_col_start_sb[i] = sb_cols;
     }
-    av1_calculate_tile_cols(pcs_ptr);
+    eb_av1_calculate_tile_cols(pcs_ptr);
 
     // configure tile rows
     if (cm->tiles_info.uniform_tile_spacing_flag) {
@@ -3486,10 +3486,10 @@ void av1_calculate_tile_rows(PictureParentControlSet * pcs_ptr)
         cm->tiles_info.tile_rows = i;
         cm->tiles_info.tile_row_start_sb[i] = sb_rows;
     }
-    av1_calculate_tile_rows(pcs_ptr);
+    eb_av1_calculate_tile_rows(pcs_ptr);
 }
 
- void av1_tile_set_row(TileInfo *tile, PictureParentControlSet * pcs_ptr, int row)
+ void eb_av1_tile_set_row(TileInfo *tile, PictureParentControlSet * pcs_ptr, int row)
  {
      Av1Common *const cm = pcs_ptr->av1_cm;
 
@@ -3503,7 +3503,7 @@ void av1_calculate_tile_rows(PictureParentControlSet * pcs_ptr)
      assert(tile->mi_row_end > tile->mi_row_start);
  }
 
- void av1_tile_set_col(TileInfo *tile, PictureParentControlSet * pcs_ptr, int col) {
+ void eb_av1_tile_set_col(TileInfo *tile, PictureParentControlSet * pcs_ptr, int col) {
      Av1Common *const cm = pcs_ptr->av1_cm;
      assert(col < cm->tiles_info.tile_cols);
      int mi_col_start = cm->tiles_info.tile_col_start_sb[col] << pcs_ptr->sequence_control_set_ptr->seq_header.sb_size_log2;
@@ -3518,21 +3518,21 @@ void av1_calculate_tile_rows(PictureParentControlSet * pcs_ptr)
 static void write_tile_info(const PictureParentControlSet *const pcs_ptr,
     //struct AomWriteBitBuffer *saved_wb,
     struct AomWriteBitBuffer *wb) {
-    av1_get_tile_limits((PictureParentControlSet *)pcs_ptr);
+    eb_av1_get_tile_limits((PictureParentControlSet *)pcs_ptr);
     write_tile_info_max_tile(pcs_ptr, wb);
 
     if (pcs_ptr->av1_cm->tiles_info.tile_rows * pcs_ptr->av1_cm->tiles_info.tile_cols > 1) {
         // tile id used for cdf update
 #if ENABLE_CDF_UPDATE
-        aom_wb_write_literal(
+        eb_aom_wb_write_literal(
             wb,
             pcs_ptr->frame_end_cdf_update_mode ? pcs_ptr->av1_cm->tiles_info.tile_rows * pcs_ptr->av1_cm->tiles_info.tile_cols - 1 : 0,
             pcs_ptr->av1_cm->log2_tile_cols + pcs_ptr->av1_cm->log2_tile_rows);
 #else
-        aom_wb_write_literal(wb, 0, pcs_ptr->av1_cm->log2_tile_cols + pcs_ptr->av1_cm->log2_tile_rows);
+        eb_aom_wb_write_literal(wb, 0, pcs_ptr->av1_cm->log2_tile_cols + pcs_ptr->av1_cm->log2_tile_rows);
 #endif
         // Number of bytes in tile size - 1
-        aom_wb_write_literal(wb, 3, 2);
+        eb_aom_wb_write_literal(wb, 3, 2);
     }
 }
 
@@ -3549,32 +3549,32 @@ static void write_frame_size(PictureParentControlSet *pcs_ptr,
     //    const SequenceHeader *seq_params = &cm->seq_params;
     //    int32_t num_bits_width = seq_params->num_bits_width;
     //    int32_t num_bits_height = seq_params->num_bits_height;
-    //    aom_wb_write_literal(wb, coded_width, num_bits_width);
-    //    aom_wb_write_literal(wb, coded_height, num_bits_height);
+    //    eb_aom_wb_write_literal(wb, coded_width, num_bits_width);
+    //    eb_aom_wb_write_literal(wb, coded_height, num_bits_height);
     //}
     if (scs_ptr->seq_header.enable_superres) {
         printf("ERROR[AN]: enable_superres not supported yet\n");
         //write_superres_scale(cm, wb);
     }
 
-    aom_wb_write_bit(wb, 0);
+    eb_aom_wb_write_bit(wb, 0);
     //write_render_size(cm, wb);
 }
 
 static void WriteProfile(BitstreamProfile profile,
     struct AomWriteBitBuffer *wb) {
     assert(profile >= PROFILE_0 && profile < MAX_PROFILES);
-    aom_wb_write_literal(wb, profile, PROFILE_BITS);
+    eb_aom_wb_write_literal(wb, profile, PROFILE_BITS);
 }
 
 static void write_bitdepth(SequenceControlSet *scs_ptr/*Av1Common *const cm*/,
     struct AomWriteBitBuffer *wb) {
     // Profile 0/1: [0] for 8 bit, [1]  10-bit
     // Profile   2: [0] for 8 bit, [10] 10-bit, [11] - 12-bit
-    aom_wb_write_bit(wb, scs_ptr->static_config.encoder_bit_depth == EB_8BIT ? 0 : 1);
+    eb_aom_wb_write_bit(wb, scs_ptr->static_config.encoder_bit_depth == EB_8BIT ? 0 : 1);
     if (scs_ptr->static_config.profile == PROFILE_2 && scs_ptr->static_config.encoder_bit_depth != EB_8BIT) {
         printf("ERROR[AN]: Profile 2 Not supported\n");
-        aom_wb_write_bit(wb, scs_ptr->static_config.encoder_bit_depth == EB_10BIT ? 0 : 1);
+        eb_aom_wb_write_bit(wb, scs_ptr->static_config.encoder_bit_depth == EB_10BIT ? 0 : 1);
     }
 }
 static void write_color_config(
@@ -3583,21 +3583,21 @@ static void write_color_config(
     write_bitdepth(scs_ptr, wb);
     const int32_t is_monochrome = 0;// cm->seq_params.monochrome;
     // monochrome bit
-    aom_wb_write_bit(wb, is_monochrome);
+    eb_aom_wb_write_bit(wb, is_monochrome);
     //if (cm->profile != PROFILE_1)
-    //    aom_wb_write_bit(wb, is_monochrome);
+    //    eb_aom_wb_write_bit(wb, is_monochrome);
     //else
     //    assert(!is_monochrome);
     if (1/*cm->color_primaries == AOM_CICP_CP_UNSPECIFIED &&
          cm->transfer_characteristics == AOM_CICP_TC_UNSPECIFIED &&
          cm->matrix_coefficients == AOM_CICP_MC_UNSPECIFIED*/) {
-        aom_wb_write_bit(wb, 0);  // No color description present
+        eb_aom_wb_write_bit(wb, 0);  // No color description present
     }
     else {
-        //aom_wb_write_bit(wb, 1);  // Color description present
-        //aom_wb_write_literal(wb, cm->color_primaries, 8);
-        //aom_wb_write_literal(wb, cm->transfer_characteristics, 8);
-        //aom_wb_write_literal(wb, cm->matrix_coefficients, 8);
+        //eb_aom_wb_write_bit(wb, 1);  // Color description present
+        //eb_aom_wb_write_literal(wb, cm->color_primaries, 8);
+        //eb_aom_wb_write_literal(wb, cm->transfer_characteristics, 8);
+        //eb_aom_wb_write_literal(wb, cm->matrix_coefficients, 8);
     }
     if (is_monochrome) {
         printf("ERROR[AN]: is_monochrome not supported yet\n");
@@ -3614,8 +3614,8 @@ static void write_color_config(
     }
     else {
         // 0: [16, 235] (i.e. xvYCC), 1: [0, 255]
-        aom_wb_write_bit(wb, 0);
-        //aom_wb_write_bit(wb, cm->color_range);
+        eb_aom_wb_write_bit(wb, 0);
+        //eb_aom_wb_write_bit(wb, cm->color_range);
 
         //if (cm->profile == PROFILE_0) {
         //    // 420 only
@@ -3628,13 +3628,13 @@ static void write_color_config(
         //else if (cm->profile == PROFILE_2) {
         //    if (cm->bit_depth == AOM_BITS_12) {
         //        // 420, 444 or 422
-        //        aom_wb_write_bit(wb, cm->subsampling_x);
+        //        eb_aom_wb_write_bit(wb, cm->subsampling_x);
         //        if (cm->subsampling_x == 0) {
         //            assert(cm->subsampling_y == 0 &&
         //                "4:4:0 subsampling not allowed in AV1");
         //        }
         //        else {
-        //            aom_wb_write_bit(wb, cm->subsampling_y);
+        //            eb_aom_wb_write_bit(wb, cm->subsampling_y);
         //        }
         //    }
         //    else {
@@ -3645,13 +3645,13 @@ static void write_color_config(
         //if (cm->matrix_coefficients == AOM_CICP_MC_IDENTITY) {
         //    assert(cm->subsampling_x == 0 && cm->subsampling_y == 0);
         //}
-        aom_wb_write_literal(wb, 0, 2);
+        eb_aom_wb_write_literal(wb, 0, 2);
         //if (cm->subsampling_x == 1 && cm->subsampling_y == 1) {
-        //    aom_wb_write_literal(wb, cm->chroma_sample_position, 2);
+        //    eb_aom_wb_write_literal(wb, cm->chroma_sample_position, 2);
         //}
     }
-    aom_wb_write_bit(wb, 0);
-    //aom_wb_write_bit(wb, cm->separate_uv_delta_q);
+    eb_aom_wb_write_bit(wb, 0);
+    //eb_aom_wb_write_bit(wb, cm->separate_uv_delta_q);
 }
 
 void write_sequence_header(SequenceControlSet *scs_ptr/*Av1Comp *cpi*/, struct AomWriteBitBuffer *wb) {
@@ -3668,10 +3668,10 @@ void write_sequence_header(SequenceControlSet *scs_ptr/*Av1Comp *cpi*/, struct A
     ? cpi->oxcf.forced_max_frame_height
     : cpi->oxcf.height;*/
 
-    aom_wb_write_literal(wb, scs_ptr->seq_header.frame_width_bits - 1, 4);
-    aom_wb_write_literal(wb, scs_ptr->seq_header.frame_height_bits - 1, 4);
-    aom_wb_write_literal(wb, max_frame_width - 1, scs_ptr->seq_header.frame_width_bits);
-    aom_wb_write_literal(wb, max_frame_height - 1, scs_ptr->seq_header.frame_height_bits);
+    eb_aom_wb_write_literal(wb, scs_ptr->seq_header.frame_width_bits - 1, 4);
+    eb_aom_wb_write_literal(wb, scs_ptr->seq_header.frame_height_bits - 1, 4);
+    eb_aom_wb_write_literal(wb, max_frame_width - 1, scs_ptr->seq_header.frame_width_bits);
+    eb_aom_wb_write_literal(wb, max_frame_height - 1, scs_ptr->seq_header.frame_height_bits);
     //
     /* Placeholder for actually writing to the bitstream */
 
@@ -3679,62 +3679,62 @@ void write_sequence_header(SequenceControlSet *scs_ptr/*Av1Comp *cpi*/, struct A
         //scs_ptr->frame_id_numbers_present_flag = 0;
         //    cm->large_scale_tile ? 0 : cm->error_resilient_mode;
 
-        aom_wb_write_bit(wb, scs_ptr->seq_header.frame_id_numbers_present_flag);
+        eb_aom_wb_write_bit(wb, scs_ptr->seq_header.frame_id_numbers_present_flag);
         if (scs_ptr->seq_header.frame_id_numbers_present_flag) {
             // We must always have delta_frame_id_length < frame_id_length,
             // in order for a frame to be referenced with a unique delta.
             // Avoid wasting bits by using a coding that enforces this restriction.
-            aom_wb_write_literal(wb, scs_ptr->seq_header.delta_frame_id_length - 2, 4);
-            aom_wb_write_literal(
+            eb_aom_wb_write_literal(wb, scs_ptr->seq_header.delta_frame_id_length - 2, 4);
+            eb_aom_wb_write_literal(
                 wb, ((scs_ptr->seq_header.frame_id_length) - (scs_ptr->seq_header.delta_frame_id_length) - 1),
                 3);
         }
     }
 
-    aom_wb_write_bit(wb, scs_ptr->seq_header.sb_size == BLOCK_128X128 ? 1 : 0);
+    eb_aom_wb_write_bit(wb, scs_ptr->seq_header.sb_size == BLOCK_128X128 ? 1 : 0);
     //    write_sb_size(seq_params, wb);
-    aom_wb_write_bit(wb, scs_ptr->seq_header.enable_filter_intra);
+    eb_aom_wb_write_bit(wb, scs_ptr->seq_header.enable_filter_intra);
 
         scs_ptr->seq_header.enable_intra_edge_filter = 1;
-    aom_wb_write_bit(wb, scs_ptr->seq_header.enable_intra_edge_filter);
+    eb_aom_wb_write_bit(wb, scs_ptr->seq_header.enable_intra_edge_filter);
 
     if (!scs_ptr->seq_header.reduced_still_picture_header) {
-        aom_wb_write_bit(wb, scs_ptr->seq_header.enable_interintra_compound);
-        aom_wb_write_bit(wb, scs_ptr->seq_header.enable_masked_compound);
-        aom_wb_write_bit(wb, scs_ptr->static_config.enable_warped_motion);
-        aom_wb_write_bit(wb, scs_ptr->seq_header.enable_dual_filter);
+        eb_aom_wb_write_bit(wb, scs_ptr->seq_header.enable_interintra_compound);
+        eb_aom_wb_write_bit(wb, scs_ptr->seq_header.enable_masked_compound);
+        eb_aom_wb_write_bit(wb, scs_ptr->static_config.enable_warped_motion);
+        eb_aom_wb_write_bit(wb, scs_ptr->seq_header.enable_dual_filter);
 
-        aom_wb_write_bit(wb, scs_ptr->seq_header.order_hint_info.enable_order_hint);
+        eb_aom_wb_write_bit(wb, scs_ptr->seq_header.order_hint_info.enable_order_hint);
 
         if (scs_ptr->seq_header.order_hint_info.enable_order_hint) {
-            aom_wb_write_bit(wb, scs_ptr->seq_header.order_hint_info.enable_jnt_comp);
-            aom_wb_write_bit(wb, scs_ptr->seq_header.order_hint_info.enable_ref_frame_mvs);
+            eb_aom_wb_write_bit(wb, scs_ptr->seq_header.order_hint_info.enable_jnt_comp);
+            eb_aom_wb_write_bit(wb, scs_ptr->seq_header.order_hint_info.enable_ref_frame_mvs);
         }
 
         if (scs_ptr->seq_header.seq_force_screen_content_tools == 2)
-            aom_wb_write_bit(wb, 1);
+            eb_aom_wb_write_bit(wb, 1);
         else {
-            aom_wb_write_bit(wb, 0);
-            aom_wb_write_bit(wb, scs_ptr->seq_header.seq_force_screen_content_tools);
+            eb_aom_wb_write_bit(wb, 0);
+            eb_aom_wb_write_bit(wb, scs_ptr->seq_header.seq_force_screen_content_tools);
         }
         //
         if (scs_ptr->seq_header.seq_force_screen_content_tools > 0) {
             if (scs_ptr->seq_header.seq_force_integer_mv == 2)
-                aom_wb_write_bit(wb, 1);
+                eb_aom_wb_write_bit(wb, 1);
             else {
-                aom_wb_write_bit(wb, 0);
-                aom_wb_write_bit(wb, scs_ptr->seq_header.seq_force_integer_mv);
+                eb_aom_wb_write_bit(wb, 0);
+                eb_aom_wb_write_bit(wb, scs_ptr->seq_header.seq_force_integer_mv);
             }
         }
         else
             assert(scs_ptr->seq_header.seq_force_integer_mv == 2);
         if (scs_ptr->seq_header.order_hint_info.enable_order_hint)
-            aom_wb_write_literal(wb, scs_ptr->seq_header.order_hint_info.order_hint_bits - 1, 3);
+            eb_aom_wb_write_literal(wb, scs_ptr->seq_header.order_hint_info.order_hint_bits - 1, 3);
     }
 
-    aom_wb_write_bit(wb, scs_ptr->seq_header.enable_superres);
-    aom_wb_write_bit(wb, scs_ptr->seq_header.enable_cdef);
-    aom_wb_write_bit(wb, scs_ptr->seq_header.enable_restoration);
+    eb_aom_wb_write_bit(wb, scs_ptr->seq_header.enable_superres);
+    eb_aom_wb_write_bit(wb, scs_ptr->seq_header.enable_cdef);
+    eb_aom_wb_write_bit(wb, scs_ptr->seq_header.enable_restoration);
 }
 
 // Recenters a non-negative literal v around a reference r
@@ -3756,12 +3756,12 @@ static uint16_t recenter_finite_nonneg(uint16_t n, uint16_t r, uint16_t v) {
         return recenter_nonneg(n - 1 - r, n - 1 - v);
 }
 
-int32_t aom_count_primitive_symmetric(int16_t v, uint32_t abs_bits) {
+int32_t eb_aom_count_primitive_symmetric(int16_t v, uint32_t abs_bits) {
     return (v == 0 ? 1 : abs_bits + 2);
 }
 
 // Encodes a value v in [0, n-1] quasi-uniformly
-void aom_write_primitive_quniform(AomWriter *w, uint16_t n, uint16_t v) {
+void eb_aom_write_primitive_quniform(AomWriter *w, uint16_t n, uint16_t v) {
     if (n <= 1) return;
     const int32_t l = get_msb(n - 1) + 1;
     const int32_t m = (1 << l) - n;
@@ -3779,14 +3779,14 @@ static void aom_wb_write_primitive_quniform(struct AomWriteBitBuffer *wb,
     const int32_t l = get_msb(n - 1) + 1;
     const int32_t m = (1 << l) - n;
     if (v < m)
-        aom_wb_write_literal(wb, v, l - 1);
+        eb_aom_wb_write_literal(wb, v, l - 1);
     else {
-        aom_wb_write_literal(wb, m + ((v - m) >> 1), l - 1);
-        aom_wb_write_bit(wb, (v - m) & 1);
+        eb_aom_wb_write_literal(wb, m + ((v - m) >> 1), l - 1);
+        eb_aom_wb_write_bit(wb, (v - m) & 1);
     }
 }
 
-int32_t aom_count_primitive_quniform(uint16_t n, uint16_t v) {
+int32_t eb_aom_count_primitive_quniform(uint16_t n, uint16_t v) {
     if (n <= 1) return 0;
     const int32_t l = get_msb(n - 1) + 1;
     const int32_t m = (1 << l) - n;
@@ -3794,7 +3794,7 @@ int32_t aom_count_primitive_quniform(uint16_t n, uint16_t v) {
 }
 
 // Finite subexponential code that codes a symbol v in [0, n-1] with parameter k
-void aom_write_primitive_subexpfin(AomWriter *w, uint16_t n, uint16_t k,
+void eb_aom_write_primitive_subexpfin(AomWriter *w, uint16_t n, uint16_t k,
     uint16_t v) {
     int32_t i = 0;
     int32_t mk = 0;
@@ -3802,7 +3802,7 @@ void aom_write_primitive_subexpfin(AomWriter *w, uint16_t n, uint16_t k,
         int32_t b = (i ? k + i - 1 : k);
         int32_t a = (1 << b);
         if (n <= mk + 3 * a) {
-            aom_write_primitive_quniform(w, (uint16_t)(n - mk), (uint16_t)(v - mk));
+            eb_aom_write_primitive_quniform(w, (uint16_t)(n - mk), (uint16_t)(v - mk));
             break;
         }
         else {
@@ -3834,20 +3834,20 @@ static void aom_wb_write_primitive_subexpfin(struct AomWriteBitBuffer *wb,
         }
         else {
             int32_t t = (v >= mk + a);
-            aom_wb_write_bit(wb, t);
+            eb_aom_wb_write_bit(wb, t);
             if (t) {
                 i = i + 1;
                 mk += a;
             }
             else {
-                aom_wb_write_literal(wb, v - mk, b);
+                eb_aom_wb_write_literal(wb, v - mk, b);
                 break;
             }
         }
     }
 }
 
-int32_t aom_count_primitive_subexpfin(uint16_t n, uint16_t k, uint16_t v) {
+int32_t eb_aom_count_primitive_subexpfin(uint16_t n, uint16_t k, uint16_t v) {
     int32_t count = 0;
     int32_t i = 0;
     int32_t mk = 0;
@@ -3855,7 +3855,7 @@ int32_t aom_count_primitive_subexpfin(uint16_t n, uint16_t k, uint16_t v) {
         int32_t b = (i ? k + i - 1 : k);
         int32_t a = (1 << b);
         if (n <= mk + 3 * a) {
-            count += aom_count_primitive_quniform((uint16_t)(n - mk), (uint16_t)(v - mk));
+            count += eb_aom_count_primitive_quniform((uint16_t)(n - mk), (uint16_t)(v - mk));
             break;
         }
         else {
@@ -3876,9 +3876,9 @@ int32_t aom_count_primitive_subexpfin(uint16_t n, uint16_t k, uint16_t v) {
 // Finite subexponential code that codes a symbol v in[0, n - 1] with parameter k
 // based on a reference ref also in [0, n-1].
 // Recenters symbol around r first and then uses a finite subexponential code.
-void aom_write_primitive_refsubexpfin(AomWriter *w, uint16_t n, uint16_t k,
+void eb_aom_write_primitive_refsubexpfin(AomWriter *w, uint16_t n, uint16_t k,
     uint16_t ref, uint16_t v) {
-    aom_write_primitive_subexpfin(w, n, k, recenter_finite_nonneg(n, ref, v));
+    eb_aom_write_primitive_subexpfin(w, n, k, recenter_finite_nonneg(n, ref, v));
 }
 
 static void aom_wb_write_primitive_refsubexpfin(struct AomWriteBitBuffer *wb,
@@ -3887,7 +3887,7 @@ static void aom_wb_write_primitive_refsubexpfin(struct AomWriteBitBuffer *wb,
     aom_wb_write_primitive_subexpfin(wb, n, k, recenter_finite_nonneg(n, ref, v));
 }
 
-void aom_wb_write_signed_primitive_refsubexpfin(struct AomWriteBitBuffer *wb,
+void eb_aom_wb_write_signed_primitive_refsubexpfin(struct AomWriteBitBuffer *wb,
     uint16_t n, uint16_t k,
     int16_t ref, int16_t v) {
     ref += n - 1;
@@ -3896,9 +3896,9 @@ void aom_wb_write_signed_primitive_refsubexpfin(struct AomWriteBitBuffer *wb,
     aom_wb_write_primitive_refsubexpfin(wb, scaled_n, k, ref, v);
 }
 
-int32_t aom_count_primitive_refsubexpfin(uint16_t n, uint16_t k, uint16_t ref,
+int32_t eb_aom_count_primitive_refsubexpfin(uint16_t n, uint16_t k, uint16_t ref,
     uint16_t v) {
-    return aom_count_primitive_subexpfin(n, k, recenter_finite_nonneg(n, ref, v));
+    return eb_aom_count_primitive_subexpfin(n, k, recenter_finite_nonneg(n, ref, v));
 }
 
 static void write_global_motion_params(const EbWarpedMotionParams *params,
@@ -3907,13 +3907,13 @@ static void write_global_motion_params(const EbWarpedMotionParams *params,
     int32_t allow_hp) {
     const TransformationType type = params->wmtype;
     assert(type == TRANSLATION || type == IDENTITY);
-    aom_wb_write_bit(wb, type != IDENTITY);
+    eb_aom_wb_write_bit(wb, type != IDENTITY);
     if (type != IDENTITY) {
 #if GLOBAL_TRANS_TYPES > 4
-        aom_wb_write_literal(wb, type - 1, GLOBAL_TYPE_BITS);
+        eb_aom_wb_write_literal(wb, type - 1, GLOBAL_TYPE_BITS);
 #else
-        aom_wb_write_bit(wb, type == ROTZOOM);
-        if (type != ROTZOOM) aom_wb_write_bit(wb, type == TRANSLATION);
+        eb_aom_wb_write_bit(wb, type == ROTZOOM);
+        if (type != ROTZOOM) eb_aom_wb_write_bit(wb, type == TRANSLATION);
 #endif  // GLOBAL_TRANS_TYPES > 4
     }
 
@@ -3924,11 +3924,11 @@ static void write_global_motion_params(const EbWarpedMotionParams *params,
         int16_t ref3 = (int16_t)(ref_params->wmmat[3] >> GM_ALPHA_PREC_DIFF);
         int16_t v3 = (int16_t)(params->wmmat[3] >> GM_ALPHA_PREC_DIFF);
 
-        aom_wb_write_signed_primitive_refsubexpfin(
+        eb_aom_wb_write_signed_primitive_refsubexpfin(
             wb, GM_ALPHA_MAX + 1, SUBEXPFIN_K,
             ref2/*(ref_params->wmmat[2] >> GM_ALPHA_PREC_DIFF) - (1 << GM_ALPHA_PREC_BITS)*/,
             v2/*(int16_t)((params->wmmat[2] >> GM_ALPHA_PREC_DIFF) - (1 << GM_ALPHA_PREC_BITS))*/);
-        aom_wb_write_signed_primitive_refsubexpfin(
+        eb_aom_wb_write_signed_primitive_refsubexpfin(
             wb, GM_ALPHA_MAX + 1, SUBEXPFIN_K,
             ref3/*(ref_params->wmmat[3] >> GM_ALPHA_PREC_DIFF)*/,
             v3/*(int16_t)(params->wmmat[3] >> GM_ALPHA_PREC_DIFF)*/);
@@ -3941,11 +3941,11 @@ static void write_global_motion_params(const EbWarpedMotionParams *params,
         int16_t ref5 = (int16_t)((ref_params->wmmat[5] >> GM_ALPHA_PREC_DIFF) - (1 << GM_ALPHA_PREC_BITS));
         int16_t v5 = (int16_t)((params->wmmat[5] >> GM_ALPHA_PREC_DIFF) - (1 << GM_ALPHA_PREC_BITS));
 
-        aom_wb_write_signed_primitive_refsubexpfin(
+        eb_aom_wb_write_signed_primitive_refsubexpfin(
             wb, GM_ALPHA_MAX + 1, SUBEXPFIN_K,
             ref4/*(ref_params->wmmat[4] >> GM_ALPHA_PREC_DIFF)*/,
             v4/*(int16_t)(params->wmmat[4] >> GM_ALPHA_PREC_DIFF)*/);
-        aom_wb_write_signed_primitive_refsubexpfin(
+        eb_aom_wb_write_signed_primitive_refsubexpfin(
             wb, GM_ALPHA_MAX + 1, SUBEXPFIN_K,
             ref5/*(ref_params->wmmat[5] >> GM_ALPHA_PREC_DIFF) -    (1 << GM_ALPHA_PREC_BITS)*/,
             v5/*(int16_t)(params->wmmat[5] >> GM_ALPHA_PREC_DIFF) - (1 << GM_ALPHA_PREC_BITS)*/);
@@ -3958,11 +3958,11 @@ static void write_global_motion_params(const EbWarpedMotionParams *params,
         const int32_t trans_prec_diff = (type == TRANSLATION)
             ? GM_TRANS_ONLY_PREC_DIFF + !allow_hp
             : GM_TRANS_PREC_DIFF;
-        aom_wb_write_signed_primitive_refsubexpfin(
+        eb_aom_wb_write_signed_primitive_refsubexpfin(
             wb, (1 << trans_bits) + 1, SUBEXPFIN_K,
             (int16_t)(ref_params->wmmat[0] >> trans_prec_diff),
             (int16_t)(params->wmmat[0] >> trans_prec_diff));
-        aom_wb_write_signed_primitive_refsubexpfin(
+        eb_aom_wb_write_signed_primitive_refsubexpfin(
             wb, (1 << trans_bits) + 1, SUBEXPFIN_K,
             (int16_t)(ref_params->wmmat[1] >> trans_prec_diff),
             (int16_t)(params->wmmat[1] >> trans_prec_diff));
@@ -4016,10 +4016,10 @@ static void write_film_grain_params(PictureParentControlSet *pcs_ptr,
     FrameHeader *frm_hdr = &pcs_ptr->frm_hdr;
     aom_film_grain_t *pars = &frm_hdr->film_grain_params;
 
-    aom_wb_write_bit(wb, pars->apply_grain);
+    eb_aom_wb_write_bit(wb, pars->apply_grain);
     if (!pars->apply_grain) return;
 
-    aom_wb_write_literal(wb, pars->random_seed, 16);
+    eb_aom_wb_write_literal(wb, pars->random_seed, 16);
 
     if (frm_hdr->frame_type == INTER_FRAME) {
         EbReferenceObject* refObj0 = (EbReferenceObject*)pcs_ptr->childPcs->ref_pic_ptr_array[REF_LIST_0][0]->object_ptr;
@@ -4037,9 +4037,9 @@ static void write_film_grain_params(PictureParentControlSet *pcs_ptr,
                 ref_idx = get_ref_frame_map_idx(pcs_ptr, ALTREF_FRAME);  //todo: will it always be ALF_REF in L1?
             }
         }
-        aom_wb_write_bit(wb, pars->update_parameters);
+        eb_aom_wb_write_bit(wb, pars->update_parameters);
         if (!pars->update_parameters) {
-            aom_wb_write_literal(wb, ref_idx, 3);
+            eb_aom_wb_write_literal(wb, ref_idx, 3);
             return;
         }
     }
@@ -4047,14 +4047,14 @@ static void write_film_grain_params(PictureParentControlSet *pcs_ptr,
         pars->update_parameters = 1;
 
     // Scaling functions parameters
-    aom_wb_write_literal(wb, pars->num_y_points, 4);  // max 14
+    eb_aom_wb_write_literal(wb, pars->num_y_points, 4);  // max 14
     for (int32_t i = 0; i < pars->num_y_points; i++) {
-        aom_wb_write_literal(wb, pars->scaling_points_y[i][0], 8);
-        aom_wb_write_literal(wb, pars->scaling_points_y[i][1], 8);
+        eb_aom_wb_write_literal(wb, pars->scaling_points_y[i][0], 8);
+        eb_aom_wb_write_literal(wb, pars->scaling_points_y[i][1], 8);
     }
 
     if (!pcs_ptr->sequence_control_set_ptr->seq_header.color_config.mono_chrome)
-        aom_wb_write_bit(wb, pars->chroma_scaling_from_luma);
+        eb_aom_wb_write_bit(wb, pars->chroma_scaling_from_luma);
     else
         pars->chroma_scaling_from_luma = 0;  // for monochrome override to 0
 
@@ -4067,26 +4067,26 @@ static void write_film_grain_params(PictureParentControlSet *pcs_ptr,
         pars->num_cr_points = 0;
     }
     else {
-        aom_wb_write_literal(wb, pars->num_cb_points, 4);  // max 10
+        eb_aom_wb_write_literal(wb, pars->num_cb_points, 4);  // max 10
         for (int32_t i = 0; i < pars->num_cb_points; i++) {
-            aom_wb_write_literal(wb, pars->scaling_points_cb[i][0], 8);
-            aom_wb_write_literal(wb, pars->scaling_points_cb[i][1], 8);
+            eb_aom_wb_write_literal(wb, pars->scaling_points_cb[i][0], 8);
+            eb_aom_wb_write_literal(wb, pars->scaling_points_cb[i][1], 8);
         }
 
-        aom_wb_write_literal(wb, pars->num_cr_points, 4);  // max 10
+        eb_aom_wb_write_literal(wb, pars->num_cr_points, 4);  // max 10
         for (int32_t i = 0; i < pars->num_cr_points; i++) {
-            aom_wb_write_literal(wb, pars->scaling_points_cr[i][0], 8);
-            aom_wb_write_literal(wb, pars->scaling_points_cr[i][1], 8);
+            eb_aom_wb_write_literal(wb, pars->scaling_points_cr[i][0], 8);
+            eb_aom_wb_write_literal(wb, pars->scaling_points_cr[i][1], 8);
         }
     }
 
-    aom_wb_write_literal(wb, pars->scaling_shift - 8, 2);  // 8 + value
+    eb_aom_wb_write_literal(wb, pars->scaling_shift - 8, 2);  // 8 + value
 
     // AR coefficients
     // Only sent if the corresponsing scaling function has
     // more than 0 points
 
-    aom_wb_write_literal(wb, pars->ar_coeff_lag, 2);
+    eb_aom_wb_write_literal(wb, pars->ar_coeff_lag, 2);
 
     int32_t num_pos_luma = 2 * pars->ar_coeff_lag * (pars->ar_coeff_lag + 1);
     int32_t num_pos_chroma = num_pos_luma;
@@ -4094,35 +4094,35 @@ static void write_film_grain_params(PictureParentControlSet *pcs_ptr,
 
     if (pars->num_y_points)
         for (int32_t i = 0; i < num_pos_luma; i++)
-            aom_wb_write_literal(wb, pars->ar_coeffs_y[i] + 128, 8);
+            eb_aom_wb_write_literal(wb, pars->ar_coeffs_y[i] + 128, 8);
 
     if (pars->num_cb_points || pars->chroma_scaling_from_luma)
         for (int32_t i = 0; i < num_pos_chroma; i++)
-            aom_wb_write_literal(wb, pars->ar_coeffs_cb[i] + 128, 8);
+            eb_aom_wb_write_literal(wb, pars->ar_coeffs_cb[i] + 128, 8);
 
     if (pars->num_cr_points || pars->chroma_scaling_from_luma)
         for (int32_t i = 0; i < num_pos_chroma; i++)
-            aom_wb_write_literal(wb, pars->ar_coeffs_cr[i] + 128, 8);
+            eb_aom_wb_write_literal(wb, pars->ar_coeffs_cr[i] + 128, 8);
 
-    aom_wb_write_literal(wb, pars->ar_coeff_shift - 6, 2);  // 8 + value
+    eb_aom_wb_write_literal(wb, pars->ar_coeff_shift - 6, 2);  // 8 + value
 
-    aom_wb_write_literal(wb, pars->grain_scale_shift, 2);
+    eb_aom_wb_write_literal(wb, pars->grain_scale_shift, 2);
 
     if (pars->num_cb_points) {
-        aom_wb_write_literal(wb, pars->cb_mult, 8);
-        aom_wb_write_literal(wb, pars->cb_luma_mult, 8);
-        aom_wb_write_literal(wb, pars->cb_offset, 9);
+        eb_aom_wb_write_literal(wb, pars->cb_mult, 8);
+        eb_aom_wb_write_literal(wb, pars->cb_luma_mult, 8);
+        eb_aom_wb_write_literal(wb, pars->cb_offset, 9);
     }
 
     if (pars->num_cr_points) {
-        aom_wb_write_literal(wb, pars->cr_mult, 8);
-        aom_wb_write_literal(wb, pars->cr_luma_mult, 8);
-        aom_wb_write_literal(wb, pars->cr_offset, 9);
+        eb_aom_wb_write_literal(wb, pars->cr_mult, 8);
+        eb_aom_wb_write_literal(wb, pars->cr_luma_mult, 8);
+        eb_aom_wb_write_literal(wb, pars->cr_offset, 9);
     }
 
-    aom_wb_write_bit(wb, pars->overlap_flag);
+    eb_aom_wb_write_bit(wb, pars->overlap_flag);
 
-    aom_wb_write_bit(wb, pars->clip_to_restricted_range);
+    eb_aom_wb_write_bit(wb, pars->clip_to_restricted_range);
 }
 
 // New function based on HLS R18
@@ -4151,14 +4151,13 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
             //}
             //ref_cnt_fb(frame_bufs, &cm->new_fb_idx, frame_to_show);
 
-            aom_wb_write_bit(wb, 1);  // show_existing_frame
-            aom_wb_write_literal(wb, frm_hdr->show_existing_frame, 3);
-
+            eb_aom_wb_write_bit(wb, 1);  // show_existing_frame
+            eb_aom_wb_write_literal(wb, frm_hdr->show_existing_frame, 3);
             if (scs_ptr->seq_header.frame_id_numbers_present_flag) {
                 printf("ERROR[AN]: frame_id_numbers_present_flag not supported yet\n");
                 /*int32_t frame_id_len = cm->seq_params.frame_id_length;
                 int32_t display_frame_id = cm->ref_frame_id[cpi->show_existing_frame];
-                aom_wb_write_literal(wb, display_frame_id, frame_id_len);*/
+                eb_aom_wb_write_literal(wb, display_frame_id, frame_id_len);*/
             }
 
             //        if (cm->reset_decoder_state &&
@@ -4171,27 +4170,27 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
             return;
         }
         else
-            aom_wb_write_bit(wb, 0);  // show_existing_frame
+            eb_aom_wb_write_bit(wb, 0);  // show_existing_frame
         //frm_hdr->frame_type = pcs_ptr->intra_only ? INTRA_ONLY_FRAME : frm_hdr->frame_type;
 
-        aom_wb_write_literal(wb, frm_hdr->frame_type, 2);
+        eb_aom_wb_write_literal(wb, frm_hdr->frame_type, 2);
 
         // if (frm_hdr->intra_only) frm_hdr->frame_type = INTRA_ONLY_FRAME;
 
-        aom_wb_write_bit(wb, frm_hdr->show_frame);
+        eb_aom_wb_write_bit(wb, frm_hdr->show_frame);
 
         if (!frm_hdr->show_frame)
-            aom_wb_write_bit(wb, frm_hdr->showable_frame);
+            eb_aom_wb_write_bit(wb, frm_hdr->showable_frame);
         if (frm_hdr->frame_type == S_FRAME)
             assert(frm_hdr->error_resilient_mode);
         else if (!(frm_hdr->frame_type == KEY_FRAME && frm_hdr->show_frame))
-            aom_wb_write_bit(wb, frm_hdr->error_resilient_mode);
+            eb_aom_wb_write_bit(wb, frm_hdr->error_resilient_mode);
     }
 
-    aom_wb_write_bit(wb, frm_hdr->disable_cdf_update);
+    eb_aom_wb_write_bit(wb, frm_hdr->disable_cdf_update);
 
     if (scs_ptr->seq_header.seq_force_screen_content_tools == 2)
-        aom_wb_write_bit(wb, frm_hdr->allow_screen_content_tools);
+        eb_aom_wb_write_bit(wb, frm_hdr->allow_screen_content_tools);
     else {
         assert(frm_hdr->allow_screen_content_tools ==
             scs_ptr->seq_header.seq_force_screen_content_tools);
@@ -4199,7 +4198,7 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
 
     if (frm_hdr->allow_screen_content_tools) {
         if (scs_ptr->seq_header.seq_force_integer_mv == 2)
-            aom_wb_write_bit(wb, frm_hdr->force_integer_mv);
+            eb_aom_wb_write_bit(wb, frm_hdr->force_integer_mv);
         else
             assert(frm_hdr->force_integer_mv == scs_ptr->seq_header.seq_force_integer_mv);
     }
@@ -4209,7 +4208,7 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
     if (!scs_ptr->seq_header.reduced_still_picture_header) {
         if (scs_ptr->seq_header.frame_id_numbers_present_flag) {
             int32_t frame_id_len = scs_ptr->seq_header.frame_id_length;
-            aom_wb_write_literal(wb, frm_hdr->current_frame_id, frame_id_len);
+            eb_aom_wb_write_literal(wb, frm_hdr->current_frame_id, frame_id_len);
         }
 
         //if (cm->width > cm->seq_params.max_frame_width ||
@@ -4222,19 +4221,19 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
         /*        (pcs_ptr->frame_type == S_FRAME) ? 1
         : (cm->width != cm->seq_params.max_frame_width ||
         cm->height != cm->seq_params.max_frame_height);*/
-        if (frm_hdr->frame_type != S_FRAME) aom_wb_write_bit(wb, frame_size_override_flag);
+        if (frm_hdr->frame_type != S_FRAME) eb_aom_wb_write_bit(wb, frame_size_override_flag);
 
         if (scs_ptr->seq_header.order_hint_info.enable_order_hint)
-            aom_wb_write_literal(wb, (int32_t)pcs_ptr->frame_offset,
+            eb_aom_wb_write_literal(wb, (int32_t)pcs_ptr->frame_offset,
                 scs_ptr->seq_header.order_hint_info.order_hint_bits);
 
         if (!frm_hdr->error_resilient_mode && !frame_is_intra_only(pcs_ptr))
-            aom_wb_write_literal(wb, frm_hdr->primary_ref_frame, PRIMARY_REF_BITS);
+            eb_aom_wb_write_literal(wb, frm_hdr->primary_ref_frame, PRIMARY_REF_BITS);
     }
     int32_t frame_size_override_flag = 0;
     if (frm_hdr->frame_type == KEY_FRAME) {
         if (!frm_hdr->show_frame)
-            aom_wb_write_literal(wb, pcs_ptr->av1_ref_signal.refresh_frame_mask, REF_FRAMES);
+            eb_aom_wb_write_literal(wb, pcs_ptr->av1_ref_signal.refresh_frame_mask, REF_FRAMES);
     }
     else {
         if (frm_hdr->frame_type == INTRA_ONLY_FRAME) {
@@ -4251,12 +4250,12 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
             assert(updated_fb >= 0);
             pcs_ptr->fb_of_context_type[pcs_ptr->frame_context_idx] = updated_fb;
 
-            aom_wb_write_literal(wb, pcs_ptr->av1_ref_signal.refresh_frame_mask, REF_FRAMES);
+            eb_aom_wb_write_literal(wb, pcs_ptr->av1_ref_signal.refresh_frame_mask, REF_FRAMES);
         }
         else if (frm_hdr->frame_type == INTER_FRAME || frame_is_sframe(pcs_ptr)) {
             //pcs_ptr->refresh_frame_mask = get_refresh_mask(cpi);
             if (frm_hdr->frame_type == INTER_FRAME)
-                aom_wb_write_literal(wb, pcs_ptr->av1_ref_signal.refresh_frame_mask, REF_FRAMES);
+                eb_aom_wb_write_literal(wb, pcs_ptr->av1_ref_signal.refresh_frame_mask, REF_FRAMES);
             else
                 assert(frame_is_sframe(pcs_ptr) && pcs_ptr->av1_ref_signal.refresh_frame_mask == 0xFF);
             int32_t updated_fb = -1;
@@ -4284,7 +4283,7 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
         //assert(av1_superres_unscaled(cm) ||
         //    !(cm->allow_intrabc && NO_FILTER_FOR_IBC));
         if (frm_hdr->allow_screen_content_tools)
-            aom_wb_write_bit(wb, frm_hdr->allow_intrabc);
+            eb_aom_wb_write_bit(wb, frm_hdr->allow_intrabc);
         // all eight fbs are refreshed, pick one that will live long enough
         pcs_ptr->fb_of_context_type[REGULAR_FRAME] = 0;
     }
@@ -4292,7 +4291,7 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
         if (frm_hdr->frame_type == INTRA_ONLY_FRAME) {
             write_frame_size(pcs_ptr, frame_size_override_flag, wb);
             if (frm_hdr->allow_screen_content_tools)
-                aom_wb_write_bit(wb, frm_hdr->allow_intrabc);
+                eb_aom_wb_write_bit(wb, frm_hdr->allow_intrabc);
         }
         else if (frm_hdr->frame_type == INTER_FRAME || frame_is_sframe(pcs_ptr)) {
             MvReferenceFrame ref_frame;
@@ -4301,18 +4300,18 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
             // NOTE: Error resilient mode turns off frame_refs_short_signaling
             //       automatically.
             if (scs_ptr->seq_header.order_hint_info.enable_order_hint)
-                aom_wb_write_bit(wb, frm_hdr->frame_refs_short_signaling);
+                eb_aom_wb_write_bit(wb, frm_hdr->frame_refs_short_signaling);
 
             if (frm_hdr->frame_refs_short_signaling) {
-                aom_wb_write_literal(wb, get_ref_frame_map_idx(pcs_ptr, LAST_FRAME),
+                eb_aom_wb_write_literal(wb, get_ref_frame_map_idx(pcs_ptr, LAST_FRAME),
                     REF_FRAMES_LOG2);
-                aom_wb_write_literal(wb, get_ref_frame_map_idx(pcs_ptr, GOLDEN_FRAME),
+                eb_aom_wb_write_literal(wb, get_ref_frame_map_idx(pcs_ptr, GOLDEN_FRAME),
                     REF_FRAMES_LOG2);
             }
             for (ref_frame = LAST_FRAME; ref_frame <= ALTREF_FRAME; ++ref_frame) {
                 assert(get_ref_frame_map_idx(pcs_ptr, ref_frame) != INVALID_IDX);
                 if (!frm_hdr->frame_refs_short_signaling)
-                    aom_wb_write_literal(wb, get_ref_frame_map_idx(pcs_ptr, ref_frame),
+                    eb_aom_wb_write_literal(wb, get_ref_frame_map_idx(pcs_ptr, ref_frame),
                         REF_FRAMES_LOG2);
 
                 if (scs_ptr->seq_header.frame_id_numbers_present_flag) {
@@ -4328,7 +4327,7 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
                     //if (delta_frame_id_minus1 < 0 ||
                     //    delta_frame_id_minus1 >= (1 << diff_len))
                     //    cm->invalid_delta_frame_id_minus1 = 1;
-                    //aom_wb_write_literal(wb, delta_frame_id_minus1, diff_len);
+                    //eb_aom_wb_write_literal(wb, delta_frame_id_minus1, diff_len);
                 }
             }
 
@@ -4341,18 +4340,18 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
             if (frm_hdr->force_integer_mv)
                 frm_hdr->allow_high_precision_mv = 0;
             else
-                aom_wb_write_bit(wb, frm_hdr->allow_high_precision_mv);
+                eb_aom_wb_write_bit(wb, frm_hdr->allow_high_precision_mv);
 #define LOG_SWITCHABLE_FILTERS  2
 
             // OPT fix_interp_filter(cm, cpi->td.counts);
             // write_frame_interp_filter(cm->interp_filter, wb);
-            aom_wb_write_bit(wb, pcs_ptr->av1_cm->interp_filter == SWITCHABLE);
+            eb_aom_wb_write_bit(wb, pcs_ptr->av1_cm->interp_filter == SWITCHABLE);
             if (pcs_ptr->av1_cm->interp_filter != SWITCHABLE)
-                aom_wb_write_literal(wb, pcs_ptr->av1_cm->interp_filter, LOG_SWITCHABLE_FILTERS);
+                eb_aom_wb_write_literal(wb, pcs_ptr->av1_cm->interp_filter, LOG_SWITCHABLE_FILTERS);
 
-            aom_wb_write_bit(wb, frm_hdr->is_motion_mode_switchable);
+            eb_aom_wb_write_bit(wb, frm_hdr->is_motion_mode_switchable);
             if (frame_might_allow_ref_frame_mvs(pcs_ptr, scs_ptr))
-                aom_wb_write_bit(wb, frm_hdr->use_ref_frame_mvs);
+                eb_aom_wb_write_bit(wb, frm_hdr->use_ref_frame_mvs);
         }
     }
 
@@ -4363,7 +4362,7 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
     if (pcs_ptr->large_scale_tile)
         pcs_ptr->refresh_frame_context = REFRESH_FRAME_CONTEXT_DISABLED;
     if (might_bwd_adapt) {
-        aom_wb_write_bit(
+        eb_aom_wb_write_bit(
             wb, pcs_ptr->refresh_frame_context == REFRESH_FRAME_CONTEXT_DISABLED);
     }
 
@@ -4371,25 +4370,25 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
 
     encode_quantization(pcs_ptr, wb);
     encode_segmentation(pcs_ptr, wb);
-    //aom_wb_write_bit(wb, 0);
+    //eb_aom_wb_write_bit(wb, 0);
     //encode_segmentation(cm, xd, wb);
         //if (pcs_ptr->delta_q_present_flag)
            // assert(delta_q_allowed == 1 && frm_hdr->quantisation_params.base_q_idx > 0);
 
     if (frm_hdr->quantization_params.base_q_idx > 0) {
-        aom_wb_write_bit(wb, frm_hdr->delta_q_params.delta_q_present);
+        eb_aom_wb_write_bit(wb, frm_hdr->delta_q_params.delta_q_present);
         if (frm_hdr->delta_q_params.delta_q_present) {
 #if ADD_DELTA_QP_SUPPORT //PART 0
-            aom_wb_write_literal(wb, OD_ILOG_NZ(frm_hdr->delta_q_params.delta_q_res) - 1, 2);
+            eb_aom_wb_write_literal(wb, OD_ILOG_NZ(frm_hdr->delta_q_params.delta_q_res) - 1, 2);
             pcs_ptr->prev_qindex = frm_hdr->quantization_params.base_q_idx;
             if (pcs_ptr->allow_intrabc)
                 assert(frm_hdr->delta_lf_params.delta_lf_present == 0);
             else
-                aom_wb_write_bit(wb, frm_hdr->delta_lf_params.delta_lf_present);
+                eb_aom_wb_write_bit(wb, frm_hdr->delta_lf_params.delta_lf_present);
             if (frm_hdr->delta_lf_params.delta_lf_present) {
-                aom_wb_write_literal(wb, OD_ILOG_NZ(frm_hdr->delta_lf_params.delta_lf_res) - 1, 2);
+                eb_aom_wb_write_literal(wb, OD_ILOG_NZ(frm_hdr->delta_lf_params.delta_lf_res) - 1, 2);
                 pcs_ptr->prev_delta_lf_from_base = 0;
-                aom_wb_write_bit(wb, frm_hdr->delta_lf_params.delta_lf_multi);
+                eb_aom_wb_write_bit(wb, frm_hdr->delta_lf_params.delta_lf_multi);
                 const int32_t frame_lf_count =
                     pcs_ptr->monochrome == 0 ? FRAME_LF_COUNT : FRAME_LF_COUNT - 2;
                 for (int32_t lf_id = 0; lf_id < frame_lf_count; ++lf_id)
@@ -4398,16 +4397,16 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
 #else
             printf("ERROR[AN]: delta_q_present_flag not supported yet\n");
 #endif
-            //                aom_wb_write_literal(wb, OD_ILOG_NZ(frm_hdr->delta_q_params.delta_q_res) - 1, 2);
+            //                eb_aom_wb_write_literal(wb, OD_ILOG_NZ(frm_hdr->delta_q_params.delta_q_res) - 1, 2);
             //                xd->prev_qindex = frm_hdr->quantization_params.base_q_idx;
             //                if (cm->allow_intrabc)
             //                    assert(frm_hdr->delta_lf_params.delta_lf_present == 0);
             //                else
-            //                    aom_wb_write_bit(wb, frm_hdr->delta_lf_params.delta_lf_present);
+            //                    eb_aom_wb_write_bit(wb, frm_hdr->delta_lf_params.delta_lf_present);
             //                if (frm_hdr->delta_lf_params.delta_lf_present) {
-            //                    aom_wb_write_literal(wb, OD_ILOG_NZ(frm_hdr->delta_lf_params.delta_lf_res) - 1, 2);
+            //                    eb_aom_wb_write_literal(wb, OD_ILOG_NZ(frm_hdr->delta_lf_params.delta_lf_res) - 1, 2);
             //                    xd->prev_delta_lf_from_base = 0;
-            //                    aom_wb_write_bit(wb, frm_hdr->delta_lf_params.delta_lf_multi);
+            //                    eb_aom_wb_write_bit(wb, frm_hdr->delta_lf_params.delta_lf_multi);
             //                    const int32_t frame_lf_count =
             //                        av1_num_planes(cm) > 1 ? FRAME_LF_COUNT : FRAME_LF_COUNT - 2;
             //                    for (int32_t lf_id = 0; lf_id < frame_lf_count; ++lf_id)
@@ -4430,23 +4429,23 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
             encode_restoration_mode(pcs_ptr, wb);
     }
 
-    aom_wb_write_bit(wb, frm_hdr->tx_mode == TX_MODE_SELECT);
+    eb_aom_wb_write_bit(wb, frm_hdr->tx_mode == TX_MODE_SELECT);
     //write_tx_mode(cm, &pcs_ptr->tx_mode, wb);
 
     if (pcs_ptr->allow_comp_inter_inter) {
         const int32_t use_hybrid_pred = frm_hdr->reference_mode == REFERENCE_MODE_SELECT;
 
-        aom_wb_write_bit(wb, use_hybrid_pred);
+        eb_aom_wb_write_bit(wb, use_hybrid_pred);
     }
 
-    if (pcs_ptr->is_skip_mode_allowed) aom_wb_write_bit(wb, pcs_ptr->skip_mode_flag);
+    if (pcs_ptr->is_skip_mode_allowed) eb_aom_wb_write_bit(wb, pcs_ptr->skip_mode_flag);
 
     if (frame_might_allow_warped_motion(pcs_ptr, scs_ptr))
-        aom_wb_write_bit(wb, frm_hdr->allow_warped_motion);
+        eb_aom_wb_write_bit(wb, frm_hdr->allow_warped_motion);
     else
         assert(!frm_hdr->allow_warped_motion);
 
-    aom_wb_write_bit(wb, frm_hdr->reduced_tx_set);
+    eb_aom_wb_write_bit(wb, frm_hdr->reduced_tx_set);
 
     if (!frame_is_intra_only(pcs_ptr)) {
         //  printf("ERROR[AN]: Global motion not supported yet\n");
@@ -4461,15 +4460,15 @@ uint32_t WriteObuHeader(obuType obuType, int32_t obuExtension,
     struct AomWriteBitBuffer wb = { dst, 0 };
     uint32_t size = 0;
 
-    aom_wb_write_literal(&wb, 0, 1);  // forbidden bit.
-    aom_wb_write_literal(&wb, (int32_t)obuType, 4);
-    aom_wb_write_literal(&wb, obuExtension ? 1 : 0, 1);
-    aom_wb_write_literal(&wb, 1, 1);  // obu_has_payload_length_field
-    aom_wb_write_literal(&wb, 0, 1);  // reserved
+    eb_aom_wb_write_literal(&wb, 0, 1);  // forbidden bit.
+    eb_aom_wb_write_literal(&wb, (int32_t)obuType, 4);
+    eb_aom_wb_write_literal(&wb, obuExtension ? 1 : 0, 1);
+    eb_aom_wb_write_literal(&wb, 1, 1);  // obu_has_payload_length_field
+    eb_aom_wb_write_literal(&wb, 0, 1);  // reserved
 
     if (obuExtension)
-        aom_wb_write_literal(&wb, obuExtension & 0xFF, 8);
-    size = aom_wb_bytes_written(&wb);
+        eb_aom_wb_write_literal(&wb, obuExtension & 0xFF, 8);
+    size = eb_aom_wb_bytes_written(&wb);
     return size;
 }
 int32_t WriteUlebObuSize(uint32_t obuHeaderSize, uint32_t obuPayloadSize,
@@ -4478,7 +4477,7 @@ int32_t WriteUlebObuSize(uint32_t obuHeaderSize, uint32_t obuPayloadSize,
     const uint32_t offset = obuHeaderSize;
     size_t codedObuSize = 0;
 
-    if (aom_uleb_encode(obuSize, sizeof(obuSize), dest + offset,
+    if (eb_aom_uleb_encode(obuSize, sizeof(obuSize), dest + offset,
         &codedObuSize) != 0) {
         return AOM_CODEC_ERROR;
     }
@@ -4490,7 +4489,7 @@ static size_t ObuMemMove(
     uint32_t obuPayloadSize,
     uint8_t *data)
 {
-    const size_t lengthFieldSize = aom_uleb_size_in_bytes(obuPayloadSize);
+    const size_t lengthFieldSize = eb_aom_uleb_size_in_bytes(obuPayloadSize);
     const uint32_t moveDstOffset =
         (uint32_t)lengthFieldSize + obuHeaderSize;
     const uint32_t moveSrcOffset = obuHeaderSize;
@@ -4500,18 +4499,18 @@ static size_t ObuMemMove(
 }
 
 static void add_trailing_bits(struct AomWriteBitBuffer *wb) {
-    if (aom_wb_is_byte_aligned(wb))
-        aom_wb_write_literal(wb, 0x80, 8);
+    if (eb_aom_wb_is_byte_aligned(wb))
+        eb_aom_wb_write_literal(wb, 0x80, 8);
     else {
         // assumes that the other bits are already 0s
-        aom_wb_write_bit(wb, 1);
+        eb_aom_wb_write_bit(wb, 1);
     }
 }
 static void write_bitstream_level(BitstreamLevel bl,
     struct AomWriteBitBuffer *wb) {
     uint8_t seq_level_idx = major_minor_to_seq_level_idx(bl);
     assert(is_valid_seq_level_idx(seq_level_idx));
-    aom_wb_write_literal(wb, seq_level_idx, LEVEL_BITS);
+    eb_aom_wb_write_literal(wb, seq_level_idx, LEVEL_BITS);
 }
 static uint32_t WriteSequenceHeaderObu(
     SequenceControlSet *scs_ptr,
@@ -4526,54 +4525,54 @@ static uint32_t WriteSequenceHeaderObu(
     WriteProfile((BitstreamProfile)scs_ptr->static_config.profile, &wb);
 
     // Still picture or not
-    aom_wb_write_bit(&wb, scs_ptr->seq_header.still_picture);
+    eb_aom_wb_write_bit(&wb, scs_ptr->seq_header.still_picture);
     assert(IMPLIES(!scs_ptr->seq_header.still_picture,
         !scs_ptr->seq_header.reduced_still_picture_header));
 
     // whether to use reduced still picture header
-    aom_wb_write_bit(&wb, scs_ptr->seq_header.reduced_still_picture_header);
+    eb_aom_wb_write_bit(&wb, scs_ptr->seq_header.reduced_still_picture_header);
 
     if (scs_ptr->seq_header.reduced_still_picture_header) {
         printf("ERROR[AN]: reduced_still_picture_hdr not supported\n");
         //write_bitstream_level(cm->seq_params.level[0], &wb);
     }
     else {
-        aom_wb_write_bit(&wb, scs_ptr->seq_header.timing_info.timing_info_present);  // timing info present flag
+        eb_aom_wb_write_bit(&wb, scs_ptr->seq_header.timing_info.timing_info_present);  // timing info present flag
 
         if (scs_ptr->seq_header.timing_info.timing_info_present) {
             // timing_info
             printf("ERROR[AN]: timing_info_present not supported\n");
             /*write_timing_info_header(cm, &wb);
-            aom_wb_write_bit(&wb, cm->decoder_model_info_present_flag);
+            eb_aom_wb_write_bit(&wb, cm->decoder_model_info_present_flag);
             if (cm->decoder_model_info_present_flag) write_decoder_model_info(cm, &wb);*/
         }
-        aom_wb_write_bit(&wb, scs_ptr->seq_header.initial_display_delay_present_flag);
+        eb_aom_wb_write_bit(&wb, scs_ptr->seq_header.initial_display_delay_present_flag);
 
         uint8_t operating_points_cnt_minus_1 =
             numberSpatialLayers > 1 ? numberSpatialLayers - 1 : 0;
-        aom_wb_write_literal(&wb, operating_points_cnt_minus_1,
+        eb_aom_wb_write_literal(&wb, operating_points_cnt_minus_1,
             OP_POINTS_CNT_MINUS_1_BITS);
         int32_t i;
         for (i = 0; i < operating_points_cnt_minus_1 + 1; i++) {
-            aom_wb_write_literal(&wb, scs_ptr->seq_header.operating_point[i].op_idc,
+            eb_aom_wb_write_literal(&wb, scs_ptr->seq_header.operating_point[i].op_idc,
                 OP_POINTS_IDC_BITS);
             write_bitstream_level(scs_ptr->level[i], &wb);
             if (scs_ptr->level[i].major > 3)
-                aom_wb_write_bit(&wb, scs_ptr->seq_header.operating_point[i].seq_tier);
+                eb_aom_wb_write_bit(&wb, scs_ptr->seq_header.operating_point[i].seq_tier);
             if (scs_ptr->seq_header.decoder_model_info_present_flag) {
                 printf("ERROR[AN]: decoder_model_info_present_flag not supported\n");
-                //aom_wb_write_bit(&wb,
+                //eb_aom_wb_write_bit(&wb,
                 //    cm->op_params[i].decoder_model_param_present_flag);
                 //if (cm->op_params[i].decoder_model_param_present_flag)
                 //    write_dec_model_op_parameters(cm, &wb, i);
             }
             if (scs_ptr->seq_header.initial_display_delay_present_flag) {
                 printf("ERROR[AN]: display_model_info_present_flag not supported\n");
-                //aom_wb_write_bit(&wb,
+                //eb_aom_wb_write_bit(&wb,
                 //    cm->op_params[i].display_model_param_present_flag);
                 //if (cm->op_params[i].display_model_param_present_flag) {
                 //    assert(cm->op_params[i].initial_display_delay <= 10);
-                //    aom_wb_write_literal(&wb, cm->op_params[i].initial_display_delay - 1,
+                //    eb_aom_wb_write_literal(&wb, cm->op_params[i].initial_display_delay - 1,
                 //        4);
                 //}
             }
@@ -4583,11 +4582,11 @@ static uint32_t WriteSequenceHeaderObu(
 
     write_color_config(scs_ptr, &wb);
 
-    aom_wb_write_bit(&wb, scs_ptr->seq_header.film_grain_params_present);
+    eb_aom_wb_write_bit(&wb, scs_ptr->seq_header.film_grain_params_present);
 
     add_trailing_bits(&wb);
 
-    size = aom_wb_bytes_written(&wb);
+    size = eb_aom_wb_bytes_written(&wb);
     return size;
 }
 static uint32_t write_tile_group_header(uint8_t *const dst, int startTile,
@@ -4598,14 +4597,14 @@ static uint32_t write_tile_group_header(uint8_t *const dst, int startTile,
     uint32_t size = 0;
 
     if (!tiles_log2) return size;
-    aom_wb_write_bit(&wb, tile_start_and_end_present_flag);
+    eb_aom_wb_write_bit(&wb, tile_start_and_end_present_flag);
 
     if (tile_start_and_end_present_flag) {
-        aom_wb_write_literal(&wb, startTile, tiles_log2);
-        aom_wb_write_literal(&wb, endTile, tiles_log2);
+        eb_aom_wb_write_literal(&wb, startTile, tiles_log2);
+        eb_aom_wb_write_literal(&wb, endTile, tiles_log2);
     }
 
-    size = aom_wb_bytes_written(&wb);
+    size = eb_aom_wb_bytes_written(&wb);
     return size;
 }
 
@@ -4626,11 +4625,11 @@ static uint32_t WriteFrameHeaderObu(
         add_trailing_bits(&wb);
 
     if (showExisting) {
-        totalSize = aom_wb_bytes_written(&wb);
+        totalSize = eb_aom_wb_bytes_written(&wb);
         return totalSize;
     }
 
-    totalSize = aom_wb_bytes_written(&wb);
+    totalSize = eb_aom_wb_bytes_written(&wb);
     return totalSize;
 }
 
@@ -4737,7 +4736,7 @@ EbErrorType encode_td_av1(
     // move data and insert OBU_TD preceded by optional 4 byte size
     uint32_t obu_header_size = 1;
     const uint32_t obu_payload_size = 0;
-    const size_t length_field_size = aom_uleb_size_in_bytes(obu_payload_size);
+    const size_t length_field_size = eb_aom_uleb_size_in_bytes(obu_payload_size);
 
     obu_header_size = WriteObuHeader(
         OBU_TEMPORAL_DELIMITER, 0, data);
@@ -4822,7 +4821,7 @@ static void write_cdef(
     }
 }
 
-void av1_reset_loop_restoration(PictureControlSet     *piCSetPtr) {
+void eb_av1_reset_loop_restoration(PictureControlSet     *piCSetPtr) {
     for (int32_t p = 0; p < 3; ++p) {
         set_default_wiener(piCSetPtr->wiener_info + p);
         set_default_sgrproj(piCSetPtr->sgrproj_info + p);
@@ -4831,7 +4830,7 @@ void av1_reset_loop_restoration(PictureControlSet     *piCSetPtr) {
 static void write_wiener_filter(int32_t wiener_win, const WienerInfo *wiener_info,
     WienerInfo *ref_wiener_info, AomWriter *wb) {
     if (wiener_win == WIENER_WIN)
-        aom_write_primitive_refsubexpfin(
+        eb_aom_write_primitive_refsubexpfin(
             wb, WIENER_FILT_TAP0_MAXV - WIENER_FILT_TAP0_MINV + 1,
             WIENER_FILT_TAP0_SUBEXP_K,
             ref_wiener_info->vfilter[0] - WIENER_FILT_TAP0_MINV,
@@ -4839,18 +4838,18 @@ static void write_wiener_filter(int32_t wiener_win, const WienerInfo *wiener_inf
     else
         assert(wiener_info->vfilter[0] == 0 &&
             wiener_info->vfilter[WIENER_WIN - 1] == 0);
-    aom_write_primitive_refsubexpfin(
+    eb_aom_write_primitive_refsubexpfin(
         wb, WIENER_FILT_TAP1_MAXV - WIENER_FILT_TAP1_MINV + 1,
         WIENER_FILT_TAP1_SUBEXP_K,
         ref_wiener_info->vfilter[1] - WIENER_FILT_TAP1_MINV,
         wiener_info->vfilter[1] - WIENER_FILT_TAP1_MINV);
-    aom_write_primitive_refsubexpfin(
+    eb_aom_write_primitive_refsubexpfin(
         wb, WIENER_FILT_TAP2_MAXV - WIENER_FILT_TAP2_MINV + 1,
         WIENER_FILT_TAP2_SUBEXP_K,
         ref_wiener_info->vfilter[2] - WIENER_FILT_TAP2_MINV,
         wiener_info->vfilter[2] - WIENER_FILT_TAP2_MINV);
     if (wiener_win == WIENER_WIN)
-        aom_write_primitive_refsubexpfin(
+        eb_aom_write_primitive_refsubexpfin(
             wb, WIENER_FILT_TAP0_MAXV - WIENER_FILT_TAP0_MINV + 1,
             WIENER_FILT_TAP0_SUBEXP_K,
             ref_wiener_info->hfilter[0] - WIENER_FILT_TAP0_MINV,
@@ -4858,12 +4857,12 @@ static void write_wiener_filter(int32_t wiener_win, const WienerInfo *wiener_inf
     else
         assert(wiener_info->hfilter[0] == 0 &&
             wiener_info->hfilter[WIENER_WIN - 1] == 0);
-    aom_write_primitive_refsubexpfin(
+    eb_aom_write_primitive_refsubexpfin(
         wb, WIENER_FILT_TAP1_MAXV - WIENER_FILT_TAP1_MINV + 1,
         WIENER_FILT_TAP1_SUBEXP_K,
         ref_wiener_info->hfilter[1] - WIENER_FILT_TAP1_MINV,
         wiener_info->hfilter[1] - WIENER_FILT_TAP1_MINV);
-    aom_write_primitive_refsubexpfin(
+    eb_aom_write_primitive_refsubexpfin(
         wb, WIENER_FILT_TAP2_MAXV - WIENER_FILT_TAP2_MINV + 1,
         WIENER_FILT_TAP2_SUBEXP_K,
         ref_wiener_info->hfilter[2] - WIENER_FILT_TAP2_MINV,
@@ -4875,27 +4874,27 @@ static void write_sgrproj_filter(const SgrprojInfo *sgrproj_info,
     SgrprojInfo *ref_sgrproj_info,
     AomWriter *wb) {
     aom_write_literal(wb, sgrproj_info->ep, SGRPROJ_PARAMS_BITS);
-    const SgrParamsType *params = &sgr_params[sgrproj_info->ep];
+    const SgrParamsType *params = &eb_sgr_params[sgrproj_info->ep];
 
     if (params->r[0] == 0) {
         assert(sgrproj_info->xqd[0] == 0);
-        aom_write_primitive_refsubexpfin(
+        eb_aom_write_primitive_refsubexpfin(
             wb, SGRPROJ_PRJ_MAX1 - SGRPROJ_PRJ_MIN1 + 1, SGRPROJ_PRJ_SUBEXP_K,
             (uint16_t)(ref_sgrproj_info->xqd[1] - SGRPROJ_PRJ_MIN1),
             (uint16_t)(sgrproj_info->xqd[1] - SGRPROJ_PRJ_MIN1));
     }
     else if (params->r[1] == 0) {
-        aom_write_primitive_refsubexpfin(
+        eb_aom_write_primitive_refsubexpfin(
             wb, SGRPROJ_PRJ_MAX0 - SGRPROJ_PRJ_MIN0 + 1, SGRPROJ_PRJ_SUBEXP_K,
             (uint16_t)(ref_sgrproj_info->xqd[0] - SGRPROJ_PRJ_MIN0),
             (uint16_t)(sgrproj_info->xqd[0] - SGRPROJ_PRJ_MIN0));
     }
     else {
-        aom_write_primitive_refsubexpfin(
+        eb_aom_write_primitive_refsubexpfin(
             wb, SGRPROJ_PRJ_MAX0 - SGRPROJ_PRJ_MIN0 + 1, SGRPROJ_PRJ_SUBEXP_K,
             (uint16_t)(ref_sgrproj_info->xqd[0] - SGRPROJ_PRJ_MIN0),
             (uint16_t)(sgrproj_info->xqd[0] - SGRPROJ_PRJ_MIN0));
-        aom_write_primitive_refsubexpfin(
+        eb_aom_write_primitive_refsubexpfin(
             wb, SGRPROJ_PRJ_MAX1 - SGRPROJ_PRJ_MIN1 + 1, SGRPROJ_PRJ_SUBEXP_K,
             (uint16_t)(ref_sgrproj_info->xqd[1] - SGRPROJ_PRJ_MIN1),
             (uint16_t)(sgrproj_info->xqd[1] - SGRPROJ_PRJ_MIN1));
@@ -5185,7 +5184,7 @@ static void write_palette_mode_info(
         }
     }
 }
-void av1_encode_dv(AomWriter *w, const MV *mv, const MV *ref,
+void eb_av1_encode_dv(AomWriter *w, const MV *mv, const MV *ref,
     NmvContext *mvctx) {
     // DV and ref DV should not have sub-pel.
     assert((mv->col & 7) == 0);
@@ -5222,7 +5221,7 @@ static void write_intrabc_info(
         mv.row = cu_ptr->prediction_unit_array[0].mv[INTRA_FRAME].y;
         mv.col = cu_ptr->prediction_unit_array[0].mv[INTRA_FRAME].x;
 
-        av1_encode_dv(w, &mv, &dv_ref.as_mv, &ec_ctx->ndvc);
+        eb_av1_encode_dv(w, &mv, &dv_ref.as_mv, &ec_ctx->ndvc);
     }
 }
 
@@ -5682,7 +5681,7 @@ int get_spatial_seg_prediction(PictureControlSet *picture_control_set_ptr,
 }
 
 
-int av1_neg_interleave(int x, int ref, int max) {
+int eb_av1_neg_interleave(int x, int ref, int max) {
     assert(x < max);
     const int diff = x - ref;
     if (!ref) return x;
@@ -5772,7 +5771,7 @@ void write_segment_id(PictureControlSet *picture_control_set_ptr,
         cu_ptr->segment_id = pred;
         return;
     }
-    const int coded_id = av1_neg_interleave(cu_ptr->segment_id, pred, segmentationParams->last_active_seg_id + 1);
+    const int coded_id = eb_av1_neg_interleave(cu_ptr->segment_id, pred, segmentationParams->last_active_seg_id + 1);
     struct segmentation_probs *segp = &frameContext->seg;
     AomCdfProb *pred_cdf = segp->spatial_pred_seg_cdf[cdf_num];
     aom_write_symbol(ecWriter, coded_id, pred_cdf, MAX_SEGMENTS);
@@ -6210,7 +6209,7 @@ assert(bsize < BlockSizeS_ALL);
                             mv.col = cu_ptr->prediction_unit_array[0].mv[1].x;
                         }
 
-                        av1_encode_mv(
+                        eb_av1_encode_mv(
                             picture_control_set_ptr->parent_pcs_ptr,
                             ec_writer,
                             &mv,
@@ -6227,7 +6226,7 @@ assert(bsize < BlockSizeS_ALL);
                     mv.row = cu_ptr->prediction_unit_array[0].mv[1].y;
                     mv.col = cu_ptr->prediction_unit_array[0].mv[1].x;
 
-                    av1_encode_mv(
+                    eb_av1_encode_mv(
                         picture_control_set_ptr->parent_pcs_ptr,
                         ec_writer,
                         &mv,
@@ -6243,7 +6242,7 @@ assert(bsize < BlockSizeS_ALL);
                     mv.row = cu_ptr->prediction_unit_array[0].mv[0].y;
                     mv.col = cu_ptr->prediction_unit_array[0].mv[0].x;
 
-                    av1_encode_mv(
+                    eb_av1_encode_mv(
                         picture_control_set_ptr->parent_pcs_ptr,
                         ec_writer,
                         &mv,
@@ -6403,7 +6402,7 @@ EB_EXTERN EbErrorType write_sb(
             if (bsize >= BLOCK_8X8) {
                 for (int32_t plane = 0; plane < 3; ++plane) {
                     int32_t rcol0, rcol1, rrow0, rrow1, tile_tl_idx;
-                    if (av1_loop_restoration_corners_in_sb(cm, plane, mi_row, mi_col, bsize,
+                    if (eb_av1_loop_restoration_corners_in_sb(cm, plane, mi_row, mi_col, bsize,
                         &rcol0, &rcol1, &rrow0, &rrow1,
                         &tile_tl_idx)) {
                         const int32_t rstride = cm->rst_info[plane].horz_units_per_tile;

--- a/Source/Lib/Common/Codec/EbEntropyCoding.h
+++ b/Source/Lib/Common/Codec/EbEntropyCoding.h
@@ -138,16 +138,16 @@ extern "C" {
         uint32_t bit_offset;
     };
 
-    int32_t aom_wb_is_byte_aligned(const struct AomWriteBitBuffer *wb);
-    uint32_t aom_wb_bytes_written(const struct AomWriteBitBuffer *wb);
+    int32_t eb_aom_wb_is_byte_aligned(const struct AomWriteBitBuffer *wb);
+    uint32_t eb_aom_wb_bytes_written(const struct AomWriteBitBuffer *wb);
 
-    void aom_wb_write_bit(struct AomWriteBitBuffer *wb, int32_t bit);
+    void eb_aom_wb_write_bit(struct AomWriteBitBuffer *wb, int32_t bit);
 
-    void aom_wb_overwrite_bit(struct AomWriteBitBuffer *wb, int32_t bit);
+    void eb_aom_wb_overwrite_bit(struct AomWriteBitBuffer *wb, int32_t bit);
 
-    void aom_wb_write_literal(struct AomWriteBitBuffer *wb, int32_t data, int32_t bits);
+    void eb_aom_wb_write_literal(struct AomWriteBitBuffer *wb, int32_t data, int32_t bits);
 
-    void aom_wb_write_inv_signed_literal(struct AomWriteBitBuffer *wb, int32_t data,
+    void eb_aom_wb_write_inv_signed_literal(struct AomWriteBitBuffer *wb, int32_t data,
         int32_t bits);
     //*******************************************************************************************//
     // bitstream.h
@@ -181,13 +181,13 @@ extern "C" {
         int16_t *const           txb_skip_ctx,
         int16_t *const           dc_sign_ctx);
 
-    extern int32_t av1_get_reference_mode_context(
+    extern int32_t eb_av1_get_reference_mode_context(
         uint32_t                  cu_origin_x,
         uint32_t                  cu_origin_y,
         NeighborArrayUnit    *mode_type_neighbor_array,
         NeighborArrayUnit    *inter_pred_dir_neighbor_array);
 
-    extern int32_t av1_get_comp_reference_type_context(
+    extern int32_t eb_av1_get_comp_reference_type_context(
         uint32_t                  cu_origin_x,
         uint32_t                  cu_origin_y,
         NeighborArrayUnit    *mode_type_neighbor_array,
@@ -211,51 +211,51 @@ extern "C" {
     // Returns a context number for the given MB prediction signal
     // Signal the first reference frame for a compound mode be either
     // GOLDEN/LAST3, or LAST/LAST2.
-    extern int32_t av1_get_pred_context_comp_ref_p(const MacroBlockD *xd);
+    extern int32_t eb_av1_get_pred_context_comp_ref_p(const MacroBlockD *xd);
 
     // Returns a context number for the given MB prediction signal
     // Signal the first reference frame for a compound mode be LAST,
     // conditioning on that it is known either LAST/LAST2.
-    extern int32_t av1_get_pred_context_comp_ref_p1(const MacroBlockD *xd);
+    extern int32_t eb_av1_get_pred_context_comp_ref_p1(const MacroBlockD *xd);
 
     // Returns a context number for the given MB prediction signal
     // Signal the first reference frame for a compound mode be GOLDEN,
     // conditioning on that it is known either GOLDEN or LAST3.
-    extern int32_t av1_get_pred_context_comp_ref_p2(const MacroBlockD *xd);
+    extern int32_t eb_av1_get_pred_context_comp_ref_p2(const MacroBlockD *xd);
 
     // Signal the 2nd reference frame for a compound mode be either
     // ALTREF, or ALTREF2/BWDREF.
-    extern int32_t av1_get_pred_context_comp_bwdref_p(const MacroBlockD *xd);
+    extern int32_t eb_av1_get_pred_context_comp_bwdref_p(const MacroBlockD *xd);
 
     // Signal the 2nd reference frame for a compound mode be either
     // ALTREF2 or BWDREF.
-    extern int32_t av1_get_pred_context_comp_bwdref_p1(const MacroBlockD *xd);
+    extern int32_t eb_av1_get_pred_context_comp_bwdref_p1(const MacroBlockD *xd);
     // == Context functions for single ref ==
     //
     // For the bit to signal whether the single reference is a forward reference
     // frame or a backward reference frame.
-    extern int32_t av1_get_pred_context_single_ref_p1(const MacroBlockD *xd);
+    extern int32_t eb_av1_get_pred_context_single_ref_p1(const MacroBlockD *xd);
 
     // For the bit to signal whether the single reference is ALTREF_FRAME or
     // non-ALTREF backward reference frame, knowing that it shall be either of
     // these 2 choices.
-    extern int32_t av1_get_pred_context_single_ref_p2(const MacroBlockD *xd);
+    extern int32_t eb_av1_get_pred_context_single_ref_p2(const MacroBlockD *xd);
 
     // For the bit to signal whether the single reference is LAST3/GOLDEN or
     // LAST2/LAST, knowing that it shall be either of these 2 choices.
-    extern int32_t av1_get_pred_context_single_ref_p3(const MacroBlockD *xd);
+    extern int32_t eb_av1_get_pred_context_single_ref_p3(const MacroBlockD *xd);
 
     // For the bit to signal whether the single reference is LAST2_FRAME or
     // LAST_FRAME, knowing that it shall be either of these 2 choices.
-    extern int32_t av1_get_pred_context_single_ref_p4(const MacroBlockD *xd);
+    extern int32_t eb_av1_get_pred_context_single_ref_p4(const MacroBlockD *xd);
 
     // For the bit to signal whether the single reference is GOLDEN_FRAME or
     // LAST3_FRAME, knowing that it shall be either of these 2 choices.
-    extern int32_t av1_get_pred_context_single_ref_p5(const MacroBlockD *xd);
+    extern int32_t eb_av1_get_pred_context_single_ref_p5(const MacroBlockD *xd);
 
     // For the bit to signal whether the single reference is ALTREF2_FRAME or
     // BWDREF_FRAME, knowing that it shall be either of these 2 choices.
-    extern int32_t av1_get_pred_context_single_ref_p6(const MacroBlockD *xd);
+    extern int32_t eb_av1_get_pred_context_single_ref_p6(const MacroBlockD *xd);
 
     extern EbErrorType write_frame_header_av1(
         Bitstream *bitstream_ptr,

--- a/Source/Lib/Common/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Common/Codec/EbEntropyCodingProcess.c
@@ -24,9 +24,9 @@
 #include "EbCabacContextModel.h"
 #endif
 #define  AV1_MIN_TILE_SIZE_BYTES 1
-void av1_reset_loop_restoration(PictureControlSet     *piCSetPtr);
-void av1_tile_set_col(TileInfo *tile, PictureParentControlSet * pcs_ptr, int col);
-void av1_tile_set_row(TileInfo *tile, PictureParentControlSet * pcs_ptr, int row);
+void eb_av1_reset_loop_restoration(PictureControlSet     *piCSetPtr);
+void eb_av1_tile_set_col(TileInfo *tile, PictureParentControlSet * pcs_ptr, int col);
+void eb_av1_tile_set_row(TileInfo *tile, PictureParentControlSet * pcs_ptr, int row);
 
 /******************************************************
  * Enc Dec Context Constructor
@@ -78,7 +78,7 @@ void av1_get_syntax_rate_from_cdf(
     const AomCdfProb       *cdf,
     const int32_t                *inv_map);
 
-void av1_cost_tokens_from_cdf(int32_t *costs, const AomCdfProb *cdf,
+void eb_av1_cost_tokens_from_cdf(int32_t *costs, const AomCdfProb *cdf,
     const int32_t *inv_map) {
     // int32_t i;
     // AomCdfProb prev_cdf = 0;
@@ -108,18 +108,18 @@ static void build_nmv_component_cost_table(int32_t *mvcost,
     int32_t class0_fp_cost[CLASS0_SIZE][MV_FP_SIZE], fp_cost[MV_FP_SIZE];
     int32_t class0_hp_cost[2], hp_cost[2];
 
-    av1_cost_tokens_from_cdf(sign_cost, mvcomp->sign_cdf, NULL);
-    av1_cost_tokens_from_cdf(class_cost, mvcomp->classes_cdf, NULL);
-    av1_cost_tokens_from_cdf(class0_cost, mvcomp->class0_cdf, NULL);
+    eb_av1_cost_tokens_from_cdf(sign_cost, mvcomp->sign_cdf, NULL);
+    eb_av1_cost_tokens_from_cdf(class_cost, mvcomp->classes_cdf, NULL);
+    eb_av1_cost_tokens_from_cdf(class0_cost, mvcomp->class0_cdf, NULL);
     for (i = 0; i < MV_OFFSET_BITS; ++i)
-        av1_cost_tokens_from_cdf(bits_cost[i], mvcomp->bits_cdf[i], NULL);
+        eb_av1_cost_tokens_from_cdf(bits_cost[i], mvcomp->bits_cdf[i], NULL);
     for (i = 0; i < CLASS0_SIZE; ++i)
-        av1_cost_tokens_from_cdf(class0_fp_cost[i], mvcomp->class0_fp_cdf[i], NULL);
-    av1_cost_tokens_from_cdf(fp_cost, mvcomp->fp_cdf, NULL);
+        eb_av1_cost_tokens_from_cdf(class0_fp_cost[i], mvcomp->class0_fp_cdf[i], NULL);
+    eb_av1_cost_tokens_from_cdf(fp_cost, mvcomp->fp_cdf, NULL);
 
     if (precision > MV_SUBPEL_LOW_PRECISION) {
-        av1_cost_tokens_from_cdf(class0_hp_cost, mvcomp->class0_hp_cdf, NULL);
-        av1_cost_tokens_from_cdf(hp_cost, mvcomp->hp_cdf, NULL);
+        eb_av1_cost_tokens_from_cdf(class0_hp_cost, mvcomp->class0_hp_cdf, NULL);
+        eb_av1_cost_tokens_from_cdf(hp_cost, mvcomp->hp_cdf, NULL);
     }
     mvcost[0] = 0;
     for (v = 1; v <= MV_MAX; ++v) {
@@ -152,10 +152,10 @@ static void build_nmv_component_cost_table(int32_t *mvcost,
         mvcost[-v] = cost + sign_cost[1];
     }
 }
-void av1_build_nmv_cost_table(int32_t *mvjoint, int32_t *mvcost[2],
+void eb_av1_build_nmv_cost_table(int32_t *mvjoint, int32_t *mvcost[2],
     const NmvContext *ctx,
     MvSubpelPrecision precision) {
-    av1_cost_tokens_from_cdf(mvjoint, ctx->joints_cdf, NULL);
+    eb_av1_cost_tokens_from_cdf(mvjoint, ctx->joints_cdf, NULL);
     build_nmv_component_cost_table(mvcost[0], &ctx->comps[0], precision);
     build_nmv_component_cost_table(mvcost[1], &ctx->comps[1], precision);
 }
@@ -198,7 +198,7 @@ static void ResetEntropyCodingPicture(
     if (picture_control_set_ptr->parent_pcs_ptr->allow_intrabc)
         assert(picture_control_set_ptr->parent_pcs_ptr->delta_lf_params.delta_lf_present == 0);
     /*else
-        aom_wb_write_bit(wb, pcs_ptr->delta_lf_params.delta_lf_present);*/
+        eb_aom_wb_write_bit(wb, pcs_ptr->delta_lf_params.delta_lf_present);*/
     if (picture_control_set_ptr->parent_pcs_ptr->delta_lf_params.delta_lf_present) {
         //aom_wb_write_literal(wb, OD_ILOG_NZ(pcs_ptr->delta_lf_params.delta_lf_res) - 1, 2);
         picture_control_set_ptr->parent_pcs_ptr->prev_delta_lf_from_base = 0;
@@ -279,11 +279,11 @@ static void reset_ec_tile(
     if (picture_control_set_ptr->parent_pcs_ptr->allow_intrabc)
         assert(picture_control_set_ptr->parent_pcs_ptr->delta_lf_params.delta_lf_present == 0);
     /*else
-        aom_wb_write_bit(wb, pcs_ptr->delta_lf_params.delta_lf_present);*/
+        eb_aom_wb_write_bit(wb, pcs_ptr->delta_lf_params.delta_lf_present);*/
     if (picture_control_set_ptr->parent_pcs_ptr->delta_lf_params.delta_lf_present) {
         //aom_wb_write_literal(wb, OD_ILOG_NZ(pcs_ptr->delta_lf_params.delta_lf_res) - 1, 2);
         picture_control_set_ptr->parent_pcs_ptr->prev_delta_lf_from_base = 0;
-        //aom_wb_write_bit(wb, pcs_ptr->delta_lf_params.delta_lf_multi);
+        //eb_aom_wb_write_bit(wb, pcs_ptr->delta_lf_params.delta_lf_multi);
         const int32_t frame_lf_count =
             picture_control_set_ptr->parent_pcs_ptr->monochrome == 0 ? FRAME_LF_COUNT : FRAME_LF_COUNT - 2;
         for (int32_t lf_id = 0; lf_id < frame_lf_count; ++lf_id)
@@ -510,7 +510,7 @@ void* entropy_coding_kernel(void *input_ptr)
                     context_ptr->sb_origin_x = sb_origin_x;
                     context_ptr->sb_origin_y = sb_origin_y;
                     if (sb_index == 0)
-                        av1_reset_loop_restoration(picture_control_set_ptr);
+                        eb_av1_reset_loop_restoration(picture_control_set_ptr);
                     // Configure the LCU
                     EntropyCodingConfigureLcu(
                         context_ptr,
@@ -604,7 +604,7 @@ void* entropy_coding_kernel(void *input_ptr)
              for (tile_row = 0; tile_row < tile_rows; tile_row++)
              {
                  TileInfo tile_info;
-                 av1_tile_set_row(&tile_info, ppcs_ptr, tile_row);
+                 eb_av1_tile_set_row(&tile_info, ppcs_ptr, tile_row);
 
                  for (tile_col = 0; tile_col < tile_cols; tile_col++)
                  {
@@ -622,9 +622,9 @@ void* entropy_coding_kernel(void *input_ptr)
                          picture_control_set_ptr,
                          sequence_control_set_ptr);
 
-                     av1_tile_set_col(&tile_info, ppcs_ptr, tile_col);
+                     eb_av1_tile_set_col(&tile_info, ppcs_ptr, tile_col);
 
-                     av1_reset_loop_restoration(picture_control_set_ptr);
+                     eb_av1_reset_loop_restoration(picture_control_set_ptr);
 
                      for (y_lcu_index = cm->tiles_info.tile_row_start_sb[tile_row]; y_lcu_index < (uint32_t)cm->tiles_info.tile_row_start_sb[tile_row + 1]; ++y_lcu_index)
                      {

--- a/Source/Lib/Common/Codec/EbFullLoop.c
+++ b/Source/Lib/Common/Codec/EbFullLoop.c
@@ -104,7 +104,7 @@ void quantize_b_helper_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs,
     }
     *eob_ptr = (uint16_t)(eob + 1);
 }
-void aom_quantize_b_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs,
+void eb_aom_quantize_b_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs,
     int32_t skip_block, const int16_t *zbin_ptr,
     const int16_t *round_ptr, const int16_t *quant_ptr,
     const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr,
@@ -116,7 +116,7 @@ void aom_quantize_b_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs,
         dequant_ptr, eob_ptr, scan, iscan, NULL, NULL, 0);
 }
 
-void aom_quantize_b_32x32_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs,
+void eb_aom_quantize_b_32x32_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs,
     int32_t skip_block, const int16_t *zbin_ptr,
     const int16_t *round_ptr, const int16_t *quant_ptr,
     const int16_t *quant_shift_ptr,
@@ -128,7 +128,7 @@ void aom_quantize_b_32x32_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs,
         dequant_ptr, eob_ptr, scan, iscan, NULL, NULL, 1);
 }
 
-void aom_quantize_b_64x64_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs,
+void eb_aom_quantize_b_64x64_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs,
     int32_t skip_block, const int16_t *zbin_ptr,
     const int16_t *round_ptr, const int16_t *quant_ptr,
     const int16_t *quant_shift_ptr,
@@ -140,7 +140,7 @@ void aom_quantize_b_64x64_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs,
         dequant_ptr, eob_ptr, scan, iscan, NULL, NULL, 2);
 }
 
-void quantize_b_helper_c(
+void eb_quantize_b_helper_c(
     const TranLow *coeff_ptr,
     int32_t stride,
 #
@@ -230,7 +230,7 @@ void quantize_b_helper_c(
 
     *eob_ptr = (uint16_t)(eob + 1);
 }
-void highbd_quantize_b_helper_c(
+void eb_highbd_quantize_b_helper_c(
     const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block,
     const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr,
     const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr,
@@ -289,44 +289,44 @@ void highbd_quantize_b_helper_c(
     *eob_ptr = (uint16_t)(eob + 1);
 }
 
-void aom_highbd_quantize_b_c(const TranLow *coeff_ptr, intptr_t n_coeffs,
+void eb_aom_highbd_quantize_b_c(const TranLow *coeff_ptr, intptr_t n_coeffs,
     int32_t skip_block, const int16_t *zbin_ptr,
     const int16_t *round_ptr, const int16_t *quant_ptr,
     const int16_t *quant_shift_ptr,
     TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr,
     const int16_t *dequant_ptr, uint16_t *eob_ptr,
     const int16_t *scan, const int16_t *iscan) {
-    highbd_quantize_b_helper_c(coeff_ptr, n_coeffs, skip_block, zbin_ptr,
+    eb_highbd_quantize_b_helper_c(coeff_ptr, n_coeffs, skip_block, zbin_ptr,
         round_ptr, quant_ptr, quant_shift_ptr, qcoeff_ptr,
         dqcoeff_ptr, dequant_ptr, eob_ptr, scan, iscan,
         NULL, NULL, 0);
 }
 
-void aom_highbd_quantize_b_32x32_c(
+void eb_aom_highbd_quantize_b_32x32_c(
     const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block,
     const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr,
     const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr,
     TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr,
     const int16_t *scan, const int16_t *iscan) {
-    highbd_quantize_b_helper_c(coeff_ptr, n_coeffs, skip_block, zbin_ptr,
+    eb_highbd_quantize_b_helper_c(coeff_ptr, n_coeffs, skip_block, zbin_ptr,
         round_ptr, quant_ptr, quant_shift_ptr, qcoeff_ptr,
         dqcoeff_ptr, dequant_ptr, eob_ptr, scan, iscan,
         NULL, NULL, 1);
 }
 
-void aom_highbd_quantize_b_64x64_c(
+void eb_aom_highbd_quantize_b_64x64_c(
     const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block,
     const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr,
     const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr,
     TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr,
     const int16_t *scan, const int16_t *iscan) {
-    highbd_quantize_b_helper_c(coeff_ptr, n_coeffs, skip_block, zbin_ptr,
+    eb_highbd_quantize_b_helper_c(coeff_ptr, n_coeffs, skip_block, zbin_ptr,
         round_ptr, quant_ptr, quant_shift_ptr, qcoeff_ptr,
         dqcoeff_ptr, dequant_ptr, eob_ptr, scan, iscan,
         NULL, NULL, 2);
 }
 
-void av1_highbd_quantize_b_facade(const TranLow *coeff_ptr,
+void eb_av1_highbd_quantize_b_facade(const TranLow *coeff_ptr,
     intptr_t n_coeffs, const MacroblockPlane *p,
     TranLow *qcoeff_ptr,
     TranLow *dqcoeff_ptr, uint16_t *eob_ptr,
@@ -337,7 +337,7 @@ void av1_highbd_quantize_b_facade(const TranLow *coeff_ptr,
     const QmVal *qm_ptr = qparam->qmatrix;
     const QmVal *iqm_ptr = qparam->iqmatrix;
     if (qm_ptr != NULL && iqm_ptr != NULL) {
-        highbd_quantize_b_helper_c(coeff_ptr, n_coeffs, skip_block, p->zbin_QTX,
+        eb_highbd_quantize_b_helper_c(coeff_ptr, n_coeffs, skip_block, p->zbin_QTX,
             p->round_QTX, p->quant_QTX, p->quant_shift_QTX,
             qcoeff_ptr, dqcoeff_ptr, p->dequant_QTX, eob_ptr,
             sc->scan, sc->iscan, qm_ptr, iqm_ptr,
@@ -347,26 +347,26 @@ void av1_highbd_quantize_b_facade(const TranLow *coeff_ptr,
         switch (qparam->log_scale) {
         case 0:
             if (LIKELY(n_coeffs >= 8)) {
-                aom_highbd_quantize_b(coeff_ptr, n_coeffs, skip_block, p->zbin_QTX,
+                eb_aom_highbd_quantize_b(coeff_ptr, n_coeffs, skip_block, p->zbin_QTX,
                     p->round_QTX, p->quant_QTX, p->quant_shift_QTX,
                     qcoeff_ptr, dqcoeff_ptr, p->dequant_QTX,
                     eob_ptr, sc->scan, sc->iscan);
             }
             else {
-                aom_highbd_quantize_b_c(coeff_ptr, n_coeffs, skip_block, p->zbin_QTX,
+                eb_aom_highbd_quantize_b_c(coeff_ptr, n_coeffs, skip_block, p->zbin_QTX,
                     p->round_QTX, p->quant_QTX,
                     p->quant_shift_QTX, qcoeff_ptr, dqcoeff_ptr,
                     p->dequant_QTX, eob_ptr, sc->scan, sc->iscan);
             }
             break;
         case 1:
-            aom_highbd_quantize_b_32x32(
+            eb_aom_highbd_quantize_b_32x32(
                 coeff_ptr, n_coeffs, skip_block, p->zbin_QTX, p->round_QTX,
                 p->quant_QTX, p->quant_shift_QTX, qcoeff_ptr, dqcoeff_ptr,
                 p->dequant_QTX, eob_ptr, sc->scan, sc->iscan);
             break;
         case 2:
-            aom_highbd_quantize_b_64x64(
+            eb_aom_highbd_quantize_b_64x64(
                 coeff_ptr, n_coeffs, skip_block, p->zbin_QTX, p->round_QTX,
                 p->quant_QTX, p->quant_shift_QTX, qcoeff_ptr, dqcoeff_ptr,
                 p->dequant_QTX, eob_ptr, sc->scan, sc->iscan);
@@ -394,7 +394,7 @@ void av1_quantize_b_facade_II(
     const QmVal *qm_ptr = qparam->qmatrix;
     const QmVal *iqm_ptr = qparam->iqmatrix;
     if (qm_ptr != NULL && iqm_ptr != NULL) {
-        quantize_b_helper_c(
+        eb_quantize_b_helper_c(
             coeff_ptr,
             stride,
             width,
@@ -418,7 +418,7 @@ void av1_quantize_b_facade_II(
     else {
         switch (qparam->log_scale) {
         case 0:
-            aom_quantize_b(coeff_ptr, n_coeffs, skip_block, p->zbin_QTX,
+            eb_aom_quantize_b(coeff_ptr, n_coeffs, skip_block, p->zbin_QTX,
                 p->round_QTX, p->quant_QTX, p->quant_shift_QTX,
                 qcoeff_ptr, dqcoeff_ptr, p->dequant_QTX, eob_ptr,
                 sc->scan, sc->iscan);
@@ -426,7 +426,7 @@ void av1_quantize_b_facade_II(
             break;
         case 1:
 
-            aom_quantize_b_32x32(coeff_ptr, n_coeffs, skip_block, p->zbin_QTX,
+            eb_aom_quantize_b_32x32(coeff_ptr, n_coeffs, skip_block, p->zbin_QTX,
                 p->round_QTX, p->quant_QTX, p->quant_shift_QTX,
                 qcoeff_ptr, dqcoeff_ptr, p->dequant_QTX, eob_ptr,
                 sc->scan, sc->iscan);
@@ -434,7 +434,7 @@ void av1_quantize_b_facade_II(
             break;
         case 2:
 
-            aom_quantize_b_64x64(coeff_ptr, n_coeffs, skip_block, p->zbin_QTX,
+            eb_aom_quantize_b_64x64(coeff_ptr, n_coeffs, skip_block, p->zbin_QTX,
                 p->round_QTX, p->quant_QTX, p->quant_shift_QTX,
                 qcoeff_ptr, dqcoeff_ptr, p->dequant_QTX, eob_ptr,
                 sc->scan, sc->iscan);
@@ -527,7 +527,7 @@ static void quantize_fp_helper_c(
     *eob_ptr = eob + 1;
 }
 
-void av1_quantize_fp_c(const TranLow *coeff_ptr, intptr_t n_coeffs,
+void eb_av1_quantize_fp_c(const TranLow *coeff_ptr, intptr_t n_coeffs,
     const int16_t *zbin_ptr, const int16_t *round_ptr,
     const int16_t *quant_ptr, const int16_t *quant_shift_ptr,
     TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr,
@@ -538,7 +538,7 @@ void av1_quantize_fp_c(const TranLow *coeff_ptr, intptr_t n_coeffs,
         eob_ptr, scan, iscan, NULL, NULL, 0);
 }
 
-void av1_quantize_fp_32x32_c(const TranLow *coeff_ptr, intptr_t n_coeffs,
+void eb_av1_quantize_fp_32x32_c(const TranLow *coeff_ptr, intptr_t n_coeffs,
     const int16_t *zbin_ptr, const int16_t *round_ptr,
     const int16_t *quant_ptr, const int16_t *quant_shift_ptr,
     TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr,
@@ -549,7 +549,7 @@ void av1_quantize_fp_32x32_c(const TranLow *coeff_ptr, intptr_t n_coeffs,
         eob_ptr, scan, iscan, NULL, NULL, 1);
 }
 
-void av1_quantize_fp_64x64_c(const TranLow *coeff_ptr, intptr_t n_coeffs,
+void eb_av1_quantize_fp_64x64_c(const TranLow *coeff_ptr, intptr_t n_coeffs,
     const int16_t *zbin_ptr, const int16_t *round_ptr,
     const int16_t *quant_ptr, const int16_t *quant_shift_ptr,
     TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr,
@@ -560,7 +560,7 @@ void av1_quantize_fp_64x64_c(const TranLow *coeff_ptr, intptr_t n_coeffs,
         eob_ptr, scan, iscan, NULL, NULL, 2);
 }
 
-void av1_quantize_fp_facade(
+void eb_av1_quantize_fp_facade(
     const TranLow *coeff_ptr,
     intptr_t n_coeffs,
     const MacroblockPlane *p,
@@ -581,19 +581,19 @@ void av1_quantize_fp_facade(
     else {
         switch (qparam->log_scale) {
         case 0:
-            av1_quantize_fp(coeff_ptr, n_coeffs, p->zbin_QTX, p->round_fp_QTX,
+            eb_av1_quantize_fp(coeff_ptr, n_coeffs, p->zbin_QTX, p->round_fp_QTX,
                 p->quant_fp_QTX, p->quant_shift_QTX, qcoeff_ptr,
                 dqcoeff_ptr, p->dequant_QTX, eob_ptr, sc->scan,
                 sc->iscan);
             break;
         case 1:
-            av1_quantize_fp_32x32(coeff_ptr, n_coeffs, p->zbin_QTX, p->round_fp_QTX,
+            eb_av1_quantize_fp_32x32(coeff_ptr, n_coeffs, p->zbin_QTX, p->round_fp_QTX,
                 p->quant_fp_QTX, p->quant_shift_QTX, qcoeff_ptr,
                 dqcoeff_ptr, p->dequant_QTX, eob_ptr, sc->scan,
                 sc->iscan);
             break;
         case 2:
-            av1_quantize_fp_64x64(coeff_ptr, n_coeffs, p->zbin_QTX, p->round_fp_QTX,
+            eb_av1_quantize_fp_64x64(coeff_ptr, n_coeffs, p->zbin_QTX, p->round_fp_QTX,
                 p->quant_fp_QTX, p->quant_shift_QTX, qcoeff_ptr,
                 dqcoeff_ptr, p->dequant_QTX, eob_ptr, sc->scan,
                 sc->iscan);
@@ -605,7 +605,7 @@ void av1_quantize_fp_facade(
 
 
 // Hsan: code clean up; from static to extern as now used @ more than 1 file
-static const int16_t k_eob_group_start[12] = { 0, 1, 2, 3, 5, 9, 17, 33, 65, 129, 257, 513 };
+static const int16_t eb_k_eob_group_start[12] = { 0, 1, 2, 3, 5, 9, 17, 33, 65, 129, 257, 513 };
 
 static const int8_t eob_to_pos_small[33] = {
     0, 1, 2,                                        // 0-2
@@ -634,7 +634,7 @@ static INLINE int32_t get_eob_pos_token(const int32_t eob, int32_t *const extra)
         t = eob_to_pos_large[e];
     }
 
-    *extra = eob - k_eob_group_start[t];
+    *extra = eob - eb_k_eob_group_start[t];
 
     return t;
 }
@@ -663,7 +663,7 @@ static INLINE TxSize get_txsize_entropy_ctx(TxSize txsize) {
 static INLINE PlaneType get_plane_type(int plane) {
     return (plane == 0) ? PLANE_TYPE_Y : PLANE_TYPE_UV;
 }
-static const int16_t k_eob_offset_bits[12] = { 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+static const int16_t eb_k_eob_offset_bits[12] = { 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 static int32_t get_eob_cost(int32_t eob, const LvMapEobCost *txb_eob_costs,
     const LvMapCoeffCost *txb_costs, TxType tx_type) {
     int32_t eob_extra;
@@ -672,11 +672,11 @@ static int32_t get_eob_cost(int32_t eob, const LvMapEobCost *txb_eob_costs,
     const int32_t eob_multi_ctx = (tx_type_to_class[tx_type] == TX_CLASS_2D) ? 0 : 1;
     eob_cost = txb_eob_costs->eob_cost[eob_multi_ctx][eob_pt - 1];
 
-    if (k_eob_offset_bits[eob_pt] > 0) {
-        const int32_t eob_shift = k_eob_offset_bits[eob_pt] - 1;
+    if (eb_k_eob_offset_bits[eob_pt] > 0) {
+        const int32_t eob_shift = eb_k_eob_offset_bits[eob_pt] - 1;
         const int32_t bit = (eob_extra & (1 << eob_shift)) ? 1 : 0;
         eob_cost += txb_costs->eob_extra_cost[eob_pt][bit];
-        const int32_t offset_bits = k_eob_offset_bits[eob_pt];
+        const int32_t offset_bits = eb_k_eob_offset_bits[eob_pt];
         if (offset_bits > 1) eob_cost += av1_cost_literal(offset_bits - 1);
     }
     return eob_cost;
@@ -725,18 +725,18 @@ static AOM_FORCE_INLINE int get_nz_mag(const uint8_t *const levels,
 // The ctx offset table when TX is TX_CLASS_2D.
 // TX col and row indices are clamped to 4
 
-const int8_t av1_nz_map_ctx_offset_4x4[16] = {
+const int8_t eb_av1_nz_map_ctx_offset_4x4[16] = {
   0, 1, 6, 6, 1, 6, 6, 21, 6, 6, 21, 21, 6, 21, 21, 21,
 };
 
-const int8_t av1_nz_map_ctx_offset_8x8[64] = {
+const int8_t eb_av1_nz_map_ctx_offset_8x8[64] = {
   0,  1,  6,  6,  21, 21, 21, 21, 1,  6,  6,  21, 21, 21, 21, 21,
   6,  6,  21, 21, 21, 21, 21, 21, 6,  21, 21, 21, 21, 21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
 };
 
-const int8_t av1_nz_map_ctx_offset_16x16[256] = {
+const int8_t eb_av1_nz_map_ctx_offset_16x16[256] = {
   0,  1,  6,  6,  21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 1,  6,  6,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 6,  6,  21, 21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 6,  21, 21, 21, 21, 21, 21, 21, 21,
@@ -753,7 +753,7 @@ const int8_t av1_nz_map_ctx_offset_16x16[256] = {
   21, 21, 21, 21, 21, 21, 21, 21, 21,
 };
 
-const int8_t av1_nz_map_ctx_offset_32x32[1024] = {
+const int8_t eb_av1_nz_map_ctx_offset_32x32[1024] = {
   0,  1,  6,  6,  21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 1,  6,  6,  21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
@@ -810,12 +810,12 @@ const int8_t av1_nz_map_ctx_offset_32x32[1024] = {
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
 };
 
-const int8_t av1_nz_map_ctx_offset_8x4[32] = {
+const int8_t eb_av1_nz_map_ctx_offset_8x4[32] = {
   0,  16, 6,  6,  21, 21, 21, 21, 16, 16, 6,  21, 21, 21, 21, 21,
   16, 16, 21, 21, 21, 21, 21, 21, 16, 16, 21, 21, 21, 21, 21, 21,
 };
 
-const int8_t av1_nz_map_ctx_offset_8x16[128] = {
+const int8_t eb_av1_nz_map_ctx_offset_8x16[128] = {
   0,  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 6,  6,  21,
   21, 21, 21, 21, 21, 6,  21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
@@ -825,7 +825,7 @@ const int8_t av1_nz_map_ctx_offset_8x16[128] = {
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
 };
 
-const int8_t av1_nz_map_ctx_offset_16x8[128] = {
+const int8_t eb_av1_nz_map_ctx_offset_16x8[128] = {
   0,  16, 6,  6,  21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 16, 16, 6,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 16, 16, 21, 21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 16, 16, 21, 21, 21, 21, 21, 21, 21,
@@ -835,7 +835,7 @@ const int8_t av1_nz_map_ctx_offset_16x8[128] = {
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
 };
 
-const int8_t av1_nz_map_ctx_offset_16x32[512] = {
+const int8_t eb_av1_nz_map_ctx_offset_16x32[512] = {
   0,  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
   11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 6,  6,  21, 21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 6,  21, 21, 21, 21, 21, 21, 21, 21,
@@ -865,7 +865,7 @@ const int8_t av1_nz_map_ctx_offset_16x32[512] = {
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
 };
 
-const int8_t av1_nz_map_ctx_offset_32x16[512] = {
+const int8_t eb_av1_nz_map_ctx_offset_32x16[512] = {
   0,  16, 6,  6,  21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 16, 16, 6,  21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
@@ -895,7 +895,7 @@ const int8_t av1_nz_map_ctx_offset_32x16[512] = {
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
 };
 
-const int8_t av1_nz_map_ctx_offset_32x64[1024] = {
+const int8_t eb_av1_nz_map_ctx_offset_32x64[1024] = {
   0,  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
   11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
   11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
@@ -952,7 +952,7 @@ const int8_t av1_nz_map_ctx_offset_32x64[1024] = {
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
 };
 
-const int8_t av1_nz_map_ctx_offset_64x32[1024] = {
+const int8_t eb_av1_nz_map_ctx_offset_64x32[1024] = {
   0,  16, 6,  6,  21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 16, 16, 6,  21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
@@ -1009,21 +1009,21 @@ const int8_t av1_nz_map_ctx_offset_64x32[1024] = {
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
 };
 
-const int8_t av1_nz_map_ctx_offset_4x16[64] = {
+const int8_t eb_av1_nz_map_ctx_offset_4x16[64] = {
   0,  11, 11, 11, 11, 11, 11, 11, 6,  6,  21, 21, 6,  21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
 };
 
-const int8_t av1_nz_map_ctx_offset_16x4[64] = {
+const int8_t eb_av1_nz_map_ctx_offset_16x4[64] = {
   0,  16, 6,  6,  21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
   16, 16, 6,  21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
   16, 16, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
   16, 16, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
 };
 
-const int8_t av1_nz_map_ctx_offset_8x32[256] = {
+const int8_t eb_av1_nz_map_ctx_offset_8x32[256] = {
   0,  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 6,  6,  21,
   21, 21, 21, 21, 21, 6,  21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
@@ -1040,7 +1040,7 @@ const int8_t av1_nz_map_ctx_offset_8x32[256] = {
   21, 21, 21, 21, 21, 21, 21, 21, 21,
 };
 
-const int8_t av1_nz_map_ctx_offset_32x8[256] = {
+const int8_t eb_av1_nz_map_ctx_offset_32x8[256] = {
   0,  16, 6,  6,  21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 16, 16, 6,  21, 21, 21,
   21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
@@ -1057,26 +1057,26 @@ const int8_t av1_nz_map_ctx_offset_32x8[256] = {
   21, 21, 21, 21, 21, 21, 21, 21, 21,
 };
 
-const int8_t *av1_nz_map_ctx_offset[19] = {
-  av1_nz_map_ctx_offset_4x4,    // TX_4x4
-  av1_nz_map_ctx_offset_8x8,    // TX_8x8
-  av1_nz_map_ctx_offset_16x16,  // TX_16x16
-  av1_nz_map_ctx_offset_32x32,  // TX_32x32
-  av1_nz_map_ctx_offset_32x32,  // TX_32x32
-  av1_nz_map_ctx_offset_4x16,   // TX_4x8
-  av1_nz_map_ctx_offset_8x4,    // TX_8x4
-  av1_nz_map_ctx_offset_8x32,   // TX_8x16
-  av1_nz_map_ctx_offset_16x8,   // TX_16x8
-  av1_nz_map_ctx_offset_16x32,  // TX_16x32
-  av1_nz_map_ctx_offset_32x16,  // TX_32x16
-  av1_nz_map_ctx_offset_32x64,  // TX_32x64
-  av1_nz_map_ctx_offset_64x32,  // TX_64x32
-  av1_nz_map_ctx_offset_4x16,   // TX_4x16
-  av1_nz_map_ctx_offset_16x4,   // TX_16x4
-  av1_nz_map_ctx_offset_8x32,   // TX_8x32
-  av1_nz_map_ctx_offset_32x8,   // TX_32x8
-  av1_nz_map_ctx_offset_16x32,  // TX_16x64
-  av1_nz_map_ctx_offset_64x32,  // TX_64x16
+const int8_t *eb_av1_nz_map_ctx_offset[19] = {
+  eb_av1_nz_map_ctx_offset_4x4,    // TX_4x4
+  eb_av1_nz_map_ctx_offset_8x8,    // TX_8x8
+  eb_av1_nz_map_ctx_offset_16x16,  // TX_16x16
+  eb_av1_nz_map_ctx_offset_32x32,  // TX_32x32
+  eb_av1_nz_map_ctx_offset_32x32,  // TX_32x32
+  eb_av1_nz_map_ctx_offset_4x16,   // TX_4x8
+  eb_av1_nz_map_ctx_offset_8x4,    // TX_8x4
+  eb_av1_nz_map_ctx_offset_8x32,   // TX_8x16
+  eb_av1_nz_map_ctx_offset_16x8,   // TX_16x8
+  eb_av1_nz_map_ctx_offset_16x32,  // TX_16x32
+  eb_av1_nz_map_ctx_offset_32x16,  // TX_32x16
+  eb_av1_nz_map_ctx_offset_32x64,  // TX_32x64
+  eb_av1_nz_map_ctx_offset_64x32,  // TX_64x32
+  eb_av1_nz_map_ctx_offset_4x16,   // TX_4x16
+  eb_av1_nz_map_ctx_offset_16x4,   // TX_16x4
+  eb_av1_nz_map_ctx_offset_8x32,   // TX_8x32
+  eb_av1_nz_map_ctx_offset_32x8,   // TX_32x8
+  eb_av1_nz_map_ctx_offset_16x32,  // TX_16x64
+  eb_av1_nz_map_ctx_offset_64x32,  // TX_64x16
 };
 
 #define NZ_MAP_CTX_0 SIG_COEF_CONTEXTS_2D
@@ -1102,7 +1102,7 @@ static AOM_FORCE_INLINE int get_nz_map_ctx_from_stats(
     ctx = AOMMIN(ctx, 4);
     switch (tx_class) {
     case TX_CLASS_2D: {
-        // This is the algorithm to generate av1_nz_map_ctx_offset[][]
+        // This is the algorithm to generate eb_av1_nz_map_ctx_offset[][]
         //   const int width = tx_size_wide[tx_size];
         //   const int height = tx_size_high[tx_size];
         //   if (width < height) {
@@ -1113,7 +1113,7 @@ static AOM_FORCE_INLINE int get_nz_map_ctx_from_stats(
         //   if (row + col < 2) return ctx + 1;
         //   if (row + col < 4) return 5 + ctx + 1;
         //   return 21 + ctx;
-        return ctx + av1_nz_map_ctx_offset[tx_size][coeff_idx];
+        return ctx + eb_av1_nz_map_ctx_offset[tx_size][coeff_idx];
     }
     case TX_CLASS_HORIZ: {
         const int row = coeff_idx >> bwl;
@@ -1621,7 +1621,7 @@ static const int plane_rd_mult[REF_TYPES][PLANE_TYPES] = {
   { 16, 10 },
 };
 
-void av1_optimize_b(
+void eb_av1_optimize_b(
     ModeDecisionContext  *md_context,
     int16_t                 txb_skip_context,
     int16_t                 dc_sign_context,
@@ -1684,7 +1684,7 @@ void av1_optimize_b(
     uint8_t levels_buf[TX_PAD_2D];
     uint8_t *const levels = set_levels(levels_buf, width);
 
-    if (*eob > 1) av1_txb_init_levels(qcoeff_ptr, width, height, levels);
+    if (*eob > 1) eb_av1_txb_init_levels(qcoeff_ptr, width, height, levels);
     // TODO(angirbird): check iqmatrix
     const int non_skip_cost = txb_costs->txb_skip_cost[txb_skip_context][0];
     const int skip_cost = txb_costs->txb_skip_cost[txb_skip_context][1];
@@ -1932,7 +1932,7 @@ int32_t av1_quantize_inv_quantize(
     EbBool perform_quantize_fp = picture_control_set_ptr->enc_mode == ENC_M0 ? EB_TRUE: EB_FALSE;
 
     if (perform_rdoq && perform_quantize_fp && !is_inter)
-        av1_quantize_fp_facade(
+        eb_av1_quantize_fp_facade(
             (TranLow*)coeff,
             n_coeffs,
             &candidate_plane,
@@ -1943,7 +1943,7 @@ int32_t av1_quantize_inv_quantize(
             &qparam);
     else
         if (bit_increment)
-            av1_highbd_quantize_b_facade(
+            eb_av1_highbd_quantize_b_facade(
                 (TranLow*)coeff,
                 n_coeffs,
                 &candidate_plane,
@@ -1970,7 +1970,7 @@ int32_t av1_quantize_inv_quantize(
 
         // Perform Trellis
         if (*eob != 0) {
-            av1_optimize_b(
+            eb_av1_optimize_b(
                 md_context,
                 txb_skip_context,
                 dc_sign_context,

--- a/Source/Lib/Common/Codec/EbInterPrediction.c
+++ b/Source/Lib/Common/Codec/EbInterPrediction.c
@@ -210,7 +210,7 @@ sub_pel_filters_4[SUBPEL_SHIFTS]) = {
 
 #define MAX_FILTER_TAP 8
 
-void av1_convolve_2d_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst,
+void eb_av1_convolve_2d_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst,
     int32_t dst_stride, int32_t w, int32_t h,
     InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y,
@@ -260,7 +260,7 @@ void av1_convolve_2d_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst,
     }
 }
 
-void av1_convolve_y_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst,
+void eb_av1_convolve_y_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst,
     int32_t dst_stride, int32_t w, int32_t h,
     InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y,
@@ -292,7 +292,7 @@ void av1_convolve_y_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst,
     }
 }
 
-void av1_convolve_x_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst,
+void eb_av1_convolve_x_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst,
     int32_t dst_stride, int32_t w, int32_t h,
     InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y,
@@ -324,7 +324,7 @@ void av1_convolve_x_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst,
     }
 }
 
-void av1_convolve_2d_copy_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst,
+void eb_av1_convolve_2d_copy_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst,
     int32_t dst_stride, int32_t w, int32_t h,
     InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y,
@@ -342,7 +342,7 @@ void av1_convolve_2d_copy_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *
     }
 }
 
-void av1_jnt_convolve_2d_c(const uint8_t *src, int32_t src_stride, uint8_t *dst8,
+void eb_av1_jnt_convolve_2d_c(const uint8_t *src, int32_t src_stride, uint8_t *dst8,
     int32_t dst8_stride, int32_t w, int32_t h,
     InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y,
@@ -408,7 +408,7 @@ void av1_jnt_convolve_2d_c(const uint8_t *src, int32_t src_stride, uint8_t *dst8
     }
 }
 
-void av1_jnt_convolve_y_c(const uint8_t *src, int32_t src_stride, uint8_t *dst8,
+void eb_av1_jnt_convolve_y_c(const uint8_t *src, int32_t src_stride, uint8_t *dst8,
     int32_t dst8_stride, int32_t w, int32_t h,
     InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y,
@@ -459,7 +459,7 @@ void av1_jnt_convolve_y_c(const uint8_t *src, int32_t src_stride, uint8_t *dst8,
     }
 }
 
-void av1_jnt_convolve_x_c(const uint8_t *src, int32_t src_stride, uint8_t *dst8,
+void eb_av1_jnt_convolve_x_c(const uint8_t *src, int32_t src_stride, uint8_t *dst8,
     int32_t dst8_stride, int32_t w, int32_t h,
     InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y,
@@ -510,7 +510,7 @@ void av1_jnt_convolve_x_c(const uint8_t *src, int32_t src_stride, uint8_t *dst8,
     }
 }
 
-void av1_jnt_convolve_2d_copy_c(const uint8_t *src, int32_t src_stride,
+void eb_av1_jnt_convolve_2d_copy_c(const uint8_t *src, int32_t src_stride,
     uint8_t *dst8, int32_t dst8_stride, int32_t w, int32_t h,
     InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y,
@@ -554,7 +554,7 @@ void av1_jnt_convolve_2d_copy_c(const uint8_t *src, int32_t src_stride,
     }
 }
 
-void av1_highbd_convolve_2d_copy_sr_c(
+void eb_av1_highbd_convolve_2d_copy_sr_c(
     const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w,
     int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
@@ -572,7 +572,7 @@ void av1_highbd_convolve_2d_copy_sr_c(
     }
 }
 
-void av1_highbd_convolve_x_sr_c(const uint16_t *src, int32_t src_stride,
+void eb_av1_highbd_convolve_x_sr_c(const uint16_t *src, int32_t src_stride,
     uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h,
     const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y,
@@ -602,7 +602,7 @@ void av1_highbd_convolve_x_sr_c(const uint16_t *src, int32_t src_stride,
     }
 }
 
-void av1_highbd_convolve_y_sr_c(const uint16_t *src, int32_t src_stride,
+void eb_av1_highbd_convolve_y_sr_c(const uint16_t *src, int32_t src_stride,
     uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h,
     const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y,
@@ -631,7 +631,7 @@ void av1_highbd_convolve_y_sr_c(const uint16_t *src, int32_t src_stride,
     }
 }
 
-void av1_highbd_convolve_2d_sr_c(const uint16_t *src, int32_t src_stride,
+void eb_av1_highbd_convolve_2d_sr_c(const uint16_t *src, int32_t src_stride,
     uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h,
     const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y,
@@ -681,7 +681,7 @@ void av1_highbd_convolve_2d_sr_c(const uint16_t *src, int32_t src_stride,
     }
 }
 
-void av1_highbd_jnt_convolve_x_c(const uint16_t *src, int32_t src_stride,
+void eb_av1_highbd_jnt_convolve_x_c(const uint16_t *src, int32_t src_stride,
     uint16_t *dst16, int32_t dst16_stride, int32_t w,
     int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y,
@@ -731,7 +731,7 @@ void av1_highbd_jnt_convolve_x_c(const uint16_t *src, int32_t src_stride,
     }
 }
 
-void av1_highbd_jnt_convolve_y_c(const uint16_t *src, int32_t src_stride,
+void eb_av1_highbd_jnt_convolve_y_c(const uint16_t *src, int32_t src_stride,
     uint16_t *dst16, int32_t dst16_stride, int32_t w,
     int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y,
@@ -781,7 +781,7 @@ void av1_highbd_jnt_convolve_y_c(const uint16_t *src, int32_t src_stride,
     }
 }
 
-void av1_highbd_jnt_convolve_2d_copy_c(
+void eb_av1_highbd_jnt_convolve_2d_copy_c(
     const uint16_t *src, int32_t src_stride, uint16_t *dst16, int32_t dst16_stride,
     int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
@@ -823,7 +823,7 @@ void av1_highbd_jnt_convolve_2d_copy_c(
     }
 }
 
-void av1_highbd_jnt_convolve_2d_c(const uint16_t *src, int32_t src_stride,
+void eb_av1_highbd_jnt_convolve_2d_c(const uint16_t *src, int32_t src_stride,
     uint16_t *dst16, int32_t dst16_stride, int32_t w,
     int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y,
@@ -896,33 +896,33 @@ void av1_highbd_jnt_convolve_2d_c(const uint16_t *src, int32_t src_stride,
 aom_highbd_convolve_fn_t convolveHbd[/*subX*/2][/*subY*/2][/*bi*/2];
 void asmSetConvolveHbdAsmTable(void)
 {
-    convolveHbd[0][0][0] = av1_highbd_convolve_2d_copy_sr;
-    convolveHbd[0][0][1] = av1_highbd_jnt_convolve_2d_copy;
+    convolveHbd[0][0][0] = eb_av1_highbd_convolve_2d_copy_sr;
+    convolveHbd[0][0][1] = eb_av1_highbd_jnt_convolve_2d_copy;
 
-    convolveHbd[0][1][0] = av1_highbd_convolve_y_sr;
-    convolveHbd[0][1][1] = av1_highbd_jnt_convolve_y;
+    convolveHbd[0][1][0] = eb_av1_highbd_convolve_y_sr;
+    convolveHbd[0][1][1] = eb_av1_highbd_jnt_convolve_y;
 
-    convolveHbd[1][0][0] = av1_highbd_convolve_x_sr;
-    convolveHbd[1][0][1] = av1_highbd_jnt_convolve_x;
+    convolveHbd[1][0][0] = eb_av1_highbd_convolve_x_sr;
+    convolveHbd[1][0][1] = eb_av1_highbd_jnt_convolve_x;
 
-    convolveHbd[1][1][0] = av1_highbd_convolve_2d_sr;
-    convolveHbd[1][1][1] = av1_highbd_jnt_convolve_2d;
+    convolveHbd[1][1][0] = eb_av1_highbd_convolve_2d_sr;
+    convolveHbd[1][1][1] = eb_av1_highbd_jnt_convolve_2d;
 }
 
 aom_convolve_fn_t convolve[/*subX*/2][/*subY*/2][/*bi*/2];
 void asmSetConvolveAsmTable(void)
 {
-    convolve[0][0][0] = av1_convolve_2d_copy_sr;
-    convolve[0][0][1] = av1_jnt_convolve_2d_copy;
+    convolve[0][0][0] = eb_av1_convolve_2d_copy_sr;
+    convolve[0][0][1] = eb_av1_jnt_convolve_2d_copy;
 
-    convolve[0][1][0] = av1_convolve_y_sr;
-    convolve[0][1][1] = av1_jnt_convolve_y;
+    convolve[0][1][0] = eb_av1_convolve_y_sr;
+    convolve[0][1][1] = eb_av1_jnt_convolve_y;
 
-    convolve[1][0][0] = av1_convolve_x_sr;
-    convolve[1][0][1] = av1_jnt_convolve_x;
+    convolve[1][0][0] = eb_av1_convolve_x_sr;
+    convolve[1][0][1] = eb_av1_jnt_convolve_x;
 
-    convolve[1][1][0] = av1_convolve_2d_sr;
-    convolve[1][1][1] = av1_jnt_convolve_2d;
+    convolve[1][1][0] = eb_av1_convolve_2d_sr;
+    convolve[1][1][1] = eb_av1_jnt_convolve_2d;
 }
 
 InterpFilterParams av1RegularFilter = { (const int16_t *)sub_pel_filters_8, SUBPEL_TAPS, SUBPEL_SHIFTS, EIGHTTAP_REGULAR };
@@ -1035,15 +1035,15 @@ static void convolve_2d_for_intrabc(const uint8_t *src, int src_stride,
     const InterpFilterParams *filter_params_y =
         subpel_y_q4 ? &av1_intrabc_filter_params : NULL;
     if (subpel_x_q4 != 0 && subpel_y_q4 != 0) {
-        av1_convolve_2d_sr_c(src, src_stride, dst, dst_stride, w, h,
+        eb_av1_convolve_2d_sr_c(src, src_stride, dst, dst_stride, w, h,
             (InterpFilterParams *)filter_params_x, (InterpFilterParams *)filter_params_y, 0, 0, conv_params);
     }
     else if (subpel_x_q4 != 0) {
-        av1_convolve_x_sr_c(src, src_stride, dst, dst_stride, w, h, (InterpFilterParams *)filter_params_x,
+        eb_av1_convolve_x_sr_c(src, src_stride, dst, dst_stride, w, h, (InterpFilterParams *)filter_params_x,
             (InterpFilterParams *)filter_params_y, 0, 0, conv_params);
     }
     else {
-        av1_convolve_y_sr_c(src, src_stride, dst, dst_stride, w, h, (InterpFilterParams *)filter_params_x,
+        eb_av1_convolve_y_sr_c(src, src_stride, dst, dst_stride, w, h, (InterpFilterParams *)filter_params_x,
             (InterpFilterParams *)filter_params_y, 0, 0, conv_params);
     }
 }
@@ -1058,17 +1058,17 @@ static void highbd_convolve_2d_for_intrabc(const uint16_t *src, int src_stride,
     const InterpFilterParams *filter_params_y =
         subpel_y_q4 ? &av1_intrabc_filter_params : NULL;
     if (subpel_x_q4 != 0 && subpel_y_q4 != 0) {
-        av1_highbd_convolve_2d_sr_c(src, src_stride, dst, dst_stride, w, h,
+        eb_av1_highbd_convolve_2d_sr_c(src, src_stride, dst, dst_stride, w, h,
             filter_params_x, filter_params_y, 0, 0,
             conv_params, bd);
     }
     else if (subpel_x_q4 != 0) {
-        av1_highbd_convolve_x_sr_c(src, src_stride, dst, dst_stride, w, h,
+        eb_av1_highbd_convolve_x_sr_c(src, src_stride, dst, dst_stride, w, h,
             filter_params_x, filter_params_y, 0, 0,
             conv_params, bd);
     }
     else {
-        av1_highbd_convolve_y_sr_c(src, src_stride, dst, dst_stride, w, h,
+        eb_av1_highbd_convolve_y_sr_c(src, src_stride, dst, dst_stride, w, h,
             filter_params_x, filter_params_y, 0, 0,
             conv_params, bd);
     }
@@ -1095,7 +1095,7 @@ void svt_inter_predictor(const uint8_t *src, int32_t src_stride,
     if (is_scaled) {
 #if SCALE_REF_FRAME
         /* TODO: Add suppport for scaling later */
-        av1_convolve_2d_scale(src, src_stride, dst, dst_stride, w, h,
+        eb_av1_convolve_2d_scale(src, src_stride, dst, dst_stride, w, h,
             interp_filters, subpel_params->subpel_x,
             subpel_params->xs, subpel_params->subpel_y,
             subpel_params->ys, 1, conv_params, sf, is_intrabc);
@@ -1139,7 +1139,7 @@ void svt_highbd_inter_predictor(const uint16_t *src, int32_t src_stride,
     if (is_scaled) {
 #if SCALE_REF_FRAME
         /* TODO: Add suppport for scaling later */
-        av1_highbd_convolve_2d_scale(src, src_stride, dst, dst_stride, w, h,
+        eb_av1_highbd_convolve_2d_scale(src, src_stride, dst, dst_stride, w, h,
         interp_filters, subpel_params->subpel_x,
         subpel_params->xs, subpel_params->subpel_y,
         subpel_params->ys, 1, conv_params, sf, is_intrabc, bd);
@@ -2081,7 +2081,7 @@ EbErrorType warped_motion_prediction(
         dst_stride = prediction_ptr->stride_y;
         conv_params = get_conv_params_no_round(0, 0, 0, NULL, 128, is_compound, EB_8BIT);
 
-        av1_warp_plane(
+        eb_av1_warp_plane(
             wm_params,
             (int) is16bit,
             bit_depth,
@@ -2112,7 +2112,7 @@ EbErrorType warped_motion_prediction(
             dst_stride = prediction_ptr->stride_cb;
             conv_params = get_conv_params_no_round(0, 0, 0, NULL, 64, is_compound, EB_8BIT);
 
-            av1_warp_plane(
+            eb_av1_warp_plane(
                 wm_params,
                 (int) is16bit,
                 bit_depth,
@@ -2139,7 +2139,7 @@ EbErrorType warped_motion_prediction(
 
             conv_params = get_conv_params_no_round(0, 0, 0, NULL, 64, is_compound, EB_8BIT);
 
-            av1_warp_plane(
+            eb_av1_warp_plane(
                 wm_params,
                 (int) is16bit,
                 bit_depth,
@@ -2417,7 +2417,7 @@ EbErrorType warped_motion_prediction_md(
     dst_stride = prediction_ptr->stride_y;
     conv_params = get_conv_params_no_round(0, 0, 0, NULL, 128, is_compound, EB_8BIT);
 
-    av1_warp_plane(
+    eb_av1_warp_plane(
         wm_params,
         0,  // int use_hbd
         8,  // int bd
@@ -2446,7 +2446,7 @@ EbErrorType warped_motion_prediction_md(
         dst_ptr = prediction_ptr->buffer_cb + (prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 + (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 * prediction_ptr->stride_cb;
         dst_stride = prediction_ptr->stride_cb;
         conv_params = get_conv_params_no_round(0, 0, 0, NULL, 64, is_compound, EB_8BIT);
-        av1_warp_plane(
+        eb_av1_warp_plane(
             wm_params,
             0, // int use_hbd
             8, // int bd
@@ -2472,7 +2472,7 @@ EbErrorType warped_motion_prediction_md(
         dst_stride = prediction_ptr->stride_cr;
 
             conv_params = get_conv_params_no_round(0, 0, 0, NULL, 64, is_compound, EB_8BIT);
-        av1_warp_plane(
+        eb_av1_warp_plane(
             wm_params,
             0, // int use_hbd
             8, // int bd
@@ -2557,7 +2557,7 @@ EbErrorType warped_motion_prediction_md(
 }
 
 #define SWITCHABLE_INTERP_RATE_FACTOR 1
-extern int32_t av1_get_pred_context_switchable_interp(
+extern int32_t eb_av1_get_pred_context_switchable_interp(
     NeighborArrayUnit     *ref_frame_type_neighbor_array,
     MvReferenceFrame rf0,
     MvReferenceFrame rf1,
@@ -2567,7 +2567,7 @@ extern int32_t av1_get_pred_context_switchable_interp(
     int32_t dir
 );
 
-int32_t av1_get_switchable_rate(
+int32_t eb_av1_get_switchable_rate(
     ModeDecisionCandidateBuffer *candidate_buffer_ptr,
     const Av1Common *const cm,
     ModeDecisionContext *md_context_ptr//,
@@ -2582,7 +2582,7 @@ int32_t av1_get_switchable_rate(
         for (dir = 0; dir < 2; ++dir) {
             MvReferenceFrame rf[2];
             av1_set_ref_frame(rf, candidate_buffer_ptr->candidate_ptr->ref_frame_type);
-            const int32_t ctx = av1_get_pred_context_switchable_interp(
+            const int32_t ctx = eb_av1_get_pred_context_switchable_interp(
                 md_context_ptr->ref_frame_type_neighbor_array,
                 rf[0],
                 rf[1],
@@ -2704,7 +2704,7 @@ static void model_rd_norm(int32_t xsq_q10, int32_t *r_q10, int32_t *d_q10) {
     *d_q10 = (dist_tab_q10[xq] * b_q10 + dist_tab_q10[xq + 1] * a_q10) >> 10;
 }
 
-void av1_model_rd_from_var_lapndz(int64_t var, uint32_t n_log2,
+void eb_av1_model_rd_from_var_lapndz(int64_t var, uint32_t n_log2,
     uint32_t qstep, int32_t *rate,
     int64_t *dist) {
     // This function models the rate and distortion for a Laplacian
@@ -2757,7 +2757,7 @@ void av1_model_rd_from_var_lapndz(int64_t var, uint32_t n_log2,
         *dist = (uint64_t)(square_error * quantizer) >> 8;
     }
     else {
-        av1_model_rd_from_var_lapndz((uint64_t)sse, num_pels_log2_lookup[bsize],
+        eb_av1_model_rd_from_var_lapndz((uint64_t)sse, num_pels_log2_lookup[bsize],
             quantizer >> dequant_shift, (int32_t*)rate,
             (int64_t*)dist);
     }
@@ -2941,7 +2941,7 @@ static const int32_t filter_sets[DUAL_FILTER_SET_SIZE][2] = {
     /*mbmi*/candidate_buffer_ptr->candidate_ptr->interp_filters =//EIGHTTAP_REGULAR ;
         av1_broadcast_interp_filter(av1_unswitchable_filter(assign_filter));
 
-    *switchable_rate = av1_get_switchable_rate(
+    *switchable_rate = eb_av1_get_switchable_rate(
         candidate_buffer_ptr,
         cm,
         md_context_ptr//,
@@ -3008,7 +3008,7 @@ static const int32_t filter_sets[DUAL_FILTER_SET_SIZE][2] = {
                     /*mbmi*/candidate_buffer_ptr->candidate_ptr->interp_filters = (InterpFilter)
                         av1_make_interp_filters((InterpFilter)filter_sets[i][0], (InterpFilter)filter_sets[i][1]);
 
-                    tmp_rs = av1_get_switchable_rate(
+                    tmp_rs = eb_av1_get_switchable_rate(
                         candidate_buffer_ptr,
                         cm,
                         md_context_ptr//,
@@ -3081,7 +3081,7 @@ static const int32_t filter_sets[DUAL_FILTER_SET_SIZE][2] = {
                     /*mbmi*/candidate_buffer_ptr->candidate_ptr->interp_filters =
                         av1_make_interp_filters((InterpFilter)filter_sets[i][0], (InterpFilter)filter_sets[i][1]);
 
-                    tmp_rs = av1_get_switchable_rate(
+                    tmp_rs = eb_av1_get_switchable_rate(
                         candidate_buffer_ptr,
                         cm,
                         md_context_ptr//,
@@ -3156,7 +3156,7 @@ static const int32_t filter_sets[DUAL_FILTER_SET_SIZE][2] = {
 
                     /*mbmi*/candidate_buffer_ptr->candidate_ptr->interp_filters = av1_make_interp_filters((InterpFilter)filter_sets[i][0], (InterpFilter)filter_sets[i][1]);
 
-                    tmp_rs = av1_get_switchable_rate(
+                    tmp_rs = eb_av1_get_switchable_rate(
                         candidate_buffer_ptr,
                         cm,
                         md_context_ptr//,

--- a/Source/Lib/Common/Codec/EbIntraPrediction.c
+++ b/Source/Lib/Common/Codec/EbIntraPrediction.c
@@ -27,7 +27,7 @@
 #include "EbEncDecProcess.h"
 #include "aom_dsp_rtcd.h"
 
-void *aom_memset16(void *dest, int32_t val, size_t length);
+void *eb_aom_memset16(void *dest, int32_t val, size_t length);
 
 int32_t is_inter_block(const MbModeInfo *mbmi);
 
@@ -102,7 +102,7 @@ int32_t use_intra_edge_upsample(int32_t bs0, int32_t bs1, int32_t delta, int32_t
 
 #define INTRA_EDGE_FILT 3
 #define INTRA_EDGE_TAPS 5
-void av1_filter_intra_edge_high_c_old(uint8_t *p, int32_t sz, int32_t strength) {
+void eb_av1_filter_intra_edge_high_c_old(uint8_t *p, int32_t sz, int32_t strength) {
     if (!strength) return;
 
     const int32_t kernel[INTRA_EDGE_FILT][INTRA_EDGE_TAPS] = {
@@ -124,7 +124,7 @@ void av1_filter_intra_edge_high_c_old(uint8_t *p, int32_t sz, int32_t strength) 
         p[i] = (uint8_t)s;
     }
 }
-void av1_filter_intra_edge_high_c_left(uint8_t *p, int32_t sz, int32_t strength, uint32_t                      size) {
+void eb_av1_filter_intra_edge_high_c_left(uint8_t *p, int32_t sz, int32_t strength, uint32_t                      size) {
     if (!strength) return;
     const uint32_t          leftBlockEnd = 2 * (size);
 
@@ -239,7 +239,7 @@ void av1_upsample_intra_edge_high_c_old(uint8_t *p, int32_t sz, int32_t bd) {
     }
 }
 
-const uint16_t dr_intra_derivative[90] = {
+const uint16_t eb_dr_intra_derivative[90] = {
     // More evenly spread out angles and limited to 10-bit
     // Values that are 0 will never be used
     //                    Approx angle
@@ -282,9 +282,9 @@ const uint16_t dr_intra_derivative[90] = {
 
 static INLINE uint16_t get_dy(int32_t angle) {
     if (angle > 90 && angle < 180)
-        return dr_intra_derivative[angle - 90];
+        return eb_dr_intra_derivative[angle - 90];
     else if (angle > 180 && angle < 270)
-        return dr_intra_derivative[270 - angle];
+        return eb_dr_intra_derivative[270 - angle];
     else {
         // In this case, we are not really going to use dy. We may return any value.
         return 1;
@@ -296,9 +296,9 @@ static INLINE uint16_t get_dy(int32_t angle) {
 // If angle > 180 && angle < 270, dx = 1;
 static INLINE uint16_t get_dx(int32_t angle) {
     if (angle > 0 && angle < 90)
-        return dr_intra_derivative[angle];
+        return eb_dr_intra_derivative[angle];
     else if (angle > 90 && angle < 180)
-        return dr_intra_derivative[180 - angle];
+        return eb_dr_intra_derivative[180 - angle];
     else {
         // In this case, we are not really going to use dx. We may return any value.
         return 1;
@@ -306,7 +306,7 @@ static INLINE uint16_t get_dx(int32_t angle) {
 }
 
 // Directional prediction, zone 3: 180 < angle < 270
-void av1_dr_prediction_z3_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh,
+void eb_av1_dr_prediction_z3_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh,
     const uint8_t *above, const uint8_t *left,
     int32_t upsample_left, int32_t dx, int32_t dy) {
     int32_t r, c, y, base, shift, val;
@@ -338,7 +338,7 @@ void av1_dr_prediction_z3_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t 
         }
     }
 }
-void av1_dr_prediction_z1_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh,
+void eb_av1_dr_prediction_z1_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh,
     const uint8_t *above, const uint8_t *left,
     int32_t upsample_above, int32_t dx, int32_t dy) {
     int32_t r, c, x, base, shift, val;
@@ -377,7 +377,7 @@ void av1_dr_prediction_z1_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t 
 }
 
 // Directional prediction, zone 2: 90 < angle < 180
-void av1_dr_prediction_z2_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh,
+void eb_av1_dr_prediction_z2_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh,
     const uint8_t *above, const uint8_t *left,
     int32_t upsample_above, int32_t upsample_left, int32_t dx,
     int32_t dy) {
@@ -1085,7 +1085,7 @@ void cfl_luma_subsampling_420_hbd_c(
         output_q3 += CFL_BUF_LINE;
     }
 }
-void subtract_average_c(
+void eb_subtract_average_c(
     int16_t *pred_buf_q3,
     int32_t width,
     int32_t height,
@@ -1112,7 +1112,7 @@ void subtract_average_c(
 
 CFL_SUB_AVG_FN(c)
 
-void cfl_predict_lbd_c(
+void eb_cfl_predict_lbd_c(
     const int16_t *pred_buf_q3,
     uint8_t *pred,// AMIR ADDED
     int32_t pred_stride,
@@ -1132,7 +1132,7 @@ void cfl_predict_lbd_c(
         pred_buf_q3 += CFL_BUF_LINE;
     }
 }
-void cfl_predict_hbd_c(
+void eb_cfl_predict_hbd_c(
     const int16_t *pred_buf_q3,
     uint16_t *pred,// AMIR ADDED
     int32_t pred_stride,
@@ -1756,7 +1756,7 @@ static INLINE void highbd_h_predictor(uint16_t *dst, ptrdiff_t stride, int32_t b
     (void)above;
     (void)bd;
     for (r = 0; r < bh; r++) {
-        aom_memset16(dst, left[r], bw);
+        eb_aom_memset16(dst, left[r], bw);
         dst += stride;
     }
 }
@@ -1915,7 +1915,7 @@ static INLINE void highbd_dc_128_predictor(uint16_t *dst, ptrdiff_t stride,
     (void)left;
 
     for (r = 0; r < bh; r++) {
-        aom_memset16(dst, 128 << (bd - 8), bw);
+        eb_aom_memset16(dst, 128 << (bd - 8), bw);
         dst += stride;
     }
 }
@@ -1932,7 +1932,7 @@ static INLINE void highbd_dc_left_predictor(uint16_t *dst, ptrdiff_t stride,
     expected_dc = (sum + (bh >> 1)) / bh;
 
     for (r = 0; r < bh; r++) {
-        aom_memset16(dst, expected_dc, bw);
+        eb_aom_memset16(dst, expected_dc, bw);
         dst += stride;
     }
 }
@@ -1949,7 +1949,7 @@ static INLINE void highbd_dc_top_predictor(uint16_t *dst, ptrdiff_t stride,
     expected_dc = (sum + (bw >> 1)) / bw;
 
     for (r = 0; r < bh; r++) {
-        aom_memset16(dst, expected_dc, bw);
+        eb_aom_memset16(dst, expected_dc, bw);
         dst += stride;
     }
 }
@@ -1968,7 +1968,7 @@ static INLINE void highbd_dc_predictor(uint16_t *dst, ptrdiff_t stride, int32_t 
     expected_dc = (sum + (count >> 1)) / count;
 
     for (r = 0; r < bh; r++) {
-        aom_memset16(dst, expected_dc, bw);
+        eb_aom_memset16(dst, expected_dc, bw);
         dst += stride;
     }
 }
@@ -1993,105 +1993,105 @@ static INLINE void highbd_dc_predictor(uint16_t *dst, ptrdiff_t stride, int32_t 
 //    assert(expected_dc < (1 << bd));
 //
 //    for (int32_t r = 0; r < bh; r++) {
-//        aom_memset16(dst, expected_dc, bw);
+//        eb_aom_memset16(dst, expected_dc, bw);
 //        dst += stride;
 //    }
 //}
 
 //#undef HIGHBD_DC_SHIFT2
 //
-//void aom_highbd_dc_predictor_4x8_c(uint16_t *dst, ptrdiff_t stride,
+//void eb_aom_highbd_dc_predictor_4x8_c(uint16_t *dst, ptrdiff_t stride,
 //    const uint16_t *above, const uint16_t *left,
 //    int32_t bd) {
 //    highbd_dc_predictor_rect(dst, stride, 4, 8, above, left, bd, 2,
 //        HIGHBD_DC_MULTIPLIER_1X2);
 //}
 //
-//void aom_highbd_dc_predictor_8x4_c(uint16_t *dst, ptrdiff_t stride,
+//void eb_aom_highbd_dc_predictor_8x4_c(uint16_t *dst, ptrdiff_t stride,
 //    const uint16_t *above, const uint16_t *left,
 //    int32_t bd) {
 //    highbd_dc_predictor_rect(dst, stride, 8, 4, above, left, bd, 2,
 //        HIGHBD_DC_MULTIPLIER_1X2);
 //}
 //
-//void aom_highbd_dc_predictor_4x16_c(uint16_t *dst, ptrdiff_t stride,
+//void eb_aom_highbd_dc_predictor_4x16_c(uint16_t *dst, ptrdiff_t stride,
 //    const uint16_t *above, const uint16_t *left,
 //    int32_t bd) {
 //    highbd_dc_predictor_rect(dst, stride, 4, 16, above, left, bd, 2,
 //        HIGHBD_DC_MULTIPLIER_1X4);
 //}
 //
-//void aom_highbd_dc_predictor_16x4_c(uint16_t *dst, ptrdiff_t stride,
+//void eb_aom_highbd_dc_predictor_16x4_c(uint16_t *dst, ptrdiff_t stride,
 //    const uint16_t *above, const uint16_t *left,
 //    int32_t bd) {
 //    highbd_dc_predictor_rect(dst, stride, 16, 4, above, left, bd, 2,
 //        HIGHBD_DC_MULTIPLIER_1X4);
 //}
 //
-//void aom_highbd_dc_predictor_8x16_c(uint16_t *dst, ptrdiff_t stride,
+//void eb_aom_highbd_dc_predictor_8x16_c(uint16_t *dst, ptrdiff_t stride,
 //    const uint16_t *above, const uint16_t *left,
 //    int32_t bd) {
 //    highbd_dc_predictor_rect(dst, stride, 8, 16, above, left, bd, 3,
 //        HIGHBD_DC_MULTIPLIER_1X2);
 //}
 //
-//void aom_highbd_dc_predictor_16x8_c(uint16_t *dst, ptrdiff_t stride,
+//void eb_aom_highbd_dc_predictor_16x8_c(uint16_t *dst, ptrdiff_t stride,
 //    const uint16_t *above, const uint16_t *left,
 //    int32_t bd) {
 //    highbd_dc_predictor_rect(dst, stride, 16, 8, above, left, bd, 3,
 //        HIGHBD_DC_MULTIPLIER_1X2);
 //}
 //
-//void aom_highbd_dc_predictor_8x32_c(uint16_t *dst, ptrdiff_t stride,
+//void eb_aom_highbd_dc_predictor_8x32_c(uint16_t *dst, ptrdiff_t stride,
 //    const uint16_t *above, const uint16_t *left,
 //    int32_t bd) {
 //    highbd_dc_predictor_rect(dst, stride, 8, 32, above, left, bd, 3,
 //        HIGHBD_DC_MULTIPLIER_1X4);
 //}
 //
-//void aom_highbd_dc_predictor_32x8_c(uint16_t *dst, ptrdiff_t stride,
+//void eb_aom_highbd_dc_predictor_32x8_c(uint16_t *dst, ptrdiff_t stride,
 //    const uint16_t *above, const uint16_t *left,
 //    int32_t bd) {
 //    highbd_dc_predictor_rect(dst, stride, 32, 8, above, left, bd, 3,
 //        HIGHBD_DC_MULTIPLIER_1X4);
 //}
 //
-//void aom_highbd_dc_predictor_16x32_c(uint16_t *dst, ptrdiff_t stride,
+//void eb_aom_highbd_dc_predictor_16x32_c(uint16_t *dst, ptrdiff_t stride,
 //    const uint16_t *above,
 //    const uint16_t *left, int32_t bd) {
 //    highbd_dc_predictor_rect(dst, stride, 16, 32, above, left, bd, 4,
 //        HIGHBD_DC_MULTIPLIER_1X2);
 //}
 //
-//void aom_highbd_dc_predictor_32x16_c(uint16_t *dst, ptrdiff_t stride,
+//void eb_aom_highbd_dc_predictor_32x16_c(uint16_t *dst, ptrdiff_t stride,
 //    const uint16_t *above,
 //    const uint16_t *left, int32_t bd) {
 //    highbd_dc_predictor_rect(dst, stride, 32, 16, above, left, bd, 4,
 //        HIGHBD_DC_MULTIPLIER_1X2);
 //}
 //
-//void aom_highbd_dc_predictor_16x64_c(uint16_t *dst, ptrdiff_t stride,
+//void eb_aom_highbd_dc_predictor_16x64_c(uint16_t *dst, ptrdiff_t stride,
 //    const uint16_t *above,
 //    const uint16_t *left, int32_t bd) {
 //    highbd_dc_predictor_rect(dst, stride, 16, 64, above, left, bd, 4,
 //        HIGHBD_DC_MULTIPLIER_1X4);
 //}
 //
-//void aom_highbd_dc_predictor_64x16_c(uint16_t *dst, ptrdiff_t stride,
+//void eb_aom_highbd_dc_predictor_64x16_c(uint16_t *dst, ptrdiff_t stride,
 //    const uint16_t *above,
 //    const uint16_t *left, int32_t bd) {
 //    highbd_dc_predictor_rect(dst, stride, 64, 16, above, left, bd, 4,
 //        HIGHBD_DC_MULTIPLIER_1X4);
 //}
 //
-//void aom_highbd_dc_predictor_32x64_c(uint16_t *dst, ptrdiff_t stride,
+//void eb_aom_highbd_dc_predictor_32x64_c(uint16_t *dst, ptrdiff_t stride,
 //    const uint16_t *above,
 //    const uint16_t *left, int32_t bd) {
 //    highbd_dc_predictor_rect(dst, stride, 32, 64, above, left, bd, 5,
 //        HIGHBD_DC_MULTIPLIER_1X2);
 //}
 //
-//void aom_highbd_dc_predictor_64x32_c(uint16_t *dst, ptrdiff_t stride,
+//void eb_aom_highbd_dc_predictor_64x32_c(uint16_t *dst, ptrdiff_t stride,
 //    const uint16_t *above,
 //    const uint16_t *left, int32_t bd) {
 //    highbd_dc_predictor_rect(dst, stride, 64, 32, above, left, bd, 5,
@@ -2102,7 +2102,7 @@ static INLINE void highbd_dc_predictor(uint16_t *dst, ptrdiff_t stride, int32_t 
 //#undef HIGHBD_DC_MULTIPLIER_1X4
 
 #define intra_pred_sized(type, width, height)                  \
-  void aom_##type##_predictor_##width##x##height##_c(          \
+  void eb_aom_##type##_predictor_##width##x##height##_c(          \
       uint8_t *dst, ptrdiff_t stride, const uint8_t *above,    \
       const uint8_t *left) {                                   \
     type##_predictor(dst, stride, width, height, above, left); \
@@ -2312,7 +2312,7 @@ intra_pred_sized(paeth, 32, 64)
 intra_pred_sized(paeth, 64, 16)
 intra_pred_sized(paeth, 64, 32)
 #define intra_pred_highbd_sized(type, width, height)                        \
-  void aom_highbd_##type##_predictor_##width##x##height##_c(                \
+  void eb_aom_highbd_##type##_predictor_##width##x##height##_c(                \
       uint16_t *dst, ptrdiff_t stride, const uint16_t *above,               \
       const uint16_t *left, int32_t bd) {                                       \
     highbd_##type##_predictor(dst, stride, width, height, above, left, bd); \
@@ -2552,500 +2552,500 @@ void init_intra_dc_predictors_c_internal(void)
 }
 
 /*static*/ void init_intra_predictors_internal(void) {
-    pred[V_PRED][TX_4X4] = aom_v_predictor_4x4;
-    pred[V_PRED][TX_8X8] = aom_v_predictor_8x8;
-    pred[V_PRED][TX_16X16] = aom_v_predictor_16x16;
-    pred[V_PRED][TX_32X32] = aom_v_predictor_32x32;
-    pred[V_PRED][TX_64X64] = aom_v_predictor_64x64;
-    pred[V_PRED][TX_4X8] = aom_v_predictor_4x8;
-    pred[V_PRED][TX_4X16] = aom_v_predictor_4x16;
-
-    pred[V_PRED][TX_8X4] = aom_v_predictor_8x4;
-    pred[V_PRED][TX_8X16] = aom_v_predictor_8x16;
-    pred[V_PRED][TX_8X32] = aom_v_predictor_8x32;
-
-    pred[V_PRED][TX_16X4] = aom_v_predictor_16x4;
-    pred[V_PRED][TX_16X8] = aom_v_predictor_16x8;
-    pred[V_PRED][TX_16X32] = aom_v_predictor_16x32;
-    pred[V_PRED][TX_16X64] = aom_v_predictor_16x64;
-
-    pred[V_PRED][TX_32X8] = aom_v_predictor_32x8;
-    pred[V_PRED][TX_32X16] = aom_v_predictor_32x16;
-    pred[V_PRED][TX_32X64] = aom_v_predictor_32x64;
-
-    pred[V_PRED][TX_64X16] = aom_v_predictor_64x16;
-    pred[V_PRED][TX_64X32] = aom_v_predictor_64x32;
-
-    pred[H_PRED][TX_4X4] = aom_h_predictor_4x4;
-    pred[H_PRED][TX_8X8] = aom_h_predictor_8x8;
-    pred[H_PRED][TX_16X16] = aom_h_predictor_16x16;
-    pred[H_PRED][TX_32X32] = aom_h_predictor_32x32;
-    pred[H_PRED][TX_64X64] = aom_h_predictor_64x64;
-
-    pred[H_PRED][TX_4X8] = aom_h_predictor_4x8;
-    pred[H_PRED][TX_4X16] = aom_h_predictor_4x16;
-
-    pred[H_PRED][TX_8X4] = aom_h_predictor_8x4;
-    pred[H_PRED][TX_8X16] = aom_h_predictor_8x16;
-    pred[H_PRED][TX_8X32] = aom_h_predictor_8x32;
-
-    pred[H_PRED][TX_16X4] = aom_h_predictor_16x4;
-    pred[H_PRED][TX_16X8] = aom_h_predictor_16x8;
-    pred[H_PRED][TX_16X32] = aom_h_predictor_16x32;
-    pred[H_PRED][TX_16X64] = aom_h_predictor_16x64;
-
-    pred[H_PRED][TX_32X8] = aom_h_predictor_32x8;
-    pred[H_PRED][TX_32X16] = aom_h_predictor_32x16;
-    pred[H_PRED][TX_32X64] = aom_h_predictor_32x64;
-
-    pred[H_PRED][TX_64X16] = aom_h_predictor_64x16;
-    pred[H_PRED][TX_64X32] = aom_h_predictor_64x32;
-
-    pred[SMOOTH_PRED][TX_4X4] = aom_smooth_predictor_4x4;
-    pred[SMOOTH_PRED][TX_8X8] = aom_smooth_predictor_8x8;
-    pred[SMOOTH_PRED][TX_16X16] = aom_smooth_predictor_16x16;
-    pred[SMOOTH_PRED][TX_32X32] = aom_smooth_predictor_32x32;
-    pred[SMOOTH_PRED][TX_64X64] = aom_smooth_predictor_64x64;
-
-    pred[SMOOTH_PRED][TX_4X8] = aom_smooth_predictor_4x8;
-    pred[SMOOTH_PRED][TX_4X16] = aom_smooth_predictor_4x16;
-
-    pred[SMOOTH_PRED][TX_8X4] = aom_smooth_predictor_8x4;
-    pred[SMOOTH_PRED][TX_8X16] = aom_smooth_predictor_8x16;
-    pred[SMOOTH_PRED][TX_8X32] = aom_smooth_predictor_8x32;
-
-    pred[SMOOTH_PRED][TX_16X4] = aom_smooth_predictor_16x4;
-    pred[SMOOTH_PRED][TX_16X8] = aom_smooth_predictor_16x8;
-    pred[SMOOTH_PRED][TX_16X32] = aom_smooth_predictor_16x32;
-    pred[SMOOTH_PRED][TX_16X64] = aom_smooth_predictor_16x64;
-
-    pred[SMOOTH_PRED][TX_32X8] = aom_smooth_predictor_32x8;
-    pred[SMOOTH_PRED][TX_32X16] = aom_smooth_predictor_32x16;
-    pred[SMOOTH_PRED][TX_32X64] = aom_smooth_predictor_32x64;
-
-    pred[SMOOTH_PRED][TX_64X16] = aom_smooth_predictor_64x16;
-    pred[SMOOTH_PRED][TX_64X32] = aom_smooth_predictor_64x32;
-
-    pred[SMOOTH_V_PRED][TX_4X4] = aom_smooth_v_predictor_4x4;
-    pred[SMOOTH_V_PRED][TX_8X8] = aom_smooth_v_predictor_8x8;
-    pred[SMOOTH_V_PRED][TX_16X16] = aom_smooth_v_predictor_16x16;
-    pred[SMOOTH_V_PRED][TX_32X32] = aom_smooth_v_predictor_32x32;
-    pred[SMOOTH_V_PRED][TX_64X64] = aom_smooth_v_predictor_64x64;
-
-    pred[SMOOTH_V_PRED][TX_4X8] = aom_smooth_v_predictor_4x8;
-    pred[SMOOTH_V_PRED][TX_4X16] = aom_smooth_v_predictor_4x16;
-
-    pred[SMOOTH_V_PRED][TX_8X4] = aom_smooth_v_predictor_8x4;
-    pred[SMOOTH_V_PRED][TX_8X16] = aom_smooth_v_predictor_8x16;
-    pred[SMOOTH_V_PRED][TX_8X32] = aom_smooth_v_predictor_8x32;
-
-    pred[SMOOTH_V_PRED][TX_16X4] = aom_smooth_v_predictor_16x4;
-    pred[SMOOTH_V_PRED][TX_16X8] = aom_smooth_v_predictor_16x8;
-    pred[SMOOTH_V_PRED][TX_16X32] = aom_smooth_v_predictor_16x32;
-    pred[SMOOTH_V_PRED][TX_16X64] = aom_smooth_v_predictor_16x64;
-
-    pred[SMOOTH_V_PRED][TX_32X8] = aom_smooth_v_predictor_32x8;
-    pred[SMOOTH_V_PRED][TX_32X16] = aom_smooth_v_predictor_32x16;
-    pred[SMOOTH_V_PRED][TX_32X64] = aom_smooth_v_predictor_32x64;
-
-    pred[SMOOTH_V_PRED][TX_64X16] = aom_smooth_v_predictor_64x16;
-    pred[SMOOTH_V_PRED][TX_64X32] = aom_smooth_v_predictor_64x32;
-
-    pred[SMOOTH_H_PRED][TX_4X4] = aom_smooth_h_predictor_4x4;
-    pred[SMOOTH_H_PRED][TX_8X8] = aom_smooth_h_predictor_8x8;
-    pred[SMOOTH_H_PRED][TX_16X16] = aom_smooth_h_predictor_16x16;
-    pred[SMOOTH_H_PRED][TX_32X32] = aom_smooth_h_predictor_32x32;
-    pred[SMOOTH_H_PRED][TX_64X64] = aom_smooth_h_predictor_64x64;
-
-    pred[SMOOTH_H_PRED][TX_4X8] = aom_smooth_h_predictor_4x8;
-    pred[SMOOTH_H_PRED][TX_4X16] = aom_smooth_h_predictor_4x16;
-
-    pred[SMOOTH_H_PRED][TX_8X4] = aom_smooth_h_predictor_8x4;
-    pred[SMOOTH_H_PRED][TX_8X16] = aom_smooth_h_predictor_8x16;
-    pred[SMOOTH_H_PRED][TX_8X32] = aom_smooth_h_predictor_8x32;
-
-    pred[SMOOTH_H_PRED][TX_16X4] = aom_smooth_h_predictor_16x4;
-    pred[SMOOTH_H_PRED][TX_16X8] = aom_smooth_h_predictor_16x8;
-    pred[SMOOTH_H_PRED][TX_16X32] = aom_smooth_h_predictor_16x32;
-    pred[SMOOTH_H_PRED][TX_16X64] = aom_smooth_h_predictor_16x64;
-
-    pred[SMOOTH_H_PRED][TX_32X8] = aom_smooth_h_predictor_32x8;
-    pred[SMOOTH_H_PRED][TX_32X16] = aom_smooth_h_predictor_32x16;
-    pred[SMOOTH_H_PRED][TX_32X64] = aom_smooth_h_predictor_32x64;
-
-    pred[SMOOTH_H_PRED][TX_64X16] = aom_smooth_h_predictor_64x16;
-    pred[SMOOTH_H_PRED][TX_64X32] = aom_smooth_h_predictor_64x32;
-
-    pred[PAETH_PRED][TX_4X4] = aom_paeth_predictor_4x4;
-    pred[PAETH_PRED][TX_8X8] = aom_paeth_predictor_8x8;
-    pred[PAETH_PRED][TX_16X16] = aom_paeth_predictor_16x16;
-    pred[PAETH_PRED][TX_32X32] = aom_paeth_predictor_32x32;
-    pred[PAETH_PRED][TX_64X64] = aom_paeth_predictor_64x64;
-
-    pred[PAETH_PRED][TX_4X8] = aom_paeth_predictor_4x8;
-    pred[PAETH_PRED][TX_4X16] = aom_paeth_predictor_4x16;
-
-    pred[PAETH_PRED][TX_8X4] = aom_paeth_predictor_8x4;
-    pred[PAETH_PRED][TX_8X16] = aom_paeth_predictor_8x16;
-    pred[PAETH_PRED][TX_8X32] = aom_paeth_predictor_8x32;
-
-    pred[PAETH_PRED][TX_16X4] = aom_paeth_predictor_16x4;
-    pred[PAETH_PRED][TX_16X8] = aom_paeth_predictor_16x8;
-    pred[PAETH_PRED][TX_16X32] = aom_paeth_predictor_16x32;
-    pred[PAETH_PRED][TX_16X64] = aom_paeth_predictor_16x64;
-
-    pred[PAETH_PRED][TX_32X8] = aom_paeth_predictor_32x8;
-    pred[PAETH_PRED][TX_32X16] = aom_paeth_predictor_32x16;
-    pred[PAETH_PRED][TX_32X64] = aom_paeth_predictor_32x64;
-
-    pred[PAETH_PRED][TX_64X16] = aom_paeth_predictor_64x16;
-    pred[PAETH_PRED][TX_64X32] = aom_paeth_predictor_64x32;
-    dc_pred[0][0][TX_4X4] = aom_dc_128_predictor_4x4;
-    dc_pred[0][0][TX_8X8] = aom_dc_128_predictor_8x8;
-    dc_pred[0][0][TX_16X16] = aom_dc_128_predictor_16x16;
-    dc_pred[0][0][TX_32X32] = aom_dc_128_predictor_32x32;
-    dc_pred[0][0][TX_64X64] = aom_dc_128_predictor_64x64;
-
-    dc_pred[0][0][TX_4X8] = aom_dc_128_predictor_4x8;
-    dc_pred[0][0][TX_4X16] = aom_dc_128_predictor_4x16;
-
-    dc_pred[0][0][TX_8X4] = aom_dc_128_predictor_8x4;
-    dc_pred[0][0][TX_8X16] = aom_dc_128_predictor_8x16;
-    dc_pred[0][0][TX_8X32] = aom_dc_128_predictor_8x32;
-
-    dc_pred[0][0][TX_16X4] = aom_dc_128_predictor_16x4;
-    dc_pred[0][0][TX_16X8] = aom_dc_128_predictor_16x8;
-    dc_pred[0][0][TX_16X32] = aom_dc_128_predictor_16x32;
-    dc_pred[0][0][TX_16X64] = aom_dc_128_predictor_16x64;
-
-    dc_pred[0][0][TX_32X8] = aom_dc_128_predictor_32x8;
-    dc_pred[0][0][TX_32X16] = aom_dc_128_predictor_32x16;
-    dc_pred[0][0][TX_32X64] = aom_dc_128_predictor_32x64;
-
-    dc_pred[0][0][TX_64X16] = aom_dc_128_predictor_64x16;
-    dc_pred[0][0][TX_64X32] = aom_dc_128_predictor_64x32;
-
-    dc_pred[0][1][TX_4X4] = aom_dc_top_predictor_4x4;
-    dc_pred[0][1][TX_8X8] = aom_dc_top_predictor_8x8;
-    dc_pred[0][1][TX_16X16] = aom_dc_top_predictor_16x16;
-    dc_pred[0][1][TX_32X32] = aom_dc_top_predictor_32x32;
-    dc_pred[0][1][TX_64X64] = aom_dc_top_predictor_64x64;
-
-    dc_pred[0][1][TX_4X8] = aom_dc_top_predictor_4x8;
-    dc_pred[0][1][TX_4X16] = aom_dc_top_predictor_4x16;
-
-    dc_pred[0][1][TX_8X4] = aom_dc_top_predictor_8x4;
-    dc_pred[0][1][TX_8X16] = aom_dc_top_predictor_8x16;
-    dc_pred[0][1][TX_8X32] = aom_dc_top_predictor_8x32;
-
-    dc_pred[0][1][TX_16X4] = aom_dc_top_predictor_16x4;
-    dc_pred[0][1][TX_16X8] = aom_dc_top_predictor_16x8;
-    dc_pred[0][1][TX_16X32] = aom_dc_top_predictor_16x32;
-    dc_pred[0][1][TX_16X64] = aom_dc_top_predictor_16x64;
-
-    dc_pred[0][1][TX_32X8] = aom_dc_top_predictor_32x8;
-    dc_pred[0][1][TX_32X16] = aom_dc_top_predictor_32x16;
-    dc_pred[0][1][TX_32X64] = aom_dc_top_predictor_32x64;
-
-    dc_pred[0][1][TX_64X16] = aom_dc_top_predictor_64x16;
-    dc_pred[0][1][TX_64X32] = aom_dc_top_predictor_64x32;
-
-    dc_pred[1][0][TX_4X4] = aom_dc_left_predictor_4x4;
-    dc_pred[1][0][TX_8X8] = aom_dc_left_predictor_8x8;
-    dc_pred[1][0][TX_16X16] = aom_dc_left_predictor_16x16;
-    dc_pred[1][0][TX_32X32] = aom_dc_left_predictor_32x32;
-    dc_pred[1][0][TX_64X64] = aom_dc_left_predictor_64x64;
-    dc_pred[1][0][TX_4X8] = aom_dc_left_predictor_4x8;
-    dc_pred[1][0][TX_4X16] = aom_dc_left_predictor_4x16;
-
-    dc_pred[1][0][TX_8X4] = aom_dc_left_predictor_8x4;
-    dc_pred[1][0][TX_8X16] = aom_dc_left_predictor_8x16;
-    dc_pred[1][0][TX_8X32] = aom_dc_left_predictor_8x32;
-
-    dc_pred[1][0][TX_16X4] = aom_dc_left_predictor_16x4;
-    dc_pred[1][0][TX_16X8] = aom_dc_left_predictor_16x8;
-    dc_pred[1][0][TX_16X32] = aom_dc_left_predictor_16x32;
-    dc_pred[1][0][TX_16X64] = aom_dc_left_predictor_16x64;
-
-    dc_pred[1][0][TX_32X8] = aom_dc_left_predictor_32x8;
-    dc_pred[1][0][TX_32X16] = aom_dc_left_predictor_32x16;
-    dc_pred[1][0][TX_32X64] = aom_dc_left_predictor_32x64;
-
-    dc_pred[1][0][TX_64X16] = aom_dc_left_predictor_64x16;
-    dc_pred[1][0][TX_64X32] = aom_dc_left_predictor_64x32;
-
-    dc_pred[1][1][TX_4X4] = aom_dc_predictor_4x4;
-    dc_pred[1][1][TX_8X8] = aom_dc_predictor_8x8;
-    dc_pred[1][1][TX_16X16] = aom_dc_predictor_16x16;
-    dc_pred[1][1][TX_32X32] = aom_dc_predictor_32x32;
-    dc_pred[1][1][TX_64X64] = aom_dc_predictor_64x64;
-    dc_pred[1][1][TX_4X8] = aom_dc_predictor_4x8;
-    dc_pred[1][1][TX_4X16] = aom_dc_predictor_4x16;
-
-    dc_pred[1][1][TX_8X4] = aom_dc_predictor_8x4;
-    dc_pred[1][1][TX_8X16] = aom_dc_predictor_8x16;
-    dc_pred[1][1][TX_8X32] = aom_dc_predictor_8x32;
-
-    dc_pred[1][1][TX_16X4] = aom_dc_predictor_16x4;
-    dc_pred[1][1][TX_16X8] = aom_dc_predictor_16x8;
-    dc_pred[1][1][TX_16X32] = aom_dc_predictor_16x32;
-    dc_pred[1][1][TX_16X64] = aom_dc_predictor_16x64;
-
-    dc_pred[1][1][TX_32X8] = aom_dc_predictor_32x8;
-    dc_pred[1][1][TX_32X16] = aom_dc_predictor_32x16;
-    dc_pred[1][1][TX_32X64] = aom_dc_predictor_32x64;
-
-    dc_pred[1][1][TX_64X16] = aom_dc_predictor_64x16;
-    dc_pred[1][1][TX_64X32] = aom_dc_predictor_64x32;
-
-    pred_high[V_PRED][TX_4X4] = aom_highbd_v_predictor_4x4;
-    pred_high[V_PRED][TX_8X8] = aom_highbd_v_predictor_8x8;
-    pred_high[V_PRED][TX_16X16] = aom_highbd_v_predictor_16x16;
-    pred_high[V_PRED][TX_32X32] = aom_highbd_v_predictor_32x32;
-    pred_high[V_PRED][TX_64X64] = aom_highbd_v_predictor_64x64;
-
-    pred_high[V_PRED][TX_4X8] = aom_highbd_v_predictor_4x8;
-    pred_high[V_PRED][TX_4X16] = aom_highbd_v_predictor_4x16;
-
-    pred_high[V_PRED][TX_8X4] = aom_highbd_v_predictor_8x4;
-    pred_high[V_PRED][TX_8X16] = aom_highbd_v_predictor_8x16;
-    pred_high[V_PRED][TX_8X32] = aom_highbd_v_predictor_8x32;
-
-    pred_high[V_PRED][TX_16X4] = aom_highbd_v_predictor_16x4;
-    pred_high[V_PRED][TX_16X8] = aom_highbd_v_predictor_16x8;
-    pred_high[V_PRED][TX_16X32] = aom_highbd_v_predictor_16x32;
-    pred_high[V_PRED][TX_16X64] = aom_highbd_v_predictor_16x64;
-
-    pred_high[V_PRED][TX_32X8] = aom_highbd_v_predictor_32x8;
-    pred_high[V_PRED][TX_32X16] = aom_highbd_v_predictor_32x16;
-    pred_high[V_PRED][TX_32X64] = aom_highbd_v_predictor_32x64;
-
-    pred_high[V_PRED][TX_64X16] = aom_highbd_v_predictor_64x16;
-    pred_high[V_PRED][TX_64X32] = aom_highbd_v_predictor_64x32;
-
-    pred_high[H_PRED][TX_4X4] = aom_highbd_h_predictor_4x4;
-    pred_high[H_PRED][TX_8X8] = aom_highbd_h_predictor_8x8;
-    pred_high[H_PRED][TX_16X16] = aom_highbd_h_predictor_16x16;
-    pred_high[H_PRED][TX_32X32] = aom_highbd_h_predictor_32x32;
-    pred_high[H_PRED][TX_64X64] = aom_highbd_h_predictor_64x64;
-
-    pred_high[H_PRED][TX_4X8] = aom_highbd_h_predictor_4x8;
-    pred_high[H_PRED][TX_4X16] = aom_highbd_h_predictor_4x16;
-
-    pred_high[H_PRED][TX_8X4] = aom_highbd_h_predictor_8x4;
-    pred_high[H_PRED][TX_8X16] = aom_highbd_h_predictor_8x16;
-    pred_high[H_PRED][TX_8X32] = aom_highbd_h_predictor_8x32;
-
-    pred_high[H_PRED][TX_16X4] = aom_highbd_h_predictor_16x4;
-    pred_high[H_PRED][TX_16X8] = aom_highbd_h_predictor_16x8;
-    pred_high[H_PRED][TX_16X32] = aom_highbd_h_predictor_16x32;
-    pred_high[H_PRED][TX_16X64] = aom_highbd_h_predictor_16x64;
-
-    pred_high[H_PRED][TX_32X8] = aom_highbd_h_predictor_32x8;
-    pred_high[H_PRED][TX_32X16] = aom_highbd_h_predictor_32x16;
-    pred_high[H_PRED][TX_32X64] = aom_highbd_h_predictor_32x64;
-
-    pred_high[H_PRED][TX_64X16] = aom_highbd_h_predictor_64x16;
-    pred_high[H_PRED][TX_64X32] = aom_highbd_h_predictor_64x32;
-
-    pred_high[SMOOTH_PRED][TX_4X4] = aom_highbd_smooth_predictor_4x4;
-    pred_high[SMOOTH_PRED][TX_8X8] = aom_highbd_smooth_predictor_8x8;
-    pred_high[SMOOTH_PRED][TX_16X16] = aom_highbd_smooth_predictor_16x16;
-    pred_high[SMOOTH_PRED][TX_32X32] = aom_highbd_smooth_predictor_32x32;
-    pred_high[SMOOTH_PRED][TX_64X64] = aom_highbd_smooth_predictor_64x64;
-
-    pred_high[SMOOTH_PRED][TX_4X8] = aom_highbd_smooth_predictor_4x8;
-    pred_high[SMOOTH_PRED][TX_4X16] = aom_highbd_smooth_predictor_4x16;
-
-    pred_high[SMOOTH_PRED][TX_8X4] = aom_highbd_smooth_predictor_8x4;
-    pred_high[SMOOTH_PRED][TX_8X16] = aom_highbd_smooth_predictor_8x16;
-    pred_high[SMOOTH_PRED][TX_8X32] = aom_highbd_smooth_predictor_8x32;
-
-    pred_high[SMOOTH_PRED][TX_16X4] = aom_highbd_smooth_predictor_16x4;
-    pred_high[SMOOTH_PRED][TX_16X8] = aom_highbd_smooth_predictor_16x8;
-    pred_high[SMOOTH_PRED][TX_16X32] = aom_highbd_smooth_predictor_16x32;
-    pred_high[SMOOTH_PRED][TX_16X64] = aom_highbd_smooth_predictor_16x64;
-
-    pred_high[SMOOTH_PRED][TX_32X8] = aom_highbd_smooth_predictor_32x8;
-    pred_high[SMOOTH_PRED][TX_32X16] = aom_highbd_smooth_predictor_32x16;
-    pred_high[SMOOTH_PRED][TX_32X64] = aom_highbd_smooth_predictor_32x64;
-
-    pred_high[SMOOTH_PRED][TX_64X16] = aom_highbd_smooth_predictor_64x16;
-    pred_high[SMOOTH_PRED][TX_64X32] = aom_highbd_smooth_predictor_64x32;
-
-    pred_high[SMOOTH_V_PRED][TX_4X4] = aom_highbd_smooth_v_predictor_4x4;
-    pred_high[SMOOTH_V_PRED][TX_8X8] = aom_highbd_smooth_v_predictor_8x8;
-    pred_high[SMOOTH_V_PRED][TX_16X16] = aom_highbd_smooth_v_predictor_16x16;
-    pred_high[SMOOTH_V_PRED][TX_32X32] = aom_highbd_smooth_v_predictor_32x32;
-    pred_high[SMOOTH_V_PRED][TX_64X64] = aom_highbd_smooth_v_predictor_64x64;
-
-    pred_high[SMOOTH_V_PRED][TX_4X8] = aom_highbd_smooth_v_predictor_4x8;
-    pred_high[SMOOTH_V_PRED][TX_4X16] = aom_highbd_smooth_v_predictor_4x16;
-
-    pred_high[SMOOTH_V_PRED][TX_8X4] = aom_highbd_smooth_v_predictor_8x4;
-    pred_high[SMOOTH_V_PRED][TX_8X16] = aom_highbd_smooth_v_predictor_8x16;
-    pred_high[SMOOTH_V_PRED][TX_8X32] = aom_highbd_smooth_v_predictor_8x32;
-
-    pred_high[SMOOTH_V_PRED][TX_16X4] = aom_highbd_smooth_v_predictor_16x4;
-    pred_high[SMOOTH_V_PRED][TX_16X8] = aom_highbd_smooth_v_predictor_16x8;
-    pred_high[SMOOTH_V_PRED][TX_16X32] = aom_highbd_smooth_v_predictor_16x32;
-    pred_high[SMOOTH_V_PRED][TX_16X64] = aom_highbd_smooth_v_predictor_16x64;
-
-    pred_high[SMOOTH_V_PRED][TX_32X8] = aom_highbd_smooth_v_predictor_32x8;
-    pred_high[SMOOTH_V_PRED][TX_32X16] = aom_highbd_smooth_v_predictor_32x16;
-    pred_high[SMOOTH_V_PRED][TX_32X64] = aom_highbd_smooth_v_predictor_32x64;
-
-    pred_high[SMOOTH_V_PRED][TX_64X16] = aom_highbd_smooth_v_predictor_64x16;
-    pred_high[SMOOTH_V_PRED][TX_64X32] = aom_highbd_smooth_v_predictor_64x32;
-
-    pred_high[SMOOTH_H_PRED][TX_4X4] = aom_highbd_smooth_h_predictor_4x4;
-    pred_high[SMOOTH_H_PRED][TX_8X8] = aom_highbd_smooth_h_predictor_8x8;
-    pred_high[SMOOTH_H_PRED][TX_16X16] = aom_highbd_smooth_h_predictor_16x16;
-    pred_high[SMOOTH_H_PRED][TX_32X32] = aom_highbd_smooth_h_predictor_32x32;
-    pred_high[SMOOTH_H_PRED][TX_64X64] = aom_highbd_smooth_h_predictor_64x64;
-
-    pred_high[SMOOTH_H_PRED][TX_4X8] = aom_highbd_smooth_h_predictor_4x8;
-    pred_high[SMOOTH_H_PRED][TX_4X16] = aom_highbd_smooth_h_predictor_4x16;
-
-    pred_high[SMOOTH_H_PRED][TX_8X4] = aom_highbd_smooth_h_predictor_8x4;
-    pred_high[SMOOTH_H_PRED][TX_8X16] = aom_highbd_smooth_h_predictor_8x16;
-    pred_high[SMOOTH_H_PRED][TX_8X32] = aom_highbd_smooth_h_predictor_8x32;
-
-    pred_high[SMOOTH_H_PRED][TX_16X4] = aom_highbd_smooth_h_predictor_16x4;
-    pred_high[SMOOTH_H_PRED][TX_16X8] = aom_highbd_smooth_h_predictor_16x8;
-    pred_high[SMOOTH_H_PRED][TX_16X32] = aom_highbd_smooth_h_predictor_16x32;
-    pred_high[SMOOTH_H_PRED][TX_16X64] = aom_highbd_smooth_h_predictor_16x64;
-
-    pred_high[SMOOTH_H_PRED][TX_32X8] = aom_highbd_smooth_h_predictor_32x8;
-    pred_high[SMOOTH_H_PRED][TX_32X16] = aom_highbd_smooth_h_predictor_32x16;
-    pred_high[SMOOTH_H_PRED][TX_32X64] = aom_highbd_smooth_h_predictor_32x64;
-
-    pred_high[SMOOTH_H_PRED][TX_64X16] = aom_highbd_smooth_h_predictor_64x16;
-    pred_high[SMOOTH_H_PRED][TX_64X32] = aom_highbd_smooth_h_predictor_64x32;
-
-    pred_high[PAETH_PRED][TX_4X4] = aom_highbd_paeth_predictor_4x4;
-    pred_high[PAETH_PRED][TX_8X8] = aom_highbd_paeth_predictor_8x8;
-    pred_high[PAETH_PRED][TX_16X16] = aom_highbd_paeth_predictor_16x16;
-    pred_high[PAETH_PRED][TX_32X32] = aom_highbd_paeth_predictor_32x32;
-    pred_high[PAETH_PRED][TX_64X64] = aom_highbd_paeth_predictor_64x64;
-
-    pred_high[PAETH_PRED][TX_4X8] = aom_highbd_paeth_predictor_4x8;
-    pred_high[PAETH_PRED][TX_4X16] = aom_highbd_paeth_predictor_4x16;
-
-    pred_high[PAETH_PRED][TX_8X4] = aom_highbd_paeth_predictor_8x4;
-    pred_high[PAETH_PRED][TX_8X16] = aom_highbd_paeth_predictor_8x16;
-    pred_high[PAETH_PRED][TX_8X32] = aom_highbd_paeth_predictor_8x32;
-
-    pred_high[PAETH_PRED][TX_16X4] = aom_highbd_paeth_predictor_16x4;
-    pred_high[PAETH_PRED][TX_16X8] = aom_highbd_paeth_predictor_16x8;
-    pred_high[PAETH_PRED][TX_16X32] = aom_highbd_paeth_predictor_16x32;
-    pred_high[PAETH_PRED][TX_16X64] = aom_highbd_paeth_predictor_16x64;
-
-    pred_high[PAETH_PRED][TX_32X8] = aom_highbd_paeth_predictor_32x8;
-    pred_high[PAETH_PRED][TX_32X16] = aom_highbd_paeth_predictor_32x16;
-    pred_high[PAETH_PRED][TX_32X64] = aom_highbd_paeth_predictor_32x64;
-
-    pred_high[PAETH_PRED][TX_64X16] = aom_highbd_paeth_predictor_64x16;
-    pred_high[PAETH_PRED][TX_64X32] = aom_highbd_paeth_predictor_64x32;
-    dc_pred_high[0][0][TX_4X4] = aom_highbd_dc_128_predictor_4x4;
-    dc_pred_high[0][0][TX_8X8] = aom_highbd_dc_128_predictor_8x8;
-    dc_pred_high[0][0][TX_16X16] = aom_highbd_dc_128_predictor_16x16;
-    dc_pred_high[0][0][TX_32X32] = aom_highbd_dc_128_predictor_32x32;
-    dc_pred_high[0][0][TX_64X64] = aom_highbd_dc_128_predictor_64x64;
-
-    dc_pred_high[0][0][TX_4X8] = aom_highbd_dc_128_predictor_4x8;
-    dc_pred_high[0][0][TX_4X16] = aom_highbd_dc_128_predictor_4x16;
-
-    dc_pred_high[0][0][TX_8X4] = aom_highbd_dc_128_predictor_8x4;
-    dc_pred_high[0][0][TX_8X16] = aom_highbd_dc_128_predictor_8x16;
-    dc_pred_high[0][0][TX_8X32] = aom_highbd_dc_128_predictor_8x32;
-
-    dc_pred_high[0][0][TX_16X4] = aom_highbd_dc_128_predictor_16x4;
-    dc_pred_high[0][0][TX_16X8] = aom_highbd_dc_128_predictor_16x8;
-    dc_pred_high[0][0][TX_16X32] = aom_highbd_dc_128_predictor_16x32;
-    dc_pred_high[0][0][TX_16X64] = aom_highbd_dc_128_predictor_16x64;
-
-    dc_pred_high[0][0][TX_32X8] = aom_highbd_dc_128_predictor_32x8;
-    dc_pred_high[0][0][TX_32X16] = aom_highbd_dc_128_predictor_32x16;
-    dc_pred_high[0][0][TX_32X64] = aom_highbd_dc_128_predictor_32x64;
-
-    dc_pred_high[0][0][TX_64X16] = aom_highbd_dc_128_predictor_64x16;
-    dc_pred_high[0][0][TX_64X32] = aom_highbd_dc_128_predictor_64x32;
-
-    dc_pred_high[0][1][TX_4X4] = aom_highbd_dc_top_predictor_4x4;
-    dc_pred_high[0][1][TX_8X8] = aom_highbd_dc_top_predictor_8x8;
-    dc_pred_high[0][1][TX_16X16] = aom_highbd_dc_top_predictor_16x16;
-    dc_pred_high[0][1][TX_32X32] = aom_highbd_dc_top_predictor_32x32;
-    dc_pred_high[0][1][TX_64X64] = aom_highbd_dc_top_predictor_64x64;
-
-    dc_pred_high[0][1][TX_4X8] = aom_highbd_dc_top_predictor_4x8;
-    dc_pred_high[0][1][TX_4X16] = aom_highbd_dc_top_predictor_4x16;
-
-    dc_pred_high[0][1][TX_8X4] = aom_highbd_dc_top_predictor_8x4;
-    dc_pred_high[0][1][TX_8X16] = aom_highbd_dc_top_predictor_8x16;
-    dc_pred_high[0][1][TX_8X32] = aom_highbd_dc_top_predictor_8x32;
-
-    dc_pred_high[0][1][TX_16X4] = aom_highbd_dc_top_predictor_16x4;
-    dc_pred_high[0][1][TX_16X8] = aom_highbd_dc_top_predictor_16x8;
-    dc_pred_high[0][1][TX_16X32] = aom_highbd_dc_top_predictor_16x32;
-    dc_pred_high[0][1][TX_16X64] = aom_highbd_dc_top_predictor_16x64;
-
-    dc_pred_high[0][1][TX_32X8] = aom_highbd_dc_top_predictor_32x8;
-    dc_pred_high[0][1][TX_32X16] = aom_highbd_dc_top_predictor_32x16;
-    dc_pred_high[0][1][TX_32X64] = aom_highbd_dc_top_predictor_32x64;
-
-    dc_pred_high[0][1][TX_64X16] = aom_highbd_dc_top_predictor_64x16;
-    dc_pred_high[0][1][TX_64X32] = aom_highbd_dc_top_predictor_64x32;
-
-    dc_pred_high[1][0][TX_4X4] = aom_highbd_dc_left_predictor_4x4;
-    dc_pred_high[1][0][TX_8X8] = aom_highbd_dc_left_predictor_8x8;
-    dc_pred_high[1][0][TX_16X16] = aom_highbd_dc_left_predictor_16x16;
-    dc_pred_high[1][0][TX_32X32] = aom_highbd_dc_left_predictor_32x32;
-    dc_pred_high[1][0][TX_64X64] = aom_highbd_dc_left_predictor_64x64;
-
-    dc_pred_high[1][0][TX_4X8] = aom_highbd_dc_left_predictor_4x8;
-    dc_pred_high[1][0][TX_4X16] = aom_highbd_dc_left_predictor_4x16;
-
-    dc_pred_high[1][0][TX_8X4] = aom_highbd_dc_left_predictor_8x4;
-    dc_pred_high[1][0][TX_8X16] = aom_highbd_dc_left_predictor_8x16;
-    dc_pred_high[1][0][TX_8X32] = aom_highbd_dc_left_predictor_8x32;
-
-    dc_pred_high[1][0][TX_16X4] = aom_highbd_dc_left_predictor_16x4;
-    dc_pred_high[1][0][TX_16X8] = aom_highbd_dc_left_predictor_16x8;
-    dc_pred_high[1][0][TX_16X32] = aom_highbd_dc_left_predictor_16x32;
-    dc_pred_high[1][0][TX_16X64] = aom_highbd_dc_left_predictor_16x64;
-
-    dc_pred_high[1][0][TX_32X8] = aom_highbd_dc_left_predictor_32x8;
-    dc_pred_high[1][0][TX_32X16] = aom_highbd_dc_left_predictor_32x16;
-    dc_pred_high[1][0][TX_32X64] = aom_highbd_dc_left_predictor_32x64;
-
-    dc_pred_high[1][0][TX_64X16] = aom_highbd_dc_left_predictor_64x16;
-    dc_pred_high[1][0][TX_64X32] = aom_highbd_dc_left_predictor_64x32;
-
-    dc_pred_high[1][1][TX_4X4] = aom_highbd_dc_predictor_4x4;
-    dc_pred_high[1][1][TX_8X8] = aom_highbd_dc_predictor_8x8;
-    dc_pred_high[1][1][TX_16X16] = aom_highbd_dc_predictor_16x16;
-    dc_pred_high[1][1][TX_32X32] = aom_highbd_dc_predictor_32x32;
-    dc_pred_high[1][1][TX_64X64] = aom_highbd_dc_predictor_64x64;
-
-    dc_pred_high[1][1][TX_4X8] = aom_highbd_dc_predictor_4x8;
-    dc_pred_high[1][1][TX_4X16] = aom_highbd_dc_predictor_4x16;
-
-    dc_pred_high[1][1][TX_8X4] = aom_highbd_dc_predictor_8x4;
-    dc_pred_high[1][1][TX_8X16] = aom_highbd_dc_predictor_8x16;
-    dc_pred_high[1][1][TX_8X32] = aom_highbd_dc_predictor_8x32;
-
-    dc_pred_high[1][1][TX_16X4] = aom_highbd_dc_predictor_16x4;
-    dc_pred_high[1][1][TX_16X8] = aom_highbd_dc_predictor_16x8;
-    dc_pred_high[1][1][TX_16X32] = aom_highbd_dc_predictor_16x32;
-    dc_pred_high[1][1][TX_16X64] = aom_highbd_dc_predictor_16x64;
-
-    dc_pred_high[1][1][TX_32X8] = aom_highbd_dc_predictor_32x8;
-    dc_pred_high[1][1][TX_32X16] = aom_highbd_dc_predictor_32x16;
-    dc_pred_high[1][1][TX_32X64] = aom_highbd_dc_predictor_32x64;
-
-    dc_pred_high[1][1][TX_64X16] = aom_highbd_dc_predictor_64x16;
-    dc_pred_high[1][1][TX_64X32] = aom_highbd_dc_predictor_64x32;
+    pred[V_PRED][TX_4X4] = eb_aom_v_predictor_4x4;
+    pred[V_PRED][TX_8X8] = eb_aom_v_predictor_8x8;
+    pred[V_PRED][TX_16X16] = eb_aom_v_predictor_16x16;
+    pred[V_PRED][TX_32X32] = eb_aom_v_predictor_32x32;
+    pred[V_PRED][TX_64X64] = eb_aom_v_predictor_64x64;
+    pred[V_PRED][TX_4X8] = eb_aom_v_predictor_4x8;
+    pred[V_PRED][TX_4X16] = eb_aom_v_predictor_4x16;
+
+    pred[V_PRED][TX_8X4] = eb_aom_v_predictor_8x4;
+    pred[V_PRED][TX_8X16] = eb_aom_v_predictor_8x16;
+    pred[V_PRED][TX_8X32] = eb_aom_v_predictor_8x32;
+
+    pred[V_PRED][TX_16X4] = eb_aom_v_predictor_16x4;
+    pred[V_PRED][TX_16X8] = eb_aom_v_predictor_16x8;
+    pred[V_PRED][TX_16X32] = eb_aom_v_predictor_16x32;
+    pred[V_PRED][TX_16X64] = eb_aom_v_predictor_16x64;
+
+    pred[V_PRED][TX_32X8] = eb_aom_v_predictor_32x8;
+    pred[V_PRED][TX_32X16] = eb_aom_v_predictor_32x16;
+    pred[V_PRED][TX_32X64] = eb_aom_v_predictor_32x64;
+
+    pred[V_PRED][TX_64X16] = eb_aom_v_predictor_64x16;
+    pred[V_PRED][TX_64X32] = eb_aom_v_predictor_64x32;
+
+    pred[H_PRED][TX_4X4] = eb_aom_h_predictor_4x4;
+    pred[H_PRED][TX_8X8] = eb_aom_h_predictor_8x8;
+    pred[H_PRED][TX_16X16] = eb_aom_h_predictor_16x16;
+    pred[H_PRED][TX_32X32] = eb_aom_h_predictor_32x32;
+    pred[H_PRED][TX_64X64] = eb_aom_h_predictor_64x64;
+
+    pred[H_PRED][TX_4X8] = eb_aom_h_predictor_4x8;
+    pred[H_PRED][TX_4X16] = eb_aom_h_predictor_4x16;
+
+    pred[H_PRED][TX_8X4] = eb_aom_h_predictor_8x4;
+    pred[H_PRED][TX_8X16] = eb_aom_h_predictor_8x16;
+    pred[H_PRED][TX_8X32] = eb_aom_h_predictor_8x32;
+
+    pred[H_PRED][TX_16X4] = eb_aom_h_predictor_16x4;
+    pred[H_PRED][TX_16X8] = eb_aom_h_predictor_16x8;
+    pred[H_PRED][TX_16X32] = eb_aom_h_predictor_16x32;
+    pred[H_PRED][TX_16X64] = eb_aom_h_predictor_16x64;
+
+    pred[H_PRED][TX_32X8] = eb_aom_h_predictor_32x8;
+    pred[H_PRED][TX_32X16] = eb_aom_h_predictor_32x16;
+    pred[H_PRED][TX_32X64] = eb_aom_h_predictor_32x64;
+
+    pred[H_PRED][TX_64X16] = eb_aom_h_predictor_64x16;
+    pred[H_PRED][TX_64X32] = eb_aom_h_predictor_64x32;
+
+    pred[SMOOTH_PRED][TX_4X4] = eb_aom_smooth_predictor_4x4;
+    pred[SMOOTH_PRED][TX_8X8] = eb_aom_smooth_predictor_8x8;
+    pred[SMOOTH_PRED][TX_16X16] = eb_aom_smooth_predictor_16x16;
+    pred[SMOOTH_PRED][TX_32X32] = eb_aom_smooth_predictor_32x32;
+    pred[SMOOTH_PRED][TX_64X64] = eb_aom_smooth_predictor_64x64;
+
+    pred[SMOOTH_PRED][TX_4X8] = eb_aom_smooth_predictor_4x8;
+    pred[SMOOTH_PRED][TX_4X16] = eb_aom_smooth_predictor_4x16;
+
+    pred[SMOOTH_PRED][TX_8X4] = eb_aom_smooth_predictor_8x4;
+    pred[SMOOTH_PRED][TX_8X16] = eb_aom_smooth_predictor_8x16;
+    pred[SMOOTH_PRED][TX_8X32] = eb_aom_smooth_predictor_8x32;
+
+    pred[SMOOTH_PRED][TX_16X4] = eb_aom_smooth_predictor_16x4;
+    pred[SMOOTH_PRED][TX_16X8] = eb_aom_smooth_predictor_16x8;
+    pred[SMOOTH_PRED][TX_16X32] = eb_aom_smooth_predictor_16x32;
+    pred[SMOOTH_PRED][TX_16X64] = eb_aom_smooth_predictor_16x64;
+
+    pred[SMOOTH_PRED][TX_32X8] = eb_aom_smooth_predictor_32x8;
+    pred[SMOOTH_PRED][TX_32X16] = eb_aom_smooth_predictor_32x16;
+    pred[SMOOTH_PRED][TX_32X64] = eb_aom_smooth_predictor_32x64;
+
+    pred[SMOOTH_PRED][TX_64X16] = eb_aom_smooth_predictor_64x16;
+    pred[SMOOTH_PRED][TX_64X32] = eb_aom_smooth_predictor_64x32;
+
+    pred[SMOOTH_V_PRED][TX_4X4] = eb_aom_smooth_v_predictor_4x4;
+    pred[SMOOTH_V_PRED][TX_8X8] = eb_aom_smooth_v_predictor_8x8;
+    pred[SMOOTH_V_PRED][TX_16X16] = eb_aom_smooth_v_predictor_16x16;
+    pred[SMOOTH_V_PRED][TX_32X32] = eb_aom_smooth_v_predictor_32x32;
+    pred[SMOOTH_V_PRED][TX_64X64] = eb_aom_smooth_v_predictor_64x64;
+
+    pred[SMOOTH_V_PRED][TX_4X8] = eb_aom_smooth_v_predictor_4x8;
+    pred[SMOOTH_V_PRED][TX_4X16] = eb_aom_smooth_v_predictor_4x16;
+
+    pred[SMOOTH_V_PRED][TX_8X4] = eb_aom_smooth_v_predictor_8x4;
+    pred[SMOOTH_V_PRED][TX_8X16] = eb_aom_smooth_v_predictor_8x16;
+    pred[SMOOTH_V_PRED][TX_8X32] = eb_aom_smooth_v_predictor_8x32;
+
+    pred[SMOOTH_V_PRED][TX_16X4] = eb_aom_smooth_v_predictor_16x4;
+    pred[SMOOTH_V_PRED][TX_16X8] = eb_aom_smooth_v_predictor_16x8;
+    pred[SMOOTH_V_PRED][TX_16X32] = eb_aom_smooth_v_predictor_16x32;
+    pred[SMOOTH_V_PRED][TX_16X64] = eb_aom_smooth_v_predictor_16x64;
+
+    pred[SMOOTH_V_PRED][TX_32X8] = eb_aom_smooth_v_predictor_32x8;
+    pred[SMOOTH_V_PRED][TX_32X16] = eb_aom_smooth_v_predictor_32x16;
+    pred[SMOOTH_V_PRED][TX_32X64] = eb_aom_smooth_v_predictor_32x64;
+
+    pred[SMOOTH_V_PRED][TX_64X16] = eb_aom_smooth_v_predictor_64x16;
+    pred[SMOOTH_V_PRED][TX_64X32] = eb_aom_smooth_v_predictor_64x32;
+
+    pred[SMOOTH_H_PRED][TX_4X4] = eb_aom_smooth_h_predictor_4x4;
+    pred[SMOOTH_H_PRED][TX_8X8] = eb_aom_smooth_h_predictor_8x8;
+    pred[SMOOTH_H_PRED][TX_16X16] = eb_aom_smooth_h_predictor_16x16;
+    pred[SMOOTH_H_PRED][TX_32X32] = eb_aom_smooth_h_predictor_32x32;
+    pred[SMOOTH_H_PRED][TX_64X64] = eb_aom_smooth_h_predictor_64x64;
+
+    pred[SMOOTH_H_PRED][TX_4X8] = eb_aom_smooth_h_predictor_4x8;
+    pred[SMOOTH_H_PRED][TX_4X16] = eb_aom_smooth_h_predictor_4x16;
+
+    pred[SMOOTH_H_PRED][TX_8X4] = eb_aom_smooth_h_predictor_8x4;
+    pred[SMOOTH_H_PRED][TX_8X16] = eb_aom_smooth_h_predictor_8x16;
+    pred[SMOOTH_H_PRED][TX_8X32] = eb_aom_smooth_h_predictor_8x32;
+
+    pred[SMOOTH_H_PRED][TX_16X4] = eb_aom_smooth_h_predictor_16x4;
+    pred[SMOOTH_H_PRED][TX_16X8] = eb_aom_smooth_h_predictor_16x8;
+    pred[SMOOTH_H_PRED][TX_16X32] = eb_aom_smooth_h_predictor_16x32;
+    pred[SMOOTH_H_PRED][TX_16X64] = eb_aom_smooth_h_predictor_16x64;
+
+    pred[SMOOTH_H_PRED][TX_32X8] = eb_aom_smooth_h_predictor_32x8;
+    pred[SMOOTH_H_PRED][TX_32X16] = eb_aom_smooth_h_predictor_32x16;
+    pred[SMOOTH_H_PRED][TX_32X64] = eb_aom_smooth_h_predictor_32x64;
+
+    pred[SMOOTH_H_PRED][TX_64X16] = eb_aom_smooth_h_predictor_64x16;
+    pred[SMOOTH_H_PRED][TX_64X32] = eb_aom_smooth_h_predictor_64x32;
+
+    pred[PAETH_PRED][TX_4X4] = eb_aom_paeth_predictor_4x4;
+    pred[PAETH_PRED][TX_8X8] = eb_aom_paeth_predictor_8x8;
+    pred[PAETH_PRED][TX_16X16] = eb_aom_paeth_predictor_16x16;
+    pred[PAETH_PRED][TX_32X32] = eb_aom_paeth_predictor_32x32;
+    pred[PAETH_PRED][TX_64X64] = eb_aom_paeth_predictor_64x64;
+
+    pred[PAETH_PRED][TX_4X8] = eb_aom_paeth_predictor_4x8;
+    pred[PAETH_PRED][TX_4X16] = eb_aom_paeth_predictor_4x16;
+
+    pred[PAETH_PRED][TX_8X4] = eb_aom_paeth_predictor_8x4;
+    pred[PAETH_PRED][TX_8X16] = eb_aom_paeth_predictor_8x16;
+    pred[PAETH_PRED][TX_8X32] = eb_aom_paeth_predictor_8x32;
+
+    pred[PAETH_PRED][TX_16X4] = eb_aom_paeth_predictor_16x4;
+    pred[PAETH_PRED][TX_16X8] = eb_aom_paeth_predictor_16x8;
+    pred[PAETH_PRED][TX_16X32] = eb_aom_paeth_predictor_16x32;
+    pred[PAETH_PRED][TX_16X64] = eb_aom_paeth_predictor_16x64;
+
+    pred[PAETH_PRED][TX_32X8] = eb_aom_paeth_predictor_32x8;
+    pred[PAETH_PRED][TX_32X16] = eb_aom_paeth_predictor_32x16;
+    pred[PAETH_PRED][TX_32X64] = eb_aom_paeth_predictor_32x64;
+
+    pred[PAETH_PRED][TX_64X16] = eb_aom_paeth_predictor_64x16;
+    pred[PAETH_PRED][TX_64X32] = eb_aom_paeth_predictor_64x32;
+    dc_pred[0][0][TX_4X4] = eb_aom_dc_128_predictor_4x4;
+    dc_pred[0][0][TX_8X8] = eb_aom_dc_128_predictor_8x8;
+    dc_pred[0][0][TX_16X16] = eb_aom_dc_128_predictor_16x16;
+    dc_pred[0][0][TX_32X32] = eb_aom_dc_128_predictor_32x32;
+    dc_pred[0][0][TX_64X64] = eb_aom_dc_128_predictor_64x64;
+
+    dc_pred[0][0][TX_4X8] = eb_aom_dc_128_predictor_4x8;
+    dc_pred[0][0][TX_4X16] = eb_aom_dc_128_predictor_4x16;
+
+    dc_pred[0][0][TX_8X4] = eb_aom_dc_128_predictor_8x4;
+    dc_pred[0][0][TX_8X16] = eb_aom_dc_128_predictor_8x16;
+    dc_pred[0][0][TX_8X32] = eb_aom_dc_128_predictor_8x32;
+
+    dc_pred[0][0][TX_16X4] = eb_aom_dc_128_predictor_16x4;
+    dc_pred[0][0][TX_16X8] = eb_aom_dc_128_predictor_16x8;
+    dc_pred[0][0][TX_16X32] = eb_aom_dc_128_predictor_16x32;
+    dc_pred[0][0][TX_16X64] = eb_aom_dc_128_predictor_16x64;
+
+    dc_pred[0][0][TX_32X8] = eb_aom_dc_128_predictor_32x8;
+    dc_pred[0][0][TX_32X16] = eb_aom_dc_128_predictor_32x16;
+    dc_pred[0][0][TX_32X64] = eb_aom_dc_128_predictor_32x64;
+
+    dc_pred[0][0][TX_64X16] = eb_aom_dc_128_predictor_64x16;
+    dc_pred[0][0][TX_64X32] = eb_aom_dc_128_predictor_64x32;
+
+    dc_pred[0][1][TX_4X4] = eb_aom_dc_top_predictor_4x4;
+    dc_pred[0][1][TX_8X8] = eb_aom_dc_top_predictor_8x8;
+    dc_pred[0][1][TX_16X16] = eb_aom_dc_top_predictor_16x16;
+    dc_pred[0][1][TX_32X32] = eb_aom_dc_top_predictor_32x32;
+    dc_pred[0][1][TX_64X64] = eb_aom_dc_top_predictor_64x64;
+
+    dc_pred[0][1][TX_4X8] = eb_aom_dc_top_predictor_4x8;
+    dc_pred[0][1][TX_4X16] = eb_aom_dc_top_predictor_4x16;
+
+    dc_pred[0][1][TX_8X4] = eb_aom_dc_top_predictor_8x4;
+    dc_pred[0][1][TX_8X16] = eb_aom_dc_top_predictor_8x16;
+    dc_pred[0][1][TX_8X32] = eb_aom_dc_top_predictor_8x32;
+
+    dc_pred[0][1][TX_16X4] = eb_aom_dc_top_predictor_16x4;
+    dc_pred[0][1][TX_16X8] = eb_aom_dc_top_predictor_16x8;
+    dc_pred[0][1][TX_16X32] = eb_aom_dc_top_predictor_16x32;
+    dc_pred[0][1][TX_16X64] = eb_aom_dc_top_predictor_16x64;
+
+    dc_pred[0][1][TX_32X8] = eb_aom_dc_top_predictor_32x8;
+    dc_pred[0][1][TX_32X16] = eb_aom_dc_top_predictor_32x16;
+    dc_pred[0][1][TX_32X64] = eb_aom_dc_top_predictor_32x64;
+
+    dc_pred[0][1][TX_64X16] = eb_aom_dc_top_predictor_64x16;
+    dc_pred[0][1][TX_64X32] = eb_aom_dc_top_predictor_64x32;
+
+    dc_pred[1][0][TX_4X4] = eb_aom_dc_left_predictor_4x4;
+    dc_pred[1][0][TX_8X8] = eb_aom_dc_left_predictor_8x8;
+    dc_pred[1][0][TX_16X16] = eb_aom_dc_left_predictor_16x16;
+    dc_pred[1][0][TX_32X32] = eb_aom_dc_left_predictor_32x32;
+    dc_pred[1][0][TX_64X64] = eb_aom_dc_left_predictor_64x64;
+    dc_pred[1][0][TX_4X8] = eb_aom_dc_left_predictor_4x8;
+    dc_pred[1][0][TX_4X16] = eb_aom_dc_left_predictor_4x16;
+
+    dc_pred[1][0][TX_8X4] = eb_aom_dc_left_predictor_8x4;
+    dc_pred[1][0][TX_8X16] = eb_aom_dc_left_predictor_8x16;
+    dc_pred[1][0][TX_8X32] = eb_aom_dc_left_predictor_8x32;
+
+    dc_pred[1][0][TX_16X4] = eb_aom_dc_left_predictor_16x4;
+    dc_pred[1][0][TX_16X8] = eb_aom_dc_left_predictor_16x8;
+    dc_pred[1][0][TX_16X32] = eb_aom_dc_left_predictor_16x32;
+    dc_pred[1][0][TX_16X64] = eb_aom_dc_left_predictor_16x64;
+
+    dc_pred[1][0][TX_32X8] = eb_aom_dc_left_predictor_32x8;
+    dc_pred[1][0][TX_32X16] = eb_aom_dc_left_predictor_32x16;
+    dc_pred[1][0][TX_32X64] = eb_aom_dc_left_predictor_32x64;
+
+    dc_pred[1][0][TX_64X16] = eb_aom_dc_left_predictor_64x16;
+    dc_pred[1][0][TX_64X32] = eb_aom_dc_left_predictor_64x32;
+
+    dc_pred[1][1][TX_4X4] = eb_aom_dc_predictor_4x4;
+    dc_pred[1][1][TX_8X8] = eb_aom_dc_predictor_8x8;
+    dc_pred[1][1][TX_16X16] = eb_aom_dc_predictor_16x16;
+    dc_pred[1][1][TX_32X32] = eb_aom_dc_predictor_32x32;
+    dc_pred[1][1][TX_64X64] = eb_aom_dc_predictor_64x64;
+    dc_pred[1][1][TX_4X8] = eb_aom_dc_predictor_4x8;
+    dc_pred[1][1][TX_4X16] = eb_aom_dc_predictor_4x16;
+
+    dc_pred[1][1][TX_8X4] = eb_aom_dc_predictor_8x4;
+    dc_pred[1][1][TX_8X16] = eb_aom_dc_predictor_8x16;
+    dc_pred[1][1][TX_8X32] = eb_aom_dc_predictor_8x32;
+
+    dc_pred[1][1][TX_16X4] = eb_aom_dc_predictor_16x4;
+    dc_pred[1][1][TX_16X8] = eb_aom_dc_predictor_16x8;
+    dc_pred[1][1][TX_16X32] = eb_aom_dc_predictor_16x32;
+    dc_pred[1][1][TX_16X64] = eb_aom_dc_predictor_16x64;
+
+    dc_pred[1][1][TX_32X8] = eb_aom_dc_predictor_32x8;
+    dc_pred[1][1][TX_32X16] = eb_aom_dc_predictor_32x16;
+    dc_pred[1][1][TX_32X64] = eb_aom_dc_predictor_32x64;
+
+    dc_pred[1][1][TX_64X16] = eb_aom_dc_predictor_64x16;
+    dc_pred[1][1][TX_64X32] = eb_aom_dc_predictor_64x32;
+
+    pred_high[V_PRED][TX_4X4] = eb_aom_highbd_v_predictor_4x4;
+    pred_high[V_PRED][TX_8X8] = eb_aom_highbd_v_predictor_8x8;
+    pred_high[V_PRED][TX_16X16] = eb_aom_highbd_v_predictor_16x16;
+    pred_high[V_PRED][TX_32X32] = eb_aom_highbd_v_predictor_32x32;
+    pred_high[V_PRED][TX_64X64] = eb_aom_highbd_v_predictor_64x64;
+
+    pred_high[V_PRED][TX_4X8] = eb_aom_highbd_v_predictor_4x8;
+    pred_high[V_PRED][TX_4X16] = eb_aom_highbd_v_predictor_4x16;
+
+    pred_high[V_PRED][TX_8X4] = eb_aom_highbd_v_predictor_8x4;
+    pred_high[V_PRED][TX_8X16] = eb_aom_highbd_v_predictor_8x16;
+    pred_high[V_PRED][TX_8X32] = eb_aom_highbd_v_predictor_8x32;
+
+    pred_high[V_PRED][TX_16X4] = eb_aom_highbd_v_predictor_16x4;
+    pred_high[V_PRED][TX_16X8] = eb_aom_highbd_v_predictor_16x8;
+    pred_high[V_PRED][TX_16X32] = eb_aom_highbd_v_predictor_16x32;
+    pred_high[V_PRED][TX_16X64] = eb_aom_highbd_v_predictor_16x64;
+
+    pred_high[V_PRED][TX_32X8] = eb_aom_highbd_v_predictor_32x8;
+    pred_high[V_PRED][TX_32X16] = eb_aom_highbd_v_predictor_32x16;
+    pred_high[V_PRED][TX_32X64] = eb_aom_highbd_v_predictor_32x64;
+
+    pred_high[V_PRED][TX_64X16] = eb_aom_highbd_v_predictor_64x16;
+    pred_high[V_PRED][TX_64X32] = eb_aom_highbd_v_predictor_64x32;
+
+    pred_high[H_PRED][TX_4X4] = eb_aom_highbd_h_predictor_4x4;
+    pred_high[H_PRED][TX_8X8] = eb_aom_highbd_h_predictor_8x8;
+    pred_high[H_PRED][TX_16X16] = eb_aom_highbd_h_predictor_16x16;
+    pred_high[H_PRED][TX_32X32] = eb_aom_highbd_h_predictor_32x32;
+    pred_high[H_PRED][TX_64X64] = eb_aom_highbd_h_predictor_64x64;
+
+    pred_high[H_PRED][TX_4X8] = eb_aom_highbd_h_predictor_4x8;
+    pred_high[H_PRED][TX_4X16] = eb_aom_highbd_h_predictor_4x16;
+
+    pred_high[H_PRED][TX_8X4] = eb_aom_highbd_h_predictor_8x4;
+    pred_high[H_PRED][TX_8X16] = eb_aom_highbd_h_predictor_8x16;
+    pred_high[H_PRED][TX_8X32] = eb_aom_highbd_h_predictor_8x32;
+
+    pred_high[H_PRED][TX_16X4] = eb_aom_highbd_h_predictor_16x4;
+    pred_high[H_PRED][TX_16X8] = eb_aom_highbd_h_predictor_16x8;
+    pred_high[H_PRED][TX_16X32] = eb_aom_highbd_h_predictor_16x32;
+    pred_high[H_PRED][TX_16X64] = eb_aom_highbd_h_predictor_16x64;
+
+    pred_high[H_PRED][TX_32X8] = eb_aom_highbd_h_predictor_32x8;
+    pred_high[H_PRED][TX_32X16] = eb_aom_highbd_h_predictor_32x16;
+    pred_high[H_PRED][TX_32X64] = eb_aom_highbd_h_predictor_32x64;
+
+    pred_high[H_PRED][TX_64X16] = eb_aom_highbd_h_predictor_64x16;
+    pred_high[H_PRED][TX_64X32] = eb_aom_highbd_h_predictor_64x32;
+
+    pred_high[SMOOTH_PRED][TX_4X4] = eb_aom_highbd_smooth_predictor_4x4;
+    pred_high[SMOOTH_PRED][TX_8X8] = eb_aom_highbd_smooth_predictor_8x8;
+    pred_high[SMOOTH_PRED][TX_16X16] = eb_aom_highbd_smooth_predictor_16x16;
+    pred_high[SMOOTH_PRED][TX_32X32] = eb_aom_highbd_smooth_predictor_32x32;
+    pred_high[SMOOTH_PRED][TX_64X64] = eb_aom_highbd_smooth_predictor_64x64;
+
+    pred_high[SMOOTH_PRED][TX_4X8] = eb_aom_highbd_smooth_predictor_4x8;
+    pred_high[SMOOTH_PRED][TX_4X16] = eb_aom_highbd_smooth_predictor_4x16;
+
+    pred_high[SMOOTH_PRED][TX_8X4] = eb_aom_highbd_smooth_predictor_8x4;
+    pred_high[SMOOTH_PRED][TX_8X16] = eb_aom_highbd_smooth_predictor_8x16;
+    pred_high[SMOOTH_PRED][TX_8X32] = eb_aom_highbd_smooth_predictor_8x32;
+
+    pred_high[SMOOTH_PRED][TX_16X4] = eb_aom_highbd_smooth_predictor_16x4;
+    pred_high[SMOOTH_PRED][TX_16X8] = eb_aom_highbd_smooth_predictor_16x8;
+    pred_high[SMOOTH_PRED][TX_16X32] = eb_aom_highbd_smooth_predictor_16x32;
+    pred_high[SMOOTH_PRED][TX_16X64] = eb_aom_highbd_smooth_predictor_16x64;
+
+    pred_high[SMOOTH_PRED][TX_32X8] = eb_aom_highbd_smooth_predictor_32x8;
+    pred_high[SMOOTH_PRED][TX_32X16] = eb_aom_highbd_smooth_predictor_32x16;
+    pred_high[SMOOTH_PRED][TX_32X64] = eb_aom_highbd_smooth_predictor_32x64;
+
+    pred_high[SMOOTH_PRED][TX_64X16] = eb_aom_highbd_smooth_predictor_64x16;
+    pred_high[SMOOTH_PRED][TX_64X32] = eb_aom_highbd_smooth_predictor_64x32;
+
+    pred_high[SMOOTH_V_PRED][TX_4X4] = eb_aom_highbd_smooth_v_predictor_4x4;
+    pred_high[SMOOTH_V_PRED][TX_8X8] = eb_aom_highbd_smooth_v_predictor_8x8;
+    pred_high[SMOOTH_V_PRED][TX_16X16] = eb_aom_highbd_smooth_v_predictor_16x16;
+    pred_high[SMOOTH_V_PRED][TX_32X32] = eb_aom_highbd_smooth_v_predictor_32x32;
+    pred_high[SMOOTH_V_PRED][TX_64X64] = eb_aom_highbd_smooth_v_predictor_64x64;
+
+    pred_high[SMOOTH_V_PRED][TX_4X8] = eb_aom_highbd_smooth_v_predictor_4x8;
+    pred_high[SMOOTH_V_PRED][TX_4X16] = eb_aom_highbd_smooth_v_predictor_4x16;
+
+    pred_high[SMOOTH_V_PRED][TX_8X4] = eb_aom_highbd_smooth_v_predictor_8x4;
+    pred_high[SMOOTH_V_PRED][TX_8X16] = eb_aom_highbd_smooth_v_predictor_8x16;
+    pred_high[SMOOTH_V_PRED][TX_8X32] = eb_aom_highbd_smooth_v_predictor_8x32;
+
+    pred_high[SMOOTH_V_PRED][TX_16X4] = eb_aom_highbd_smooth_v_predictor_16x4;
+    pred_high[SMOOTH_V_PRED][TX_16X8] = eb_aom_highbd_smooth_v_predictor_16x8;
+    pred_high[SMOOTH_V_PRED][TX_16X32] = eb_aom_highbd_smooth_v_predictor_16x32;
+    pred_high[SMOOTH_V_PRED][TX_16X64] = eb_aom_highbd_smooth_v_predictor_16x64;
+
+    pred_high[SMOOTH_V_PRED][TX_32X8] = eb_aom_highbd_smooth_v_predictor_32x8;
+    pred_high[SMOOTH_V_PRED][TX_32X16] = eb_aom_highbd_smooth_v_predictor_32x16;
+    pred_high[SMOOTH_V_PRED][TX_32X64] = eb_aom_highbd_smooth_v_predictor_32x64;
+
+    pred_high[SMOOTH_V_PRED][TX_64X16] = eb_aom_highbd_smooth_v_predictor_64x16;
+    pred_high[SMOOTH_V_PRED][TX_64X32] = eb_aom_highbd_smooth_v_predictor_64x32;
+
+    pred_high[SMOOTH_H_PRED][TX_4X4] = eb_aom_highbd_smooth_h_predictor_4x4;
+    pred_high[SMOOTH_H_PRED][TX_8X8] = eb_aom_highbd_smooth_h_predictor_8x8;
+    pred_high[SMOOTH_H_PRED][TX_16X16] = eb_aom_highbd_smooth_h_predictor_16x16;
+    pred_high[SMOOTH_H_PRED][TX_32X32] = eb_aom_highbd_smooth_h_predictor_32x32;
+    pred_high[SMOOTH_H_PRED][TX_64X64] = eb_aom_highbd_smooth_h_predictor_64x64;
+
+    pred_high[SMOOTH_H_PRED][TX_4X8] = eb_aom_highbd_smooth_h_predictor_4x8;
+    pred_high[SMOOTH_H_PRED][TX_4X16] = eb_aom_highbd_smooth_h_predictor_4x16;
+
+    pred_high[SMOOTH_H_PRED][TX_8X4] = eb_aom_highbd_smooth_h_predictor_8x4;
+    pred_high[SMOOTH_H_PRED][TX_8X16] = eb_aom_highbd_smooth_h_predictor_8x16;
+    pred_high[SMOOTH_H_PRED][TX_8X32] = eb_aom_highbd_smooth_h_predictor_8x32;
+
+    pred_high[SMOOTH_H_PRED][TX_16X4] = eb_aom_highbd_smooth_h_predictor_16x4;
+    pred_high[SMOOTH_H_PRED][TX_16X8] = eb_aom_highbd_smooth_h_predictor_16x8;
+    pred_high[SMOOTH_H_PRED][TX_16X32] = eb_aom_highbd_smooth_h_predictor_16x32;
+    pred_high[SMOOTH_H_PRED][TX_16X64] = eb_aom_highbd_smooth_h_predictor_16x64;
+
+    pred_high[SMOOTH_H_PRED][TX_32X8] = eb_aom_highbd_smooth_h_predictor_32x8;
+    pred_high[SMOOTH_H_PRED][TX_32X16] = eb_aom_highbd_smooth_h_predictor_32x16;
+    pred_high[SMOOTH_H_PRED][TX_32X64] = eb_aom_highbd_smooth_h_predictor_32x64;
+
+    pred_high[SMOOTH_H_PRED][TX_64X16] = eb_aom_highbd_smooth_h_predictor_64x16;
+    pred_high[SMOOTH_H_PRED][TX_64X32] = eb_aom_highbd_smooth_h_predictor_64x32;
+
+    pred_high[PAETH_PRED][TX_4X4] = eb_aom_highbd_paeth_predictor_4x4;
+    pred_high[PAETH_PRED][TX_8X8] = eb_aom_highbd_paeth_predictor_8x8;
+    pred_high[PAETH_PRED][TX_16X16] = eb_aom_highbd_paeth_predictor_16x16;
+    pred_high[PAETH_PRED][TX_32X32] = eb_aom_highbd_paeth_predictor_32x32;
+    pred_high[PAETH_PRED][TX_64X64] = eb_aom_highbd_paeth_predictor_64x64;
+
+    pred_high[PAETH_PRED][TX_4X8] = eb_aom_highbd_paeth_predictor_4x8;
+    pred_high[PAETH_PRED][TX_4X16] = eb_aom_highbd_paeth_predictor_4x16;
+
+    pred_high[PAETH_PRED][TX_8X4] = eb_aom_highbd_paeth_predictor_8x4;
+    pred_high[PAETH_PRED][TX_8X16] = eb_aom_highbd_paeth_predictor_8x16;
+    pred_high[PAETH_PRED][TX_8X32] = eb_aom_highbd_paeth_predictor_8x32;
+
+    pred_high[PAETH_PRED][TX_16X4] = eb_aom_highbd_paeth_predictor_16x4;
+    pred_high[PAETH_PRED][TX_16X8] = eb_aom_highbd_paeth_predictor_16x8;
+    pred_high[PAETH_PRED][TX_16X32] = eb_aom_highbd_paeth_predictor_16x32;
+    pred_high[PAETH_PRED][TX_16X64] = eb_aom_highbd_paeth_predictor_16x64;
+
+    pred_high[PAETH_PRED][TX_32X8] = eb_aom_highbd_paeth_predictor_32x8;
+    pred_high[PAETH_PRED][TX_32X16] = eb_aom_highbd_paeth_predictor_32x16;
+    pred_high[PAETH_PRED][TX_32X64] = eb_aom_highbd_paeth_predictor_32x64;
+
+    pred_high[PAETH_PRED][TX_64X16] = eb_aom_highbd_paeth_predictor_64x16;
+    pred_high[PAETH_PRED][TX_64X32] = eb_aom_highbd_paeth_predictor_64x32;
+    dc_pred_high[0][0][TX_4X4] = eb_aom_highbd_dc_128_predictor_4x4;
+    dc_pred_high[0][0][TX_8X8] = eb_aom_highbd_dc_128_predictor_8x8;
+    dc_pred_high[0][0][TX_16X16] = eb_aom_highbd_dc_128_predictor_16x16;
+    dc_pred_high[0][0][TX_32X32] = eb_aom_highbd_dc_128_predictor_32x32;
+    dc_pred_high[0][0][TX_64X64] = eb_aom_highbd_dc_128_predictor_64x64;
+
+    dc_pred_high[0][0][TX_4X8] = eb_aom_highbd_dc_128_predictor_4x8;
+    dc_pred_high[0][0][TX_4X16] = eb_aom_highbd_dc_128_predictor_4x16;
+
+    dc_pred_high[0][0][TX_8X4] = eb_aom_highbd_dc_128_predictor_8x4;
+    dc_pred_high[0][0][TX_8X16] = eb_aom_highbd_dc_128_predictor_8x16;
+    dc_pred_high[0][0][TX_8X32] = eb_aom_highbd_dc_128_predictor_8x32;
+
+    dc_pred_high[0][0][TX_16X4] = eb_aom_highbd_dc_128_predictor_16x4;
+    dc_pred_high[0][0][TX_16X8] = eb_aom_highbd_dc_128_predictor_16x8;
+    dc_pred_high[0][0][TX_16X32] = eb_aom_highbd_dc_128_predictor_16x32;
+    dc_pred_high[0][0][TX_16X64] = eb_aom_highbd_dc_128_predictor_16x64;
+
+    dc_pred_high[0][0][TX_32X8] = eb_aom_highbd_dc_128_predictor_32x8;
+    dc_pred_high[0][0][TX_32X16] = eb_aom_highbd_dc_128_predictor_32x16;
+    dc_pred_high[0][0][TX_32X64] = eb_aom_highbd_dc_128_predictor_32x64;
+
+    dc_pred_high[0][0][TX_64X16] = eb_aom_highbd_dc_128_predictor_64x16;
+    dc_pred_high[0][0][TX_64X32] = eb_aom_highbd_dc_128_predictor_64x32;
+
+    dc_pred_high[0][1][TX_4X4] = eb_aom_highbd_dc_top_predictor_4x4;
+    dc_pred_high[0][1][TX_8X8] = eb_aom_highbd_dc_top_predictor_8x8;
+    dc_pred_high[0][1][TX_16X16] = eb_aom_highbd_dc_top_predictor_16x16;
+    dc_pred_high[0][1][TX_32X32] = eb_aom_highbd_dc_top_predictor_32x32;
+    dc_pred_high[0][1][TX_64X64] = eb_aom_highbd_dc_top_predictor_64x64;
+
+    dc_pred_high[0][1][TX_4X8] = eb_aom_highbd_dc_top_predictor_4x8;
+    dc_pred_high[0][1][TX_4X16] = eb_aom_highbd_dc_top_predictor_4x16;
+
+    dc_pred_high[0][1][TX_8X4] = eb_aom_highbd_dc_top_predictor_8x4;
+    dc_pred_high[0][1][TX_8X16] = eb_aom_highbd_dc_top_predictor_8x16;
+    dc_pred_high[0][1][TX_8X32] = eb_aom_highbd_dc_top_predictor_8x32;
+
+    dc_pred_high[0][1][TX_16X4] = eb_aom_highbd_dc_top_predictor_16x4;
+    dc_pred_high[0][1][TX_16X8] = eb_aom_highbd_dc_top_predictor_16x8;
+    dc_pred_high[0][1][TX_16X32] = eb_aom_highbd_dc_top_predictor_16x32;
+    dc_pred_high[0][1][TX_16X64] = eb_aom_highbd_dc_top_predictor_16x64;
+
+    dc_pred_high[0][1][TX_32X8] = eb_aom_highbd_dc_top_predictor_32x8;
+    dc_pred_high[0][1][TX_32X16] = eb_aom_highbd_dc_top_predictor_32x16;
+    dc_pred_high[0][1][TX_32X64] = eb_aom_highbd_dc_top_predictor_32x64;
+
+    dc_pred_high[0][1][TX_64X16] = eb_aom_highbd_dc_top_predictor_64x16;
+    dc_pred_high[0][1][TX_64X32] = eb_aom_highbd_dc_top_predictor_64x32;
+
+    dc_pred_high[1][0][TX_4X4] = eb_aom_highbd_dc_left_predictor_4x4;
+    dc_pred_high[1][0][TX_8X8] = eb_aom_highbd_dc_left_predictor_8x8;
+    dc_pred_high[1][0][TX_16X16] = eb_aom_highbd_dc_left_predictor_16x16;
+    dc_pred_high[1][0][TX_32X32] = eb_aom_highbd_dc_left_predictor_32x32;
+    dc_pred_high[1][0][TX_64X64] = eb_aom_highbd_dc_left_predictor_64x64;
+
+    dc_pred_high[1][0][TX_4X8] = eb_aom_highbd_dc_left_predictor_4x8;
+    dc_pred_high[1][0][TX_4X16] = eb_aom_highbd_dc_left_predictor_4x16;
+
+    dc_pred_high[1][0][TX_8X4] = eb_aom_highbd_dc_left_predictor_8x4;
+    dc_pred_high[1][0][TX_8X16] = eb_aom_highbd_dc_left_predictor_8x16;
+    dc_pred_high[1][0][TX_8X32] = eb_aom_highbd_dc_left_predictor_8x32;
+
+    dc_pred_high[1][0][TX_16X4] = eb_aom_highbd_dc_left_predictor_16x4;
+    dc_pred_high[1][0][TX_16X8] = eb_aom_highbd_dc_left_predictor_16x8;
+    dc_pred_high[1][0][TX_16X32] = eb_aom_highbd_dc_left_predictor_16x32;
+    dc_pred_high[1][0][TX_16X64] = eb_aom_highbd_dc_left_predictor_16x64;
+
+    dc_pred_high[1][0][TX_32X8] = eb_aom_highbd_dc_left_predictor_32x8;
+    dc_pred_high[1][0][TX_32X16] = eb_aom_highbd_dc_left_predictor_32x16;
+    dc_pred_high[1][0][TX_32X64] = eb_aom_highbd_dc_left_predictor_32x64;
+
+    dc_pred_high[1][0][TX_64X16] = eb_aom_highbd_dc_left_predictor_64x16;
+    dc_pred_high[1][0][TX_64X32] = eb_aom_highbd_dc_left_predictor_64x32;
+
+    dc_pred_high[1][1][TX_4X4] = eb_aom_highbd_dc_predictor_4x4;
+    dc_pred_high[1][1][TX_8X8] = eb_aom_highbd_dc_predictor_8x8;
+    dc_pred_high[1][1][TX_16X16] = eb_aom_highbd_dc_predictor_16x16;
+    dc_pred_high[1][1][TX_32X32] = eb_aom_highbd_dc_predictor_32x32;
+    dc_pred_high[1][1][TX_64X64] = eb_aom_highbd_dc_predictor_64x64;
+
+    dc_pred_high[1][1][TX_4X8] = eb_aom_highbd_dc_predictor_4x8;
+    dc_pred_high[1][1][TX_4X16] = eb_aom_highbd_dc_predictor_4x16;
+
+    dc_pred_high[1][1][TX_8X4] = eb_aom_highbd_dc_predictor_8x4;
+    dc_pred_high[1][1][TX_8X16] = eb_aom_highbd_dc_predictor_8x16;
+    dc_pred_high[1][1][TX_8X32] = eb_aom_highbd_dc_predictor_8x32;
+
+    dc_pred_high[1][1][TX_16X4] = eb_aom_highbd_dc_predictor_16x4;
+    dc_pred_high[1][1][TX_16X8] = eb_aom_highbd_dc_predictor_16x8;
+    dc_pred_high[1][1][TX_16X32] = eb_aom_highbd_dc_predictor_16x32;
+    dc_pred_high[1][1][TX_16X64] = eb_aom_highbd_dc_predictor_16x64;
+
+    dc_pred_high[1][1][TX_32X8] = eb_aom_highbd_dc_predictor_32x8;
+    dc_pred_high[1][1][TX_32X16] = eb_aom_highbd_dc_predictor_32x16;
+    dc_pred_high[1][1][TX_32X64] = eb_aom_highbd_dc_predictor_32x64;
+
+    dc_pred_high[1][1][TX_64X16] = eb_aom_highbd_dc_predictor_64x16;
+    dc_pred_high[1][1][TX_64X32] = eb_aom_highbd_dc_predictor_64x32;
 }
 void dr_predictor(uint8_t *dst, ptrdiff_t stride, TxSize tx_size,
     const uint8_t *above, const uint8_t *left,
@@ -3057,15 +3057,15 @@ void dr_predictor(uint8_t *dst, ptrdiff_t stride, TxSize tx_size,
     assert(angle > 0 && angle < 270);
 
     if (angle > 0 && angle < 90) {
-        av1_dr_prediction_z1(dst, stride, bw, bh, above, left, upsample_above, dx,
+        eb_av1_dr_prediction_z1(dst, stride, bw, bh, above, left, upsample_above, dx,
             dy);
     }
     else if (angle > 90 && angle < 180) {
-        av1_dr_prediction_z2(dst, stride, bw, bh, above, left, upsample_above,
+        eb_av1_dr_prediction_z2(dst, stride, bw, bh, above, left, upsample_above,
             upsample_left, dx, dy);
     }
     else if (angle > 180 && angle < 270) {
-        av1_dr_prediction_z3(dst, stride, bw, bh, above, left, upsample_left, dx,
+        eb_av1_dr_prediction_z3(dst, stride, bw, bh, above, left, upsample_left, dx,
             dy);
     }
     else if (angle == 90)
@@ -3085,7 +3085,7 @@ void filter_intra_edge_corner(uint8_t *p_above, uint8_t *p_left) {
 }
 
 // Directional prediction, zone 1: 0 < angle < 90
-void av1_highbd_dr_prediction_z1_c(uint16_t *dst, ptrdiff_t stride, int32_t bw,
+void eb_av1_highbd_dr_prediction_z1_c(uint16_t *dst, ptrdiff_t stride, int32_t bw,
     int32_t bh, const uint16_t *above,
     const uint16_t *left, int32_t upsample_above,
     int32_t dx, int32_t dy, int32_t bd) {
@@ -3107,7 +3107,7 @@ void av1_highbd_dr_prediction_z1_c(uint16_t *dst, ptrdiff_t stride, int32_t bw,
 
         if (base >= max_base_x) {
             for (int32_t i = r; i < bh; ++i) {
-                aom_memset16(dst, above[max_base_x], bw);
+                eb_aom_memset16(dst, above[max_base_x], bw);
                 dst += stride;
             }
             return;
@@ -3126,7 +3126,7 @@ void av1_highbd_dr_prediction_z1_c(uint16_t *dst, ptrdiff_t stride, int32_t bw,
 }
 
 // Directional prediction, zone 2: 90 < angle < 180
-void av1_highbd_dr_prediction_z2_c(uint16_t *dst, ptrdiff_t stride, int32_t bw,
+void eb_av1_highbd_dr_prediction_z2_c(uint16_t *dst, ptrdiff_t stride, int32_t bw,
     int32_t bh, const uint16_t *above,
     const uint16_t *left, int32_t upsample_above,
     int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd) {
@@ -3164,7 +3164,7 @@ void av1_highbd_dr_prediction_z2_c(uint16_t *dst, ptrdiff_t stride, int32_t bw,
 }
 
 // Directional prediction, zone 3: 180 < angle < 270
-void av1_highbd_dr_prediction_z3_c(uint16_t *dst, ptrdiff_t stride, int32_t bw,
+void eb_av1_highbd_dr_prediction_z3_c(uint16_t *dst, ptrdiff_t stride, int32_t bw,
     int32_t bh, const uint16_t *above,
     const uint16_t *left, int32_t upsample_left,
     int32_t dx, int32_t dy, int32_t bd) {
@@ -3209,15 +3209,15 @@ void highbd_dr_predictor(uint16_t *dst, ptrdiff_t stride,
     assert(angle > 0 && angle < 270);
 
     if (angle > 0 && angle < 90) {
-        av1_highbd_dr_prediction_z1(dst, stride, bw, bh, above, left,
+        eb_av1_highbd_dr_prediction_z1(dst, stride, bw, bh, above, left,
             upsample_above, dx, dy, bd);
     }
     else if (angle > 90 && angle < 180) {
-        av1_highbd_dr_prediction_z2(dst, stride, bw, bh, above, left,
+        eb_av1_highbd_dr_prediction_z2(dst, stride, bw, bh, above, left,
             upsample_above, upsample_left, dx, dy, bd);
     }
     else if (angle > 180 && angle < 270) {
-        av1_highbd_dr_prediction_z3(dst, stride, bw, bh, above, left, upsample_left,
+        eb_av1_highbd_dr_prediction_z3(dst, stride, bw, bh, above, left, upsample_left,
             dx, dy, bd);
     }
     else if (angle == 90)
@@ -3226,7 +3226,7 @@ void highbd_dr_predictor(uint16_t *dst, ptrdiff_t stride,
         pred_high[H_PRED][tx_size](dst, stride, above, left, bd);
 }
 
-void av1_filter_intra_edge_high_c(uint16_t *p, int32_t sz, int32_t strength) {
+void eb_av1_filter_intra_edge_high_c(uint16_t *p, int32_t sz, int32_t strength) {
     if (!strength) return;
 
     const int32_t kernel[INTRA_EDGE_FILT][INTRA_EDGE_TAPS] = {
@@ -3259,7 +3259,7 @@ void filter_intra_edge_corner_high(uint16_t *p_above, uint16_t *p_left) {
     p_left[-1] = (uint16_t)s;
 }
 
-void av1_upsample_intra_edge_high_c(uint16_t *p, int32_t sz, int32_t bd) {
+void eb_av1_upsample_intra_edge_high_c(uint16_t *p, int32_t sz, int32_t bd) {
     // interpolate half-sample positions
     assert(sz <= MAX_UPSAMPLE_SZ);
 
@@ -3282,7 +3282,7 @@ void av1_upsample_intra_edge_high_c(uint16_t *p, int32_t sz, int32_t bd) {
     }
 }
 
-void av1_upsample_intra_edge_c(uint8_t *p, int32_t sz) {
+void eb_av1_upsample_intra_edge_c(uint8_t *p, int32_t sz) {
     // interpolate half-sample positions
     assert(sz <= MAX_UPSAMPLE_SZ);
 
@@ -3355,7 +3355,7 @@ void av1_upsample_intra_edge_c(uint8_t *p, int32_t sz) {
 ////////////########...........Recurssive intra prediction starting...........#########
 
 DECLARE_ALIGNED(16, const int8_t,
-                av1_filter_intra_taps[FILTER_INTRA_MODES][8][8]) = {
+                eb_av1_filter_intra_taps[FILTER_INTRA_MODES][8][8]) = {
   {
       { -6, 10, 0, 0, 0, 12, 0, 0 },
       { -5, 2, 10, 0, 0, 9, 0, 0 },
@@ -3408,7 +3408,7 @@ DECLARE_ALIGNED(16, const int8_t,
   },
 };
 
-void av1_filter_intra_predictor_c(uint8_t *dst, ptrdiff_t stride,
+void eb_av1_filter_intra_predictor_c(uint8_t *dst, ptrdiff_t stride,
                                   TxSize tx_size,
                                   const uint8_t *above,
                                   const uint8_t *left, int32_t mode) {
@@ -3440,13 +3440,13 @@ void av1_filter_intra_predictor_c(uint8_t *dst, ptrdiff_t stride,
         int c_offset = k & 0x03;
         buffer[r + r_offset][c + c_offset] =
             clip_pixel(ROUND_POWER_OF_TWO_SIGNED(
-                av1_filter_intra_taps[mode][k][0] * p0 +
-                    av1_filter_intra_taps[mode][k][1] * p1 +
-                    av1_filter_intra_taps[mode][k][2] * p2 +
-                    av1_filter_intra_taps[mode][k][3] * p3 +
-                    av1_filter_intra_taps[mode][k][4] * p4 +
-                    av1_filter_intra_taps[mode][k][5] * p5 +
-                    av1_filter_intra_taps[mode][k][6] * p6,
+                eb_av1_filter_intra_taps[mode][k][0] * p0 +
+                    eb_av1_filter_intra_taps[mode][k][1] * p1 +
+                    eb_av1_filter_intra_taps[mode][k][2] * p2 +
+                    eb_av1_filter_intra_taps[mode][k][3] * p3 +
+                    eb_av1_filter_intra_taps[mode][k][4] * p4 +
+                    eb_av1_filter_intra_taps[mode][k][5] * p5 +
+                    eb_av1_filter_intra_taps[mode][k][6] * p6,
                 FILTER_INTRA_SCALE_BITS));
       }
     }
@@ -3490,13 +3490,13 @@ void av1_filter_intra_predictor_c(uint8_t *dst, ptrdiff_t stride,
                 int c_offset = k & 0x03;
                 buffer[r + r_offset][c + c_offset] =
                     clip_pixel_highbd(ROUND_POWER_OF_TWO_SIGNED(
-                        av1_filter_intra_taps[mode][k][0] * p0 +
-                        av1_filter_intra_taps[mode][k][1] * p1 +
-                        av1_filter_intra_taps[mode][k][2] * p2 +
-                        av1_filter_intra_taps[mode][k][3] * p3 +
-                        av1_filter_intra_taps[mode][k][4] * p4 +
-                        av1_filter_intra_taps[mode][k][5] * p5 +
-                        av1_filter_intra_taps[mode][k][6] * p6,
+                        eb_av1_filter_intra_taps[mode][k][0] * p0 +
+                        eb_av1_filter_intra_taps[mode][k][1] * p1 +
+                        eb_av1_filter_intra_taps[mode][k][2] * p2 +
+                        eb_av1_filter_intra_taps[mode][k][3] * p3 +
+                        eb_av1_filter_intra_taps[mode][k][4] * p4 +
+                        eb_av1_filter_intra_taps[mode][k][5] * p5 +
+                        eb_av1_filter_intra_taps[mode][k][6] * p6,
                         FILTER_INTRA_SCALE_BITS),
                         bd);
             }
@@ -3635,7 +3635,7 @@ static void build_intra_predictors(
     }
 
     //    if (use_filter_intra) {
-    ////        av1_filter_intra_predictor(dst, dst_stride, tx_size, above_row, left_col,
+    ////        eb_av1_filter_intra_predictor(dst, dst_stride, tx_size, above_row, left_col,
     ////CHKN            filter_intra_mode);
     //        return;
     //    }
@@ -3656,26 +3656,26 @@ static void build_intra_predictors(
                     const int32_t strength =
                         intra_edge_filter_strength(txwpx, txhpx, p_angle - 90, filt_type);
                     const int32_t n_px = n_top_px + ab_le + (need_right ? txhpx : 0);
-                    av1_filter_intra_edge(above_row - ab_le, n_px, strength);
+                    eb_av1_filter_intra_edge(above_row - ab_le, n_px, strength);
                 }
                 if (need_left && n_left_px > 0) {
                     const int32_t strength = intra_edge_filter_strength(
                         txhpx, txwpx, p_angle - 180, filt_type);
                     const int32_t n_px = n_left_px + ab_le + (need_bottom ? txwpx : 0);
-                    av1_filter_intra_edge(left_col - ab_le, n_px, strength);
+                    eb_av1_filter_intra_edge(left_col - ab_le, n_px, strength);
                 }
             }
             upsample_above =
                 use_intra_edge_upsample(txwpx, txhpx, p_angle - 90, filt_type);
             if (need_above && upsample_above) {
                 const int32_t n_px = txwpx + (need_right ? txhpx : 0);
-                av1_upsample_intra_edge(above_row, n_px);
+                eb_av1_upsample_intra_edge(above_row, n_px);
             }
             upsample_left =
                 use_intra_edge_upsample(txhpx, txwpx, p_angle - 180, filt_type);
             if (need_left && upsample_left) {
                 const int32_t n_px = txhpx + (need_bottom ? txwpx : 0);
-                av1_upsample_intra_edge(left_col, n_px);
+                eb_av1_upsample_intra_edge(left_col, n_px);
             }
         }
         dr_predictor(dst, dst_stride, tx_size, above_row, left_col, upsample_above,
@@ -3756,7 +3756,7 @@ static void build_intra_predictors_high(
         else
             val = (n_left_px > 0) ? left_ref[0] : base - 1;
         for (i = 0; i < txhpx; ++i) {
-            aom_memset16(dst, val, txwpx);
+            eb_aom_memset16(dst, val, txwpx);
             dst += dst_stride;
         }
         return;
@@ -3777,13 +3777,13 @@ static void build_intra_predictors_high(
                     left_col[i] = left_ref[i * ref_stride];
             }
             if (i < num_left_pixels_needed)
-                aom_memset16(&left_col[i], left_col[i - 1], num_left_pixels_needed - i);
+                eb_aom_memset16(&left_col[i], left_col[i - 1], num_left_pixels_needed - i);
         }
         else {
             if (n_top_px > 0)
-                aom_memset16(left_col, above_ref[0], num_left_pixels_needed);
+                eb_aom_memset16(left_col, above_ref[0], num_left_pixels_needed);
             else
-                aom_memset16(left_col, base + 1, num_left_pixels_needed);
+                eb_aom_memset16(left_col, base + 1, num_left_pixels_needed);
         }
     }
 
@@ -3803,14 +3803,14 @@ static void build_intra_predictors_high(
                 i += n_topright_px;
             }
             if (i < num_top_pixels_needed)
-                aom_memset16(&above_row[i], above_row[i - 1],
+                eb_aom_memset16(&above_row[i], above_row[i - 1],
                     num_top_pixels_needed - i);
         }
         else {
             if (n_left_px > 0)
-                aom_memset16(above_row, left_ref[0], num_top_pixels_needed);
+                eb_aom_memset16(above_row, left_ref[0], num_top_pixels_needed);
             else
-                aom_memset16(above_row, base - 1, num_top_pixels_needed);
+                eb_aom_memset16(above_row, base - 1, num_top_pixels_needed);
         }
     }
 
@@ -3848,14 +3848,14 @@ static void build_intra_predictors_high(
                     const int32_t strength =
                         intra_edge_filter_strength(txwpx, txhpx, p_angle - 90, filt_type);
                     const int32_t n_px = n_top_px + ab_le + (need_right ? txhpx : 0);
-                    av1_filter_intra_edge_high(above_row - ab_le, n_px, strength);
+                    eb_av1_filter_intra_edge_high(above_row - ab_le, n_px, strength);
                 }
                 if (need_left && n_left_px > 0) {
                     const int32_t strength = intra_edge_filter_strength(
                         txhpx, txwpx, p_angle - 180, filt_type);
                     const int32_t n_px = n_left_px + ab_le + (need_bottom ? txwpx : 0);
 
-                    av1_filter_intra_edge_high(left_col - ab_le, n_px, strength);
+                    eb_av1_filter_intra_edge_high(left_col - ab_le, n_px, strength);
                 }
             }
             upsample_above =
@@ -3863,14 +3863,14 @@ static void build_intra_predictors_high(
             if (need_above && upsample_above) {
                 const int32_t n_px = txwpx + (need_right ? txhpx : 0);
                 //av1_upsample_intra_edge_high(above_row, n_px, bd);// AMIR : to be replaced by optimized code
-                av1_upsample_intra_edge_high_c(above_row, n_px, bd);
+                eb_av1_upsample_intra_edge_high_c(above_row, n_px, bd);
             }
             upsample_left =
                 use_intra_edge_upsample(txhpx, txwpx, p_angle - 180, filt_type);
             if (need_left && upsample_left) {
                 const int32_t n_px = txhpx + (need_bottom ? txwpx : 0);
                 //av1_upsample_intra_edge_high(left_col, n_px, bd);// AMIR: to be replaced by optimized code
-                av1_upsample_intra_edge_high_c(left_col, n_px, bd);
+                eb_av1_upsample_intra_edge_high_c(left_col, n_px, bd);
             }
         }
         highbd_dr_predictor(dst, dst_stride, tx_size, above_row, left_col,
@@ -3887,7 +3887,7 @@ static void build_intra_predictors_high(
         pred_high[mode][tx_size](dst, dst_stride, above_row, left_col, bd);
 }
 
-void av1_predict_intra_block(
+void eb_av1_predict_intra_block(
     TileInfo * tile,
     STAGE       stage,
     const BlockGeom * blk_geom,
@@ -4127,7 +4127,7 @@ void av1_predict_intra_block(
         have_bottom_left ? AOMMIN(txhpx, yd) : 0, plane);
 }
 
-void av1_predict_intra_block_16bit(
+void eb_av1_predict_intra_block_16bit(
     TileInfo * tile,
     STAGE       stage,
     const BlockGeom * blk_geom,
@@ -4360,7 +4360,7 @@ void av1_predict_intra_block_16bit(
 /** IntraPrediction()
 is the main function to compute intra prediction for a PU
 */
-EbErrorType av1_intra_prediction_cl(
+EbErrorType eb_av1_intra_prediction_cl(
     ModeDecisionContext                  *md_context_ptr,
     PictureControlSet                    *picture_control_set_ptr,
     ModeDecisionCandidateBuffer           *candidate_buffer_ptr,
@@ -4454,7 +4454,7 @@ EbErrorType av1_intra_prediction_cl(
             else
                 mode = candidate_buffer_ptr->candidate_ptr->pred_mode;
 
-            av1_predict_intra_block(
+            eb_av1_predict_intra_block(
                 &md_context_ptr->sb_ptr->tile_info,
                 MD_STAGE,
                 md_context_ptr->blk_geom,
@@ -4526,7 +4526,7 @@ EbErrorType av1_intra_prediction_cl(
             else
                 mode = candidate_buffer_ptr->candidate_ptr->pred_mode;
 
-            av1_predict_intra_block_16bit(
+            eb_av1_predict_intra_block_16bit(
                 &md_context_ptr->sb_ptr->tile_info,
                 MD_STAGE,
                 md_context_ptr->blk_geom,

--- a/Source/Lib/Common/Codec/EbIntraPrediction.h
+++ b/Source/Lib/Common/Codec/EbIntraPrediction.h
@@ -115,10 +115,10 @@ extern "C" {
 /////####.... For recursive intra prediction.....#####///
 
 #define FILTER_INTRA_SCALE_BITS 4
-extern const int8_t av1_filter_intra_taps[FILTER_INTRA_MODES][8][8];
+extern const int8_t eb_av1_filter_intra_taps[FILTER_INTRA_MODES][8][8];
 
 /////####.... To make functions common between EbIntraPrediction.c &
-void *aom_memset16(void *dest, int32_t val, size_t length);
+void *eb_aom_memset16(void *dest, int32_t val, size_t length);
 
 int32_t use_intra_edge_upsample(int32_t bs0, int32_t bs1, int32_t delta,
                                        int32_t type);
@@ -176,7 +176,7 @@ void highbd_filter_intra_predictor(uint16_t *dst, ptrdiff_t stride,
 
 /////////..............................................//////////////////////////
 
-    extern EbErrorType av1_intra_prediction_cl(
+    extern EbErrorType eb_av1_intra_prediction_cl(
         struct ModeDecisionContext           *context_ptr,
         PictureControlSet                    *picture_control_set_ptr,
         ModeDecisionCandidateBuffer           *candidate_buffer_ptr,
@@ -542,7 +542,7 @@ typedef struct CflCtx {
         const uint16_t *input,
         int32_t input_stride, int16_t *output_q3,
         int32_t width, int32_t height);
-    extern void subtract_average_c(
+    extern void eb_subtract_average_c(
         int16_t *pred_buf_q3,
         int32_t width,
         int32_t height,
@@ -560,7 +560,7 @@ typedef struct CflCtx {
 
     //CFL_PREDICT_FN(c, lbd)
 
-    void cfl_predict_lbd_c(
+    void eb_cfl_predict_lbd_c(
         const int16_t *pred_buf_q3,
         uint8_t *pred,// AMIR ADDED
         int32_t pred_stride,
@@ -571,7 +571,7 @@ typedef struct CflCtx {
         int32_t width,
         int32_t height);
 
-    void cfl_predict_hbd_c(
+    void eb_cfl_predict_hbd_c(
         const int16_t *pred_buf_q3,
         uint16_t *pred,// AMIR ADDED
         int32_t pred_stride,
@@ -626,8 +626,8 @@ cfl_subsample_hbd_fn cfl_get_luma_subsampling_444_hbd_c(TxSize tx_size);
 #define cfl_get_luma_subsampling_444_lbd cfl_get_luma_subsampling_444_lbd_c
 cfl_subsample_lbd_fn cfl_get_luma_subsampling_444_lbd_c(TxSize tx_size);
 
-cfl_subtract_average_fn get_subtract_average_fn_c(TxSize tx_size);
-#define get_subtract_average_fn get_subtract_average_fn_c
+cfl_subtract_average_fn eb_get_subtract_average_fn_c(TxSize tx_size);
+#define get_subtract_average_fn eb_get_subtract_average_fn_c
 
    // Allows the CFL_SUBSAMPLE function to switch types depending on the bitdepth.
 #define CFL_lbd_TYPE uint8_t *cfl_type
@@ -706,8 +706,8 @@ cfl_subtract_average_fn get_subtract_average_fn_c(TxSize tx_size);
     // will be constant allowing for loop unrolling and other constant propagated
     // goodness.
 #define CFL_SUB_AVG_X(arch, width, height, round_offset, num_pel_log2)   \
-  void subtract_average_##width##x##height##_##arch(int16_t *buf) {      \
-    subtract_average_##arch(buf, width, height, round_offset,       \
+  void eb_subtract_average_##width##x##height##_##arch(int16_t *buf) {      \
+    eb_subtract_average_##arch(buf, width, height, round_offset,       \
                             num_pel_log2);                               \
   }
 
@@ -727,25 +727,25 @@ cfl_subtract_average_fn get_subtract_average_fn_c(TxSize tx_size);
       CFL_SUB_AVG_X(arch, 32, 8, 128, 8)                                        \
       CFL_SUB_AVG_X(arch, 32, 16, 256, 9)                                       \
       CFL_SUB_AVG_X(arch, 32, 32, 512, 10)                                      \
-      cfl_subtract_average_fn get_subtract_average_fn_##arch(TxSize tx_size) { \
+      cfl_subtract_average_fn eb_get_subtract_average_fn_##arch(TxSize tx_size) { \
               const cfl_subtract_average_fn sub_avg[TX_SIZES_ALL] = {          \
-          subtract_average_4x4_##arch,   /* 4x4 */                              \
-          subtract_average_8x8_##arch,   /* 8x8 */                              \
-          subtract_average_16x16_##arch, /* 16x16 */                            \
-          subtract_average_32x32_##arch, /* 32x32 */                            \
+          eb_subtract_average_4x4_##arch,   /* 4x4 */                              \
+          eb_subtract_average_8x8_##arch,   /* 8x8 */                              \
+          eb_subtract_average_16x16_##arch, /* 16x16 */                            \
+          eb_subtract_average_32x32_##arch, /* 32x32 */                            \
           NULL,                          /* 64x64 (invalid CFL size) */         \
-          subtract_average_4x8_##arch,   /* 4x8 */                              \
-          subtract_average_8x4_##arch,   /* 8x4 */                              \
-          subtract_average_8x16_##arch,  /* 8x16 */                             \
-          subtract_average_16x8_##arch,  /* 16x8 */                             \
-          subtract_average_16x32_##arch, /* 16x32 */                            \
-          subtract_average_32x16_##arch, /* 32x16 */                            \
+          eb_subtract_average_4x8_##arch,   /* 4x8 */                              \
+          eb_subtract_average_8x4_##arch,   /* 8x4 */                              \
+          eb_subtract_average_8x16_##arch,  /* 8x16 */                             \
+          eb_subtract_average_16x8_##arch,  /* 16x8 */                             \
+          eb_subtract_average_16x32_##arch, /* 16x32 */                            \
+          eb_subtract_average_32x16_##arch, /* 32x16 */                            \
           NULL,                          /* 32x64 (invalid CFL size) */         \
           NULL,                          /* 64x32 (invalid CFL size) */         \
-          subtract_average_4x16_##arch,  /* 4x16 (invalid CFL size) */          \
-          subtract_average_16x4_##arch,  /* 16x4 (invalid CFL size) */          \
-          subtract_average_8x32_##arch,  /* 8x32 (invalid CFL size) */          \
-          subtract_average_32x8_##arch,  /* 32x8 (invalid CFL size) */          \
+          eb_subtract_average_4x16_##arch,  /* 4x16 (invalid CFL size) */          \
+          eb_subtract_average_16x4_##arch,  /* 16x4 (invalid CFL size) */          \
+          eb_subtract_average_8x32_##arch,  /* 8x32 (invalid CFL size) */          \
+          eb_subtract_average_32x8_##arch,  /* 32x8 (invalid CFL size) */          \
           NULL,                          /* 16x64 (invalid CFL size) */         \
           NULL,                          /* 64x16 (invalid CFL size) */         \
         };                                                                      \
@@ -754,7 +754,7 @@ cfl_subtract_average_fn get_subtract_average_fn_c(TxSize tx_size);
         return sub_avg[tx_size % TX_SIZES_ALL];                                 \
       }
 
-void av1_predict_intra_block(
+void eb_av1_predict_intra_block(
     TileInfo *tile,
     STAGE stage,
     const BlockGeom *blk_geom,
@@ -780,7 +780,7 @@ void av1_predict_intra_block(
     uint32_t bl_org_x_mb,
     uint32_t bl_org_y_mb);
 
-void av1_predict_intra_block_16bit(
+void eb_av1_predict_intra_block_16bit(
     TileInfo * tile,
     STAGE stage,
     const BlockGeom * blk_geom,

--- a/Source/Lib/Common/Codec/EbMdRateEstimation.c
+++ b/Source/Lib/Common/Codec/EbMdRateEstimation.c
@@ -334,11 +334,11 @@ MvClassType av1_get_mv_class(int32_t z, int32_t *offset) {
     return c;
 }
 
-//void av1_build_nmv_cost_table(int32_t *mvjoint, int32_t *mvcost[2],
+//void eb_av1_build_nmv_cost_table(int32_t *mvjoint, int32_t *mvcost[2],
 //    const NmvContext *ctx,
 //    MvSubpelPrecision precision)
 
-void av1_build_nmv_cost_table(int32_t *mvjoint, int32_t *mvcost[2],
+void eb_av1_build_nmv_cost_table(int32_t *mvjoint, int32_t *mvcost[2],
     const NmvContext *ctx,
     MvSubpelPrecision precision);
 
@@ -361,7 +361,7 @@ void av1_estimate_mv_rate(
     nmvcost_hp[0] = &md_rate_estimation_array->nmv_costs_hp[0][MV_MAX];
     nmvcost_hp[1] = &md_rate_estimation_array->nmv_costs_hp[1][MV_MAX];
 
-    av1_build_nmv_cost_table(
+    eb_av1_build_nmv_cost_table(
         md_rate_estimation_array->nmv_vec_cost,//out
         frm_hdr->allow_high_precision_mv ? nmvcost_hp : nmvcost, //out
         nmv_ctx,
@@ -372,7 +372,7 @@ void av1_estimate_mv_rate(
 
     if (frm_hdr->allow_intrabc) {
         int32_t *dvcost[2] = { &md_rate_estimation_array->dv_cost[0][MV_MAX], &md_rate_estimation_array->dv_cost[1][MV_MAX] };
-        av1_build_nmv_cost_table(md_rate_estimation_array->dv_joint_cost, dvcost, &picture_control_set_ptr->coeff_est_entropy_coder_ptr->fc->ndvc,
+        eb_av1_build_nmv_cost_table(md_rate_estimation_array->dv_joint_cost, dvcost, &picture_control_set_ptr->coeff_est_entropy_coder_ptr->fc->ndvc,
             MV_SUBPEL_NONE);
     }
 }

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -88,7 +88,7 @@ MvReferenceFrame svt_get_ref_frame_type(uint8_t list, uint8_t ref_idx) {
 extern uint32_t stage1ModesArray[];
 
 uint8_t GetMaxDrlIndex(uint8_t  refmvCnt, PredictionMode   mode);
-int32_t av1_mv_bit_cost(const MV *mv, const MV *ref, const int32_t *mvjcost,
+int32_t eb_av1_mv_bit_cost(const MV *mv, const MV *ref, const int32_t *mvjcost,
     int32_t *mvcost[2], int32_t weight);
 #define MV_COST_WEIGHT 108
 
@@ -133,7 +133,7 @@ void ChooseBestAv1MvPred(
         mv.row = mv0y;
         mv.col = mv0x;
 
-        uint32_t mvRate = (uint32_t)av1_mv_bit_cost(
+        uint32_t mvRate = (uint32_t)eb_av1_mv_bit_cost(
             &mv,
             &(ref_mv[0].as_mv),
             md_rate_estimation_ptr->nmv_vec_cost,
@@ -144,7 +144,7 @@ void ChooseBestAv1MvPred(
             mv.row = mv1y;
             mv.col = mv1x;
 
-            mvRate += (uint32_t)av1_mv_bit_cost(
+            mvRate += (uint32_t)eb_av1_mv_bit_cost(
                 &mv,
                 &(ref_mv[1].as_mv),
                 md_rate_estimation_ptr->nmv_vec_cost,
@@ -2202,7 +2202,7 @@ void  inject_inter_candidates(
 
     uint32_t mi_row = context_ptr->cu_origin_y >> MI_SIZE_LOG2;
     uint32_t mi_col = context_ptr->cu_origin_x >> MI_SIZE_LOG2;
-    av1_count_overlappable_neighbors(
+    eb_av1_count_overlappable_neighbors(
         picture_control_set_ptr,
         context_ptr->cu_ptr,
         context_ptr->blk_geom->bsize,
@@ -2720,7 +2720,7 @@ void  inject_intra_candidates_ois(
     return;
 }
 
-double av1_convert_qindex_to_q(int32_t qindex, AomBitDepth bit_depth);
+double eb_av1_convert_qindex_to_q(int32_t qindex, AomBitDepth bit_depth);
 
 static INLINE void setup_pred_plane(struct Buf2D *dst, BlockSize bsize,
     uint8_t *src, int width, int height,
@@ -2740,7 +2740,7 @@ static INLINE void setup_pred_plane(struct Buf2D *dst, BlockSize bsize,
     dst->height = height;
     dst->stride = stride;
 }
-void av1_setup_pred_block(BlockSize sb_type,
+void eb_av1_setup_pred_block(BlockSize sb_type,
     struct Buf2D dst[MAX_MB_PLANE],
     const Yv12BufferConfig *src, int mi_row, int mi_col) {
     int i;
@@ -2769,13 +2769,13 @@ static void init_me_luts_bd(int *bit16lut, int *bit4lut, int range,
     // This is to make it easier to resolve the impact of experimental changes
     // to the quantizer tables.
     for (i = 0; i < range; i++) {
-        const double q = av1_convert_qindex_to_q(i, bit_depth);
+        const double q = eb_av1_convert_qindex_to_q(i, bit_depth);
         bit16lut[i] = (int)(0.0418 * q + 2.4107);
         bit4lut[i] = (int)(0.063 * q + 2.742);
     }
 }
 
-void av1_init_me_luts(void) {
+void eb_av1_init_me_luts(void) {
     init_me_luts_bd(sad_per_bit16lut_8, sad_per_bit4lut_8, QINDEX_RANGE,
         AOM_BITS_8);
 }
@@ -2857,7 +2857,7 @@ void  intra_bc_search(
             x->hash_value_buffer[xi][yj] = (uint32_t*)malloc(AOM_BUFFER_SIZE_FOR_BLOCK_HASH * sizeof(uint32_t));
 
     IntMv nearestmv, nearmv;
-    av1_find_best_ref_mvs_from_stack(0, context_ptr->md_local_cu_unit[context_ptr->blk_geom->blkidx_mds].ed_ref_mv_stack /*mbmi_ext*/, xd, ref_frame, &nearestmv, &nearmv,
+    eb_av1_find_best_ref_mvs_from_stack(0, context_ptr->md_local_cu_unit[context_ptr->blk_geom->blkidx_mds].ed_ref_mv_stack /*mbmi_ext*/, xd, ref_frame, &nearestmv, &nearmv,
         0);
     if (nearestmv.as_int == INVALID_MV)
         nearestmv.as_int = 0;
@@ -2877,7 +2877,7 @@ void  intra_bc_search(
         pcs->parent_pcs_ptr->enhanced_picture_ptr,
         &cur_buf);
     struct Buf2D yv12_mb[MAX_MB_PLANE];
-    av1_setup_pred_block(bsize, yv12_mb, &cur_buf, mi_row, mi_col);
+    eb_av1_setup_pred_block(bsize, yv12_mb, &cur_buf, mi_row, mi_col);
     for (int i = 0; i < num_planes; ++i)
         x->xdplane[i].pre[0] = yv12_mb[i];  //ref in ME
     //setup src for DV search same as ref
@@ -2922,7 +2922,7 @@ void  intra_bc_search(
         assert_release(x->mv_limits.row_min >= tmp_mv_limits.row_min);
         assert_release(x->mv_limits.row_max <= tmp_mv_limits.row_max);
 
-        av1_set_mv_search_range(&x->mv_limits, &dv_ref.as_mv);
+        eb_av1_set_mv_search_range(&x->mv_limits, &dv_ref.as_mv);
 
         if (x->mv_limits.col_max < x->mv_limits.col_min ||
             x->mv_limits.row_max < x->mv_limits.row_min) {
@@ -2939,7 +2939,7 @@ void  intra_bc_search(
 
 #define INT_VAR_MAX  2147483647    // maximum (signed) int value
 
-        const int bestsme = av1_full_pixel_search(
+        const int bestsme = eb_av1_full_pixel_search(
             pcs, x, bsize, &mvp_full, step_param, 1, 0,
             sadpb, NULL, &dv_ref.as_mv, INT_VAR_MAX, 1,
             (MI_SIZE * mi_col), (MI_SIZE * mi_row), 1);

--- a/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
@@ -273,7 +273,7 @@ static const int16_t ac_qlookup_12_Q3[QINDEX_RANGE] = {
     28143, 28687, 29247,
 };
 
-int16_t av1_dc_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth) {
+int16_t eb_av1_dc_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth) {
     switch (bit_depth) {
     case AOM_BITS_8: return dc_qlookup_Q3[clamp(qindex + delta, 0, MAXQ)];
     case AOM_BITS_10: return dc_qlookup_10_Q3[clamp(qindex + delta, 0, MAXQ)];
@@ -283,7 +283,7 @@ int16_t av1_dc_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth) {
         return -1;
     }
 }
-int16_t av1_ac_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth) {
+int16_t eb_av1_ac_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth) {
     switch (bit_depth) {
     case AOM_BITS_8: return ac_qlookup_Q3[clamp(qindex + delta, 0, MAXQ)];
     case AOM_BITS_10: return ac_qlookup_10_Q3[clamp(qindex + delta, 0, MAXQ)];
@@ -295,7 +295,7 @@ int16_t av1_ac_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth) {
 }
 
 static int32_t get_qzbin_factor(int32_t q, AomBitDepth bit_depth) {
-    const int32_t quant = av1_dc_quant_Q3(q, 0, bit_depth);
+    const int32_t quant = eb_av1_dc_quant_Q3(q, 0, bit_depth);
     switch (bit_depth) {
     case AOM_BITS_8: return q == 0 ? 64 : (quant < 148 ? 84 : 80);
     case AOM_BITS_10: return q == 0 ? 64 : (quant < 592 ? 84 : 80);
@@ -309,11 +309,11 @@ static int32_t get_qzbin_factor(int32_t q, AomBitDepth bit_depth) {
 // In AV1 TX, the coefficients are always scaled up a factor of 8 (3
 // bits), so QTX == Q3.
 
-int16_t av1_dc_quant_QTX(int32_t qindex, int32_t delta, AomBitDepth bit_depth) {
-    return av1_dc_quant_Q3(qindex, delta, bit_depth);
+int16_t eb_av1_dc_quant_QTX(int32_t qindex, int32_t delta, AomBitDepth bit_depth) {
+    return eb_av1_dc_quant_Q3(qindex, delta, bit_depth);
 }
-int16_t av1_ac_quant_QTX(int32_t qindex, int32_t delta, AomBitDepth bit_depth) {
-    return av1_ac_quant_Q3(qindex, delta, bit_depth);
+int16_t eb_av1_ac_quant_QTX(int32_t qindex, int32_t delta, AomBitDepth bit_depth) {
+    return eb_av1_ac_quant_Q3(qindex, delta, bit_depth);
 }
 
 static void invert_quant(int16_t *quant, int16_t *shift, int32_t d) {
@@ -387,7 +387,7 @@ void SetGlobalMotionField(
     //    picture_control_set_ptr->parent_pcs_ptr->global_motion[LAST_FRAME].wmmat[1]) *GM_TRANS_ONLY_DECODE_FACTOR;
 }
 
-void av1_set_quantizer(
+void eb_av1_set_quantizer(
     PictureParentControlSet                    *picture_control_set_ptr,
     int32_t q)
 {
@@ -416,7 +416,7 @@ void av1_set_quantizer(
             picture_control_set_ptr->min_qmlevel, picture_control_set_ptr->max_qmlevel);
 }
 
-void av1_build_quantizer(
+void eb_av1_build_quantizer(
     AomBitDepth bit_depth,
     int32_t y_dc_delta_q,
     int32_t u_dc_delta_q,
@@ -435,11 +435,11 @@ void av1_build_quantizer(
         for (i = 0; i < 2; ++i) {
             int32_t qrounding_factor_fp = 64;
             // y quantizer setup with original coeff shift of Q3
-            quant_Q3 = i == 0 ? av1_dc_quant_Q3(q, y_dc_delta_q, bit_depth)
-                : av1_ac_quant_Q3(q, 0, bit_depth);
+            quant_Q3 = i == 0 ? eb_av1_dc_quant_Q3(q, y_dc_delta_q, bit_depth)
+                : eb_av1_ac_quant_Q3(q, 0, bit_depth);
             // y quantizer with TX scale
-            quant_QTX = i == 0 ? av1_dc_quant_QTX(q, y_dc_delta_q, bit_depth)
-                : av1_ac_quant_QTX(q, 0, bit_depth);
+            quant_QTX = i == 0 ? eb_av1_dc_quant_QTX(q, y_dc_delta_q, bit_depth)
+                : eb_av1_ac_quant_QTX(q, 0, bit_depth);
             invert_quant(&quants->y_quant[q][i], &quants->y_quant_shift[q][i],
                 quant_QTX);
             quants->y_quant_fp[q][i] = (int16_t)((1 << 16) / quant_QTX);
@@ -450,11 +450,11 @@ void av1_build_quantizer(
             deq->y_dequant_Q3[q][i] = (int16_t)quant_Q3;
 
             // u quantizer setup with original coeff shift of Q3
-            quant_Q3 = i == 0 ? av1_dc_quant_Q3(q, u_dc_delta_q, bit_depth)
-                : av1_ac_quant_Q3(q, u_ac_delta_q, bit_depth);
+            quant_Q3 = i == 0 ? eb_av1_dc_quant_Q3(q, u_dc_delta_q, bit_depth)
+                : eb_av1_ac_quant_Q3(q, u_ac_delta_q, bit_depth);
             // u quantizer with TX scale
-            quant_QTX = i == 0 ? av1_dc_quant_QTX(q, u_dc_delta_q, bit_depth)
-                : av1_ac_quant_QTX(q, u_ac_delta_q, bit_depth);
+            quant_QTX = i == 0 ? eb_av1_dc_quant_QTX(q, u_dc_delta_q, bit_depth)
+                : eb_av1_ac_quant_QTX(q, u_ac_delta_q, bit_depth);
             invert_quant(&quants->u_quant[q][i], &quants->u_quant_shift[q][i],
                 quant_QTX);
             quants->u_quant_fp[q][i] = (int16_t)((1 << 16) / quant_QTX);
@@ -465,11 +465,11 @@ void av1_build_quantizer(
             deq->u_dequant_Q3[q][i] = (int16_t)quant_Q3;
 
             // v quantizer setup with original coeff shift of Q3
-            quant_Q3 = i == 0 ? av1_dc_quant_Q3(q, v_dc_delta_q, bit_depth)
-                : av1_ac_quant_Q3(q, v_ac_delta_q, bit_depth);
+            quant_Q3 = i == 0 ? eb_av1_dc_quant_Q3(q, v_dc_delta_q, bit_depth)
+                : eb_av1_ac_quant_Q3(q, v_ac_delta_q, bit_depth);
             // v quantizer with TX scale
-            quant_QTX = i == 0 ? av1_dc_quant_QTX(q, v_dc_delta_q, bit_depth)
-                : av1_ac_quant_QTX(q, v_ac_delta_q, bit_depth);
+            quant_QTX = i == 0 ? eb_av1_dc_quant_QTX(q, v_dc_delta_q, bit_depth)
+                : eb_av1_ac_quant_QTX(q, v_ac_delta_q, bit_depth);
             invert_quant(&quants->v_quant[q][i], &quants->v_quant_shift[q][i],
                 quant_QTX);
             quants->v_quant_fp[q][i] = (int16_t)((1 << 16) / quant_QTX);
@@ -510,7 +510,7 @@ void av1_build_quantizer(
     }
 }
 
-void av1_qm_init(
+void eb_av1_qm_init(
     PictureParentControlSet                   *picture_control_set_ptr
 )
 {
@@ -1756,16 +1756,16 @@ void* mode_decision_configuration_kernel(void *input_ptr)
         SetGlobalMotionField(
             picture_control_set_ptr);
 
-        av1_qm_init(
+        eb_av1_qm_init(
             picture_control_set_ptr->parent_pcs_ptr);
 
         Quants *const quants = &picture_control_set_ptr->parent_pcs_ptr->quants;
         Dequants *const dequants = &picture_control_set_ptr->parent_pcs_ptr->deq;
 
-        av1_set_quantizer(
+        eb_av1_set_quantizer(
             picture_control_set_ptr->parent_pcs_ptr,
             frm_hdr->quantization_params.base_q_idx);
-        av1_build_quantizer(
+        eb_av1_build_quantizer(
             (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth,
             frm_hdr->quantization_params.delta_q_y_dc,
             frm_hdr->quantization_params.delta_q_u_dc,
@@ -1777,7 +1777,7 @@ void* mode_decision_configuration_kernel(void *input_ptr)
 
         Quants *const quantsMd = &picture_control_set_ptr->parent_pcs_ptr->quantsMd;
         Dequants *const dequantsMd = &picture_control_set_ptr->parent_pcs_ptr->deqMd;
-        av1_build_quantizer(
+        eb_av1_build_quantizer(
             picture_control_set_ptr->hbd_mode_decision ? AOM_BITS_10 : AOM_BITS_8,
             frm_hdr->quantization_params.delta_q_y_dc,
             frm_hdr->quantization_params.delta_q_u_dc,
@@ -2048,7 +2048,7 @@ void* mode_decision_configuration_kernel(void *input_ptr)
                 }
             }
 
-            av1_init3smotion_compensation(&picture_control_set_ptr->ss_cfg, picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr->stride_y);
+            eb_av1_init3smotion_compensation(&picture_control_set_ptr->ss_cfg, picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr->stride_y);
         }
 
         // Derive MD parameters

--- a/Source/Lib/Common/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Common/Codec/EbPacketizationProcess.c
@@ -329,7 +329,7 @@ void* packetization_kernel(void *input_ptr)
             picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&
             picture_control_set_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr) {
 
-            av1_reset_cdf_symbol_counters(picture_control_set_ptr->entropy_coder_ptr->fc);
+            eb_av1_reset_cdf_symbol_counters(picture_control_set_ptr->entropy_coder_ptr->fc);
             ((EbReferenceObject*)picture_control_set_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)->frame_context
                 = (*picture_control_set_ptr->entropy_coder_ptr->fc);
 

--- a/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
@@ -3288,7 +3288,7 @@ static int32_t apply_denoise_2d(SequenceControlSet        *scs_ptr,
     PictureParentControlSet   *pcs_ptr,
     EbPictureBufferDesc *inputPicturePointer,
     EbAsm asm_type) {
-    if (aom_denoise_and_model_run(pcs_ptr->denoise_and_model, inputPicturePointer,
+    if (eb_aom_denoise_and_model_run(pcs_ptr->denoise_and_model, inputPicturePointer,
         &pcs_ptr->frm_hdr.film_grain_params,
         scs_ptr->static_config.encoder_bit_depth > EB_8BIT, asm_type)) {
     }
@@ -4639,7 +4639,7 @@ void DownsampleDecimationInputPicture(
         sixteenth_decimated_picture_ptr->origin_y);
 
 }
-int av1_count_colors(const uint8_t *src, int stride, int rows, int cols,
+int eb_av1_count_colors(const uint8_t *src, int stride, int rows, int cols,
     int *val_count) {
     const int max_pix_val = 1 << 8;
     memset(val_count, 0, max_pix_val * sizeof(val_count[0]));
@@ -4661,7 +4661,7 @@ extern aom_variance_fn_ptr_t mefn_ptr[BlockSizeS_ALL];
 //  purposes of activity masking.
 // Eventually this should be replaced by custom no-reference routines,
 //  which will be faster.
-const uint8_t AV1_VAR_OFFS[MAX_SB_SIZE] = {
+const uint8_t eb_AV1_VAR_OFFS[MAX_SB_SIZE] = {
   128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
   128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
   128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128,
@@ -4673,13 +4673,13 @@ const uint8_t AV1_VAR_OFFS[MAX_SB_SIZE] = {
   128, 128, 128, 128, 128, 128, 128, 128
 };
 
-unsigned int av1_get_sby_perpixel_variance(const aom_variance_fn_ptr_t *fn_ptr, //const AV1_COMP *cpi,
+unsigned int eb_av1_get_sby_perpixel_variance(const aom_variance_fn_ptr_t *fn_ptr, //const AV1_COMP *cpi,
                                            const uint8_t *src,int stride,//const struct buf_2d *ref,
                                            BlockSize bs) {
   unsigned int sse;
   const unsigned int var =
-      //cpi->fn_ptr[bs].vf(ref->buf, ref->stride, AV1_VAR_OFFS, 0, &sse);
-     fn_ptr->vf(src,  stride, AV1_VAR_OFFS, 0, &sse);
+      //cpi->fn_ptr[bs].vf(ref->buf, ref->stride, eb_AV1_VAR_OFFS, 0, &sse);
+     fn_ptr->vf(src,  stride, eb_AV1_VAR_OFFS, 0, &sse);
   return ROUND_POWER_OF_TWO(var, num_pels_log2_lookup[bs]);
 }
 
@@ -4710,7 +4710,7 @@ static void is_screen_content(
             const int n_colors =
                 use_hbd ? 0 /*av1_count_colors_highbd(src + r * stride + c, stride, blk_w,
                     blk_h, bd, count_buf)*/
-                : av1_count_colors(src + r * stride + c, stride, blk_w, blk_h,
+                : eb_av1_count_colors(src + r * stride + c, stride, blk_w, blk_h,
                     count_buf);
             if (n_colors > 1 && n_colors <= color_thresh) {
                 ++counts_1;
@@ -4719,7 +4719,7 @@ static void is_screen_content(
                 //buf.buf = (uint8_t *)src;
                 const aom_variance_fn_ptr_t *fn_ptr = &mefn_ptr[BLOCK_16X16];
 
-                const unsigned int var = av1_get_sby_perpixel_variance(fn_ptr, src + r * stride + c,stride, BLOCK_16X16);
+                const unsigned int var = eb_av1_get_sby_perpixel_variance(fn_ptr, src + r * stride + c,stride, BLOCK_16X16);
                                /* use_hbd
                 ? av1_high_get_sby_perpixel_variance(cpi, &buf, BLOCK_16X16, bd)
                 : */

--- a/Source/Lib/Common/Codec/EbPictureBufferDesc.c
+++ b/Source/Lib/Common/Codec/EbPictureBufferDesc.c
@@ -289,13 +289,13 @@ void link_eb_to_aom_buffer_desc(
     }
 }
 
-void *aom_memalign(size_t align, size_t size);
-void aom_free(void *memblk);
+void *eb_aom_memalign(size_t align, size_t size);
+void eb_aom_free(void *memblk);
 
 #define yv12_align_addr(addr, align) \
   (void *)(((size_t)(addr) + ((align)-1)) & (size_t) - (align))
 
-int32_t aom_realloc_frame_buffer(Yv12BufferConfig *ybf, int32_t width, int32_t height,
+int32_t eb_aom_realloc_frame_buffer(Yv12BufferConfig *ybf, int32_t width, int32_t height,
     int32_t ss_x, int32_t ss_y, int32_t use_highbitdepth,
     int32_t border, int32_t byte_alignment,
     AomCodecFrameBuffer *fb,
@@ -406,8 +406,8 @@ int32_t aom_realloc_frame_buffer(Yv12BufferConfig *ybf, int32_t width, int32_t h
         ybf->use_external_refernce_buffers = 0;
 
         //if (use_highbitdepth) {
-        //    if (ybf->y_buffer_8bit) aom_free(ybf->y_buffer_8bit);
-        //    ybf->y_buffer_8bit = (uint8_t *)aom_memalign(32, (size_t)yplane_size);
+        //    if (ybf->y_buffer_8bit) eb_aom_free(ybf->y_buffer_8bit);
+        //    ybf->y_buffer_8bit = (uint8_t *)eb_aom_memalign(32, (size_t)yplane_size);
         //    if (!ybf->y_buffer_8bit) return -1;
         //}
         //else {

--- a/Source/Lib/Common/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.c
@@ -20,11 +20,11 @@
 #include "EbPictureControlSet.h"
 #include "EbPictureBufferDesc.h"
 
-void *aom_memalign(size_t align, size_t size);
-void aom_free(void *memblk);
-void *aom_malloc(size_t size);
+void *eb_aom_memalign(size_t align, size_t size);
+void eb_aom_free(void *memblk);
+void *eb_aom_malloc(size_t size);
 
-EbErrorType av1_alloc_restoration_buffers(Av1Common *cm);
+EbErrorType eb_av1_alloc_restoration_buffers(Av1Common *cm);
 
 EbErrorType av1_hash_table_create(HashTable *p_hash_table);
 
@@ -993,8 +993,8 @@ EbErrorType picture_control_set_ctor(
 
     EB_CREATE_MUTEX(object_ptr->cdef_search_mutex);
 
-    //object_ptr->mse_seg[0] = (uint64_t(*)[64])aom_malloc(sizeof(**object_ptr->mse_seg) *  pictureLcuWidth * pictureLcuHeight);
-   // object_ptr->mse_seg[1] = (uint64_t(*)[64])aom_malloc(sizeof(**object_ptr->mse_seg) *  pictureLcuWidth * pictureLcuHeight);
+    //object_ptr->mse_seg[0] = (uint64_t(*)[64])eb_aom_malloc(sizeof(**object_ptr->mse_seg) *  pictureLcuWidth * pictureLcuHeight);
+   // object_ptr->mse_seg[1] = (uint64_t(*)[64])eb_aom_malloc(sizeof(**object_ptr->mse_seg) *  pictureLcuWidth * pictureLcuHeight);
 
     EB_MALLOC_ARRAY(object_ptr->mse_seg[0], pictureLcuWidth * pictureLcuHeight);
     EB_MALLOC_ARRAY(object_ptr->mse_seg[1], pictureLcuWidth * pictureLcuHeight);
@@ -1273,7 +1273,7 @@ EbErrorType picture_parent_control_set_ctor(
 
     set_restoration_unit_size(initDataPtr->picture_width, initDataPtr->picture_height, 1, 1, object_ptr->av1_cm->rst_info);
 
-    return_error = av1_alloc_restoration_buffers(object_ptr->av1_cm);
+    return_error = eb_av1_alloc_restoration_buffers(object_ptr->av1_cm);
 
     memset(&object_ptr->av1_cm->rst_frame, 0, sizeof(Yv12BufferConfig));
 

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -67,7 +67,8 @@ static INLINE int get_relative_dist(const OrderHintInfo *oh, int a, int b) {
     diff = (diff & (m - 1)) - (diff & m);
     return diff;
 }
-void av1_setup_skip_mode_allowed(PictureParentControlSet  *parent_pcs_ptr) {
+
+void eb_av1_setup_skip_mode_allowed(PictureParentControlSet  *parent_pcs_ptr) {
 
     FrameHeader *frm_hdr = &parent_pcs_ptr->frm_hdr;
 
@@ -3530,7 +3531,7 @@ void* picture_decision_kernel(void *input_ptr)
                                 }
                             }
 
-                            av1_setup_skip_mode_allowed(picture_control_set_ptr);
+                            eb_av1_setup_skip_mode_allowed(picture_control_set_ptr);
 
                             picture_control_set_ptr->is_skip_mode_allowed = frm_hdr->skip_mode_params.skip_mode_allowed;
                             picture_control_set_ptr->skip_mode_flag = picture_control_set_ptr->is_skip_mode_allowed;

--- a/Source/Lib/Common/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureManagerProcess.c
@@ -21,8 +21,8 @@
 #include "EbRateControlTasks.h"
 #include "EbSvtAv1ErrorCodes.h"
 
-void av1_tile_set_col(TileInfo *tile, PictureParentControlSet * pcs_ptr, int col);
-void av1_tile_set_row(TileInfo *tile, PictureParentControlSet * pcs_ptr, int row);
+void eb_av1_tile_set_col(TileInfo *tile, PictureParentControlSet * pcs_ptr, int col);
+void eb_av1_tile_set_row(TileInfo *tile, PictureParentControlSet * pcs_ptr, int row);
 void set_tile_info(PictureParentControlSet * pcs_ptr);
 #if ENABLE_CDF_UPDATE
 extern MvReferenceFrame svt_get_ref_frame_type(uint8_t list, uint8_t ref_idx);
@@ -710,11 +710,11 @@ void* picture_manager_kernel(void *input_ptr)
                         //Tile Loop
                         for (tile_row = 0; tile_row < tile_rows; tile_row++)
                         {
-                            av1_tile_set_row(&tile_info, ppcs_ptr, tile_row);
+                            eb_av1_tile_set_row(&tile_info, ppcs_ptr, tile_row);
 
                             for (tile_col = 0; tile_col < tile_cols; tile_col++)
                             {
-                                av1_tile_set_col(&tile_info, ppcs_ptr, tile_col);
+                                eb_av1_tile_set_col(&tile_info, ppcs_ptr, tile_col);
 
                                 for (y_lcu_index = cm->tiles_info.tile_row_start_sb[tile_row]; y_lcu_index < (uint32_t)cm->tiles_info.tile_row_start_sb[tile_row + 1]; ++y_lcu_index)
                                 {

--- a/Source/Lib/Common/Codec/EbPictureOperators.c
+++ b/Source/Lib/Common/Codec/EbPictureOperators.c
@@ -24,7 +24,7 @@
 #define VARIANCE_PRECISION      16
 #define MEAN_PRECISION      (VARIANCE_PRECISION >> 1)
 
-void *aom_memset16(void *dest, int32_t val, size_t length);
+void *eb_aom_memset16(void *dest, int32_t val, size_t length);
 
 /*********************************
  * x86 implememtation of Picture Addition
@@ -792,8 +792,8 @@ static void extend_plane_high(uint8_t *const src8, int32_t src_stride, int32_t w
     uint16_t *dst_ptr2 = src + width;
 
     for (i = 0; i < height; ++i) {
-        aom_memset16(dst_ptr1, src_ptr1[0], extend_left);
-        aom_memset16(dst_ptr2, src_ptr2[0], extend_right);
+        eb_aom_memset16(dst_ptr1, src_ptr1[0], extend_left);
+        eb_aom_memset16(dst_ptr2, src_ptr2[0], extend_right);
         src_ptr1 += src_stride;
         src_ptr2 += src_stride;
         dst_ptr1 += src_stride;
@@ -819,7 +819,7 @@ static void extend_plane_high(uint8_t *const src8, int32_t src_stride, int32_t w
     }
 }
 
-void aom_yv12_extend_frame_borders_c(Yv12BufferConfig *ybf,
+void eb_aom_yv12_extend_frame_borders_c(Yv12BufferConfig *ybf,
     const int32_t num_planes) {
     assert(ybf->border % 2 == 0);
     assert(ybf->y_height - ybf->y_crop_height < 16);
@@ -859,7 +859,7 @@ static void memcpy_short_addr(uint8_t *dst8, const uint8_t *src8, int32_t num) {
 // Copies the source image into the destination image and updates the
 // destination's UMV borders.
 // Note: The frames are assumed to be identical in size.
-void aom_yv12_copy_frame_c(const Yv12BufferConfig *src_bc,
+void eb_aom_yv12_copy_frame_c(const Yv12BufferConfig *src_bc,
     Yv12BufferConfig *dst_bc, const int32_t num_planes) {
     assert((src_bc->flags & YV12_FLAG_HIGHBITDEPTH) ==
         (dst_bc->flags & YV12_FLAG_HIGHBITDEPTH));
@@ -876,7 +876,7 @@ void aom_yv12_copy_frame_c(const Yv12BufferConfig *src_bc,
                 plane_dst += dst_bc->strides[is_uv];
             }
         }
-        aom_yv12_extend_frame_borders_c(dst_bc, num_planes);
+        eb_aom_yv12_extend_frame_borders_c(dst_bc, num_planes);
         return;
     }
     for (int32_t plane = 0; plane < num_planes; ++plane) {
@@ -890,10 +890,10 @@ void aom_yv12_copy_frame_c(const Yv12BufferConfig *src_bc,
             plane_dst += dst_bc->strides[is_uv];
         }
     }
-    aom_yv12_extend_frame_borders_c(dst_bc, num_planes);
+    eb_aom_yv12_extend_frame_borders_c(dst_bc, num_planes);
 }
 
-void aom_yv12_copy_y_c(const Yv12BufferConfig *src_ybc,
+void eb_aom_yv12_copy_y_c(const Yv12BufferConfig *src_ybc,
     Yv12BufferConfig *dst_ybc) {
     int32_t row;
     const uint8_t *src = src_ybc->y_buffer;
@@ -917,7 +917,7 @@ void aom_yv12_copy_y_c(const Yv12BufferConfig *src_ybc,
     }
 }
 
-void aom_yv12_copy_u_c(const Yv12BufferConfig *src_bc,
+void eb_aom_yv12_copy_u_c(const Yv12BufferConfig *src_bc,
     Yv12BufferConfig *dst_bc) {
     int32_t row;
     const uint8_t *src = src_bc->u_buffer;
@@ -941,7 +941,7 @@ void aom_yv12_copy_u_c(const Yv12BufferConfig *src_bc,
     }
 }
 
-void aom_yv12_copy_v_c(const Yv12BufferConfig *src_bc,
+void eb_aom_yv12_copy_v_c(const Yv12BufferConfig *src_bc,
     Yv12BufferConfig *dst_bc) {
     int32_t row;
     const uint8_t *src = src_bc->v_buffer;

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -53,7 +53,7 @@ EbErrorType ProductGenerateMdCandidatesCu(
 *
 *******************************************/
 
-const EbPredictionFunc  ProductPredictionFunTable[3] = { NULL, inter_pu_prediction_av1, av1_intra_prediction_cl};
+const EbPredictionFunc  ProductPredictionFunTable[3] = { NULL, inter_pu_prediction_av1, eb_av1_intra_prediction_cl};
 
 const EbFastCostFunc   Av1ProductFastCostFuncTable[3] =
 {
@@ -1755,7 +1755,7 @@ void AV1CostCalcCfl(
             CFL_BUF_SQUARE);
 
         if (!context_ptr->hbd_mode_decision) {
-            cfl_predict_lbd(
+            eb_cfl_predict_lbd(
                 context_ptr->pred_buf_q3,
                 &(candidateBuffer->prediction_ptr->buffer_cb[cuChromaOriginIndex]),
                 candidateBuffer->prediction_ptr->stride_cb,
@@ -1766,7 +1766,7 @@ void AV1CostCalcCfl(
                 chroma_width,
                 chroma_height);
         } else {
-            cfl_predict_hbd(
+            eb_cfl_predict_hbd(
                 context_ptr->pred_buf_q3,
                 ((uint16_t*)candidateBuffer->prediction_ptr->buffer_cb) + cuChromaOriginIndex,
                 candidateBuffer->prediction_ptr->stride_cb,
@@ -1840,7 +1840,7 @@ void AV1CostCalcCfl(
             CFL_BUF_SQUARE);
 
         if (!context_ptr->hbd_mode_decision) {
-            cfl_predict_lbd(
+            eb_cfl_predict_lbd(
                 context_ptr->pred_buf_q3,
                 &(candidateBuffer->prediction_ptr->buffer_cr[cuChromaOriginIndex]),
                 candidateBuffer->prediction_ptr->stride_cr,
@@ -1851,7 +1851,7 @@ void AV1CostCalcCfl(
                 chroma_width,
                 chroma_height);
         } else {
-            cfl_predict_hbd(
+            eb_cfl_predict_hbd(
                 context_ptr->pred_buf_q3,
                 ((uint16_t*)candidateBuffer->prediction_ptr->buffer_cr) + cuChromaOriginIndex,
                 candidateBuffer->prediction_ptr->stride_cr,
@@ -2125,7 +2125,7 @@ static void CflPrediction(
     }
     int32_t round_offset = chroma_width * chroma_height / 2;
 
-    subtract_average(
+    eb_subtract_average(
         context_ptr->pred_buf_q3,
         chroma_width,
         chroma_height,
@@ -2154,7 +2154,7 @@ static void CflPrediction(
             CFL_BUF_SQUARE);
 
         if (!context_ptr->hbd_mode_decision) {
-            cfl_predict_lbd(
+            eb_cfl_predict_lbd(
                 context_ptr->pred_buf_q3,
                 &(candidateBuffer->prediction_ptr->buffer_cb[cuChromaOriginIndex]),
                 candidateBuffer->prediction_ptr->stride_cb,
@@ -2165,7 +2165,7 @@ static void CflPrediction(
                 chroma_width,
                 chroma_height);
 
-            cfl_predict_lbd(
+            eb_cfl_predict_lbd(
                 context_ptr->pred_buf_q3,
                 &(candidateBuffer->prediction_ptr->buffer_cr[cuChromaOriginIndex]),
                 candidateBuffer->prediction_ptr->stride_cr,
@@ -2176,7 +2176,7 @@ static void CflPrediction(
                 chroma_width,
                 chroma_height);
         } else {
-            cfl_predict_hbd(
+            eb_cfl_predict_hbd(
                 context_ptr->pred_buf_q3,
                 ((uint16_t*)candidateBuffer->prediction_ptr->buffer_cb) + cuChromaOriginIndex,
                 candidateBuffer->prediction_ptr->stride_cb,
@@ -2187,7 +2187,7 @@ static void CflPrediction(
                 chroma_width,
                 chroma_height);
 
-            cfl_predict_hbd(
+            eb_cfl_predict_hbd(
                 context_ptr->pred_buf_q3,
                 ((uint16_t*)candidateBuffer->prediction_ptr->buffer_cr) + cuChromaOriginIndex,
                 candidateBuffer->prediction_ptr->stride_cr,
@@ -2539,7 +2539,7 @@ EbErrorType av1_intra_luma_prediction(
             topNeighArray[0] = leftNeighArray[0] = md_context_ptr->tx_search_luma_recon_neighbor_array->top_left_array[MAX_PICTURE_HEIGHT_SIZE + txb_origin_x - txb_origin_y];
 
         mode = candidate_buffer_ptr->candidate_ptr->pred_mode;
-        av1_predict_intra_block(
+        eb_av1_predict_intra_block(
             &md_context_ptr->sb_ptr->tile_info,
             MD_STAGE,
             md_context_ptr->blk_geom,
@@ -2577,7 +2577,7 @@ EbErrorType av1_intra_luma_prediction(
             topNeighArray[0] = leftNeighArray[0] = ((uint16_t*)(md_context_ptr->tx_search_luma_recon_neighbor_array16bit->top_left_array) + MAX_PICTURE_HEIGHT_SIZE + txb_origin_x - txb_origin_y)[0];
 
         mode = candidate_buffer_ptr->candidate_ptr->pred_mode;
-        av1_predict_intra_block_16bit(
+        eb_av1_predict_intra_block_16bit(
             &md_context_ptr->sb_ptr->tile_info,
             MD_STAGE,
             md_context_ptr->blk_geom,

--- a/Source/Lib/Common/Codec/EbPsnr.c
+++ b/Source/Lib/Common/Codec/EbPsnr.c
@@ -16,7 +16,7 @@
 #include "EbPictureBufferDesc.h"
 #include "aom_dsp_rtcd.h"
 
-double aom_sse_to_psnr(double samples, double peak, double sse) {
+double eb_aom_sse_to_psnr(double samples, double peak, double sse) {
     if (sse > 0.0) {
         const double psnr = 10.0 * log10(samples * peak * peak / sse);
         return psnr > MAX_PSNR ? MAX_PSNR : psnr;
@@ -86,7 +86,7 @@ static void variance(const uint8_t *a, int32_t a_stride, const uint8_t *b,
     }
 }
 
-uint32_t aom_mse16x16_c(const uint8_t *src_ptr, int32_t  source_stride,
+uint32_t eb_aom_mse16x16_c(const uint8_t *src_ptr, int32_t  source_stride,
     const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse){
     int32_t sum;
     variance(src_ptr, source_stride, ref_ptr, recon_stride,16, 16, sse, &sum);
@@ -117,7 +117,7 @@ static int64_t get_sse(const uint8_t *a, int32_t a_stride, const uint8_t *b,
         const uint8_t *pa = a;
         const uint8_t *pb = b;
         for (x = 0; x < width / 16; ++x) {
-            aom_mse16x16(pa, a_stride, pb, b_stride, &sse);
+            eb_aom_mse16x16(pa, a_stride, pb, b_stride, &sse);
 
             total_sse += sse;
 
@@ -154,7 +154,7 @@ static int64_t highbd_get_sse(const uint8_t *a, int32_t a_stride, const uint8_t 
         const uint8_t *pa = a;
         const uint8_t *pb = b;
         for (x = 0; x < width / 16; ++x) {
-            aom_highbd_8_mse16x16(pa, a_stride, pb, b_stride, &sse);
+            eb_aom_highbd_8_mse16x16(pa, a_stride, pb, b_stride, &sse);
 
             total_sse += sse;
             pa += 16;
@@ -166,7 +166,7 @@ static int64_t highbd_get_sse(const uint8_t *a, int32_t a_stride, const uint8_t 
     return total_sse;
 }
 
-int64_t aom_get_y_sse_part(const Yv12BufferConfig *a,
+int64_t eb_aom_get_y_sse_part(const Yv12BufferConfig *a,
     const Yv12BufferConfig *b, int32_t hstart, int32_t width,
     int32_t vstart, int32_t height) {
     return get_sse(a->y_buffer + vstart * a->y_stride + hstart, a->y_stride,
@@ -174,7 +174,7 @@ int64_t aom_get_y_sse_part(const Yv12BufferConfig *a,
         width, height);
 }
 
-int64_t aom_get_y_sse(const Yv12BufferConfig *a,
+int64_t eb_aom_get_y_sse(const Yv12BufferConfig *a,
     const Yv12BufferConfig *b) {
     assert(a->y_crop_width == b->y_crop_width);
     assert(a->y_crop_height == b->y_crop_height);
@@ -183,7 +183,7 @@ int64_t aom_get_y_sse(const Yv12BufferConfig *a,
         a->y_crop_width, a->y_crop_height);
 }
 
-int64_t aom_get_u_sse_part(const Yv12BufferConfig *a,
+int64_t eb_aom_get_u_sse_part(const Yv12BufferConfig *a,
     const Yv12BufferConfig *b, int32_t hstart, int32_t width,
     int32_t vstart, int32_t height) {
     return get_sse(a->u_buffer + vstart * a->uv_stride + hstart, a->uv_stride,
@@ -191,7 +191,7 @@ int64_t aom_get_u_sse_part(const Yv12BufferConfig *a,
         width, height);
 }
 
-int64_t aom_get_u_sse(const Yv12BufferConfig *a,
+int64_t eb_aom_get_u_sse(const Yv12BufferConfig *a,
     const Yv12BufferConfig *b) {
     assert(a->uv_crop_width == b->uv_crop_width);
     assert(a->uv_crop_height == b->uv_crop_height);
@@ -200,7 +200,7 @@ int64_t aom_get_u_sse(const Yv12BufferConfig *a,
         a->uv_crop_width, a->uv_crop_height);
 }
 
-int64_t aom_get_v_sse_part(const Yv12BufferConfig *a,
+int64_t eb_aom_get_v_sse_part(const Yv12BufferConfig *a,
     const Yv12BufferConfig *b, int32_t hstart, int32_t width,
     int32_t vstart, int32_t height) {
     return get_sse(a->v_buffer + vstart * a->uv_stride + hstart, a->uv_stride,
@@ -208,7 +208,7 @@ int64_t aom_get_v_sse_part(const Yv12BufferConfig *a,
         width, height);
 }
 
-int64_t aom_get_v_sse(const Yv12BufferConfig *a,
+int64_t eb_aom_get_v_sse(const Yv12BufferConfig *a,
     const Yv12BufferConfig *b) {
     assert(a->uv_crop_width == b->uv_crop_width);
     assert(a->uv_crop_height == b->uv_crop_height);
@@ -217,7 +217,7 @@ int64_t aom_get_v_sse(const Yv12BufferConfig *a,
         a->uv_crop_width, a->uv_crop_height);
 }
 
-int64_t aom_highbd_get_y_sse_part(const Yv12BufferConfig *a,
+int64_t eb_aom_highbd_get_y_sse_part(const Yv12BufferConfig *a,
     const Yv12BufferConfig *b, int32_t hstart,
     int32_t width, int32_t vstart, int32_t height) {
     return highbd_get_sse(
@@ -225,7 +225,7 @@ int64_t aom_highbd_get_y_sse_part(const Yv12BufferConfig *a,
         b->y_buffer + vstart * b->y_stride + hstart, b->y_stride, width, height);
 }
 
-int64_t aom_highbd_get_y_sse(const Yv12BufferConfig *a,
+int64_t eb_aom_highbd_get_y_sse(const Yv12BufferConfig *a,
     const Yv12BufferConfig *b) {
     assert(a->y_crop_width == b->y_crop_width);
     assert(a->y_crop_height == b->y_crop_height);
@@ -236,7 +236,7 @@ int64_t aom_highbd_get_y_sse(const Yv12BufferConfig *a,
         a->y_crop_width, a->y_crop_height);
 }
 
-int64_t aom_highbd_get_u_sse_part(const Yv12BufferConfig *a,
+int64_t eb_aom_highbd_get_u_sse_part(const Yv12BufferConfig *a,
     const Yv12BufferConfig *b, int32_t hstart,
     int32_t width, int32_t vstart, int32_t height) {
     return highbd_get_sse(a->u_buffer + vstart * a->uv_stride + hstart,
@@ -245,7 +245,7 @@ int64_t aom_highbd_get_u_sse_part(const Yv12BufferConfig *a,
         b->uv_stride, width, height);
 }
 
-int64_t aom_highbd_get_u_sse(const Yv12BufferConfig *a,
+int64_t eb_aom_highbd_get_u_sse(const Yv12BufferConfig *a,
     const Yv12BufferConfig *b) {
     assert(a->uv_crop_width == b->uv_crop_width);
     assert(a->uv_crop_height == b->uv_crop_height);
@@ -256,7 +256,7 @@ int64_t aom_highbd_get_u_sse(const Yv12BufferConfig *a,
         a->uv_crop_width, a->uv_crop_height);
 }
 
-int64_t aom_highbd_get_v_sse_part(const Yv12BufferConfig *a,
+int64_t eb_aom_highbd_get_v_sse_part(const Yv12BufferConfig *a,
     const Yv12BufferConfig *b, int32_t hstart,
     int32_t width, int32_t vstart, int32_t height) {
     return highbd_get_sse(a->v_buffer + vstart * a->uv_stride + hstart,
@@ -265,7 +265,7 @@ int64_t aom_highbd_get_v_sse_part(const Yv12BufferConfig *a,
         b->uv_stride, width, height);
 }
 
-int64_t aom_highbd_get_v_sse(const Yv12BufferConfig *a,
+int64_t eb_aom_highbd_get_v_sse(const Yv12BufferConfig *a,
     const Yv12BufferConfig *b) {
     assert(a->uv_crop_width == b->uv_crop_width);
     assert(a->uv_crop_height == b->uv_crop_height);

--- a/Source/Lib/Common/Codec/EbPsnr.h
+++ b/Source/Lib/Common/Codec/EbPsnr.h
@@ -37,12 +37,12 @@ extern "C" {
      * \param[in]    peak          Max sample value
      * \param[in]    sse           Sum of squared errors
      */
-    double aom_sse_to_psnr(
+    double eb_aom_sse_to_psnr(
         double samples,
         double peak,
         double sse);
 
-    int64_t aom_get_y_sse_part(
+    int64_t eb_aom_get_y_sse_part(
         const Yv12BufferConfig *a,
         const Yv12BufferConfig *b,
         int32_t hstart,
@@ -50,11 +50,11 @@ extern "C" {
         int32_t vstart,
         int32_t height);
 
-    int64_t aom_get_y_sse(
+    int64_t eb_aom_get_y_sse(
         const Yv12BufferConfig *a,
         const Yv12BufferConfig *b);
 
-    int64_t aom_get_u_sse_part(
+    int64_t eb_aom_get_u_sse_part(
         const Yv12BufferConfig *a,
         const Yv12BufferConfig *b,
         int32_t hstart,
@@ -62,11 +62,11 @@ extern "C" {
         int32_t vstart,
         int32_t height);
 
-    int64_t aom_get_u_sse(
+    int64_t eb_aom_get_u_sse(
         const Yv12BufferConfig *a,
         const Yv12BufferConfig *b);
 
-    int64_t aom_get_v_sse_part(
+    int64_t eb_aom_get_v_sse_part(
         const Yv12BufferConfig *a,
         const Yv12BufferConfig *b,
         int32_t hstart,
@@ -74,11 +74,11 @@ extern "C" {
         int32_t vstart,
         int32_t height);
 
-    int64_t aom_get_v_sse(
+    int64_t eb_aom_get_v_sse(
         const Yv12BufferConfig *a,
         const Yv12BufferConfig *b);
 
-    int64_t aom_highbd_get_y_sse_part(
+    int64_t eb_aom_highbd_get_y_sse_part(
         const Yv12BufferConfig *a,
         const Yv12BufferConfig *b,
         int32_t hstart,
@@ -86,11 +86,11 @@ extern "C" {
         int32_t vstart,
         int32_t height);
 
-    int64_t aom_highbd_get_y_sse(
+    int64_t eb_aom_highbd_get_y_sse(
         const Yv12BufferConfig *a,
         const Yv12BufferConfig *b);
 
-    int64_t aom_highbd_get_u_sse_part(
+    int64_t eb_aom_highbd_get_u_sse_part(
         const Yv12BufferConfig *a,
         const Yv12BufferConfig *b,
         int32_t hstart,
@@ -98,11 +98,11 @@ extern "C" {
         int32_t vstart,
         int32_t height);
 
-    int64_t aom_highbd_get_u_sse(
+    int64_t eb_aom_highbd_get_u_sse(
         const Yv12BufferConfig *a,
         const Yv12BufferConfig *b);
 
-    int64_t aom_highbd_get_v_sse_part(
+    int64_t eb_aom_highbd_get_v_sse_part(
         const Yv12BufferConfig *a,
         const Yv12BufferConfig *b,
         int32_t hstart,
@@ -110,7 +110,7 @@ extern "C" {
         int32_t vstart,
         int32_t height);
 
-    int64_t aom_highbd_get_v_sse(
+    int64_t eb_aom_highbd_get_v_sse(
         const Yv12BufferConfig *a,
         const Yv12BufferConfig *b);
 

--- a/Source/Lib/Common/Codec/EbRateDistortionCost.h
+++ b/Source/Lib/Common/Codec/EbRateDistortionCost.h
@@ -20,7 +20,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-    extern uint64_t av1_cost_coeffs_txb(
+    extern uint64_t eb_av1_cost_coeffs_txb(
         uint8_t                             allow_update_cdf,
         FRAME_CONTEXT                      *ec_ctx,
         struct ModeDecisionCandidateBuffer *candidate_buffer_ptr,

--- a/Source/Lib/Common/Codec/EbRestProcess.c
+++ b/Source/Lib/Common/Codec/EbRestProcess.c
@@ -26,7 +26,7 @@
 void ReconOutput(
     PictureControlSet    *picture_control_set_ptr,
     SequenceControlSet   *sequence_control_set_ptr);
-void av1_loop_restoration_filter_frame(Yv12BufferConfig *frame,
+void eb_av1_loop_restoration_filter_frame(Yv12BufferConfig *frame,
     Av1Common *cm, int32_t optimized_lr);
 void CopyStatisticsToRefObject(
     PictureControlSet    *picture_control_set_ptr,
@@ -275,7 +275,7 @@ void* rest_kernel(void *input_ptr)
                     cm->rst_info[1].frame_restoration_type != RESTORE_NONE ||
                     cm->rst_info[2].frame_restoration_type != RESTORE_NONE)
                 {
-                    av1_loop_restoration_filter_frame(
+                    eb_av1_loop_restoration_filter_frame(
                         cm->frame_to_show,
                         cm,
                         0);

--- a/Source/Lib/Common/Codec/EbRestoration.c
+++ b/Source/Lib/Common/Codec/EbRestoration.c
@@ -21,11 +21,11 @@ void av1_foreach_rest_unit_in_frame(Av1Common *cm, int32_t plane,
     RestUnitVisitor on_rest_unit,
     void *priv);
 
-void aom_yv12_copy_y_c(const Yv12BufferConfig *src_ybc, Yv12BufferConfig *dst_ybc);
-void aom_yv12_copy_u_c(const Yv12BufferConfig *src_bc, Yv12BufferConfig *dst_bc);
-void aom_yv12_copy_v_c(const Yv12BufferConfig *src_bc, Yv12BufferConfig *dst_bc);
+void eb_aom_yv12_copy_y_c(const Yv12BufferConfig *src_ybc, Yv12BufferConfig *dst_ybc);
+void eb_aom_yv12_copy_u_c(const Yv12BufferConfig *src_bc, Yv12BufferConfig *dst_bc);
+void eb_aom_yv12_copy_v_c(const Yv12BufferConfig *src_bc, Yv12BufferConfig *dst_bc);
 
-int32_t aom_realloc_frame_buffer(Yv12BufferConfig *ybf, int32_t width, int32_t height,
+int32_t eb_aom_realloc_frame_buffer(Yv12BufferConfig *ybf, int32_t width, int32_t height,
     int32_t ss_x, int32_t ss_y, int32_t use_highbitdepth,
     int32_t border, int32_t byte_alignment,
     AomCodecFrameBuffer *fb,
@@ -60,7 +60,7 @@ typedef uint32_t InterpFilters;
 InterpFilterParams av1_get_interp_filter_params_with_block_size(
     const InterpFilter interp_filter, const int32_t w);
 
-void *aom_memset16(void *dest, int32_t val, size_t length);
+void *eb_aom_memset16(void *dest, int32_t val, size_t length);
 
 ///---convolve.h
 #define FILTER_BITS 7
@@ -128,14 +128,14 @@ static INLINE ConvolveParams get_conv_params_wiener(int32_t bd) {
     return conv_params;
 }
 
-void av1_wiener_convolve_add_src_c(const uint8_t *src, ptrdiff_t src_stride,
+void eb_av1_wiener_convolve_add_src_c(const uint8_t *src, ptrdiff_t src_stride,
     uint8_t *dst, ptrdiff_t dst_stride,
     const int16_t *filter_x, int32_t x_step_q4,
     const int16_t *filter_y, int32_t y_step_q4,
     int32_t w, int32_t h,
     const ConvolveParams *conv_params);
 
-void av1_highbd_wiener_convolve_add_src_c(
+void eb_av1_highbd_wiener_convolve_add_src_c(
     const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst,
     ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4,
     const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h,
@@ -149,13 +149,13 @@ static INLINE int32_t av1_superres_unscaled(const Av1Common *cm) {
     return (cm->frm_size.frame_width == cm->frm_size.superres_upscaled_width);
 }
 
-void *aom_memalign(size_t align, size_t size);
-void aom_free(void *memblk);
+void *eb_aom_memalign(size_t align, size_t size);
+void eb_aom_free(void *memblk);
 
 // The 's' values are calculated based on original 'r' and 'e' values in the
 // spec using GenSgrprojVtable().
 // Note: Setting r = 0 skips the filter; with corresponding s = -1 (invalid).
-const SgrParamsType sgr_params[SGRPROJ_PARAMS] = {
+const SgrParamsType eb_sgr_params[SGRPROJ_PARAMS] = {
   { { 2, 1 }, { 140, 3236 } }, { { 2, 1 }, { 112, 2158 } },
   { { 2, 1 }, { 93, 1618 } },  { { 2, 1 }, { 80, 1438 } },
   { { 2, 1 }, { 70, 1295 } },  { { 2, 1 }, { 58, 1177 } },
@@ -190,7 +190,7 @@ static int32_t count_units_in_tile(int32_t unit_size, int32_t tile_size) {
     return AOMMAX((tile_size + (unit_size >> 1)) / unit_size, 1);
 }
 
-EbErrorType av1_alloc_restoration_struct(struct Av1Common *cm, RestorationInfo *rsi,
+EbErrorType eb_av1_alloc_restoration_struct(struct Av1Common *cm, RestorationInfo *rsi,
     int32_t is_uv) {
     // We need to allocate enough space for restoration units to cover the
     // largest tile. Without CONFIG_MAX_TILE, this is always the tile at the
@@ -262,7 +262,7 @@ static void extend_frame_highbd(uint16_t *data, int32_t width, int32_t height,
     }
 }
 
-void extend_frame(uint8_t *data, int32_t width, int32_t height, int32_t stride,
+void eb_extend_frame(uint8_t *data, int32_t width, int32_t height, int32_t stride,
     int32_t border_horz, int32_t border_vert, int32_t highbd) {
     if (highbd)
         extend_frame_highbd(CONVERT_TO_SHORTPTR(data), width, height, stride,
@@ -301,7 +301,7 @@ static void copy_tile(int32_t width, int32_t height, const uint8_t *src, int32_t
 // rules:
 //
 // * At a frame boundary, we copy the outermost row of CDEF pixels three times.
-//   This extension is done by a call to extend_frame() at the start of the loop
+//   This extension is done by a call to eb_extend_frame() at the start of the loop
 //   restoration process, so the value of copy_above/copy_below doesn't strictly
 //   matter.
 //   However, by setting *copy_above = *copy_below = 1 whenever loop filtering
@@ -326,7 +326,7 @@ static void copy_tile(int32_t width, int32_t height, const uint8_t *src, int32_t
 //   take 2 rows of deblocked pixels and extend them to 3 rows of context.
 //
 // The distinction between the latter two cases is handled by the
-// av1_loop_restoration_save_boundary_lines() function, so here we just need
+// eb_av1_loop_restoration_save_boundary_lines() function, so here we just need
 // to decide if we're overwriting the above/below boundary pixels or not.
 static void get_stripe_boundary_info(const RestorationTileLimits *limits,
     const AV1PixelRect *tile_rect, int32_t ss_y,
@@ -532,7 +532,7 @@ static void wiener_filter_stripe(const RestorationUnitInfo *rui,
         int32_t w = AOMMIN(procunit_width, (stripe_width - j + 15) & ~15);
         const uint8_t *src_p = src + j;
         uint8_t *dst_p = dst + j;//CHKN  SSE
-        av1_wiener_convolve_add_src(
+        eb_av1_wiener_convolve_add_src(
             src_p, src_stride, dst_p, dst_stride, rui->wiener_info.hfilter, 16,
             rui->wiener_info.vfilter, 16, w, stripe_height, &conv_params);
     }
@@ -713,7 +713,7 @@ static void boxsum(int32_t *src, int32_t width, int32_t height, int32_t src_stri
         assert(0 && "Invalid value of r in self-guided filter");
 }
 
-void decode_xq(const int32_t *xqd, int32_t *xq, const SgrParamsType *params) {
+void eb_decode_xq(const int32_t *xqd, int32_t *xq, const SgrParamsType *params) {
     if (params->r[0] == 0) {
         xq[0] = 0;
         xq[1] = (1 << SGRPROJ_PRJ_BITS) - xqd[1];
@@ -728,7 +728,7 @@ void decode_xq(const int32_t *xqd, int32_t *xq, const SgrParamsType *params) {
     }
 }
 
-const int32_t x_by_xplus1[256] = {
+const int32_t eb_x_by_xplus1[256] = {
     // Special case: Map 0 -> 1 (corresponding to a value of 1/256)
     // instead of 0. See comments in selfguided_restoration_internal() for why
     1,   128, 171, 192, 205, 213, 219, 224, 228, 230, 233, 235, 236, 238, 239,
@@ -751,7 +751,7 @@ const int32_t x_by_xplus1[256] = {
     256,
 };
 
-const int32_t one_by_x[MAX_NELEM] = {
+const int32_t eb_one_by_x[MAX_NELEM] = {
   4096, 2048, 1365, 1024, 819, 683, 585, 512, 455, 410, 372, 341, 315,
   293,  273,  256,  241,  228, 216, 205, 195, 186, 178, 171, 164,
 };
@@ -760,7 +760,7 @@ static void selfguided_restoration_fast_internal(
     int32_t *dgd, int32_t width, int32_t height, int32_t dgd_stride, int32_t *dst,
     int32_t dst_stride, int32_t bit_depth, int32_t sgr_params_idx, int32_t radius_idx)
 {
-    const SgrParamsType *const params = &sgr_params[sgr_params_idx];
+    const SgrParamsType *const params = &eb_sgr_params[sgr_params_idx];
     const int32_t r = params->r[radius_idx];
     const int32_t width_ext = width + 2 * SGRPROJ_BORDER_HORZ;
     const int32_t height_ext = height + 2 * SGRPROJ_BORDER_VERT;
@@ -824,7 +824,7 @@ static void selfguided_restoration_fast_internal(
             // Further, in the calculation of B[k] below, if z == 0 and r == 2,
             // then A[k] "should be" 0. But then we can end up setting B[k] to a value
             // slightly above 2^(8 + bit depth), due to rounding in the value of
-            // one_by_x[25-1].
+            // eb_one_by_x[25-1].
             //
             // Thus we saturate so that, when z == 0, A[k] is set to 1 instead of 0.
             // This fixes the above issues (256 - A[k] fits in a uint8, and we can't
@@ -836,17 +836,17 @@ static void selfguided_restoration_fast_internal(
             // would be a bad idea, as that corresponds to the case where the image
             // is very variable, when we want to preserve the local pixel value as
             // much as possible.
-            A[k] = x_by_xplus1[AOMMIN(z, 255)];  // in range [1, 256]
+            A[k] = eb_x_by_xplus1[AOMMIN(z, 255)];  // in range [1, 256]
 
             // SGRPROJ_SGR - A[k] < 2^8 (from above), B[k] < 2^(bit_depth) * n,
-            // one_by_x[n - 1] = round(2^12 / n)
+            // eb_one_by_x[n - 1] = round(2^12 / n)
             // => the product here is < 2^(20 + bit_depth) <= 2^32,
             // and B[k] is set to a value < 2^(8 + bit depth)
-            // This holds even with the rounding in one_by_x and in the overall
+            // This holds even with the rounding in eb_one_by_x and in the overall
             // result, as long as SGRPROJ_SGR - A[k] is strictly less than 2^8.
             B[k] = (int32_t)ROUND_POWER_OF_TWO((uint32_t)(SGRPROJ_SGR - A[k]) *
                 (uint32_t)B[k] *
-                (uint32_t)one_by_x[n - 1],
+                (uint32_t)eb_one_by_x[n - 1],
                 SGRPROJ_RECIP_BITS);
         }
     }
@@ -893,7 +893,7 @@ static void selfguided_restoration_internal(int32_t *dgd, int32_t width, int32_t
     int32_t dst_stride, int32_t bit_depth,
     int32_t sgr_params_idx,
     int32_t radius_idx) {
-    const SgrParamsType *const params = &sgr_params[sgr_params_idx];
+    const SgrParamsType *const params = &eb_sgr_params[sgr_params_idx];
     const int32_t r = params->r[radius_idx];
     const int32_t width_ext = width + 2 * SGRPROJ_BORDER_HORZ;
     const int32_t height_ext = height + 2 * SGRPROJ_BORDER_VERT;
@@ -957,7 +957,7 @@ static void selfguided_restoration_internal(int32_t *dgd, int32_t width, int32_t
             // Further, in the calculation of B[k] below, if z == 0 and r == 2,
             // then A[k] "should be" 0. But then we can end up setting B[k] to a value
             // slightly above 2^(8 + bit depth), due to rounding in the value of
-            // one_by_x[25-1].
+            // eb_one_by_x[25-1].
             //
             // Thus we saturate so that, when z == 0, A[k] is set to 1 instead of 0.
             // This fixes the above issues (256 - A[k] fits in a uint8, and we can't
@@ -969,17 +969,17 @@ static void selfguided_restoration_internal(int32_t *dgd, int32_t width, int32_t
             // would be a bad idea, as that corresponds to the case where the image
             // is very variable, when we want to preserve the local pixel value as
             // much as possible.
-            A[k] = x_by_xplus1[AOMMIN(z, 255)];  // in range [1, 256]
+            A[k] = eb_x_by_xplus1[AOMMIN(z, 255)];  // in range [1, 256]
 
             // SGRPROJ_SGR - A[k] < 2^8 (from above), B[k] < 2^(bit_depth) * n,
-            // one_by_x[n - 1] = round(2^12 / n)
+            // eb_one_by_x[n - 1] = round(2^12 / n)
             // => the product here is < 2^(20 + bit_depth) <= 2^32,
             // and B[k] is set to a value < 2^(8 + bit depth)
-            // This holds even with the rounding in one_by_x and in the overall
+            // This holds even with the rounding in eb_one_by_x and in the overall
             // result, as long as SGRPROJ_SGR - A[k] is strictly less than 2^8.
             B[k] = (int32_t)ROUND_POWER_OF_TWO((uint32_t)(SGRPROJ_SGR - A[k]) *
                 (uint32_t)B[k] *
-                (uint32_t)one_by_x[n - 1],
+                (uint32_t)eb_one_by_x[n - 1],
                 SGRPROJ_RECIP_BITS);
         }
     }
@@ -1008,7 +1008,7 @@ static void selfguided_restoration_internal(int32_t *dgd, int32_t width, int32_t
     }
 }
 
-void av1_selfguided_restoration_c(const uint8_t *dgd8, int32_t width, int32_t height,
+void eb_av1_selfguided_restoration_c(const uint8_t *dgd8, int32_t width, int32_t height,
     int32_t dgd_stride, int32_t *flt0, int32_t *flt1,
     int32_t flt_stride, int32_t sgr_params_idx,
     int32_t bit_depth, int32_t highbd) {
@@ -1031,7 +1031,7 @@ void av1_selfguided_restoration_c(const uint8_t *dgd8, int32_t width, int32_t he
         }
     }
 
-    const SgrParamsType *const params = &sgr_params[sgr_params_idx];
+    const SgrParamsType *const params = &eb_sgr_params[sgr_params_idx];
     // If params->r == 0 we skip the corresponding filter. We only allow one of
     // the radii to be 0, as having both equal to 0 would be equivalent to
     // skipping SGR entirely.
@@ -1046,7 +1046,7 @@ void av1_selfguided_restoration_c(const uint8_t *dgd8, int32_t width, int32_t he
             flt_stride, bit_depth, sgr_params_idx, 1);
 }
 
-void apply_selfguided_restoration_c(const uint8_t *dat8, int32_t width, int32_t height,
+void eb_apply_selfguided_restoration_c(const uint8_t *dat8, int32_t width, int32_t height,
     int32_t stride, int32_t eps, const int32_t *xqd,
     uint8_t *dst8, int32_t dst_stride,
     int32_t *tmpbuf, int32_t bit_depth,
@@ -1055,11 +1055,11 @@ void apply_selfguided_restoration_c(const uint8_t *dat8, int32_t width, int32_t 
     int32_t *flt1 = flt0 + RESTORATION_UNITPELS_MAX;
     assert(width * height <= RESTORATION_UNITPELS_MAX);
 
-    av1_selfguided_restoration_c(dat8, width, height, stride, flt0, flt1, width,
+    eb_av1_selfguided_restoration_c(dat8, width, height, stride, flt0, flt1, width,
         eps, bit_depth, highbd);
-    const SgrParamsType *const params = &sgr_params[eps];
+    const SgrParamsType *const params = &eb_sgr_params[eps];
     int32_t xq[2];
-    decode_xq(xqd, xq, params);
+    eb_decode_xq(xqd, xq, params);
     for (int32_t i = 0; i < height; ++i) {
         for (int32_t j = 0; j < width; ++j) {
             const int32_t k = i * width + j;
@@ -1070,7 +1070,7 @@ void apply_selfguided_restoration_c(const uint8_t *dat8, int32_t width, int32_t 
             const int32_t u = (int32_t)pre_u << SGRPROJ_RST_BITS;
             int32_t v = u << SGRPROJ_PRJ_BITS;
             // If params->r == 0 then we skipped the filtering in
-            // av1_selfguided_restoration_c, i.e. flt[k] == u
+            // eb_av1_selfguided_restoration_c, i.e. flt[k] == u
             if (params->r[0] > 0) v += xq[0] * (flt0[k] - u);
             if (params->r[1] > 0) v += xq[1] * (flt1[k] - u);
             const int16_t w =
@@ -1096,7 +1096,7 @@ static void sgrproj_filter_stripe(const RestorationUnitInfo *rui,
     for (int32_t j = 0; j < stripe_width; j += procunit_width) {
         int32_t w = AOMMIN(procunit_width, stripe_width - j);
         //CHKN SSE
-        apply_selfguided_restoration(src + j, w, stripe_height, src_stride,
+        eb_apply_selfguided_restoration(src + j, w, stripe_height, src_stride,
             rui->sgrproj_info.ep, rui->sgrproj_info.xqd,
             dst + j, dst_stride, tmpbuf, bit_depth, 0);
     }
@@ -1115,7 +1115,7 @@ static void wiener_filter_stripe_highbd(const RestorationUnitInfo *rui,
         int32_t w = AOMMIN(procunit_width, (stripe_width - j + 15) & ~15);
         const uint8_t *src8_p = src8 + j;
         uint8_t *dst8_p = dst8 + j;
-        av1_highbd_wiener_convolve_add_src(src8_p, src_stride, dst8_p, dst_stride,  //CHKN  SSE
+        eb_av1_highbd_wiener_convolve_add_src(src8_p, src_stride, dst8_p, dst_stride,  //CHKN  SSE
             rui->wiener_info.hfilter, 16,
             rui->wiener_info.vfilter, 16, w,
             stripe_height, &conv_params, bit_depth);
@@ -1132,7 +1132,7 @@ static void sgrproj_filter_stripe_highbd(const RestorationUnitInfo *rui,
         int32_t w = AOMMIN(procunit_width, stripe_width - j);
 
         //CHKN SSE
-        apply_selfguided_restoration(src8 + j, w, stripe_height, src_stride,
+        eb_apply_selfguided_restoration(src8 + j, w, stripe_height, src_stride,
             rui->sgrproj_info.ep, rui->sgrproj_info.xqd,
             dst8 + j, dst_stride, tmpbuf, bit_depth, 1);
     }
@@ -1152,7 +1152,7 @@ static const stripe_filter_fun stripe_filters[NUM_STRIPE_FILTERS] = {
 };
 
 // Filter one restoration unit
-void av1_loop_restoration_filter_unit(
+void eb_av1_loop_restoration_filter_unit(
     uint8_t need_bounadaries,
     const RestorationTileLimits *limits, const RestorationUnitInfo *rui,
     const RestorationStripeBoundaries *rsb, RestorationLineBuffers *rlbs,
@@ -1247,7 +1247,7 @@ static void filter_frame_on_unit(const RestorationTileLimits *limits,
     FilterFrameCtxt *ctxt = (FilterFrameCtxt *)priv;
     const RestorationInfo *rsi = ctxt->rsi;
 
-    av1_loop_restoration_filter_unit(
+    eb_av1_loop_restoration_filter_unit(
         1,
         limits, &rsi->unit_info[rest_unit_idx], &rsi->boundaries, ctxt->rlbs,
         tile_rect, ctxt->tile_stripe0, ctxt->ss_x, ctxt->ss_y, ctxt->highbd,
@@ -1255,19 +1255,19 @@ static void filter_frame_on_unit(const RestorationTileLimits *limits,
         ctxt->dst_stride, ctxt->tmpbuf, rsi->optimized_lr);
 }
 
-void av1_loop_restoration_filter_frame(Yv12BufferConfig *frame,
+void eb_av1_loop_restoration_filter_frame(Yv12BufferConfig *frame,
     Av1Common *cm, int32_t optimized_lr) {
     // assert(!cm->all_lossless);
     const int32_t num_planes = 3;// av1_num_planes(cm);
     typedef void(*copy_fun)(const Yv12BufferConfig *src,
         Yv12BufferConfig *dst);
-    static const copy_fun copy_funs[3] = { aom_yv12_copy_y_c, aom_yv12_copy_u_c, aom_yv12_copy_v_c };//CHKN SSE
+    static const copy_fun copy_funs[3] = { eb_aom_yv12_copy_y_c, eb_aom_yv12_copy_u_c, eb_aom_yv12_copy_v_c };//CHKN SSE
 
     Yv12BufferConfig *dst = &cm->rst_frame;
 
     const int32_t frame_width = frame->crop_widths[0];
     const int32_t frame_height = frame->crop_heights[0];
-    if (aom_realloc_frame_buffer(dst, frame_width, frame_height,
+    if (eb_aom_realloc_frame_buffer(dst, frame_width, frame_height,
         cm->subsampling_x, cm->subsampling_y,
         cm->use_highbitdepth, AOM_BORDER_IN_PIXELS,
         cm->byte_alignment, NULL, NULL, NULL) < 0)
@@ -1288,7 +1288,7 @@ void av1_loop_restoration_filter_frame(Yv12BufferConfig *frame,
         const int32_t plane_width = frame->crop_widths[is_uv];
         const int32_t plane_height = frame->crop_heights[is_uv];
 
-        extend_frame(frame->buffers[plane], plane_width, plane_height,
+        eb_extend_frame(frame->buffers[plane], plane_width, plane_height,
             frame->strides[is_uv], RESTORATION_BORDER, RESTORATION_BORDER,
             highbd);
 
@@ -1472,7 +1472,7 @@ void av1_foreach_rest_unit_in_frame_seg(Av1Common *cm, int32_t plane,
         segment_index);
 }
 
-int32_t av1_loop_restoration_corners_in_sb(Av1Common *cm, int32_t plane,
+int32_t eb_av1_loop_restoration_corners_in_sb(Av1Common *cm, int32_t plane,
     int32_t mi_row, int32_t mi_col, BlockSize bsize,
     int32_t *rcol0, int32_t *rcol1, int32_t *rrow0,
     int32_t *rrow1, int32_t *tile_tl_idx) {
@@ -1555,8 +1555,8 @@ static void extend_lines(uint8_t *buf, int32_t width, int32_t height, int32_t st
     for (int32_t i = 0; i < height; ++i) {
         if (use_highbitdepth) {
             uint16_t *buf16 = (uint16_t *)buf;
-            aom_memset16(buf16 - extend, buf16[0], extend);
-            aom_memset16(buf16 + width, buf16[width - 1], extend);
+            eb_aom_memset16(buf16 - extend, buf16[0], extend);
+            eb_aom_memset16(buf16 + width, buf16[width - 1], extend);
         }
         else {
             memset(buf - extend, buf[0], extend);
@@ -1713,7 +1713,7 @@ static void save_tile_row_boundary_lines(const Yv12BufferConfig *frame,
 // For each RESTORATION_PROC_UNIT_SIZE pixel high stripe, save 4 scan
 // lines to be used as boundary in the loop restoration process. The
 // lines are saved in rst_internal.stripe_boundary_lines
-void av1_loop_restoration_save_boundary_lines(const Yv12BufferConfig *frame,
+void eb_av1_loop_restoration_save_boundary_lines(const Yv12BufferConfig *frame,
     Av1Common *cm, int32_t after_cdef) {
     const int32_t num_planes = 3;// av1_num_planes(cm);
     const int32_t use_highbd = cm->use_highbitdepth;
@@ -1723,16 +1723,16 @@ void av1_loop_restoration_save_boundary_lines(const Yv12BufferConfig *frame,
 
 // Assumes cm->rst_info[p].restoration_unit_size is already initialized
 
-EbErrorType av1_alloc_restoration_buffers(Av1Common *cm) {
+EbErrorType eb_av1_alloc_restoration_buffers(Av1Common *cm) {
     EbErrorType return_error = EB_ErrorNone;
     const int32_t num_planes = 3;// av1_num_planes(cm);
     for (int32_t p = 0; p < num_planes; ++p)
-        return_error = av1_alloc_restoration_struct(cm, &cm->rst_info[p], p > 0);
+        return_error = eb_av1_alloc_restoration_struct(cm, &cm->rst_info[p], p > 0);
 
     //CHKNif (cm->rst_tmpbuf == NULL)
     {
         //CHKN CHECK_MEM_ERROR(cm, cm->rst_tmpbuf,
-       //cm->rst_tmpbuf = (int32_t *)aom_memalign(16, RESTORATION_TMPBUF_SIZE);
+       //cm->rst_tmpbuf = (int32_t *)eb_aom_memalign(16, RESTORATION_TMPBUF_SIZE);
 
         EB_MALLOC_ALIGNED(cm->rst_tmpbuf, RESTORATION_TMPBUF_SIZE);
     }
@@ -1746,7 +1746,7 @@ EbErrorType av1_alloc_restoration_buffers(Av1Common *cm) {
     int32_t num_stripes = 0;
     for (int32_t i = 0; i < 1/*cm->tile_rows*/; ++i) {
         //TileInfo tile_info;
-        //av1_tile_set_row(&tile_info, cm, i);
+        //eb_av1_tile_set_row(&tile_info, cm, i);
 
         const int32_t mi_h = cm->mi_rows;// tile_info.mi_row_end - tile_info.mi_row_start;
         const int32_t ext_h = RESTORATION_UNIT_OFFSET + (mi_h << MI_SIZE_LOG2);

--- a/Source/Lib/Common/Codec/EbRestoration.h
+++ b/Source/Lib/Common/Codec/EbRestoration.h
@@ -20,7 +20,7 @@
 extern "C" {
 #endif
 
-    void apply_selfguided_restoration_c(const uint8_t *dat8, int32_t width, int32_t height,
+    void eb_apply_selfguided_restoration_c(const uint8_t *dat8, int32_t width, int32_t height,
         int32_t stride, int32_t eps, const int32_t *xqd,
         uint8_t *dst8, int32_t dst_stride,
         int32_t *tmpbuf, int32_t bit_depth,
@@ -233,7 +233,7 @@ extern "C" {
         int32_t restoration_unit_size;
 
         // Fields below here are allocated and initialised by
-        // av1_alloc_restoration_struct. (horz_)units_per_tile give the number of
+        // eb_av1_alloc_restoration_struct. (horz_)units_per_tile give the number of
         // restoration units in (one row of) the largest tile in the frame. The data
         // in unit_info is laid out with units_per_tile entries for each tile, which
         // have stride horz_units_per_tile.
@@ -268,16 +268,16 @@ extern "C" {
         int32_t h_start, h_end, v_start, v_end;
     } RestorationTileLimits;
 
-    extern const SgrParamsType sgr_params[SGRPROJ_PARAMS];
+    extern const SgrParamsType eb_sgr_params[SGRPROJ_PARAMS];
     extern int32_t sgrproj_mtable[SGRPROJ_PARAMS][2];
-    extern const int32_t x_by_xplus1[256];
-    extern const int32_t one_by_x[MAX_NELEM];
+    extern const int32_t eb_x_by_xplus1[256];
+    extern const int32_t eb_one_by_x[MAX_NELEM];
 
-    //void av1_alloc_restoration_struct(struct Av1Common *cm, RestorationInfo *rsi,
+    //void eb_av1_alloc_restoration_struct(struct Av1Common *cm, RestorationInfo *rsi,
     //                                  int32_t is_uv);
-    void extend_frame(uint8_t *data, int32_t width, int32_t height, int32_t stride,
+    void eb_extend_frame(uint8_t *data, int32_t width, int32_t height, int32_t stride,
         int32_t border_horz, int32_t border_vert, int32_t highbd);
-    void decode_xq(const int32_t *xqd, int32_t *xq, const SgrParamsType *params);
+    void eb_decode_xq(const int32_t *xqd, int32_t *xq, const SgrParamsType *params);
 
     // Filter a single loop restoration unit.
     //
@@ -298,7 +298,7 @@ extern "C" {
     //
     // Finally tmpbuf is a scratch buffer used by the sgrproj filter which should
     // be at least SGRPROJ_TMPBUF_SIZE big.
-    void av1_loop_restoration_filter_unit(
+    void eb_av1_loop_restoration_filter_unit(
         uint8_t need_bounadaries,
         const RestorationTileLimits *limits, const RestorationUnitInfo *rui,
         const RestorationStripeBoundaries *rsb, RestorationLineBuffers *rlbs,
@@ -306,7 +306,7 @@ extern "C" {
         int32_t highbd, int32_t bit_depth, uint8_t *data8, int32_t stride, uint8_t *dst8,
         int32_t dst_stride, int32_t *tmpbuf, int32_t optimized_lr);
 
-    //void av1_loop_restoration_filter_frame(Yv12BufferConfig *frame,
+    //void eb_av1_loop_restoration_filter_frame(Yv12BufferConfig *frame,
     //                                       Av1Common *cm, int32_t optimized_lr);
     typedef void(*RestUnitVisitor)(const RestorationTileLimits *limits,
         const AV1PixelRect *tile_rect,
@@ -331,12 +331,12 @@ extern "C" {
     // indices given by [*rcol0, *rcol1) x [*rrow0, *rrow1) are relative
     // to the current tile, whose starting index is returned as
     // *tile_tl_idx.
-    //int32_t av1_loop_restoration_corners_in_sb(const struct AV1Common *cm, int32_t plane,
+    //int32_t eb_av1_loop_restoration_corners_in_sb(const struct AV1Common *cm, int32_t plane,
     //                                       int32_t mi_row, int32_t mi_col, BlockSize bsize,
     //                                       int32_t *rcol0, int32_t *rcol1, int32_t *rrow0,
     //                                       int32_t *rrow1, int32_t *tile_tl_idx);
 
-    //void av1_loop_restoration_save_boundary_lines(const Yv12BufferConfig *frame,
+    //void eb_av1_loop_restoration_save_boundary_lines(const Yv12BufferConfig *frame,
     //                                              struct AV1Common *cm,
     //                                              int32_t after_cdef);
 

--- a/Source/Lib/Common/Codec/EbTransforms.c
+++ b/Source/Lib/Common/Codec/EbTransforms.c
@@ -40,7 +40,7 @@ uint32_t CheckNZero4x4(
     return 0;
 }
 
-const int8_t *inv_txfm_shift_ls[TX_SIZES_ALL] = {
+const int8_t *eb_inv_txfm_shift_ls[TX_SIZES_ALL] = {
     inv_shift_4x4, inv_shift_8x8, inv_shift_16x16, inv_shift_32x32,
     inv_shift_64x64, inv_shift_4x8, inv_shift_8x4, inv_shift_8x16,
     inv_shift_16x8, inv_shift_16x32, inv_shift_32x16, inv_shift_32x64,
@@ -1174,7 +1174,7 @@ void mat_mult(
     }
 }
 
-void av1_gen_fwd_stage_range(int8_t *stage_range_col, int8_t *stage_range_row,
+void eb_av1_gen_fwd_stage_range(int8_t *stage_range_col, int8_t *stage_range_row,
     const Txfm2DFlipCfg *cfg, int32_t bd) {
     // Take the shift from the larger dimension in the rectangular case.
     const int8_t *shift = cfg->shift;
@@ -1199,7 +1199,7 @@ typedef void(*TxfmFunc)(const int32_t *input, int32_t *output, int8_t cos_bit,
   }
 
 // av1_cospi_arr[i][j] = (int32_t)round(cos(M_PI*j/128) * (1<<(cos_bit_min+i)));
-const int32_t av1_cospi_arr_data[7][64] = {
+const int32_t eb_av1_cospi_arr_data[7][64] = {
     { 1024, 1024, 1023, 1021, 1019, 1016, 1013, 1009, 1004, 999, 993, 987, 980,
     972, 964, 955, 946, 936, 926, 915, 903, 891, 878, 865, 851, 837,
     822, 807, 792, 775, 759, 742, 724, 706, 688, 669, 650, 630, 610,
@@ -1255,16 +1255,16 @@ static INLINE int32_t half_btf(int32_t w0, int32_t in0, int32_t w1, int32_t in1,
     return round_shift(result_64, bit);
 }
 
-// av1_sinpi_arr_data[i][j] = (int32_t)round((sqrt(2) * sin(j*Pi/9) * 2 / 3) * (1
+// eb_av1_sinpi_arr_data[i][j] = (int32_t)round((sqrt(2) * sin(j*Pi/9) * 2 / 3) * (1
 // << (cos_bit_min + i))) modified so that elements j=1,2 sum to element j=4.
-const int32_t av1_sinpi_arr_data[7][5] = {
+const int32_t eb_av1_sinpi_arr_data[7][5] = {
     { 0, 330, 621, 836, 951 }, { 0, 660, 1241, 1672, 1901 },
     { 0, 1321, 2482, 3344, 3803 }, { 0, 2642, 4964, 6689, 7606 },
     { 0, 5283, 9929, 13377, 15212 }, { 0, 10566, 19858, 26755, 30424 },
     { 0, 21133, 39716, 53510, 60849 }
 };
 
-void av1_fdct4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fdct4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     const int32_t size = 4;
     const int32_t *cospi;
@@ -1307,7 +1307,7 @@ void av1_fdct4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     range_check(stage, input, bf1, size, stage_range[stage]);
 }
 
-void av1_fdct8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fdct8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     const int32_t size = 8;
     const int32_t *cospi;
@@ -1392,7 +1392,7 @@ void av1_fdct8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     range_check(stage, input, bf1, size, stage_range[stage]);
 }
 
-void av1_fdct16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fdct16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     const int32_t size = 16;
     const int32_t *cospi;
@@ -1563,7 +1563,7 @@ void av1_fdct16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     range_check(stage, input, bf1, size, stage_range[stage]);
 }
 
-void av1_fdct32_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fdct32_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     const int32_t size = 32;
     const int32_t *cospi;
@@ -1923,7 +1923,7 @@ void av1_fdct32_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     bf1[31] = bf0[31];
     range_check(stage, input, bf1, size, stage_range[stage]);
 }
-void av1_fdct64_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fdct64_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     const int32_t size = 64;
     const int32_t *cospi;
@@ -2714,7 +2714,7 @@ void av1_fdct64_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     range_check(stage, input, bf1, size, stage_range[stage]);
 }
 
-void av1_fadst4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fadst4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     int32_t bit = cos_bit;
     const int32_t *sinpi = sinpi_arr(bit);
@@ -2805,7 +2805,7 @@ void av1_fadst4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     range_check(6, input, output, 4, stage_range[6]);
 }
 
-void av1_fadst8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fadst8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     const int32_t size = 8;
     const int32_t *cospi;
@@ -2919,7 +2919,7 @@ void av1_fadst8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     range_check(stage, input, bf1, size, stage_range[stage]);
 }
 
-void av1_fadst16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fadst16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     const int32_t size = 16;
     const int32_t *cospi;
@@ -3569,7 +3569,7 @@ void av1_fadst32_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     range_check(stage, input, bf1, size, stage_range[stage]);
 }
 
-void av1_fidentity4_c(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fidentity4_c(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     (void)cos_bit;
     for (int32_t i = 0; i < 4; ++i)
@@ -3578,14 +3578,14 @@ void av1_fidentity4_c(const int32_t *input, int32_t *output, int8_t cos_bit,
     range_check(0, input, output, 4, stage_range[0]);
 }
 
-void av1_fidentity8_c(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fidentity8_c(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     (void)cos_bit;
     for (int32_t i = 0; i < 8; ++i) output[i] = input[i] * 2;
     range_check(0, input, output, 8, stage_range[0]);
 }
 
-void av1_fidentity16_c(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fidentity16_c(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     (void)cos_bit;
     for (int32_t i = 0; i < 16; ++i)
@@ -3594,7 +3594,7 @@ void av1_fidentity16_c(const int32_t *input, int32_t *output, int8_t cos_bit,
     range_check(0, input, output, 16, stage_range[0]);
 }
 
-void av1_fidentity32_c(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fidentity32_c(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     (void)cos_bit;
     for (int32_t i = 0; i < 32; ++i) output[i] = input[i] * 4;
@@ -3612,25 +3612,25 @@ void av1_fidentity64_c(const int32_t *input, int32_t *output, int8_t cos_bit,
 
 static INLINE TxfmFunc fwd_txfm_type_to_func(TxfmType TxfmType) {
     switch (TxfmType) {
-    case TXFM_TYPE_DCT4: return av1_fdct4_new;
-    case TXFM_TYPE_DCT8: return av1_fdct8_new;
-    case TXFM_TYPE_DCT16: return av1_fdct16_new;
-    case TXFM_TYPE_DCT32: return av1_fdct32_new;
-    case TXFM_TYPE_DCT64: return av1_fdct64_new;
-    case TXFM_TYPE_ADST4: return av1_fadst4_new;
-    case TXFM_TYPE_ADST8: return av1_fadst8_new;
-    case TXFM_TYPE_ADST16: return av1_fadst16_new;
+    case TXFM_TYPE_DCT4: return eb_av1_fdct4_new;
+    case TXFM_TYPE_DCT8: return eb_av1_fdct8_new;
+    case TXFM_TYPE_DCT16: return eb_av1_fdct16_new;
+    case TXFM_TYPE_DCT32: return eb_av1_fdct32_new;
+    case TXFM_TYPE_DCT64: return eb_av1_fdct64_new;
+    case TXFM_TYPE_ADST4: return eb_av1_fadst4_new;
+    case TXFM_TYPE_ADST8: return eb_av1_fadst8_new;
+    case TXFM_TYPE_ADST16: return eb_av1_fadst16_new;
     case TXFM_TYPE_ADST32: return av1_fadst32_new;
-    case TXFM_TYPE_IDENTITY4: return av1_fidentity4_c;
-    case TXFM_TYPE_IDENTITY8: return av1_fidentity8_c;
-    case TXFM_TYPE_IDENTITY16: return av1_fidentity16_c;
-    case TXFM_TYPE_IDENTITY32: return av1_fidentity32_c;
+    case TXFM_TYPE_IDENTITY4: return eb_av1_fidentity4_c;
+    case TXFM_TYPE_IDENTITY8: return eb_av1_fidentity8_c;
+    case TXFM_TYPE_IDENTITY16: return eb_av1_fidentity16_c;
+    case TXFM_TYPE_IDENTITY32: return eb_av1_fidentity32_c;
     case TXFM_TYPE_IDENTITY64: return av1_fidentity64_c;
     default: assert(0); return NULL;
     }
 }
 
-void av1_round_shift_array_c(int32_t *arr, int32_t size, int32_t bit) {
+void eb_av1_round_shift_array_c(int32_t *arr, int32_t size, int32_t bit) {
     int32_t i;
     if (bit == 0)
         return;
@@ -3670,7 +3670,7 @@ static INLINE void Av1TranformTwoDCore_c(
     int8_t stage_range_row[MAX_TXFM_STAGE_NUM];
     assert(cfg->stage_num_col <= MAX_TXFM_STAGE_NUM);
     assert(cfg->stage_num_row <= MAX_TXFM_STAGE_NUM);
-    av1_gen_fwd_stage_range(stage_range_col, stage_range_row, cfg, bit_depth);
+    eb_av1_gen_fwd_stage_range(stage_range_col, stage_range_row, cfg, bit_depth);
 
     const int8_t cos_bit_col = cfg->cos_bit_col;
     const int8_t cos_bit_row = cfg->cos_bit_row;
@@ -3691,9 +3691,9 @@ static INLINE void Av1TranformTwoDCore_c(
                 // flip upside down
                 temp_in[r] = input[(txfm_size_row - r - 1) * input_stride + c];
         }
-        av1_round_shift_array_c(temp_in, txfm_size_row, -shift[0]); // NM av1_round_shift_array_c
+        eb_av1_round_shift_array_c(temp_in, txfm_size_row, -shift[0]); // NM eb_av1_round_shift_array_c
         txfm_func_col(temp_in, temp_out, cos_bit_col, stage_range_col);
-        av1_round_shift_array_c(temp_out, txfm_size_row, -shift[1]); // NM av1_round_shift_array_c
+        eb_av1_round_shift_array_c(temp_out, txfm_size_row, -shift[1]); // NM eb_av1_round_shift_array_c
         if (cfg->lr_flip == 0) {
             for (r = 0; r < txfm_size_row; ++r)
                 buf[r * txfm_size_col + c] = temp_out[r];
@@ -3711,7 +3711,7 @@ static INLINE void Av1TranformTwoDCore_c(
             output + r * txfm_size_col,
             cos_bit_row,
             stage_range_row);
-        av1_round_shift_array_c(output + r * txfm_size_col, txfm_size_col, -shift[2]);
+        eb_av1_round_shift_array_c(output + r * txfm_size_col, txfm_size_col, -shift[2]);
 
         if (abs(rect_type) == 1) {
             // Multiply everything by Sqrt2 if the transform is rectangular and the
@@ -4103,19 +4103,19 @@ void av1_fdct32_pf_new(const int32_t *input, int32_t *output, int8_t cos_bit,
 }
 static INLINE TxfmFunc fwd_txfm_pf_type_to_func(TxfmType TxfmType) {
     switch (TxfmType) {
-    case TXFM_TYPE_DCT4: return av1_fdct4_new;
-    case TXFM_TYPE_DCT8: return av1_fdct8_new;
-    case TXFM_TYPE_DCT16: return av1_fdct16_new;
+    case TXFM_TYPE_DCT4: return eb_av1_fdct4_new;
+    case TXFM_TYPE_DCT8: return eb_av1_fdct8_new;
+    case TXFM_TYPE_DCT16: return eb_av1_fdct16_new;
     case TXFM_TYPE_DCT32: return av1_fdct32_pf_new;
-    case TXFM_TYPE_DCT64: return av1_fdct64_new;
-    case TXFM_TYPE_ADST4: return av1_fadst4_new;
-    case TXFM_TYPE_ADST8: return av1_fadst8_new;
-    case TXFM_TYPE_ADST16: return av1_fadst16_new;
+    case TXFM_TYPE_DCT64: return eb_av1_fdct64_new;
+    case TXFM_TYPE_ADST4: return eb_av1_fadst4_new;
+    case TXFM_TYPE_ADST8: return eb_av1_fadst8_new;
+    case TXFM_TYPE_ADST16: return eb_av1_fadst16_new;
     case TXFM_TYPE_ADST32: return av1_fadst32_new;
-    case TXFM_TYPE_IDENTITY4: return av1_fidentity4_c;
-    case TXFM_TYPE_IDENTITY8: return av1_fidentity8_c;
-    case TXFM_TYPE_IDENTITY16: return av1_fidentity16_c;
-    case TXFM_TYPE_IDENTITY32: return av1_fidentity32_c;
+    case TXFM_TYPE_IDENTITY4: return eb_av1_fidentity4_c;
+    case TXFM_TYPE_IDENTITY8: return eb_av1_fidentity8_c;
+    case TXFM_TYPE_IDENTITY16: return eb_av1_fidentity16_c;
+    case TXFM_TYPE_IDENTITY32: return eb_av1_fidentity32_c;
     case TXFM_TYPE_IDENTITY64: return av1_fidentity64_c;
     default: assert(0); return NULL;
     }
@@ -4144,7 +4144,7 @@ static INLINE void Av1TranformTwoDCore_pf_c(
     int8_t stage_range_row[MAX_TXFM_STAGE_NUM];
     assert(cfg->stage_num_col <= MAX_TXFM_STAGE_NUM);
     assert(cfg->stage_num_row <= MAX_TXFM_STAGE_NUM);
-    av1_gen_fwd_stage_range(stage_range_col, stage_range_row, cfg, bit_depth);
+    eb_av1_gen_fwd_stage_range(stage_range_col, stage_range_row, cfg, bit_depth);
 
     const int8_t cos_bit_col = cfg->cos_bit_col;
     const int8_t cos_bit_row = cfg->cos_bit_row;
@@ -4167,9 +4167,9 @@ static INLINE void Av1TranformTwoDCore_pf_c(
                 // flip upside down
                 temp_in[r] = input[(txfm_size_row - r - 1) * inputStride + c];
         }
-        av1_round_shift_array_c(temp_in, txfm_size_row, -shift[0]); // NM av1_round_shift_array_c
+        eb_av1_round_shift_array_c(temp_in, txfm_size_row, -shift[0]); // NM eb_av1_round_shift_array_c
         txfm_func_col(temp_in, temp_out, cos_bit_col, stage_range_col);
-        av1_round_shift_array_c(temp_out, 16/*txfm_size_row*/, -shift[1]); // NM av1_round_shift_array_c
+        eb_av1_round_shift_array_c(temp_out, 16/*txfm_size_row*/, -shift[1]); // NM eb_av1_round_shift_array_c
         if (cfg->lr_flip == 0) {
             for (r = 0; r < txfm_size_row; ++r)
                 buf[r * txfm_size_col + c] = temp_out[r];
@@ -4442,7 +4442,7 @@ void Av1TransformTwoD_4x4_c(
 /*********************************************************************
 * Calculate CBF
 *********************************************************************/
-void av1_fwd_txfm2d_64x32_c(
+void eb_av1_fwd_txfm2d_64x32_c(
     int16_t         *input,
     int32_t         *output,
     uint32_t         input_stride,
@@ -4478,7 +4478,7 @@ uint64_t HandleTransform64x32_c(int32_t *output) {
     return three_quad_energy;
 }
 
-void av1_fwd_txfm2d_32x64_c(
+void eb_av1_fwd_txfm2d_32x64_c(
     int16_t         *input,
     int32_t         *output,
     uint32_t         input_stride,
@@ -4510,7 +4510,7 @@ uint64_t HandleTransform32x64_c(int32_t *output) {
     return three_quad_energy;
 }
 
-void av1_fwd_txfm2d_64x16_c(
+void eb_av1_fwd_txfm2d_64x16_c(
     int16_t         *input,
     int32_t         *output,
     uint32_t         input_stride,
@@ -4546,7 +4546,7 @@ uint64_t HandleTransform64x16_c(int32_t *output) {
     return three_quad_energy;
 }
 
-void av1_fwd_txfm2d_16x64_c(
+void eb_av1_fwd_txfm2d_16x64_c(
     int16_t         *input,
     int32_t         *output,
     uint32_t         input_stride,
@@ -4578,7 +4578,7 @@ uint64_t HandleTransform16x64_c(int32_t *output) {
     return three_quad_energy;
 }
 
-void av1_fwd_txfm2d_32x16_c(
+void eb_av1_fwd_txfm2d_32x16_c(
     int16_t         *input,
     int32_t         *output,
     uint32_t         input_stride,
@@ -4596,7 +4596,7 @@ void av1_fwd_txfm2d_32x16_c(
         bit_depth);
 }
 
-void av1_fwd_txfm2d_16x32_c(
+void eb_av1_fwd_txfm2d_16x32_c(
     int16_t         *input,
     int32_t         *output,
     uint32_t         input_stride,
@@ -4614,7 +4614,7 @@ void av1_fwd_txfm2d_16x32_c(
         bit_depth);
 }
 
-void av1_fwd_txfm2d_16x8_c(
+void eb_av1_fwd_txfm2d_16x8_c(
     int16_t         *input,
     int32_t         *output,
     uint32_t         input_stride,
@@ -4632,7 +4632,7 @@ void av1_fwd_txfm2d_16x8_c(
         bit_depth);
 }
 
-void av1_fwd_txfm2d_8x16_c(
+void eb_av1_fwd_txfm2d_8x16_c(
     int16_t         *input,
     int32_t         *output,
     uint32_t         input_stride,
@@ -4650,7 +4650,7 @@ void av1_fwd_txfm2d_8x16_c(
         bit_depth);
 }
 
-void av1_fwd_txfm2d_32x8_c(
+void eb_av1_fwd_txfm2d_32x8_c(
     int16_t         *input,
     int32_t         *output,
     uint32_t         input_stride,
@@ -4668,7 +4668,7 @@ void av1_fwd_txfm2d_32x8_c(
         bit_depth);
 }
 
-void av1_fwd_txfm2d_8x32_c(
+void eb_av1_fwd_txfm2d_8x32_c(
     int16_t         *input,
     int32_t         *output,
     uint32_t         input_stride,
@@ -4686,7 +4686,7 @@ void av1_fwd_txfm2d_8x32_c(
         bit_depth);
 }
 
-void av1_fwd_txfm2d_16x4_c(
+void eb_av1_fwd_txfm2d_16x4_c(
     int16_t         *input,
     int32_t         *output,
     uint32_t         input_stride,
@@ -4704,7 +4704,7 @@ void av1_fwd_txfm2d_16x4_c(
         bit_depth);
 }
 
-void av1_fwd_txfm2d_4x16_c(
+void eb_av1_fwd_txfm2d_4x16_c(
     int16_t         *input,
     int32_t         *output,
     uint32_t         input_stride,
@@ -4722,7 +4722,7 @@ void av1_fwd_txfm2d_4x16_c(
         bit_depth);
 }
 
-void av1_fwd_txfm2d_8x4_c(
+void eb_av1_fwd_txfm2d_8x4_c(
     int16_t         *input,
     int32_t         *output,
     uint32_t         input_stride,
@@ -4740,7 +4740,7 @@ void av1_fwd_txfm2d_8x4_c(
         bit_depth);
 }
 
-void av1_fwd_txfm2d_4x8_c(
+void eb_av1_fwd_txfm2d_4x8_c(
     int16_t         *input,
     int32_t         *output,
     uint32_t         input_stride,
@@ -4790,14 +4790,14 @@ EbErrorType av1_estimate_transform(
     switch (transform_size) {
     case TX_64X32:
         if (transform_type == DCT_DCT)
-            av1_fwd_txfm2d_64x32(
+            eb_av1_fwd_txfm2d_64x32(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
                 transform_type,
                 bit_depth);
         else
-            av1_fwd_txfm2d_64x32_c(
+            eb_av1_fwd_txfm2d_64x32_c(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
@@ -4810,14 +4810,14 @@ EbErrorType av1_estimate_transform(
 
     case TX_32X64:
         if (transform_type == DCT_DCT)
-            av1_fwd_txfm2d_32x64(
+            eb_av1_fwd_txfm2d_32x64(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
                 transform_type,
                 bit_depth);
         else
-            av1_fwd_txfm2d_32x64_c(
+            eb_av1_fwd_txfm2d_32x64_c(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
@@ -4830,14 +4830,14 @@ EbErrorType av1_estimate_transform(
 
     case TX_64X16:
         if (transform_type == DCT_DCT)
-            av1_fwd_txfm2d_64x16(
+            eb_av1_fwd_txfm2d_64x16(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
                 transform_type,
                 bit_depth);
         else
-            av1_fwd_txfm2d_64x16_c(
+            eb_av1_fwd_txfm2d_64x16_c(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
@@ -4850,14 +4850,14 @@ EbErrorType av1_estimate_transform(
 
     case TX_16X64:
         if (transform_type == DCT_DCT)
-            av1_fwd_txfm2d_16x64(
+            eb_av1_fwd_txfm2d_16x64(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
                 transform_type,
                 bit_depth);
         else
-            av1_fwd_txfm2d_16x64_c(
+            eb_av1_fwd_txfm2d_16x64_c(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
@@ -4871,14 +4871,14 @@ EbErrorType av1_estimate_transform(
     case TX_32X16:
         // TTK
         if (transform_type == IDTX)
-            av1_fwd_txfm2d_32x16(
+            eb_av1_fwd_txfm2d_32x16(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
                 transform_type,
                 bit_depth);
         else
-            av1_fwd_txfm2d_32x16_c(
+            eb_av1_fwd_txfm2d_32x16_c(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
@@ -4888,14 +4888,14 @@ EbErrorType av1_estimate_transform(
 
     case TX_16X32:
         if ((transform_type == DCT_DCT) || (transform_type == IDTX))
-            av1_fwd_txfm2d_16x32(
+            eb_av1_fwd_txfm2d_16x32(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
                 transform_type,
                 bit_depth);
         else
-            av1_fwd_txfm2d_16x32_c(
+            eb_av1_fwd_txfm2d_16x32_c(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
@@ -4904,7 +4904,7 @@ EbErrorType av1_estimate_transform(
         break;
 
     case TX_16X8:
-        av1_fwd_txfm2d_16x8(
+        eb_av1_fwd_txfm2d_16x8(
             residual_buffer,
             coeff_buffer,
             residual_stride,
@@ -4913,7 +4913,7 @@ EbErrorType av1_estimate_transform(
         break;
 
     case TX_8X16:
-        av1_fwd_txfm2d_8x16(
+        eb_av1_fwd_txfm2d_8x16(
             residual_buffer,
             coeff_buffer,
             residual_stride,
@@ -4923,14 +4923,14 @@ EbErrorType av1_estimate_transform(
 
     case TX_32X8:
         if ((transform_type == DCT_DCT) || (transform_type == IDTX))
-            av1_fwd_txfm2d_32x8(
+            eb_av1_fwd_txfm2d_32x8(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
                 transform_type,
                 bit_depth);
         else
-            av1_fwd_txfm2d_32x8_c(
+            eb_av1_fwd_txfm2d_32x8_c(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
@@ -4940,14 +4940,14 @@ EbErrorType av1_estimate_transform(
 
     case TX_8X32:
         if ((transform_type == DCT_DCT) || (transform_type == IDTX))
-            av1_fwd_txfm2d_8x32(
+            eb_av1_fwd_txfm2d_8x32(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
                 transform_type,
                 bit_depth);
         else
-            av1_fwd_txfm2d_8x32_c(
+            eb_av1_fwd_txfm2d_8x32_c(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
@@ -4955,7 +4955,7 @@ EbErrorType av1_estimate_transform(
                 bit_depth);
         break;
     case TX_16X4:
-        av1_fwd_txfm2d_16x4(
+        eb_av1_fwd_txfm2d_16x4(
             residual_buffer,
             coeff_buffer,
             residual_stride,
@@ -4963,7 +4963,7 @@ EbErrorType av1_estimate_transform(
             bit_depth);
         break;
     case TX_4X16:
-        av1_fwd_txfm2d_4x16(
+        eb_av1_fwd_txfm2d_4x16(
             residual_buffer,
             coeff_buffer,
             residual_stride,
@@ -4972,7 +4972,7 @@ EbErrorType av1_estimate_transform(
         break;
     case TX_8X4:
 
-        av1_fwd_txfm2d_8x4(
+        eb_av1_fwd_txfm2d_8x4(
             residual_buffer,
             coeff_buffer,
             residual_stride,
@@ -4982,7 +4982,7 @@ EbErrorType av1_estimate_transform(
         break;
     case TX_4X8:
 
-        av1_fwd_txfm2d_4x8(
+        eb_av1_fwd_txfm2d_4x8(
             residual_buffer,
             coeff_buffer,
             residual_stride,
@@ -4993,7 +4993,7 @@ EbErrorType av1_estimate_transform(
 
     case TX_64X64:
 
-        av1_fwd_txfm2d_64x64(
+        eb_av1_fwd_txfm2d_64x64(
             residual_buffer,
             coeff_buffer,
             residual_stride,
@@ -5015,7 +5015,7 @@ EbErrorType av1_estimate_transform(
                 bit_depth);
 
         else {
-            av1_fwd_txfm2d_32x32(
+            eb_av1_fwd_txfm2d_32x32(
                 residual_buffer,
                 coeff_buffer,
                 residual_stride,
@@ -5027,7 +5027,7 @@ EbErrorType av1_estimate_transform(
 
     case TX_16X16:
 
-        av1_fwd_txfm2d_16x16(
+        eb_av1_fwd_txfm2d_16x16(
             residual_buffer,
             coeff_buffer,
             residual_stride,
@@ -5037,7 +5037,7 @@ EbErrorType av1_estimate_transform(
         break;
     case TX_8X8:
 
-        av1_fwd_txfm2d_8x8(
+        eb_av1_fwd_txfm2d_8x8(
             residual_buffer,
             coeff_buffer,
             residual_stride,
@@ -5047,7 +5047,7 @@ EbErrorType av1_estimate_transform(
         break;
     case TX_4X4:
 
-        av1_fwd_txfm2d_4x4(
+        eb_av1_fwd_txfm2d_4x4(
             residual_buffer,
             coeff_buffer,
             residual_stride,
@@ -5153,7 +5153,7 @@ void Av1InverseTransformConfig(
     set_flip_cfg(tx_type, cfg);
     const TxType1D tx_type_1d_col = vtx_tab[tx_type];
     const TxType1D tx_type_1d_row = htx_tab[tx_type];
-    cfg->shift = inv_txfm_shift_ls[tx_size];
+    cfg->shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     cfg->cos_bit_col = inv_cos_bit_col[txw_idx][txh_idx];
@@ -5168,7 +5168,7 @@ void Av1InverseTransformConfig(
     cfg->stage_num_row = av1_txfm_stage_num_list[cfg->txfm_type_row];
 }
 
-void av1_gen_inv_stage_range(
+void eb_av1_gen_inv_stage_range(
     int8_t *stage_range_col,
     int8_t *stage_range_row,
     const Txfm2DFlipCfg *cfg,
@@ -5229,7 +5229,7 @@ static INLINE int32_t clamp_value(int32_t value, int8_t bit) {
     return (int32_t)clamp64(value, min_value, max_value);
 }
 
-void av1_idct4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_idct4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     assert(output != input);
     const int32_t *cospi = cospi_arr(cos_bit);
@@ -5268,7 +5268,7 @@ void av1_idct4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     bf1[2] = clamp_value(bf0[1] - bf0[2], stage_range[stage]);
     bf1[3] = clamp_value(bf0[0] - bf0[3], stage_range[stage]);
 }
-void av1_idct8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_idct8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     assert(output != input);
     const int32_t *cospi = cospi_arr(cos_bit);
@@ -5347,7 +5347,7 @@ void av1_idct8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     bf1[6] = clamp_value(bf0[1] - bf0[6], stage_range[stage]);
     bf1[7] = clamp_value(bf0[0] - bf0[7], stage_range[stage]);
 }
-void av1_idct16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_idct16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     assert(output != input);
     const int32_t *cospi = cospi_arr(cos_bit);
@@ -5510,7 +5510,7 @@ void av1_idct16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     bf1[14] = clamp_value(bf0[1] - bf0[14], stage_range[stage]);
     bf1[15] = clamp_value(bf0[0] - bf0[15], stage_range[stage]);
 }
-void av1_idct32_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_idct32_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     assert(output != input);
     const int32_t *cospi = cospi_arr(cos_bit);
@@ -5861,7 +5861,7 @@ void av1_idct32_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     bf1[30] = clamp_value(bf0[1] - bf0[30], stage_range[stage]);
     bf1[31] = clamp_value(bf0[0] - bf0[31], stage_range[stage]);
 }
-void av1_iadst4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_iadst4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     (void)stage_range;
     int32_t bit = cos_bit;
@@ -5899,7 +5899,7 @@ void av1_iadst4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
 
     // stage 2
     // NOTICE: (x0 - x2) here may use one extra bit compared to the
-    // opt_range_row/col specified in av1_gen_inv_stage_range()
+    // opt_range_row/col specified in eb_av1_gen_inv_stage_range()
     //s7 = range_check_value((x0 - x2) + x3, stage_range[2]);
 
     //// stage 3
@@ -5951,7 +5951,7 @@ void av1_iadst4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
 static INLINE void clamp_buf(int32_t *buf, int32_t size, int8_t bit) {
     for (int32_t i = 0; i < size; ++i) buf[i] = clamp_value(buf[i], bit);
 }
-void av1_iadst8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_iadst8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     assert(output != input);
     const int32_t *cospi = cospi_arr(cos_bit);
@@ -6058,7 +6058,7 @@ void av1_iadst8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     bf1[6] = bf0[5];
     bf1[7] = -bf0[1];
 }
-void av1_iadst16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_iadst16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     assert(output != input);
     const int32_t *cospi = cospi_arr(cos_bit);
@@ -6700,7 +6700,7 @@ void av1_iadst32_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     bf1[31] = bf0[0];
     clamp_buf(bf1, size, stage_range[stage]);
 }
-void av1_idct64_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_idct64_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     assert(output != input);
     const int32_t *cospi = cospi_arr(cos_bit);
@@ -7479,7 +7479,7 @@ void av1_idct64_new(const int32_t *input, int32_t *output, int8_t cos_bit,
     bf1[62] = clamp_value(bf0[1] - bf0[62], stage_range[stage]);
     bf1[63] = clamp_value(bf0[0] - bf0[63], stage_range[stage]);
 }
-void av1_iidentity4_c(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_iidentity4_c(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     (void)cos_bit;
     (void)stage_range;
@@ -7490,13 +7490,13 @@ void av1_iidentity4_c(const int32_t *input, int32_t *output, int8_t cos_bit,
     }
     assert(stage_range[0] + NewSqrt2Bits <= 32);
 }
-void av1_iidentity8_c(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_iidentity8_c(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     (void)cos_bit;
     (void)stage_range;
     for (int32_t i = 0; i < 8; ++i) output[i] = (int32_t)((int64_t)input[i] * 2);
 }
-void av1_iidentity16_c(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_iidentity16_c(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     (void)cos_bit;
     (void)stage_range;
@@ -7504,7 +7504,7 @@ void av1_iidentity16_c(const int32_t *input, int32_t *output, int8_t cos_bit,
         output[i] = round_shift((int64_t)NewSqrt2 * 2 * input[i], NewSqrt2Bits);
     assert(stage_range[0] + NewSqrt2Bits <= 32);
 }
-void av1_iidentity32_c(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_iidentity32_c(const int32_t *input, int32_t *output, int8_t cos_bit,
     const int8_t *stage_range) {
     (void)cos_bit;
     (void)stage_range;
@@ -7520,25 +7520,25 @@ void av1_iidentity64_c(const int32_t *input, int32_t *output, int8_t cos_bit,
 }
 static INLINE TxfmFunc inv_txfm_type_to_func(TxfmType TxfmType) {
     switch (TxfmType) {
-    case TXFM_TYPE_DCT4: return av1_idct4_new;
-    case TXFM_TYPE_DCT8: return av1_idct8_new;
-    case TXFM_TYPE_DCT16: return av1_idct16_new;
-    case TXFM_TYPE_DCT32: return av1_idct32_new;
-    case TXFM_TYPE_DCT64: return av1_idct64_new;
-    case TXFM_TYPE_ADST4: return av1_iadst4_new;
-    case TXFM_TYPE_ADST8: return av1_iadst8_new;
-    case TXFM_TYPE_ADST16: return av1_iadst16_new;
+    case TXFM_TYPE_DCT4: return eb_av1_idct4_new;
+    case TXFM_TYPE_DCT8: return eb_av1_idct8_new;
+    case TXFM_TYPE_DCT16: return eb_av1_idct16_new;
+    case TXFM_TYPE_DCT32: return eb_av1_idct32_new;
+    case TXFM_TYPE_DCT64: return eb_av1_idct64_new;
+    case TXFM_TYPE_ADST4: return eb_av1_iadst4_new;
+    case TXFM_TYPE_ADST8: return eb_av1_iadst8_new;
+    case TXFM_TYPE_ADST16: return eb_av1_iadst16_new;
     case TXFM_TYPE_ADST32: return av1_iadst32_new;
-    case TXFM_TYPE_IDENTITY4: return av1_iidentity4_c;
-    case TXFM_TYPE_IDENTITY8: return av1_iidentity8_c;
-    case TXFM_TYPE_IDENTITY16: return av1_iidentity16_c;
-    case TXFM_TYPE_IDENTITY32: return av1_iidentity32_c;
+    case TXFM_TYPE_IDENTITY4: return eb_av1_iidentity4_c;
+    case TXFM_TYPE_IDENTITY8: return eb_av1_iidentity8_c;
+    case TXFM_TYPE_IDENTITY16: return eb_av1_iidentity16_c;
+    case TXFM_TYPE_IDENTITY32: return eb_av1_iidentity32_c;
     case TXFM_TYPE_IDENTITY64: return av1_iidentity64_c;
     default: assert(0); return NULL;
     }
 }
 
-//void av1_round_shift_array_c(int32_t *arr, int32_t size, int32_t bit) {
+//void eb_av1_round_shift_array_c(int32_t *arr, int32_t size, int32_t bit) {
 //    int32_t i;
 //    if (bit == 0) {
 //        return;
@@ -7601,7 +7601,7 @@ static INLINE void Av1InverseTransformTwoDCore_c(
     int8_t stage_range_col[MAX_TXFM_STAGE_NUM];
     assert(cfg->stage_num_row <= MAX_TXFM_STAGE_NUM);
     assert(cfg->stage_num_col <= MAX_TXFM_STAGE_NUM);
-    av1_gen_inv_stage_range(stage_range_col, stage_range_row, cfg, tx_size, bd);
+    eb_av1_gen_inv_stage_range(stage_range_col, stage_range_row, cfg, tx_size, bd);
 
     const int8_t cos_bit_col = cfg->cos_bit_col;
     const int8_t cos_bit_row = cfg->cos_bit_row;
@@ -7633,7 +7633,7 @@ static INLINE void Av1InverseTransformTwoDCore_c(
             clamp_buf(temp_in, txfm_size_col, (int8_t)(bd + 8));
             txfm_func_row(temp_in, buf_ptr, cos_bit_row, stage_range_row);
         }
-        av1_round_shift_array_c(buf_ptr, txfm_size_col, -shift[0]);
+        eb_av1_round_shift_array_c(buf_ptr, txfm_size_col, -shift[0]);
         input += inpuStride;// txfm_size_col;
         buf_ptr += txfm_size_col;
     }
@@ -7650,7 +7650,7 @@ static INLINE void Av1InverseTransformTwoDCore_c(
         }
         clamp_buf(temp_in, txfm_size_row, (int8_t)AOMMAX(bd + 6, 16));
         txfm_func_col(temp_in, temp_out, cos_bit_col, stage_range_col);
-        av1_round_shift_array_c(temp_out, txfm_size_row, -shift[1]);
+        eb_av1_round_shift_array_c(temp_out, txfm_size_row, -shift[1]);
         if (cfg->ud_flip == 0) {
             for (r = 0; r < txfm_size_row; ++r)
                 output[r * ouputStride + c] = temp_out[r];
@@ -7679,7 +7679,7 @@ void Av1InverseTransformTwoD_4x4_c(
         TX_4X4,
         &cfg);
     // Forward shift sum uses larger square size, to be consistent with what
-    // av1_gen_inv_stage_range() does for inverse shifts.
+    // eb_av1_gen_inv_stage_range() does for inverse shifts.
     Av1InverseTransformTwoDCore_c(
         input,
         input_stride,
@@ -7707,7 +7707,7 @@ void Av1InverseTransformTwoD_8x8_c(
         TX_8X8,
         &cfg);
     // Forward shift sum uses larger square size, to be consistent with what
-    // av1_gen_inv_stage_range() does for inverse shifts.
+    // eb_av1_gen_inv_stage_range() does for inverse shifts.
     Av1InverseTransformTwoDCore_c(
         input,
         input_stride,
@@ -7735,7 +7735,7 @@ void Av1InverseTransformTwoD_16x16_c(
         TX_16X16,
         &cfg);
     // Forward shift sum uses larger square size, to be consistent with what
-    // av1_gen_inv_stage_range() does for inverse shifts.
+    // eb_av1_gen_inv_stage_range() does for inverse shifts.
     Av1InverseTransformTwoDCore_c(
         input,
         input_stride,
@@ -7763,7 +7763,7 @@ void Av1InverseTransformTwoD_32x32_c(
         TX_32X32,
         &cfg);
     // Forward shift sum uses larger square size, to be consistent with what
-    // av1_gen_inv_stage_range() does for inverse shifts.
+    // eb_av1_gen_inv_stage_range() does for inverse shifts.
     Av1InverseTransformTwoDCore_c(
         input,
         input_stride,
@@ -7806,7 +7806,7 @@ void Av1InverseTransformTwoD_64x64_c(
         TX_64X64,
         &cfg);
     // Forward shift sum uses larger square size, to be consistent with what
-    // av1_gen_inv_stage_range() does for inverse shifts.
+    // eb_av1_gen_inv_stage_range() does for inverse shifts.
     Av1InverseTransformTwoDCore_c(
         mod_input,
         64,
@@ -7910,7 +7910,7 @@ static const int32_t *cast_to_int32(const TranLow *input) {
     assert(sizeof(int32_t) == sizeof(TranLow));
     return (const int32_t *)input;
 }
-void av1_get_inv_txfm_cfg(TxType tx_type, TxSize tx_size,
+void eb_av1_get_inv_txfm_cfg(TxType tx_type, TxSize tx_size,
     Txfm2DFlipCfg *cfg) {
     assert(cfg != NULL);
     cfg->tx_size = tx_size;
@@ -7920,7 +7920,7 @@ void av1_get_inv_txfm_cfg(TxType tx_type, TxSize tx_size,
     set_flip_cfg(tx_type, cfg);
     const TxType1D tx_type_1d_col = vtx_tab[tx_type];
     const TxType1D tx_type_1d_row = htx_tab[tx_type];
-    cfg->shift = inv_txfm_shift_ls[tx_size];
+    cfg->shift = eb_inv_txfm_shift_ls[tx_size];
     const int32_t txw_idx = get_txw_idx(tx_size);
     const int32_t txh_idx = get_txh_idx(tx_size);
     cfg->cos_bit_col = inv_cos_bit_col[txw_idx][txh_idx];
@@ -7953,7 +7953,7 @@ static INLINE void inv_txfm2d_add_c(const int32_t *input, uint16_t *output,
     int8_t stage_range_col[MAX_TXFM_STAGE_NUM];
     assert(cfg->stage_num_row <= MAX_TXFM_STAGE_NUM);
     assert(cfg->stage_num_col <= MAX_TXFM_STAGE_NUM);
-    av1_gen_inv_stage_range(stage_range_col, stage_range_row, cfg, tx_size, bd);
+    eb_av1_gen_inv_stage_range(stage_range_col, stage_range_row, cfg, tx_size, bd);
 
     const int8_t cos_bit_col = cfg->cos_bit_col;
     const int8_t cos_bit_row = cfg->cos_bit_row;
@@ -7985,7 +7985,7 @@ static INLINE void inv_txfm2d_add_c(const int32_t *input, uint16_t *output,
             clamp_buf(temp_in, txfm_size_col, (int8_t)(bd + 8));
             txfm_func_row(temp_in, buf_ptr, cos_bit_row, stage_range_row);
         }
-        av1_round_shift_array_c(buf_ptr, txfm_size_col, -shift[0]);
+        eb_av1_round_shift_array_c(buf_ptr, txfm_size_col, -shift[0]);
         input += txfm_size_col;
         buf_ptr += txfm_size_col;
     }
@@ -8003,7 +8003,7 @@ static INLINE void inv_txfm2d_add_c(const int32_t *input, uint16_t *output,
         }
         clamp_buf(temp_in, txfm_size_row, (int8_t)(AOMMAX(bd + 6, 16)));
         txfm_func_col(temp_in, temp_out, cos_bit_col, stage_range_col);
-        av1_round_shift_array_c(temp_out, txfm_size_row, -shift[1]);
+        eb_av1_round_shift_array_c(temp_out, txfm_size_row, -shift[1]);
         if (cfg->ud_flip == 0) {
             for (r = 0; r < txfm_size_row; ++r) {
                 output[r * stride + c] =
@@ -8024,34 +8024,34 @@ static INLINE void inv_txfm2d_add_facade(const int32_t *input, uint16_t *output,
     TxType tx_type, TxSize tx_size,
     int32_t bd) {
     Txfm2DFlipCfg cfg;
-    av1_get_inv_txfm_cfg(tx_type, tx_size, &cfg);
+    eb_av1_get_inv_txfm_cfg(tx_type, tx_size, &cfg);
     // Forward shift sum uses larger square size, to be consistent with what
-    // av1_gen_inv_stage_range() does for inverse shifts.
+    // eb_av1_gen_inv_stage_range() does for inverse shifts.
     inv_txfm2d_add_c(input, output, stride, &cfg, txfm_buf, tx_size, bd);
 }
-void av1_inv_txfm2d_add_4x4_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_4x4_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, int32_t bd) {
     DECLARE_ALIGNED(32, int32_t, txfm_buf[4 * 4 + 4 + 4]);
     inv_txfm2d_add_facade(input, output, stride, txfm_buf, tx_type, TX_4X4, bd);
 }
-void av1_inv_txfm2d_add_8x8_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_8x8_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, int32_t bd) {
     DECLARE_ALIGNED(32, int32_t, txfm_buf[8 * 8 + 8 + 8]);
     inv_txfm2d_add_facade(input, output, stride, txfm_buf, tx_type, TX_8X8, bd);
 }
-void av1_inv_txfm2d_add_16x16_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_16x16_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, int32_t bd) {
     DECLARE_ALIGNED(32, int32_t, txfm_buf[16 * 16 + 16 + 16]);
     inv_txfm2d_add_facade(input, output, stride, txfm_buf, tx_type, TX_16X16, bd);
 }
 
-void av1_inv_txfm2d_add_32x32_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_32x32_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, int32_t bd) {
     DECLARE_ALIGNED(32, int32_t, txfm_buf[32 * 32 + 32 + 32]);
     inv_txfm2d_add_facade(input, output, stride, txfm_buf, tx_type, TX_32X32, bd);
 }
 
-void av1_inv_txfm2d_add_64x64_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_64x64_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, int32_t bd) {
     // TODO(urvang): Can the same array be reused, instead of using a new array?
     // Remap 32x32 input into a modified 64x64 by:
@@ -8068,21 +8068,21 @@ void av1_inv_txfm2d_add_64x64_c(const int32_t *input, uint16_t *output,
         bd);
 }
 
-void av1_inv_txfm2d_add_4x8_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_4x8_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd) {
     (void)tx_size;
     DECLARE_ALIGNED(32, int32_t, txfm_buf[4 * 8 + 8 + 8]);
     inv_txfm2d_add_facade(input, output, stride, txfm_buf, tx_type, TX_4X8, bd);
 }
 
-void av1_inv_txfm2d_add_8x4_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_8x4_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd) {
     (void)tx_size;
     DECLARE_ALIGNED(32, int32_t, txfm_buf[8 * 4 + 8 + 8]);
     inv_txfm2d_add_facade(input, output, stride, txfm_buf, tx_type, TX_8X4, bd);
 }
 
-void av1_inv_txfm2d_add_8x16_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_8x16_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd) {
     UNUSED(tx_size);
     UNUSED(eob);
@@ -8090,7 +8090,7 @@ void av1_inv_txfm2d_add_8x16_c(const int32_t *input, uint16_t *output,
     inv_txfm2d_add_facade(input, output, stride, txfm_buf, tx_type, TX_8X16, bd);
 }
 
-void av1_inv_txfm2d_add_16x8_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_16x8_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd) {
     UNUSED(tx_size);
     UNUSED(eob);
@@ -8098,7 +8098,7 @@ void av1_inv_txfm2d_add_16x8_c(const int32_t *input, uint16_t *output,
     inv_txfm2d_add_facade(input, output, stride, txfm_buf, tx_type, TX_16X8, bd);
 }
 
-void av1_inv_txfm2d_add_16x32_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_16x32_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd) {
     UNUSED(tx_size);
     UNUSED(eob);
@@ -8106,7 +8106,7 @@ void av1_inv_txfm2d_add_16x32_c(const int32_t *input, uint16_t *output,
     inv_txfm2d_add_facade(input, output, stride, txfm_buf, tx_type, TX_16X32, bd);
 }
 
-void av1_inv_txfm2d_add_32x16_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_32x16_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd) {
     UNUSED(tx_size);
     UNUSED(eob);
@@ -8114,7 +8114,7 @@ void av1_inv_txfm2d_add_32x16_c(const int32_t *input, uint16_t *output,
     inv_txfm2d_add_facade(input, output, stride, txfm_buf, tx_type, TX_32X16, bd);
 }
 
-void av1_inv_txfm2d_add_64x32_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_64x32_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd) {
     UNUSED(tx_size);
     UNUSED(eob);
@@ -8131,7 +8131,7 @@ void av1_inv_txfm2d_add_64x32_c(const int32_t *input, uint16_t *output,
         bd);
 }
 
-void av1_inv_txfm2d_add_32x64_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_32x64_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd)  {
     UNUSED(tx_size);
     UNUSED(eob);
@@ -8146,7 +8146,7 @@ void av1_inv_txfm2d_add_32x64_c(const int32_t *input, uint16_t *output,
         bd);
 }
 
-void av1_inv_txfm2d_add_16x64_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_16x64_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd)  {
     UNUSED(tx_size);
     UNUSED(eob);
@@ -8161,7 +8161,7 @@ void av1_inv_txfm2d_add_16x64_c(const int32_t *input, uint16_t *output,
         bd);
 }
 
-void av1_inv_txfm2d_add_64x16_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_64x16_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd) {
     UNUSED(tx_size);
     UNUSED(eob);
@@ -8178,21 +8178,21 @@ void av1_inv_txfm2d_add_64x16_c(const int32_t *input, uint16_t *output,
         bd);
 }
 
-void av1_inv_txfm2d_add_4x16_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_4x16_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd)  {
     UNUSED(tx_size);
     DECLARE_ALIGNED(32, int32_t, txfm_buf[4 * 16 + 16 + 16]);
     inv_txfm2d_add_facade(input, output, stride, txfm_buf, tx_type, TX_4X16, bd);
 }
 
-void av1_inv_txfm2d_add_16x4_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_16x4_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd)  {
     UNUSED(tx_size);
     DECLARE_ALIGNED(32, int32_t, txfm_buf[4 * 16 + 16 + 16]);
     inv_txfm2d_add_facade(input, output, stride, txfm_buf, tx_type, TX_16X4, bd);
 }
 
-void av1_inv_txfm2d_add_8x32_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_8x32_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd)  {
     UNUSED(tx_size);
     UNUSED(eob);
@@ -8200,7 +8200,7 @@ void av1_inv_txfm2d_add_8x32_c(const int32_t *input, uint16_t *output,
     inv_txfm2d_add_facade(input, output, stride, txfm_buf, tx_type, TX_8X32, bd);
 }
 
-void av1_inv_txfm2d_add_32x8_c(const int32_t *input, uint16_t *output,
+void eb_av1_inv_txfm2d_add_32x8_c(const int32_t *input, uint16_t *output,
     int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd) {
     UNUSED(tx_size);
     UNUSED(eob);
@@ -8225,7 +8225,7 @@ static INLINE int32_t range_check_value(int32_t value, int8_t bit) {
     return value;
 }
 
-void av1_highbd_iwht4x4_16_add_c(const TranLow *input, uint8_t *dest8,
+void eb_av1_highbd_iwht4x4_16_add_c(const TranLow *input, uint8_t *dest8,
     int32_t stride, int32_t bd) {
     /* 4-point reversible, orthonormal inverse Walsh-Hadamard in 3.5 adds,
        0.5 shifts per pixel. */
@@ -8284,7 +8284,7 @@ void av1_highbd_iwht4x4_16_add_c(const TranLow *input, uint8_t *dest8,
     }
 }
 
-void av1_highbd_iwht4x4_1_add_c(const TranLow *in, uint8_t *dest8,
+void eb_av1_highbd_iwht4x4_1_add_c(const TranLow *in, uint8_t *dest8,
     int32_t dest_stride, int32_t bd) {
     int32_t i;
     TranLow a1, e1;
@@ -8319,11 +8319,11 @@ void av1_highbd_iwht4x4_1_add_c(const TranLow *in, uint8_t *dest8,
 static void highbd_iwht4x4_add(const TranLow *input, uint8_t *dest,
     int32_t stride, int32_t eob, int32_t bd) {
     if (eob > 1)
-        av1_highbd_iwht4x4_16_add_c(input, dest, stride, bd);
+        eb_av1_highbd_iwht4x4_16_add_c(input, dest, stride, bd);
     else
-        av1_highbd_iwht4x4_1_add_c(input, dest, stride, bd);
+        eb_av1_highbd_iwht4x4_1_add_c(input, dest, stride, bd);
 }
-void av1_highbd_inv_txfm_add_4x4(const TranLow *input, uint8_t *dest,
+void eb_av1_highbd_inv_txfm_add_4x4(const TranLow *input, uint8_t *dest,
     int32_t stride, const TxfmParam *txfm_param) {
     // assert(av1_ext_tx_used[txfm_param->tx_set_type][txfm_param->tx_type]);
     int32_t eob = txfm_param->eob;
@@ -8336,14 +8336,14 @@ void av1_highbd_inv_txfm_add_4x4(const TranLow *input, uint8_t *dest,
         highbd_iwht4x4_add(input, dest, stride, eob, bd);
         return;
     }
-    av1_inv_txfm2d_add_4x4(src, CONVERT_TO_SHORTPTR(dest), stride, tx_type, bd);
+    eb_av1_inv_txfm2d_add_4x4(src, CONVERT_TO_SHORTPTR(dest), stride, tx_type, bd);
 }
 static void highbd_inv_txfm_add_8x8(const TranLow *input, uint8_t *dest,
     int32_t stride, const TxfmParam *txfm_param) {
     int32_t bd = txfm_param->bd;
     const TxType tx_type = txfm_param->tx_type;
     const int32_t *src = cast_to_int32(input);
-    av1_inv_txfm2d_add_8x8(src, CONVERT_TO_SHORTPTR(dest), stride, tx_type, bd);
+    eb_av1_inv_txfm2d_add_8x8(src, CONVERT_TO_SHORTPTR(dest), stride, tx_type, bd);
 }
 
 static void highbd_inv_txfm_add_16x16(const TranLow *input, uint8_t *dest,
@@ -8351,7 +8351,7 @@ static void highbd_inv_txfm_add_16x16(const TranLow *input, uint8_t *dest,
     int32_t bd = txfm_param->bd;
     const TxType tx_type = txfm_param->tx_type;
     const int32_t *src = cast_to_int32(input);
-    av1_inv_txfm2d_add_16x16(src, CONVERT_TO_SHORTPTR(dest), stride, tx_type,
+    eb_av1_inv_txfm2d_add_16x16(src, CONVERT_TO_SHORTPTR(dest), stride, tx_type,
         bd);
 }
 
@@ -8363,7 +8363,7 @@ static void highbd_inv_txfm_add_32x32(const TranLow *input, uint8_t *dest,
     switch (tx_type) {
     case DCT_DCT:
     case IDTX:
-        av1_inv_txfm2d_add_32x32(src, CONVERT_TO_SHORTPTR(dest), stride, tx_type,
+        eb_av1_inv_txfm2d_add_32x32(src, CONVERT_TO_SHORTPTR(dest), stride, tx_type,
             bd);
         break;
     default:
@@ -8377,14 +8377,14 @@ static void highbd_inv_txfm_add_64x64(const TranLow *input, uint8_t *dest,
     const TxType tx_type = txfm_param->tx_type;
     const int32_t *src = cast_to_int32(input);
     assert(tx_type == DCT_DCT);
-    av1_inv_txfm2d_add_64x64(src, CONVERT_TO_SHORTPTR(dest), stride, tx_type, bd);
+    eb_av1_inv_txfm2d_add_64x64(src, CONVERT_TO_SHORTPTR(dest), stride, tx_type, bd);
 }
 
 static void highbd_inv_txfm_add_4x8(const TranLow *input, uint8_t *dest,
     int32_t stride, const TxfmParam *txfm_param) {
     //TODO: add this assert once we fill tx_set_type    assert(av1_ext_tx_used[txfm_param->tx_set_type][txfm_param->tx_type]);
     const int32_t *src = cast_to_int32(input);
-    av1_inv_txfm2d_add_4x8(src, CONVERT_TO_SHORTPTR(dest), stride,
+    eb_av1_inv_txfm2d_add_4x8(src, CONVERT_TO_SHORTPTR(dest), stride,
         txfm_param->tx_type, txfm_param->tx_size, txfm_param->bd);
 }
 
@@ -8392,91 +8392,91 @@ static void highbd_inv_txfm_add_8x4(const TranLow *input, uint8_t *dest,
     int32_t stride, const TxfmParam *txfm_param) {
     //TODO: add this assert once we fill tx_set_type    assert(av1_ext_tx_used[txfm_param->tx_set_type][txfm_param->tx_type]);
     const int32_t *src = cast_to_int32(input);
-    av1_inv_txfm2d_add_8x4(src, CONVERT_TO_SHORTPTR(dest), stride,
+    eb_av1_inv_txfm2d_add_8x4(src, CONVERT_TO_SHORTPTR(dest), stride,
         txfm_param->tx_type, txfm_param->tx_size, txfm_param->bd);
 }
 
 static void highbd_inv_txfm_add_8x16(const TranLow *input, uint8_t *dest,
     int32_t stride, const TxfmParam *txfm_param) {
     const int32_t *src = cast_to_int32(input);
-    av1_inv_txfm2d_add_8x16(src, CONVERT_TO_SHORTPTR(dest), stride,
+    eb_av1_inv_txfm2d_add_8x16(src, CONVERT_TO_SHORTPTR(dest), stride,
         txfm_param->tx_type, txfm_param->tx_size, txfm_param->eob, txfm_param->bd);
 }
 
 static void highbd_inv_txfm_add_16x8(const TranLow *input, uint8_t *dest,
     int32_t stride, const TxfmParam *txfm_param) {
     const int32_t *src = cast_to_int32(input);
-    av1_inv_txfm2d_add_16x8(src, CONVERT_TO_SHORTPTR(dest), stride,
+    eb_av1_inv_txfm2d_add_16x8(src, CONVERT_TO_SHORTPTR(dest), stride,
         txfm_param->tx_type, txfm_param->tx_size, txfm_param->eob, txfm_param->bd);
 }
 
 static void highbd_inv_txfm_add_16x32(const TranLow *input, uint8_t *dest,
     int32_t stride, const TxfmParam *txfm_param) {
     const int32_t *src = cast_to_int32(input);
-    av1_inv_txfm2d_add_16x32(src, CONVERT_TO_SHORTPTR(dest), stride,
+    eb_av1_inv_txfm2d_add_16x32(src, CONVERT_TO_SHORTPTR(dest), stride,
         txfm_param->tx_type, txfm_param->tx_size, txfm_param->eob, txfm_param->bd);
 }
 
 static void highbd_inv_txfm_add_32x16(const TranLow *input, uint8_t *dest,
     int32_t stride, const TxfmParam *txfm_param) {
     const int32_t *src = cast_to_int32(input);
-    av1_inv_txfm2d_add_32x16(src, CONVERT_TO_SHORTPTR(dest), stride,
+    eb_av1_inv_txfm2d_add_32x16(src, CONVERT_TO_SHORTPTR(dest), stride,
         txfm_param->tx_type, txfm_param->tx_size, txfm_param->eob, txfm_param->bd);
 }
 
 static void highbd_inv_txfm_add_16x4(const TranLow *input, uint8_t *dest,
     int32_t stride, const TxfmParam *txfm_param) {
     const int32_t *src = cast_to_int32(input);
-    av1_inv_txfm2d_add_16x4(src, CONVERT_TO_SHORTPTR(dest), stride,
+    eb_av1_inv_txfm2d_add_16x4(src, CONVERT_TO_SHORTPTR(dest), stride,
         txfm_param->tx_type, txfm_param->tx_size, txfm_param->bd);
 }
 
 static void highbd_inv_txfm_add_4x16(const TranLow *input, uint8_t *dest,
     int32_t stride, const TxfmParam *txfm_param) {
     const int32_t *src = cast_to_int32(input);
-    av1_inv_txfm2d_add_4x16(src, CONVERT_TO_SHORTPTR(dest), stride,
+    eb_av1_inv_txfm2d_add_4x16(src, CONVERT_TO_SHORTPTR(dest), stride,
         txfm_param->tx_type, txfm_param->tx_size, txfm_param->bd);
 }
 
 static void highbd_inv_txfm_add_32x8(const TranLow *input, uint8_t *dest,
     int32_t stride, const TxfmParam *txfm_param) {
     const int32_t *src = cast_to_int32(input);
-    av1_inv_txfm2d_add_32x8(src, CONVERT_TO_SHORTPTR(dest), stride,
+    eb_av1_inv_txfm2d_add_32x8(src, CONVERT_TO_SHORTPTR(dest), stride,
         txfm_param->tx_type, txfm_param->tx_size, txfm_param->eob, txfm_param->bd);
 }
 
 static void highbd_inv_txfm_add_8x32(const TranLow *input, uint8_t *dest,
     int32_t stride, const TxfmParam *txfm_param) {
     const int32_t *src = cast_to_int32(input);
-    av1_inv_txfm2d_add_8x32(src, CONVERT_TO_SHORTPTR(dest), stride,
+    eb_av1_inv_txfm2d_add_8x32(src, CONVERT_TO_SHORTPTR(dest), stride,
         txfm_param->tx_type, txfm_param->tx_size, txfm_param->eob, txfm_param->bd);
 }
 
 static void highbd_inv_txfm_add_32x64(const TranLow *input, uint8_t *dest,
     int32_t stride, const TxfmParam *txfm_param) {
     const int32_t *src = cast_to_int32(input);
-    av1_inv_txfm2d_add_32x64(src, CONVERT_TO_SHORTPTR(dest), stride,
+    eb_av1_inv_txfm2d_add_32x64(src, CONVERT_TO_SHORTPTR(dest), stride,
         txfm_param->tx_type, txfm_param->tx_size, txfm_param->eob, txfm_param->bd);
 }
 
 static void highbd_inv_txfm_add_64x32(const TranLow *input, uint8_t *dest,
     int32_t stride, const TxfmParam *txfm_param) {
     const int32_t *src = cast_to_int32(input);
-    av1_inv_txfm2d_add_64x32(src, CONVERT_TO_SHORTPTR(dest), stride,
+    eb_av1_inv_txfm2d_add_64x32(src, CONVERT_TO_SHORTPTR(dest), stride,
         txfm_param->tx_type, txfm_param->tx_size, txfm_param->eob, txfm_param->bd);
 }
 
 static void highbd_inv_txfm_add_16x64(const TranLow *input, uint8_t *dest,
     int32_t stride, const TxfmParam *txfm_param) {
     const int32_t *src = cast_to_int32(input);
-    av1_inv_txfm2d_add_16x64(src, CONVERT_TO_SHORTPTR(dest), stride,
+    eb_av1_inv_txfm2d_add_16x64(src, CONVERT_TO_SHORTPTR(dest), stride,
         txfm_param->tx_type, txfm_param->tx_size, txfm_param->eob, txfm_param->bd);
 }
 
 static void highbd_inv_txfm_add_64x16(const TranLow *input, uint8_t *dest,
     int32_t stride, const TxfmParam *txfm_param) {
     const int32_t *src = cast_to_int32(input);
-    av1_inv_txfm2d_add_64x16(src, CONVERT_TO_SHORTPTR(dest), stride,
+    eb_av1_inv_txfm2d_add_64x16(src, CONVERT_TO_SHORTPTR(dest), stride,
         txfm_param->tx_type, txfm_param->tx_size, txfm_param->eob, txfm_param->bd);
 }
 
@@ -8531,7 +8531,7 @@ static void highbd_inv_txfm_add(const TranLow *input, uint8_t *dest,
         // this is like av1_short_idct4x4 but has a special case around eob<=1
         // which is significant (not just an optimization) for the lossless
         // case.
-        av1_highbd_inv_txfm_add_4x4(input, dest, stride, txfm_param);
+        eb_av1_highbd_inv_txfm_add_4x4(input, dest, stride, txfm_param);
         break;
     case TX_16X4:
         highbd_inv_txfm_add_16x4(input, dest, stride, txfm_param);
@@ -8549,7 +8549,7 @@ static void highbd_inv_txfm_add(const TranLow *input, uint8_t *dest,
     }
 }
 
-void av1_inv_txfm_add_c(const TranLow *dqcoeff, uint8_t *dst, int32_t stride,
+void eb_av1_inv_txfm_add_c(const TranLow *dqcoeff, uint8_t *dst, int32_t stride,
     const TxfmParam *txfm_param) {
     const TxSize tx_size = txfm_param->tx_size;
     DECLARE_ALIGNED(32, uint16_t, tmp[MAX_TX_SQUARE]);
@@ -8620,7 +8620,7 @@ EbErrorType av1_inv_transform_recon8bit(
     txfm_param.is_hbd = 1;
     //TxfmParam.tx_set_type = av1_get_ext_tx_set_type(   txfm_param->tx_size, is_inter_block(xd->mi[0]), reduced_tx_set);
 
-    av1_inv_txfm_add((const TranLow *)coeff_buffer, recon_buffer,
+    eb_av1_inv_txfm_add((const TranLow *)coeff_buffer, recon_buffer,
         recon_stride, &txfm_param);
 
     return return_error;

--- a/Source/Lib/Common/Codec/EbTransforms.h
+++ b/Source/Lib/Common/Codec/EbTransforms.h
@@ -3915,9 +3915,9 @@ extern "C" {
     }
     static const uint32_t q_func[] = { 26214,23302,20560,18396,16384,14564 };
 
-    extern const int32_t av1_cospi_arr_data[7][64];
-    extern const int32_t av1_sinpi_arr_data[7][5];
-    extern const int8_t *inv_txfm_shift_ls[TX_SIZES_ALL];
+    extern const int32_t eb_av1_cospi_arr_data[7][64];
+    extern const int32_t eb_av1_sinpi_arr_data[7][5];
+    extern const int8_t *eb_inv_txfm_shift_ls[TX_SIZES_ALL];
 
     static const int32_t cos_bit_min = 10;
 
@@ -3928,11 +3928,11 @@ extern "C" {
     static const int32_t NewInvSqrt2 = 2896;
 
     static INLINE const int32_t *cospi_arr(int32_t n) {
-        return av1_cospi_arr_data[n - cos_bit_min];
+        return eb_av1_cospi_arr_data[n - cos_bit_min];
     }
 
     static INLINE const int32_t *sinpi_arr(int32_t n) {
-        return av1_sinpi_arr_data[n - cos_bit_min];
+        return eb_av1_sinpi_arr_data[n - cos_bit_min];
     }
 
     static INLINE void get_flip_cfg(TxType tx_type, int32_t *ud_flip, int32_t *lr_flip) {

--- a/Source/Lib/Common/Codec/EbUtility.h
+++ b/Source/Lib/Common/Codec/EbUtility.h
@@ -143,10 +143,10 @@ extern "C" {
         uint8_t  offset_y;
     } TransformUnitStats;
 
-    extern void *aom_memalign(size_t align, size_t size);
-    extern void *aom_malloc(size_t size);
-    extern void aom_free(void *memblk);
-    extern void *aom_memset16(void *dest, int32_t val, size_t length);
+    extern void *eb_aom_memalign(size_t align, size_t size);
+    extern void *eb_aom_malloc(size_t size);
+    extern void eb_aom_free(void *memblk);
+    extern void *eb_aom_memset16(void *dest, int32_t val, size_t length);
 
     extern uint64_t log2f_high_precision(uint64_t x, uint8_t precision);
 

--- a/Source/Lib/Common/Codec/EbWarpedMotion.c
+++ b/Source/Lib/Common/Codec/EbWarpedMotion.c
@@ -94,7 +94,7 @@ const int error_measure_lut[512] = {
 // [-1, 2) * WARPEDPIXEL_PREC_SHIFTS.
 // We need an extra 2 taps to fit this in, for a total of 8 taps.
 /* clang-format off */
-EB_ALIGN(16) const int16_t warped_filter[WARPEDPIXEL_PREC_SHIFTS * 3 + 1][8] = {
+EB_ALIGN(16) const int16_t eb_warped_filter[WARPEDPIXEL_PREC_SHIFTS * 3 + 1][8] = {
 #if WARPEDPIXEL_PREC_BITS == 6
   // [-1, 0)
   { 0,   0, 127,   1,   0, 0, 0, 0 }, { 0, - 1, 127,   2,   0, 0, 0, 0 },
@@ -337,7 +337,7 @@ static int is_affine_shear_allowed(int16_t alpha, int16_t beta, int16_t gamma,
 }
 
 // Returns 1 on success or 0 on an invalid affine set
-int get_shear_params(EbWarpedMotionParams *wm) {
+int eb_get_shear_params(EbWarpedMotionParams *wm) {
   const int32_t *mat = wm->wmmat;
   if (!is_affine_valid(wm)) return 0;
   wm->alpha =
@@ -380,9 +380,9 @@ static INLINE int highbd_error_measure(int err, int bd) {
 }
 
 /* Note: For an explanation of the warp algorithm, and some notes on bit widths
-    for hardware implementations, see the comments above av1_warp_affine_c
+    for hardware implementations, see the comments above eb_av1_warp_affine_c
 */
-void av1_highbd_warp_affine_c(const int32_t *mat, const uint16_t *ref,
+void eb_av1_highbd_warp_affine_c(const int32_t *mat, const uint16_t *ref,
                               int width, int height, int stride, uint16_t *pred,
                               int p_col, int p_row, int p_width, int p_height,
                               int p_stride, int subsampling_x,
@@ -439,7 +439,7 @@ void av1_highbd_warp_affine_c(const int32_t *mat, const uint16_t *ref,
           const int offs = ROUND_POWER_OF_TWO(sx, WARPEDDIFF_PREC_BITS) +
                            WARPEDPIXEL_PREC_SHIFTS;
           assert(offs >= 0 && offs <= WARPEDPIXEL_PREC_SHIFTS * 3);
-          const int16_t *coeffs = warped_filter[offs];
+          const int16_t *coeffs = eb_warped_filter[offs];
 
           int32_t sum = 1 << offset_bits_horiz;
           for (int m = 0; m < 8; ++m) {
@@ -460,7 +460,7 @@ void av1_highbd_warp_affine_c(const int32_t *mat, const uint16_t *ref,
           const int offs = ROUND_POWER_OF_TWO(sy, WARPEDDIFF_PREC_BITS) +
                            WARPEDPIXEL_PREC_SHIFTS;
           assert(offs >= 0 && offs <= WARPEDPIXEL_PREC_SHIFTS * 3);
-          const int16_t *coeffs = warped_filter[offs];
+          const int16_t *coeffs = eb_warped_filter[offs];
 
           int32_t sum = 1 << offset_bits_vert;
           for (int m = 0; m < 8; ++m)
@@ -522,7 +522,7 @@ static void highbd_warp_plane(EbWarpedMotionParams *wm, const uint8_t *const ref
 
   const uint16_t *const ref = CONVERT_TO_SHORTPTR(ref8);
   uint16_t *pred = CONVERT_TO_SHORTPTR(pred8);
-  av1_highbd_warp_affine_c(mat, ref, width, height, stride, pred, p_col, p_row,
+  eb_av1_highbd_warp_affine_c(mat, ref, width, height, stride, pred, p_col, p_row,
                          p_width, p_height, p_stride, subsampling_x,
                          subsampling_y, bd, conv_params, alpha, beta, gamma,
                          delta);
@@ -658,7 +658,7 @@ static int64_t highbd_warp_error(
     leads to a maximum value of about 282 * 2^k after applying the offset.
     So in that case we still need to clamp.
 */
-void av1_warp_affine_c(const int32_t *mat, const uint8_t *ref, int width,
+void eb_av1_warp_affine_c(const int32_t *mat, const uint8_t *ref, int width,
                        int height, int stride, uint8_t *pred, int p_col,
                        int p_row, int p_width, int p_height, int p_stride,
                        int subsampling_x, int subsampling_y,
@@ -717,7 +717,7 @@ void av1_warp_affine_c(const int32_t *mat, const uint8_t *ref, int width,
           const int offs = ROUND_POWER_OF_TWO(sx, WARPEDDIFF_PREC_BITS) +
                            WARPEDPIXEL_PREC_SHIFTS;
           assert(offs >= 0 && offs <= WARPEDPIXEL_PREC_SHIFTS * 3);
-          const int16_t *coeffs = warped_filter[offs];
+          const int16_t *coeffs = eb_warped_filter[offs];
 
           int32_t sum = 1 << offset_bits_horiz;
           for (int m = 0; m < 8; ++m) {
@@ -741,7 +741,7 @@ void av1_warp_affine_c(const int32_t *mat, const uint8_t *ref, int width,
           const int offs = ROUND_POWER_OF_TWO(sy, WARPEDDIFF_PREC_BITS) +
                            WARPEDPIXEL_PREC_SHIFTS;
           assert(offs >= 0 && offs <= WARPEDPIXEL_PREC_SHIFTS * 3);
-          const int16_t *coeffs = warped_filter[offs];
+          const int16_t *coeffs = eb_warped_filter[offs];
 
           int32_t sum = 1 << offset_bits_vert;
           for (int m = 0; m < 8; ++m)
@@ -798,12 +798,12 @@ static void warp_plane(EbWarpedMotionParams *wm, const uint8_t *const ref,
   const int16_t beta = wm->beta;
   const int16_t gamma = wm->gamma;
   const int16_t delta = wm->delta;
-  av1_warp_affine(mat, ref, width, height, stride, pred, p_col, p_row, p_width,
+  eb_av1_warp_affine(mat, ref, width, height, stride, pred, p_col, p_row, p_width,
                   p_height, p_stride, subsampling_x, subsampling_y, conv_params,
                   alpha, beta, gamma, delta);
 }
 
-int64_t av1_calc_frame_error_c(const uint8_t *const ref, int stride,
+int64_t eb_av1_calc_frame_error_c(const uint8_t *const ref, int stride,
     const uint8_t *const dst, int p_width, int p_height, int p_stride) {
   int64_t sum_error = 0;
   for (int i = 0; i < p_height; ++i) {
@@ -838,7 +838,7 @@ static int64_t warp_error(EbWarpedMotionParams *wm, const uint8_t *const ref,
       warp_plane(wm, ref, width, height, stride, tmp, j, i, warp_w, warp_h,
                  WARP_ERROR_BLOCK, subsampling_x, subsampling_y, &conv_params);
 
-      gm_sumerr += av1_calc_frame_error(tmp, WARP_ERROR_BLOCK, dst + j + i * p_stride,
+      gm_sumerr += eb_av1_calc_frame_error(tmp, WARP_ERROR_BLOCK, dst + j + i * p_stride,
                                warp_w, warp_h, p_stride);
       if (gm_sumerr > best_error) return gm_sumerr;
     }
@@ -846,23 +846,23 @@ static int64_t warp_error(EbWarpedMotionParams *wm, const uint8_t *const ref,
   return gm_sumerr;
 }
 
-int64_t av1_frame_error(int use_hbd, int bd, const uint8_t *ref, int stride,
+int64_t eb_av1_frame_error(int use_hbd, int bd, const uint8_t *ref, int stride,
                         uint8_t *dst, int p_width, int p_height, int p_stride) {
   if (use_hbd) {
     return highbd_frame_error(CONVERT_TO_SHORTPTR(ref), stride,
                               CONVERT_TO_SHORTPTR(dst), p_width, p_height,
                               p_stride, bd);
   }
-  return av1_calc_frame_error(ref, stride, dst, p_width, p_height, p_stride);
+  return eb_av1_calc_frame_error(ref, stride, dst, p_width, p_height, p_stride);
 }
 
-int64_t av1_warp_error(EbWarpedMotionParams *wm, int use_hbd, int bd,
+int64_t eb_av1_warp_error(EbWarpedMotionParams *wm, int use_hbd, int bd,
                        const uint8_t *ref, int width, int height, int stride,
                        uint8_t *dst, int p_col, int p_row, int p_width,
                        int p_height, int p_stride, int subsampling_x,
                        int subsampling_y, int64_t best_error) {
   if (wm->wmtype <= AFFINE)
-    if (!get_shear_params(wm)) return 1;
+    if (!eb_get_shear_params(wm)) return 1;
   if (use_hbd)
     return highbd_warp_error(wm, ref, width, height, stride, dst, p_col, p_row,
                              p_width, p_height, p_stride, subsampling_x,
@@ -872,7 +872,7 @@ int64_t av1_warp_error(EbWarpedMotionParams *wm, int use_hbd, int bd,
                     best_error);
 }
 
-void av1_warp_plane(EbWarpedMotionParams *wm, int use_hbd, int bd,
+void eb_av1_warp_plane(EbWarpedMotionParams *wm, int use_hbd, int bd,
                     const uint8_t *ref, int width, int height, int stride,
                     uint8_t *pred, int p_col, int p_row, int p_width,
                     int p_height, int p_stride, int subsampling_x,
@@ -914,7 +914,7 @@ void av1_warp_plane_hbd(
   const int16_t gamma = wm->gamma;
   const int16_t delta = wm->delta;
 
-  av1_highbd_warp_affine_c(
+  eb_av1_highbd_warp_affine_c(
       mat,
       ref,
       width,
@@ -1163,7 +1163,7 @@ static int find_affine_int(int np, const int *pts1, const int *pts2,
   return 0;
 }
 
-EbBool find_projection(
+EbBool eb_find_projection(
     int np,
     int *pts1,
     int *pts2,
@@ -1181,7 +1181,7 @@ EbBool find_projection(
     }
 
     // check compatibility with the fast warp filter
-    if (!get_shear_params(wm_params))
+    if (!eb_get_shear_params(wm_params))
         return 1;
 
     return 0;

--- a/Source/Lib/Common/Codec/EbWarpedMotion.h
+++ b/Source/Lib/Common/Codec/EbWarpedMotion.h
@@ -53,7 +53,7 @@ extern "C" {
 #define WARPED_MOTION_DEBUG 0
 #define DEFAULT_WMTYPE AFFINE
 
-extern const int16_t warped_filter[WARPEDPIXEL_PREC_SHIFTS * 3 + 1][8];
+extern const int16_t eb_warped_filter[WARPEDPIXEL_PREC_SHIFTS * 3 + 1][8];
 extern const int error_measure_lut[512];
 
 EB_ALIGN(16) static const uint8_t warp_pad_left[14][16] = {
@@ -96,7 +96,7 @@ static INLINE int error_measure(int err) {
 
 // Returns the error between the result of applying motion 'wm' to the frame
 // described by 'ref' and the frame described by 'dst'.
-int64_t av1_warp_error(
+int64_t eb_av1_warp_error(
     EbWarpedMotionParams *wm,
     int            use_hbd,
     int            bd,
@@ -116,7 +116,7 @@ int64_t av1_warp_error(
 
 // Returns the error between the frame described by 'ref' and the frame
 // described by 'dst'.
-int64_t av1_frame_error(
+int64_t eb_av1_frame_error(
     int            use_hbd,
     int            bd,
     const uint8_t *ref,
@@ -126,7 +126,7 @@ int64_t av1_frame_error(
     int            p_height,
     int            p_stride);
 
-void av1_warp_plane(
+void eb_av1_warp_plane(
     EbWarpedMotionParams *wm,
     int             use_hbd,
     int             bd,
@@ -161,7 +161,7 @@ void av1_warp_plane_hbd(
     int             subsampling_y,
     ConvolveParams *conv_params);
 
-EbBool find_projection(
+EbBool eb_find_projection(
     int        np,
     int       *pts1,
     int       *pts2,
@@ -172,7 +172,7 @@ EbBool find_projection(
     int        mi_row,
     int        mi_col);
 
-int get_shear_params(EbWarpedMotionParams *wm);
+int eb_get_shear_params(EbWarpedMotionParams *wm);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -48,210 +48,210 @@ extern "C" {
     struct ConvolveParams;
     struct InterpFilterParams;
 
-    void apply_selfguided_restoration_c(const uint8_t *dat, int32_t width, int32_t height, int32_t stride, int32_t eps, const int32_t *xqd, uint8_t *dst, int32_t dst_stride, int32_t *tmpbuf, int32_t bit_depth, int32_t highbd);
-    void apply_selfguided_restoration_avx2(const uint8_t *dat, int32_t width, int32_t height, int32_t stride, int32_t eps, const int32_t *xqd, uint8_t *dst, int32_t dst_stride, int32_t *tmpbuf, int32_t bit_depth, int32_t highbd);
-    RTCD_EXTERN void(*apply_selfguided_restoration)(const uint8_t *dat, int32_t width, int32_t height, int32_t stride, int32_t eps, const int32_t *xqd, uint8_t *dst, int32_t dst_stride, int32_t *tmpbuf, int32_t bit_depth, int32_t highbd);
+    void eb_apply_selfguided_restoration_c(const uint8_t *dat, int32_t width, int32_t height, int32_t stride, int32_t eps, const int32_t *xqd, uint8_t *dst, int32_t dst_stride, int32_t *tmpbuf, int32_t bit_depth, int32_t highbd);
+    void eb_apply_selfguided_restoration_avx2(const uint8_t *dat, int32_t width, int32_t height, int32_t stride, int32_t eps, const int32_t *xqd, uint8_t *dst, int32_t dst_stride, int32_t *tmpbuf, int32_t bit_depth, int32_t highbd);
+    RTCD_EXTERN void(*eb_apply_selfguided_restoration)(const uint8_t *dat, int32_t width, int32_t height, int32_t stride, int32_t eps, const int32_t *xqd, uint8_t *dst, int32_t dst_stride, int32_t *tmpbuf, int32_t bit_depth, int32_t highbd);
 
-    void av1_wiener_convolve_add_src_c(const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst, ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4, const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h, const ConvolveParams *conv_params);
-    void av1_wiener_convolve_add_src_avx2(const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst, ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4, const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h, const ConvolveParams *conv_params);
-    RTCD_EXTERN void(*av1_wiener_convolve_add_src)(const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst, ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4, const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h, const ConvolveParams *conv_params);
+    void eb_av1_wiener_convolve_add_src_c(const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst, ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4, const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h, const ConvolveParams *conv_params);
+    void eb_av1_wiener_convolve_add_src_avx2(const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst, ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4, const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h, const ConvolveParams *conv_params);
+    RTCD_EXTERN void(*eb_av1_wiener_convolve_add_src)(const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst, ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4, const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h, const ConvolveParams *conv_params);
 
-    void av1_highbd_wiener_convolve_add_src_c(const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst, ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4, const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h, const ConvolveParams *conv_params, int32_t bps);
-    void av1_highbd_wiener_convolve_add_src_avx2(const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst, ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4, const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h, const ConvolveParams *conv_params, int32_t bps);
-    RTCD_EXTERN void(*av1_highbd_wiener_convolve_add_src)(const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst, ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4, const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h, const ConvolveParams *conv_params, int32_t bps);
+    void eb_av1_highbd_wiener_convolve_add_src_c(const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst, ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4, const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h, const ConvolveParams *conv_params, int32_t bps);
+    void eb_av1_highbd_wiener_convolve_add_src_avx2(const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst, ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4, const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h, const ConvolveParams *conv_params, int32_t bps);
+    RTCD_EXTERN void(*eb_av1_highbd_wiener_convolve_add_src)(const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst, ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4, const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h, const ConvolveParams *conv_params, int32_t bps);
 
-    void av1_selfguided_restoration_c(const uint8_t *dgd8, int32_t width, int32_t height,
+    void eb_av1_selfguided_restoration_c(const uint8_t *dgd8, int32_t width, int32_t height,
         int32_t dgd_stride, int32_t *flt0, int32_t *flt1, int32_t flt_stride,
         int32_t sgr_params_idx, int32_t bit_depth, int32_t highbd);
-    void av1_selfguided_restoration_avx2(const uint8_t *dgd8, int32_t width, int32_t height,
+    void eb_av1_selfguided_restoration_avx2(const uint8_t *dgd8, int32_t width, int32_t height,
         int32_t dgd_stride, int32_t *flt0, int32_t *flt1, int32_t flt_stride,
         int32_t sgr_params_idx, int32_t bit_depth, int32_t highbd);
-    RTCD_EXTERN void(*av1_selfguided_restoration)(const uint8_t *dgd8, int32_t width, int32_t height,
+    RTCD_EXTERN void(*eb_av1_selfguided_restoration)(const uint8_t *dgd8, int32_t width, int32_t height,
         int32_t dgd_stride, int32_t *flt0, int32_t *flt1, int32_t flt_stride,
         int32_t sgr_params_idx, int32_t bit_depth, int32_t highbd);
 
-    int32_t cdef_find_dir_c(const uint16_t *img, int32_t stride, int32_t *var, int32_t coeff_shift);
-    int32_t cdef_find_dir_avx2(const uint16_t *img, int32_t stride, int32_t *var, int32_t coeff_shift);
-    RTCD_EXTERN int32_t(*cdef_find_dir)(const uint16_t *img, int32_t stride, int32_t *var, int32_t coeff_shift);
+    int32_t eb_cdef_find_dir_c(const uint16_t *img, int32_t stride, int32_t *var, int32_t coeff_shift);
+    int32_t eb_cdef_find_dir_avx2(const uint16_t *img, int32_t stride, int32_t *var, int32_t coeff_shift);
+    RTCD_EXTERN int32_t(*eb_cdef_find_dir)(const uint16_t *img, int32_t stride, int32_t *var, int32_t coeff_shift);
 
-    void cdef_filter_block_c(uint8_t *dst8, uint16_t *dst16, int32_t dstride, const uint16_t *in, int32_t pri_strength, int32_t sec_strength, int32_t dir, int32_t pri_damping, int32_t sec_damping, int32_t bsize, int32_t max, int32_t coeff_shift);
-    void cdef_filter_block_avx2(uint8_t *dst8, uint16_t *dst16, int32_t dstride, const uint16_t *in, int32_t pri_strength, int32_t sec_strength, int32_t dir, int32_t pri_damping, int32_t sec_damping, int32_t bsize, int32_t max, int32_t coeff_shift);
-    RTCD_EXTERN void(*cdef_filter_block)(uint8_t *dst8, uint16_t *dst16, int32_t dstride, const uint16_t *in, int32_t pri_strength, int32_t sec_strength, int32_t dir, int32_t pri_damping, int32_t sec_damping, int32_t bsize, int32_t max, int32_t coeff_shift);
+    void eb_cdef_filter_block_c(uint8_t *dst8, uint16_t *dst16, int32_t dstride, const uint16_t *in, int32_t pri_strength, int32_t sec_strength, int32_t dir, int32_t pri_damping, int32_t sec_damping, int32_t bsize, int32_t max, int32_t coeff_shift);
+    void eb_cdef_filter_block_avx2(uint8_t *dst8, uint16_t *dst16, int32_t dstride, const uint16_t *in, int32_t pri_strength, int32_t sec_strength, int32_t dir, int32_t pri_damping, int32_t sec_damping, int32_t bsize, int32_t max, int32_t coeff_shift);
+    RTCD_EXTERN void(*eb_cdef_filter_block)(uint8_t *dst8, uint16_t *dst16, int32_t dstride, const uint16_t *in, int32_t pri_strength, int32_t sec_strength, int32_t dir, int32_t pri_damping, int32_t sec_damping, int32_t bsize, int32_t max, int32_t coeff_shift);
 
     uint64_t compute_cdef_dist_c(const uint16_t *dst, int32_t dstride, const uint16_t *src, const cdef_list *dlist, int32_t cdef_count, BlockSize bsize, int32_t coeff_shift, int32_t pli);
     uint64_t compute_cdef_dist_avx2(const uint16_t *dst, int32_t dstride, const uint16_t *src, const cdef_list *dlist, int32_t cdef_count, BlockSize bsize, int32_t coeff_shift, int32_t pli);
-    RTCD_EXTERN uint64_t(*compute_cdef_dist)(const uint16_t *dst, int32_t dstride, const uint16_t *src, const cdef_list *dlist, int32_t cdef_count, BlockSize bsize, int32_t coeff_shift, int32_t pli);
-    void copy_rect8_8bit_to_16bit_c(uint16_t *dst, int32_t dstride, const uint8_t *src, int32_t sstride, int32_t v, int32_t h);
-    void copy_rect8_8bit_to_16bit_avx2(uint16_t *dst, int32_t dstride, const uint8_t *src, int32_t sstride, int32_t v, int32_t h);
-    RTCD_EXTERN void(*copy_rect8_8bit_to_16bit)(uint16_t *dst, int32_t dstride, const uint8_t *src, int32_t sstride, int32_t v, int32_t h);
+    RTCD_EXTERN uint64_t(*eb_compute_cdef_dist)(const uint16_t *dst, int32_t dstride, const uint16_t *src, const cdef_list *dlist, int32_t cdef_count, BlockSize bsize, int32_t coeff_shift, int32_t pli);
+    void eb_copy_rect8_8bit_to_16bit_c(uint16_t *dst, int32_t dstride, const uint8_t *src, int32_t sstride, int32_t v, int32_t h);
+    void eb_copy_rect8_8bit_to_16bit_avx2(uint16_t *dst, int32_t dstride, const uint8_t *src, int32_t sstride, int32_t v, int32_t h);
+    RTCD_EXTERN void(*eb_copy_rect8_8bit_to_16bit)(uint16_t *dst, int32_t dstride, const uint8_t *src, int32_t sstride, int32_t v, int32_t h);
 
-    void av1_compute_stats_c(int32_t wiener_win, const uint8_t *dgd8, const uint8_t *src8, int32_t h_start, int32_t h_end, int32_t v_start, int32_t v_end, int32_t dgd_stride, int32_t src_stride, int64_t *M, int64_t *H);
-    void av1_compute_stats_avx2(int32_t wiener_win, const uint8_t *dgd8, const uint8_t *src8, int32_t h_start, int32_t h_end, int32_t v_start, int32_t v_end, int32_t dgd_stride, int32_t src_stride, int64_t *M, int64_t *H);
-    RTCD_EXTERN void(*av1_compute_stats)(int32_t wiener_win, const uint8_t *dgd8, const uint8_t *src8, int32_t h_start, int32_t h_end, int32_t v_start, int32_t v_end, int32_t dgd_stride, int32_t src_stride, int64_t *M, int64_t *H);
+    void eb_av1_compute_stats_c(int32_t wiener_win, const uint8_t *dgd8, const uint8_t *src8, int32_t h_start, int32_t h_end, int32_t v_start, int32_t v_end, int32_t dgd_stride, int32_t src_stride, int64_t *M, int64_t *H);
+    void eb_av1_compute_stats_avx2(int32_t wiener_win, const uint8_t *dgd8, const uint8_t *src8, int32_t h_start, int32_t h_end, int32_t v_start, int32_t v_end, int32_t dgd_stride, int32_t src_stride, int64_t *M, int64_t *H);
+    RTCD_EXTERN void(*eb_av1_compute_stats)(int32_t wiener_win, const uint8_t *dgd8, const uint8_t *src8, int32_t h_start, int32_t h_end, int32_t v_start, int32_t v_end, int32_t dgd_stride, int32_t src_stride, int64_t *M, int64_t *H);
 
-    void av1_compute_stats_highbd_c(int32_t wiener_win, const uint8_t *dgd8, const uint8_t *src8, int32_t h_start, int32_t h_end, int32_t v_start, int32_t v_end, int32_t dgd_stride, int32_t src_stride, int64_t *M, int64_t *H, AomBitDepth bit_depth);
-    void av1_compute_stats_highbd_avx2(int32_t wiener_win, const uint8_t *dgd8, const uint8_t *src8, int32_t h_start, int32_t h_end, int32_t v_start, int32_t v_end, int32_t dgd_stride, int32_t src_stride, int64_t *M, int64_t *H, AomBitDepth bit_depth);
-    RTCD_EXTERN void(*av1_compute_stats_highbd)(int32_t wiener_win, const uint8_t *dgd8, const uint8_t *src8, int32_t h_start, int32_t h_end, int32_t v_start, int32_t v_end, int32_t dgd_stride, int32_t src_stride, int64_t *M, int64_t *H, AomBitDepth bit_depth);
+    void eb_av1_compute_stats_highbd_c(int32_t wiener_win, const uint8_t *dgd8, const uint8_t *src8, int32_t h_start, int32_t h_end, int32_t v_start, int32_t v_end, int32_t dgd_stride, int32_t src_stride, int64_t *M, int64_t *H, AomBitDepth bit_depth);
+    void eb_av1_compute_stats_highbd_avx2(int32_t wiener_win, const uint8_t *dgd8, const uint8_t *src8, int32_t h_start, int32_t h_end, int32_t v_start, int32_t v_end, int32_t dgd_stride, int32_t src_stride, int64_t *M, int64_t *H, AomBitDepth bit_depth);
+    RTCD_EXTERN void(*eb_av1_compute_stats_highbd)(int32_t wiener_win, const uint8_t *dgd8, const uint8_t *src8, int32_t h_start, int32_t h_end, int32_t v_start, int32_t v_end, int32_t dgd_stride, int32_t src_stride, int64_t *M, int64_t *H, AomBitDepth bit_depth);
 
-    int64_t av1_lowbd_pixel_proj_error_c(const uint8_t *src8, int32_t width, int32_t height, int32_t src_stride, const uint8_t *dat8, int32_t dat_stride, int32_t *flt0, int32_t flt0_stride, int32_t *flt1, int32_t flt1_stride, int32_t xq[2], const SgrParamsType *params);
-    int64_t av1_lowbd_pixel_proj_error_avx2(const uint8_t *src8, int32_t width, int32_t height, int32_t src_stride, const uint8_t *dat8, int32_t dat_stride, int32_t *flt0, int32_t flt0_stride, int32_t *flt1, int32_t flt1_stride, int32_t xq[2], const SgrParamsType *params);
-    RTCD_EXTERN int64_t(*av1_lowbd_pixel_proj_error)(const uint8_t *src8, int32_t width, int32_t height, int32_t src_stride, const uint8_t *dat8, int32_t dat_stride, int32_t *flt0, int32_t flt0_stride, int32_t *flt1, int32_t flt1_stride, int32_t xq[2], const SgrParamsType *params);
+    int64_t eb_av1_lowbd_pixel_proj_error_c(const uint8_t *src8, int32_t width, int32_t height, int32_t src_stride, const uint8_t *dat8, int32_t dat_stride, int32_t *flt0, int32_t flt0_stride, int32_t *flt1, int32_t flt1_stride, int32_t xq[2], const SgrParamsType *params);
+    int64_t eb_av1_lowbd_pixel_proj_error_avx2(const uint8_t *src8, int32_t width, int32_t height, int32_t src_stride, const uint8_t *dat8, int32_t dat_stride, int32_t *flt0, int32_t flt0_stride, int32_t *flt1, int32_t flt1_stride, int32_t xq[2], const SgrParamsType *params);
+    RTCD_EXTERN int64_t(*eb_av1_lowbd_pixel_proj_error)(const uint8_t *src8, int32_t width, int32_t height, int32_t src_stride, const uint8_t *dat8, int32_t dat_stride, int32_t *flt0, int32_t flt0_stride, int32_t *flt1, int32_t flt1_stride, int32_t xq[2], const SgrParamsType *params);
 
-    int64_t av1_highbd_pixel_proj_error_c(const uint8_t *src8, int32_t width, int32_t height, int32_t src_stride, const uint8_t *dat8, int32_t dat_stride, int32_t *flt0, int32_t flt0_stride, int32_t *flt1, int32_t flt1_stride, int32_t xq[2], const SgrParamsType *params);
-    int64_t av1_highbd_pixel_proj_error_avx2(const uint8_t *src8, int32_t width, int32_t height, int32_t src_stride, const uint8_t *dat8, int32_t dat_stride, int32_t *flt0, int32_t flt0_stride, int32_t *flt1, int32_t flt1_stride, int32_t xq[2], const SgrParamsType *params);
-    RTCD_EXTERN int64_t(*av1_highbd_pixel_proj_error)(const uint8_t *src8, int32_t width, int32_t height, int32_t src_stride, const uint8_t *dat8, int32_t dat_stride, int32_t *flt0, int32_t flt0_stride, int32_t *flt1, int32_t flt1_stride, int32_t xq[2], const SgrParamsType *params);
+    int64_t eb_av1_highbd_pixel_proj_error_c(const uint8_t *src8, int32_t width, int32_t height, int32_t src_stride, const uint8_t *dat8, int32_t dat_stride, int32_t *flt0, int32_t flt0_stride, int32_t *flt1, int32_t flt1_stride, int32_t xq[2], const SgrParamsType *params);
+    int64_t eb_av1_highbd_pixel_proj_error_avx2(const uint8_t *src8, int32_t width, int32_t height, int32_t src_stride, const uint8_t *dat8, int32_t dat_stride, int32_t *flt0, int32_t flt0_stride, int32_t *flt1, int32_t flt1_stride, int32_t xq[2], const SgrParamsType *params);
+    RTCD_EXTERN int64_t(*eb_av1_highbd_pixel_proj_error)(const uint8_t *src8, int32_t width, int32_t height, int32_t src_stride, const uint8_t *dat8, int32_t dat_stride, int32_t *flt0, int32_t flt0_stride, int32_t *flt1, int32_t flt1_stride, int32_t xq[2], const SgrParamsType *params);
 
-    void av1_highbd_convolve_2d_copy_sr_c(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-    void av1_highbd_convolve_2d_copy_sr_avx2(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-    RTCD_EXTERN void(*av1_highbd_convolve_2d_copy_sr)(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    void eb_av1_highbd_convolve_2d_copy_sr_c(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    void eb_av1_highbd_convolve_2d_copy_sr_avx2(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_highbd_convolve_2d_copy_sr)(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
 
-    void av1_highbd_jnt_convolve_2d_copy_c(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-    void av1_highbd_jnt_convolve_2d_copy_avx2(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-    RTCD_EXTERN void(*av1_highbd_jnt_convolve_2d_copy)(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    void eb_av1_highbd_jnt_convolve_2d_copy_c(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    void eb_av1_highbd_jnt_convolve_2d_copy_avx2(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_highbd_jnt_convolve_2d_copy)(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
 
-    void av1_highbd_convolve_y_sr_c(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-    void av1_highbd_convolve_y_sr_avx2(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-    RTCD_EXTERN void(*av1_highbd_convolve_y_sr)(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    void eb_av1_highbd_convolve_y_sr_c(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    void eb_av1_highbd_convolve_y_sr_avx2(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_highbd_convolve_y_sr)(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
 
-    void av1_highbd_convolve_2d_sr_c(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-    void av1_highbd_convolve_2d_sr_avx2(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-    RTCD_EXTERN void(*av1_highbd_convolve_2d_sr)(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    void eb_av1_highbd_convolve_2d_sr_c(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    void eb_av1_highbd_convolve_2d_sr_avx2(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_highbd_convolve_2d_sr)(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
 
-    void av1_highbd_jnt_convolve_2d_c(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-    void av1_highbd_jnt_convolve_2d_avx2(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-    RTCD_EXTERN void(*av1_highbd_jnt_convolve_2d)(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    void eb_av1_highbd_jnt_convolve_2d_c(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    void eb_av1_highbd_jnt_convolve_2d_avx2(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_highbd_jnt_convolve_2d)(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
 
-    void av1_highbd_jnt_convolve_x_c(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-    void av1_highbd_jnt_convolve_x_avx2(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-    RTCD_EXTERN void(*av1_highbd_jnt_convolve_x)(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    void eb_av1_highbd_jnt_convolve_x_c(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    void eb_av1_highbd_jnt_convolve_x_avx2(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_highbd_jnt_convolve_x)(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
 
-    void av1_highbd_jnt_convolve_y_c(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-    void av1_highbd_jnt_convolve_y_avx2(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-    RTCD_EXTERN void(*av1_highbd_jnt_convolve_y)(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    void eb_av1_highbd_jnt_convolve_y_c(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    void eb_av1_highbd_jnt_convolve_y_avx2(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_highbd_jnt_convolve_y)(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
 
-    void av1_highbd_convolve_x_sr_c(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-    void av1_highbd_convolve_x_sr_avx2(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-    RTCD_EXTERN void(*av1_highbd_convolve_x_sr)(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    void eb_av1_highbd_convolve_x_sr_c(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    void eb_av1_highbd_convolve_x_sr_avx2(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_highbd_convolve_x_sr)(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
 
-    void subtract_average_c(int16_t *pred_buf_q3, int32_t width, int32_t height, int32_t round_offset, int32_t num_pel_log2);
-    void subtract_average_avx2(int16_t *pred_buf_q3, int32_t width, int32_t height, int32_t round_offset, int32_t num_pel_log2);
-    RTCD_EXTERN void(*subtract_average)(int16_t *pred_buf_q3, int32_t width, int32_t height, int32_t round_offset, int32_t num_pel_log2);
+    void eb_subtract_average_c(int16_t *pred_buf_q3, int32_t width, int32_t height, int32_t round_offset, int32_t num_pel_log2);
+    void eb_subtract_average_avx2(int16_t *pred_buf_q3, int32_t width, int32_t height, int32_t round_offset, int32_t num_pel_log2);
+    RTCD_EXTERN void(*eb_subtract_average)(int16_t *pred_buf_q3, int32_t width, int32_t height, int32_t round_offset, int32_t num_pel_log2);
 
-    void cfl_predict_lbd_c(const int16_t *pred_buf_q3, uint8_t *pred, int32_t pred_stride, uint8_t *dst, int32_t dst_stride, int32_t alpha_q3, int32_t bit_depth, int32_t width, int32_t height);
-    void cfl_predict_lbd_avx2(const int16_t *pred_buf_q3, uint8_t *pred, int32_t pred_stride, uint8_t *dst, int32_t dst_stride, int32_t alpha_q3, int32_t bit_depth, int32_t width, int32_t height);
-    RTCD_EXTERN void(*cfl_predict_lbd)(const int16_t *pred_buf_q3, uint8_t *pred, int32_t pred_stride, uint8_t *dst, int32_t dst_stride, int32_t alpha_q3, int32_t bit_depth, int32_t width, int32_t height);
+    void eb_cfl_predict_lbd_c(const int16_t *pred_buf_q3, uint8_t *pred, int32_t pred_stride, uint8_t *dst, int32_t dst_stride, int32_t alpha_q3, int32_t bit_depth, int32_t width, int32_t height);
+    void eb_cfl_predict_lbd_avx2(const int16_t *pred_buf_q3, uint8_t *pred, int32_t pred_stride, uint8_t *dst, int32_t dst_stride, int32_t alpha_q3, int32_t bit_depth, int32_t width, int32_t height);
+    RTCD_EXTERN void(*eb_cfl_predict_lbd)(const int16_t *pred_buf_q3, uint8_t *pred, int32_t pred_stride, uint8_t *dst, int32_t dst_stride, int32_t alpha_q3, int32_t bit_depth, int32_t width, int32_t height);
 
-    void cfl_predict_hbd_c(const int16_t *pred_buf_q3, uint16_t *pred, int32_t pred_stride, uint16_t *dst, int32_t dst_stride, int32_t alpha_q3, int32_t bit_depth, int32_t width, int32_t height);
-    void cfl_predict_hbd_avx2(const int16_t *pred_buf_q3, uint16_t *pred, int32_t pred_stride, uint16_t *dst, int32_t dst_stride, int32_t alpha_q3, int32_t bit_depth, int32_t width, int32_t height);
-    RTCD_EXTERN void(*cfl_predict_hbd)(const int16_t *pred_buf_q3, uint16_t *pred, int32_t pred_stride, uint16_t *dst, int32_t dst_stride, int32_t alpha_q3, int32_t bit_depth, int32_t width, int32_t height);
+    void eb_cfl_predict_hbd_c(const int16_t *pred_buf_q3, uint16_t *pred, int32_t pred_stride, uint16_t *dst, int32_t dst_stride, int32_t alpha_q3, int32_t bit_depth, int32_t width, int32_t height);
+    void eb_cfl_predict_hbd_avx2(const int16_t *pred_buf_q3, uint16_t *pred, int32_t pred_stride, uint16_t *dst, int32_t dst_stride, int32_t alpha_q3, int32_t bit_depth, int32_t width, int32_t height);
+    RTCD_EXTERN void(*eb_cfl_predict_hbd)(const int16_t *pred_buf_q3, uint16_t *pred, int32_t pred_stride, uint16_t *dst, int32_t dst_stride, int32_t alpha_q3, int32_t bit_depth, int32_t width, int32_t height);
 
-    void av1_filter_intra_edge_high_c_old(uint8_t *p, int32_t sz, int32_t strength);
-    void av1_filter_intra_edge_sse4_1(uint8_t *p, int32_t sz, int32_t strength);
-    RTCD_EXTERN void(*av1_filter_intra_edge)(uint8_t *p, int32_t sz, int32_t strength);
+    void eb_av1_filter_intra_edge_high_c_old(uint8_t *p, int32_t sz, int32_t strength);
+    void eb_av1_filter_intra_edge_sse4_1(uint8_t *p, int32_t sz, int32_t strength);
+    RTCD_EXTERN void(*eb_av1_filter_intra_edge)(uint8_t *p, int32_t sz, int32_t strength);
 
-    void av1_filter_intra_edge_high_c(uint16_t *p, int32_t sz, int32_t strength);
-    void av1_filter_intra_edge_high_sse4_1(uint16_t *p, int32_t sz, int32_t strength);
-    RTCD_EXTERN void(*av1_filter_intra_edge_high)(uint16_t *p, int32_t sz, int32_t strength);
+    void eb_av1_filter_intra_edge_high_c(uint16_t *p, int32_t sz, int32_t strength);
+    void eb_av1_filter_intra_edge_high_sse4_1(uint16_t *p, int32_t sz, int32_t strength);
+    RTCD_EXTERN void(*eb_av1_filter_intra_edge_high)(uint16_t *p, int32_t sz, int32_t strength);
 
-    int64_t av1_calc_frame_error_c(const uint8_t *const ref, int stride, const uint8_t *const dst, int p_width, int p_height, int p_stride);
-    int64_t av1_calc_frame_error_avx2(const uint8_t *const ref, int stride, const uint8_t *const dst, int p_width, int p_height, int p_stride);
-    RTCD_EXTERN int64_t (*av1_calc_frame_error)(const uint8_t *const ref, int stride, const uint8_t *const dst, int p_width, int p_height, int p_stride);
+    int64_t eb_av1_calc_frame_error_c(const uint8_t *const ref, int stride, const uint8_t *const dst, int p_width, int p_height, int p_stride);
+    int64_t eb_av1_calc_frame_error_avx2(const uint8_t *const ref, int stride, const uint8_t *const dst, int p_width, int p_height, int p_stride);
+    RTCD_EXTERN int64_t (*eb_av1_calc_frame_error)(const uint8_t *const ref, int stride, const uint8_t *const dst, int p_width, int p_height, int p_stride);
 
-    void av1_fwd_txfm2d_4x16_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_4x16_avx2(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_4x16)(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_4x16_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_4x16_avx2(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_4x16)(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_16x4_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_16x4_avx2(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_16x4)(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_16x4_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_16x4_avx2(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_16x4)(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_4x8_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_4x8_avx2(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_4x8)(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_4x8_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_4x8_avx2(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_4x8)(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_8x4_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_8x4_avx2(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_8x4)(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_8x4_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_8x4_avx2(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_8x4)(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_8x16_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_8x16_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_8x16)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_8x16_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_8x16_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_8x16)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_16x8_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_16x8_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_16x8)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_16x8_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_16x8_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_16x8)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_4x16_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_4x16_sse4_1(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_4x16)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_4x16_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_4x16_sse4_1(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_4x16)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_16x4_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_16x4_sse4_1(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_16x4)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_16x4_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_16x4_sse4_1(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_16x4)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_4x8_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_4x8_sse4_1(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_4x8)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_4x8_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_4x8_sse4_1(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_4x8)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_8x4_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_8x4_sse4_1(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_8x4)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_8x4_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_8x4_sse4_1(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_8x4)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_32x16_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_32x16_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_32x16)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_32x16_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_32x16_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_32x16)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_32x8_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_32x8_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_32x8)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_32x8_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_32x8_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_32x8)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_8x32_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_8x32_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_8x32)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_8x32_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_8x32_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_8x32)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_16x32_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_16x32_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_16x32)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_16x32_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_16x32_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_16x32)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_32x64_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_32x64_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_32x64)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_32x64_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_32x64_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_32x64)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_64x32_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_64x32_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_64x32)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_64x32_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_64x32_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_64x32)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_16x64_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_16x64_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_16x64)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_16x64_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_16x64_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_16x64)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_64x16_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_64x16_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_64x16)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_64x16_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_64x16_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_64x16)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
     void Av1TransformTwoD_64x64_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_64x64_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_64x64)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_64x64_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_64x64)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
     void Av1TransformTwoD_32x32_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_32x32_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_32x32)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_32x32_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_32x32)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
-    void av1_fwd_txfm2d_pf_32x32_c(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_pf_32x32_avx2(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
-    #define av1_fwd_txfm2d_pf_32x32 av1_fwd_txfm2d_pf_32x32_avx2
+    void eb_av1_fwd_txfm2d_pf_32x32_c(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_pf_32x32_avx2(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
+    #define eb_av1_fwd_txfm2d_pf_32x32 eb_av1_fwd_txfm2d_pf_32x32_avx2
 
     void Av1TransformTwoD_16x16_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_16x16_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_16x16)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_16x16_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_16x16)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
     void Av1TransformTwoD_8x8_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_8x8_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_8x8)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_8x8_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_8x8)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
     void Av1TransformTwoD_4x4_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    void av1_fwd_txfm2d_4x4_sse4_1(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
-    RTCD_EXTERN void(*av1_fwd_txfm2d_4x4)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void eb_av1_fwd_txfm2d_4x4_sse4_1(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    RTCD_EXTERN void(*eb_av1_fwd_txfm2d_4x4)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
     void smooth_v_predictor_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left);
     void eb_smooth_v_predictor_all_ssse3(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left);
@@ -289,2074 +289,2074 @@ extern "C" {
     uint64_t search_one_dual_avx2(int *lev0, int *lev1, int nb_strengths, uint64_t(**mse)[64], int sb_count, int fast, int start_gi, int end_gi);
     RTCD_EXTERN uint64_t(*search_one_dual)(int *lev0, int *lev1, int nb_strengths, uint64_t(**mse)[64], int sb_count, int fast, int start_gi, int end_gi);
 
-    uint32_t aom_mse16x16_c(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
-    uint32_t aom_mse16x16_avx2(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
-    RTCD_EXTERN uint32_t (*aom_mse16x16)(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
+    uint32_t eb_aom_mse16x16_c(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
+    uint32_t eb_aom_mse16x16_avx2(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
+    RTCD_EXTERN uint32_t (*eb_aom_mse16x16)(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
 
-    void av1_convolve_2d_copy_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
-    void av1_convolve_2d_copy_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
-    RTCD_EXTERN void(*av1_convolve_2d_copy_sr)(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    void eb_av1_convolve_2d_copy_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    void eb_av1_convolve_2d_copy_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    RTCD_EXTERN void(*eb_av1_convolve_2d_copy_sr)(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
 
-    void av1_convolve_2d_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
-    void av1_convolve_2d_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
-    RTCD_EXTERN void(*av1_convolve_2d_sr)(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    void eb_av1_convolve_2d_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    void eb_av1_convolve_2d_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    RTCD_EXTERN void(*eb_av1_convolve_2d_sr)(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
 
-    void av1_jnt_convolve_2d_copy_c(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
-    void av1_jnt_convolve_2d_copy_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
-    RTCD_EXTERN void(*av1_jnt_convolve_2d_copy)(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    void eb_av1_jnt_convolve_2d_copy_c(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    void eb_av1_jnt_convolve_2d_copy_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    RTCD_EXTERN void(*eb_av1_jnt_convolve_2d_copy)(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
 
-    void av1_convolve_x_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
-    void av1_convolve_x_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
-    RTCD_EXTERN void(*av1_convolve_x_sr)(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    void eb_av1_convolve_x_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    void eb_av1_convolve_x_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    RTCD_EXTERN void(*eb_av1_convolve_x_sr)(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
 
-    void av1_convolve_y_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
-    void av1_convolve_y_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
-    RTCD_EXTERN void(*av1_convolve_y_sr)(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    void eb_av1_convolve_y_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    void eb_av1_convolve_y_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    RTCD_EXTERN void(*eb_av1_convolve_y_sr)(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
 
-    void av1_jnt_convolve_x_c(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
-    void av1_jnt_convolve_x_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
-    RTCD_EXTERN void(*av1_jnt_convolve_x)(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    void eb_av1_jnt_convolve_x_c(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    void eb_av1_jnt_convolve_x_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    RTCD_EXTERN void(*eb_av1_jnt_convolve_x)(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
 
-    void av1_jnt_convolve_y_c(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
-    void av1_jnt_convolve_y_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
-    RTCD_EXTERN void(*av1_jnt_convolve_y)(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    void eb_av1_jnt_convolve_y_c(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    void eb_av1_jnt_convolve_y_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    RTCD_EXTERN void(*eb_av1_jnt_convolve_y)(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
 
-    void av1_jnt_convolve_2d_c(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
-    void av1_jnt_convolve_2d_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
-    RTCD_EXTERN void(*av1_jnt_convolve_2d)(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    void eb_av1_jnt_convolve_2d_c(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    void eb_av1_jnt_convolve_2d_avx2(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
+    RTCD_EXTERN void(*eb_av1_jnt_convolve_2d)(const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride, int32_t w, int32_t h, InterpFilterParams *filter_params_x, InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params);
 
-    void aom_quantize_b_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
-    void aom_highbd_quantize_b_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
-    RTCD_EXTERN void(*aom_quantize_b)(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    void eb_aom_quantize_b_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    void eb_aom_highbd_quantize_b_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    RTCD_EXTERN void(*eb_aom_quantize_b)(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
 
-    void aom_quantize_b_32x32_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
-    void aom_highbd_quantize_b_32x32_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs, int skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
-    RTCD_EXTERN void(*aom_quantize_b_32x32)(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    void eb_aom_quantize_b_32x32_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    void eb_aom_highbd_quantize_b_32x32_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs, int skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    RTCD_EXTERN void(*eb_aom_quantize_b_32x32)(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
 
-    void aom_quantize_b_64x64_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
-    void aom_highbd_quantize_b_64x64_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
-    RTCD_EXTERN void(*aom_quantize_b_64x64)(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    void eb_aom_quantize_b_64x64_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    void eb_aom_highbd_quantize_b_64x64_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    RTCD_EXTERN void(*eb_aom_quantize_b_64x64)(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
 
-    void aom_highbd_quantize_b_c(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
-    RTCD_EXTERN void(*aom_highbd_quantize_b)(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    void eb_aom_highbd_quantize_b_c(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    RTCD_EXTERN void(*eb_aom_highbd_quantize_b)(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
 
-    void aom_highbd_quantize_b_32x32_c(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
-    RTCD_EXTERN void(*aom_highbd_quantize_b_32x32)(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    void eb_aom_highbd_quantize_b_32x32_c(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    RTCD_EXTERN void(*eb_aom_highbd_quantize_b_32x32)(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
 
-    void aom_highbd_quantize_b_64x64_c(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
-    RTCD_EXTERN void(*aom_highbd_quantize_b_64x64)(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    void eb_aom_highbd_quantize_b_64x64_c(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    RTCD_EXTERN void(*eb_aom_highbd_quantize_b_64x64)(const TranLow *coeff_ptr, intptr_t n_coeffs, int32_t skip_block, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
 
-    void av1_highbd_warp_affine_c(const int32_t *mat, const uint16_t *ref, int width, int height, int stride, uint16_t *pred, int p_col, int p_row, int p_width, int p_height, int p_stride, int subsampling_x, int subsampling_y, int bd, ConvolveParams *conv_params, int16_t alpha, int16_t beta, int16_t gamma, int16_t delta);
+    void eb_av1_highbd_warp_affine_c(const int32_t *mat, const uint16_t *ref, int width, int height, int stride, uint16_t *pred, int p_col, int p_row, int p_width, int p_height, int p_stride, int subsampling_x, int subsampling_y, int bd, ConvolveParams *conv_params, int16_t alpha, int16_t beta, int16_t gamma, int16_t delta);
 
-    void av1_inv_txfm2d_add_4x4_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
-    void av1_inv_txfm2d_add_4x4_sse4_1(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
-    void av1_inv_txfm2d_add_4x4_avx2(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_4x4)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    void eb_av1_inv_txfm2d_add_4x4_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    void eb_av1_inv_txfm2d_add_4x4_sse4_1(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    void eb_av1_inv_txfm2d_add_4x4_avx2(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_4x4)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
 
-    void av1_inv_txfm2d_add_8x8_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
-    void av1_inv_txfm2d_add_8x8_sse4_1(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
-    void av1_inv_txfm2d_add_8x8_avx2(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_8x8)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    void eb_av1_inv_txfm2d_add_8x8_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    void eb_av1_inv_txfm2d_add_8x8_sse4_1(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    void eb_av1_inv_txfm2d_add_8x8_avx2(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_8x8)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
 
-    void av1_inv_txfm2d_add_16x16_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
-    void av1_inv_txfm2d_add_16x16_sse4_1(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
-    void av1_inv_txfm2d_add_16x16_avx2(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_16x16)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    void eb_av1_inv_txfm2d_add_16x16_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    void eb_av1_inv_txfm2d_add_16x16_sse4_1(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    void eb_av1_inv_txfm2d_add_16x16_avx2(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_16x16)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
 
-    void av1_inv_txfm2d_add_32x32_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
-    void av1_inv_txfm2d_add_32x32_avx2(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_32x32)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    void eb_av1_inv_txfm2d_add_32x32_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    void eb_av1_inv_txfm2d_add_32x32_avx2(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_32x32)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
 
-    void av1_inv_txfm2d_add_64x64_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
-    void av1_inv_txfm2d_add_64x64_sse4_1(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_64x64)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    void eb_av1_inv_txfm2d_add_64x64_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    void eb_av1_inv_txfm2d_add_64x64_sse4_1(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_64x64)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, int32_t bd);
 
-    void av1_highbd_inv_txfm_add_avx2(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    void eb_av1_highbd_inv_txfm_add_avx2(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
 
-    void av1_inv_txfm2d_add_8x16_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_8x16)(const int32_t *input, uint16_t *output, int32_t stride, const TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    void eb_av1_inv_txfm2d_add_8x16_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_8x16)(const int32_t *input, uint16_t *output, int32_t stride, const TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
 
-    void av1_inv_txfm2d_add_16x8_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_16x8)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    void eb_av1_inv_txfm2d_add_16x8_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_16x8)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
 
-    void av1_inv_txfm2d_add_16x32_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_16x32)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    void eb_av1_inv_txfm2d_add_16x32_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_16x32)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
 
-    void av1_inv_txfm2d_add_32x16_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_32x16)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    void eb_av1_inv_txfm2d_add_32x16_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_32x16)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
 
-    void av1_inv_txfm2d_add_32x8_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_32x8)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    void eb_av1_inv_txfm2d_add_32x8_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_32x8)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
 
-    void av1_inv_txfm2d_add_8x32_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_8x32)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    void eb_av1_inv_txfm2d_add_8x32_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_8x32)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
 
-    void av1_inv_txfm2d_add_32x64_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_32x64)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    void eb_av1_inv_txfm2d_add_32x64_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_32x64)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
 
-    void av1_inv_txfm2d_add_64x32_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_64x32)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    void eb_av1_inv_txfm2d_add_64x32_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_64x32)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
 
-    void av1_inv_txfm2d_add_16x64_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_16x64)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    void eb_av1_inv_txfm2d_add_16x64_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_16x64)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
 
-    void av1_inv_txfm2d_add_64x16_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_64x16)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    void eb_av1_inv_txfm2d_add_64x16_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_64x16)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t eob, int32_t bd);
 
-    void av1_inv_txfm2d_add_4x8_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
-    void av1_inv_txfm2d_add_4x8_sse4_1(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_4x8)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
+    void eb_av1_inv_txfm2d_add_4x8_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
+    void eb_av1_inv_txfm2d_add_4x8_sse4_1(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_4x8)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
 
-    void av1_inv_txfm2d_add_8x4_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
-    void av1_inv_txfm2d_add_8x4_sse4_1(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_8x4)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
+    void eb_av1_inv_txfm2d_add_8x4_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
+    void eb_av1_inv_txfm2d_add_8x4_sse4_1(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_8x4)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
 
-    void av1_inv_txfm2d_add_4x16_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
-    void av1_inv_txfm2d_add_4x16_sse4_1(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_4x16)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
+    void eb_av1_inv_txfm2d_add_4x16_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
+    void eb_av1_inv_txfm2d_add_4x16_sse4_1(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_4x16)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
 
-    void av1_inv_txfm2d_add_16x4_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
-    void av1_inv_txfm2d_add_16x4_sse4_1(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
-    RTCD_EXTERN void(*av1_inv_txfm2d_add_16x4)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
+    void eb_av1_inv_txfm2d_add_16x4_c(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
+    void eb_av1_inv_txfm2d_add_16x4_sse4_1(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_inv_txfm2d_add_16x4)(const int32_t *input, uint16_t *output, int32_t stride, TxType tx_type, TxSize tx_size, int32_t bd);
 
-    void av1_inv_txfm_add_c(const TranLow *dqcoeff, uint8_t *dst, int32_t stride, const TxfmParam *txfm_param);
-    void av1_inv_txfm_add_ssse3(const TranLow *dqcoeff, uint8_t *dst, int32_t stride, const TxfmParam *txfm_param);
-    void av1_inv_txfm_add_avx2(const TranLow *dqcoeff, uint8_t *dst, int32_t stride, const TxfmParam *txfm_param);
-    RTCD_EXTERN void(*av1_inv_txfm_add)(const TranLow *dqcoeff, uint8_t *dst, int32_t stride, const TxfmParam *txfm_param);
+    void eb_av1_inv_txfm_add_c(const TranLow *dqcoeff, uint8_t *dst, int32_t stride, const TxfmParam *txfm_param);
+    void eb_av1_inv_txfm_add_ssse3(const TranLow *dqcoeff, uint8_t *dst, int32_t stride, const TxfmParam *txfm_param);
+    void eb_av1_inv_txfm_add_avx2(const TranLow *dqcoeff, uint8_t *dst, int32_t stride, const TxfmParam *txfm_param);
+    RTCD_EXTERN void(*eb_av1_inv_txfm_add)(const TranLow *dqcoeff, uint8_t *dst, int32_t stride, const TxfmParam *txfm_param);
 
-    void av1_quantize_fp_c(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
-    void av1_quantize_fp_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
-    RTCD_EXTERN void (*av1_quantize_fp)(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    void eb_av1_quantize_fp_c(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    void eb_av1_quantize_fp_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    RTCD_EXTERN void (*eb_av1_quantize_fp)(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
 
-    void av1_quantize_fp_32x32_c(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
-    void av1_quantize_fp_32x32_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
-    RTCD_EXTERN void(*av1_quantize_fp_32x32)(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    void eb_av1_quantize_fp_32x32_c(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    void eb_av1_quantize_fp_32x32_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    RTCD_EXTERN void(*eb_av1_quantize_fp_32x32)(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
 
-    void av1_quantize_fp_64x64_c(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
-    void av1_quantize_fp_64x64_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
-    RTCD_EXTERN void(*av1_quantize_fp_64x64)(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    void eb_av1_quantize_fp_64x64_c(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    void eb_av1_quantize_fp_64x64_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
+    RTCD_EXTERN void(*eb_av1_quantize_fp_64x64)(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
 
-    //uint32_t aom_highbd_8_mse16x16_c(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
-    void      aom_highbd_8_mse16x16_sse2(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
-    RTCD_EXTERN void(*aom_highbd_8_mse16x16)(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
+    //uint32_t eb_aom_highbd_8_mse16x16_c(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
+    void      eb_aom_highbd_8_mse16x16_sse2(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
+    RTCD_EXTERN void(*eb_aom_highbd_8_mse16x16)(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
 
-    void av1_upsample_intra_edge_c(uint8_t *p, int32_t sz);
-    void av1_upsample_intra_edge_sse4_1(uint8_t *p, int32_t sz);
-    RTCD_EXTERN void(*av1_upsample_intra_edge)(uint8_t *p, int32_t sz);
+    void eb_av1_upsample_intra_edge_c(uint8_t *p, int32_t sz);
+    void eb_av1_upsample_intra_edge_sse4_1(uint8_t *p, int32_t sz);
+    RTCD_EXTERN void(*eb_av1_upsample_intra_edge)(uint8_t *p, int32_t sz);
 
     // AMIR
-    void av1_upsample_intra_edge_high_c(uint16_t *p, int32_t sz, int32_t bd);
-    //void av1_upsample_intra_edge_high_sse4_1(uint16_t *p, int32_t sz, int32_t bd);
-    //RTCD_EXTERN void(*av1_upsample_intra_edge_high)(uint16_t *p, int32_t sz, int32_t bd);
+    void eb_av1_upsample_intra_edge_high_c(uint16_t *p, int32_t sz, int32_t bd);
+    //void eb_av1_upsample_intra_edge_high_sse4_1(uint16_t *p, int32_t sz, int32_t bd);
+    //RTCD_EXTERN void(*eb_av1_upsample_intra_edge_high)(uint16_t *p, int32_t sz, int32_t bd);
 /* DC_PRED top */
 
-    void av1_warp_affine_c(const int32_t *mat, const uint8_t *ref, int width, int height, int stride, uint8_t *pred, int p_col, int p_row, int p_width, int p_height, int p_stride, int subsampling_x, int subsampling_y, ConvolveParams *conv_params, int16_t alpha, int16_t beta, int16_t gamma, int16_t delta);
-    void av1_warp_affine_avx2(const int32_t *mat, const uint8_t *ref, int width, int height, int stride, uint8_t *pred, int p_col, int p_row, int p_width, int p_height, int p_stride, int subsampling_x, int subsampling_y, ConvolveParams *conv_params, int16_t alpha, int16_t beta, int16_t gamma, int16_t delta);
-    RTCD_EXTERN void (*av1_warp_affine)(const int32_t *mat, const uint8_t *ref, int width, int height, int stride, uint8_t *pred, int p_col, int p_row, int p_width, int p_height, int p_stride, int subsampling_x, int subsampling_y, ConvolveParams *conv_params, int16_t alpha, int16_t beta, int16_t gamma, int16_t delta);
+    void eb_av1_warp_affine_c(const int32_t *mat, const uint8_t *ref, int width, int height, int stride, uint8_t *pred, int p_col, int p_row, int p_width, int p_height, int p_stride, int subsampling_x, int subsampling_y, ConvolveParams *conv_params, int16_t alpha, int16_t beta, int16_t gamma, int16_t delta);
+    void eb_av1_warp_affine_avx2(const int32_t *mat, const uint8_t *ref, int width, int height, int stride, uint8_t *pred, int p_col, int p_row, int p_width, int p_height, int p_stride, int subsampling_x, int subsampling_y, ConvolveParams *conv_params, int16_t alpha, int16_t beta, int16_t gamma, int16_t delta);
+    RTCD_EXTERN void (*eb_av1_warp_affine)(const int32_t *mat, const uint8_t *ref, int width, int height, int stride, uint8_t *pred, int p_col, int p_row, int p_width, int p_height, int p_stride, int subsampling_x, int subsampling_y, ConvolveParams *conv_params, int16_t alpha, int16_t beta, int16_t gamma, int16_t delta);
 
-    void aom_dc_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_4x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_4x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_8x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_8x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_16x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_16x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    /* DC_PRED top */
-
-    void aom_dc_left_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_4x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_8x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_16x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_dc_left_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_left_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_left_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
     /* DC_PRED top */
 
-    void aom_dc_top_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_4x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_4x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_8x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_8x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_16x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_16x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_top_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_top_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_top_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_left_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_left_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    /* DC_PRED top */
+
+    void eb_aom_dc_top_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_4x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_8x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_16x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_dc_top_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_top_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_top_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
     /* DC_PRED 128 */
-    void aom_dc_128_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_4x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_4x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_8x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_8x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_16x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_16x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_dc_128_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_dc_128_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_dc_128_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_dc_128_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_dc_128_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
     /* SMOOTH_H_PRED */
-    void aom_smooth_h_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_h_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_h_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_h_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_h_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_h_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
     /* SMOOTH_V_PRED */
 
-    void aom_smooth_v_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_v_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_v_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_v_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_v_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_v_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
     /* SMOOTH_PRED */
 
-    void aom_smooth_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_smooth_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_smooth_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_smooth_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_smooth_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_smooth_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
     /* V_PRED */
-    void aom_v_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_4x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_4x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_8x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_8x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_16x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_16x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
-    void aom_v_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_v_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_v_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_v_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_v_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
 
     /* H_PRED */
 
-    void aom_h_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_4x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_8x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_16x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_64x64_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_32x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_32x64_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_64x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_64x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_h_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_h_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void(*aom_h_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_16x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_16x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_16x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_16x8_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_2x2_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    #define aom_paeth_predictor_2x2 aom_paeth_predictor_2x2_c
-
-    void aom_paeth_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_paeth_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    void aom_paeth_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-    RTCD_EXTERN void (*aom_paeth_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
-
-    void aom_highbd_paeth_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_2x2_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_4x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_4x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_4x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    void aom_highbd_paeth_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    void aom_highbd_paeth_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-    RTCD_EXTERN void(*aom_highbd_paeth_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
-
-    uint32_t aom_sad128x128_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad128x128_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad128x128)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad128x128x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad128x128x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad128x128x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad128x64_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad128x64_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad128x64)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad128x64x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad128x64x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad128x64x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad16x16_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad16x16_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad16x16)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad16x16x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad16x16x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad16x16x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad16x32_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad16x32_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad16x32)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad16x32x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad16x32x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad16x32x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad16x4_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad16x4_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad16x4)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad16x4x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad16x4x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad16x4x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad16x64_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad16x64_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad16x64)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad16x64x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad16x64x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad16x64x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad16x8_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad16x8_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad16x8)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad16x8x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad16x8x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad16x8x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad32x16_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad32x16_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad32x16)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad32x16x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad32x16x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad32x16x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad32x32_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad32x32_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad32x32)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad32x32x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad32x32x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad32x32x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad32x64_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad32x64_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad32x64)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad32x64x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad32x64x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad32x64x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad32x8_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad32x8_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad32x8)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad32x8x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad32x8x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad32x8x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad4x16_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad4x16_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad4x16)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad4x16x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad4x16x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad4x16x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad4x4_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad4x4_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad4x4)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad4x4x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad4x4x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad4x4x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad4x8_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad4x8_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad4x8)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad4x8x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad4x8x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad4x8x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad64x128_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad64x128_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad64x128)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad64x128x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad64x128x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad64x128x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad64x16_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad64x16_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad64x16)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad64x16x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad64x16x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad64x16x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad64x32_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad64x32_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad64x32)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad64x32x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad64x32x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad64x32x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad64x64_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad64x64_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad64x64)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad64x64x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad64x64x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad64x64x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad8x16_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad8x16_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad8x16)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad8x16x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad8x16x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad8x16x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad8x32_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad8x32_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad8x32)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad8x32x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad8x32x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad8x32x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad8x4_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad8x4_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad8x4)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad8x4x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad8x4x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad8x4x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    uint32_t aom_sad8x8_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    uint32_t aom_sad8x8_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-    RTCD_EXTERN uint32_t(*aom_sad8x8)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
-
-    void aom_sad8x8x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    void aom_sad8x8x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-    RTCD_EXTERN void(*aom_sad8x8x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
-
-    unsigned int aom_variance4x4_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance4x4_sse2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance4x4)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    void eb_aom_h_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_4x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_8x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_16x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_64x64_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_32x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_32x64_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_4x8_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_64x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_64x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_8x16_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_8x32_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_h_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_h_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void(*eb_aom_h_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_16x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_16x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_16x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_16x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_16x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_16x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_16x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_16x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_16x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_16x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_16x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_16x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_16x8_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_16x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_2x2_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    #define eb_aom_paeth_predictor_2x2 eb_aom_paeth_predictor_2x2_c
+
+    void eb_aom_paeth_predictor_32x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_32x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_32x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_32x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_32x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_32x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_32x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_32x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_32x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_32x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_32x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_4x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_4x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_4x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_4x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_4x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_4x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_4x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_64x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_64x16_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_64x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_64x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_64x32_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_64x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_64x64_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_64x64_avx2(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_64x64)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_8x16_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_8x16)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_8x32_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_8x32)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_8x4_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_8x4_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_8x4)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_paeth_predictor_8x8_c(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    void eb_aom_paeth_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+    RTCD_EXTERN void (*eb_aom_paeth_predictor_8x8)(uint8_t *dst, ptrdiff_t y_stride, const uint8_t *above, const uint8_t *left);
+
+    void eb_aom_highbd_paeth_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_2x2_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_4x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_4x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_4x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    void eb_aom_highbd_paeth_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    void eb_aom_highbd_paeth_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+    RTCD_EXTERN void(*eb_aom_highbd_paeth_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int bd);
+
+    uint32_t eb_aom_sad128x128_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad128x128_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad128x128)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad128x128x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad128x128x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad128x128x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad128x64_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad128x64_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad128x64)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad128x64x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad128x64x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad128x64x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad16x16_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad16x16_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad16x16)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad16x16x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad16x16x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad16x16x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad16x32_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad16x32_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad16x32)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad16x32x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad16x32x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad16x32x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad16x4_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad16x4_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad16x4)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad16x4x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad16x4x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad16x4x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad16x64_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad16x64_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad16x64)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad16x64x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad16x64x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad16x64x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad16x8_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad16x8_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad16x8)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad16x8x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad16x8x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad16x8x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad32x16_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad32x16_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad32x16)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad32x16x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad32x16x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad32x16x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad32x32_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad32x32_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad32x32)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad32x32x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad32x32x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad32x32x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad32x64_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad32x64_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad32x64)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad32x64x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad32x64x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad32x64x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad32x8_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad32x8_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad32x8)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad32x8x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad32x8x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad32x8x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad4x16_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad4x16_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad4x16)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad4x16x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad4x16x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad4x16x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad4x4_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad4x4_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad4x4)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad4x4x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad4x4x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad4x4x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad4x8_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad4x8_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad4x8)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad4x8x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad4x8x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad4x8x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad64x128_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad64x128_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad64x128)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad64x128x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad64x128x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad64x128x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad64x16_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad64x16_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad64x16)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad64x16x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad64x16x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad64x16x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad64x32_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad64x32_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad64x32)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad64x32x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad64x32x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad64x32x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad64x64_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad64x64_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad64x64)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad64x64x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad64x64x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad64x64x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad8x16_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad8x16_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad8x16)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad8x16x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad8x16x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad8x16x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad8x32_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad8x32_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad8x32)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad8x32x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad8x32x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad8x32x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad8x4_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad8x4_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad8x4)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad8x4x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad8x4x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad8x4x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    uint32_t eb_aom_sad8x8_c(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    uint32_t eb_aom_sad8x8_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+    RTCD_EXTERN uint32_t(*eb_aom_sad8x8)(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr, int ref_stride);
+
+    void eb_aom_sad8x8x4d_c(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    void eb_aom_sad8x8x4d_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+    RTCD_EXTERN void(*eb_aom_sad8x8x4d)(const uint8_t *src_ptr, int src_stride, const uint8_t * const ref_ptr[], int ref_stride, uint32_t *sad_array);
+
+    unsigned int eb_aom_variance4x4_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance4x4_sse2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance4x4)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance4x8_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance4x8_sse2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance4x8)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance4x8_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance4x8_sse2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance4x8)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance4x16_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance4x16_sse2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance4x16)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance4x16_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance4x16_sse2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance4x16)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance8x4_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance8x4_sse2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance8x4)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance8x4_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance8x4_sse2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance8x4)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance8x8_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance8x8_sse2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance8x8)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance8x8_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance8x8_sse2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance8x8)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance8x16_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance8x16_sse2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance8x16)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance8x16_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance8x16_sse2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance8x16)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance8x32_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance8x32_sse2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance8x32)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance8x32_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance8x32_sse2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance8x32)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance16x4_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance16x4_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance16x4)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance16x4_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance16x4_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance16x4)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance16x8_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance16x8_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance16x8)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance16x8_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance16x8_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance16x8)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance16x16_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance16x16_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance16x16)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance16x16_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance16x16_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance16x16)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance16x32_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance16x32_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance16x32)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance16x32_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance16x32_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance16x32)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance16x64_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance16x64_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance16x64)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance16x64_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance16x64_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance16x64)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance32x8_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance32x8_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance32x8)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance32x8_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance32x8_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance32x8)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance32x16_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance32x16_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance32x16)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance32x16_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance32x16_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance32x16)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance32x32_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance32x32_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance32x32)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance32x32_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance32x32_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance32x32)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance32x64_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance32x64_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance32x64)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance32x64_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance32x64_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance32x64)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance64x16_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance64x16_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance64x16)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance64x16_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance64x16_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance64x16)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance64x32_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance64x32_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance64x32)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance64x32_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance64x32_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance64x32)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance64x64_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance64x64_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance64x64)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance64x64_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance64x64_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance64x64)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance64x128_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance64x128_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance64x128)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance64x128_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance64x128_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance64x128)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance128x64_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance128x64_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance128x64)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance128x64_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance128x64_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance128x64)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    unsigned int aom_variance128x128_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    unsigned int aom_variance128x128_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
-    RTCD_EXTERN unsigned int(*aom_variance128x128)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance128x128_c(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    unsigned int eb_aom_variance128x128_avx2(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
+    RTCD_EXTERN unsigned int(*eb_aom_variance128x128)(const uint8_t *src_ptr, int source_stride, const uint8_t *ref_ptr, int ref_stride, unsigned int *sse);
 
-    void aom_ifft16x16_float_avx2(const float *input, float *temp, float *output);
-    RTCD_EXTERN void(*aom_ifft16x16_float)(const float *input, float *temp, float *output);
+    void eb_aom_ifft16x16_float_avx2(const float *input, float *temp, float *output);
+    RTCD_EXTERN void(*eb_aom_ifft16x16_float)(const float *input, float *temp, float *output);
 
-    void aom_ifft2x2_float_c(const float *input, float *temp, float *output);
-    RTCD_EXTERN void(*aom_ifft2x2_float)(const float *input, float *temp, float *output);
+    void eb_aom_ifft2x2_float_c(const float *input, float *temp, float *output);
+    RTCD_EXTERN void(*eb_aom_ifft2x2_float)(const float *input, float *temp, float *output);
 
-    void aom_ifft32x32_float_avx2(const float *input, float *temp, float *output);
-    RTCD_EXTERN void(*aom_ifft32x32_float)(const float *input, float *temp, float *output);
+    void eb_aom_ifft32x32_float_avx2(const float *input, float *temp, float *output);
+    RTCD_EXTERN void(*eb_aom_ifft32x32_float)(const float *input, float *temp, float *output);
 
-    void aom_ifft4x4_float_sse2(const float *input, float *temp, float *output);
-    RTCD_EXTERN void(*aom_ifft4x4_float)(const float *input, float *temp, float *output);
+    void eb_aom_ifft4x4_float_sse2(const float *input, float *temp, float *output);
+    RTCD_EXTERN void(*eb_aom_ifft4x4_float)(const float *input, float *temp, float *output);
 
-    void aom_ifft8x8_float_avx2(const float *input, float *temp, float *output);
-    RTCD_EXTERN void(*aom_ifft8x8_float)(const float *input, float *temp, float *output);
+    void eb_aom_ifft8x8_float_avx2(const float *input, float *temp, float *output);
+    RTCD_EXTERN void(*eb_aom_ifft8x8_float)(const float *input, float *temp, float *output);
 
-    void aom_fft16x16_float_c(const float *input, float *temp, float *output);
-    void aom_fft16x16_float_avx2(const float *input, float *temp, float *output);
-    RTCD_EXTERN void(*aom_fft16x16_float)(const float *input, float *temp, float *output);
+    void eb_aom_fft16x16_float_c(const float *input, float *temp, float *output);
+    void eb_aom_fft16x16_float_avx2(const float *input, float *temp, float *output);
+    RTCD_EXTERN void(*eb_aom_fft16x16_float)(const float *input, float *temp, float *output);
 
-    void aom_fft2x2_float_c(const float *input, float *temp, float *output);
-    RTCD_EXTERN void(*aom_fft2x2_float)(const float *input, float *temp, float *output);
+    void eb_aom_fft2x2_float_c(const float *input, float *temp, float *output);
+    RTCD_EXTERN void(*eb_aom_fft2x2_float)(const float *input, float *temp, float *output);
 
-    void aom_fft32x32_float_c(const float *input, float *temp, float *output);
-    void aom_fft32x32_float_avx2(const float *input, float *temp, float *output);
-    RTCD_EXTERN void(*aom_fft32x32_float)(const float *input, float *temp, float *output);
+    void eb_aom_fft32x32_float_c(const float *input, float *temp, float *output);
+    void eb_aom_fft32x32_float_avx2(const float *input, float *temp, float *output);
+    RTCD_EXTERN void(*eb_aom_fft32x32_float)(const float *input, float *temp, float *output);
 
-    void aom_fft4x4_float_c(const float *input, float *temp, float *output);
-    void aom_fft4x4_float_sse2(const float *input, float *temp, float *output);
-    RTCD_EXTERN void(*aom_fft4x4_float)(const float *input, float *temp, float *output);
+    void eb_aom_fft4x4_float_c(const float *input, float *temp, float *output);
+    void eb_aom_fft4x4_float_sse2(const float *input, float *temp, float *output);
+    RTCD_EXTERN void(*eb_aom_fft4x4_float)(const float *input, float *temp, float *output);
 
-    void aom_fft8x8_float_c(const float *input, float *temp, float *output);
-    void aom_fft8x8_float_avx2(const float *input, float *temp, float *output);
-    RTCD_EXTERN void(*aom_fft8x8_float)(const float *input, float *temp, float *output);
+    void eb_aom_fft8x8_float_c(const float *input, float *temp, float *output);
+    void eb_aom_fft8x8_float_avx2(const float *input, float *temp, float *output);
+    RTCD_EXTERN void(*eb_aom_fft8x8_float)(const float *input, float *temp, float *output);
 
-    void aom_highbd_dc_128_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_128_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_128_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_128_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_128_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_128_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_left_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_left_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_left_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_left_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_dc_top_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_dc_top_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_dc_top_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_dc_top_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_16x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_16x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_16x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_16x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_16x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_16x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_32x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_32x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_32x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_32x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_h_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_h_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_h_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_h_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_h_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_4x16_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_4x16_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_4x4_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_4x4_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_h_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_h_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_h_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_h_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_h_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_4x16_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_4x16_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_4x4_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_4x4_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_4x16_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_4x16_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_4x4_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_4x4_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_8x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_8x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_8x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_smooth_v_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_smooth_v_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_smooth_v_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_smooth_v_predictor_8x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_smooth_v_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_16x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_16x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_16x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_16x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_16x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_16x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_16x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_16x4_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_16x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_16x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_16x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_16x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_16x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_16x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_2x2_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_2x2)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_4x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_4x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_4x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_4x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_4x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_4x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_8x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_8x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_8x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_8x4_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_8x4)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void aom_highbd_v_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    void aom_highbd_v_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
-    RTCD_EXTERN void(*aom_highbd_v_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_8x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void eb_aom_highbd_v_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    RTCD_EXTERN void(*eb_aom_highbd_v_predictor_8x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
-    void av1_dr_prediction_z1_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t dx, int32_t dy);
-    void av1_dr_prediction_z1_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t dx, int32_t dy);
-    RTCD_EXTERN void(*av1_dr_prediction_z1)(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t dx, int32_t dy);
+    void eb_av1_dr_prediction_z1_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t dx, int32_t dy);
+    void eb_av1_dr_prediction_z1_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t dx, int32_t dy);
+    RTCD_EXTERN void(*eb_av1_dr_prediction_z1)(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t dx, int32_t dy);
 
-    void av1_dr_prediction_z2_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy);
-    void av1_dr_prediction_z2_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy);
-    RTCD_EXTERN void(*av1_dr_prediction_z2)(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy);
+    void eb_av1_dr_prediction_z2_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy);
+    void eb_av1_dr_prediction_z2_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy);
+    RTCD_EXTERN void(*eb_av1_dr_prediction_z2)(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy);
 
-    void av1_dr_prediction_z3_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_left, int32_t dx, int32_t dy);
-    void av1_dr_prediction_z3_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_left, int32_t dx, int32_t dy);
-    RTCD_EXTERN void(*av1_dr_prediction_z3)(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_left, int32_t dx, int32_t dy);
+    void eb_av1_dr_prediction_z3_c(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_left, int32_t dx, int32_t dy);
+    void eb_av1_dr_prediction_z3_avx2(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_left, int32_t dx, int32_t dy);
+    RTCD_EXTERN void(*eb_av1_dr_prediction_z3)(uint8_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint8_t *above, const uint8_t *left, int32_t upsample_left, int32_t dx, int32_t dy);
 
-    void av1_highbd_dr_prediction_z1_c(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t dx, int32_t dy, int32_t bd);
-    void av1_highbd_dr_prediction_z1_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t dx, int32_t dy, int32_t bd);
-    RTCD_EXTERN void(*av1_highbd_dr_prediction_z1)(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t dx, int32_t dy, int32_t bd);
+    void eb_av1_highbd_dr_prediction_z1_c(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t dx, int32_t dy, int32_t bd);
+    void eb_av1_highbd_dr_prediction_z1_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t dx, int32_t dy, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_highbd_dr_prediction_z1)(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t dx, int32_t dy, int32_t bd);
 
-    void av1_highbd_dr_prediction_z2_c(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
-    void av1_highbd_dr_prediction_z2_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
-    RTCD_EXTERN void(*av1_highbd_dr_prediction_z2)(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
+    void eb_av1_highbd_dr_prediction_z2_c(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
+    void eb_av1_highbd_dr_prediction_z2_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_highbd_dr_prediction_z2)(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_above, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
 
-    void av1_highbd_dr_prediction_z3_c(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
-    void av1_highbd_dr_prediction_z3_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
-    RTCD_EXTERN void(*av1_highbd_dr_prediction_z3)(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
+    void eb_av1_highbd_dr_prediction_z3_c(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
+    void eb_av1_highbd_dr_prediction_z3_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
+    RTCD_EXTERN void(*eb_av1_highbd_dr_prediction_z3)(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
 
-    void av1_filter_intra_predictor_c(uint8_t *dst, ptrdiff_t stride, TxSize tx_size, const uint8_t *above, const uint8_t *left, int32_t mode);
-    RTCD_EXTERN void (*av1_filter_intra_predictor) (uint8_t *dst, ptrdiff_t stride, TxSize tx_size, const uint8_t *above, const uint8_t *left, int32_t mode);
+    void eb_av1_filter_intra_predictor_c(uint8_t *dst, ptrdiff_t stride, TxSize tx_size, const uint8_t *above, const uint8_t *left, int32_t mode);
+    RTCD_EXTERN void (*eb_av1_filter_intra_predictor) (uint8_t *dst, ptrdiff_t stride, TxSize tx_size, const uint8_t *above, const uint8_t *left, int32_t mode);
 
-    //void av1_get_nz_map_contexts_c(const uint8_t *const levels, const int16_t *const scan, const uint16_t eob, const TxSize tx_size, const TxClass tx_class, int8_t *const coeff_contexts);
-    void av1_get_nz_map_contexts_sse2(const uint8_t *const levels, const int16_t *const scan, const uint16_t eob, const TxSize tx_size, const TxClass tx_class, int8_t *const coeff_contexts);
-    RTCD_EXTERN void(*av1_get_nz_map_contexts)(const uint8_t *const levels, const int16_t *const scan, const uint16_t eob, const TxSize tx_size, const TxClass tx_class, int8_t *const coeff_contexts);
+    //void eb_av1_get_nz_map_contexts_c(const uint8_t *const levels, const int16_t *const scan, const uint16_t eob, const TxSize tx_size, const TxClass tx_class, int8_t *const coeff_contexts);
+    void eb_av1_get_nz_map_contexts_sse2(const uint8_t *const levels, const int16_t *const scan, const uint16_t eob, const TxSize tx_size, const TxClass tx_class, int8_t *const coeff_contexts);
+    RTCD_EXTERN void(*eb_av1_get_nz_map_contexts)(const uint8_t *const levels, const int16_t *const scan, const uint16_t eob, const TxSize tx_size, const TxClass tx_class, int8_t *const coeff_contexts);
 
     void highbd_variance64_c(const uint8_t *a8, int32_t a_stride, const uint8_t *b8, int32_t b_stride, int32_t w, int32_t h, uint64_t *sse);
     void highbd_variance64_avx2(const uint8_t *a8, int32_t a_stride, const uint8_t *b8, int32_t b_stride, int32_t w, int32_t h, uint64_t *sse);
@@ -2366,11 +2366,11 @@ extern "C" {
     void ResidualKernel_avx2(uint8_t *input, uint32_t input_stride, uint8_t *pred, uint32_t pred_stride, int16_t *residual, uint32_t residual_stride, uint32_t area_width, uint32_t area_height);
     RTCD_EXTERN void(*ResidualKernel)(uint8_t *input, uint32_t input_stride, uint8_t *pred, uint32_t pred_stride, int16_t *residual, uint32_t residual_stride, uint32_t area_width, uint32_t area_height);
 
-    void av1_txb_init_levels_c(const TranLow *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
-    void av1_txb_init_levels_avx2(const TranLow *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
-    RTCD_EXTERN void(*av1_txb_init_levels)(const TranLow *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
+    void eb_av1_txb_init_levels_c(const TranLow *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
+    void eb_av1_txb_init_levels_avx2(const TranLow *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
+    RTCD_EXTERN void(*eb_av1_txb_init_levels)(const TranLow *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
 
-    void aom_dsp_rtcd(void);
+    void eb_aom_dsp_rtcd(void);
 
 #ifdef RTCD_C
 
@@ -2385,63 +2385,63 @@ extern "C" {
 
         //to use C: flags=0
 
-        apply_selfguided_restoration = apply_selfguided_restoration_c;
-        if (flags & HAS_AVX2) apply_selfguided_restoration = apply_selfguided_restoration_avx2;
+        eb_apply_selfguided_restoration = eb_apply_selfguided_restoration_c;
+        if (flags & HAS_AVX2) eb_apply_selfguided_restoration = eb_apply_selfguided_restoration_avx2;
 
-        av1_wiener_convolve_add_src = av1_wiener_convolve_add_src_c;
-        if (flags & HAS_AVX2) av1_wiener_convolve_add_src = av1_wiener_convolve_add_src_avx2;
+        eb_av1_wiener_convolve_add_src = eb_av1_wiener_convolve_add_src_c;
+        if (flags & HAS_AVX2) eb_av1_wiener_convolve_add_src = eb_av1_wiener_convolve_add_src_avx2;
 
-        av1_highbd_wiener_convolve_add_src = av1_highbd_wiener_convolve_add_src_c;
-        if (flags & HAS_AVX2) av1_highbd_wiener_convolve_add_src = av1_highbd_wiener_convolve_add_src_avx2;
+        eb_av1_highbd_wiener_convolve_add_src = eb_av1_highbd_wiener_convolve_add_src_c;
+        if (flags & HAS_AVX2) eb_av1_highbd_wiener_convolve_add_src = eb_av1_highbd_wiener_convolve_add_src_avx2;
 
-        av1_selfguided_restoration = av1_selfguided_restoration_c;
-        if (flags & HAS_AVX2) av1_selfguided_restoration = av1_selfguided_restoration_avx2;
+        eb_av1_selfguided_restoration = eb_av1_selfguided_restoration_c;
+        if (flags & HAS_AVX2) eb_av1_selfguided_restoration = eb_av1_selfguided_restoration_avx2;
 
-        cdef_find_dir = cdef_find_dir_c;
-        if (flags & HAS_AVX2) cdef_find_dir = cdef_find_dir_avx2;
+        eb_cdef_find_dir = eb_cdef_find_dir_c;
+        if (flags & HAS_AVX2) eb_cdef_find_dir = eb_cdef_find_dir_avx2;
 
-        cdef_filter_block = cdef_filter_block_c;
-        if (flags & HAS_AVX2) cdef_filter_block = cdef_filter_block_avx2;
-        compute_cdef_dist = compute_cdef_dist_c;
-        if (flags & HAS_AVX2) compute_cdef_dist = compute_cdef_dist_avx2;
+        eb_cdef_filter_block = eb_cdef_filter_block_c;
+        if (flags & HAS_AVX2) eb_cdef_filter_block = eb_cdef_filter_block_avx2;
+        eb_compute_cdef_dist = compute_cdef_dist_c;
+        if (flags & HAS_AVX2) eb_compute_cdef_dist = compute_cdef_dist_avx2;
 
-        copy_rect8_8bit_to_16bit = copy_rect8_8bit_to_16bit_c;
-        if (flags & HAS_AVX2) copy_rect8_8bit_to_16bit = copy_rect8_8bit_to_16bit_avx2;
+        eb_copy_rect8_8bit_to_16bit = eb_copy_rect8_8bit_to_16bit_c;
+        if (flags & HAS_AVX2) eb_copy_rect8_8bit_to_16bit = eb_copy_rect8_8bit_to_16bit_avx2;
 
-        av1_compute_stats = av1_compute_stats_c;
-        if (flags & HAS_AVX2) av1_compute_stats = av1_compute_stats_avx2;
-        av1_compute_stats_highbd = av1_compute_stats_highbd_c;
-        if (flags & HAS_AVX2) av1_compute_stats_highbd = av1_compute_stats_highbd_avx2;
-        av1_lowbd_pixel_proj_error = av1_lowbd_pixel_proj_error_c;
-        if (flags & HAS_AVX2) av1_lowbd_pixel_proj_error = av1_lowbd_pixel_proj_error_avx2;
-        av1_highbd_pixel_proj_error = av1_highbd_pixel_proj_error_c;
-        if (flags & HAS_AVX2) av1_highbd_pixel_proj_error = av1_highbd_pixel_proj_error_avx2;
-        av1_filter_intra_edge_high = av1_filter_intra_edge_high_c;
-        if (flags & HAS_SSE4_1) av1_filter_intra_edge_high = av1_filter_intra_edge_high_sse4_1;
-        av1_calc_frame_error = av1_calc_frame_error_c;
-        if (flags & HAS_AVX2) av1_calc_frame_error = av1_calc_frame_error_avx2;
-        av1_highbd_convolve_2d_copy_sr = av1_highbd_convolve_2d_copy_sr_c;
-        if (flags & HAS_AVX2) av1_highbd_convolve_2d_copy_sr = av1_highbd_convolve_2d_copy_sr_avx2;
-        av1_highbd_jnt_convolve_2d_copy = av1_highbd_jnt_convolve_2d_copy_c;
-        if (flags & HAS_AVX2) av1_highbd_jnt_convolve_2d_copy = av1_highbd_jnt_convolve_2d_copy_avx2;
-        av1_highbd_convolve_y_sr = av1_highbd_convolve_y_sr_c;
-        if (flags & HAS_AVX2) av1_highbd_convolve_y_sr = av1_highbd_convolve_y_sr_avx2;
-        av1_highbd_convolve_2d_sr = av1_highbd_convolve_2d_sr_c;
-        if (flags & HAS_AVX2) av1_highbd_convolve_2d_sr = av1_highbd_convolve_2d_sr_avx2;
-        av1_highbd_jnt_convolve_2d = av1_highbd_jnt_convolve_2d_c;
-        if (flags & HAS_AVX2) av1_highbd_jnt_convolve_2d = av1_highbd_jnt_convolve_2d_avx2;
-        av1_highbd_jnt_convolve_x = av1_highbd_jnt_convolve_x_c;
-        if (flags & HAS_AVX2) av1_highbd_jnt_convolve_x = av1_highbd_jnt_convolve_x_avx2;
-        av1_highbd_jnt_convolve_y = av1_highbd_jnt_convolve_y_c;
-        if (flags & HAS_AVX2) av1_highbd_jnt_convolve_y = av1_highbd_jnt_convolve_y_avx2;
-        av1_highbd_convolve_x_sr = av1_highbd_convolve_x_sr_c;
-        if (flags & HAS_AVX2) av1_highbd_convolve_x_sr = av1_highbd_convolve_x_sr_avx2;
-        subtract_average = subtract_average_c;
-        if (flags & HAS_AVX2) subtract_average = subtract_average_avx2;
+        eb_av1_compute_stats = eb_av1_compute_stats_c;
+        if (flags & HAS_AVX2) eb_av1_compute_stats = eb_av1_compute_stats_avx2;
+        eb_av1_compute_stats_highbd = eb_av1_compute_stats_highbd_c;
+        if (flags & HAS_AVX2) eb_av1_compute_stats_highbd = eb_av1_compute_stats_highbd_avx2;
+        eb_av1_lowbd_pixel_proj_error = eb_av1_lowbd_pixel_proj_error_c;
+        if (flags & HAS_AVX2) eb_av1_lowbd_pixel_proj_error = eb_av1_lowbd_pixel_proj_error_avx2;
+        eb_av1_highbd_pixel_proj_error = eb_av1_highbd_pixel_proj_error_c;
+        if (flags & HAS_AVX2) eb_av1_highbd_pixel_proj_error = eb_av1_highbd_pixel_proj_error_avx2;
+        eb_av1_filter_intra_edge_high = eb_av1_filter_intra_edge_high_c;
+        if (flags & HAS_SSE4_1) eb_av1_filter_intra_edge_high = eb_av1_filter_intra_edge_high_sse4_1;
+        eb_av1_calc_frame_error = eb_av1_calc_frame_error_c;
+        if (flags & HAS_AVX2) eb_av1_calc_frame_error = eb_av1_calc_frame_error_avx2;
+        eb_av1_highbd_convolve_2d_copy_sr = eb_av1_highbd_convolve_2d_copy_sr_c;
+        if (flags & HAS_AVX2) eb_av1_highbd_convolve_2d_copy_sr = eb_av1_highbd_convolve_2d_copy_sr_avx2;
+        eb_av1_highbd_jnt_convolve_2d_copy = eb_av1_highbd_jnt_convolve_2d_copy_c;
+        if (flags & HAS_AVX2) eb_av1_highbd_jnt_convolve_2d_copy = eb_av1_highbd_jnt_convolve_2d_copy_avx2;
+        eb_av1_highbd_convolve_y_sr = eb_av1_highbd_convolve_y_sr_c;
+        if (flags & HAS_AVX2) eb_av1_highbd_convolve_y_sr = eb_av1_highbd_convolve_y_sr_avx2;
+        eb_av1_highbd_convolve_2d_sr = eb_av1_highbd_convolve_2d_sr_c;
+        if (flags & HAS_AVX2) eb_av1_highbd_convolve_2d_sr = eb_av1_highbd_convolve_2d_sr_avx2;
+        eb_av1_highbd_jnt_convolve_2d = eb_av1_highbd_jnt_convolve_2d_c;
+        if (flags & HAS_AVX2) eb_av1_highbd_jnt_convolve_2d = eb_av1_highbd_jnt_convolve_2d_avx2;
+        eb_av1_highbd_jnt_convolve_x = eb_av1_highbd_jnt_convolve_x_c;
+        if (flags & HAS_AVX2) eb_av1_highbd_jnt_convolve_x = eb_av1_highbd_jnt_convolve_x_avx2;
+        eb_av1_highbd_jnt_convolve_y = eb_av1_highbd_jnt_convolve_y_c;
+        if (flags & HAS_AVX2) eb_av1_highbd_jnt_convolve_y = eb_av1_highbd_jnt_convolve_y_avx2;
+        eb_av1_highbd_convolve_x_sr = eb_av1_highbd_convolve_x_sr_c;
+        if (flags & HAS_AVX2) eb_av1_highbd_convolve_x_sr = eb_av1_highbd_convolve_x_sr_avx2;
+        eb_subtract_average = eb_subtract_average_c;
+        if (flags & HAS_AVX2) eb_subtract_average = eb_subtract_average_avx2;
 
-        av1_filter_intra_edge = av1_filter_intra_edge_high_c_old;
+        eb_av1_filter_intra_edge = eb_av1_filter_intra_edge_high_c_old;
 
-        if (flags & HAS_SSE4_1) av1_filter_intra_edge = av1_filter_intra_edge_sse4_1;
+        if (flags & HAS_SSE4_1) eb_av1_filter_intra_edge = eb_av1_filter_intra_edge_sse4_1;
 
         eb_smooth_v_predictor = smooth_v_predictor_c;
         if (flags & HAS_SSSE3) eb_smooth_v_predictor = eb_smooth_v_predictor_all_ssse3;
@@ -2455,799 +2455,799 @@ extern "C" {
         search_one_dual = search_one_dual_c;
         if (flags & HAS_AVX2) search_one_dual = search_one_dual_avx2;
 
-        aom_mse16x16 = aom_mse16x16_c;
-        if (flags & HAS_AVX2) aom_mse16x16 = aom_mse16x16_avx2;
+        eb_aom_mse16x16 = eb_aom_mse16x16_c;
+        if (flags & HAS_AVX2) eb_aom_mse16x16 = eb_aom_mse16x16_avx2;
 
-        av1_convolve_2d_copy_sr = av1_convolve_2d_copy_sr_c;
-        if (flags & HAS_AVX2) av1_convolve_2d_copy_sr = av1_convolve_2d_copy_sr_avx2;
+        eb_av1_convolve_2d_copy_sr = eb_av1_convolve_2d_copy_sr_c;
+        if (flags & HAS_AVX2) eb_av1_convolve_2d_copy_sr = eb_av1_convolve_2d_copy_sr_avx2;
 
-        av1_convolve_2d_sr = av1_convolve_2d_sr_c;
-        if (flags & HAS_AVX2) av1_convolve_2d_sr = av1_convolve_2d_sr_avx2;
+        eb_av1_convolve_2d_sr = eb_av1_convolve_2d_sr_c;
+        if (flags & HAS_AVX2) eb_av1_convolve_2d_sr = eb_av1_convolve_2d_sr_avx2;
 
-        av1_jnt_convolve_2d_copy = av1_jnt_convolve_2d_copy_c;
-        if (flags & HAS_AVX2) av1_jnt_convolve_2d_copy = av1_jnt_convolve_2d_copy_avx2;
+        eb_av1_jnt_convolve_2d_copy = eb_av1_jnt_convolve_2d_copy_c;
+        if (flags & HAS_AVX2) eb_av1_jnt_convolve_2d_copy = eb_av1_jnt_convolve_2d_copy_avx2;
 
-        av1_convolve_x_sr = av1_convolve_x_sr_c;
-        if (flags & HAS_AVX2) av1_convolve_x_sr = av1_convolve_x_sr_avx2;
-        av1_convolve_y_sr = av1_convolve_y_sr_c;
-        if (flags & HAS_AVX2) av1_convolve_y_sr = av1_convolve_y_sr_avx2;
+        eb_av1_convolve_x_sr = eb_av1_convolve_x_sr_c;
+        if (flags & HAS_AVX2) eb_av1_convolve_x_sr = eb_av1_convolve_x_sr_avx2;
+        eb_av1_convolve_y_sr = eb_av1_convolve_y_sr_c;
+        if (flags & HAS_AVX2) eb_av1_convolve_y_sr = eb_av1_convolve_y_sr_avx2;
 
-        av1_jnt_convolve_x = av1_jnt_convolve_x_c;
-        if (flags & HAS_AVX2) av1_jnt_convolve_x = av1_jnt_convolve_x_avx2;
-        av1_jnt_convolve_y = av1_jnt_convolve_y_c;
-        if (flags & HAS_AVX2) av1_jnt_convolve_y = av1_jnt_convolve_y_avx2;
+        eb_av1_jnt_convolve_x = eb_av1_jnt_convolve_x_c;
+        if (flags & HAS_AVX2) eb_av1_jnt_convolve_x = eb_av1_jnt_convolve_x_avx2;
+        eb_av1_jnt_convolve_y = eb_av1_jnt_convolve_y_c;
+        if (flags & HAS_AVX2) eb_av1_jnt_convolve_y = eb_av1_jnt_convolve_y_avx2;
 
-        av1_jnt_convolve_2d = av1_jnt_convolve_2d_c;
-        if (flags & HAS_AVX2) av1_jnt_convolve_2d = av1_jnt_convolve_2d_avx2;
+        eb_av1_jnt_convolve_2d = eb_av1_jnt_convolve_2d_c;
+        if (flags & HAS_AVX2) eb_av1_jnt_convolve_2d = eb_av1_jnt_convolve_2d_avx2;
 
-        aom_quantize_b = aom_quantize_b_c_II;
-        if (flags & HAS_AVX2) aom_quantize_b = aom_highbd_quantize_b_avx2;
+        eb_aom_quantize_b = eb_aom_quantize_b_c_II;
+        if (flags & HAS_AVX2) eb_aom_quantize_b = eb_aom_highbd_quantize_b_avx2;
 
-        aom_quantize_b_32x32 = aom_quantize_b_32x32_c_II;
-        if (flags & HAS_AVX2) aom_quantize_b_32x32 = aom_highbd_quantize_b_32x32_avx2;
+        eb_aom_quantize_b_32x32 = eb_aom_quantize_b_32x32_c_II;
+        if (flags & HAS_AVX2) eb_aom_quantize_b_32x32 = eb_aom_highbd_quantize_b_32x32_avx2;
 
-        aom_highbd_quantize_b_32x32 = aom_highbd_quantize_b_32x32_c;
-        if (flags & HAS_AVX2) aom_highbd_quantize_b_32x32 = aom_highbd_quantize_b_32x32_avx2;
+        eb_aom_highbd_quantize_b_32x32 = eb_aom_highbd_quantize_b_32x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_quantize_b_32x32 = eb_aom_highbd_quantize_b_32x32_avx2;
 
-        aom_highbd_quantize_b = aom_highbd_quantize_b_c;
-        if (flags & HAS_AVX2) aom_highbd_quantize_b = aom_highbd_quantize_b_avx2;
+        eb_aom_highbd_quantize_b = eb_aom_highbd_quantize_b_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_quantize_b = eb_aom_highbd_quantize_b_avx2;
 
-        av1_inv_txfm2d_add_16x16 = av1_inv_txfm2d_add_16x16_c;
-        if (flags & HAS_AVX2) av1_inv_txfm2d_add_16x16 = av1_inv_txfm2d_add_16x16_avx2;
-        av1_inv_txfm2d_add_32x32 = av1_inv_txfm2d_add_32x32_c;
-        if (flags & HAS_AVX2) av1_inv_txfm2d_add_32x32 = av1_inv_txfm2d_add_32x32_avx2;
-        av1_inv_txfm2d_add_4x4 = av1_inv_txfm2d_add_4x4_c;
-        if (flags & HAS_AVX2) av1_inv_txfm2d_add_4x4 = av1_inv_txfm2d_add_4x4_avx2;
-        av1_inv_txfm2d_add_64x64 = av1_inv_txfm2d_add_64x64_c;
-        if (flags & HAS_SSE4_1) av1_inv_txfm2d_add_64x64 = av1_inv_txfm2d_add_64x64_sse4_1;
-        av1_inv_txfm2d_add_8x8 = av1_inv_txfm2d_add_8x8_c;
-        if (flags & HAS_AVX2) av1_inv_txfm2d_add_8x8 = av1_inv_txfm2d_add_8x8_avx2;
+        eb_av1_inv_txfm2d_add_16x16 = eb_av1_inv_txfm2d_add_16x16_c;
+        if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_16x16 = eb_av1_inv_txfm2d_add_16x16_avx2;
+        eb_av1_inv_txfm2d_add_32x32 = eb_av1_inv_txfm2d_add_32x32_c;
+        if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_32x32 = eb_av1_inv_txfm2d_add_32x32_avx2;
+        eb_av1_inv_txfm2d_add_4x4 = eb_av1_inv_txfm2d_add_4x4_c;
+        if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_4x4 = eb_av1_inv_txfm2d_add_4x4_avx2;
+        eb_av1_inv_txfm2d_add_64x64 = eb_av1_inv_txfm2d_add_64x64_c;
+        if (flags & HAS_SSE4_1) eb_av1_inv_txfm2d_add_64x64 = eb_av1_inv_txfm2d_add_64x64_sse4_1;
+        eb_av1_inv_txfm2d_add_8x8 = eb_av1_inv_txfm2d_add_8x8_c;
+        if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_8x8 = eb_av1_inv_txfm2d_add_8x8_avx2;
 
-        av1_inv_txfm2d_add_8x16 = av1_inv_txfm2d_add_8x16_c;
-        if (flags & HAS_AVX2) av1_inv_txfm2d_add_8x16 = av1_highbd_inv_txfm_add_avx2;
-        av1_inv_txfm2d_add_16x8 = av1_inv_txfm2d_add_16x8_c;
-        if (flags & HAS_AVX2) av1_inv_txfm2d_add_16x8 = av1_highbd_inv_txfm_add_avx2;
-        av1_inv_txfm2d_add_16x32 = av1_inv_txfm2d_add_16x32_c;
-        if (flags & HAS_AVX2) av1_inv_txfm2d_add_16x32 = av1_highbd_inv_txfm_add_avx2;
-        av1_inv_txfm2d_add_32x16 = av1_inv_txfm2d_add_32x16_c;
-        if (flags & HAS_AVX2) av1_inv_txfm2d_add_32x16 = av1_highbd_inv_txfm_add_avx2;
-        av1_inv_txfm2d_add_32x8 = av1_inv_txfm2d_add_32x8_c;
-        if (flags & HAS_AVX2) av1_inv_txfm2d_add_32x8 = av1_highbd_inv_txfm_add_avx2;
-        av1_inv_txfm2d_add_8x32 = av1_inv_txfm2d_add_8x32_c;
-        if (flags & HAS_AVX2) av1_inv_txfm2d_add_8x32 = av1_highbd_inv_txfm_add_avx2;
-        av1_inv_txfm2d_add_32x64 = av1_inv_txfm2d_add_32x64_c;
-        if (flags & HAS_AVX2) av1_inv_txfm2d_add_32x64 = av1_highbd_inv_txfm_add_avx2;
-        av1_inv_txfm2d_add_64x32 = av1_inv_txfm2d_add_64x32_c;
-        if (flags & HAS_AVX2) av1_inv_txfm2d_add_64x32 = av1_highbd_inv_txfm_add_avx2;
-        av1_inv_txfm2d_add_16x64 = av1_inv_txfm2d_add_16x64_c;
-        if (flags & HAS_AVX2) av1_inv_txfm2d_add_16x64 = av1_highbd_inv_txfm_add_avx2;
-        av1_inv_txfm2d_add_64x16 = av1_inv_txfm2d_add_64x16_c;
-        if (flags & HAS_AVX2) av1_inv_txfm2d_add_64x16 = av1_highbd_inv_txfm_add_avx2;
-        av1_inv_txfm2d_add_4x8 = av1_inv_txfm2d_add_4x8_c;
-        if (flags & HAS_SSE4_1) av1_inv_txfm2d_add_4x8 = av1_inv_txfm2d_add_4x8_sse4_1;
-        av1_inv_txfm2d_add_8x4 = av1_inv_txfm2d_add_8x4_c;
-        if (flags & HAS_SSE4_1) av1_inv_txfm2d_add_8x4 = av1_inv_txfm2d_add_8x4_sse4_1;
-        av1_inv_txfm2d_add_4x16 = av1_inv_txfm2d_add_4x16_c;
-        if (flags & HAS_SSE4_1) av1_inv_txfm2d_add_4x16 = av1_inv_txfm2d_add_4x16_sse4_1;
-        av1_inv_txfm2d_add_16x4 = av1_inv_txfm2d_add_16x4_c;
-        if (flags & HAS_SSE4_1) av1_inv_txfm2d_add_16x4 = av1_inv_txfm2d_add_16x4_sse4_1;
+        eb_av1_inv_txfm2d_add_8x16 = eb_av1_inv_txfm2d_add_8x16_c;
+        if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_8x16 = eb_av1_highbd_inv_txfm_add_avx2;
+        eb_av1_inv_txfm2d_add_16x8 = eb_av1_inv_txfm2d_add_16x8_c;
+        if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_16x8 = eb_av1_highbd_inv_txfm_add_avx2;
+        eb_av1_inv_txfm2d_add_16x32 = eb_av1_inv_txfm2d_add_16x32_c;
+        if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_16x32 = eb_av1_highbd_inv_txfm_add_avx2;
+        eb_av1_inv_txfm2d_add_32x16 = eb_av1_inv_txfm2d_add_32x16_c;
+        if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_32x16 = eb_av1_highbd_inv_txfm_add_avx2;
+        eb_av1_inv_txfm2d_add_32x8 = eb_av1_inv_txfm2d_add_32x8_c;
+        if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_32x8 = eb_av1_highbd_inv_txfm_add_avx2;
+        eb_av1_inv_txfm2d_add_8x32 = eb_av1_inv_txfm2d_add_8x32_c;
+        if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_8x32 = eb_av1_highbd_inv_txfm_add_avx2;
+        eb_av1_inv_txfm2d_add_32x64 = eb_av1_inv_txfm2d_add_32x64_c;
+        if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_32x64 = eb_av1_highbd_inv_txfm_add_avx2;
+        eb_av1_inv_txfm2d_add_64x32 = eb_av1_inv_txfm2d_add_64x32_c;
+        if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_64x32 = eb_av1_highbd_inv_txfm_add_avx2;
+        eb_av1_inv_txfm2d_add_16x64 = eb_av1_inv_txfm2d_add_16x64_c;
+        if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_16x64 = eb_av1_highbd_inv_txfm_add_avx2;
+        eb_av1_inv_txfm2d_add_64x16 = eb_av1_inv_txfm2d_add_64x16_c;
+        if (flags & HAS_AVX2) eb_av1_inv_txfm2d_add_64x16 = eb_av1_highbd_inv_txfm_add_avx2;
+        eb_av1_inv_txfm2d_add_4x8 = eb_av1_inv_txfm2d_add_4x8_c;
+        if (flags & HAS_SSE4_1) eb_av1_inv_txfm2d_add_4x8 = eb_av1_inv_txfm2d_add_4x8_sse4_1;
+        eb_av1_inv_txfm2d_add_8x4 = eb_av1_inv_txfm2d_add_8x4_c;
+        if (flags & HAS_SSE4_1) eb_av1_inv_txfm2d_add_8x4 = eb_av1_inv_txfm2d_add_8x4_sse4_1;
+        eb_av1_inv_txfm2d_add_4x16 = eb_av1_inv_txfm2d_add_4x16_c;
+        if (flags & HAS_SSE4_1) eb_av1_inv_txfm2d_add_4x16 = eb_av1_inv_txfm2d_add_4x16_sse4_1;
+        eb_av1_inv_txfm2d_add_16x4 = eb_av1_inv_txfm2d_add_16x4_c;
+        if (flags & HAS_SSE4_1) eb_av1_inv_txfm2d_add_16x4 = eb_av1_inv_txfm2d_add_16x4_sse4_1;
 
-        av1_inv_txfm_add = av1_inv_txfm_add_c;
-        if (flags & HAS_SSSE3) av1_inv_txfm_add = av1_inv_txfm_add_ssse3;
-        if (flags & HAS_AVX2) av1_inv_txfm_add = av1_inv_txfm_add_avx2;
+        eb_av1_inv_txfm_add = eb_av1_inv_txfm_add_c;
+        if (flags & HAS_SSSE3) eb_av1_inv_txfm_add = eb_av1_inv_txfm_add_ssse3;
+        if (flags & HAS_AVX2) eb_av1_inv_txfm_add = eb_av1_inv_txfm_add_avx2;
 
-        av1_quantize_fp = av1_quantize_fp_c;
-        if (flags & HAS_AVX2) av1_quantize_fp = av1_quantize_fp_avx2;
+        eb_av1_quantize_fp = eb_av1_quantize_fp_c;
+        if (flags & HAS_AVX2) eb_av1_quantize_fp = eb_av1_quantize_fp_avx2;
 
-        av1_quantize_fp_32x32 = av1_quantize_fp_32x32_c;
-        if (flags & HAS_AVX2) av1_quantize_fp_32x32 = av1_quantize_fp_32x32_avx2;
+        eb_av1_quantize_fp_32x32 = eb_av1_quantize_fp_32x32_c;
+        if (flags & HAS_AVX2) eb_av1_quantize_fp_32x32 = eb_av1_quantize_fp_32x32_avx2;
 
-        av1_quantize_fp_64x64 = av1_quantize_fp_64x64_c;
-        if (flags & HAS_AVX2) av1_quantize_fp_64x64 = av1_quantize_fp_64x64_avx2;
+        eb_av1_quantize_fp_64x64 = eb_av1_quantize_fp_64x64_c;
+        if (flags & HAS_AVX2) eb_av1_quantize_fp_64x64 = eb_av1_quantize_fp_64x64_avx2;
 
         highbd_variance64 = highbd_variance64_c;
         if (flags & HAS_AVX2) highbd_variance64 = highbd_variance64_avx2;
 
-        //aom_highbd_8_mse16x16 = aom_highbd_8_mse16x16_c;
-        if (flags & HAS_SSE2) aom_highbd_8_mse16x16 = aom_highbd_8_mse16x16_sse2;
+        //aom_highbd_8_mse16x16 = eb_aom_highbd_8_mse16x16_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_8_mse16x16 = eb_aom_highbd_8_mse16x16_sse2;
 
-        av1_upsample_intra_edge = av1_upsample_intra_edge_c;
-        if (flags & HAS_SSE4_1) av1_upsample_intra_edge = av1_upsample_intra_edge_sse4_1;
+        eb_av1_upsample_intra_edge = eb_av1_upsample_intra_edge_c;
+        if (flags & HAS_SSE4_1) eb_av1_upsample_intra_edge = eb_av1_upsample_intra_edge_sse4_1;
 
-        av1_warp_affine = av1_warp_affine_c;
-        if (flags & HAS_AVX2) av1_warp_affine = av1_warp_affine_avx2;
+        eb_av1_warp_affine = eb_av1_warp_affine_c;
+        if (flags & HAS_AVX2) eb_av1_warp_affine = eb_av1_warp_affine_avx2;
 
-        av1_filter_intra_predictor = av1_filter_intra_predictor_c;
+        eb_av1_filter_intra_predictor = eb_av1_filter_intra_predictor_c;
 
-        aom_highbd_smooth_v_predictor_16x16 = aom_highbd_smooth_v_predictor_16x16_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_16x16 = aom_highbd_smooth_v_predictor_16x16_avx2;
-        aom_highbd_smooth_v_predictor_16x32 = aom_highbd_smooth_v_predictor_16x32_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_16x32 = aom_highbd_smooth_v_predictor_16x32_avx2;
-        aom_highbd_smooth_v_predictor_16x4 = aom_highbd_smooth_v_predictor_16x4_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_16x4 = aom_highbd_smooth_v_predictor_16x4_avx2;
-        aom_highbd_smooth_v_predictor_16x64 = aom_highbd_smooth_v_predictor_16x64_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_16x64 = aom_highbd_smooth_v_predictor_16x64_avx2;
-        aom_highbd_smooth_v_predictor_16x8 = aom_highbd_smooth_v_predictor_16x8_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_16x8 = aom_highbd_smooth_v_predictor_16x8_avx2;
-        aom_highbd_smooth_v_predictor_2x2 = aom_highbd_smooth_v_predictor_2x2_c;
-        aom_highbd_smooth_v_predictor_32x16 = aom_highbd_smooth_v_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_32x16 = aom_highbd_smooth_v_predictor_32x16_avx2;
-        aom_highbd_smooth_v_predictor_32x32 = aom_highbd_smooth_v_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_32x32 = aom_highbd_smooth_v_predictor_32x32_avx2;
-        aom_highbd_smooth_v_predictor_32x64 = aom_highbd_smooth_v_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_32x64 = aom_highbd_smooth_v_predictor_32x64_avx2;
-        aom_highbd_smooth_v_predictor_32x8 = aom_highbd_smooth_v_predictor_32x8_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_32x8 = aom_highbd_smooth_v_predictor_32x8_avx2;
-        aom_highbd_smooth_v_predictor_4x16 = aom_highbd_smooth_v_predictor_4x16_c;
-        if (flags & HAS_SSSE3) aom_highbd_smooth_v_predictor_4x16 = aom_highbd_smooth_v_predictor_4x16_ssse3;
-        aom_highbd_smooth_v_predictor_4x4 = aom_highbd_smooth_v_predictor_4x4_c;
-        if (flags & HAS_SSSE3) aom_highbd_smooth_v_predictor_4x4 = aom_highbd_smooth_v_predictor_4x4_ssse3;
-        aom_highbd_smooth_v_predictor_4x8 = aom_highbd_smooth_v_predictor_4x8_c;
-        if (flags & HAS_SSSE3) aom_highbd_smooth_v_predictor_4x8 = aom_highbd_smooth_v_predictor_4x8_ssse3;
-        aom_highbd_smooth_v_predictor_64x16 = aom_highbd_smooth_v_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_64x16 = aom_highbd_smooth_v_predictor_64x16_avx2;
-        aom_highbd_smooth_v_predictor_64x32 = aom_highbd_smooth_v_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_64x32 = aom_highbd_smooth_v_predictor_64x32_avx2;
-        aom_highbd_smooth_v_predictor_64x64 = aom_highbd_smooth_v_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_64x64 = aom_highbd_smooth_v_predictor_64x64_avx2;
-        aom_highbd_smooth_v_predictor_8x16 = aom_highbd_smooth_v_predictor_8x16_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_8x16 = aom_highbd_smooth_v_predictor_8x16_avx2;
-        aom_highbd_smooth_v_predictor_8x32 = aom_highbd_smooth_v_predictor_8x32_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_8x32 = aom_highbd_smooth_v_predictor_8x32_avx2;
-        aom_highbd_smooth_v_predictor_8x4 = aom_highbd_smooth_v_predictor_8x4_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_8x4 = aom_highbd_smooth_v_predictor_8x4_avx2;
-        aom_highbd_smooth_v_predictor_8x8 = aom_highbd_smooth_v_predictor_8x8_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_v_predictor_8x8 = aom_highbd_smooth_v_predictor_8x8_avx2;
+        eb_aom_highbd_smooth_v_predictor_16x16 = eb_aom_highbd_smooth_v_predictor_16x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_16x16 = eb_aom_highbd_smooth_v_predictor_16x16_avx2;
+        eb_aom_highbd_smooth_v_predictor_16x32 = eb_aom_highbd_smooth_v_predictor_16x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_16x32 = eb_aom_highbd_smooth_v_predictor_16x32_avx2;
+        eb_aom_highbd_smooth_v_predictor_16x4 = eb_aom_highbd_smooth_v_predictor_16x4_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_16x4 = eb_aom_highbd_smooth_v_predictor_16x4_avx2;
+        eb_aom_highbd_smooth_v_predictor_16x64 = eb_aom_highbd_smooth_v_predictor_16x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_16x64 = eb_aom_highbd_smooth_v_predictor_16x64_avx2;
+        eb_aom_highbd_smooth_v_predictor_16x8 = eb_aom_highbd_smooth_v_predictor_16x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_16x8 = eb_aom_highbd_smooth_v_predictor_16x8_avx2;
+        eb_aom_highbd_smooth_v_predictor_2x2 = eb_aom_highbd_smooth_v_predictor_2x2_c;
+        eb_aom_highbd_smooth_v_predictor_32x16 = eb_aom_highbd_smooth_v_predictor_32x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_32x16 = eb_aom_highbd_smooth_v_predictor_32x16_avx2;
+        eb_aom_highbd_smooth_v_predictor_32x32 = eb_aom_highbd_smooth_v_predictor_32x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_32x32 = eb_aom_highbd_smooth_v_predictor_32x32_avx2;
+        eb_aom_highbd_smooth_v_predictor_32x64 = eb_aom_highbd_smooth_v_predictor_32x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_32x64 = eb_aom_highbd_smooth_v_predictor_32x64_avx2;
+        eb_aom_highbd_smooth_v_predictor_32x8 = eb_aom_highbd_smooth_v_predictor_32x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_32x8 = eb_aom_highbd_smooth_v_predictor_32x8_avx2;
+        eb_aom_highbd_smooth_v_predictor_4x16 = eb_aom_highbd_smooth_v_predictor_4x16_c;
+        if (flags & HAS_SSSE3) eb_aom_highbd_smooth_v_predictor_4x16 = eb_aom_highbd_smooth_v_predictor_4x16_ssse3;
+        eb_aom_highbd_smooth_v_predictor_4x4 = eb_aom_highbd_smooth_v_predictor_4x4_c;
+        if (flags & HAS_SSSE3) eb_aom_highbd_smooth_v_predictor_4x4 = eb_aom_highbd_smooth_v_predictor_4x4_ssse3;
+        eb_aom_highbd_smooth_v_predictor_4x8 = eb_aom_highbd_smooth_v_predictor_4x8_c;
+        if (flags & HAS_SSSE3) eb_aom_highbd_smooth_v_predictor_4x8 = eb_aom_highbd_smooth_v_predictor_4x8_ssse3;
+        eb_aom_highbd_smooth_v_predictor_64x16 = eb_aom_highbd_smooth_v_predictor_64x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_64x16 = eb_aom_highbd_smooth_v_predictor_64x16_avx2;
+        eb_aom_highbd_smooth_v_predictor_64x32 = eb_aom_highbd_smooth_v_predictor_64x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_64x32 = eb_aom_highbd_smooth_v_predictor_64x32_avx2;
+        eb_aom_highbd_smooth_v_predictor_64x64 = eb_aom_highbd_smooth_v_predictor_64x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_64x64 = eb_aom_highbd_smooth_v_predictor_64x64_avx2;
+        eb_aom_highbd_smooth_v_predictor_8x16 = eb_aom_highbd_smooth_v_predictor_8x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_8x16 = eb_aom_highbd_smooth_v_predictor_8x16_avx2;
+        eb_aom_highbd_smooth_v_predictor_8x32 = eb_aom_highbd_smooth_v_predictor_8x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_8x32 = eb_aom_highbd_smooth_v_predictor_8x32_avx2;
+        eb_aom_highbd_smooth_v_predictor_8x4 = eb_aom_highbd_smooth_v_predictor_8x4_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_8x4 = eb_aom_highbd_smooth_v_predictor_8x4_avx2;
+        eb_aom_highbd_smooth_v_predictor_8x8 = eb_aom_highbd_smooth_v_predictor_8x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_8x8 = eb_aom_highbd_smooth_v_predictor_8x8_avx2;
 
-        cfl_predict_lbd = cfl_predict_lbd_c;
-        if (flags & HAS_AVX2) cfl_predict_lbd = cfl_predict_lbd_avx2;
-        cfl_predict_hbd = cfl_predict_hbd_c;
-        if (flags & HAS_AVX2) cfl_predict_hbd = cfl_predict_hbd_avx2;
+        eb_cfl_predict_lbd = eb_cfl_predict_lbd_c;
+        if (flags & HAS_AVX2) eb_cfl_predict_lbd = eb_cfl_predict_lbd_avx2;
+        eb_cfl_predict_hbd = eb_cfl_predict_hbd_c;
+        if (flags & HAS_AVX2) eb_cfl_predict_hbd = eb_cfl_predict_hbd_avx2;
 
-        av1_dr_prediction_z1 = av1_dr_prediction_z1_c;
-        if (flags & HAS_AVX2) av1_dr_prediction_z1 = av1_dr_prediction_z1_avx2;
-        av1_dr_prediction_z2 = av1_dr_prediction_z2_c;
-        if (flags & HAS_AVX2) av1_dr_prediction_z2 = av1_dr_prediction_z2_avx2;
-        av1_dr_prediction_z3 = av1_dr_prediction_z3_c;
-        if (flags & HAS_AVX2) av1_dr_prediction_z3 = av1_dr_prediction_z3_avx2;
-        av1_highbd_dr_prediction_z1 = av1_highbd_dr_prediction_z1_c;
-        if (flags & HAS_AVX2) av1_highbd_dr_prediction_z1 = av1_highbd_dr_prediction_z1_avx2;
-        av1_highbd_dr_prediction_z2 = av1_highbd_dr_prediction_z2_c;
-        if (flags & HAS_AVX2) av1_highbd_dr_prediction_z2 = av1_highbd_dr_prediction_z2_avx2;
-        av1_highbd_dr_prediction_z3 = av1_highbd_dr_prediction_z3_c;
-        if (flags & HAS_AVX2) av1_highbd_dr_prediction_z3 = av1_highbd_dr_prediction_z3_avx2;
-        //av1_get_nz_map_contexts = av1_get_nz_map_contexts_c;
-        if (flags & HAS_SSE2) av1_get_nz_map_contexts = av1_get_nz_map_contexts_sse2;
+        eb_av1_dr_prediction_z1 = eb_av1_dr_prediction_z1_c;
+        if (flags & HAS_AVX2) eb_av1_dr_prediction_z1 = eb_av1_dr_prediction_z1_avx2;
+        eb_av1_dr_prediction_z2 = eb_av1_dr_prediction_z2_c;
+        if (flags & HAS_AVX2) eb_av1_dr_prediction_z2 = eb_av1_dr_prediction_z2_avx2;
+        eb_av1_dr_prediction_z3 = eb_av1_dr_prediction_z3_c;
+        if (flags & HAS_AVX2) eb_av1_dr_prediction_z3 = eb_av1_dr_prediction_z3_avx2;
+        eb_av1_highbd_dr_prediction_z1 = eb_av1_highbd_dr_prediction_z1_c;
+        if (flags & HAS_AVX2) eb_av1_highbd_dr_prediction_z1 = eb_av1_highbd_dr_prediction_z1_avx2;
+        eb_av1_highbd_dr_prediction_z2 = eb_av1_highbd_dr_prediction_z2_c;
+        if (flags & HAS_AVX2) eb_av1_highbd_dr_prediction_z2 = eb_av1_highbd_dr_prediction_z2_avx2;
+        eb_av1_highbd_dr_prediction_z3 = eb_av1_highbd_dr_prediction_z3_c;
+        if (flags & HAS_AVX2) eb_av1_highbd_dr_prediction_z3 = eb_av1_highbd_dr_prediction_z3_avx2;
+        //av1_get_nz_map_contexts = eb_av1_get_nz_map_contexts_c;
+        if (flags & HAS_SSE2) eb_av1_get_nz_map_contexts = eb_av1_get_nz_map_contexts_sse2;
 
         ResidualKernel = residual_kernel_c;
         if (flags & HAS_AVX2) ResidualKernel = ResidualKernel_avx2;
 
-        av1_txb_init_levels = av1_txb_init_levels_c;
-        if (flags & HAS_AVX2) av1_txb_init_levels = av1_txb_init_levels_avx2;
-    aom_paeth_predictor_16x16 = aom_paeth_predictor_16x16_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_16x16 = aom_paeth_predictor_16x16_ssse3;
-    if (flags & HAS_AVX2) aom_paeth_predictor_16x16 = aom_paeth_predictor_16x16_avx2;
-    aom_paeth_predictor_16x32 = aom_paeth_predictor_16x32_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_16x32 = aom_paeth_predictor_16x32_ssse3;
-    if (flags & HAS_AVX2) aom_paeth_predictor_16x32 = aom_paeth_predictor_16x32_avx2;
-    aom_paeth_predictor_16x4 = aom_paeth_predictor_16x4_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_16x4 = aom_paeth_predictor_16x4_ssse3;
-    aom_paeth_predictor_16x64 = aom_paeth_predictor_16x64_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_16x64 = aom_paeth_predictor_16x64_ssse3;
-    if (flags & HAS_AVX2) aom_paeth_predictor_16x64 = aom_paeth_predictor_16x64_avx2;
-    aom_paeth_predictor_16x8 = aom_paeth_predictor_16x8_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_16x8 = aom_paeth_predictor_16x8_ssse3;
-    if (flags & HAS_AVX2) aom_paeth_predictor_16x8 = aom_paeth_predictor_16x8_avx2;
-    aom_paeth_predictor_32x16 = aom_paeth_predictor_32x16_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_32x16 = aom_paeth_predictor_32x16_ssse3;
-    if (flags & HAS_AVX2) aom_paeth_predictor_32x16 = aom_paeth_predictor_32x16_avx2;
-    aom_paeth_predictor_32x32 = aom_paeth_predictor_32x32_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_32x32 = aom_paeth_predictor_32x32_ssse3;
-    if (flags & HAS_AVX2) aom_paeth_predictor_32x32 = aom_paeth_predictor_32x32_avx2;
-    aom_paeth_predictor_32x64 = aom_paeth_predictor_32x64_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_32x64 = aom_paeth_predictor_32x64_ssse3;
-    if (flags & HAS_AVX2) aom_paeth_predictor_32x64 = aom_paeth_predictor_32x64_avx2;
-    aom_paeth_predictor_32x8 = aom_paeth_predictor_32x8_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_32x8 = aom_paeth_predictor_32x8_ssse3;
-    aom_paeth_predictor_4x16 = aom_paeth_predictor_4x16_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_4x16 = aom_paeth_predictor_4x16_ssse3;
-    aom_paeth_predictor_4x4 = aom_paeth_predictor_4x4_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_4x4 = aom_paeth_predictor_4x4_ssse3;
-    aom_paeth_predictor_4x8 = aom_paeth_predictor_4x8_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_4x8 = aom_paeth_predictor_4x8_ssse3;
-    aom_paeth_predictor_64x16 = aom_paeth_predictor_64x16_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_64x16 = aom_paeth_predictor_64x16_ssse3;
-    if (flags & HAS_AVX2) aom_paeth_predictor_64x16 = aom_paeth_predictor_64x16_avx2;
-    aom_paeth_predictor_64x32 = aom_paeth_predictor_64x32_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_64x32 = aom_paeth_predictor_64x32_ssse3;
-    if (flags & HAS_AVX2) aom_paeth_predictor_64x32 = aom_paeth_predictor_64x32_avx2;
-    aom_paeth_predictor_64x64 = aom_paeth_predictor_64x64_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_64x64 = aom_paeth_predictor_64x64_ssse3;
-    if (flags & HAS_AVX2) aom_paeth_predictor_64x64 = aom_paeth_predictor_64x64_avx2;
-    aom_paeth_predictor_8x16 = aom_paeth_predictor_8x16_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_8x16 = aom_paeth_predictor_8x16_ssse3;
-    aom_paeth_predictor_8x32 = aom_paeth_predictor_8x32_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_8x32 = aom_paeth_predictor_8x32_ssse3;
-    aom_paeth_predictor_8x4 = aom_paeth_predictor_8x4_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_8x4 = aom_paeth_predictor_8x4_ssse3;
-    aom_paeth_predictor_8x8 = aom_paeth_predictor_8x8_c;
-    if (flags & HAS_SSSE3) aom_paeth_predictor_8x8 = aom_paeth_predictor_8x8_ssse3;
+        eb_av1_txb_init_levels = eb_av1_txb_init_levels_c;
+        if (flags & HAS_AVX2) eb_av1_txb_init_levels = eb_av1_txb_init_levels_avx2;
+    eb_aom_paeth_predictor_16x16 = eb_aom_paeth_predictor_16x16_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_16x16 = eb_aom_paeth_predictor_16x16_ssse3;
+    if (flags & HAS_AVX2) eb_aom_paeth_predictor_16x16 = eb_aom_paeth_predictor_16x16_avx2;
+    eb_aom_paeth_predictor_16x32 = eb_aom_paeth_predictor_16x32_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_16x32 = eb_aom_paeth_predictor_16x32_ssse3;
+    if (flags & HAS_AVX2) eb_aom_paeth_predictor_16x32 = eb_aom_paeth_predictor_16x32_avx2;
+    eb_aom_paeth_predictor_16x4 = eb_aom_paeth_predictor_16x4_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_16x4 = eb_aom_paeth_predictor_16x4_ssse3;
+    eb_aom_paeth_predictor_16x64 = eb_aom_paeth_predictor_16x64_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_16x64 = eb_aom_paeth_predictor_16x64_ssse3;
+    if (flags & HAS_AVX2) eb_aom_paeth_predictor_16x64 = eb_aom_paeth_predictor_16x64_avx2;
+    eb_aom_paeth_predictor_16x8 = eb_aom_paeth_predictor_16x8_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_16x8 = eb_aom_paeth_predictor_16x8_ssse3;
+    if (flags & HAS_AVX2) eb_aom_paeth_predictor_16x8 = eb_aom_paeth_predictor_16x8_avx2;
+    eb_aom_paeth_predictor_32x16 = eb_aom_paeth_predictor_32x16_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_32x16 = eb_aom_paeth_predictor_32x16_ssse3;
+    if (flags & HAS_AVX2) eb_aom_paeth_predictor_32x16 = eb_aom_paeth_predictor_32x16_avx2;
+    eb_aom_paeth_predictor_32x32 = eb_aom_paeth_predictor_32x32_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_32x32 = eb_aom_paeth_predictor_32x32_ssse3;
+    if (flags & HAS_AVX2) eb_aom_paeth_predictor_32x32 = eb_aom_paeth_predictor_32x32_avx2;
+    eb_aom_paeth_predictor_32x64 = eb_aom_paeth_predictor_32x64_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_32x64 = eb_aom_paeth_predictor_32x64_ssse3;
+    if (flags & HAS_AVX2) eb_aom_paeth_predictor_32x64 = eb_aom_paeth_predictor_32x64_avx2;
+    eb_aom_paeth_predictor_32x8 = eb_aom_paeth_predictor_32x8_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_32x8 = eb_aom_paeth_predictor_32x8_ssse3;
+    eb_aom_paeth_predictor_4x16 = eb_aom_paeth_predictor_4x16_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_4x16 = eb_aom_paeth_predictor_4x16_ssse3;
+    eb_aom_paeth_predictor_4x4 = eb_aom_paeth_predictor_4x4_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_4x4 = eb_aom_paeth_predictor_4x4_ssse3;
+    eb_aom_paeth_predictor_4x8 = eb_aom_paeth_predictor_4x8_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_4x8 = eb_aom_paeth_predictor_4x8_ssse3;
+    eb_aom_paeth_predictor_64x16 = eb_aom_paeth_predictor_64x16_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_64x16 = eb_aom_paeth_predictor_64x16_ssse3;
+    if (flags & HAS_AVX2) eb_aom_paeth_predictor_64x16 = eb_aom_paeth_predictor_64x16_avx2;
+    eb_aom_paeth_predictor_64x32 = eb_aom_paeth_predictor_64x32_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_64x32 = eb_aom_paeth_predictor_64x32_ssse3;
+    if (flags & HAS_AVX2) eb_aom_paeth_predictor_64x32 = eb_aom_paeth_predictor_64x32_avx2;
+    eb_aom_paeth_predictor_64x64 = eb_aom_paeth_predictor_64x64_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_64x64 = eb_aom_paeth_predictor_64x64_ssse3;
+    if (flags & HAS_AVX2) eb_aom_paeth_predictor_64x64 = eb_aom_paeth_predictor_64x64_avx2;
+    eb_aom_paeth_predictor_8x16 = eb_aom_paeth_predictor_8x16_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_8x16 = eb_aom_paeth_predictor_8x16_ssse3;
+    eb_aom_paeth_predictor_8x32 = eb_aom_paeth_predictor_8x32_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_8x32 = eb_aom_paeth_predictor_8x32_ssse3;
+    eb_aom_paeth_predictor_8x4 = eb_aom_paeth_predictor_8x4_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_8x4 = eb_aom_paeth_predictor_8x4_ssse3;
+    eb_aom_paeth_predictor_8x8 = eb_aom_paeth_predictor_8x8_c;
+    if (flags & HAS_SSSE3) eb_aom_paeth_predictor_8x8 = eb_aom_paeth_predictor_8x8_ssse3;
 
-        aom_highbd_paeth_predictor_16x16 = aom_highbd_paeth_predictor_16x16_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_16x16 = aom_highbd_paeth_predictor_16x16_avx2;
-        aom_highbd_paeth_predictor_16x32 = aom_highbd_paeth_predictor_16x32_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_16x32 = aom_highbd_paeth_predictor_16x32_avx2;
-        aom_highbd_paeth_predictor_16x4 = aom_highbd_paeth_predictor_16x4_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_16x4 = aom_highbd_paeth_predictor_16x4_avx2;
-        aom_highbd_paeth_predictor_16x64 = aom_highbd_paeth_predictor_16x64_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_16x64 = aom_highbd_paeth_predictor_16x64_avx2;
-        aom_highbd_paeth_predictor_16x8 = aom_highbd_paeth_predictor_16x8_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_16x8 = aom_highbd_paeth_predictor_16x8_avx2;
-        aom_highbd_paeth_predictor_2x2 = aom_highbd_paeth_predictor_2x2_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_2x2 = aom_highbd_paeth_predictor_2x2_avx2;
-        aom_highbd_paeth_predictor_32x16 = aom_highbd_paeth_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_32x16 = aom_highbd_paeth_predictor_32x16_avx2;
-        aom_highbd_paeth_predictor_32x32 = aom_highbd_paeth_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_32x32 = aom_highbd_paeth_predictor_32x32_avx2;
-        aom_highbd_paeth_predictor_32x64 = aom_highbd_paeth_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_32x64 = aom_highbd_paeth_predictor_32x64_avx2;
-        aom_highbd_paeth_predictor_32x8 = aom_highbd_paeth_predictor_32x8_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_32x8 = aom_highbd_paeth_predictor_32x8_avx2;
-        aom_highbd_paeth_predictor_4x16 = aom_highbd_paeth_predictor_4x16_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_4x16 = aom_highbd_paeth_predictor_4x16_avx2;
-        aom_highbd_paeth_predictor_4x4 = aom_highbd_paeth_predictor_4x4_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_4x4 = aom_highbd_paeth_predictor_4x4_avx2;
-        aom_highbd_paeth_predictor_4x8 = aom_highbd_paeth_predictor_4x8_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_4x8 = aom_highbd_paeth_predictor_4x8_avx2;
-        aom_highbd_paeth_predictor_64x16 = aom_highbd_paeth_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_64x16 = aom_highbd_paeth_predictor_64x16_avx2;
-        aom_highbd_paeth_predictor_64x32 = aom_highbd_paeth_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_64x32 = aom_highbd_paeth_predictor_64x32_avx2;
-        aom_highbd_paeth_predictor_64x64 = aom_highbd_paeth_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_64x64 = aom_highbd_paeth_predictor_64x64_avx2;
-        aom_highbd_paeth_predictor_8x16 = aom_highbd_paeth_predictor_8x16_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_8x16 = aom_highbd_paeth_predictor_8x16_avx2;
-        aom_highbd_paeth_predictor_8x32 = aom_highbd_paeth_predictor_8x32_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_8x32 = aom_highbd_paeth_predictor_8x32_avx2;
-        aom_highbd_paeth_predictor_8x4 = aom_highbd_paeth_predictor_8x4_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_8x4 = aom_highbd_paeth_predictor_8x4_avx2;
-        aom_highbd_paeth_predictor_8x8 = aom_highbd_paeth_predictor_8x8_c;
-        if (flags & HAS_AVX2) aom_highbd_paeth_predictor_8x8 = aom_highbd_paeth_predictor_8x8_avx2;
+        eb_aom_highbd_paeth_predictor_16x16 = eb_aom_highbd_paeth_predictor_16x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_16x16 = eb_aom_highbd_paeth_predictor_16x16_avx2;
+        eb_aom_highbd_paeth_predictor_16x32 = eb_aom_highbd_paeth_predictor_16x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_16x32 = eb_aom_highbd_paeth_predictor_16x32_avx2;
+        eb_aom_highbd_paeth_predictor_16x4 = eb_aom_highbd_paeth_predictor_16x4_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_16x4 = eb_aom_highbd_paeth_predictor_16x4_avx2;
+        eb_aom_highbd_paeth_predictor_16x64 = eb_aom_highbd_paeth_predictor_16x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_16x64 = eb_aom_highbd_paeth_predictor_16x64_avx2;
+        eb_aom_highbd_paeth_predictor_16x8 = eb_aom_highbd_paeth_predictor_16x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_16x8 = eb_aom_highbd_paeth_predictor_16x8_avx2;
+        eb_aom_highbd_paeth_predictor_2x2 = eb_aom_highbd_paeth_predictor_2x2_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_2x2 = eb_aom_highbd_paeth_predictor_2x2_avx2;
+        eb_aom_highbd_paeth_predictor_32x16 = eb_aom_highbd_paeth_predictor_32x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_32x16 = eb_aom_highbd_paeth_predictor_32x16_avx2;
+        eb_aom_highbd_paeth_predictor_32x32 = eb_aom_highbd_paeth_predictor_32x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_32x32 = eb_aom_highbd_paeth_predictor_32x32_avx2;
+        eb_aom_highbd_paeth_predictor_32x64 = eb_aom_highbd_paeth_predictor_32x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_32x64 = eb_aom_highbd_paeth_predictor_32x64_avx2;
+        eb_aom_highbd_paeth_predictor_32x8 = eb_aom_highbd_paeth_predictor_32x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_32x8 = eb_aom_highbd_paeth_predictor_32x8_avx2;
+        eb_aom_highbd_paeth_predictor_4x16 = eb_aom_highbd_paeth_predictor_4x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_4x16 = eb_aom_highbd_paeth_predictor_4x16_avx2;
+        eb_aom_highbd_paeth_predictor_4x4 = eb_aom_highbd_paeth_predictor_4x4_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_4x4 = eb_aom_highbd_paeth_predictor_4x4_avx2;
+        eb_aom_highbd_paeth_predictor_4x8 = eb_aom_highbd_paeth_predictor_4x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_4x8 = eb_aom_highbd_paeth_predictor_4x8_avx2;
+        eb_aom_highbd_paeth_predictor_64x16 = eb_aom_highbd_paeth_predictor_64x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_64x16 = eb_aom_highbd_paeth_predictor_64x16_avx2;
+        eb_aom_highbd_paeth_predictor_64x32 = eb_aom_highbd_paeth_predictor_64x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_64x32 = eb_aom_highbd_paeth_predictor_64x32_avx2;
+        eb_aom_highbd_paeth_predictor_64x64 = eb_aom_highbd_paeth_predictor_64x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_64x64 = eb_aom_highbd_paeth_predictor_64x64_avx2;
+        eb_aom_highbd_paeth_predictor_8x16 = eb_aom_highbd_paeth_predictor_8x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_8x16 = eb_aom_highbd_paeth_predictor_8x16_avx2;
+        eb_aom_highbd_paeth_predictor_8x32 = eb_aom_highbd_paeth_predictor_8x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_8x32 = eb_aom_highbd_paeth_predictor_8x32_avx2;
+        eb_aom_highbd_paeth_predictor_8x4 = eb_aom_highbd_paeth_predictor_8x4_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_8x4 = eb_aom_highbd_paeth_predictor_8x4_avx2;
+        eb_aom_highbd_paeth_predictor_8x8 = eb_aom_highbd_paeth_predictor_8x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_paeth_predictor_8x8 = eb_aom_highbd_paeth_predictor_8x8_avx2;
 
-        aom_dc_predictor_4x4 = aom_dc_predictor_4x4_c;
-        if (flags & HAS_SSE2) aom_dc_predictor_4x4 = aom_dc_predictor_4x4_sse2;
-        aom_dc_predictor_8x8 = aom_dc_predictor_8x8_c;
-        if (flags & HAS_SSE2) aom_dc_predictor_8x8 = aom_dc_predictor_8x8_sse2;
-        aom_dc_predictor_16x16 = aom_dc_predictor_16x16_c;
-        if (flags & HAS_SSE2) aom_dc_predictor_16x16 = aom_dc_predictor_16x16_sse2;
-        aom_dc_predictor_32x32 = aom_dc_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_dc_predictor_32x32 = aom_dc_predictor_32x32_avx2;
-        aom_dc_predictor_64x64 = aom_dc_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_dc_predictor_64x64 = aom_dc_predictor_64x64_avx2;
-        aom_dc_predictor_32x16 = aom_dc_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_dc_predictor_32x16 = aom_dc_predictor_32x16_avx2;
-        aom_dc_predictor_32x64 = aom_dc_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_dc_predictor_32x64 = aom_dc_predictor_32x64_avx2;
-        aom_dc_predictor_64x16 = aom_dc_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_dc_predictor_64x16 = aom_dc_predictor_64x16_avx2;
-        aom_dc_predictor_8x16 = aom_dc_predictor_8x16_c;
-        if (flags & HAS_SSE2) aom_dc_predictor_8x16 = aom_dc_predictor_8x16_sse2;
-        aom_dc_predictor_8x32 = aom_dc_predictor_8x32_c;
-        if (flags & HAS_SSE2) aom_dc_predictor_8x32 = aom_dc_predictor_8x32_sse2;
-        aom_dc_predictor_8x4 = aom_dc_predictor_8x4_c;
-        if (flags & HAS_SSE2) aom_dc_predictor_8x4 = aom_dc_predictor_8x4_sse2;
-        aom_dc_predictor_64x32 = aom_dc_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_dc_predictor_64x32 = aom_dc_predictor_64x32_avx2;
-        aom_dc_predictor_16x32 = aom_dc_predictor_16x32_c;
-        if (flags & HAS_SSE2) aom_dc_predictor_16x32 = aom_dc_predictor_16x32_sse2;
-        aom_dc_predictor_16x4 = aom_dc_predictor_16x4_c;
-        if (flags & HAS_SSE2) aom_dc_predictor_16x4 = aom_dc_predictor_16x4_sse2;
-        aom_dc_predictor_16x64 = aom_dc_predictor_16x64_c;
-        if (flags & HAS_SSE2) aom_dc_predictor_16x64 = aom_dc_predictor_16x64_sse2;
-        aom_dc_predictor_16x8 = aom_dc_predictor_16x8_c;
-        if (flags & HAS_SSE2) aom_dc_predictor_16x8 = aom_dc_predictor_16x8_sse2;
-        aom_dc_predictor_32x8 = aom_dc_predictor_32x8_c;
-        if (flags & HAS_SSE2) aom_dc_predictor_32x8 = aom_dc_predictor_32x8_sse2;
-        aom_dc_predictor_4x16 = aom_dc_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_dc_predictor_4x16 = aom_dc_predictor_4x16_sse2;
-        aom_dc_predictor_4x8 = aom_dc_predictor_4x8_c;
-        if (flags & HAS_SSE2) aom_dc_predictor_4x8 = aom_dc_predictor_4x8_sse2;
+        eb_aom_dc_predictor_4x4 = eb_aom_dc_predictor_4x4_c;
+        if (flags & HAS_SSE2) eb_aom_dc_predictor_4x4 = eb_aom_dc_predictor_4x4_sse2;
+        eb_aom_dc_predictor_8x8 = eb_aom_dc_predictor_8x8_c;
+        if (flags & HAS_SSE2) eb_aom_dc_predictor_8x8 = eb_aom_dc_predictor_8x8_sse2;
+        eb_aom_dc_predictor_16x16 = eb_aom_dc_predictor_16x16_c;
+        if (flags & HAS_SSE2) eb_aom_dc_predictor_16x16 = eb_aom_dc_predictor_16x16_sse2;
+        eb_aom_dc_predictor_32x32 = eb_aom_dc_predictor_32x32_c;
+        if (flags & HAS_AVX2) eb_aom_dc_predictor_32x32 = eb_aom_dc_predictor_32x32_avx2;
+        eb_aom_dc_predictor_64x64 = eb_aom_dc_predictor_64x64_c;
+        if (flags & HAS_AVX2) eb_aom_dc_predictor_64x64 = eb_aom_dc_predictor_64x64_avx2;
+        eb_aom_dc_predictor_32x16 = eb_aom_dc_predictor_32x16_c;
+        if (flags & HAS_AVX2) eb_aom_dc_predictor_32x16 = eb_aom_dc_predictor_32x16_avx2;
+        eb_aom_dc_predictor_32x64 = eb_aom_dc_predictor_32x64_c;
+        if (flags & HAS_AVX2) eb_aom_dc_predictor_32x64 = eb_aom_dc_predictor_32x64_avx2;
+        eb_aom_dc_predictor_64x16 = eb_aom_dc_predictor_64x16_c;
+        if (flags & HAS_AVX2) eb_aom_dc_predictor_64x16 = eb_aom_dc_predictor_64x16_avx2;
+        eb_aom_dc_predictor_8x16 = eb_aom_dc_predictor_8x16_c;
+        if (flags & HAS_SSE2) eb_aom_dc_predictor_8x16 = eb_aom_dc_predictor_8x16_sse2;
+        eb_aom_dc_predictor_8x32 = eb_aom_dc_predictor_8x32_c;
+        if (flags & HAS_SSE2) eb_aom_dc_predictor_8x32 = eb_aom_dc_predictor_8x32_sse2;
+        eb_aom_dc_predictor_8x4 = eb_aom_dc_predictor_8x4_c;
+        if (flags & HAS_SSE2) eb_aom_dc_predictor_8x4 = eb_aom_dc_predictor_8x4_sse2;
+        eb_aom_dc_predictor_64x32 = eb_aom_dc_predictor_64x32_c;
+        if (flags & HAS_AVX2) eb_aom_dc_predictor_64x32 = eb_aom_dc_predictor_64x32_avx2;
+        eb_aom_dc_predictor_16x32 = eb_aom_dc_predictor_16x32_c;
+        if (flags & HAS_SSE2) eb_aom_dc_predictor_16x32 = eb_aom_dc_predictor_16x32_sse2;
+        eb_aom_dc_predictor_16x4 = eb_aom_dc_predictor_16x4_c;
+        if (flags & HAS_SSE2) eb_aom_dc_predictor_16x4 = eb_aom_dc_predictor_16x4_sse2;
+        eb_aom_dc_predictor_16x64 = eb_aom_dc_predictor_16x64_c;
+        if (flags & HAS_SSE2) eb_aom_dc_predictor_16x64 = eb_aom_dc_predictor_16x64_sse2;
+        eb_aom_dc_predictor_16x8 = eb_aom_dc_predictor_16x8_c;
+        if (flags & HAS_SSE2) eb_aom_dc_predictor_16x8 = eb_aom_dc_predictor_16x8_sse2;
+        eb_aom_dc_predictor_32x8 = eb_aom_dc_predictor_32x8_c;
+        if (flags & HAS_SSE2) eb_aom_dc_predictor_32x8 = eb_aom_dc_predictor_32x8_sse2;
+        eb_aom_dc_predictor_4x16 = eb_aom_dc_predictor_4x16_c;
+        if (flags & HAS_SSE2) eb_aom_dc_predictor_4x16 = eb_aom_dc_predictor_4x16_sse2;
+        eb_aom_dc_predictor_4x8 = eb_aom_dc_predictor_4x8_c;
+        if (flags & HAS_SSE2) eb_aom_dc_predictor_4x8 = eb_aom_dc_predictor_4x8_sse2;
 
-        aom_dc_top_predictor_4x4 = aom_dc_top_predictor_4x4_c;
-        if (flags & HAS_SSE2) aom_dc_top_predictor_4x4 = aom_dc_top_predictor_4x4_sse2;
-        aom_dc_top_predictor_8x8 = aom_dc_top_predictor_8x8_c;
-        if (flags & HAS_SSE2) aom_dc_top_predictor_8x8 = aom_dc_top_predictor_8x8_sse2;
-        aom_dc_top_predictor_16x16 = aom_dc_top_predictor_16x16_c;
-        if (flags & HAS_SSE2) aom_dc_top_predictor_16x16 = aom_dc_top_predictor_16x16_sse2;
-        aom_dc_top_predictor_32x32 = aom_dc_top_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_dc_top_predictor_32x32 = aom_dc_top_predictor_32x32_avx2;
-        aom_dc_top_predictor_64x64 = aom_dc_top_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_dc_top_predictor_64x64 = aom_dc_top_predictor_64x64_avx2;
-        aom_dc_top_predictor_16x32 = aom_dc_top_predictor_16x32_c;
-        if (flags & HAS_SSE2) aom_dc_top_predictor_16x32 = aom_dc_top_predictor_16x32_sse2;
-        aom_dc_top_predictor_16x4 = aom_dc_top_predictor_16x4_c;
-        if (flags & HAS_SSE2) aom_dc_top_predictor_16x4 = aom_dc_top_predictor_16x4_sse2;
-        aom_dc_top_predictor_16x64 = aom_dc_top_predictor_16x64_c;
-        if (flags & HAS_SSE2) aom_dc_top_predictor_16x64 = aom_dc_top_predictor_16x64_sse2;
-        aom_dc_top_predictor_16x8 = aom_dc_top_predictor_16x8_c;
-        if (flags & HAS_SSE2) aom_dc_top_predictor_16x8 = aom_dc_top_predictor_16x8_sse2;
-        aom_dc_top_predictor_32x16 = aom_dc_top_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_dc_top_predictor_32x16 = aom_dc_top_predictor_32x16_avx2;
-        aom_dc_top_predictor_32x64 = aom_dc_top_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_dc_top_predictor_32x64 = aom_dc_top_predictor_32x64_avx2;
-        aom_dc_top_predictor_32x8 = aom_dc_top_predictor_32x8_c;
-        if (flags & HAS_SSE2) aom_dc_top_predictor_32x8 = aom_dc_top_predictor_32x8_sse2;
-        aom_dc_top_predictor_4x16 = aom_dc_top_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_dc_top_predictor_4x16 = aom_dc_top_predictor_4x16_sse2;
-        aom_dc_top_predictor_4x8 = aom_dc_top_predictor_4x8_c;
-        if (flags & HAS_SSE2) aom_dc_top_predictor_4x8 = aom_dc_top_predictor_4x8_sse2;
-        aom_dc_top_predictor_64x16 = aom_dc_top_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_dc_top_predictor_64x16 = aom_dc_top_predictor_64x16_avx2;
-        aom_dc_top_predictor_64x32 = aom_dc_top_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_dc_top_predictor_64x32 = aom_dc_top_predictor_64x32_avx2;
-        aom_dc_top_predictor_8x16 = aom_dc_top_predictor_8x16_c;
-        if (flags & HAS_SSE2) aom_dc_top_predictor_8x16 = aom_dc_top_predictor_8x16_sse2;
-        aom_dc_top_predictor_8x32 = aom_dc_top_predictor_8x32_c;
-        if (flags & HAS_SSE2) aom_dc_top_predictor_8x32 = aom_dc_top_predictor_8x32_sse2;
-        aom_dc_top_predictor_8x4 = aom_dc_top_predictor_8x4_c;
-        if (flags & HAS_SSE2) aom_dc_top_predictor_8x4 = aom_dc_top_predictor_8x4_sse2;
+        eb_aom_dc_top_predictor_4x4 = eb_aom_dc_top_predictor_4x4_c;
+        if (flags & HAS_SSE2) eb_aom_dc_top_predictor_4x4 = eb_aom_dc_top_predictor_4x4_sse2;
+        eb_aom_dc_top_predictor_8x8 = eb_aom_dc_top_predictor_8x8_c;
+        if (flags & HAS_SSE2) eb_aom_dc_top_predictor_8x8 = eb_aom_dc_top_predictor_8x8_sse2;
+        eb_aom_dc_top_predictor_16x16 = eb_aom_dc_top_predictor_16x16_c;
+        if (flags & HAS_SSE2) eb_aom_dc_top_predictor_16x16 = eb_aom_dc_top_predictor_16x16_sse2;
+        eb_aom_dc_top_predictor_32x32 = eb_aom_dc_top_predictor_32x32_c;
+        if (flags & HAS_AVX2) eb_aom_dc_top_predictor_32x32 = eb_aom_dc_top_predictor_32x32_avx2;
+        eb_aom_dc_top_predictor_64x64 = eb_aom_dc_top_predictor_64x64_c;
+        if (flags & HAS_AVX2) eb_aom_dc_top_predictor_64x64 = eb_aom_dc_top_predictor_64x64_avx2;
+        eb_aom_dc_top_predictor_16x32 = eb_aom_dc_top_predictor_16x32_c;
+        if (flags & HAS_SSE2) eb_aom_dc_top_predictor_16x32 = eb_aom_dc_top_predictor_16x32_sse2;
+        eb_aom_dc_top_predictor_16x4 = eb_aom_dc_top_predictor_16x4_c;
+        if (flags & HAS_SSE2) eb_aom_dc_top_predictor_16x4 = eb_aom_dc_top_predictor_16x4_sse2;
+        eb_aom_dc_top_predictor_16x64 = eb_aom_dc_top_predictor_16x64_c;
+        if (flags & HAS_SSE2) eb_aom_dc_top_predictor_16x64 = eb_aom_dc_top_predictor_16x64_sse2;
+        eb_aom_dc_top_predictor_16x8 = eb_aom_dc_top_predictor_16x8_c;
+        if (flags & HAS_SSE2) eb_aom_dc_top_predictor_16x8 = eb_aom_dc_top_predictor_16x8_sse2;
+        eb_aom_dc_top_predictor_32x16 = eb_aom_dc_top_predictor_32x16_c;
+        if (flags & HAS_AVX2) eb_aom_dc_top_predictor_32x16 = eb_aom_dc_top_predictor_32x16_avx2;
+        eb_aom_dc_top_predictor_32x64 = eb_aom_dc_top_predictor_32x64_c;
+        if (flags & HAS_AVX2) eb_aom_dc_top_predictor_32x64 = eb_aom_dc_top_predictor_32x64_avx2;
+        eb_aom_dc_top_predictor_32x8 = eb_aom_dc_top_predictor_32x8_c;
+        if (flags & HAS_SSE2) eb_aom_dc_top_predictor_32x8 = eb_aom_dc_top_predictor_32x8_sse2;
+        eb_aom_dc_top_predictor_4x16 = eb_aom_dc_top_predictor_4x16_c;
+        if (flags & HAS_SSE2) eb_aom_dc_top_predictor_4x16 = eb_aom_dc_top_predictor_4x16_sse2;
+        eb_aom_dc_top_predictor_4x8 = eb_aom_dc_top_predictor_4x8_c;
+        if (flags & HAS_SSE2) eb_aom_dc_top_predictor_4x8 = eb_aom_dc_top_predictor_4x8_sse2;
+        eb_aom_dc_top_predictor_64x16 = eb_aom_dc_top_predictor_64x16_c;
+        if (flags & HAS_AVX2) eb_aom_dc_top_predictor_64x16 = eb_aom_dc_top_predictor_64x16_avx2;
+        eb_aom_dc_top_predictor_64x32 = eb_aom_dc_top_predictor_64x32_c;
+        if (flags & HAS_AVX2) eb_aom_dc_top_predictor_64x32 = eb_aom_dc_top_predictor_64x32_avx2;
+        eb_aom_dc_top_predictor_8x16 = eb_aom_dc_top_predictor_8x16_c;
+        if (flags & HAS_SSE2) eb_aom_dc_top_predictor_8x16 = eb_aom_dc_top_predictor_8x16_sse2;
+        eb_aom_dc_top_predictor_8x32 = eb_aom_dc_top_predictor_8x32_c;
+        if (flags & HAS_SSE2) eb_aom_dc_top_predictor_8x32 = eb_aom_dc_top_predictor_8x32_sse2;
+        eb_aom_dc_top_predictor_8x4 = eb_aom_dc_top_predictor_8x4_c;
+        if (flags & HAS_SSE2) eb_aom_dc_top_predictor_8x4 = eb_aom_dc_top_predictor_8x4_sse2;
 
-        aom_dc_left_predictor_4x4 = aom_dc_left_predictor_4x4_c;
-        if (flags & HAS_SSE2) aom_dc_left_predictor_4x4 = aom_dc_left_predictor_4x4_sse2;
-        aom_dc_left_predictor_8x8 = aom_dc_left_predictor_8x8_c;
-        if (flags & HAS_SSE2) aom_dc_left_predictor_8x8 = aom_dc_left_predictor_8x8_sse2;
-        aom_dc_left_predictor_16x16 = aom_dc_left_predictor_16x16_c;
-        if (flags & HAS_SSE2) aom_dc_left_predictor_16x16 = aom_dc_left_predictor_16x16_sse2;
-        aom_dc_left_predictor_32x32 = aom_dc_left_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_dc_left_predictor_32x32 = aom_dc_left_predictor_32x32_avx2;
-        aom_dc_left_predictor_64x64 = aom_dc_left_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_dc_left_predictor_64x64 = aom_dc_left_predictor_64x64_avx2;
-        aom_dc_left_predictor_16x32 = aom_dc_left_predictor_16x32_c;
-        if (flags & HAS_SSE2) aom_dc_left_predictor_16x32 = aom_dc_left_predictor_16x32_sse2;
-        aom_dc_left_predictor_16x4 = aom_dc_left_predictor_16x4_c;
-        if (flags & HAS_SSE2) aom_dc_left_predictor_16x4 = aom_dc_left_predictor_16x4_sse2;
-        aom_dc_left_predictor_16x64 = aom_dc_left_predictor_16x64_c;
-        if (flags & HAS_SSE2) aom_dc_left_predictor_16x64 = aom_dc_left_predictor_16x64_sse2;
-        aom_dc_left_predictor_16x8 = aom_dc_left_predictor_16x8_c;
-        if (flags & HAS_SSE2)  aom_dc_left_predictor_16x8 = aom_dc_left_predictor_16x8_sse2;
-        aom_dc_left_predictor_32x16 = aom_dc_left_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_dc_left_predictor_32x16 = aom_dc_left_predictor_32x16_avx2;
-        aom_dc_left_predictor_32x64 = aom_dc_left_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_dc_left_predictor_32x64 = aom_dc_left_predictor_32x64_avx2;
-        aom_dc_left_predictor_64x16 = aom_dc_left_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_dc_left_predictor_64x16 = aom_dc_left_predictor_64x16_avx2;
-        aom_dc_left_predictor_64x32 = aom_dc_left_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_dc_left_predictor_64x32 = aom_dc_left_predictor_64x32_avx2;
-        aom_dc_left_predictor_32x8 = aom_dc_left_predictor_32x8_c;
-        if (flags & HAS_SSE2) aom_dc_left_predictor_32x8 = aom_dc_left_predictor_32x8_sse2;
-        aom_dc_left_predictor_4x16 = aom_dc_left_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_dc_left_predictor_4x16 = aom_dc_left_predictor_4x16_sse2;
-        aom_dc_left_predictor_4x8 = aom_dc_left_predictor_4x8_c;
-        if (flags & HAS_SSE2) aom_dc_left_predictor_4x8 = aom_dc_left_predictor_4x8_sse2;
-        aom_dc_left_predictor_8x16 = aom_dc_left_predictor_8x16_c;
-        if (flags & HAS_SSE2) aom_dc_left_predictor_8x16 = aom_dc_left_predictor_8x16_sse2;
-        aom_dc_left_predictor_8x32 = aom_dc_left_predictor_8x32_c;
-        if (flags & HAS_SSE2) aom_dc_left_predictor_8x32 = aom_dc_left_predictor_8x32_sse2;
-        aom_dc_left_predictor_8x4 = aom_dc_left_predictor_8x4_c;
-        if (flags & HAS_SSE2) aom_dc_left_predictor_8x4 = aom_dc_left_predictor_8x4_sse2;
+        eb_aom_dc_left_predictor_4x4 = eb_aom_dc_left_predictor_4x4_c;
+        if (flags & HAS_SSE2) eb_aom_dc_left_predictor_4x4 = eb_aom_dc_left_predictor_4x4_sse2;
+        eb_aom_dc_left_predictor_8x8 = eb_aom_dc_left_predictor_8x8_c;
+        if (flags & HAS_SSE2) eb_aom_dc_left_predictor_8x8 = eb_aom_dc_left_predictor_8x8_sse2;
+        eb_aom_dc_left_predictor_16x16 = eb_aom_dc_left_predictor_16x16_c;
+        if (flags & HAS_SSE2) eb_aom_dc_left_predictor_16x16 = eb_aom_dc_left_predictor_16x16_sse2;
+        eb_aom_dc_left_predictor_32x32 = eb_aom_dc_left_predictor_32x32_c;
+        if (flags & HAS_AVX2) eb_aom_dc_left_predictor_32x32 = eb_aom_dc_left_predictor_32x32_avx2;
+        eb_aom_dc_left_predictor_64x64 = eb_aom_dc_left_predictor_64x64_c;
+        if (flags & HAS_AVX2) eb_aom_dc_left_predictor_64x64 = eb_aom_dc_left_predictor_64x64_avx2;
+        eb_aom_dc_left_predictor_16x32 = eb_aom_dc_left_predictor_16x32_c;
+        if (flags & HAS_SSE2) eb_aom_dc_left_predictor_16x32 = eb_aom_dc_left_predictor_16x32_sse2;
+        eb_aom_dc_left_predictor_16x4 = eb_aom_dc_left_predictor_16x4_c;
+        if (flags & HAS_SSE2) eb_aom_dc_left_predictor_16x4 = eb_aom_dc_left_predictor_16x4_sse2;
+        eb_aom_dc_left_predictor_16x64 = eb_aom_dc_left_predictor_16x64_c;
+        if (flags & HAS_SSE2) eb_aom_dc_left_predictor_16x64 = eb_aom_dc_left_predictor_16x64_sse2;
+        eb_aom_dc_left_predictor_16x8 = eb_aom_dc_left_predictor_16x8_c;
+        if (flags & HAS_SSE2)  eb_aom_dc_left_predictor_16x8 = eb_aom_dc_left_predictor_16x8_sse2;
+        eb_aom_dc_left_predictor_32x16 = eb_aom_dc_left_predictor_32x16_c;
+        if (flags & HAS_AVX2) eb_aom_dc_left_predictor_32x16 = eb_aom_dc_left_predictor_32x16_avx2;
+        eb_aom_dc_left_predictor_32x64 = eb_aom_dc_left_predictor_32x64_c;
+        if (flags & HAS_AVX2) eb_aom_dc_left_predictor_32x64 = eb_aom_dc_left_predictor_32x64_avx2;
+        eb_aom_dc_left_predictor_64x16 = eb_aom_dc_left_predictor_64x16_c;
+        if (flags & HAS_AVX2) eb_aom_dc_left_predictor_64x16 = eb_aom_dc_left_predictor_64x16_avx2;
+        eb_aom_dc_left_predictor_64x32 = eb_aom_dc_left_predictor_64x32_c;
+        if (flags & HAS_AVX2) eb_aom_dc_left_predictor_64x32 = eb_aom_dc_left_predictor_64x32_avx2;
+        eb_aom_dc_left_predictor_32x8 = eb_aom_dc_left_predictor_32x8_c;
+        if (flags & HAS_SSE2) eb_aom_dc_left_predictor_32x8 = eb_aom_dc_left_predictor_32x8_sse2;
+        eb_aom_dc_left_predictor_4x16 = eb_aom_dc_left_predictor_4x16_c;
+        if (flags & HAS_SSE2) eb_aom_dc_left_predictor_4x16 = eb_aom_dc_left_predictor_4x16_sse2;
+        eb_aom_dc_left_predictor_4x8 = eb_aom_dc_left_predictor_4x8_c;
+        if (flags & HAS_SSE2) eb_aom_dc_left_predictor_4x8 = eb_aom_dc_left_predictor_4x8_sse2;
+        eb_aom_dc_left_predictor_8x16 = eb_aom_dc_left_predictor_8x16_c;
+        if (flags & HAS_SSE2) eb_aom_dc_left_predictor_8x16 = eb_aom_dc_left_predictor_8x16_sse2;
+        eb_aom_dc_left_predictor_8x32 = eb_aom_dc_left_predictor_8x32_c;
+        if (flags & HAS_SSE2) eb_aom_dc_left_predictor_8x32 = eb_aom_dc_left_predictor_8x32_sse2;
+        eb_aom_dc_left_predictor_8x4 = eb_aom_dc_left_predictor_8x4_c;
+        if (flags & HAS_SSE2) eb_aom_dc_left_predictor_8x4 = eb_aom_dc_left_predictor_8x4_sse2;
 
-        aom_dc_128_predictor_4x4 = aom_dc_128_predictor_4x4_c;
-        if (flags & HAS_SSE2) aom_dc_128_predictor_4x4 = aom_dc_128_predictor_4x4_sse2;
-        aom_dc_128_predictor_8x8 = aom_dc_128_predictor_8x8_c;
-        if (flags & HAS_SSE2) aom_dc_128_predictor_8x8 = aom_dc_128_predictor_8x8_sse2;
-        aom_dc_128_predictor_16x16 = aom_dc_128_predictor_16x16_c;
-        if (flags & HAS_SSE2) aom_dc_128_predictor_16x16 = aom_dc_128_predictor_16x16_sse2;
-        aom_dc_128_predictor_32x32 = aom_dc_128_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_dc_128_predictor_32x32 = aom_dc_128_predictor_32x32_avx2;
-        aom_dc_128_predictor_64x64 = aom_dc_128_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_dc_128_predictor_64x64 = aom_dc_128_predictor_64x64_avx2;
-        aom_dc_128_predictor_16x32 = aom_dc_128_predictor_16x32_c;
-        if (flags & HAS_SSE2) aom_dc_128_predictor_16x32 = aom_dc_128_predictor_16x32_sse2;
-        aom_dc_128_predictor_16x4 = aom_dc_128_predictor_16x4_c;
-        if (flags & HAS_SSE2) aom_dc_128_predictor_16x4 = aom_dc_128_predictor_16x4_sse2;
-        aom_dc_128_predictor_16x64 = aom_dc_128_predictor_16x64_c;
-        if (flags & HAS_SSE2) aom_dc_128_predictor_16x64 = aom_dc_128_predictor_16x64_sse2;
-        aom_dc_128_predictor_16x8 = aom_dc_128_predictor_16x8_c;
-        if (flags & HAS_SSE2) aom_dc_128_predictor_16x8 = aom_dc_128_predictor_16x8_sse2;
-        aom_dc_128_predictor_32x16 = aom_dc_128_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_dc_128_predictor_32x16 = aom_dc_128_predictor_32x16_avx2;
-        aom_dc_128_predictor_32x64 = aom_dc_128_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_dc_128_predictor_32x64 = aom_dc_128_predictor_32x64_avx2;
-        aom_dc_128_predictor_32x8 = aom_dc_128_predictor_32x8_c;
-        if (flags & HAS_SSE2) aom_dc_128_predictor_32x8 = aom_dc_128_predictor_32x8_sse2;
-        aom_dc_128_predictor_4x16 = aom_dc_128_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_dc_128_predictor_4x16 = aom_dc_128_predictor_4x16_sse2;
-        aom_dc_128_predictor_4x8 = aom_dc_128_predictor_4x8_c;
-        if (flags & HAS_SSE2) aom_dc_128_predictor_4x8 = aom_dc_128_predictor_4x8_sse2;
-        aom_dc_128_predictor_64x16 = aom_dc_128_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_dc_128_predictor_64x16 = aom_dc_128_predictor_64x16_avx2;
-        aom_dc_128_predictor_64x32 = aom_dc_128_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_dc_128_predictor_64x32 = aom_dc_128_predictor_64x32_avx2;
-        aom_dc_128_predictor_8x16 = aom_dc_128_predictor_8x16_c;
-        if (flags & HAS_SSE2) aom_dc_128_predictor_8x16 = aom_dc_128_predictor_8x16_sse2;
-        aom_dc_128_predictor_8x32 = aom_dc_128_predictor_8x32_c;
-        if (flags & HAS_SSE2) aom_dc_128_predictor_8x32 = aom_dc_128_predictor_8x32_sse2;
-        aom_dc_128_predictor_8x4 = aom_dc_128_predictor_8x4_c;
-        if (flags & HAS_SSE2) aom_dc_128_predictor_8x4 = aom_dc_128_predictor_8x4_sse2;
+        eb_aom_dc_128_predictor_4x4 = eb_aom_dc_128_predictor_4x4_c;
+        if (flags & HAS_SSE2) eb_aom_dc_128_predictor_4x4 = eb_aom_dc_128_predictor_4x4_sse2;
+        eb_aom_dc_128_predictor_8x8 = eb_aom_dc_128_predictor_8x8_c;
+        if (flags & HAS_SSE2) eb_aom_dc_128_predictor_8x8 = eb_aom_dc_128_predictor_8x8_sse2;
+        eb_aom_dc_128_predictor_16x16 = eb_aom_dc_128_predictor_16x16_c;
+        if (flags & HAS_SSE2) eb_aom_dc_128_predictor_16x16 = eb_aom_dc_128_predictor_16x16_sse2;
+        eb_aom_dc_128_predictor_32x32 = eb_aom_dc_128_predictor_32x32_c;
+        if (flags & HAS_AVX2) eb_aom_dc_128_predictor_32x32 = eb_aom_dc_128_predictor_32x32_avx2;
+        eb_aom_dc_128_predictor_64x64 = eb_aom_dc_128_predictor_64x64_c;
+        if (flags & HAS_AVX2) eb_aom_dc_128_predictor_64x64 = eb_aom_dc_128_predictor_64x64_avx2;
+        eb_aom_dc_128_predictor_16x32 = eb_aom_dc_128_predictor_16x32_c;
+        if (flags & HAS_SSE2) eb_aom_dc_128_predictor_16x32 = eb_aom_dc_128_predictor_16x32_sse2;
+        eb_aom_dc_128_predictor_16x4 = eb_aom_dc_128_predictor_16x4_c;
+        if (flags & HAS_SSE2) eb_aom_dc_128_predictor_16x4 = eb_aom_dc_128_predictor_16x4_sse2;
+        eb_aom_dc_128_predictor_16x64 = eb_aom_dc_128_predictor_16x64_c;
+        if (flags & HAS_SSE2) eb_aom_dc_128_predictor_16x64 = eb_aom_dc_128_predictor_16x64_sse2;
+        eb_aom_dc_128_predictor_16x8 = eb_aom_dc_128_predictor_16x8_c;
+        if (flags & HAS_SSE2) eb_aom_dc_128_predictor_16x8 = eb_aom_dc_128_predictor_16x8_sse2;
+        eb_aom_dc_128_predictor_32x16 = eb_aom_dc_128_predictor_32x16_c;
+        if (flags & HAS_AVX2) eb_aom_dc_128_predictor_32x16 = eb_aom_dc_128_predictor_32x16_avx2;
+        eb_aom_dc_128_predictor_32x64 = eb_aom_dc_128_predictor_32x64_c;
+        if (flags & HAS_AVX2) eb_aom_dc_128_predictor_32x64 = eb_aom_dc_128_predictor_32x64_avx2;
+        eb_aom_dc_128_predictor_32x8 = eb_aom_dc_128_predictor_32x8_c;
+        if (flags & HAS_SSE2) eb_aom_dc_128_predictor_32x8 = eb_aom_dc_128_predictor_32x8_sse2;
+        eb_aom_dc_128_predictor_4x16 = eb_aom_dc_128_predictor_4x16_c;
+        if (flags & HAS_SSE2) eb_aom_dc_128_predictor_4x16 = eb_aom_dc_128_predictor_4x16_sse2;
+        eb_aom_dc_128_predictor_4x8 = eb_aom_dc_128_predictor_4x8_c;
+        if (flags & HAS_SSE2) eb_aom_dc_128_predictor_4x8 = eb_aom_dc_128_predictor_4x8_sse2;
+        eb_aom_dc_128_predictor_64x16 = eb_aom_dc_128_predictor_64x16_c;
+        if (flags & HAS_AVX2) eb_aom_dc_128_predictor_64x16 = eb_aom_dc_128_predictor_64x16_avx2;
+        eb_aom_dc_128_predictor_64x32 = eb_aom_dc_128_predictor_64x32_c;
+        if (flags & HAS_AVX2) eb_aom_dc_128_predictor_64x32 = eb_aom_dc_128_predictor_64x32_avx2;
+        eb_aom_dc_128_predictor_8x16 = eb_aom_dc_128_predictor_8x16_c;
+        if (flags & HAS_SSE2) eb_aom_dc_128_predictor_8x16 = eb_aom_dc_128_predictor_8x16_sse2;
+        eb_aom_dc_128_predictor_8x32 = eb_aom_dc_128_predictor_8x32_c;
+        if (flags & HAS_SSE2) eb_aom_dc_128_predictor_8x32 = eb_aom_dc_128_predictor_8x32_sse2;
+        eb_aom_dc_128_predictor_8x4 = eb_aom_dc_128_predictor_8x4_c;
+        if (flags & HAS_SSE2) eb_aom_dc_128_predictor_8x4 = eb_aom_dc_128_predictor_8x4_sse2;
 
-        aom_smooth_h_predictor_16x32 = aom_smooth_h_predictor_16x32_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_16x32 = aom_smooth_h_predictor_16x32_ssse3;
-        aom_smooth_h_predictor_16x4 = aom_smooth_h_predictor_16x4_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_16x4 = aom_smooth_h_predictor_16x4_ssse3;
-        aom_smooth_h_predictor_16x64 = aom_smooth_h_predictor_16x64_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_16x64 = aom_smooth_h_predictor_16x64_ssse3;
-        aom_smooth_h_predictor_16x8 = aom_smooth_h_predictor_16x8_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_16x8 = aom_smooth_h_predictor_16x8_ssse3;
-        aom_smooth_h_predictor_32x16 = aom_smooth_h_predictor_32x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_32x16 = aom_smooth_h_predictor_32x16_ssse3;
-        aom_smooth_h_predictor_32x64 = aom_smooth_h_predictor_32x64_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_32x64 = aom_smooth_h_predictor_32x64_ssse3;
-        aom_smooth_h_predictor_32x8 = aom_smooth_h_predictor_32x8_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_32x8 = aom_smooth_h_predictor_32x8_ssse3;
-        aom_smooth_h_predictor_4x16 = aom_smooth_h_predictor_4x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_4x16 = aom_smooth_h_predictor_4x16_ssse3;
-        aom_smooth_h_predictor_4x8 = aom_smooth_h_predictor_4x8_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_4x8 = aom_smooth_h_predictor_4x8_ssse3;
-        aom_smooth_h_predictor_64x16 = aom_smooth_h_predictor_64x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_64x16 = aom_smooth_h_predictor_64x16_ssse3;
-        aom_smooth_h_predictor_64x32 = aom_smooth_h_predictor_64x32_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_64x32 = aom_smooth_h_predictor_64x32_ssse3;
-        aom_smooth_h_predictor_8x16 = aom_smooth_h_predictor_8x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_8x16 = aom_smooth_h_predictor_8x16_ssse3;
-        aom_smooth_h_predictor_8x32 = aom_smooth_h_predictor_8x32_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_8x32 = aom_smooth_h_predictor_8x32_ssse3;
-        aom_smooth_h_predictor_8x4 = aom_smooth_h_predictor_8x4_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_8x4 = aom_smooth_h_predictor_8x4_ssse3;
-        aom_smooth_h_predictor_64x64 = aom_smooth_h_predictor_64x64_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_64x64 = aom_smooth_h_predictor_64x64_ssse3;
-        aom_smooth_h_predictor_32x32 = aom_smooth_h_predictor_32x32_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_32x32 = aom_smooth_h_predictor_32x32_ssse3;
-        aom_smooth_h_predictor_16x16 = aom_smooth_h_predictor_16x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_16x16 = aom_smooth_h_predictor_16x16_ssse3;
-        aom_smooth_h_predictor_8x8 = aom_smooth_h_predictor_8x8_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_8x8 = aom_smooth_h_predictor_8x8_ssse3;
-        aom_smooth_h_predictor_4x4 = aom_smooth_h_predictor_4x4_c;
-        if (flags & HAS_SSSE3) aom_smooth_h_predictor_4x4 = aom_smooth_h_predictor_4x4_ssse3;
+        eb_aom_smooth_h_predictor_16x32 = eb_aom_smooth_h_predictor_16x32_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_16x32 = eb_aom_smooth_h_predictor_16x32_ssse3;
+        eb_aom_smooth_h_predictor_16x4 = eb_aom_smooth_h_predictor_16x4_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_16x4 = eb_aom_smooth_h_predictor_16x4_ssse3;
+        eb_aom_smooth_h_predictor_16x64 = eb_aom_smooth_h_predictor_16x64_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_16x64 = eb_aom_smooth_h_predictor_16x64_ssse3;
+        eb_aom_smooth_h_predictor_16x8 = eb_aom_smooth_h_predictor_16x8_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_16x8 = eb_aom_smooth_h_predictor_16x8_ssse3;
+        eb_aom_smooth_h_predictor_32x16 = eb_aom_smooth_h_predictor_32x16_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_32x16 = eb_aom_smooth_h_predictor_32x16_ssse3;
+        eb_aom_smooth_h_predictor_32x64 = eb_aom_smooth_h_predictor_32x64_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_32x64 = eb_aom_smooth_h_predictor_32x64_ssse3;
+        eb_aom_smooth_h_predictor_32x8 = eb_aom_smooth_h_predictor_32x8_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_32x8 = eb_aom_smooth_h_predictor_32x8_ssse3;
+        eb_aom_smooth_h_predictor_4x16 = eb_aom_smooth_h_predictor_4x16_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_4x16 = eb_aom_smooth_h_predictor_4x16_ssse3;
+        eb_aom_smooth_h_predictor_4x8 = eb_aom_smooth_h_predictor_4x8_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_4x8 = eb_aom_smooth_h_predictor_4x8_ssse3;
+        eb_aom_smooth_h_predictor_64x16 = eb_aom_smooth_h_predictor_64x16_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_64x16 = eb_aom_smooth_h_predictor_64x16_ssse3;
+        eb_aom_smooth_h_predictor_64x32 = eb_aom_smooth_h_predictor_64x32_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_64x32 = eb_aom_smooth_h_predictor_64x32_ssse3;
+        eb_aom_smooth_h_predictor_8x16 = eb_aom_smooth_h_predictor_8x16_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_8x16 = eb_aom_smooth_h_predictor_8x16_ssse3;
+        eb_aom_smooth_h_predictor_8x32 = eb_aom_smooth_h_predictor_8x32_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_8x32 = eb_aom_smooth_h_predictor_8x32_ssse3;
+        eb_aom_smooth_h_predictor_8x4 = eb_aom_smooth_h_predictor_8x4_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_8x4 = eb_aom_smooth_h_predictor_8x4_ssse3;
+        eb_aom_smooth_h_predictor_64x64 = eb_aom_smooth_h_predictor_64x64_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_64x64 = eb_aom_smooth_h_predictor_64x64_ssse3;
+        eb_aom_smooth_h_predictor_32x32 = eb_aom_smooth_h_predictor_32x32_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_32x32 = eb_aom_smooth_h_predictor_32x32_ssse3;
+        eb_aom_smooth_h_predictor_16x16 = eb_aom_smooth_h_predictor_16x16_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_16x16 = eb_aom_smooth_h_predictor_16x16_ssse3;
+        eb_aom_smooth_h_predictor_8x8 = eb_aom_smooth_h_predictor_8x8_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_8x8 = eb_aom_smooth_h_predictor_8x8_ssse3;
+        eb_aom_smooth_h_predictor_4x4 = eb_aom_smooth_h_predictor_4x4_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_h_predictor_4x4 = eb_aom_smooth_h_predictor_4x4_ssse3;
 
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_16x32 = aom_smooth_v_predictor_16x32_ssse3;
-        aom_smooth_v_predictor_16x4 = aom_smooth_v_predictor_16x4_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_16x4 = aom_smooth_v_predictor_16x4_ssse3;
-        aom_smooth_v_predictor_16x64 = aom_smooth_v_predictor_16x64_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_16x64 = aom_smooth_v_predictor_16x64_ssse3;
-        aom_smooth_v_predictor_16x8 = aom_smooth_v_predictor_16x8_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_16x8 = aom_smooth_v_predictor_16x8_ssse3;
-        aom_smooth_v_predictor_32x16 = aom_smooth_v_predictor_32x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_32x16 = aom_smooth_v_predictor_32x16_ssse3;
-        aom_smooth_v_predictor_32x64 = aom_smooth_v_predictor_32x64_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_32x64 = aom_smooth_v_predictor_32x64_ssse3;
-        aom_smooth_v_predictor_32x8 = aom_smooth_v_predictor_32x8_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_32x8 = aom_smooth_v_predictor_32x8_ssse3;
-        aom_smooth_v_predictor_4x16 = aom_smooth_v_predictor_4x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_4x16 = aom_smooth_v_predictor_4x16_ssse3;
-        aom_smooth_v_predictor_4x8 = aom_smooth_v_predictor_4x8_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_4x8 = aom_smooth_v_predictor_4x8_ssse3;
-        aom_smooth_v_predictor_64x16 = aom_smooth_v_predictor_64x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_64x16 = aom_smooth_v_predictor_64x16_ssse3;
-        aom_smooth_v_predictor_64x32 = aom_smooth_v_predictor_64x32_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_64x32 = aom_smooth_v_predictor_64x32_ssse3;
-        aom_smooth_v_predictor_8x16 = aom_smooth_v_predictor_8x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_8x16 = aom_smooth_v_predictor_8x16_ssse3;
-        aom_smooth_v_predictor_8x32 = aom_smooth_v_predictor_8x32_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_8x32 = aom_smooth_v_predictor_8x32_ssse3;
-        aom_smooth_v_predictor_8x4 = aom_smooth_v_predictor_8x4_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_8x4 = aom_smooth_v_predictor_8x4_ssse3;
-        aom_smooth_v_predictor_64x64 = aom_smooth_v_predictor_64x64_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_64x64 = aom_smooth_v_predictor_64x64_ssse3;
-        aom_smooth_v_predictor_32x32 = aom_smooth_v_predictor_32x32_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_32x32 = aom_smooth_v_predictor_32x32_ssse3;
-        aom_smooth_v_predictor_16x16 = aom_smooth_v_predictor_16x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_16x16 = aom_smooth_v_predictor_16x16_ssse3;
-        aom_smooth_v_predictor_8x8 = aom_smooth_v_predictor_8x8_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_8x8 = aom_smooth_v_predictor_8x8_ssse3;
-        aom_smooth_v_predictor_4x4 = aom_smooth_v_predictor_4x4_c;
-        if (flags & HAS_SSSE3) aom_smooth_v_predictor_4x4 = aom_smooth_v_predictor_4x4_ssse3;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_16x32 = eb_aom_smooth_v_predictor_16x32_ssse3;
+        eb_aom_smooth_v_predictor_16x4 = eb_aom_smooth_v_predictor_16x4_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_16x4 = eb_aom_smooth_v_predictor_16x4_ssse3;
+        eb_aom_smooth_v_predictor_16x64 = eb_aom_smooth_v_predictor_16x64_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_16x64 = eb_aom_smooth_v_predictor_16x64_ssse3;
+        eb_aom_smooth_v_predictor_16x8 = eb_aom_smooth_v_predictor_16x8_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_16x8 = eb_aom_smooth_v_predictor_16x8_ssse3;
+        eb_aom_smooth_v_predictor_32x16 = eb_aom_smooth_v_predictor_32x16_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_32x16 = eb_aom_smooth_v_predictor_32x16_ssse3;
+        eb_aom_smooth_v_predictor_32x64 = eb_aom_smooth_v_predictor_32x64_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_32x64 = eb_aom_smooth_v_predictor_32x64_ssse3;
+        eb_aom_smooth_v_predictor_32x8 = eb_aom_smooth_v_predictor_32x8_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_32x8 = eb_aom_smooth_v_predictor_32x8_ssse3;
+        eb_aom_smooth_v_predictor_4x16 = eb_aom_smooth_v_predictor_4x16_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_4x16 = eb_aom_smooth_v_predictor_4x16_ssse3;
+        eb_aom_smooth_v_predictor_4x8 = eb_aom_smooth_v_predictor_4x8_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_4x8 = eb_aom_smooth_v_predictor_4x8_ssse3;
+        eb_aom_smooth_v_predictor_64x16 = eb_aom_smooth_v_predictor_64x16_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_64x16 = eb_aom_smooth_v_predictor_64x16_ssse3;
+        eb_aom_smooth_v_predictor_64x32 = eb_aom_smooth_v_predictor_64x32_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_64x32 = eb_aom_smooth_v_predictor_64x32_ssse3;
+        eb_aom_smooth_v_predictor_8x16 = eb_aom_smooth_v_predictor_8x16_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_8x16 = eb_aom_smooth_v_predictor_8x16_ssse3;
+        eb_aom_smooth_v_predictor_8x32 = eb_aom_smooth_v_predictor_8x32_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_8x32 = eb_aom_smooth_v_predictor_8x32_ssse3;
+        eb_aom_smooth_v_predictor_8x4 = eb_aom_smooth_v_predictor_8x4_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_8x4 = eb_aom_smooth_v_predictor_8x4_ssse3;
+        eb_aom_smooth_v_predictor_64x64 = eb_aom_smooth_v_predictor_64x64_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_64x64 = eb_aom_smooth_v_predictor_64x64_ssse3;
+        eb_aom_smooth_v_predictor_32x32 = eb_aom_smooth_v_predictor_32x32_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_32x32 = eb_aom_smooth_v_predictor_32x32_ssse3;
+        eb_aom_smooth_v_predictor_16x16 = eb_aom_smooth_v_predictor_16x16_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_16x16 = eb_aom_smooth_v_predictor_16x16_ssse3;
+        eb_aom_smooth_v_predictor_8x8 = eb_aom_smooth_v_predictor_8x8_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_8x8 = eb_aom_smooth_v_predictor_8x8_ssse3;
+        eb_aom_smooth_v_predictor_4x4 = eb_aom_smooth_v_predictor_4x4_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_v_predictor_4x4 = eb_aom_smooth_v_predictor_4x4_ssse3;
 
-        aom_smooth_predictor_16x32 = aom_smooth_predictor_16x32_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_16x32 = aom_smooth_predictor_16x32_ssse3;
-        aom_smooth_predictor_16x4 = aom_smooth_predictor_16x4_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_16x4 = aom_smooth_predictor_16x4_ssse3;
-        aom_smooth_predictor_16x64 = aom_smooth_predictor_16x64_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_16x64 = aom_smooth_predictor_16x64_ssse3;
-        aom_smooth_predictor_16x8 = aom_smooth_predictor_16x8_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_16x8 = aom_smooth_predictor_16x8_ssse3;
-        aom_smooth_predictor_32x16 = aom_smooth_predictor_32x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_32x16 = aom_smooth_predictor_32x16_ssse3;
-        aom_smooth_predictor_32x64 = aom_smooth_predictor_32x64_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_32x64 = aom_smooth_predictor_32x64_ssse3;
-        aom_smooth_predictor_32x8 = aom_smooth_predictor_32x8_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_32x8 = aom_smooth_predictor_32x8_ssse3;
-        aom_smooth_predictor_4x16 = aom_smooth_predictor_4x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_4x16 = aom_smooth_predictor_4x16_ssse3;
-        aom_smooth_predictor_4x8 = aom_smooth_predictor_4x8_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_4x8 = aom_smooth_predictor_4x8_ssse3;
-        aom_smooth_predictor_64x16 = aom_smooth_predictor_64x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_64x16 = aom_smooth_predictor_64x16_ssse3;
-        aom_smooth_predictor_64x32 = aom_smooth_predictor_64x32_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_64x32 = aom_smooth_predictor_64x32_ssse3;
-        aom_smooth_predictor_8x16 = aom_smooth_predictor_8x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_8x16 = aom_smooth_predictor_8x16_ssse3;
-        aom_smooth_predictor_8x32 = aom_smooth_predictor_8x32_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_8x32 = aom_smooth_predictor_8x32_ssse3;
-        aom_smooth_predictor_8x4 = aom_smooth_predictor_8x4_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_8x4 = aom_smooth_predictor_8x4_ssse3;
-        aom_smooth_predictor_64x64 = aom_smooth_predictor_64x64_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_64x64 = aom_smooth_predictor_64x64_ssse3;
-        aom_smooth_predictor_32x32 = aom_smooth_predictor_32x32_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_32x32 = aom_smooth_predictor_32x32_ssse3;
-        aom_smooth_predictor_16x16 = aom_smooth_predictor_16x16_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_16x16 = aom_smooth_predictor_16x16_ssse3;
-        aom_smooth_predictor_8x8 = aom_smooth_predictor_8x8_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_8x8 = aom_smooth_predictor_8x8_ssse3;
-        aom_smooth_predictor_4x4 = aom_smooth_predictor_4x4_c;
-        if (flags & HAS_SSSE3) aom_smooth_predictor_4x4 = aom_smooth_predictor_4x4_ssse3;
+        eb_aom_smooth_predictor_16x32 = eb_aom_smooth_predictor_16x32_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_16x32 = eb_aom_smooth_predictor_16x32_ssse3;
+        eb_aom_smooth_predictor_16x4 = eb_aom_smooth_predictor_16x4_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_16x4 = eb_aom_smooth_predictor_16x4_ssse3;
+        eb_aom_smooth_predictor_16x64 = eb_aom_smooth_predictor_16x64_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_16x64 = eb_aom_smooth_predictor_16x64_ssse3;
+        eb_aom_smooth_predictor_16x8 = eb_aom_smooth_predictor_16x8_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_16x8 = eb_aom_smooth_predictor_16x8_ssse3;
+        eb_aom_smooth_predictor_32x16 = eb_aom_smooth_predictor_32x16_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_32x16 = eb_aom_smooth_predictor_32x16_ssse3;
+        eb_aom_smooth_predictor_32x64 = eb_aom_smooth_predictor_32x64_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_32x64 = eb_aom_smooth_predictor_32x64_ssse3;
+        eb_aom_smooth_predictor_32x8 = eb_aom_smooth_predictor_32x8_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_32x8 = eb_aom_smooth_predictor_32x8_ssse3;
+        eb_aom_smooth_predictor_4x16 = eb_aom_smooth_predictor_4x16_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_4x16 = eb_aom_smooth_predictor_4x16_ssse3;
+        eb_aom_smooth_predictor_4x8 = eb_aom_smooth_predictor_4x8_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_4x8 = eb_aom_smooth_predictor_4x8_ssse3;
+        eb_aom_smooth_predictor_64x16 = eb_aom_smooth_predictor_64x16_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_64x16 = eb_aom_smooth_predictor_64x16_ssse3;
+        eb_aom_smooth_predictor_64x32 = eb_aom_smooth_predictor_64x32_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_64x32 = eb_aom_smooth_predictor_64x32_ssse3;
+        eb_aom_smooth_predictor_8x16 = eb_aom_smooth_predictor_8x16_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_8x16 = eb_aom_smooth_predictor_8x16_ssse3;
+        eb_aom_smooth_predictor_8x32 = eb_aom_smooth_predictor_8x32_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_8x32 = eb_aom_smooth_predictor_8x32_ssse3;
+        eb_aom_smooth_predictor_8x4 = eb_aom_smooth_predictor_8x4_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_8x4 = eb_aom_smooth_predictor_8x4_ssse3;
+        eb_aom_smooth_predictor_64x64 = eb_aom_smooth_predictor_64x64_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_64x64 = eb_aom_smooth_predictor_64x64_ssse3;
+        eb_aom_smooth_predictor_32x32 = eb_aom_smooth_predictor_32x32_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_32x32 = eb_aom_smooth_predictor_32x32_ssse3;
+        eb_aom_smooth_predictor_16x16 = eb_aom_smooth_predictor_16x16_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_16x16 = eb_aom_smooth_predictor_16x16_ssse3;
+        eb_aom_smooth_predictor_8x8 = eb_aom_smooth_predictor_8x8_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_8x8 = eb_aom_smooth_predictor_8x8_ssse3;
+        eb_aom_smooth_predictor_4x4 = eb_aom_smooth_predictor_4x4_c;
+        if (flags & HAS_SSSE3) eb_aom_smooth_predictor_4x4 = eb_aom_smooth_predictor_4x4_ssse3;
 
-        aom_v_predictor_4x4 = aom_v_predictor_4x4_c;
-        if (flags & HAS_SSE2) aom_v_predictor_4x4 = aom_v_predictor_4x4_sse2;
-        aom_v_predictor_8x8 = aom_v_predictor_8x8_c;
-        if (flags & HAS_SSE2) aom_v_predictor_8x8 = aom_v_predictor_8x8_sse2;
-        aom_v_predictor_16x16 = aom_v_predictor_16x16_c;
-        if (flags & HAS_SSE2) aom_v_predictor_16x16 = aom_v_predictor_16x16_sse2;
-        aom_v_predictor_32x32 = aom_v_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_v_predictor_32x32 = aom_v_predictor_32x32_avx2;
-        aom_v_predictor_64x64 = aom_v_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_v_predictor_64x64 = aom_v_predictor_64x64_avx2;
-        aom_v_predictor_16x32 = aom_v_predictor_16x32_c;
-        if (flags & HAS_SSE2) aom_v_predictor_16x32 = aom_v_predictor_16x32_sse2;
-        aom_v_predictor_16x4 = aom_v_predictor_16x4_c;
-        if (flags & HAS_SSE2) aom_v_predictor_16x4 = aom_v_predictor_16x4_sse2;
-        aom_v_predictor_16x64 = aom_v_predictor_16x64_c;
-        if (flags & HAS_SSE2) aom_v_predictor_16x64 = aom_v_predictor_16x64_sse2;
-        aom_v_predictor_16x8 = aom_v_predictor_16x8_c;
-        if (flags & HAS_SSE2) aom_v_predictor_16x8 = aom_v_predictor_16x8_sse2;
-        aom_v_predictor_32x16 = aom_v_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_v_predictor_32x16 = aom_v_predictor_32x16_avx2;
-        aom_v_predictor_32x64 = aom_v_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_v_predictor_32x64 = aom_v_predictor_32x64_avx2;
-        aom_v_predictor_32x8 = aom_v_predictor_32x8_c;
-        if (flags & HAS_SSE2) aom_v_predictor_32x8 = aom_v_predictor_32x8_sse2;
-        aom_v_predictor_4x16 = aom_v_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_v_predictor_4x16 = aom_v_predictor_4x16_sse2;
-        aom_v_predictor_4x8 = aom_v_predictor_4x8_c;
-        if (flags & HAS_SSE2) aom_v_predictor_4x8 = aom_v_predictor_4x8_sse2;
-        aom_v_predictor_64x16 = aom_v_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_v_predictor_64x16 = aom_v_predictor_64x16_avx2;
-        aom_v_predictor_64x32 = aom_v_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_v_predictor_64x32 = aom_v_predictor_64x32_avx2;
-        aom_v_predictor_8x16 = aom_v_predictor_8x16_c;
-        if (flags & HAS_SSE2) aom_v_predictor_8x16 = aom_v_predictor_8x16_sse2;
-        aom_v_predictor_8x32 = aom_v_predictor_8x32_c;
-        if (flags & HAS_SSE2) aom_v_predictor_8x32 = aom_v_predictor_8x32_sse2;
-        aom_v_predictor_8x4 = aom_v_predictor_8x4_c;
-        if (flags & HAS_SSE2) aom_v_predictor_8x4 = aom_v_predictor_8x4_sse2;
+        eb_aom_v_predictor_4x4 = eb_aom_v_predictor_4x4_c;
+        if (flags & HAS_SSE2) eb_aom_v_predictor_4x4 = eb_aom_v_predictor_4x4_sse2;
+        eb_aom_v_predictor_8x8 = eb_aom_v_predictor_8x8_c;
+        if (flags & HAS_SSE2) eb_aom_v_predictor_8x8 = eb_aom_v_predictor_8x8_sse2;
+        eb_aom_v_predictor_16x16 = eb_aom_v_predictor_16x16_c;
+        if (flags & HAS_SSE2) eb_aom_v_predictor_16x16 = eb_aom_v_predictor_16x16_sse2;
+        eb_aom_v_predictor_32x32 = eb_aom_v_predictor_32x32_c;
+        if (flags & HAS_AVX2) eb_aom_v_predictor_32x32 = eb_aom_v_predictor_32x32_avx2;
+        eb_aom_v_predictor_64x64 = eb_aom_v_predictor_64x64_c;
+        if (flags & HAS_AVX2) eb_aom_v_predictor_64x64 = eb_aom_v_predictor_64x64_avx2;
+        eb_aom_v_predictor_16x32 = eb_aom_v_predictor_16x32_c;
+        if (flags & HAS_SSE2) eb_aom_v_predictor_16x32 = eb_aom_v_predictor_16x32_sse2;
+        eb_aom_v_predictor_16x4 = eb_aom_v_predictor_16x4_c;
+        if (flags & HAS_SSE2) eb_aom_v_predictor_16x4 = eb_aom_v_predictor_16x4_sse2;
+        eb_aom_v_predictor_16x64 = eb_aom_v_predictor_16x64_c;
+        if (flags & HAS_SSE2) eb_aom_v_predictor_16x64 = eb_aom_v_predictor_16x64_sse2;
+        eb_aom_v_predictor_16x8 = eb_aom_v_predictor_16x8_c;
+        if (flags & HAS_SSE2) eb_aom_v_predictor_16x8 = eb_aom_v_predictor_16x8_sse2;
+        eb_aom_v_predictor_32x16 = eb_aom_v_predictor_32x16_c;
+        if (flags & HAS_AVX2) eb_aom_v_predictor_32x16 = eb_aom_v_predictor_32x16_avx2;
+        eb_aom_v_predictor_32x64 = eb_aom_v_predictor_32x64_c;
+        if (flags & HAS_AVX2) eb_aom_v_predictor_32x64 = eb_aom_v_predictor_32x64_avx2;
+        eb_aom_v_predictor_32x8 = eb_aom_v_predictor_32x8_c;
+        if (flags & HAS_SSE2) eb_aom_v_predictor_32x8 = eb_aom_v_predictor_32x8_sse2;
+        eb_aom_v_predictor_4x16 = eb_aom_v_predictor_4x16_c;
+        if (flags & HAS_SSE2) eb_aom_v_predictor_4x16 = eb_aom_v_predictor_4x16_sse2;
+        eb_aom_v_predictor_4x8 = eb_aom_v_predictor_4x8_c;
+        if (flags & HAS_SSE2) eb_aom_v_predictor_4x8 = eb_aom_v_predictor_4x8_sse2;
+        eb_aom_v_predictor_64x16 = eb_aom_v_predictor_64x16_c;
+        if (flags & HAS_AVX2) eb_aom_v_predictor_64x16 = eb_aom_v_predictor_64x16_avx2;
+        eb_aom_v_predictor_64x32 = eb_aom_v_predictor_64x32_c;
+        if (flags & HAS_AVX2) eb_aom_v_predictor_64x32 = eb_aom_v_predictor_64x32_avx2;
+        eb_aom_v_predictor_8x16 = eb_aom_v_predictor_8x16_c;
+        if (flags & HAS_SSE2) eb_aom_v_predictor_8x16 = eb_aom_v_predictor_8x16_sse2;
+        eb_aom_v_predictor_8x32 = eb_aom_v_predictor_8x32_c;
+        if (flags & HAS_SSE2) eb_aom_v_predictor_8x32 = eb_aom_v_predictor_8x32_sse2;
+        eb_aom_v_predictor_8x4 = eb_aom_v_predictor_8x4_c;
+        if (flags & HAS_SSE2) eb_aom_v_predictor_8x4 = eb_aom_v_predictor_8x4_sse2;
 
-        aom_h_predictor_4x4 = aom_h_predictor_4x4_c;
-        if (flags & HAS_SSE2) aom_h_predictor_4x4 = aom_h_predictor_4x4_sse2;
-        aom_h_predictor_8x8 = aom_h_predictor_8x8_c;
-        if (flags & HAS_SSE2) aom_h_predictor_8x8 = aom_h_predictor_8x8_sse2;
-        aom_h_predictor_16x16 = aom_h_predictor_16x16_c;
-        if (flags & HAS_SSE2) aom_h_predictor_16x16 = aom_h_predictor_16x16_sse2;
-        aom_h_predictor_32x32 = aom_h_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_h_predictor_32x32 = aom_h_predictor_32x32_avx2;
-        aom_h_predictor_64x64 = aom_h_predictor_64x64_c;
-        if (flags & HAS_SSE2) aom_h_predictor_64x64 = aom_h_predictor_64x64_sse2;
-        aom_h_predictor_16x32 = aom_h_predictor_16x32_c;
-        if (flags & HAS_SSE2) aom_h_predictor_16x32 = aom_h_predictor_16x32_sse2;
-        aom_h_predictor_16x4 = aom_h_predictor_16x4_c;
-        if (flags & HAS_SSE2) aom_h_predictor_16x4 = aom_h_predictor_16x4_sse2;
-        aom_h_predictor_16x64 = aom_h_predictor_16x64_c;
-        if (flags & HAS_SSE2) aom_h_predictor_16x64 = aom_h_predictor_16x64_sse2;
-        aom_h_predictor_16x8 = aom_h_predictor_16x8_c;
-        if (flags & HAS_SSE2) aom_h_predictor_16x8 = aom_h_predictor_16x8_sse2;
-        aom_h_predictor_32x16 = aom_h_predictor_32x16_c;
-        if (flags & HAS_SSE2) aom_h_predictor_32x16 = aom_h_predictor_32x16_sse2;
-        aom_h_predictor_32x64 = aom_h_predictor_32x64_c;
-        if (flags & HAS_SSE2) aom_h_predictor_32x64 = aom_h_predictor_32x64_sse2;
-        aom_h_predictor_32x8 = aom_h_predictor_32x8_c;
-        if (flags & HAS_SSE2) aom_h_predictor_32x8 = aom_h_predictor_32x8_sse2;
-        aom_h_predictor_4x16 = aom_h_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_h_predictor_4x16 = aom_h_predictor_4x16_sse2;
-        aom_h_predictor_4x8 = aom_h_predictor_4x8_c;
-        if (flags & HAS_SSE2) aom_h_predictor_4x8 = aom_h_predictor_4x8_sse2;
-        aom_h_predictor_64x16 = aom_h_predictor_64x16_c;
-        if (flags & HAS_SSE2) aom_h_predictor_64x16 = aom_h_predictor_64x16_sse2;
-        aom_h_predictor_64x32 = aom_h_predictor_64x32_c;
-        if (flags & HAS_SSE2) aom_h_predictor_64x32 = aom_h_predictor_64x32_sse2;
-        aom_h_predictor_8x16 = aom_h_predictor_8x16_c;
-        if (flags & HAS_SSE2) aom_h_predictor_8x16 = aom_h_predictor_8x16_sse2;
-        aom_h_predictor_8x32 = aom_h_predictor_8x32_c;
-        if (flags & HAS_SSE2) aom_h_predictor_8x32 = aom_h_predictor_8x32_sse2;
-        aom_h_predictor_8x4 = aom_h_predictor_8x4_c;
-        if (flags & HAS_SSE2) aom_h_predictor_8x4 = aom_h_predictor_8x4_sse2;
+        eb_aom_h_predictor_4x4 = eb_aom_h_predictor_4x4_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_4x4 = eb_aom_h_predictor_4x4_sse2;
+        eb_aom_h_predictor_8x8 = eb_aom_h_predictor_8x8_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_8x8 = eb_aom_h_predictor_8x8_sse2;
+        eb_aom_h_predictor_16x16 = eb_aom_h_predictor_16x16_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_16x16 = eb_aom_h_predictor_16x16_sse2;
+        eb_aom_h_predictor_32x32 = eb_aom_h_predictor_32x32_c;
+        if (flags & HAS_AVX2) eb_aom_h_predictor_32x32 = eb_aom_h_predictor_32x32_avx2;
+        eb_aom_h_predictor_64x64 = eb_aom_h_predictor_64x64_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_64x64 = eb_aom_h_predictor_64x64_sse2;
+        eb_aom_h_predictor_16x32 = eb_aom_h_predictor_16x32_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_16x32 = eb_aom_h_predictor_16x32_sse2;
+        eb_aom_h_predictor_16x4 = eb_aom_h_predictor_16x4_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_16x4 = eb_aom_h_predictor_16x4_sse2;
+        eb_aom_h_predictor_16x64 = eb_aom_h_predictor_16x64_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_16x64 = eb_aom_h_predictor_16x64_sse2;
+        eb_aom_h_predictor_16x8 = eb_aom_h_predictor_16x8_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_16x8 = eb_aom_h_predictor_16x8_sse2;
+        eb_aom_h_predictor_32x16 = eb_aom_h_predictor_32x16_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_32x16 = eb_aom_h_predictor_32x16_sse2;
+        eb_aom_h_predictor_32x64 = eb_aom_h_predictor_32x64_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_32x64 = eb_aom_h_predictor_32x64_sse2;
+        eb_aom_h_predictor_32x8 = eb_aom_h_predictor_32x8_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_32x8 = eb_aom_h_predictor_32x8_sse2;
+        eb_aom_h_predictor_4x16 = eb_aom_h_predictor_4x16_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_4x16 = eb_aom_h_predictor_4x16_sse2;
+        eb_aom_h_predictor_4x8 = eb_aom_h_predictor_4x8_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_4x8 = eb_aom_h_predictor_4x8_sse2;
+        eb_aom_h_predictor_64x16 = eb_aom_h_predictor_64x16_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_64x16 = eb_aom_h_predictor_64x16_sse2;
+        eb_aom_h_predictor_64x32 = eb_aom_h_predictor_64x32_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_64x32 = eb_aom_h_predictor_64x32_sse2;
+        eb_aom_h_predictor_8x16 = eb_aom_h_predictor_8x16_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_8x16 = eb_aom_h_predictor_8x16_sse2;
+        eb_aom_h_predictor_8x32 = eb_aom_h_predictor_8x32_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_8x32 = eb_aom_h_predictor_8x32_sse2;
+        eb_aom_h_predictor_8x4 = eb_aom_h_predictor_8x4_c;
+        if (flags & HAS_SSE2) eb_aom_h_predictor_8x4 = eb_aom_h_predictor_8x4_sse2;
 
         //SAD
-        aom_sad4x4 = aom_sad4x4_c;
-        if (flags & HAS_AVX2) aom_sad4x4 = aom_sad4x4_avx2;
-        aom_sad4x4x4d = aom_sad4x4x4d_c;
-        if (flags & HAS_AVX2) aom_sad4x4x4d = aom_sad4x4x4d_avx2;
-        aom_sad4x16 = aom_sad4x16_c;
-        if (flags & HAS_AVX2) aom_sad4x16 = aom_sad4x16_avx2;
-        aom_sad4x16x4d = aom_sad4x16x4d_c;
-        if (flags & HAS_AVX2) aom_sad4x16x4d = aom_sad4x16x4d_avx2;
-        aom_sad4x8 = aom_sad4x8_c;
-        if (flags & HAS_AVX2) aom_sad4x8 = aom_sad4x8_avx2;
-        aom_sad4x8x4d = aom_sad4x8x4d_c;
-        if (flags & HAS_AVX2) aom_sad4x8x4d = aom_sad4x8x4d_avx2;
-        aom_sad64x128 = aom_sad64x128_c;
-        if (flags & HAS_AVX2) aom_sad64x128 = aom_sad64x128_avx2;
-        aom_sad64x128x4d = aom_sad64x128x4d_c;
-        if (flags & HAS_AVX2) aom_sad64x128x4d = aom_sad64x128x4d_avx2;
-        aom_sad64x16 = aom_sad64x16_c;
-        if (flags & HAS_AVX2) aom_sad64x16 = aom_sad64x16_avx2;
-        aom_sad64x16x4d = aom_sad64x16x4d_c;
-        if (flags & HAS_AVX2) aom_sad64x16x4d = aom_sad64x16x4d_avx2;
-        aom_sad64x32 = aom_sad64x32_c;
-        if (flags & HAS_AVX2) aom_sad64x32 = aom_sad64x32_avx2;
-        aom_sad64x32x4d = aom_sad64x32x4d_c;
-        if (flags & HAS_AVX2) aom_sad64x32x4d = aom_sad64x32x4d_avx2;
-        aom_sad64x64 = aom_sad64x64_c;
-        if (flags & HAS_AVX2) aom_sad64x64 = aom_sad64x64_avx2;
-        aom_sad64x64x4d = aom_sad64x64x4d_c;
-        if (flags & HAS_AVX2) aom_sad64x64x4d = aom_sad64x64x4d_avx2;
-        aom_sad8x16 = aom_sad8x16_c;
-        if (flags & HAS_AVX2) aom_sad8x16 = aom_sad8x16_avx2;
-        aom_sad8x16x4d = aom_sad8x16x4d_c;
-        if (flags & HAS_AVX2) aom_sad8x16x4d = aom_sad8x16x4d_avx2;
-        aom_sad8x32 = aom_sad8x32_c;
-        if (flags & HAS_AVX2) aom_sad8x32 = aom_sad8x32_avx2;
-        aom_sad8x32x4d = aom_sad8x32x4d_c;
-        if (flags & HAS_AVX2) aom_sad8x32x4d = aom_sad8x32x4d_avx2;
-        aom_sad8x8 = aom_sad8x8_c;
-        if (flags & HAS_AVX2) aom_sad8x8 = aom_sad8x8_avx2;
-        aom_sad8x8x4d = aom_sad8x8x4d_c;
-        if (flags & HAS_AVX2) aom_sad8x8x4d = aom_sad8x8x4d_avx2;
-        aom_sad16x4 = aom_sad16x4_c;
-        if (flags & HAS_AVX2) aom_sad16x4 = aom_sad16x4_avx2;
-        aom_sad16x4x4d = aom_sad16x4x4d_c;
-        if (flags & HAS_AVX2) aom_sad16x4x4d = aom_sad16x4x4d_avx2;
-        aom_sad32x8 = aom_sad32x8_c;
-        if (flags & HAS_AVX2) aom_sad32x8 = aom_sad32x8_avx2;
-        aom_sad32x8x4d = aom_sad32x8x4d_c;
-        if (flags & HAS_AVX2) aom_sad32x8x4d = aom_sad32x8x4d_avx2;
-        aom_sad16x64 = aom_sad16x64_c;
-        if (flags & HAS_AVX2) aom_sad16x64 = aom_sad16x64_avx2;
-        aom_sad16x64x4d = aom_sad16x64x4d_c;
-        if (flags & HAS_AVX2) aom_sad16x64x4d = aom_sad16x64x4d_avx2;
-        aom_sad128x128 = aom_sad128x128_c;
-        if (flags & HAS_AVX2) aom_sad128x128 = aom_sad128x128_avx2;
-        aom_sad128x128x4d = aom_sad128x128x4d_c;
-        if (flags & HAS_AVX2) aom_sad128x128x4d = aom_sad128x128x4d_avx2;
-        aom_sad128x64 = aom_sad128x64_c;
-        if (flags & HAS_AVX2) aom_sad128x64 = aom_sad128x64_avx2;
-        aom_sad128x64x4d = aom_sad128x64x4d_c;
-        if (flags & HAS_AVX2) aom_sad128x64x4d = aom_sad128x64x4d_avx2;
-        aom_sad32x16 = aom_sad32x16_c;
-        if (flags & HAS_AVX2) aom_sad32x16 = aom_sad32x16_avx2;
-        aom_sad32x16x4d = aom_sad32x16x4d_c;
-        if (flags & HAS_AVX2) aom_sad32x16x4d = aom_sad32x16x4d_avx2;
-        aom_sad16x32 = aom_sad16x32_c;
-        if (flags & HAS_AVX2) aom_sad16x32 = aom_sad16x32_avx2;
-        aom_sad16x32x4d = aom_sad16x32x4d_c;
-        if (flags & HAS_AVX2) aom_sad16x32x4d = aom_sad16x32x4d_avx2;
-        aom_sad32x64 = aom_sad32x64_c;
-        if (flags & HAS_AVX2) aom_sad32x64 = aom_sad32x64_avx2;
-        aom_sad32x64x4d = aom_sad32x64x4d_c;
-        if (flags & HAS_AVX2) aom_sad32x64x4d = aom_sad32x64x4d_avx2;
-        aom_sad32x32 = aom_sad32x32_c;
-        if (flags & HAS_AVX2) aom_sad32x32 = aom_sad32x32_avx2;
-        aom_sad32x32x4d = aom_sad32x32x4d_c;
-        if (flags & HAS_AVX2) aom_sad32x32x4d = aom_sad32x32x4d_avx2;
-        aom_sad16x16 = aom_sad16x16_c;
-        if (flags & HAS_AVX2) aom_sad16x16 = aom_sad16x16_avx2;
-        aom_sad16x16x4d = aom_sad16x16x4d_c;
-        if (flags & HAS_AVX2) aom_sad16x16x4d = aom_sad16x16x4d_avx2;
-        aom_sad16x8 = aom_sad16x8_c;
-        if (flags & HAS_AVX2) aom_sad16x8 = aom_sad16x8_avx2;
-        aom_sad16x8x4d = aom_sad16x8x4d_c;
-        if (flags & HAS_AVX2) aom_sad16x8x4d = aom_sad16x8x4d_avx2;
-        aom_sad8x4 = aom_sad8x4_c;
-        if (flags & HAS_AVX2) aom_sad8x4 = aom_sad8x4_avx2;
-        aom_sad8x4x4d = aom_sad8x4x4d_c;
-        if (flags & HAS_AVX2) aom_sad8x4x4d = aom_sad8x4x4d_avx2;
+        eb_aom_sad4x4 = eb_aom_sad4x4_c;
+        if (flags & HAS_AVX2) eb_aom_sad4x4 = eb_aom_sad4x4_avx2;
+        eb_aom_sad4x4x4d = eb_aom_sad4x4x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad4x4x4d = eb_aom_sad4x4x4d_avx2;
+        eb_aom_sad4x16 = eb_aom_sad4x16_c;
+        if (flags & HAS_AVX2) eb_aom_sad4x16 = eb_aom_sad4x16_avx2;
+        eb_aom_sad4x16x4d = eb_aom_sad4x16x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad4x16x4d = eb_aom_sad4x16x4d_avx2;
+        eb_aom_sad4x8 = eb_aom_sad4x8_c;
+        if (flags & HAS_AVX2) eb_aom_sad4x8 = eb_aom_sad4x8_avx2;
+        eb_aom_sad4x8x4d = eb_aom_sad4x8x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad4x8x4d = eb_aom_sad4x8x4d_avx2;
+        eb_aom_sad64x128 = eb_aom_sad64x128_c;
+        if (flags & HAS_AVX2) eb_aom_sad64x128 = eb_aom_sad64x128_avx2;
+        eb_aom_sad64x128x4d = eb_aom_sad64x128x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad64x128x4d = eb_aom_sad64x128x4d_avx2;
+        eb_aom_sad64x16 = eb_aom_sad64x16_c;
+        if (flags & HAS_AVX2) eb_aom_sad64x16 = eb_aom_sad64x16_avx2;
+        eb_aom_sad64x16x4d = eb_aom_sad64x16x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad64x16x4d = eb_aom_sad64x16x4d_avx2;
+        eb_aom_sad64x32 = eb_aom_sad64x32_c;
+        if (flags & HAS_AVX2) eb_aom_sad64x32 = eb_aom_sad64x32_avx2;
+        eb_aom_sad64x32x4d = eb_aom_sad64x32x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad64x32x4d = eb_aom_sad64x32x4d_avx2;
+        eb_aom_sad64x64 = eb_aom_sad64x64_c;
+        if (flags & HAS_AVX2) eb_aom_sad64x64 = eb_aom_sad64x64_avx2;
+        eb_aom_sad64x64x4d = eb_aom_sad64x64x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad64x64x4d = eb_aom_sad64x64x4d_avx2;
+        eb_aom_sad8x16 = eb_aom_sad8x16_c;
+        if (flags & HAS_AVX2) eb_aom_sad8x16 = eb_aom_sad8x16_avx2;
+        eb_aom_sad8x16x4d = eb_aom_sad8x16x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad8x16x4d = eb_aom_sad8x16x4d_avx2;
+        eb_aom_sad8x32 = eb_aom_sad8x32_c;
+        if (flags & HAS_AVX2) eb_aom_sad8x32 = eb_aom_sad8x32_avx2;
+        eb_aom_sad8x32x4d = eb_aom_sad8x32x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad8x32x4d = eb_aom_sad8x32x4d_avx2;
+        eb_aom_sad8x8 = eb_aom_sad8x8_c;
+        if (flags & HAS_AVX2) eb_aom_sad8x8 = eb_aom_sad8x8_avx2;
+        eb_aom_sad8x8x4d = eb_aom_sad8x8x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad8x8x4d = eb_aom_sad8x8x4d_avx2;
+        eb_aom_sad16x4 = eb_aom_sad16x4_c;
+        if (flags & HAS_AVX2) eb_aom_sad16x4 = eb_aom_sad16x4_avx2;
+        eb_aom_sad16x4x4d = eb_aom_sad16x4x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad16x4x4d = eb_aom_sad16x4x4d_avx2;
+        eb_aom_sad32x8 = eb_aom_sad32x8_c;
+        if (flags & HAS_AVX2) eb_aom_sad32x8 = eb_aom_sad32x8_avx2;
+        eb_aom_sad32x8x4d = eb_aom_sad32x8x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad32x8x4d = eb_aom_sad32x8x4d_avx2;
+        eb_aom_sad16x64 = eb_aom_sad16x64_c;
+        if (flags & HAS_AVX2) eb_aom_sad16x64 = eb_aom_sad16x64_avx2;
+        eb_aom_sad16x64x4d = eb_aom_sad16x64x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad16x64x4d = eb_aom_sad16x64x4d_avx2;
+        eb_aom_sad128x128 = eb_aom_sad128x128_c;
+        if (flags & HAS_AVX2) eb_aom_sad128x128 = eb_aom_sad128x128_avx2;
+        eb_aom_sad128x128x4d = eb_aom_sad128x128x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad128x128x4d = eb_aom_sad128x128x4d_avx2;
+        eb_aom_sad128x64 = eb_aom_sad128x64_c;
+        if (flags & HAS_AVX2) eb_aom_sad128x64 = eb_aom_sad128x64_avx2;
+        eb_aom_sad128x64x4d = eb_aom_sad128x64x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad128x64x4d = eb_aom_sad128x64x4d_avx2;
+        eb_aom_sad32x16 = eb_aom_sad32x16_c;
+        if (flags & HAS_AVX2) eb_aom_sad32x16 = eb_aom_sad32x16_avx2;
+        eb_aom_sad32x16x4d = eb_aom_sad32x16x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad32x16x4d = eb_aom_sad32x16x4d_avx2;
+        eb_aom_sad16x32 = eb_aom_sad16x32_c;
+        if (flags & HAS_AVX2) eb_aom_sad16x32 = eb_aom_sad16x32_avx2;
+        eb_aom_sad16x32x4d = eb_aom_sad16x32x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad16x32x4d = eb_aom_sad16x32x4d_avx2;
+        eb_aom_sad32x64 = eb_aom_sad32x64_c;
+        if (flags & HAS_AVX2) eb_aom_sad32x64 = eb_aom_sad32x64_avx2;
+        eb_aom_sad32x64x4d = eb_aom_sad32x64x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad32x64x4d = eb_aom_sad32x64x4d_avx2;
+        eb_aom_sad32x32 = eb_aom_sad32x32_c;
+        if (flags & HAS_AVX2) eb_aom_sad32x32 = eb_aom_sad32x32_avx2;
+        eb_aom_sad32x32x4d = eb_aom_sad32x32x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad32x32x4d = eb_aom_sad32x32x4d_avx2;
+        eb_aom_sad16x16 = eb_aom_sad16x16_c;
+        if (flags & HAS_AVX2) eb_aom_sad16x16 = eb_aom_sad16x16_avx2;
+        eb_aom_sad16x16x4d = eb_aom_sad16x16x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad16x16x4d = eb_aom_sad16x16x4d_avx2;
+        eb_aom_sad16x8 = eb_aom_sad16x8_c;
+        if (flags & HAS_AVX2) eb_aom_sad16x8 = eb_aom_sad16x8_avx2;
+        eb_aom_sad16x8x4d = eb_aom_sad16x8x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad16x8x4d = eb_aom_sad16x8x4d_avx2;
+        eb_aom_sad8x4 = eb_aom_sad8x4_c;
+        if (flags & HAS_AVX2) eb_aom_sad8x4 = eb_aom_sad8x4_avx2;
+        eb_aom_sad8x4x4d = eb_aom_sad8x4x4d_c;
+        if (flags & HAS_AVX2) eb_aom_sad8x4x4d = eb_aom_sad8x4x4d_avx2;
 
 //VARIANCE
-        aom_variance4x4 = aom_variance4x4_c;
-        if (flags & HAS_AVX2) aom_variance4x4 = aom_variance4x4_sse2;
-        aom_variance4x8 = aom_variance4x8_c;
-        if (flags & HAS_AVX2) aom_variance4x8 = aom_variance4x8_sse2;
-        aom_variance4x16 = aom_variance4x16_c;
-        if (flags & HAS_AVX2) aom_variance4x16 = aom_variance4x16_sse2;
-        aom_variance8x4 = aom_variance8x4_c;
-        if (flags & HAS_AVX2) aom_variance8x4 = aom_variance8x4_sse2;
-        aom_variance8x8 = aom_variance8x8_c;
-        if (flags & HAS_AVX2) aom_variance8x8 = aom_variance8x8_sse2;
-        aom_variance8x16 = aom_variance8x16_c;
-        if (flags & HAS_AVX2) aom_variance8x16 = aom_variance8x16_sse2;
-        aom_variance8x32 = aom_variance8x32_c;
-        if (flags & HAS_AVX2) aom_variance8x32 = aom_variance8x32_sse2;
-        aom_variance16x4 = aom_variance16x4_c;
-        if (flags & HAS_AVX2) aom_variance16x4 = aom_variance16x4_avx2;
-        aom_variance16x8 = aom_variance16x8_c;
-        if (flags & HAS_AVX2) aom_variance16x8 = aom_variance16x8_avx2;
-        aom_variance16x16 = aom_variance16x16_c;
-        if (flags & HAS_AVX2) aom_variance16x16 = aom_variance16x16_avx2;
-        aom_variance16x32 = aom_variance16x32_c;
-        if (flags & HAS_AVX2) aom_variance16x32 = aom_variance16x32_avx2;
-        aom_variance16x64 = aom_variance16x64_c;
-        if (flags & HAS_AVX2) aom_variance16x64 = aom_variance16x64_avx2;
-        aom_variance32x8 = aom_variance32x8_c;
-        if (flags & HAS_AVX2) aom_variance32x8 = aom_variance32x8_avx2;
-        aom_variance32x16 = aom_variance32x16_c;
-        if (flags & HAS_AVX2) aom_variance32x16 = aom_variance32x16_avx2;
-        aom_variance32x32 = aom_variance32x32_c;
-        if (flags & HAS_AVX2) aom_variance32x32 = aom_variance32x32_avx2;
-        aom_variance32x64 = aom_variance32x64_c;
-        if (flags & HAS_AVX2) aom_variance32x64 = aom_variance32x64_avx2;
-        aom_variance64x16 = aom_variance64x16_c;
-        if (flags & HAS_AVX2) aom_variance64x16 = aom_variance64x16_avx2;
-        aom_variance64x32 = aom_variance64x32_c;
-        if (flags & HAS_AVX2) aom_variance64x32 = aom_variance64x32_avx2;
-        aom_variance64x64 = aom_variance64x64_c;
-        if (flags & HAS_AVX2) aom_variance64x64 = aom_variance64x64_avx2;
-        aom_variance64x128 = aom_variance64x128_c;
-        if (flags & HAS_AVX2) aom_variance64x128 = aom_variance64x128_avx2;
-        aom_variance128x64 = aom_variance128x64_c;
-        if (flags & HAS_AVX2) aom_variance128x64 = aom_variance128x64_avx2;
-        aom_variance128x128 = aom_variance128x128_c;
-        if (flags & HAS_AVX2) aom_variance128x128 = aom_variance128x128_avx2;
+        eb_aom_variance4x4 = eb_aom_variance4x4_c;
+        if (flags & HAS_AVX2) eb_aom_variance4x4 = eb_aom_variance4x4_sse2;
+        eb_aom_variance4x8 = eb_aom_variance4x8_c;
+        if (flags & HAS_AVX2) eb_aom_variance4x8 = eb_aom_variance4x8_sse2;
+        eb_aom_variance4x16 = eb_aom_variance4x16_c;
+        if (flags & HAS_AVX2) eb_aom_variance4x16 = eb_aom_variance4x16_sse2;
+        eb_aom_variance8x4 = eb_aom_variance8x4_c;
+        if (flags & HAS_AVX2) eb_aom_variance8x4 = eb_aom_variance8x4_sse2;
+        eb_aom_variance8x8 = eb_aom_variance8x8_c;
+        if (flags & HAS_AVX2) eb_aom_variance8x8 = eb_aom_variance8x8_sse2;
+        eb_aom_variance8x16 = eb_aom_variance8x16_c;
+        if (flags & HAS_AVX2) eb_aom_variance8x16 = eb_aom_variance8x16_sse2;
+        eb_aom_variance8x32 = eb_aom_variance8x32_c;
+        if (flags & HAS_AVX2) eb_aom_variance8x32 = eb_aom_variance8x32_sse2;
+        eb_aom_variance16x4 = eb_aom_variance16x4_c;
+        if (flags & HAS_AVX2) eb_aom_variance16x4 = eb_aom_variance16x4_avx2;
+        eb_aom_variance16x8 = eb_aom_variance16x8_c;
+        if (flags & HAS_AVX2) eb_aom_variance16x8 = eb_aom_variance16x8_avx2;
+        eb_aom_variance16x16 = eb_aom_variance16x16_c;
+        if (flags & HAS_AVX2) eb_aom_variance16x16 = eb_aom_variance16x16_avx2;
+        eb_aom_variance16x32 = eb_aom_variance16x32_c;
+        if (flags & HAS_AVX2) eb_aom_variance16x32 = eb_aom_variance16x32_avx2;
+        eb_aom_variance16x64 = eb_aom_variance16x64_c;
+        if (flags & HAS_AVX2) eb_aom_variance16x64 = eb_aom_variance16x64_avx2;
+        eb_aom_variance32x8 = eb_aom_variance32x8_c;
+        if (flags & HAS_AVX2) eb_aom_variance32x8 = eb_aom_variance32x8_avx2;
+        eb_aom_variance32x16 = eb_aom_variance32x16_c;
+        if (flags & HAS_AVX2) eb_aom_variance32x16 = eb_aom_variance32x16_avx2;
+        eb_aom_variance32x32 = eb_aom_variance32x32_c;
+        if (flags & HAS_AVX2) eb_aom_variance32x32 = eb_aom_variance32x32_avx2;
+        eb_aom_variance32x64 = eb_aom_variance32x64_c;
+        if (flags & HAS_AVX2) eb_aom_variance32x64 = eb_aom_variance32x64_avx2;
+        eb_aom_variance64x16 = eb_aom_variance64x16_c;
+        if (flags & HAS_AVX2) eb_aom_variance64x16 = eb_aom_variance64x16_avx2;
+        eb_aom_variance64x32 = eb_aom_variance64x32_c;
+        if (flags & HAS_AVX2) eb_aom_variance64x32 = eb_aom_variance64x32_avx2;
+        eb_aom_variance64x64 = eb_aom_variance64x64_c;
+        if (flags & HAS_AVX2) eb_aom_variance64x64 = eb_aom_variance64x64_avx2;
+        eb_aom_variance64x128 = eb_aom_variance64x128_c;
+        if (flags & HAS_AVX2) eb_aom_variance64x128 = eb_aom_variance64x128_avx2;
+        eb_aom_variance128x64 = eb_aom_variance128x64_c;
+        if (flags & HAS_AVX2) eb_aom_variance128x64 = eb_aom_variance128x64_avx2;
+        eb_aom_variance128x128 = eb_aom_variance128x128_c;
+        if (flags & HAS_AVX2) eb_aom_variance128x128 = eb_aom_variance128x128_avx2;
 
         //QIQ
-        aom_quantize_b_64x64 = aom_quantize_b_64x64_c_II;
-        if (flags & HAS_AVX2) aom_quantize_b_64x64 = aom_highbd_quantize_b_64x64_avx2;
+        eb_aom_quantize_b_64x64 = eb_aom_quantize_b_64x64_c_II;
+        if (flags & HAS_AVX2) eb_aom_quantize_b_64x64 = eb_aom_highbd_quantize_b_64x64_avx2;
 
-        aom_highbd_quantize_b_64x64 = aom_highbd_quantize_b_64x64_c;
-        if (flags & HAS_AVX2) aom_highbd_quantize_b_64x64 = aom_highbd_quantize_b_64x64_avx2;
+        eb_aom_highbd_quantize_b_64x64 = eb_aom_highbd_quantize_b_64x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_quantize_b_64x64 = eb_aom_highbd_quantize_b_64x64_avx2;
         // transform
-        av1_fwd_txfm2d_16x8 = av1_fwd_txfm2d_16x8_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_16x8 = av1_fwd_txfm2d_16x8_avx2;
-        av1_fwd_txfm2d_8x16 = av1_fwd_txfm2d_8x16_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_8x16 = av1_fwd_txfm2d_8x16_avx2;
+        eb_av1_fwd_txfm2d_16x8 = eb_av1_fwd_txfm2d_16x8_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x8 = eb_av1_fwd_txfm2d_16x8_avx2;
+        eb_av1_fwd_txfm2d_8x16 = eb_av1_fwd_txfm2d_8x16_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_8x16 = eb_av1_fwd_txfm2d_8x16_avx2;
 
-        av1_fwd_txfm2d_16x4 = av1_fwd_txfm2d_16x4_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_16x4 = av1_fwd_txfm2d_16x4_avx2;
-        av1_fwd_txfm2d_4x16 = av1_fwd_txfm2d_4x16_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_4x16 = av1_fwd_txfm2d_4x16_avx2;
+        eb_av1_fwd_txfm2d_16x4 = eb_av1_fwd_txfm2d_16x4_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x4 = eb_av1_fwd_txfm2d_16x4_avx2;
+        eb_av1_fwd_txfm2d_4x16 = eb_av1_fwd_txfm2d_4x16_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_4x16 = eb_av1_fwd_txfm2d_4x16_avx2;
 
-        av1_fwd_txfm2d_8x4 = av1_fwd_txfm2d_8x4_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_8x4 = av1_fwd_txfm2d_8x4_avx2;
-        av1_fwd_txfm2d_4x8 = av1_fwd_txfm2d_4x8_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_4x8 = av1_fwd_txfm2d_4x8_avx2;
+        eb_av1_fwd_txfm2d_8x4 = eb_av1_fwd_txfm2d_8x4_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_8x4 = eb_av1_fwd_txfm2d_8x4_avx2;
+        eb_av1_fwd_txfm2d_4x8 = eb_av1_fwd_txfm2d_4x8_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_4x8 = eb_av1_fwd_txfm2d_4x8_avx2;
 
-        av1_fwd_txfm2d_32x16 = av1_fwd_txfm2d_32x16_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_32x16 = av1_fwd_txfm2d_32x16_avx2;
-        av1_fwd_txfm2d_32x8 = av1_fwd_txfm2d_32x8_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_32x8 = av1_fwd_txfm2d_32x8_avx2;
-        av1_fwd_txfm2d_8x32 = av1_fwd_txfm2d_8x32_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_8x32 = av1_fwd_txfm2d_8x32_avx2;
-        av1_fwd_txfm2d_16x32 = av1_fwd_txfm2d_16x32_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_16x32 = av1_fwd_txfm2d_16x32_avx2;
-        av1_fwd_txfm2d_32x64 = av1_fwd_txfm2d_32x64_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_32x64 = av1_fwd_txfm2d_32x64_avx2;
-        av1_fwd_txfm2d_64x32 = av1_fwd_txfm2d_64x32_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_64x32 = av1_fwd_txfm2d_64x32_avx2;
-        av1_fwd_txfm2d_16x64 = av1_fwd_txfm2d_16x64_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_16x64 = av1_fwd_txfm2d_16x64_avx2;
-        av1_fwd_txfm2d_64x16 = av1_fwd_txfm2d_64x16_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_64x16 = av1_fwd_txfm2d_64x16_avx2;
-        av1_fwd_txfm2d_64x64 = Av1TransformTwoD_64x64_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_64x64 = av1_fwd_txfm2d_64x64_avx2;
-        av1_fwd_txfm2d_32x32 = Av1TransformTwoD_32x32_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_32x32 = av1_fwd_txfm2d_32x32_avx2;
-        av1_fwd_txfm2d_16x16 = Av1TransformTwoD_16x16_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_16x16 = av1_fwd_txfm2d_16x16_avx2;
-        av1_fwd_txfm2d_8x8 = Av1TransformTwoD_8x8_c;
-        if (flags & HAS_AVX2) av1_fwd_txfm2d_8x8 = av1_fwd_txfm2d_8x8_avx2;
-        av1_fwd_txfm2d_4x4 = Av1TransformTwoD_4x4_c;
-        if (flags & HAS_SSE4_1) av1_fwd_txfm2d_4x4 = av1_fwd_txfm2d_4x4_sse4_1;
+        eb_av1_fwd_txfm2d_32x16 = eb_av1_fwd_txfm2d_32x16_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x16 = eb_av1_fwd_txfm2d_32x16_avx2;
+        eb_av1_fwd_txfm2d_32x8 = eb_av1_fwd_txfm2d_32x8_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x8 = eb_av1_fwd_txfm2d_32x8_avx2;
+        eb_av1_fwd_txfm2d_8x32 = eb_av1_fwd_txfm2d_8x32_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_8x32 = eb_av1_fwd_txfm2d_8x32_avx2;
+        eb_av1_fwd_txfm2d_16x32 = eb_av1_fwd_txfm2d_16x32_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x32 = eb_av1_fwd_txfm2d_16x32_avx2;
+        eb_av1_fwd_txfm2d_32x64 = eb_av1_fwd_txfm2d_32x64_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x64 = eb_av1_fwd_txfm2d_32x64_avx2;
+        eb_av1_fwd_txfm2d_64x32 = eb_av1_fwd_txfm2d_64x32_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x32 = eb_av1_fwd_txfm2d_64x32_avx2;
+        eb_av1_fwd_txfm2d_16x64 = eb_av1_fwd_txfm2d_16x64_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x64 = eb_av1_fwd_txfm2d_16x64_avx2;
+        eb_av1_fwd_txfm2d_64x16 = eb_av1_fwd_txfm2d_64x16_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x16 = eb_av1_fwd_txfm2d_64x16_avx2;
+        eb_av1_fwd_txfm2d_64x64 = Av1TransformTwoD_64x64_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x64 = eb_av1_fwd_txfm2d_64x64_avx2;
+        eb_av1_fwd_txfm2d_32x32 = Av1TransformTwoD_32x32_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x32 = eb_av1_fwd_txfm2d_32x32_avx2;
+        eb_av1_fwd_txfm2d_16x16 = Av1TransformTwoD_16x16_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x16 = eb_av1_fwd_txfm2d_16x16_avx2;
+        eb_av1_fwd_txfm2d_8x8 = Av1TransformTwoD_8x8_c;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_8x8 = eb_av1_fwd_txfm2d_8x8_avx2;
+        eb_av1_fwd_txfm2d_4x4 = Av1TransformTwoD_4x4_c;
+        if (flags & HAS_SSE4_1) eb_av1_fwd_txfm2d_4x4 = eb_av1_fwd_txfm2d_4x4_sse4_1;
 
         HandleTransform16x64 = HandleTransform16x64_c;
         if (flags & HAS_AVX2) HandleTransform16x64 = HandleTransform16x64_avx2;
@@ -3260,347 +3260,347 @@ extern "C" {
         HandleTransform64x64 = HandleTransform64x64_c;
         if (flags & HAS_AVX2) HandleTransform64x64 = HandleTransform64x64_avx2;
 
-        // aom_highbd_v_predictor
-        aom_highbd_v_predictor_16x16 = aom_highbd_v_predictor_16x16_c;
-        if (flags & HAS_AVX2) aom_highbd_v_predictor_16x16 = aom_highbd_v_predictor_16x16_avx2;
-        aom_highbd_v_predictor_16x32 = aom_highbd_v_predictor_16x32_c;
-        if (flags & HAS_AVX2) aom_highbd_v_predictor_16x32 = aom_highbd_v_predictor_16x32_avx2;
-        aom_highbd_v_predictor_16x4 = aom_highbd_v_predictor_16x4_c;
-        if (flags & HAS_AVX2) aom_highbd_v_predictor_16x4 = aom_highbd_v_predictor_16x4_avx2;
-        aom_highbd_v_predictor_16x64 = aom_highbd_v_predictor_16x64_c;
-        if (flags & HAS_AVX2) aom_highbd_v_predictor_16x64 = aom_highbd_v_predictor_16x64_avx2;
-        aom_highbd_v_predictor_16x8 = aom_highbd_v_predictor_16x8_c;
-        if (flags & HAS_AVX2) aom_highbd_v_predictor_16x8 = aom_highbd_v_predictor_16x8_avx2;
-        aom_highbd_v_predictor_2x2 = aom_highbd_v_predictor_2x2_c;
-        aom_highbd_v_predictor_32x16 = aom_highbd_v_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_highbd_v_predictor_32x16 = aom_highbd_v_predictor_32x16_avx2;
-        aom_highbd_v_predictor_32x32 = aom_highbd_v_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_highbd_v_predictor_32x32 = aom_highbd_v_predictor_32x32_avx2;
-        aom_highbd_v_predictor_32x64 = aom_highbd_v_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_highbd_v_predictor_32x64 = aom_highbd_v_predictor_32x64_avx2;
-        aom_highbd_v_predictor_32x8 = aom_highbd_v_predictor_32x8_c;
-        if (flags & HAS_AVX2) aom_highbd_v_predictor_32x8 = aom_highbd_v_predictor_32x8_avx2;
-        aom_highbd_v_predictor_4x16 = aom_highbd_v_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_highbd_v_predictor_4x16 = aom_highbd_v_predictor_4x16_sse2;
-        aom_highbd_v_predictor_4x4 = aom_highbd_v_predictor_4x4_c;
-        if (flags & HAS_SSE2) aom_highbd_v_predictor_4x4 = aom_highbd_v_predictor_4x4_sse2;
-        aom_highbd_v_predictor_4x8 = aom_highbd_v_predictor_4x8_c;
-        if (flags & HAS_SSE2) aom_highbd_v_predictor_4x8 = aom_highbd_v_predictor_4x8_sse2;
-        aom_highbd_v_predictor_64x16 = aom_highbd_v_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_highbd_v_predictor_64x16 = aom_highbd_v_predictor_64x16_avx2;
-        aom_highbd_v_predictor_64x32 = aom_highbd_v_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_highbd_v_predictor_64x32 = aom_highbd_v_predictor_64x32_avx2;
-        aom_highbd_v_predictor_8x32 = aom_highbd_v_predictor_8x32_c;
-        if (flags & HAS_SSE2) aom_highbd_v_predictor_8x32 = aom_highbd_v_predictor_8x32_sse2;
-        aom_highbd_v_predictor_64x64 = aom_highbd_v_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_highbd_v_predictor_64x64 = aom_highbd_v_predictor_64x64_avx2;
-        aom_highbd_v_predictor_8x16 = aom_highbd_v_predictor_8x16_c;
-        if (flags & HAS_SSE2) aom_highbd_v_predictor_8x16 = aom_highbd_v_predictor_8x16_sse2;
-        aom_highbd_v_predictor_8x4 = aom_highbd_v_predictor_8x4_c;
-        if (flags & HAS_SSE2) aom_highbd_v_predictor_8x4 = aom_highbd_v_predictor_8x4_sse2;
-        aom_highbd_v_predictor_8x8 = aom_highbd_v_predictor_8x8_c;
-        if (flags & HAS_SSE2) aom_highbd_v_predictor_8x8 = aom_highbd_v_predictor_8x8_sse2;
+        // eb_aom_highbd_v_predictor
+        eb_aom_highbd_v_predictor_16x16 = eb_aom_highbd_v_predictor_16x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_16x16 = eb_aom_highbd_v_predictor_16x16_avx2;
+        eb_aom_highbd_v_predictor_16x32 = eb_aom_highbd_v_predictor_16x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_16x32 = eb_aom_highbd_v_predictor_16x32_avx2;
+        eb_aom_highbd_v_predictor_16x4 = eb_aom_highbd_v_predictor_16x4_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_16x4 = eb_aom_highbd_v_predictor_16x4_avx2;
+        eb_aom_highbd_v_predictor_16x64 = eb_aom_highbd_v_predictor_16x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_16x64 = eb_aom_highbd_v_predictor_16x64_avx2;
+        eb_aom_highbd_v_predictor_16x8 = eb_aom_highbd_v_predictor_16x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_16x8 = eb_aom_highbd_v_predictor_16x8_avx2;
+        eb_aom_highbd_v_predictor_2x2 = eb_aom_highbd_v_predictor_2x2_c;
+        eb_aom_highbd_v_predictor_32x16 = eb_aom_highbd_v_predictor_32x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_32x16 = eb_aom_highbd_v_predictor_32x16_avx2;
+        eb_aom_highbd_v_predictor_32x32 = eb_aom_highbd_v_predictor_32x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_32x32 = eb_aom_highbd_v_predictor_32x32_avx2;
+        eb_aom_highbd_v_predictor_32x64 = eb_aom_highbd_v_predictor_32x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_32x64 = eb_aom_highbd_v_predictor_32x64_avx2;
+        eb_aom_highbd_v_predictor_32x8 = eb_aom_highbd_v_predictor_32x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_32x8 = eb_aom_highbd_v_predictor_32x8_avx2;
+        eb_aom_highbd_v_predictor_4x16 = eb_aom_highbd_v_predictor_4x16_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_v_predictor_4x16 = eb_aom_highbd_v_predictor_4x16_sse2;
+        eb_aom_highbd_v_predictor_4x4 = eb_aom_highbd_v_predictor_4x4_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_v_predictor_4x4 = eb_aom_highbd_v_predictor_4x4_sse2;
+        eb_aom_highbd_v_predictor_4x8 = eb_aom_highbd_v_predictor_4x8_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_v_predictor_4x8 = eb_aom_highbd_v_predictor_4x8_sse2;
+        eb_aom_highbd_v_predictor_64x16 = eb_aom_highbd_v_predictor_64x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_64x16 = eb_aom_highbd_v_predictor_64x16_avx2;
+        eb_aom_highbd_v_predictor_64x32 = eb_aom_highbd_v_predictor_64x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_64x32 = eb_aom_highbd_v_predictor_64x32_avx2;
+        eb_aom_highbd_v_predictor_8x32 = eb_aom_highbd_v_predictor_8x32_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_v_predictor_8x32 = eb_aom_highbd_v_predictor_8x32_sse2;
+        eb_aom_highbd_v_predictor_64x64 = eb_aom_highbd_v_predictor_64x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_64x64 = eb_aom_highbd_v_predictor_64x64_avx2;
+        eb_aom_highbd_v_predictor_8x16 = eb_aom_highbd_v_predictor_8x16_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_v_predictor_8x16 = eb_aom_highbd_v_predictor_8x16_sse2;
+        eb_aom_highbd_v_predictor_8x4 = eb_aom_highbd_v_predictor_8x4_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_v_predictor_8x4 = eb_aom_highbd_v_predictor_8x4_sse2;
+        eb_aom_highbd_v_predictor_8x8 = eb_aom_highbd_v_predictor_8x8_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_v_predictor_8x8 = eb_aom_highbd_v_predictor_8x8_sse2;
 
         //aom_highbd_smooth_predictor
-        aom_highbd_smooth_predictor_16x16 = aom_highbd_smooth_predictor_16x16_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_predictor_16x16 = aom_highbd_smooth_predictor_16x16_avx2;
-        aom_highbd_smooth_predictor_16x32 = aom_highbd_smooth_predictor_16x32_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_predictor_16x32 = aom_highbd_smooth_predictor_16x32_avx2;
-        aom_highbd_smooth_predictor_16x4 = aom_highbd_smooth_predictor_16x4_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_predictor_16x4 = aom_highbd_smooth_predictor_16x4_avx2;
-        aom_highbd_smooth_predictor_16x64 = aom_highbd_smooth_predictor_16x64_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_predictor_16x64 = aom_highbd_smooth_predictor_16x64_avx2;
-        aom_highbd_smooth_predictor_16x8 = aom_highbd_smooth_predictor_16x8_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_predictor_16x8 = aom_highbd_smooth_predictor_16x8_avx2;
-        aom_highbd_smooth_predictor_2x2 = aom_highbd_smooth_predictor_2x2_c;
-        aom_highbd_smooth_predictor_32x16 = aom_highbd_smooth_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_predictor_32x16 = aom_highbd_smooth_predictor_32x16_avx2;
-        aom_highbd_smooth_predictor_32x32 = aom_highbd_smooth_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_predictor_32x32 = aom_highbd_smooth_predictor_32x32_avx2;
-        aom_highbd_smooth_predictor_32x64 = aom_highbd_smooth_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_predictor_32x64 = aom_highbd_smooth_predictor_32x64_avx2;
-        aom_highbd_smooth_predictor_32x8 = aom_highbd_smooth_predictor_32x8_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_predictor_32x8 = aom_highbd_smooth_predictor_32x8_avx2;
-        aom_highbd_smooth_predictor_4x16 = aom_highbd_smooth_predictor_4x16_c;
-        if (flags & HAS_SSSE3) aom_highbd_smooth_predictor_4x16 = aom_highbd_smooth_predictor_4x16_ssse3;
-        aom_highbd_smooth_predictor_4x4 = aom_highbd_smooth_predictor_4x4_c;
-        if (flags & HAS_SSSE3) aom_highbd_smooth_predictor_4x4 = aom_highbd_smooth_predictor_4x4_ssse3;
-        aom_highbd_smooth_predictor_4x8 = aom_highbd_smooth_predictor_4x8_c;
-        if (flags & HAS_SSSE3) aom_highbd_smooth_predictor_4x8 = aom_highbd_smooth_predictor_4x8_ssse3;
-        aom_highbd_smooth_predictor_64x16 = aom_highbd_smooth_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_predictor_64x16 = aom_highbd_smooth_predictor_64x16_avx2;
-        aom_highbd_smooth_predictor_64x32 = aom_highbd_smooth_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_predictor_64x32 = aom_highbd_smooth_predictor_64x32_avx2;
-        aom_highbd_smooth_predictor_64x64 = aom_highbd_smooth_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_predictor_64x64 = aom_highbd_smooth_predictor_64x64_avx2;
-        aom_highbd_smooth_predictor_8x16 = aom_highbd_smooth_predictor_8x16_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_predictor_8x16 = aom_highbd_smooth_predictor_8x16_avx2;
-        aom_highbd_smooth_predictor_8x32 = aom_highbd_smooth_predictor_8x32_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_predictor_8x32 = aom_highbd_smooth_predictor_8x32_avx2;
-        aom_highbd_smooth_predictor_8x4 = aom_highbd_smooth_predictor_8x4_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_predictor_8x4 = aom_highbd_smooth_predictor_8x4_avx2;
-        aom_highbd_smooth_predictor_8x8 = aom_highbd_smooth_predictor_8x8_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_predictor_8x8 = aom_highbd_smooth_predictor_8x8_avx2;
+        eb_aom_highbd_smooth_predictor_16x16 = eb_aom_highbd_smooth_predictor_16x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_predictor_16x16 = eb_aom_highbd_smooth_predictor_16x16_avx2;
+        eb_aom_highbd_smooth_predictor_16x32 = eb_aom_highbd_smooth_predictor_16x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_predictor_16x32 = eb_aom_highbd_smooth_predictor_16x32_avx2;
+        eb_aom_highbd_smooth_predictor_16x4 = eb_aom_highbd_smooth_predictor_16x4_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_predictor_16x4 = eb_aom_highbd_smooth_predictor_16x4_avx2;
+        eb_aom_highbd_smooth_predictor_16x64 = eb_aom_highbd_smooth_predictor_16x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_predictor_16x64 = eb_aom_highbd_smooth_predictor_16x64_avx2;
+        eb_aom_highbd_smooth_predictor_16x8 = eb_aom_highbd_smooth_predictor_16x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_predictor_16x8 = eb_aom_highbd_smooth_predictor_16x8_avx2;
+        eb_aom_highbd_smooth_predictor_2x2 = eb_aom_highbd_smooth_predictor_2x2_c;
+        eb_aom_highbd_smooth_predictor_32x16 = eb_aom_highbd_smooth_predictor_32x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_predictor_32x16 = eb_aom_highbd_smooth_predictor_32x16_avx2;
+        eb_aom_highbd_smooth_predictor_32x32 = eb_aom_highbd_smooth_predictor_32x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_predictor_32x32 = eb_aom_highbd_smooth_predictor_32x32_avx2;
+        eb_aom_highbd_smooth_predictor_32x64 = eb_aom_highbd_smooth_predictor_32x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_predictor_32x64 = eb_aom_highbd_smooth_predictor_32x64_avx2;
+        eb_aom_highbd_smooth_predictor_32x8 = eb_aom_highbd_smooth_predictor_32x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_predictor_32x8 = eb_aom_highbd_smooth_predictor_32x8_avx2;
+        eb_aom_highbd_smooth_predictor_4x16 = eb_aom_highbd_smooth_predictor_4x16_c;
+        if (flags & HAS_SSSE3) eb_aom_highbd_smooth_predictor_4x16 = eb_aom_highbd_smooth_predictor_4x16_ssse3;
+        eb_aom_highbd_smooth_predictor_4x4 = eb_aom_highbd_smooth_predictor_4x4_c;
+        if (flags & HAS_SSSE3) eb_aom_highbd_smooth_predictor_4x4 = eb_aom_highbd_smooth_predictor_4x4_ssse3;
+        eb_aom_highbd_smooth_predictor_4x8 = eb_aom_highbd_smooth_predictor_4x8_c;
+        if (flags & HAS_SSSE3) eb_aom_highbd_smooth_predictor_4x8 = eb_aom_highbd_smooth_predictor_4x8_ssse3;
+        eb_aom_highbd_smooth_predictor_64x16 = eb_aom_highbd_smooth_predictor_64x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_predictor_64x16 = eb_aom_highbd_smooth_predictor_64x16_avx2;
+        eb_aom_highbd_smooth_predictor_64x32 = eb_aom_highbd_smooth_predictor_64x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_predictor_64x32 = eb_aom_highbd_smooth_predictor_64x32_avx2;
+        eb_aom_highbd_smooth_predictor_64x64 = eb_aom_highbd_smooth_predictor_64x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_predictor_64x64 = eb_aom_highbd_smooth_predictor_64x64_avx2;
+        eb_aom_highbd_smooth_predictor_8x16 = eb_aom_highbd_smooth_predictor_8x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_predictor_8x16 = eb_aom_highbd_smooth_predictor_8x16_avx2;
+        eb_aom_highbd_smooth_predictor_8x32 = eb_aom_highbd_smooth_predictor_8x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_predictor_8x32 = eb_aom_highbd_smooth_predictor_8x32_avx2;
+        eb_aom_highbd_smooth_predictor_8x4 = eb_aom_highbd_smooth_predictor_8x4_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_predictor_8x4 = eb_aom_highbd_smooth_predictor_8x4_avx2;
+        eb_aom_highbd_smooth_predictor_8x8 = eb_aom_highbd_smooth_predictor_8x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_predictor_8x8 = eb_aom_highbd_smooth_predictor_8x8_avx2;
 
         //aom_highbd_smooth_h_predictor
-        aom_highbd_smooth_h_predictor_16x16 = aom_highbd_smooth_h_predictor_16x16_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_16x16 = aom_highbd_smooth_h_predictor_16x16_avx2;
-        aom_highbd_smooth_h_predictor_16x32 = aom_highbd_smooth_h_predictor_16x32_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_16x32 = aom_highbd_smooth_h_predictor_16x32_avx2;
-        aom_highbd_smooth_h_predictor_16x4 = aom_highbd_smooth_h_predictor_16x4_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_16x4 = aom_highbd_smooth_h_predictor_16x4_avx2;
-        aom_highbd_smooth_h_predictor_16x64 = aom_highbd_smooth_h_predictor_16x64_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_16x64 = aom_highbd_smooth_h_predictor_16x64_avx2;
-        aom_highbd_smooth_h_predictor_16x8 = aom_highbd_smooth_h_predictor_16x8_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_16x8 = aom_highbd_smooth_h_predictor_16x8_avx2;
-        aom_highbd_smooth_h_predictor_2x2 = aom_highbd_smooth_h_predictor_2x2_c;
-        aom_highbd_smooth_h_predictor_32x16 = aom_highbd_smooth_h_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_32x16 = aom_highbd_smooth_h_predictor_32x16_avx2;
-        aom_highbd_smooth_h_predictor_32x32 = aom_highbd_smooth_h_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_32x32 = aom_highbd_smooth_h_predictor_32x32_avx2;
-        aom_highbd_smooth_h_predictor_32x64 = aom_highbd_smooth_h_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_32x64 = aom_highbd_smooth_h_predictor_32x64_avx2;
-        aom_highbd_smooth_h_predictor_32x8 = aom_highbd_smooth_h_predictor_32x8_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_32x8 = aom_highbd_smooth_h_predictor_32x8_avx2;
-        aom_highbd_smooth_h_predictor_4x16 = aom_highbd_smooth_h_predictor_4x16_c;
-        if (flags & HAS_SSSE3) aom_highbd_smooth_h_predictor_4x16 = aom_highbd_smooth_h_predictor_4x16_ssse3;
-        aom_highbd_smooth_h_predictor_4x4 = aom_highbd_smooth_h_predictor_4x4_c;
-        if (flags & HAS_SSSE3) aom_highbd_smooth_h_predictor_4x4 = aom_highbd_smooth_h_predictor_4x4_ssse3;
-        aom_highbd_smooth_h_predictor_4x8 = aom_highbd_smooth_h_predictor_4x8_c;
-        if (flags & HAS_SSSE3) aom_highbd_smooth_h_predictor_4x8 = aom_highbd_smooth_h_predictor_4x8_ssse3;
-        aom_highbd_smooth_h_predictor_64x16 = aom_highbd_smooth_h_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_64x16 = aom_highbd_smooth_h_predictor_64x16_avx2;
-        aom_highbd_smooth_h_predictor_64x32 = aom_highbd_smooth_h_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_64x32 = aom_highbd_smooth_h_predictor_64x32_avx2;
-        aom_highbd_smooth_h_predictor_64x64 = aom_highbd_smooth_h_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_64x64 = aom_highbd_smooth_h_predictor_64x64_avx2;
-        aom_highbd_smooth_h_predictor_8x16 = aom_highbd_smooth_h_predictor_8x16_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_8x16 = aom_highbd_smooth_h_predictor_8x16_avx2;
-        aom_highbd_smooth_h_predictor_8x32 = aom_highbd_smooth_h_predictor_8x32_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_8x32 = aom_highbd_smooth_h_predictor_8x32_avx2;
-        aom_highbd_smooth_h_predictor_8x4 = aom_highbd_smooth_h_predictor_8x4_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_8x4 = aom_highbd_smooth_h_predictor_8x4_avx2;
-        aom_highbd_smooth_h_predictor_8x8 = aom_highbd_smooth_h_predictor_8x8_c;
-        if (flags & HAS_AVX2) aom_highbd_smooth_h_predictor_8x8 = aom_highbd_smooth_h_predictor_8x8_avx2;
+        eb_aom_highbd_smooth_h_predictor_16x16 = eb_aom_highbd_smooth_h_predictor_16x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_h_predictor_16x16 = eb_aom_highbd_smooth_h_predictor_16x16_avx2;
+        eb_aom_highbd_smooth_h_predictor_16x32 = eb_aom_highbd_smooth_h_predictor_16x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_h_predictor_16x32 = eb_aom_highbd_smooth_h_predictor_16x32_avx2;
+        eb_aom_highbd_smooth_h_predictor_16x4 = eb_aom_highbd_smooth_h_predictor_16x4_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_h_predictor_16x4 = eb_aom_highbd_smooth_h_predictor_16x4_avx2;
+        eb_aom_highbd_smooth_h_predictor_16x64 = eb_aom_highbd_smooth_h_predictor_16x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_h_predictor_16x64 = eb_aom_highbd_smooth_h_predictor_16x64_avx2;
+        eb_aom_highbd_smooth_h_predictor_16x8 = eb_aom_highbd_smooth_h_predictor_16x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_h_predictor_16x8 = eb_aom_highbd_smooth_h_predictor_16x8_avx2;
+        eb_aom_highbd_smooth_h_predictor_2x2 = eb_aom_highbd_smooth_h_predictor_2x2_c;
+        eb_aom_highbd_smooth_h_predictor_32x16 = eb_aom_highbd_smooth_h_predictor_32x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_h_predictor_32x16 = eb_aom_highbd_smooth_h_predictor_32x16_avx2;
+        eb_aom_highbd_smooth_h_predictor_32x32 = eb_aom_highbd_smooth_h_predictor_32x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_h_predictor_32x32 = eb_aom_highbd_smooth_h_predictor_32x32_avx2;
+        eb_aom_highbd_smooth_h_predictor_32x64 = eb_aom_highbd_smooth_h_predictor_32x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_h_predictor_32x64 = eb_aom_highbd_smooth_h_predictor_32x64_avx2;
+        eb_aom_highbd_smooth_h_predictor_32x8 = eb_aom_highbd_smooth_h_predictor_32x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_h_predictor_32x8 = eb_aom_highbd_smooth_h_predictor_32x8_avx2;
+        eb_aom_highbd_smooth_h_predictor_4x16 = eb_aom_highbd_smooth_h_predictor_4x16_c;
+        if (flags & HAS_SSSE3) eb_aom_highbd_smooth_h_predictor_4x16 = eb_aom_highbd_smooth_h_predictor_4x16_ssse3;
+        eb_aom_highbd_smooth_h_predictor_4x4 = eb_aom_highbd_smooth_h_predictor_4x4_c;
+        if (flags & HAS_SSSE3) eb_aom_highbd_smooth_h_predictor_4x4 = eb_aom_highbd_smooth_h_predictor_4x4_ssse3;
+        eb_aom_highbd_smooth_h_predictor_4x8 = eb_aom_highbd_smooth_h_predictor_4x8_c;
+        if (flags & HAS_SSSE3) eb_aom_highbd_smooth_h_predictor_4x8 = eb_aom_highbd_smooth_h_predictor_4x8_ssse3;
+        eb_aom_highbd_smooth_h_predictor_64x16 = eb_aom_highbd_smooth_h_predictor_64x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_h_predictor_64x16 = eb_aom_highbd_smooth_h_predictor_64x16_avx2;
+        eb_aom_highbd_smooth_h_predictor_64x32 = eb_aom_highbd_smooth_h_predictor_64x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_h_predictor_64x32 = eb_aom_highbd_smooth_h_predictor_64x32_avx2;
+        eb_aom_highbd_smooth_h_predictor_64x64 = eb_aom_highbd_smooth_h_predictor_64x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_h_predictor_64x64 = eb_aom_highbd_smooth_h_predictor_64x64_avx2;
+        eb_aom_highbd_smooth_h_predictor_8x16 = eb_aom_highbd_smooth_h_predictor_8x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_h_predictor_8x16 = eb_aom_highbd_smooth_h_predictor_8x16_avx2;
+        eb_aom_highbd_smooth_h_predictor_8x32 = eb_aom_highbd_smooth_h_predictor_8x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_h_predictor_8x32 = eb_aom_highbd_smooth_h_predictor_8x32_avx2;
+        eb_aom_highbd_smooth_h_predictor_8x4 = eb_aom_highbd_smooth_h_predictor_8x4_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_h_predictor_8x4 = eb_aom_highbd_smooth_h_predictor_8x4_avx2;
+        eb_aom_highbd_smooth_h_predictor_8x8 = eb_aom_highbd_smooth_h_predictor_8x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_smooth_h_predictor_8x8 = eb_aom_highbd_smooth_h_predictor_8x8_avx2;
 
         //aom_highbd_dc_128_predictor
-        aom_highbd_dc_128_predictor_16x16 = aom_highbd_dc_128_predictor_16x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_16x16 = aom_highbd_dc_128_predictor_16x16_avx2;
-        aom_highbd_dc_128_predictor_16x32 = aom_highbd_dc_128_predictor_16x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_16x32 = aom_highbd_dc_128_predictor_16x32_avx2;
-        aom_highbd_dc_128_predictor_16x4 = aom_highbd_dc_128_predictor_16x4_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_16x4 = aom_highbd_dc_128_predictor_16x4_avx2;
-        aom_highbd_dc_128_predictor_16x64 = aom_highbd_dc_128_predictor_16x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_16x64 = aom_highbd_dc_128_predictor_16x64_avx2;
-        aom_highbd_dc_128_predictor_16x8 = aom_highbd_dc_128_predictor_16x8_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_16x8 = aom_highbd_dc_128_predictor_16x8_avx2;
-        aom_highbd_dc_128_predictor_2x2 = aom_highbd_dc_128_predictor_2x2_c;
-        aom_highbd_dc_128_predictor_32x16 = aom_highbd_dc_128_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_32x16 = aom_highbd_dc_128_predictor_32x16_avx2;
-        aom_highbd_dc_128_predictor_32x32 = aom_highbd_dc_128_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_32x32 = aom_highbd_dc_128_predictor_32x32_avx2;
-        aom_highbd_dc_128_predictor_32x64 = aom_highbd_dc_128_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_32x64 = aom_highbd_dc_128_predictor_32x64_avx2;
-        aom_highbd_dc_128_predictor_32x8 = aom_highbd_dc_128_predictor_32x8_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_32x8 = aom_highbd_dc_128_predictor_32x8_avx2;
-        aom_highbd_dc_128_predictor_4x16 = aom_highbd_dc_128_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_128_predictor_4x16 = aom_highbd_dc_128_predictor_4x16_sse2;
-        aom_highbd_dc_128_predictor_4x4 = aom_highbd_dc_128_predictor_4x4_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_128_predictor_4x4 = aom_highbd_dc_128_predictor_4x4_sse2;
-        aom_highbd_dc_128_predictor_4x8 = aom_highbd_dc_128_predictor_4x8_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_128_predictor_4x8 = aom_highbd_dc_128_predictor_4x8_sse2;
-        aom_highbd_dc_128_predictor_8x32 = aom_highbd_dc_128_predictor_8x32_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_128_predictor_8x32 = aom_highbd_dc_128_predictor_8x32_sse2;
-        aom_highbd_dc_128_predictor_64x16 = aom_highbd_dc_128_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_64x16 = aom_highbd_dc_128_predictor_64x16_avx2;
-        aom_highbd_dc_128_predictor_64x32 = aom_highbd_dc_128_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_64x32 = aom_highbd_dc_128_predictor_64x32_avx2;
-        aom_highbd_dc_128_predictor_64x64 = aom_highbd_dc_128_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_128_predictor_64x64 = aom_highbd_dc_128_predictor_64x64_avx2;
-        aom_highbd_dc_128_predictor_8x16 = aom_highbd_dc_128_predictor_8x16_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_128_predictor_8x16 = aom_highbd_dc_128_predictor_8x16_sse2;
-        aom_highbd_dc_128_predictor_8x4 = aom_highbd_dc_128_predictor_8x4_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_128_predictor_8x4 = aom_highbd_dc_128_predictor_8x4_sse2;
-        aom_highbd_dc_128_predictor_8x8 = aom_highbd_dc_128_predictor_8x8_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_128_predictor_8x8 = aom_highbd_dc_128_predictor_8x8_sse2;
+        eb_aom_highbd_dc_128_predictor_16x16 = eb_aom_highbd_dc_128_predictor_16x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_128_predictor_16x16 = eb_aom_highbd_dc_128_predictor_16x16_avx2;
+        eb_aom_highbd_dc_128_predictor_16x32 = eb_aom_highbd_dc_128_predictor_16x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_128_predictor_16x32 = eb_aom_highbd_dc_128_predictor_16x32_avx2;
+        eb_aom_highbd_dc_128_predictor_16x4 = eb_aom_highbd_dc_128_predictor_16x4_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_128_predictor_16x4 = eb_aom_highbd_dc_128_predictor_16x4_avx2;
+        eb_aom_highbd_dc_128_predictor_16x64 = eb_aom_highbd_dc_128_predictor_16x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_128_predictor_16x64 = eb_aom_highbd_dc_128_predictor_16x64_avx2;
+        eb_aom_highbd_dc_128_predictor_16x8 = eb_aom_highbd_dc_128_predictor_16x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_128_predictor_16x8 = eb_aom_highbd_dc_128_predictor_16x8_avx2;
+        eb_aom_highbd_dc_128_predictor_2x2 = eb_aom_highbd_dc_128_predictor_2x2_c;
+        eb_aom_highbd_dc_128_predictor_32x16 = eb_aom_highbd_dc_128_predictor_32x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_128_predictor_32x16 = eb_aom_highbd_dc_128_predictor_32x16_avx2;
+        eb_aom_highbd_dc_128_predictor_32x32 = eb_aom_highbd_dc_128_predictor_32x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_128_predictor_32x32 = eb_aom_highbd_dc_128_predictor_32x32_avx2;
+        eb_aom_highbd_dc_128_predictor_32x64 = eb_aom_highbd_dc_128_predictor_32x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_128_predictor_32x64 = eb_aom_highbd_dc_128_predictor_32x64_avx2;
+        eb_aom_highbd_dc_128_predictor_32x8 = eb_aom_highbd_dc_128_predictor_32x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_128_predictor_32x8 = eb_aom_highbd_dc_128_predictor_32x8_avx2;
+        eb_aom_highbd_dc_128_predictor_4x16 = eb_aom_highbd_dc_128_predictor_4x16_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_128_predictor_4x16 = eb_aom_highbd_dc_128_predictor_4x16_sse2;
+        eb_aom_highbd_dc_128_predictor_4x4 = eb_aom_highbd_dc_128_predictor_4x4_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_128_predictor_4x4 = eb_aom_highbd_dc_128_predictor_4x4_sse2;
+        eb_aom_highbd_dc_128_predictor_4x8 = eb_aom_highbd_dc_128_predictor_4x8_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_128_predictor_4x8 = eb_aom_highbd_dc_128_predictor_4x8_sse2;
+        eb_aom_highbd_dc_128_predictor_8x32 = eb_aom_highbd_dc_128_predictor_8x32_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_128_predictor_8x32 = eb_aom_highbd_dc_128_predictor_8x32_sse2;
+        eb_aom_highbd_dc_128_predictor_64x16 = eb_aom_highbd_dc_128_predictor_64x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_128_predictor_64x16 = eb_aom_highbd_dc_128_predictor_64x16_avx2;
+        eb_aom_highbd_dc_128_predictor_64x32 = eb_aom_highbd_dc_128_predictor_64x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_128_predictor_64x32 = eb_aom_highbd_dc_128_predictor_64x32_avx2;
+        eb_aom_highbd_dc_128_predictor_64x64 = eb_aom_highbd_dc_128_predictor_64x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_128_predictor_64x64 = eb_aom_highbd_dc_128_predictor_64x64_avx2;
+        eb_aom_highbd_dc_128_predictor_8x16 = eb_aom_highbd_dc_128_predictor_8x16_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_128_predictor_8x16 = eb_aom_highbd_dc_128_predictor_8x16_sse2;
+        eb_aom_highbd_dc_128_predictor_8x4 = eb_aom_highbd_dc_128_predictor_8x4_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_128_predictor_8x4 = eb_aom_highbd_dc_128_predictor_8x4_sse2;
+        eb_aom_highbd_dc_128_predictor_8x8 = eb_aom_highbd_dc_128_predictor_8x8_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_128_predictor_8x8 = eb_aom_highbd_dc_128_predictor_8x8_sse2;
 
         //aom_highbd_dc_left_predictor
-        aom_highbd_dc_left_predictor_16x16 = aom_highbd_dc_left_predictor_16x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_16x16 = aom_highbd_dc_left_predictor_16x16_avx2;
-        aom_highbd_dc_left_predictor_16x32 = aom_highbd_dc_left_predictor_16x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_16x32 = aom_highbd_dc_left_predictor_16x32_avx2;
-        aom_highbd_dc_left_predictor_16x4 = aom_highbd_dc_left_predictor_16x4_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_16x4 = aom_highbd_dc_left_predictor_16x4_avx2;
-        aom_highbd_dc_left_predictor_16x64 = aom_highbd_dc_left_predictor_16x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_16x64 = aom_highbd_dc_left_predictor_16x64_avx2;
-        aom_highbd_dc_left_predictor_16x8 = aom_highbd_dc_left_predictor_16x8_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_16x8 = aom_highbd_dc_left_predictor_16x8_avx2;
-        aom_highbd_dc_left_predictor_2x2 = aom_highbd_dc_left_predictor_2x2_c;
-        aom_highbd_dc_left_predictor_32x16 = aom_highbd_dc_left_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_32x16 = aom_highbd_dc_left_predictor_32x16_avx2;
-        aom_highbd_dc_left_predictor_32x32 = aom_highbd_dc_left_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_32x32 = aom_highbd_dc_left_predictor_32x32_avx2;
-        aom_highbd_dc_left_predictor_32x64 = aom_highbd_dc_left_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_32x64 = aom_highbd_dc_left_predictor_32x64_avx2;
-        aom_highbd_dc_left_predictor_32x8 = aom_highbd_dc_left_predictor_32x8_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_32x8 = aom_highbd_dc_left_predictor_32x8_avx2;
-        aom_highbd_dc_left_predictor_4x16 = aom_highbd_dc_left_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_left_predictor_4x16 = aom_highbd_dc_left_predictor_4x16_sse2;
-        aom_highbd_dc_left_predictor_4x4 = aom_highbd_dc_left_predictor_4x4_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_left_predictor_4x4 = aom_highbd_dc_left_predictor_4x4_sse2;
-        aom_highbd_dc_left_predictor_4x8 = aom_highbd_dc_left_predictor_4x8_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_left_predictor_4x8 = aom_highbd_dc_left_predictor_4x8_sse2;
-        aom_highbd_dc_left_predictor_8x32 = aom_highbd_dc_left_predictor_8x32_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_left_predictor_8x32 = aom_highbd_dc_left_predictor_8x32_sse2;
-        aom_highbd_dc_left_predictor_64x16 = aom_highbd_dc_left_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_64x16 = aom_highbd_dc_left_predictor_64x16_avx2;
-        aom_highbd_dc_left_predictor_64x32 = aom_highbd_dc_left_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_64x32 = aom_highbd_dc_left_predictor_64x32_avx2;
-        aom_highbd_dc_left_predictor_64x64 = aom_highbd_dc_left_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_left_predictor_64x64 = aom_highbd_dc_left_predictor_64x64_avx2;
-        aom_highbd_dc_left_predictor_8x16 = aom_highbd_dc_left_predictor_8x16_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_left_predictor_8x16 = aom_highbd_dc_left_predictor_8x16_sse2;
-        aom_highbd_dc_left_predictor_8x4 = aom_highbd_dc_left_predictor_8x4_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_left_predictor_8x4 = aom_highbd_dc_left_predictor_8x4_sse2;
-        aom_highbd_dc_left_predictor_8x8 = aom_highbd_dc_left_predictor_8x8_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_left_predictor_8x8 = aom_highbd_dc_left_predictor_8x8_sse2;
+        eb_aom_highbd_dc_left_predictor_16x16 = eb_aom_highbd_dc_left_predictor_16x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_16x16 = eb_aom_highbd_dc_left_predictor_16x16_avx2;
+        eb_aom_highbd_dc_left_predictor_16x32 = eb_aom_highbd_dc_left_predictor_16x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_16x32 = eb_aom_highbd_dc_left_predictor_16x32_avx2;
+        eb_aom_highbd_dc_left_predictor_16x4 = eb_aom_highbd_dc_left_predictor_16x4_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_16x4 = eb_aom_highbd_dc_left_predictor_16x4_avx2;
+        eb_aom_highbd_dc_left_predictor_16x64 = eb_aom_highbd_dc_left_predictor_16x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_16x64 = eb_aom_highbd_dc_left_predictor_16x64_avx2;
+        eb_aom_highbd_dc_left_predictor_16x8 = eb_aom_highbd_dc_left_predictor_16x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_16x8 = eb_aom_highbd_dc_left_predictor_16x8_avx2;
+        eb_aom_highbd_dc_left_predictor_2x2 = eb_aom_highbd_dc_left_predictor_2x2_c;
+        eb_aom_highbd_dc_left_predictor_32x16 = eb_aom_highbd_dc_left_predictor_32x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_32x16 = eb_aom_highbd_dc_left_predictor_32x16_avx2;
+        eb_aom_highbd_dc_left_predictor_32x32 = eb_aom_highbd_dc_left_predictor_32x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_32x32 = eb_aom_highbd_dc_left_predictor_32x32_avx2;
+        eb_aom_highbd_dc_left_predictor_32x64 = eb_aom_highbd_dc_left_predictor_32x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_32x64 = eb_aom_highbd_dc_left_predictor_32x64_avx2;
+        eb_aom_highbd_dc_left_predictor_32x8 = eb_aom_highbd_dc_left_predictor_32x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_32x8 = eb_aom_highbd_dc_left_predictor_32x8_avx2;
+        eb_aom_highbd_dc_left_predictor_4x16 = eb_aom_highbd_dc_left_predictor_4x16_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_left_predictor_4x16 = eb_aom_highbd_dc_left_predictor_4x16_sse2;
+        eb_aom_highbd_dc_left_predictor_4x4 = eb_aom_highbd_dc_left_predictor_4x4_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_left_predictor_4x4 = eb_aom_highbd_dc_left_predictor_4x4_sse2;
+        eb_aom_highbd_dc_left_predictor_4x8 = eb_aom_highbd_dc_left_predictor_4x8_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_left_predictor_4x8 = eb_aom_highbd_dc_left_predictor_4x8_sse2;
+        eb_aom_highbd_dc_left_predictor_8x32 = eb_aom_highbd_dc_left_predictor_8x32_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_left_predictor_8x32 = eb_aom_highbd_dc_left_predictor_8x32_sse2;
+        eb_aom_highbd_dc_left_predictor_64x16 = eb_aom_highbd_dc_left_predictor_64x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_64x16 = eb_aom_highbd_dc_left_predictor_64x16_avx2;
+        eb_aom_highbd_dc_left_predictor_64x32 = eb_aom_highbd_dc_left_predictor_64x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_64x32 = eb_aom_highbd_dc_left_predictor_64x32_avx2;
+        eb_aom_highbd_dc_left_predictor_64x64 = eb_aom_highbd_dc_left_predictor_64x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_64x64 = eb_aom_highbd_dc_left_predictor_64x64_avx2;
+        eb_aom_highbd_dc_left_predictor_8x16 = eb_aom_highbd_dc_left_predictor_8x16_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_left_predictor_8x16 = eb_aom_highbd_dc_left_predictor_8x16_sse2;
+        eb_aom_highbd_dc_left_predictor_8x4 = eb_aom_highbd_dc_left_predictor_8x4_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_left_predictor_8x4 = eb_aom_highbd_dc_left_predictor_8x4_sse2;
+        eb_aom_highbd_dc_left_predictor_8x8 = eb_aom_highbd_dc_left_predictor_8x8_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_left_predictor_8x8 = eb_aom_highbd_dc_left_predictor_8x8_sse2;
 
-        aom_highbd_dc_predictor_16x16 = aom_highbd_dc_predictor_16x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_16x16 = aom_highbd_dc_predictor_16x16_avx2;
-        aom_highbd_dc_predictor_16x32 = aom_highbd_dc_predictor_16x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_16x32 = aom_highbd_dc_predictor_16x32_avx2;
-        aom_highbd_dc_predictor_16x4 = aom_highbd_dc_predictor_16x4_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_16x4 = aom_highbd_dc_predictor_16x4_avx2;
-        aom_highbd_dc_predictor_16x64 = aom_highbd_dc_predictor_16x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_16x64 = aom_highbd_dc_predictor_16x64_avx2;
-        aom_highbd_dc_predictor_16x8 = aom_highbd_dc_predictor_16x8_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_16x8 = aom_highbd_dc_predictor_16x8_avx2;
-        aom_highbd_dc_predictor_2x2 = aom_highbd_dc_predictor_2x2_c;
-        aom_highbd_dc_predictor_32x16 = aom_highbd_dc_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_32x16 = aom_highbd_dc_predictor_32x16_avx2;
-        aom_highbd_dc_predictor_32x32 = aom_highbd_dc_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_32x32 = aom_highbd_dc_predictor_32x32_avx2;
-        aom_highbd_dc_predictor_32x64 = aom_highbd_dc_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_32x64 = aom_highbd_dc_predictor_32x64_avx2;
-        aom_highbd_dc_predictor_32x8 = aom_highbd_dc_predictor_32x8_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_32x8 = aom_highbd_dc_predictor_32x8_avx2;
-        aom_highbd_dc_predictor_4x16 = aom_highbd_dc_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_predictor_4x16 = aom_highbd_dc_predictor_4x16_sse2;
-        aom_highbd_dc_predictor_4x4 = aom_highbd_dc_predictor_4x4_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_predictor_4x4 = aom_highbd_dc_predictor_4x4_sse2;
-        aom_highbd_dc_predictor_4x8 = aom_highbd_dc_predictor_4x8_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_predictor_4x8 = aom_highbd_dc_predictor_4x8_sse2;
-        aom_highbd_dc_predictor_64x16 = aom_highbd_dc_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_64x16 = aom_highbd_dc_predictor_64x16_avx2;
-        aom_highbd_dc_predictor_64x32 = aom_highbd_dc_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_64x32 = aom_highbd_dc_predictor_64x32_avx2;
-        aom_highbd_dc_predictor_64x64 = aom_highbd_dc_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_predictor_64x64 = aom_highbd_dc_predictor_64x64_avx2;
-        aom_highbd_dc_predictor_8x16 = aom_highbd_dc_predictor_8x16_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_predictor_8x16 = aom_highbd_dc_predictor_8x16_sse2;
-        aom_highbd_dc_predictor_8x4 = aom_highbd_dc_predictor_8x4_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_predictor_8x4 = aom_highbd_dc_predictor_8x4_sse2;
-        aom_highbd_dc_predictor_8x8 = aom_highbd_dc_predictor_8x8_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_predictor_8x8 = aom_highbd_dc_predictor_8x8_sse2;
-        aom_highbd_dc_predictor_8x32 = aom_highbd_dc_predictor_8x32_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_predictor_8x32 = aom_highbd_dc_predictor_8x32_sse2;
+        eb_aom_highbd_dc_predictor_16x16 = eb_aom_highbd_dc_predictor_16x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_16x16 = eb_aom_highbd_dc_predictor_16x16_avx2;
+        eb_aom_highbd_dc_predictor_16x32 = eb_aom_highbd_dc_predictor_16x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_16x32 = eb_aom_highbd_dc_predictor_16x32_avx2;
+        eb_aom_highbd_dc_predictor_16x4 = eb_aom_highbd_dc_predictor_16x4_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_16x4 = eb_aom_highbd_dc_predictor_16x4_avx2;
+        eb_aom_highbd_dc_predictor_16x64 = eb_aom_highbd_dc_predictor_16x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_16x64 = eb_aom_highbd_dc_predictor_16x64_avx2;
+        eb_aom_highbd_dc_predictor_16x8 = eb_aom_highbd_dc_predictor_16x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_16x8 = eb_aom_highbd_dc_predictor_16x8_avx2;
+        eb_aom_highbd_dc_predictor_2x2 = eb_aom_highbd_dc_predictor_2x2_c;
+        eb_aom_highbd_dc_predictor_32x16 = eb_aom_highbd_dc_predictor_32x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_32x16 = eb_aom_highbd_dc_predictor_32x16_avx2;
+        eb_aom_highbd_dc_predictor_32x32 = eb_aom_highbd_dc_predictor_32x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_32x32 = eb_aom_highbd_dc_predictor_32x32_avx2;
+        eb_aom_highbd_dc_predictor_32x64 = eb_aom_highbd_dc_predictor_32x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_32x64 = eb_aom_highbd_dc_predictor_32x64_avx2;
+        eb_aom_highbd_dc_predictor_32x8 = eb_aom_highbd_dc_predictor_32x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_32x8 = eb_aom_highbd_dc_predictor_32x8_avx2;
+        eb_aom_highbd_dc_predictor_4x16 = eb_aom_highbd_dc_predictor_4x16_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_predictor_4x16 = eb_aom_highbd_dc_predictor_4x16_sse2;
+        eb_aom_highbd_dc_predictor_4x4 = eb_aom_highbd_dc_predictor_4x4_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_predictor_4x4 = eb_aom_highbd_dc_predictor_4x4_sse2;
+        eb_aom_highbd_dc_predictor_4x8 = eb_aom_highbd_dc_predictor_4x8_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_predictor_4x8 = eb_aom_highbd_dc_predictor_4x8_sse2;
+        eb_aom_highbd_dc_predictor_64x16 = eb_aom_highbd_dc_predictor_64x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_64x16 = eb_aom_highbd_dc_predictor_64x16_avx2;
+        eb_aom_highbd_dc_predictor_64x32 = eb_aom_highbd_dc_predictor_64x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_64x32 = eb_aom_highbd_dc_predictor_64x32_avx2;
+        eb_aom_highbd_dc_predictor_64x64 = eb_aom_highbd_dc_predictor_64x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_64x64 = eb_aom_highbd_dc_predictor_64x64_avx2;
+        eb_aom_highbd_dc_predictor_8x16 = eb_aom_highbd_dc_predictor_8x16_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_predictor_8x16 = eb_aom_highbd_dc_predictor_8x16_sse2;
+        eb_aom_highbd_dc_predictor_8x4 = eb_aom_highbd_dc_predictor_8x4_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_predictor_8x4 = eb_aom_highbd_dc_predictor_8x4_sse2;
+        eb_aom_highbd_dc_predictor_8x8 = eb_aom_highbd_dc_predictor_8x8_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_predictor_8x8 = eb_aom_highbd_dc_predictor_8x8_sse2;
+        eb_aom_highbd_dc_predictor_8x32 = eb_aom_highbd_dc_predictor_8x32_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_predictor_8x32 = eb_aom_highbd_dc_predictor_8x32_sse2;
 
         //aom_highbd_dc_top_predictor
-        aom_highbd_dc_top_predictor_16x16 = aom_highbd_dc_top_predictor_16x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_16x16 = aom_highbd_dc_top_predictor_16x16_avx2;
-        aom_highbd_dc_top_predictor_16x32 = aom_highbd_dc_top_predictor_16x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_16x32 = aom_highbd_dc_top_predictor_16x32_avx2;
-        aom_highbd_dc_top_predictor_16x4 = aom_highbd_dc_top_predictor_16x4_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_16x4 = aom_highbd_dc_top_predictor_16x4_avx2;
-        aom_highbd_dc_top_predictor_16x64 = aom_highbd_dc_top_predictor_16x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_16x64 = aom_highbd_dc_top_predictor_16x64_avx2;
-        aom_highbd_dc_top_predictor_16x8 = aom_highbd_dc_top_predictor_16x8_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_16x8 = aom_highbd_dc_top_predictor_16x8_avx2;
-        aom_highbd_dc_top_predictor_2x2 = aom_highbd_dc_top_predictor_2x2_c;
-        aom_highbd_dc_top_predictor_32x16 = aom_highbd_dc_top_predictor_32x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_32x16 = aom_highbd_dc_top_predictor_32x16_avx2;
-        aom_highbd_dc_top_predictor_32x32 = aom_highbd_dc_top_predictor_32x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_32x32 = aom_highbd_dc_top_predictor_32x32_avx2;
-        aom_highbd_dc_top_predictor_32x64 = aom_highbd_dc_top_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_32x64 = aom_highbd_dc_top_predictor_32x64_avx2;
-        aom_highbd_dc_top_predictor_32x8 = aom_highbd_dc_top_predictor_32x8_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_32x8 = aom_highbd_dc_top_predictor_32x8_avx2;
-        aom_highbd_dc_top_predictor_4x16 = aom_highbd_dc_top_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_top_predictor_4x16 = aom_highbd_dc_top_predictor_4x16_sse2;
-        aom_highbd_dc_top_predictor_4x4 = aom_highbd_dc_top_predictor_4x4_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_top_predictor_4x4 = aom_highbd_dc_top_predictor_4x4_sse2;
-        aom_highbd_dc_top_predictor_4x8 = aom_highbd_dc_top_predictor_4x8_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_top_predictor_4x8 = aom_highbd_dc_top_predictor_4x8_sse2;
-        aom_highbd_dc_top_predictor_64x16 = aom_highbd_dc_top_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_64x16 = aom_highbd_dc_top_predictor_64x16_avx2;
-        aom_highbd_dc_top_predictor_64x32 = aom_highbd_dc_top_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_64x32 = aom_highbd_dc_top_predictor_64x32_avx2;
-        aom_highbd_dc_top_predictor_64x64 = aom_highbd_dc_top_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_highbd_dc_top_predictor_64x64 = aom_highbd_dc_top_predictor_64x64_avx2;
-        aom_highbd_dc_top_predictor_8x16 = aom_highbd_dc_top_predictor_8x16_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_top_predictor_8x16 = aom_highbd_dc_top_predictor_8x16_sse2;
-        if (flags & HAS_SSE2) aom_highbd_dc_top_predictor_8x32 = aom_highbd_dc_top_predictor_8x32_c;
-        aom_highbd_dc_top_predictor_8x4 = aom_highbd_dc_top_predictor_8x4_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_top_predictor_8x4 = aom_highbd_dc_top_predictor_8x4_sse2;
-        aom_highbd_dc_top_predictor_8x8 = aom_highbd_dc_top_predictor_8x8_c;
-        if (flags & HAS_SSE2) aom_highbd_dc_top_predictor_8x8 = aom_highbd_dc_top_predictor_8x8_sse2;
+        eb_aom_highbd_dc_top_predictor_16x16 = eb_aom_highbd_dc_top_predictor_16x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_16x16 = eb_aom_highbd_dc_top_predictor_16x16_avx2;
+        eb_aom_highbd_dc_top_predictor_16x32 = eb_aom_highbd_dc_top_predictor_16x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_16x32 = eb_aom_highbd_dc_top_predictor_16x32_avx2;
+        eb_aom_highbd_dc_top_predictor_16x4 = eb_aom_highbd_dc_top_predictor_16x4_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_16x4 = eb_aom_highbd_dc_top_predictor_16x4_avx2;
+        eb_aom_highbd_dc_top_predictor_16x64 = eb_aom_highbd_dc_top_predictor_16x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_16x64 = eb_aom_highbd_dc_top_predictor_16x64_avx2;
+        eb_aom_highbd_dc_top_predictor_16x8 = eb_aom_highbd_dc_top_predictor_16x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_16x8 = eb_aom_highbd_dc_top_predictor_16x8_avx2;
+        eb_aom_highbd_dc_top_predictor_2x2 = eb_aom_highbd_dc_top_predictor_2x2_c;
+        eb_aom_highbd_dc_top_predictor_32x16 = eb_aom_highbd_dc_top_predictor_32x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_32x16 = eb_aom_highbd_dc_top_predictor_32x16_avx2;
+        eb_aom_highbd_dc_top_predictor_32x32 = eb_aom_highbd_dc_top_predictor_32x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_32x32 = eb_aom_highbd_dc_top_predictor_32x32_avx2;
+        eb_aom_highbd_dc_top_predictor_32x64 = eb_aom_highbd_dc_top_predictor_32x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_32x64 = eb_aom_highbd_dc_top_predictor_32x64_avx2;
+        eb_aom_highbd_dc_top_predictor_32x8 = eb_aom_highbd_dc_top_predictor_32x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_32x8 = eb_aom_highbd_dc_top_predictor_32x8_avx2;
+        eb_aom_highbd_dc_top_predictor_4x16 = eb_aom_highbd_dc_top_predictor_4x16_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_top_predictor_4x16 = eb_aom_highbd_dc_top_predictor_4x16_sse2;
+        eb_aom_highbd_dc_top_predictor_4x4 = eb_aom_highbd_dc_top_predictor_4x4_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_top_predictor_4x4 = eb_aom_highbd_dc_top_predictor_4x4_sse2;
+        eb_aom_highbd_dc_top_predictor_4x8 = eb_aom_highbd_dc_top_predictor_4x8_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_top_predictor_4x8 = eb_aom_highbd_dc_top_predictor_4x8_sse2;
+        eb_aom_highbd_dc_top_predictor_64x16 = eb_aom_highbd_dc_top_predictor_64x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_64x16 = eb_aom_highbd_dc_top_predictor_64x16_avx2;
+        eb_aom_highbd_dc_top_predictor_64x32 = eb_aom_highbd_dc_top_predictor_64x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_64x32 = eb_aom_highbd_dc_top_predictor_64x32_avx2;
+        eb_aom_highbd_dc_top_predictor_64x64 = eb_aom_highbd_dc_top_predictor_64x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_64x64 = eb_aom_highbd_dc_top_predictor_64x64_avx2;
+        eb_aom_highbd_dc_top_predictor_8x16 = eb_aom_highbd_dc_top_predictor_8x16_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_top_predictor_8x16 = eb_aom_highbd_dc_top_predictor_8x16_sse2;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_top_predictor_8x32 = eb_aom_highbd_dc_top_predictor_8x32_c;
+        eb_aom_highbd_dc_top_predictor_8x4 = eb_aom_highbd_dc_top_predictor_8x4_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_top_predictor_8x4 = eb_aom_highbd_dc_top_predictor_8x4_sse2;
+        eb_aom_highbd_dc_top_predictor_8x8 = eb_aom_highbd_dc_top_predictor_8x8_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_dc_top_predictor_8x8 = eb_aom_highbd_dc_top_predictor_8x8_sse2;
 
-        // aom_highbd_h_predictor
-        aom_highbd_h_predictor_16x4 = aom_highbd_h_predictor_16x4_c;
-        if (flags & HAS_AVX2) aom_highbd_h_predictor_16x4 = aom_highbd_h_predictor_16x4_avx2;
-        aom_highbd_h_predictor_16x64 = aom_highbd_h_predictor_16x64_c;
-        if (flags & HAS_AVX2) aom_highbd_h_predictor_16x64 = aom_highbd_h_predictor_16x64_avx2;
-        aom_highbd_h_predictor_16x8 = aom_highbd_h_predictor_16x8_c;
-        if (flags & HAS_SSE2) aom_highbd_h_predictor_16x8 = aom_highbd_h_predictor_16x8_sse2;
-        aom_highbd_h_predictor_2x2 = aom_highbd_h_predictor_2x2_c;
-        aom_highbd_h_predictor_32x16 = aom_highbd_h_predictor_32x16_c;
-        if (flags & HAS_SSE2) aom_highbd_h_predictor_32x16 = aom_highbd_h_predictor_32x16_sse2;
-        aom_highbd_h_predictor_32x32 = aom_highbd_h_predictor_32x32_c;
-        if (flags & HAS_SSE2) aom_highbd_h_predictor_32x32 = aom_highbd_h_predictor_32x32_sse2;
-        aom_highbd_h_predictor_32x64 = aom_highbd_h_predictor_32x64_c;
-        if (flags & HAS_AVX2) aom_highbd_h_predictor_32x64 = aom_highbd_h_predictor_32x64_avx2;
-        aom_highbd_h_predictor_32x8 = aom_highbd_h_predictor_32x8_c;
-        if (flags & HAS_AVX2) aom_highbd_h_predictor_32x8 = aom_highbd_h_predictor_32x8_avx2;
-        aom_highbd_h_predictor_4x16 = aom_highbd_h_predictor_4x16_c;
-        if (flags & HAS_SSE2) aom_highbd_h_predictor_4x16 = aom_highbd_h_predictor_4x16_sse2;
-        aom_highbd_h_predictor_4x4 = aom_highbd_h_predictor_4x4_c;
-        if (flags & HAS_SSE2) aom_highbd_h_predictor_4x4 = aom_highbd_h_predictor_4x4_sse2;
-        aom_highbd_h_predictor_4x8 = aom_highbd_h_predictor_4x8_c;
-        if (flags & HAS_SSE2) aom_highbd_h_predictor_4x8 = aom_highbd_h_predictor_4x8_sse2;
-        aom_highbd_h_predictor_64x16 = aom_highbd_h_predictor_64x16_c;
-        if (flags & HAS_AVX2) aom_highbd_h_predictor_64x16 = aom_highbd_h_predictor_64x16_avx2;
-        aom_highbd_h_predictor_64x32 = aom_highbd_h_predictor_64x32_c;
-        if (flags & HAS_AVX2) aom_highbd_h_predictor_64x32 = aom_highbd_h_predictor_64x32_avx2;
-        aom_highbd_h_predictor_8x32 = aom_highbd_h_predictor_8x32_c;
-        if (flags & HAS_SSE2) aom_highbd_h_predictor_8x32 = aom_highbd_h_predictor_8x32_sse2;
-        aom_highbd_h_predictor_64x64 = aom_highbd_h_predictor_64x64_c;
-        if (flags & HAS_AVX2) aom_highbd_h_predictor_64x64 = aom_highbd_h_predictor_64x64_avx2;
-        aom_highbd_h_predictor_8x16 = aom_highbd_h_predictor_8x16_c;
-        if (flags & HAS_SSE2) aom_highbd_h_predictor_8x16 = aom_highbd_h_predictor_8x16_sse2;
-        aom_highbd_h_predictor_8x4 = aom_highbd_h_predictor_8x4_c;
-        if (flags & HAS_SSE2) aom_highbd_h_predictor_8x4 = aom_highbd_h_predictor_8x4_sse2;
-        aom_highbd_h_predictor_8x8 = aom_highbd_h_predictor_8x8_c;
-        if (flags & HAS_SSE2) aom_highbd_h_predictor_8x8 = aom_highbd_h_predictor_8x8_sse2;
-        aom_highbd_h_predictor_16x16 = aom_highbd_h_predictor_16x16_c;
-        if (flags & HAS_SSE2) aom_highbd_h_predictor_16x16 = aom_highbd_h_predictor_16x16_sse2;
-        aom_highbd_h_predictor_16x32 = aom_highbd_h_predictor_16x32_c;
-        if (flags & HAS_SSE2) aom_highbd_h_predictor_16x32 = aom_highbd_h_predictor_16x32_sse2;
+        // eb_aom_highbd_h_predictor
+        eb_aom_highbd_h_predictor_16x4 = eb_aom_highbd_h_predictor_16x4_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_16x4 = eb_aom_highbd_h_predictor_16x4_avx2;
+        eb_aom_highbd_h_predictor_16x64 = eb_aom_highbd_h_predictor_16x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_16x64 = eb_aom_highbd_h_predictor_16x64_avx2;
+        eb_aom_highbd_h_predictor_16x8 = eb_aom_highbd_h_predictor_16x8_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_16x8 = eb_aom_highbd_h_predictor_16x8_sse2;
+        eb_aom_highbd_h_predictor_2x2 = eb_aom_highbd_h_predictor_2x2_c;
+        eb_aom_highbd_h_predictor_32x16 = eb_aom_highbd_h_predictor_32x16_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_32x16 = eb_aom_highbd_h_predictor_32x16_sse2;
+        eb_aom_highbd_h_predictor_32x32 = eb_aom_highbd_h_predictor_32x32_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_32x32 = eb_aom_highbd_h_predictor_32x32_sse2;
+        eb_aom_highbd_h_predictor_32x64 = eb_aom_highbd_h_predictor_32x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_32x64 = eb_aom_highbd_h_predictor_32x64_avx2;
+        eb_aom_highbd_h_predictor_32x8 = eb_aom_highbd_h_predictor_32x8_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_32x8 = eb_aom_highbd_h_predictor_32x8_avx2;
+        eb_aom_highbd_h_predictor_4x16 = eb_aom_highbd_h_predictor_4x16_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_4x16 = eb_aom_highbd_h_predictor_4x16_sse2;
+        eb_aom_highbd_h_predictor_4x4 = eb_aom_highbd_h_predictor_4x4_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_4x4 = eb_aom_highbd_h_predictor_4x4_sse2;
+        eb_aom_highbd_h_predictor_4x8 = eb_aom_highbd_h_predictor_4x8_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_4x8 = eb_aom_highbd_h_predictor_4x8_sse2;
+        eb_aom_highbd_h_predictor_64x16 = eb_aom_highbd_h_predictor_64x16_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_64x16 = eb_aom_highbd_h_predictor_64x16_avx2;
+        eb_aom_highbd_h_predictor_64x32 = eb_aom_highbd_h_predictor_64x32_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_64x32 = eb_aom_highbd_h_predictor_64x32_avx2;
+        eb_aom_highbd_h_predictor_8x32 = eb_aom_highbd_h_predictor_8x32_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_8x32 = eb_aom_highbd_h_predictor_8x32_sse2;
+        eb_aom_highbd_h_predictor_64x64 = eb_aom_highbd_h_predictor_64x64_c;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_64x64 = eb_aom_highbd_h_predictor_64x64_avx2;
+        eb_aom_highbd_h_predictor_8x16 = eb_aom_highbd_h_predictor_8x16_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_8x16 = eb_aom_highbd_h_predictor_8x16_sse2;
+        eb_aom_highbd_h_predictor_8x4 = eb_aom_highbd_h_predictor_8x4_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_8x4 = eb_aom_highbd_h_predictor_8x4_sse2;
+        eb_aom_highbd_h_predictor_8x8 = eb_aom_highbd_h_predictor_8x8_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_8x8 = eb_aom_highbd_h_predictor_8x8_sse2;
+        eb_aom_highbd_h_predictor_16x16 = eb_aom_highbd_h_predictor_16x16_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_16x16 = eb_aom_highbd_h_predictor_16x16_sse2;
+        eb_aom_highbd_h_predictor_16x32 = eb_aom_highbd_h_predictor_16x32_c;
+        if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_16x32 = eb_aom_highbd_h_predictor_16x32_sse2;
 
-        aom_fft2x2_float = aom_fft2x2_float_c;
-        aom_fft4x4_float = aom_fft4x4_float_c;
-        if (flags & HAS_SSE2) aom_fft4x4_float = aom_fft4x4_float_sse2;
-        aom_fft16x16_float = aom_fft16x16_float_c;
-        if (flags & HAS_AVX2) aom_fft16x16_float = aom_fft16x16_float_avx2;
-        aom_fft32x32_float = aom_fft32x32_float_c;
-        if (flags & HAS_AVX2) aom_fft32x32_float = aom_fft32x32_float_avx2;
-        aom_fft8x8_float = aom_fft8x8_float_c;
-        if (flags & HAS_AVX2) aom_fft8x8_float = aom_fft8x8_float_avx2;
+        eb_aom_fft2x2_float = eb_aom_fft2x2_float_c;
+        eb_aom_fft4x4_float = eb_aom_fft4x4_float_c;
+        if (flags & HAS_SSE2) eb_aom_fft4x4_float = eb_aom_fft4x4_float_sse2;
+        eb_aom_fft16x16_float = eb_aom_fft16x16_float_c;
+        if (flags & HAS_AVX2) eb_aom_fft16x16_float = eb_aom_fft16x16_float_avx2;
+        eb_aom_fft32x32_float = eb_aom_fft32x32_float_c;
+        if (flags & HAS_AVX2) eb_aom_fft32x32_float = eb_aom_fft32x32_float_avx2;
+        eb_aom_fft8x8_float = eb_aom_fft8x8_float_c;
+        if (flags & HAS_AVX2) eb_aom_fft8x8_float = eb_aom_fft8x8_float_avx2;
 
-        /*if (flags & HAS_AVX2)*/ aom_ifft16x16_float = aom_ifft16x16_float_avx2;
-        /*if (flags & HAS_AVX2)*/ aom_ifft32x32_float = aom_ifft32x32_float_avx2;
-        /*if (flags & HAS_AVX2)*/ aom_ifft8x8_float = aom_ifft8x8_float_avx2;
-        aom_ifft2x2_float = aom_ifft2x2_float_c;
-        /*if (flags & HAS_SSE2)*/ aom_ifft4x4_float = aom_ifft4x4_float_sse2;
+        /*if (flags & HAS_AVX2)*/ eb_aom_ifft16x16_float = eb_aom_ifft16x16_float_avx2;
+        /*if (flags & HAS_AVX2)*/ eb_aom_ifft32x32_float = eb_aom_ifft32x32_float_avx2;
+        /*if (flags & HAS_AVX2)*/ eb_aom_ifft8x8_float = eb_aom_ifft8x8_float_avx2;
+        eb_aom_ifft2x2_float = eb_aom_ifft2x2_float_c;
+        /*if (flags & HAS_SSE2)*/ eb_aom_ifft4x4_float = eb_aom_ifft4x4_float_sse2;
     }
 #endif
 

--- a/Source/Lib/Common/Codec/av1me.c
+++ b/Source/Lib/Common/Codec/av1me.c
@@ -83,7 +83,7 @@ typedef unsigned int(*aom_obmc_subpixvariance_fn_t)(
     const uint8_t *pred, int pred_stride, int xoffset, int yoffset,
     const int32_t *wsrc, const int32_t *msk, unsigned int *sse);
 
-int av1_refining_search_sad(IntraBcContext  *x, MV *ref_mv, int error_per_bit,
+int eb_av1_refining_search_sad(IntraBcContext  *x, MV *ref_mv, int error_per_bit,
     int search_range,
     const aom_variance_fn_ptr_t *fn_ptr,
     const MV *center_mv);
@@ -97,28 +97,28 @@ void init_fn_ptr(void)
   mefn_ptr[BT].vf = VF;                                      \
   mefn_ptr[BT].sdx4df = SDX4DF;
 
-        BFP0(BLOCK_4X16, aom_sad4x16, aom_variance4x16, aom_sad4x16x4d)
-        BFP0(BLOCK_16X4, aom_sad16x4, aom_variance16x4, aom_sad16x4x4d)
-        BFP0(BLOCK_8X32, aom_sad8x32, aom_variance8x32, aom_sad8x32x4d)
-        BFP0(BLOCK_32X8, aom_sad32x8, aom_variance32x8, aom_sad32x8x4d)
-        BFP0(BLOCK_16X64, aom_sad16x64, aom_variance16x64, aom_sad16x64x4d)
-        BFP0(BLOCK_64X16, aom_sad64x16, aom_variance64x16, aom_sad64x16x4d)
-        BFP0(BLOCK_128X128, aom_sad128x128, aom_variance128x128, aom_sad128x128x4d)
-        BFP0(BLOCK_128X64, aom_sad128x64, aom_variance128x64, aom_sad128x64x4d)
-        BFP0(BLOCK_64X128, aom_sad64x128, aom_variance64x128, aom_sad64x128x4d)
-        BFP0(BLOCK_32X16, aom_sad32x16, aom_variance32x16, aom_sad32x16x4d)
-        BFP0(BLOCK_16X32, aom_sad16x32, aom_variance16x32, aom_sad16x32x4d)
-        BFP0(BLOCK_64X32, aom_sad64x32, aom_variance64x32, aom_sad64x32x4d)
-        BFP0(BLOCK_32X64, aom_sad32x64, aom_variance32x64, aom_sad32x64x4d)
-        BFP0(BLOCK_32X32, aom_sad32x32, aom_variance32x32, aom_sad32x32x4d)
-        BFP0(BLOCK_64X64, aom_sad64x64, aom_variance64x64, aom_sad64x64x4d)
-        BFP0(BLOCK_16X16, aom_sad16x16, aom_variance16x16, aom_sad16x16x4d)
-        BFP0(BLOCK_16X8, aom_sad16x8, aom_variance16x8, aom_sad16x8x4d)
-        BFP0(BLOCK_8X16, aom_sad8x16, aom_variance8x16, aom_sad8x16x4d)
-        BFP0(BLOCK_8X8, aom_sad8x8, aom_variance8x8, aom_sad8x8x4d)
-        BFP0(BLOCK_8X4, aom_sad8x4, aom_variance8x4, aom_sad8x4x4d)
-        BFP0(BLOCK_4X8, aom_sad4x8, aom_variance4x8, aom_sad4x8x4d)
-        BFP0(BLOCK_4X4, aom_sad4x4, aom_variance4x4, aom_sad4x4x4d)
+        BFP0(BLOCK_4X16, eb_aom_sad4x16, eb_aom_variance4x16, eb_aom_sad4x16x4d)
+        BFP0(BLOCK_16X4, eb_aom_sad16x4, eb_aom_variance16x4, eb_aom_sad16x4x4d)
+        BFP0(BLOCK_8X32, eb_aom_sad8x32, eb_aom_variance8x32, eb_aom_sad8x32x4d)
+        BFP0(BLOCK_32X8, eb_aom_sad32x8, eb_aom_variance32x8, eb_aom_sad32x8x4d)
+        BFP0(BLOCK_16X64, eb_aom_sad16x64, eb_aom_variance16x64, eb_aom_sad16x64x4d)
+        BFP0(BLOCK_64X16, eb_aom_sad64x16, eb_aom_variance64x16, eb_aom_sad64x16x4d)
+        BFP0(BLOCK_128X128, eb_aom_sad128x128, eb_aom_variance128x128, eb_aom_sad128x128x4d)
+        BFP0(BLOCK_128X64, eb_aom_sad128x64, eb_aom_variance128x64, eb_aom_sad128x64x4d)
+        BFP0(BLOCK_64X128, eb_aom_sad64x128, eb_aom_variance64x128, eb_aom_sad64x128x4d)
+        BFP0(BLOCK_32X16, eb_aom_sad32x16, eb_aom_variance32x16, eb_aom_sad32x16x4d)
+        BFP0(BLOCK_16X32, eb_aom_sad16x32, eb_aom_variance16x32, eb_aom_sad16x32x4d)
+        BFP0(BLOCK_64X32, eb_aom_sad64x32, eb_aom_variance64x32, eb_aom_sad64x32x4d)
+        BFP0(BLOCK_32X64, eb_aom_sad32x64, eb_aom_variance32x64, eb_aom_sad32x64x4d)
+        BFP0(BLOCK_32X32, eb_aom_sad32x32, eb_aom_variance32x32, eb_aom_sad32x32x4d)
+        BFP0(BLOCK_64X64, eb_aom_sad64x64, eb_aom_variance64x64, eb_aom_sad64x64x4d)
+        BFP0(BLOCK_16X16, eb_aom_sad16x16, eb_aom_variance16x16, eb_aom_sad16x16x4d)
+        BFP0(BLOCK_16X8, eb_aom_sad16x8, eb_aom_variance16x8, eb_aom_sad16x8x4d)
+        BFP0(BLOCK_8X16, eb_aom_sad8x16, eb_aom_variance8x16, eb_aom_sad8x16x4d)
+        BFP0(BLOCK_8X8, eb_aom_sad8x8, eb_aom_variance8x8, eb_aom_sad8x8x4d)
+        BFP0(BLOCK_8X4, eb_aom_sad8x4, eb_aom_variance8x4, eb_aom_sad8x4x4d)
+        BFP0(BLOCK_4X8, eb_aom_sad4x8, eb_aom_variance4x8, eb_aom_sad4x8x4d)
+        BFP0(BLOCK_4X4, eb_aom_sad4x4, eb_aom_variance4x4, eb_aom_sad4x4x4d)
 }
 
 // #define NEW_DIAMOND_SEARCH
@@ -128,7 +128,7 @@ static INLINE const uint8_t *get_buf_from_mv(const struct Buf2D *buf,
   return &buf->buf[mv->row * buf->stride + mv->col];
 }
 
-void av1_set_mv_search_range(MvLimits *mv_limits, const MV *mv) {
+void eb_av1_set_mv_search_range(MvLimits *mv_limits, const MV *mv) {
   int col_min = (mv->col >> 3) - MAX_FULL_PEL_VAL + (mv->col & 7 ? 1 : 0);
   int row_min = (mv->row >> 3) - MAX_FULL_PEL_VAL + (mv->row & 7 ? 1 : 0);
   int col_max = (mv->col >> 3) + MAX_FULL_PEL_VAL;
@@ -176,7 +176,7 @@ static int mvsad_err_cost(const IntraBcContext *x, const MV *mv, const MV *ref,
       AV1_PROB_COST_SHIFT);
 }
 
-void av1_init3smotion_compensation(SearchSiteConfig *cfg, int stride) {
+void eb_av1_init3smotion_compensation(SearchSiteConfig *cfg, int stride) {
   int len, ss_count = 1;
 
   cfg->ss[0].mv.col = cfg->ss[0].mv.row = 0;
@@ -220,7 +220,7 @@ static INLINE int is_mv_in(const MvLimits *mv_limits, const MV *mv) {
 #define MAX_PATTERN_CANDIDATES 8  // max number of canddiates per scale
 #define PATTERN_CANDIDATES_REF 3  // number of refinement candidates
 
-int av1_get_mvpred_var(const IntraBcContext *x, const MV *best_mv,
+int eb_av1_get_mvpred_var(const IntraBcContext *x, const MV *best_mv,
                        const MV *center_mv, const aom_variance_fn_ptr_t *vfp,
                        int use_mvcost) {
   const struct Buf2D *const what = &x->plane[0].src;
@@ -325,7 +325,7 @@ static int exhuastive_mesh_search(IntraBcContext  *x, MV *ref_mv, MV *best_mv,
   return best_sad;
 }
 
-int av1_diamond_search_sad_c(IntraBcContext  *x, const SearchSiteConfig *cfg,
+int eb_av1_diamond_search_sad_c(IntraBcContext  *x, const SearchSiteConfig *cfg,
                              MV *ref_mv, MV *best_mv, int search_param,
                              int sad_per_bit, int *num00,
                              const aom_variance_fn_ptr_t *fn_ptr,
@@ -479,11 +479,11 @@ static int full_pixel_diamond(PictureControlSet *pcs, IntraBcContext /*MACROBLOC
   (void)cost_list;
   /*int bestsme = cpi->diamond_search_sad(x, &cpi->ss_cfg, mvp_full, &temp_mv,
                                         step_param, sadpb, &n, fn_ptr, ref_mv);*/
-  int bestsme = av1_diamond_search_sad_c(x, &pcs->ss_cfg, mvp_full, &temp_mv,
+  int bestsme = eb_av1_diamond_search_sad_c(x, &pcs->ss_cfg, mvp_full, &temp_mv,
       step_param, sadpb, &n, fn_ptr, ref_mv);
 
   if (bestsme < INT_MAX)
-    bestsme = av1_get_mvpred_var(x, &temp_mv, ref_mv, fn_ptr, 1);
+    bestsme = eb_av1_get_mvpred_var(x, &temp_mv, ref_mv, fn_ptr, 1);
   x->best_mv.as_mv = temp_mv;
 
   // If there won't be more n-step search, check to see if refining search is
@@ -499,12 +499,12 @@ static int full_pixel_diamond(PictureControlSet *pcs, IntraBcContext /*MACROBLOC
       /*thissme = cpi->diamond_search_sad(x, &cpi->ss_cfg, mvp_full, &temp_mv,
                                         step_param + n, sadpb, &num00, fn_ptr,
                                         ref_mv);*/
-      thissme = av1_diamond_search_sad_c(x, &pcs->ss_cfg, mvp_full, &temp_mv,
+      thissme = eb_av1_diamond_search_sad_c(x, &pcs->ss_cfg, mvp_full, &temp_mv,
           step_param + n, sadpb, &num00, fn_ptr,
           ref_mv);
 
       if (thissme < INT_MAX)
-        thissme = av1_get_mvpred_var(x, &temp_mv, ref_mv, fn_ptr, 1);
+        thissme = eb_av1_get_mvpred_var(x, &temp_mv, ref_mv, fn_ptr, 1);
 
       // check to see if refining search is needed.
       if (num00 > further_steps - n) do_refine = 0;
@@ -520,10 +520,10 @@ static int full_pixel_diamond(PictureControlSet *pcs, IntraBcContext /*MACROBLOC
   if (do_refine) {
     const int search_range = 8;
     MV best_mv = x->best_mv.as_mv;
-    thissme = av1_refining_search_sad(x, &best_mv, sadpb, search_range, fn_ptr,
+    thissme = eb_av1_refining_search_sad(x, &best_mv, sadpb, search_range, fn_ptr,
                                       ref_mv);
     if (thissme < INT_MAX)
-      thissme = av1_get_mvpred_var(x, &best_mv, ref_mv, fn_ptr, 1);
+      thissme = eb_av1_get_mvpred_var(x, &best_mv, ref_mv, fn_ptr, 1);
     if (thissme < bestsme) {
       bestsme = thissme;
       x->best_mv.as_mv = best_mv;
@@ -591,7 +591,7 @@ static int full_pixel_exhaustive(PictureControlSet *pcs, IntraBcContext  *x,
   }
 
   if (bestsme < INT_MAX)
-    bestsme = av1_get_mvpred_var(x, &temp_mv, ref_mv, fn_ptr, 1);
+    bestsme = eb_av1_get_mvpred_var(x, &temp_mv, ref_mv, fn_ptr, 1);
   *dst_mv = temp_mv;
 
   // Return cost list.
@@ -601,7 +601,7 @@ static int full_pixel_exhaustive(PictureControlSet *pcs, IntraBcContext  *x,
   return bestsme;
 }
 
-int av1_refining_search_sad(IntraBcContext  *x, MV *ref_mv, int error_per_bit,
+int eb_av1_refining_search_sad(IntraBcContext  *x, MV *ref_mv, int error_per_bit,
                             int search_range,
                             const aom_variance_fn_ptr_t *fn_ptr,
                             const MV *center_mv) {
@@ -674,7 +674,7 @@ int av1_refining_search_sad(IntraBcContext  *x, MV *ref_mv, int error_per_bit,
   return best_sad;
 }
 
-int av1_full_pixel_search(PictureControlSet *pcs, IntraBcContext  *x, BlockSize bsize,
+int eb_av1_full_pixel_search(PictureControlSet *pcs, IntraBcContext  *x, BlockSize bsize,
                           MV *mvp_full, int step_param, int method,
                           int run_mesh_search, int error_per_bit,
                           int *cost_list, const MV *ref_mv, int var_max, int rd,
@@ -801,7 +801,7 @@ int av1_full_pixel_search(PictureControlSet *pcs, IntraBcContext  *x, BlockSize 
             hash_mv.row = ref_block_hash.y - y_pos;
             if (!is_mv_in(&x->mv_limits, &hash_mv)) continue;
             const int refCost =
-                av1_get_mvpred_var(x, &hash_mv, ref_mv, fn_ptr, 1);
+                eb_av1_get_mvpred_var(x, &hash_mv, ref_mv, fn_ptr, 1);
             if (refCost < best_hash_cost) {
               best_hash_cost = refCost;
               best_hash_mv = hash_mv;

--- a/Source/Lib/Common/Codec/av1me.h
+++ b/Source/Lib/Common/Codec/av1me.h
@@ -75,12 +75,12 @@ typedef struct aom_variance_vtable {
 } aom_variance_fn_ptr_t;
 
 void av1_init_dsmotion_compensation(SearchSiteConfig *cfg, int stride);
-void av1_init3smotion_compensation(SearchSiteConfig *cfg, int stride);
-void av1_set_mv_search_range(MvLimits *mv_limits, const MV *mv);
+void eb_av1_init3smotion_compensation(SearchSiteConfig *cfg, int stride);
+void eb_av1_set_mv_search_range(MvLimits *mv_limits, const MV *mv);
 struct Av1Comp;
 struct SpeedFeatures;
 
-int av1_full_pixel_search(struct PictureControlSet *pcs, IntraBcContext /*MACROBLOCK*/ *x,
+int eb_av1_full_pixel_search(struct PictureControlSet *pcs, IntraBcContext /*MACROBLOCK*/ *x,
                           BlockSize bsize, MV *mvp_full, int step_param,
                           int method, int run_mesh_search, int error_per_bit,
                           int *cost_list, const MV *ref_mv, int var_max, int rd,

--- a/Source/Lib/Common/Codec/convolve.c
+++ b/Source/Lib/Common/Codec/convolve.c
@@ -110,7 +110,7 @@ static void convolve_add_src_vert_hip(const uint16_t *src, ptrdiff_t src_stride,
     }
 }
 
-void av1_wiener_convolve_add_src_c(const uint8_t *src, ptrdiff_t src_stride,
+void eb_av1_wiener_convolve_add_src_c(const uint8_t *src, ptrdiff_t src_stride,
     uint8_t *dst, ptrdiff_t dst_stride,
     const int16_t *filter_x, int32_t x_step_q4,
     const int16_t *filter_y, int32_t y_step_q4,
@@ -189,7 +189,7 @@ static void highbd_convolve_add_src_vert_hip(
     }
 }
 
-void av1_highbd_wiener_convolve_add_src_c(
+void eb_av1_highbd_wiener_convolve_add_src_c(
     const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst,
     ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4,
     const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h,

--- a/Source/Lib/Common/Codec/fft.c
+++ b/Source/Lib/Common/Codec/fft.c
@@ -54,7 +54,7 @@ static INLINE void unpack_2d_output(const float *col_fft, float *output,
     }
 }
 
-void aom_fft_2d_gen(const float *input, float *temp, float *output, int32_t n,
+void eb_aom_fft_2d_gen(const float *input, float *temp, float *output, int32_t n,
     aom_fft_1d_func_t tform, aom_fft_transpose_func_t transpose,
     aom_fft_unpack_func_t unpack, int32_t vec_size) {
     for (int32_t x = 0; x < n; x += vec_size)
@@ -83,32 +83,32 @@ GEN_FFT_16(void, float, float, float, *, store_float, (float), add_float,
 GEN_FFT_32(void, float, float, float, *, store_float, (float), add_float,
     sub_float, mul_float);
 
-void aom_fft2x2_float_c(const float *input, float *temp, float *output) {
-    aom_fft_2d_gen(input, temp, output, 2, aom_fft1d_2_float, simple_transpose,
+void eb_aom_fft2x2_float_c(const float *input, float *temp, float *output) {
+    eb_aom_fft_2d_gen(input, temp, output, 2, eb_aom_fft1d_2_float, simple_transpose,
         unpack_2d_output, 1);
 }
 
-void aom_fft4x4_float_c(const float *input, float *temp, float *output) {
-    aom_fft_2d_gen(input, temp, output, 4, aom_fft1d_4_float, simple_transpose,
+void eb_aom_fft4x4_float_c(const float *input, float *temp, float *output) {
+    eb_aom_fft_2d_gen(input, temp, output, 4, eb_aom_fft1d_4_float, simple_transpose,
         unpack_2d_output, 1);
 }
 
-void aom_fft8x8_float_c(const float *input, float *temp, float *output) {
-    aom_fft_2d_gen(input, temp, output, 8, aom_fft1d_8_float, simple_transpose,
+void eb_aom_fft8x8_float_c(const float *input, float *temp, float *output) {
+    eb_aom_fft_2d_gen(input, temp, output, 8, eb_aom_fft1d_8_float, simple_transpose,
         unpack_2d_output, 1);
 }
 
-void aom_fft16x16_float_c(const float *input, float *temp, float *output) {
-    aom_fft_2d_gen(input, temp, output, 16, aom_fft1d_16_float, simple_transpose,
+void eb_aom_fft16x16_float_c(const float *input, float *temp, float *output) {
+    eb_aom_fft_2d_gen(input, temp, output, 16, eb_aom_fft1d_16_float, simple_transpose,
         unpack_2d_output, 1);
 }
 
-void aom_fft32x32_float_c(const float *input, float *temp, float *output) {
-    aom_fft_2d_gen(input, temp, output, 32, aom_fft1d_32_float, simple_transpose,
+void eb_aom_fft32x32_float_c(const float *input, float *temp, float *output) {
+    eb_aom_fft_2d_gen(input, temp, output, 32, eb_aom_fft1d_32_float, simple_transpose,
         unpack_2d_output, 1);
 }
 
-void aom_ifft_2d_gen(const float *input, float *temp, float *output, int32_t n,
+void eb_aom_ifft_2d_gen(const float *input, float *temp, float *output, int32_t n,
     aom_fft_1d_func_t fft_single, aom_fft_1d_func_t fft_multi,
     aom_fft_1d_func_t ifft_multi,
     aom_fft_transpose_func_t transpose, int32_t vec_size) {
@@ -182,7 +182,7 @@ GEN_IFFT_16(void, float, float, float, *, store_float, (float), add_float,
 GEN_IFFT_32(void, float, float, float, *, store_float, (float), add_float,
     sub_float, mul_float);
 
-void aom_ifft2x2_float_c(const float *input, float *temp, float *output) {
-    aom_ifft_2d_gen(input, temp, output, 2, aom_fft1d_2_float, aom_fft1d_2_float,
-        aom_ifft1d_2_float, simple_transpose, 1);
+void eb_aom_ifft2x2_float_c(const float *input, float *temp, float *output) {
+    eb_aom_ifft_2d_gen(input, temp, output, 2, eb_aom_fft1d_2_float, eb_aom_fft1d_2_float,
+        eb_aom_ifft1d_2_float, simple_transpose, 1);
 }

--- a/Source/Lib/Common/Codec/fft_common.h
+++ b/Source/Lib/Common/Codec/fft_common.h
@@ -47,10 +47,10 @@ extern "C" {
 
     // Declare some of the forward non-vectorized transforms which are used in some
     // of the vectorized implementations
-    void aom_fft1d_4_float(const float *input, float *output, int32_t stride);
-    void aom_fft1d_8_float(const float *input, float *output, int32_t stride);
-    void aom_fft1d_16_float(const float *input, float *output, int32_t stride);
-    void aom_fft1d_32_float(const float *input, float *output, int32_t stride);
+    void eb_aom_fft1d_4_float(const float *input, float *output, int32_t stride);
+    void eb_aom_fft1d_8_float(const float *input, float *output, int32_t stride);
+    void eb_aom_fft1d_16_float(const float *input, float *output, int32_t stride);
+    void eb_aom_fft1d_32_float(const float *input, float *output, int32_t stride);
 
     /**\!brief Function pointer for transposing a matrix of floats.
      *
@@ -87,7 +87,7 @@ extern "C" {
      * \param[in]  vec_size  Vector size (the transform is done vec_size units at
      *                       a time)
      */
-    void aom_fft_2d_gen(const float *input, float *temp, float *output, int32_t n,
+    void eb_aom_fft_2d_gen(const float *input, float *temp, float *output, int32_t n,
         aom_fft_1d_func_t tform, aom_fft_transpose_func_t transpose,
         aom_fft_unpack_func_t unpack, int32_t vec_size);
 
@@ -103,7 +103,7 @@ extern "C" {
      * \param[in]  vec_size   Vector size (the transform is done vec_size
      *                        units at a time)
      */
-    void aom_ifft_2d_gen(const float *input, float *temp, float *output, int32_t n,
+    void eb_aom_ifft_2d_gen(const float *input, float *temp, float *output, int32_t n,
         aom_fft_1d_func_t fft_single, aom_fft_1d_func_t fft_multi,
         aom_fft_1d_func_t ifft_multi,
         aom_fft_transpose_func_t transpose, int32_t vec_size);
@@ -115,7 +115,7 @@ extern "C" {
 // different simd vector intrinsic types.
 
 #define GEN_FFT_2(ret, suffix, T, T_VEC, load, store)               \
-  ret aom_fft1d_2_##suffix(const T *input, T *output, int32_t stride) { \
+  ret eb_aom_fft1d_2_##suffix(const T *input, T *output, int32_t stride) { \
     const T_VEC i0 = load(input + 0 * stride);                      \
     const T_VEC i1 = load(input + 1 * stride);                      \
     store(output + 0 * stride, i0 + i1);                            \
@@ -123,7 +123,7 @@ extern "C" {
   }
 
 #define GEN_FFT_4(ret, suffix, T, T_VEC, load, store, constant, add, sub) \
-  ret aom_fft1d_4_##suffix(const T *input, T *output, int32_t stride) {       \
+  ret eb_aom_fft1d_4_##suffix(const T *input, T *output, int32_t stride) {       \
     const T_VEC kWeight0 = constant(0.0f);                                \
     const T_VEC i0 = load(input + 0 * stride);                            \
     const T_VEC i1 = load(input + 1 * stride);                            \
@@ -140,7 +140,7 @@ extern "C" {
   }
 
 #define GEN_FFT_8(ret, suffix, T, T_VEC, load, store, constant, add, sub, mul) \
-  ret aom_fft1d_8_##suffix(const T *input, T *output, int32_t stride) {            \
+  ret eb_aom_fft1d_8_##suffix(const T *input, T *output, int32_t stride) {            \
     const T_VEC kWeight0 = constant(0.0f);                                     \
     const T_VEC kWeight2 = constant(0.707107f);                                \
     const T_VEC i0 = load(input + 0 * stride);                                 \
@@ -176,7 +176,7 @@ extern "C" {
 
 #define GEN_FFT_16(ret, suffix, T, T_VEC, load, store, constant, add, sub, \
                    mul)                                                    \
-  ret aom_fft1d_16_##suffix(const T *input, T *output, int32_t stride) {       \
+  ret eb_aom_fft1d_16_##suffix(const T *input, T *output, int32_t stride) {       \
     const T_VEC kWeight0 = constant(0.0f);                                 \
     const T_VEC kWeight2 = constant(0.707107f);                            \
     const T_VEC kWeight3 = constant(0.92388f);                             \
@@ -268,7 +268,7 @@ extern "C" {
 
 #define GEN_FFT_32(ret, suffix, T, T_VEC, load, store, constant, add, sub,   \
                    mul)                                                      \
-  ret aom_fft1d_32_##suffix(const T *input, T *output, int32_t stride) {         \
+  ret eb_aom_fft1d_32_##suffix(const T *input, T *output, int32_t stride) {         \
     const T_VEC kWeight0 = constant(0.0f);                                   \
     const T_VEC kWeight2 = constant(0.707107f);                              \
     const T_VEC kWeight3 = constant(0.92388f);                               \
@@ -511,7 +511,7 @@ extern "C" {
   }
 
 #define GEN_IFFT_2(ret, suffix, T, T_VEC, load, store)               \
-  ret aom_ifft1d_2_##suffix(const T *input, T *output, int32_t stride) { \
+  ret eb_aom_ifft1d_2_##suffix(const T *input, T *output, int32_t stride) { \
     const T_VEC i0 = load(input + 0 * stride);                       \
     const T_VEC i1 = load(input + 1 * stride);                       \
     store(output + 0 * stride, i0 + i1);                             \
@@ -519,7 +519,7 @@ extern "C" {
   }
 
 #define GEN_IFFT_4(ret, suffix, T, T_VEC, load, store, constant, add, sub) \
-  ret aom_ifft1d_4_##suffix(const T *input, T *output, int32_t stride) {       \
+  ret eb_aom_ifft1d_4_##suffix(const T *input, T *output, int32_t stride) {       \
     const T_VEC kWeight0 = constant(0.0f);                                 \
     const T_VEC i0 = load(input + 0 * stride);                             \
     const T_VEC i1 = load(input + 1 * stride);                             \
@@ -537,7 +537,7 @@ extern "C" {
 
 #define GEN_IFFT_8(ret, suffix, T, T_VEC, load, store, constant, add, sub, \
                    mul)                                                    \
-  ret aom_ifft1d_8_##suffix(const T *input, T *output, int32_t stride) {       \
+  ret eb_aom_ifft1d_8_##suffix(const T *input, T *output, int32_t stride) {       \
     const T_VEC kWeight0 = constant(0.0f);                                 \
     const T_VEC kWeight2 = constant(0.707107f);                            \
     const T_VEC i0 = load(input + 0 * stride);                             \
@@ -581,7 +581,7 @@ extern "C" {
 
 #define GEN_IFFT_16(ret, suffix, T, T_VEC, load, store, constant, add, sub,   \
                     mul)                                                      \
-  ret aom_ifft1d_16_##suffix(const T *input, T *output, int32_t stride) {         \
+  ret eb_aom_ifft1d_16_##suffix(const T *input, T *output, int32_t stride) {         \
     const T_VEC kWeight0 = constant(0.0f);                                    \
     const T_VEC kWeight2 = constant(0.707107f);                               \
     const T_VEC kWeight3 = constant(0.92388f);                                \
@@ -696,7 +696,7 @@ extern "C" {
   }
 #define GEN_IFFT_32(ret, suffix, T, T_VEC, load, store, constant, add, sub,    \
                     mul)                                                       \
-  ret aom_ifft1d_32_##suffix(const T *input, T *output, int32_t stride) {          \
+  ret eb_aom_ifft1d_32_##suffix(const T *input, T *output, int32_t stride) {          \
     const T_VEC kWeight0 = constant(0.0f);                                     \
     const T_VEC kWeight2 = constant(0.707107f);                                \
     const T_VEC kWeight3 = constant(0.92388f);                                 \

--- a/Source/Lib/Common/Codec/grainSynthesis.c
+++ b/Source/Lib/Common/Codec/grainSynthesis.c
@@ -275,7 +275,7 @@ static void *GetActualMallocAddress(void *const mem) {
     return (void *)(*malloc_addr_location);
 }
 
-void *aom_memalign(size_t align, size_t size) {
+void *eb_aom_memalign(size_t align, size_t size) {
     void *x = NULL;
     const size_t aligned_size = GetAlignedMallocSize(size, align);
 #if defined(AOM_MAX_ALLOCABLE_MEMORY)
@@ -289,9 +289,9 @@ void *aom_memalign(size_t align, size_t size) {
     return x;
 }
 
-void *aom_malloc(size_t size) { return aom_memalign(DEFAULT_ALIGNMENT, size); }
+void *eb_aom_malloc(size_t size) { return eb_aom_memalign(DEFAULT_ALIGNMENT, size); }
 
-void aom_free(void *memblk) {
+void eb_aom_free(void *memblk) {
     if (memblk) {
         void *addr = GetActualMallocAddress(memblk);
         free(addr);
@@ -980,7 +980,7 @@ static void hor_boundary_overlap(int32_t *top_block, int32_t top_stride,
     }
 }
 
-void av1_add_film_grain_run(aom_film_grain_t *params, uint8_t *luma,
+void eb_av1_add_film_grain_run(aom_film_grain_t *params, uint8_t *luma,
     uint8_t *cb, uint8_t *cr, int32_t height, int32_t width,
     int32_t luma_stride, int32_t chroma_stride,
     int32_t use_high_bit_depth, int32_t chroma_subsamp_y,
@@ -1373,35 +1373,35 @@ void av1_add_film_grain_run(aom_film_grain_t *params, uint8_t *luma,
 void av1_film_grain_write_updated(const aom_film_grain_t *pars,
                                   int32_t monochrome,
                                   struct AomWriteBitBuffer *wb) {
-  aom_wb_write_literal(wb, pars->num_y_points, 4);  // max 14
+  eb_aom_wb_write_literal(wb, pars->num_y_points, 4);  // max 14
   for (int32_t i = 0; i < pars->num_y_points; i++) {
-    aom_wb_write_literal(wb, pars->scaling_points_y[i][0], 8);
-    aom_wb_write_literal(wb, pars->scaling_points_y[i][1], 8);
+    eb_aom_wb_write_literal(wb, pars->scaling_points_y[i][0], 8);
+    eb_aom_wb_write_literal(wb, pars->scaling_points_y[i][1], 8);
   }
 
   if (!monochrome)
-    aom_wb_write_bit(wb, pars->chroma_scaling_from_luma);
+    eb_aom_wb_write_bit(wb, pars->chroma_scaling_from_luma);
 
   if (!(monochrome || pars->chroma_scaling_from_luma)) {
-    aom_wb_write_literal(wb, pars->num_cb_points, 4);  // max 10
+    eb_aom_wb_write_literal(wb, pars->num_cb_points, 4);  // max 10
     for (int32_t i = 0; i < pars->num_cb_points; i++) {
-      aom_wb_write_literal(wb, pars->scaling_points_cb[i][0], 8);
-      aom_wb_write_literal(wb, pars->scaling_points_cb[i][1], 8);
+      eb_aom_wb_write_literal(wb, pars->scaling_points_cb[i][0], 8);
+      eb_aom_wb_write_literal(wb, pars->scaling_points_cb[i][1], 8);
     }
 
-    aom_wb_write_literal(wb, pars->num_cr_points, 4);  // max 10
+    eb_aom_wb_write_literal(wb, pars->num_cr_points, 4);  // max 10
     for (int32_t i = 0; i < pars->num_cr_points; i++) {
-      aom_wb_write_literal(wb, pars->scaling_points_cr[i][0], 8);
-      aom_wb_write_literal(wb, pars->scaling_points_cr[i][1], 8);
+      eb_aom_wb_write_literal(wb, pars->scaling_points_cr[i][0], 8);
+      eb_aom_wb_write_literal(wb, pars->scaling_points_cr[i][1], 8);
     }
   }
 
-  aom_wb_write_literal(wb, pars->scaling_shift - 8, 2);  // 8 + value
+  eb_aom_wb_write_literal(wb, pars->scaling_shift - 8, 2);  // 8 + value
 
   // AR coefficients
   // Only sent if the corresponsing scaling function has
   // more than 0 points
-  aom_wb_write_literal(wb, pars->ar_coeff_lag, 2);
+  eb_aom_wb_write_literal(wb, pars->ar_coeff_lag, 2);
 
   int32_t num_pos_luma = 2 * pars->ar_coeff_lag * (pars->ar_coeff_lag + 1);
   int32_t num_pos_chroma = num_pos_luma;
@@ -1409,35 +1409,35 @@ void av1_film_grain_write_updated(const aom_film_grain_t *pars,
 
   if (pars->num_y_points)
     for (int32_t i = 0; i < num_pos_luma; i++)
-      aom_wb_write_literal(wb, pars->ar_coeffs_y[i] + 128, 8);
+      eb_aom_wb_write_literal(wb, pars->ar_coeffs_y[i] + 128, 8);
 
   if (pars->num_cb_points || pars->chroma_scaling_from_luma)
     for (int32_t i = 0; i < num_pos_chroma; i++)
-      aom_wb_write_literal(wb, pars->ar_coeffs_cb[i] + 128, 8);
+      eb_aom_wb_write_literal(wb, pars->ar_coeffs_cb[i] + 128, 8);
 
   if (pars->num_cr_points || pars->chroma_scaling_from_luma)
     for (int32_t i = 0; i < num_pos_chroma; i++)
-      aom_wb_write_literal(wb, pars->ar_coeffs_cr[i] + 128, 8);
+      eb_aom_wb_write_literal(wb, pars->ar_coeffs_cr[i] + 128, 8);
 
-  aom_wb_write_literal(wb, pars->ar_coeff_shift - 6, 2);  // 8 + value
+  eb_aom_wb_write_literal(wb, pars->ar_coeff_shift - 6, 2);  // 8 + value
 
-  aom_wb_write_literal(wb, pars->grain_scale_shift, 2);
+  eb_aom_wb_write_literal(wb, pars->grain_scale_shift, 2);
 
   if (pars->num_cb_points) {
-    aom_wb_write_literal(wb, pars->cb_mult, 8);
-    aom_wb_write_literal(wb, pars->cb_luma_mult, 8);
-    aom_wb_write_literal(wb, pars->cb_offset, 9);
+    eb_aom_wb_write_literal(wb, pars->cb_mult, 8);
+    eb_aom_wb_write_literal(wb, pars->cb_luma_mult, 8);
+    eb_aom_wb_write_literal(wb, pars->cb_offset, 9);
   }
 
   if (pars->num_cr_points) {
-    aom_wb_write_literal(wb, pars->cr_mult, 8);
-    aom_wb_write_literal(wb, pars->cr_luma_mult, 8);
-    aom_wb_write_literal(wb, pars->cr_offset, 9);
+    eb_aom_wb_write_literal(wb, pars->cr_mult, 8);
+    eb_aom_wb_write_literal(wb, pars->cr_luma_mult, 8);
+    eb_aom_wb_write_literal(wb, pars->cr_offset, 9);
   }
 
-  aom_wb_write_bit(wb, pars->overlap_flag);
+  eb_aom_wb_write_bit(wb, pars->overlap_flag);
 
-  aom_wb_write_bit(wb, pars->clip_to_restricted_range);
+  eb_aom_wb_write_bit(wb, pars->clip_to_restricted_range);
 }
 */
 /*

--- a/Source/Lib/Common/Codec/grainSynthesis.h
+++ b/Source/Lib/Common/Codec/grainSynthesis.h
@@ -95,7 +95,7 @@ extern "C" {
      * \param[in]    luma_stride      luma plane stride
      * \param[in]    chroma_stride    chroma plane stride
      */
-    void av1_add_film_grain_run(aom_film_grain_t *grain_params, uint8_t *luma,
+    void eb_av1_add_film_grain_run(aom_film_grain_t *grain_params, uint8_t *luma,
         uint8_t *cb, uint8_t *cr, int32_t height, int32_t width,
         int32_t luma_stride, int32_t chroma_stride,
         int32_t use_high_bit_depth, int32_t chroma_subsamp_y,
@@ -110,7 +110,7 @@ extern "C" {
      * \param[in]    dst              Resulting image with grain
      */
 
-     //void av1_add_film_grain(aom_film_grain_t *grain_params, EbPictureBufferDesc *src,
+     //void eb_av1_add_film_grain(aom_film_grain_t *grain_params, EbPictureBufferDesc *src,
      //        EbPictureBufferDesc *dst);
 
      //void av1_film_grain_write_updated(const aom_film_grain_t *pars,

--- a/Source/Lib/Common/Codec/hash_motion.c
+++ b/Source/Lib/Common/Codec/hash_motion.c
@@ -16,7 +16,7 @@
 #include "hash_motion.h"
 #include "EbPictureControlSet.h"
 
-void aom_free(void *memblk);
+void eb_aom_free(void *memblk);
 static const int crc_bits = 16;
 static const int block_size_bits = 3;
 
@@ -26,8 +26,8 @@ static void hash_table_clear_all(HashTable *p_hash_table) {
   int max_addr = 1 << (crc_bits + block_size_bits);
   for (int i = 0; i < max_addr; i++) {
     if (p_hash_table->p_lookup_table[i] != NULL) {
-      aom_vector_destroy(p_hash_table->p_lookup_table[i]);
-      aom_free(p_hash_table->p_lookup_table[i]);
+      eb_aom_vector_destroy(p_hash_table->p_lookup_table[i]);
+      eb_aom_free(p_hash_table->p_lookup_table[i]);
       p_hash_table->p_lookup_table[i] = NULL;
     }
   }
@@ -132,12 +132,12 @@ static void hash_table_add_to_table(HashTable *p_hash_table,
   if (p_hash_table->p_lookup_table[hash_value] == NULL) {
     p_hash_table->p_lookup_table[hash_value] =
         malloc(sizeof(p_hash_table->p_lookup_table[0][0]));
-    aom_vector_setup(p_hash_table->p_lookup_table[hash_value], 10,
+    eb_aom_vector_setup(p_hash_table->p_lookup_table[hash_value], 10,
                      sizeof(curr_block_hash[0]));
-    aom_vector_push_back(p_hash_table->p_lookup_table[hash_value],
+    eb_aom_vector_push_back(p_hash_table->p_lookup_table[hash_value],
                          curr_block_hash);
   } else {
-    aom_vector_push_back(p_hash_table->p_lookup_table[hash_value],
+    eb_aom_vector_push_back(p_hash_table->p_lookup_table[hash_value],
                          curr_block_hash);
   }
 }
@@ -153,7 +153,7 @@ int32_t av1_hash_table_count(const HashTable *p_hash_table,
 Iterator av1_hash_get_first_iterator(HashTable *p_hash_table,
                                      uint32_t hash_value) {
   assert(av1_hash_table_count(p_hash_table, hash_value) > 0);
-  return aom_vector_begin(p_hash_table->p_lookup_table[hash_value]);
+  return eb_aom_vector_begin(p_hash_table->p_lookup_table[hash_value]);
 }
 
 int32_t av1_has_exact_match(HashTable *p_hash_table, uint32_t hash_value1,
@@ -161,8 +161,8 @@ int32_t av1_has_exact_match(HashTable *p_hash_table, uint32_t hash_value1,
   if (p_hash_table->p_lookup_table[hash_value1] == NULL)
     return 0;
   Iterator iterator =
-      aom_vector_begin(p_hash_table->p_lookup_table[hash_value1]);
-  Iterator last = aom_vector_end(p_hash_table->p_lookup_table[hash_value1]);
+      eb_aom_vector_begin(p_hash_table->p_lookup_table[hash_value1]);
+  Iterator last = eb_aom_vector_end(p_hash_table->p_lookup_table[hash_value1]);
   for (; !iterator_equals(&iterator, &last); iterator_increment(&iterator)) {
     if ((*(block_hash *)iterator_get(&iterator)).hash_value2 == hash_value2)
       return 1;

--- a/Source/Lib/Common/Codec/noise_model.c
+++ b/Source/Lib/Common/Codec/noise_model.c
@@ -20,8 +20,8 @@
 
 static const int32_t kMaxLag = 4;
 
-void *aom_memalign(size_t align, size_t size);
-void aom_free(void *memblk);
+void *eb_aom_memalign(size_t align, size_t size);
+void eb_aom_free(void *memblk);
 
 void un_pack2d(
     uint16_t      *in16_bit_buffer,
@@ -228,7 +228,7 @@ static int32_t noise_state_init(aom_noise_state_t *state, int32_t n, int32_t bit
     }
     state->ar_gain = 1.0;
     state->num_observations = 0;
-    return aom_noise_strength_solver_init(&state->strength_solver, kNumBins,
+    return eb_aom_noise_strength_solver_init(&state->strength_solver, kNumBins,
         bit_depth);
 }
 
@@ -242,7 +242,7 @@ static void set_chroma_coefficient_fallback_soln(aom_equation_system_t *eqns) {
         eqns->x[last] = eqns->b[last] / eqns->A[last * eqns->n + last];
 }
 
-int32_t aom_noise_strength_lut_init(aom_noise_strength_lut_t *lut, int32_t num_points) {
+int32_t eb_aom_noise_strength_lut_init(aom_noise_strength_lut_t *lut, int32_t num_points) {
     if (!lut) return 0;
     lut->points = (double(*)[2])malloc(num_points * sizeof(*lut->points));
     if (!lut->points) return 0;
@@ -251,13 +251,13 @@ int32_t aom_noise_strength_lut_init(aom_noise_strength_lut_t *lut, int32_t num_p
     return 1;
 }
 
-void aom_noise_strength_lut_free(aom_noise_strength_lut_t *lut) {
+void eb_aom_noise_strength_lut_free(aom_noise_strength_lut_t *lut) {
     if (!lut) return;
     free(lut->points);
     memset(lut, 0, sizeof(*lut));
 }
 
-double aom_noise_strength_lut_eval(const aom_noise_strength_lut_t *lut,
+double eb_aom_noise_strength_lut_eval(const aom_noise_strength_lut_t *lut,
     double x) {
     int32_t i = 0;
     // Constant extrapolation for x <  x_0.
@@ -290,7 +290,7 @@ static double noise_strength_solver_get_value(
     return (1.0 - a) * solver->eqns.x[bin_i0] + a * solver->eqns.x[bin_i1];
 }
 
-void aom_noise_strength_solver_add_measurement(
+void eb_aom_noise_strength_solver_add_measurement(
     aom_noise_strength_solver_t *solver, double block_mean, double noise_std) {
     const double bin = noise_strength_solver_get_bin_index(solver, block_mean);
     const int32_t bin_i0 = (int32_t)floor(bin);
@@ -307,7 +307,7 @@ void aom_noise_strength_solver_add_measurement(
     solver->num_equations++;
 }
 
-int32_t aom_noise_strength_solver_solve(aom_noise_strength_solver_t *solver) {
+int32_t eb_aom_noise_strength_solver_solve(aom_noise_strength_solver_t *solver) {
     // Add regularization proportional to the number of constraints
     const int32_t n = solver->num_bins;
     const double kAlpha = 2.0 * (double)(solver->num_equations) / n;
@@ -345,7 +345,7 @@ int32_t aom_noise_strength_solver_solve(aom_noise_strength_solver_t *solver) {
     return result;
 }
 
-int32_t aom_noise_strength_solver_init(aom_noise_strength_solver_t *solver,
+int32_t eb_aom_noise_strength_solver_init(aom_noise_strength_solver_t *solver,
     int32_t num_bins, int32_t bit_depth) {
     if (!solver) return 0;
     memset(solver, 0, sizeof(*solver));
@@ -357,7 +357,7 @@ int32_t aom_noise_strength_solver_init(aom_noise_strength_solver_t *solver,
     return equation_system_init(&solver->eqns, num_bins);
 }
 
-double aom_noise_strength_solver_get_center(
+double eb_aom_noise_strength_solver_get_center(
     const aom_noise_strength_solver_t *solver, int32_t i) {
     const double range = solver->max_intensity - solver->min_intensity;
     const int32_t n = solver->num_bins;
@@ -379,7 +379,7 @@ static void update_piecewise_linear_residual(
                 solver, lut->points[i + 1][0])));
         double r = 0;
         for (int32_t j = lower; j <= upper; ++j) {
-            const double x = aom_noise_strength_solver_get_center(solver, j);
+            const double x = eb_aom_noise_strength_solver_get_center(solver, j);
             if (x < lut->points[i - 1][0]) continue;
             if (x >= lut->points[i + 1][0]) continue;
             const double y = solver->eqns.x[j];
@@ -393,18 +393,18 @@ static void update_piecewise_linear_residual(
     }
 }
 
-int32_t aom_noise_strength_solver_fit_piecewise(
+int32_t eb_aom_noise_strength_solver_fit_piecewise(
     const aom_noise_strength_solver_t *solver, int32_t max_output_points,
     aom_noise_strength_lut_t *lut) {
     // The tolerance is normalized to be give consistent results between
     // different bit-depths.
     const double kTolerance = solver->max_intensity * 0.00625 / 255.0;
-    if (!aom_noise_strength_lut_init(lut, solver->num_bins)) {
+    if (!eb_aom_noise_strength_lut_init(lut, solver->num_bins)) {
         fprintf(stderr, "Failed to init lut\n");
         return 0;
     }
     for (int32_t i = 0; i < solver->num_bins; ++i) {
-        lut->points[i][0] = aom_noise_strength_solver_get_center(solver, i);
+        lut->points[i][0] = eb_aom_noise_strength_solver_get_center(solver, i);
         lut->points[i][1] = solver->eqns.x[i];
     }
     if (max_output_points < 0)
@@ -440,7 +440,7 @@ int32_t aom_noise_strength_solver_fit_piecewise(
     return 1;
 }
 
-int32_t aom_flat_block_finder_init(aom_flat_block_finder_t *block_finder,
+int32_t eb_aom_flat_block_finder_init(aom_flat_block_finder_t *block_finder,
     int32_t block_size, int32_t bit_depth, int32_t use_highbd) {
     const int32_t n = block_size * block_size;
     aom_equation_system_t eqns;
@@ -501,14 +501,14 @@ int32_t aom_flat_block_finder_init(aom_flat_block_finder_t *block_finder,
     return 1;
 }
 
-void aom_flat_block_finder_free(aom_flat_block_finder_t *block_finder) {
+void eb_aom_flat_block_finder_free(aom_flat_block_finder_t *block_finder) {
     if (!block_finder) return;
     free(block_finder->A);
     free(block_finder->AtA_inv);
     memset(block_finder, 0, sizeof(*block_finder));
 }
 
-void aom_flat_block_finder_extract_block(
+void eb_aom_flat_block_finder_extract_block(
     const aom_flat_block_finder_t *block_finder, const uint8_t *const data,
     int32_t w, int32_t h, int32_t stride, int32_t offsx, int32_t offsy, double *plane,
     double *block) {
@@ -565,7 +565,7 @@ static int32_t compare_scores(const void *a, const void *b) {
     return 0;
 }
 
-int32_t aom_flat_block_finder_run(const aom_flat_block_finder_t *block_finder,
+int32_t eb_aom_flat_block_finder_run(const aom_flat_block_finder_t *block_finder,
     const uint8_t *const data, int32_t w, int32_t h,
     int32_t stride, uint8_t *flat_blocks) {
     // The gradient-based features used in this code are based on:
@@ -605,7 +605,7 @@ int32_t aom_flat_block_finder_run(const aom_flat_block_finder_t *block_finder,
             double var = 0;
             double mean = 0;
             int32_t xi, yi;
-            aom_flat_block_finder_extract_block(block_finder, data, w, h, stride,
+            eb_aom_flat_block_finder_extract_block(block_finder, data, w, h, stride,
                 bx * block_size, by * block_size,
                 plane, block);
 
@@ -690,7 +690,7 @@ int32_t aom_flat_block_finder_run(const aom_flat_block_finder_t *block_finder,
     return num_flat;
 }
 
-int32_t aom_noise_model_init(aom_noise_model_t *model,
+int32_t eb_aom_noise_model_init(aom_noise_model_t *model,
     const aom_noise_model_params_t params) {
     const int32_t n = num_coeffs(params);
     const int32_t lag = params.lag;
@@ -712,12 +712,12 @@ int32_t aom_noise_model_init(aom_noise_model_t *model,
     for (c = 0; c < 3; ++c) {
         if (!noise_state_init(&model->combined_state[c], n + (c > 0), bit_depth)) {
             fprintf(stderr, "Failed to allocate noise state for channel %d\n", c);
-            aom_noise_model_free(model);
+            eb_aom_noise_model_free(model);
             return 0;
         }
         if (!noise_state_init(&model->latest_state[c], n + (c > 0), bit_depth)) {
             fprintf(stderr, "Failed to allocate noise state for channel %d\n", c);
-            aom_noise_model_free(model);
+            eb_aom_noise_model_free(model);
             return 0;
         }
     }
@@ -742,7 +742,7 @@ int32_t aom_noise_model_init(aom_noise_model_t *model,
                 break;
             default:
                 fprintf(stderr, "Invalid shape\n");
-                aom_noise_model_free(model);
+                eb_aom_noise_model_free(model);
                 return 0;
             }
         }
@@ -751,7 +751,7 @@ int32_t aom_noise_model_init(aom_noise_model_t *model,
     return 1;
 }
 
-void aom_noise_model_free(aom_noise_model_t *model) {
+void eb_aom_noise_model_free(aom_noise_model_t *model) {
     int32_t c = 0;
     if (!model) return;
 
@@ -925,7 +925,7 @@ static void add_noise_std_observations(
                 // After we've removed correlation with luma, undo the gain that will
                 // come from running the IIR filter.
                 const double adjusted_strength = uncorr_std / noise_gain;
-                aom_noise_strength_solver_add_measurement(
+                eb_aom_noise_strength_solver_add_measurement(
                     noise_strength_solver, block_mean, adjusted_strength);
             }
         }
@@ -946,7 +946,7 @@ static int32_t is_noise_model_different(aom_noise_model_t *const noise_model) {
       0.005 * (1 << (noise_model->params.bit_depth - 8));
   for (int32_t c = 0; c < 1; ++c) {
     const double corr =
-        aom_normalized_cross_correlation(noise_model->latest_state[c].eqns.x,
+        eb_aom_normalized_cross_correlation(noise_model->latest_state[c].eqns.x,
                                          noise_model->combined_state[c].eqns.x,
                                          noise_model->combined_state[c].eqns.n);
     if (corr < kCoeffThreshold) return 1;
@@ -1010,7 +1010,7 @@ static int32_t ar_equation_system_solve(aom_noise_state_t *state, int32_t is_chr
     return ret;
 }
 
-aom_noise_status_t aom_noise_model_update(
+aom_noise_status_t eb_aom_noise_model_update(
     aom_noise_model_t *const noise_model, const uint8_t *const data[3],
     const uint8_t *const denoised[3], int32_t w, int32_t h, int32_t stride[3],
     int32_t chroma_sub_log2[2], const uint8_t *const flat_blocks, int32_t block_size) {
@@ -1082,7 +1082,7 @@ aom_noise_status_t aom_noise_model_update(
             data[channel], denoised[channel], w, h, stride[channel], sub, alt_data,
             stride[0], flat_blocks, block_size, num_blocks_w, num_blocks_h);
 
-        if (!aom_noise_strength_solver_solve(
+        if (!eb_aom_noise_strength_solver_solve(
             &noise_model->latest_state[channel].strength_solver)) {
             fprintf(stderr, "Solving latest noise strength failed!\n");
             return AOM_NOISE_STATUS_INTERNAL_ERROR;
@@ -1117,7 +1117,7 @@ aom_noise_status_t aom_noise_model_update(
             &noise_model->combined_state[channel].strength_solver,
             &noise_model->latest_state[channel].strength_solver);
 
-        if (!aom_noise_strength_solver_solve(
+        if (!eb_aom_noise_strength_solver_solve(
             &noise_model->combined_state[channel].strength_solver)) {
             fprintf(stderr, "Solving combined noise strength failed!\n");
             return AOM_NOISE_STATUS_INTERNAL_ERROR;
@@ -1127,7 +1127,7 @@ aom_noise_status_t aom_noise_model_update(
     return AOM_NOISE_STATUS_OK;
 }
 
-void aom_noise_model_save_latest(aom_noise_model_t *noise_model) {
+void eb_aom_noise_model_save_latest(aom_noise_model_t *noise_model) {
     for (int32_t c = 0; c < 3; c++) {
         equation_system_copy(&noise_model->combined_state[c].eqns,
             &noise_model->latest_state[c].eqns);
@@ -1142,7 +1142,7 @@ void aom_noise_model_save_latest(aom_noise_model_t *noise_model) {
     }
 }
 
-int32_t aom_noise_model_get_grain_parameters(aom_noise_model_t *const noise_model,
+int32_t eb_aom_noise_model_get_grain_parameters(aom_noise_model_t *const noise_model,
     aom_film_grain_t *film_grain) {
     if (noise_model->params.lag > 3) {
         fprintf(stderr, "params.lag = %d > 3\n", noise_model->params.lag);
@@ -1159,11 +1159,11 @@ int32_t aom_noise_model_get_grain_parameters(aom_noise_model_t *const noise_mode
 
     // Convert the scaling functions to 8 bit values
     aom_noise_strength_lut_t scaling_points[3];
-    aom_noise_strength_solver_fit_piecewise(
+    eb_aom_noise_strength_solver_fit_piecewise(
         &noise_model->combined_state[0].strength_solver, 14, scaling_points + 0);
-    aom_noise_strength_solver_fit_piecewise(
+    eb_aom_noise_strength_solver_fit_piecewise(
         &noise_model->combined_state[1].strength_solver, 10, scaling_points + 1);
-    aom_noise_strength_solver_fit_piecewise(
+    eb_aom_noise_strength_solver_fit_piecewise(
         &noise_model->combined_state[2].strength_solver, 10, scaling_points + 2);
 
     // Both the domain and the range of the scaling functions in the film_grain
@@ -1204,9 +1204,9 @@ int32_t aom_noise_model_get_grain_parameters(aom_noise_model_t *const noise_mode
                 (int32_t)(scale_factor * scaling_points[c].points[i][1] + 0.5), 0, 255);
         }
     }
-    aom_noise_strength_lut_free(scaling_points + 0);
-    aom_noise_strength_lut_free(scaling_points + 1);
-    aom_noise_strength_lut_free(scaling_points + 2);
+    eb_aom_noise_strength_lut_free(scaling_points + 0);
+    eb_aom_noise_strength_lut_free(scaling_points + 1);
+    eb_aom_noise_strength_lut_free(scaling_points + 2);
 
     // Convert the ar_coeffs into 8-bit values
     const int32_t n_coeff = noise_model->combined_state[0].eqns.n;
@@ -1338,7 +1338,7 @@ static float *get_half_cos_window(int32_t block_size) {
 DITHER_AND_QUANTIZE(uint8_t, lowbd);
 DITHER_AND_QUANTIZE(uint16_t, highbd);
 
-int32_t aom_wiener_denoise_2d(const uint8_t *const data[3], uint8_t *denoised[3],
+int32_t eb_aom_wiener_denoise_2d(const uint8_t *const data[3], uint8_t *denoised[3],
     int32_t w, int32_t h, int32_t stride[3], int32_t chroma_sub[2],
     float *noise_psd[3], int32_t block_size, int32_t bit_depth,
     int32_t use_highbd) {
@@ -1360,28 +1360,28 @@ int32_t aom_wiener_denoise_2d(const uint8_t *const data[3], uint8_t *denoised[3]
     const float kBlockNormalization = (float)((1 << bit_depth) - 1);
     if (chroma_sub[0] != chroma_sub[1]) {
         fprintf(stderr,
-            "aom_wiener_denoise_2d doesn't handle different chroma "
+            "eb_aom_wiener_denoise_2d doesn't handle different chroma "
             "subsampling");
         return 0;
     }
-    init_success &= aom_flat_block_finder_init(&block_finder_full, block_size,
+    init_success &= eb_aom_flat_block_finder_init(&block_finder_full, block_size,
         bit_depth, use_highbd);
     result = (float *)malloc((num_blocks_h + 2) * block_size * result_stride *
         sizeof(*result));
     plane = (float *)malloc(block_size * block_size * sizeof(*plane));
     block =
-        (float *)aom_memalign(32, 2 * block_size * block_size * sizeof(*block));
+        (float *)eb_aom_memalign(32, 2 * block_size * block_size * sizeof(*block));
     block_d = (double *)malloc(block_size * block_size * sizeof(*block_d));
     plane_d = (double *)malloc(block_size * block_size * sizeof(*plane_d));
     window_full = get_half_cos_window(block_size);
-    tx_full = aom_noise_tx_malloc(block_size);
+    tx_full = eb_aom_noise_tx_malloc(block_size);
 
     if (chroma_sub[0] != 0) {
-        init_success &= aom_flat_block_finder_init(&block_finder_chroma,
+        init_success &= eb_aom_flat_block_finder_init(&block_finder_chroma,
             block_size >> chroma_sub[0],
             bit_depth, use_highbd);
         window_chroma = get_half_cos_window(block_size >> chroma_sub[0]);
-        tx_chroma = aom_noise_tx_malloc(block_size >> chroma_sub[0]);
+        tx_chroma = eb_aom_noise_tx_malloc(block_size >> chroma_sub[0]);
     }
     else {
         window_chroma = window_full;
@@ -1414,7 +1414,7 @@ int32_t aom_wiener_denoise_2d(const uint8_t *const data[3], uint8_t *denoised[3]
                     for (int32_t bx = -1; bx < num_blocks_w; ++bx) {
                         const int32_t pixels_per_block =
                             (block_size >> chroma_sub_w) * (block_size >> chroma_sub_h);
-                        aom_flat_block_finder_extract_block(
+                        eb_aom_flat_block_finder_extract_block(
                             block_finder, data[c], w >> chroma_sub_w, h >> chroma_sub_h,
                             stride[c], bx * (block_size >> chroma_sub_w) + offsx,
                             by * (block_size >> chroma_sub_h) + offsy, plane_d, block_d);
@@ -1423,9 +1423,9 @@ int32_t aom_wiener_denoise_2d(const uint8_t *const data[3], uint8_t *denoised[3]
                             plane[j] = (float)plane_d[j];
                         }
                         pointwise_multiply(window_function, block, pixels_per_block);
-                        aom_noise_tx_forward(tx, block);
-                        aom_noise_tx_filter(tx, noise_psd[c]);
-                        aom_noise_tx_inverse(tx, block);
+                        eb_aom_noise_tx_forward(tx, block);
+                        eb_aom_noise_tx_filter(tx, noise_psd[c]);
+                        eb_aom_noise_tx_inverse(tx, block);
 
                         // Apply window function to the plane approximation (we will apply
                         // it to the sum of plane + block when composing the results).
@@ -1460,23 +1460,23 @@ int32_t aom_wiener_denoise_2d(const uint8_t *const data[3], uint8_t *denoised[3]
     }
     free(result);
     free(plane);
-    aom_free(block);
+    eb_aom_free(block);
     free(plane_d);
     free(block_d);
     free(window_full);
 
-    aom_noise_tx_free(tx_full);
+    eb_aom_noise_tx_free(tx_full);
 
-    aom_flat_block_finder_free(&block_finder_full);
+    eb_aom_flat_block_finder_free(&block_finder_full);
     if (chroma_sub[0] != 0) {
-        aom_flat_block_finder_free(&block_finder_chroma);
+        eb_aom_flat_block_finder_free(&block_finder_chroma);
         free(window_chroma);
-        aom_noise_tx_free(tx_chroma);
+        eb_aom_noise_tx_free(tx_chroma);
     }
     return init_success;
 }
 
-EbErrorType aom_denoise_and_model_alloc(aom_denoise_and_model_t *ctx,
+EbErrorType eb_aom_denoise_and_model_alloc(aom_denoise_and_model_t *ctx,
     int32_t bit_depth,
     int32_t block_size,
     float noise_level) {
@@ -1500,8 +1500,8 @@ void denoise_and_model_dctor(EbPtr p) {
         EB_FREE_ARRAY(obj->noise_psd[i]);
         EB_FREE_ARRAY(obj->packed[i]);
     }
-    aom_noise_model_free(&obj->noise_model);
-    aom_flat_block_finder_free(&obj->flat_block_finder);
+    eb_aom_noise_model_free(&obj->noise_model);
+    eb_aom_flat_block_finder_free(&obj->flat_block_finder);
 }
 
 
@@ -1517,7 +1517,7 @@ EbErrorType denoise_and_model_ctor(aom_denoise_and_model_t *object_ptr,
 
     object_ptr->dctor = denoise_and_model_dctor;
 
-    return_error = aom_denoise_and_model_alloc(object_ptr,
+    return_error = eb_aom_denoise_and_model_alloc(object_ptr,
         init_data_ptr->encoder_bit_depth > EB_8BIT ? 10 : 8,
         DENOISING_BlockSize,
         (float)(init_data_ptr->noise_level / 10.0));
@@ -1556,8 +1556,8 @@ static int32_t denoise_and_model_realloc_if_necessary(struct aom_denoise_and_mod
     ctx->num_blocks_h = (sd->height + ctx->block_size - 1) / ctx->block_size;
     ctx->flat_blocks = malloc(ctx->num_blocks_w * ctx->num_blocks_h);
 
-    aom_flat_block_finder_free(&ctx->flat_block_finder);
-    if (!aom_flat_block_finder_init(&ctx->flat_block_finder, ctx->block_size,
+    eb_aom_flat_block_finder_free(&ctx->flat_block_finder);
+    if (!eb_aom_flat_block_finder_init(&ctx->flat_block_finder, ctx->block_size,
         ctx->bit_depth, use_highbd)) {
         fprintf(stderr, "Unable to init flat block finder\n");
         return 0;
@@ -1565,8 +1565,8 @@ static int32_t denoise_and_model_realloc_if_necessary(struct aom_denoise_and_mod
 
     const aom_noise_model_params_t params = { AOM_NOISE_SHAPE_SQUARE, 3,
                                               ctx->bit_depth, use_highbd };
-    //  aom_noise_model_free(&ctx->noise_model);
-    if (!aom_noise_model_init(&ctx->noise_model, params)) {
+    //  eb_aom_noise_model_free(&ctx->noise_model);
+    if (!eb_aom_noise_model_init(&ctx->noise_model, params)) {
         fprintf(stderr, "Unable to init noise model\n");
         return 0;
     }
@@ -1574,8 +1574,8 @@ static int32_t denoise_and_model_realloc_if_necessary(struct aom_denoise_and_mod
     // Simply use a flat PSD (although we could use the flat blocks to estimate
     // PSD) those to estimate an actual noise PSD)
     const float y_noise_level =
-        aom_noise_psd_get_default_value(ctx->block_size, ctx->noise_level);
-    const float uv_noise_level = aom_noise_psd_get_default_value(
+        eb_aom_noise_psd_get_default_value(ctx->block_size, ctx->noise_level);
+    const float uv_noise_level = eb_aom_noise_psd_get_default_value(
         ctx->block_size >> chroma_sub_log2[1], ctx->noise_level);
     for (int32_t i = 0; i < block_size * block_size; ++i) {
         ctx->noise_psd[0][i] = y_noise_level;
@@ -1672,7 +1672,7 @@ static void unpack_2d_pic(uint8_t *packed[3],
         asm_type);
 }
 
-int32_t aom_denoise_and_model_run(struct aom_denoise_and_model_t *ctx,
+int32_t eb_aom_denoise_and_model_run(struct aom_denoise_and_model_t *ctx,
     EbPictureBufferDesc *sd,
     aom_film_grain_t *film_grain,
     int32_t use_highbd,
@@ -1704,30 +1704,30 @@ int32_t aom_denoise_and_model_run(struct aom_denoise_and_model_t *ctx,
 
     const uint8_t *const data[3] = { raw_data[0], raw_data[1], raw_data[2] };
 
-    aom_flat_block_finder_run(&ctx->flat_block_finder, data[0], sd->width,
+    eb_aom_flat_block_finder_run(&ctx->flat_block_finder, data[0], sd->width,
         sd->height, strides[0], ctx->flat_blocks);
 
-    if (!aom_wiener_denoise_2d(data, ctx->denoised, sd->width, sd->height,
+    if (!eb_aom_wiener_denoise_2d(data, ctx->denoised, sd->width, sd->height,
         strides, chroma_sub_log2, ctx->noise_psd,
         block_size, ctx->bit_depth, use_highbd)) {
         fprintf(stderr, "Unable to denoise image\n");
         return 0;
     }
 
-    const aom_noise_status_t status = aom_noise_model_update(
+    const aom_noise_status_t status = eb_aom_noise_model_update(
         &ctx->noise_model, data, (const uint8_t *const *)ctx->denoised,
         sd->width, sd->height, strides, chroma_sub_log2, ctx->flat_blocks,
         block_size);
 
     int32_t have_noise_estimate = 0;
     if (status == AOM_NOISE_STATUS_OK || status == AOM_NOISE_STATUS_DIFFERENT_NOISE_TYPE) {
-        aom_noise_model_save_latest(&ctx->noise_model);
+        eb_aom_noise_model_save_latest(&ctx->noise_model);
         have_noise_estimate = 1;
     }
 
     film_grain->apply_grain = 0;
     if (have_noise_estimate) {
-        if (!aom_noise_model_get_grain_parameters(&ctx->noise_model, film_grain)) {
+        if (!eb_aom_noise_model_get_grain_parameters(&ctx->noise_model, film_grain)) {
             fprintf(stderr, "Unable to get grain parameters.\n");
             return 0;
         }
@@ -1744,8 +1744,8 @@ int32_t aom_denoise_and_model_run(struct aom_denoise_and_model_t *ctx,
         else
             unpack_2d_pic(ctx->denoised, sd, asm_type);
     }
-    aom_flat_block_finder_free(&ctx->flat_block_finder);
-    aom_noise_model_free(&ctx->noise_model);
+    eb_aom_flat_block_finder_free(&ctx->flat_block_finder);
+    eb_aom_noise_model_free(&ctx->noise_model);
     free(ctx->flat_blocks);
 
     return 1;

--- a/Source/Lib/Common/Codec/noise_model.h
+++ b/Source/Lib/Common/Codec/noise_model.h
@@ -42,17 +42,17 @@ extern "C" {
     } aom_noise_strength_lut_t;
 
     /*!\brief Init the noise strength lut with the given number of points*/
-    int32_t aom_noise_strength_lut_init(aom_noise_strength_lut_t *lut, int32_t num_points);
+    int32_t eb_aom_noise_strength_lut_init(aom_noise_strength_lut_t *lut, int32_t num_points);
 
     /*!\brief Frees the noise strength lut. */
-    void aom_noise_strength_lut_free(aom_noise_strength_lut_t *lut);
+    void eb_aom_noise_strength_lut_free(aom_noise_strength_lut_t *lut);
 
     /*!\brief Evaluate the lut at the point x.
      *
      * \param[in] lut  The lut data.
      * \param[in] x    The coordinate to evaluate the lut.
      */
-    double aom_noise_strength_lut_eval(const aom_noise_strength_lut_t *lut,
+    double eb_aom_noise_strength_lut_eval(const aom_noise_strength_lut_t *lut,
         double x);
 
     /*!\brief Helper struct to model noise strength as a function of intensity.
@@ -89,13 +89,13 @@ extern "C" {
      * \param[in]  num_bins  Number of bins to use in the internal representation.
      * \param[in]  bit_depth The bit depth used to derive {min,max}_intensity.
      */
-    int32_t aom_noise_strength_solver_init(aom_noise_strength_solver_t *solver,
+    int32_t eb_aom_noise_strength_solver_init(aom_noise_strength_solver_t *solver,
         int32_t num_bins, int32_t bit_depth);
     /*!\brief Gets the x coordinate of bin i.
      *
      * \param[in]  i  The bin whose coordinate to query.
      */
-    double aom_noise_strength_solver_get_center(
+    double eb_aom_noise_strength_solver_get_center(
         const aom_noise_strength_solver_t *solver, int32_t i);
 
     /*!\brief Add an observation of the block mean intensity to its noise strength.
@@ -103,18 +103,18 @@ extern "C" {
      * \param[in]  block_mean  The average block intensity,
      * \param[in]  noise_std   The observed noise strength.
      */
-    void aom_noise_strength_solver_add_measurement(
+    void eb_aom_noise_strength_solver_add_measurement(
         aom_noise_strength_solver_t *solver, double block_mean, double noise_std);
 
     /*!\brief Solves the current set of equations for the noise strength. */
-    int32_t aom_noise_strength_solver_solve(aom_noise_strength_solver_t *solver);
+    int32_t eb_aom_noise_strength_solver_solve(aom_noise_strength_solver_t *solver);
 
     /*!\brief Fits a reduced piecewise linear lut to the internal solution
      *
      * \param[in] max_num_points  The maximum number of output points
      * \param[out] lut  The output piecewise linear lut.
      */
-    int32_t aom_noise_strength_solver_fit_piecewise(
+    int32_t eb_aom_noise_strength_solver_fit_piecewise(
         const aom_noise_strength_solver_t *solver, int32_t max_num_points,
         aom_noise_strength_lut_t *lut);
 
@@ -137,12 +137,12 @@ extern "C" {
     } aom_flat_block_finder_t;
 
     /*!\brief Init the block_finder with the given block size, bit_depth */
-    int32_t aom_flat_block_finder_init(aom_flat_block_finder_t *block_finder,
+    int32_t eb_aom_flat_block_finder_init(aom_flat_block_finder_t *block_finder,
         int32_t block_size, int32_t bit_depth, int32_t use_highbd);
-    void aom_flat_block_finder_free(aom_flat_block_finder_t *block_finder);
+    void eb_aom_flat_block_finder_free(aom_flat_block_finder_t *block_finder);
 
     /*!\brief Helper to extract a block and low order "planar" model. */
-    void aom_flat_block_finder_extract_block(
+    void eb_aom_flat_block_finder_extract_block(
         const aom_flat_block_finder_t *block_finder, const uint8_t *const data,
         int32_t w, int32_t h, int32_t stride, int32_t offsx, int32_t offsy, double *plane,
         double *block);
@@ -154,7 +154,7 @@ extern "C" {
      * when a block is determined to be flat. A higher value indicates a bigger
      * confidence in the decision.
      */
-    int32_t aom_flat_block_finder_run(const aom_flat_block_finder_t *block_finder,
+    int32_t eb_aom_flat_block_finder_run(const aom_flat_block_finder_t *block_finder,
         const uint8_t *const data, int32_t w, int32_t h,
         int32_t stride, uint8_t *flat_blocks);
 
@@ -264,9 +264,9 @@ extern "C" {
      *
      * Returns 0 on failure.
      */
-    int32_t aom_noise_model_init(aom_noise_model_t *model,
+    int32_t eb_aom_noise_model_init(aom_noise_model_t *model,
         const aom_noise_model_params_t params);
-    void aom_noise_model_free(aom_noise_model_t *model);
+    void eb_aom_noise_model_free(aom_noise_model_t *model);
 
     /*!\brief Updates the noise model with a new frame observation.
      *
@@ -289,7 +289,7 @@ extern "C" {
      * \param[in]     flat_blocks     A map to blocks that have been determined flat
      * \param[in]     block_size      The size of blocks.
      */
-    aom_noise_status_t aom_noise_model_update(
+    aom_noise_status_t eb_aom_noise_model_update(
         aom_noise_model_t *const noise_model, const uint8_t *const data[3],
         const uint8_t *const denoised[3], int32_t w, int32_t h, int32_t strides[3],
         int32_t chroma_sub_log2[2], const uint8_t *const flat_blocks, int32_t block_size);
@@ -300,7 +300,7 @@ extern "C" {
      * in parameters (or for example, if a user wanted to reset estimation at
      * a shot boundary).
      */
-    void aom_noise_model_save_latest(aom_noise_model_t *noise_model);
+    void eb_aom_noise_model_save_latest(aom_noise_model_t *noise_model);
 
     /*!\brief Converts the noise_model parameters to the corresponding
      *    grain_parameters.
@@ -309,7 +309,7 @@ extern "C" {
      * floats), but the grain parameters in the bitstream are quantized. This
      * function does the conversion by selecting the correct quantization levels.
      */
-    int32_t aom_noise_model_get_grain_parameters(aom_noise_model_t *const noise_model,
+    int32_t eb_aom_noise_model_get_grain_parameters(aom_noise_model_t *const noise_model,
         aom_film_grain_t *film_grain);
 
     /*!\brief Perform a Wiener filter denoising in 2D using the provided noise psd.
@@ -327,7 +327,7 @@ extern "C" {
      *                                uint16 and stride is measured in uint16.
      *                                This must be true when bit_depth >= 10.
      */
-    int32_t aom_wiener_denoise_2d(const uint8_t *const data[3], uint8_t *denoised[3],
+    int32_t eb_aom_wiener_denoise_2d(const uint8_t *const data[3], uint8_t *denoised[3],
         int32_t w, int32_t h, int32_t stride[3], int32_t chroma_sub_log2[2],
         float *noise_psd[3], int32_t block_size, int32_t bit_depth,
         int32_t use_highbd);
@@ -342,13 +342,13 @@ extern "C" {
      * parameter will be true when the input buffer was successfully denoised and
      * grain was modelled. Returns false on error.
      *
-     * \param[in]      ctx   Struct allocated with aom_denoise_and_model_alloc
+     * \param[in]      ctx   Struct allocated with eb_aom_denoise_and_model_alloc
      *                       that holds some buffers for denoising and the current
      *                       noise estimate.
      * \param[in/out]   buf  The raw input buffer to be denoised.
      * \param[out]    grain  Output film grain parameters
      */
-    int32_t aom_denoise_and_model_run(struct aom_denoise_and_model_t *ctx,
+    int32_t eb_aom_denoise_and_model_run(struct aom_denoise_and_model_t *ctx,
         EbPictureBufferDesc *sd,
         aom_film_grain_t *film_grain,
         int32_t use_highbd,
@@ -363,7 +363,7 @@ extern "C" {
      *                         higher levels of noise)
      */
 
-     /*!\brief Frees the denoise context allocated with aom_denoise_and_model_alloc
+     /*!\brief Frees the denoise context allocated with eb_aom_denoise_and_model_alloc
       */
     void aom_denoise_and_model_free(struct aom_denoise_and_model_t *denoise_model, int32_t use_highbd);
 

--- a/Source/Lib/Common/Codec/noise_util.c
+++ b/Source/Lib/Common/Codec/noise_util.c
@@ -19,10 +19,10 @@
 #include "noise_util.h"
 #include "aom_dsp_rtcd.h"
 
-void *aom_memalign(size_t align, size_t size);
-void aom_free(void *memblk);
+void *eb_aom_memalign(size_t align, size_t size);
+void eb_aom_free(void *memblk);
 
-float aom_noise_psd_get_default_value(int32_t block_size, float factor) {
+float eb_aom_noise_psd_get_default_value(int32_t block_size, float factor) {
     return (factor * factor / 10000) * block_size * block_size / 8;
 }
 
@@ -37,31 +37,31 @@ struct aom_noise_tx_t {
     void(*ifft)(const float *, float *, float *);
 };
 
-struct aom_noise_tx_t *aom_noise_tx_malloc(int32_t block_size) {
+struct aom_noise_tx_t *eb_aom_noise_tx_malloc(int32_t block_size) {
     struct aom_noise_tx_t *noise_tx =
         (struct aom_noise_tx_t *)malloc(sizeof(struct aom_noise_tx_t));
     if (!noise_tx) return NULL;
     memset(noise_tx, 0, sizeof(*noise_tx));
     switch (block_size) {
     case 2:
-        noise_tx->fft = aom_fft2x2_float;
-        noise_tx->ifft = aom_ifft2x2_float;
+        noise_tx->fft = eb_aom_fft2x2_float;
+        noise_tx->ifft = eb_aom_ifft2x2_float;
         break;
     case 4:
-        noise_tx->fft = aom_fft4x4_float;
-        noise_tx->ifft = aom_ifft4x4_float;
+        noise_tx->fft = eb_aom_fft4x4_float;
+        noise_tx->ifft = eb_aom_ifft4x4_float;
         break;
     case 8:
-        noise_tx->fft = aom_fft8x8_float;
-        noise_tx->ifft = aom_ifft8x8_float;
+        noise_tx->fft = eb_aom_fft8x8_float;
+        noise_tx->ifft = eb_aom_ifft8x8_float;
         break;
     case 16:
-        noise_tx->fft = aom_fft16x16_float;
-        noise_tx->ifft = aom_ifft16x16_float;
+        noise_tx->fft = eb_aom_fft16x16_float;
+        noise_tx->ifft = eb_aom_ifft16x16_float;
         break;
     case 32:
-        noise_tx->fft = aom_fft32x32_float;
-        noise_tx->ifft = aom_ifft32x32_float;
+        noise_tx->fft = eb_aom_fft32x32_float;
+        noise_tx->ifft = eb_aom_ifft32x32_float;
         break;
     default:
         free(noise_tx);
@@ -69,12 +69,12 @@ struct aom_noise_tx_t *aom_noise_tx_malloc(int32_t block_size) {
         return NULL;
     }
     noise_tx->block_size = block_size;
-    noise_tx->tx_block = (float *)aom_memalign(
+    noise_tx->tx_block = (float *)eb_aom_memalign(
         32, 2 * sizeof(*noise_tx->tx_block) * block_size * block_size);
-    noise_tx->temp = (float *)aom_memalign(
+    noise_tx->temp = (float *)eb_aom_memalign(
         32, 2 * sizeof(*noise_tx->temp) * block_size * block_size);
     if (!noise_tx->tx_block || !noise_tx->temp) {
-        aom_noise_tx_free(noise_tx);
+        eb_aom_noise_tx_free(noise_tx);
         return NULL;
     }
     // Clear the buffers up front. Some outputs of the forward transform are
@@ -86,11 +86,11 @@ struct aom_noise_tx_t *aom_noise_tx_malloc(int32_t block_size) {
     return noise_tx;
 }
 
-void aom_noise_tx_forward(struct aom_noise_tx_t *noise_tx, const float *data) {
+void eb_aom_noise_tx_forward(struct aom_noise_tx_t *noise_tx, const float *data) {
     noise_tx->fft(data, noise_tx->temp, noise_tx->tx_block);
 }
 
-void aom_noise_tx_filter(struct aom_noise_tx_t *noise_tx, const float *psd) {
+void eb_aom_noise_tx_filter(struct aom_noise_tx_t *noise_tx, const float *psd) {
     const int32_t block_size = noise_tx->block_size;
     const float kBeta = 1.1f;
     const float kEps = 1e-6f;
@@ -111,21 +111,21 @@ void aom_noise_tx_filter(struct aom_noise_tx_t *noise_tx, const float *psd) {
     }
 }
 
-void aom_noise_tx_inverse(struct aom_noise_tx_t *noise_tx, float *data) {
+void eb_aom_noise_tx_inverse(struct aom_noise_tx_t *noise_tx, float *data) {
     const int32_t n = noise_tx->block_size * noise_tx->block_size;
     noise_tx->ifft(noise_tx->tx_block, noise_tx->temp, data);
     for (int32_t i = 0; i < n; ++i)
         data[i] /= n;
 }
 
-void aom_noise_tx_free(struct aom_noise_tx_t *noise_tx) {
+void eb_aom_noise_tx_free(struct aom_noise_tx_t *noise_tx) {
     if (!noise_tx) return;
-    aom_free(noise_tx->tx_block);
-    aom_free(noise_tx->temp);
+    eb_aom_free(noise_tx->tx_block);
+    eb_aom_free(noise_tx->temp);
     free(noise_tx);
 }
 
-double aom_normalized_cross_correlation(const double *a, const double *b,
+double eb_aom_normalized_cross_correlation(const double *a, const double *b,
     int32_t n) {
     double c = 0;
     double a_len = 0;

--- a/Source/Lib/Common/Codec/noise_util.h
+++ b/Source/Lib/Common/Codec/noise_util.h
@@ -23,35 +23,35 @@ extern "C" {
 
     // Allocates and returns a aom_noise_tx_t useful for denoising the given
     // block_size. The resulting aom_noise_tx_t should be free'd with
-    // aom_noise_tx_free.
-    struct aom_noise_tx_t *aom_noise_tx_malloc(int32_t block_size);
-    void aom_noise_tx_free(struct aom_noise_tx_t *aom_noise_tx);
+    // eb_aom_noise_tx_free.
+    struct aom_noise_tx_t *eb_aom_noise_tx_malloc(int32_t block_size);
+    void eb_aom_noise_tx_free(struct aom_noise_tx_t *aom_noise_tx);
 
     // Transforms the internal data and holds it in the aom_noise_tx's internal
     // buffer. For compatibility with existing SIMD implementations, "data" must
     // be 32-byte aligned.
-    void aom_noise_tx_forward(struct aom_noise_tx_t *aom_noise_tx,
+    void eb_aom_noise_tx_forward(struct aom_noise_tx_t *aom_noise_tx,
         const float *data);
 
     // Filters aom_noise_tx's internal data using the provided noise power spectral
     // density. The PSD must be at least BlockSize * BlockSize and should be
     // populated with a constant or via estimates taken from
     // aom_noise_tx_add_energy.
-    void aom_noise_tx_filter(struct aom_noise_tx_t *aom_noise_tx, const float *psd);
+    void eb_aom_noise_tx_filter(struct aom_noise_tx_t *aom_noise_tx, const float *psd);
 
     // Performs an inverse transform using the internal transform data.
     // For compatibility with existing SIMD implementations, "data" must be 32-byte
     // aligned.
-    void aom_noise_tx_inverse(struct aom_noise_tx_t *aom_noise_tx, float *data);
+    void eb_aom_noise_tx_inverse(struct aom_noise_tx_t *aom_noise_tx, float *data);
 
     // Returns a default value suitable for denosing a transform of the given
     // BlockSize. The noise "factor" determines the strength of the noise to
     // be removed. A value of about 2.5 can be used for moderate denoising,
     // where a value of 5.0 can be used for a high level of denoising.
-    float aom_noise_psd_get_default_value(int32_t block_size, float factor);
+    float eb_aom_noise_psd_get_default_value(int32_t block_size, float factor);
 
     // Computes normalized cross correlation of two vectors a and b of length n.
-    double aom_normalized_cross_correlation(const double *a, const double *b,
+    double eb_aom_normalized_cross_correlation(const double *a, const double *b,
         int32_t n);
 
 #ifdef __cplusplus

--- a/Source/Lib/Common/Codec/vector.c
+++ b/Source/Lib/Common/Codec/vector.c
@@ -28,7 +28,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include "vector.h"
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
-int aom_vector_setup(Vector *vector, size_t capacity, size_t element_size) {
+int eb_aom_vector_setup(Vector *vector, size_t capacity, size_t element_size) {
   assert(vector != NULL);
 
   if (vector == NULL) return VECTOR_ERROR;
@@ -41,16 +41,16 @@ int aom_vector_setup(Vector *vector, size_t capacity, size_t element_size) {
   return vector->data == NULL ? VECTOR_ERROR : VECTOR_SUCCESS;
 }
 
-int aom_vector_copy(Vector *destination, Vector *source) {
+int eb_aom_vector_copy(Vector *destination, Vector *source) {
   assert(destination != NULL);
   assert(source != NULL);
-  assert(aom_vector_is_initialized(source));
-  assert(!aom_vector_is_initialized(destination));
+  assert(eb_aom_vector_is_initialized(source));
+  assert(!eb_aom_vector_is_initialized(destination));
 
   if (destination == NULL) return VECTOR_ERROR;
   if (source == NULL) return VECTOR_ERROR;
-  if (aom_vector_is_initialized(destination)) return VECTOR_ERROR;
-  if (!aom_vector_is_initialized(source)) return VECTOR_ERROR;
+  if (eb_aom_vector_is_initialized(destination)) return VECTOR_ERROR;
+  if (!eb_aom_vector_is_initialized(source)) return VECTOR_ERROR;
 
   /* Copy ALL the data */
   destination->size = source->size;
@@ -61,28 +61,28 @@ int aom_vector_copy(Vector *destination, Vector *source) {
   destination->data = malloc(destination->capacity * source->element_size);
   if (destination->data == NULL) return VECTOR_ERROR;
 
-  memcpy(destination->data, source->data, aom_vector_byte_size(source));
+  memcpy(destination->data, source->data, eb_aom_vector_byte_size(source));
 
   return VECTOR_SUCCESS;
 }
 
-int aom_vector_copy_assign(Vector *destination, Vector *source) {
+int eb_aom_vector_copy_assign(Vector *destination, Vector *source) {
   assert(destination != NULL);
   assert(source != NULL);
-  assert(aom_vector_is_initialized(source));
-  assert(aom_vector_is_initialized(destination));
+  assert(eb_aom_vector_is_initialized(source));
+  assert(eb_aom_vector_is_initialized(destination));
 
   if (destination == NULL) return VECTOR_ERROR;
   if (source == NULL) return VECTOR_ERROR;
-  if (!aom_vector_is_initialized(destination)) return VECTOR_ERROR;
-  if (!aom_vector_is_initialized(source)) return VECTOR_ERROR;
+  if (!eb_aom_vector_is_initialized(destination)) return VECTOR_ERROR;
+  if (!eb_aom_vector_is_initialized(source)) return VECTOR_ERROR;
 
-  aom_vector_destroy(destination);
+  eb_aom_vector_destroy(destination);
 
-  return aom_vector_copy(destination, source);
+  return eb_aom_vector_copy(destination, source);
 }
 
-int aom_vector_move(Vector *destination, Vector *source) {
+int eb_aom_vector_move(Vector *destination, Vector *source) {
   assert(destination != NULL);
   assert(source != NULL);
 
@@ -95,23 +95,23 @@ int aom_vector_move(Vector *destination, Vector *source) {
   return VECTOR_SUCCESS;
 }
 
-int aom_vector_move_assign(Vector *destination, Vector *source) {
-  aom_vector_swap(destination, source);
-  return aom_vector_destroy(source);
+int eb_aom_vector_move_assign(Vector *destination, Vector *source) {
+  eb_aom_vector_swap(destination, source);
+  return eb_aom_vector_destroy(source);
 }
 
-int aom_vector_swap(Vector *destination, Vector *source) {
+int eb_aom_vector_swap(Vector *destination, Vector *source) {
   void *temp;
 
   assert(destination != NULL);
   assert(source != NULL);
-  assert(aom_vector_is_initialized(source));
-  assert(aom_vector_is_initialized(destination));
+  assert(eb_aom_vector_is_initialized(source));
+  assert(eb_aom_vector_is_initialized(destination));
 
   if (destination == NULL) return VECTOR_ERROR;
   if (source == NULL) return VECTOR_ERROR;
-  if (!aom_vector_is_initialized(destination)) return VECTOR_ERROR;
-  if (!aom_vector_is_initialized(source)) return VECTOR_ERROR;
+  if (!eb_aom_vector_is_initialized(destination)) return VECTOR_ERROR;
+  if (!eb_aom_vector_is_initialized(source)) return VECTOR_ERROR;
 
   _vector_swap(&destination->size, &source->size);
   _vector_swap(&destination->capacity, &source->capacity);
@@ -124,7 +124,7 @@ int aom_vector_swap(Vector *destination, Vector *source) {
   return VECTOR_SUCCESS;
 }
 
-int aom_vector_destroy(Vector *vector) {
+int eb_aom_vector_destroy(Vector *vector) {
   assert(vector != NULL);
 
   if (vector == NULL) return VECTOR_ERROR;
@@ -136,7 +136,7 @@ int aom_vector_destroy(Vector *vector) {
 }
 
 /* Insertion */
-int aom_vector_push_back(Vector *vector, void *element) {
+int eb_aom_vector_push_back(Vector *vector, void *element) {
   assert(vector != NULL);
   assert(element != NULL);
 
@@ -152,11 +152,11 @@ int aom_vector_push_back(Vector *vector, void *element) {
   return VECTOR_SUCCESS;
 }
 
-int aom_vector_push_front(Vector *vector, void *element) {
-  return aom_vector_insert(vector, 0, element);
+int eb_aom_vector_push_front(Vector *vector, void *element) {
+  return eb_aom_vector_insert(vector, 0, element);
 }
 
-int aom_vector_insert(Vector *vector, size_t index, void *element) {
+int eb_aom_vector_insert(Vector *vector, size_t index, void *element) {
   void *offset;
 
   assert(vector != NULL);
@@ -184,7 +184,7 @@ int aom_vector_insert(Vector *vector, size_t index, void *element) {
   return VECTOR_SUCCESS;
 }
 
-int aom_vector_assign(Vector *vector, size_t index, void *element) {
+int eb_aom_vector_assign(Vector *vector, size_t index, void *element) {
   assert(vector != NULL);
   assert(element != NULL);
   assert(index < vector->size);
@@ -200,7 +200,7 @@ int aom_vector_assign(Vector *vector, size_t index, void *element) {
 }
 
 /* Deletion */
-int aom_vector_pop_back(Vector *vector) {
+int eb_aom_vector_pop_back(Vector *vector) {
   assert(vector != NULL);
   assert(vector->size > 0);
 
@@ -217,9 +217,9 @@ int aom_vector_pop_back(Vector *vector) {
   return VECTOR_SUCCESS;
 }
 
-int aom_vector_pop_front(Vector *vector) { return aom_vector_erase(vector, 0); }
+int eb_aom_vector_pop_front(Vector *vector) { return eb_aom_vector_erase(vector, 0); }
 
-int aom_vector_erase(Vector *vector, size_t index) {
+int eb_aom_vector_erase(Vector *vector, size_t index) {
   assert(vector != NULL);
   assert(index < vector->size);
 
@@ -238,10 +238,10 @@ int aom_vector_erase(Vector *vector, size_t index) {
   return VECTOR_SUCCESS;
 }
 
-int aom_vector_clear(Vector *vector) { return aom_vector_resize(vector, 0); }
+int eb_aom_vector_clear(Vector *vector) { return eb_aom_vector_resize(vector, 0); }
 
 /* Lookup */
-void *aom_vector_get(Vector *vector, size_t index) {
+void *eb_aom_vector_get(Vector *vector, size_t index) {
   assert(vector != NULL);
   assert(index < vector->size);
 
@@ -252,7 +252,7 @@ void *aom_vector_get(Vector *vector, size_t index) {
   return _vector_offset(vector, index);
 }
 
-const void *aom_vector_const_get(const Vector *vector, size_t index) {
+const void *eb_aom_vector_const_get(const Vector *vector, size_t index) {
   assert(vector != NULL);
   assert(index < vector->size);
 
@@ -263,30 +263,30 @@ const void *aom_vector_const_get(const Vector *vector, size_t index) {
   return _vector_const_offset(vector, index);
 }
 
-void *aom_vector_front(Vector *vector) { return aom_vector_get(vector, 0); }
+void *eb_aom_vector_front(Vector *vector) { return eb_aom_vector_get(vector, 0); }
 
-void *aom_vector_back(Vector *vector) {
-  return aom_vector_get(vector, vector->size - 1);
+void *eb_aom_vector_back(Vector *vector) {
+  return eb_aom_vector_get(vector, vector->size - 1);
 }
 
 /* Information */
 
-bool aom_vector_is_initialized(const Vector *vector) {
+bool eb_aom_vector_is_initialized(const Vector *vector) {
   return vector->data != NULL;
 }
 
-size_t aom_vector_byte_size(const Vector *vector) {
+size_t eb_aom_vector_byte_size(const Vector *vector) {
   return vector->size * vector->element_size;
 }
 
-size_t aom_vector_free_space(const Vector *vector) {
+size_t eb_aom_vector_free_space(const Vector *vector) {
   return vector->capacity - vector->size;
 }
 
-bool aom_vector_is_empty(const Vector *vector) { return vector->size == 0; }
+bool eb_aom_vector_is_empty(const Vector *vector) { return vector->size == 0; }
 
 /* Memory management */
-int aom_vector_resize(Vector *vector, size_t new_size) {
+int eb_aom_vector_resize(Vector *vector, size_t new_size) {
   if (new_size <= vector->capacity * VECTOR_SHRINK_THRESHOLD) {
     vector->size = new_size;
     if (_vector_reallocate(vector, new_size * VECTOR_GROWTH_FACTOR) == -1)
@@ -301,7 +301,7 @@ int aom_vector_resize(Vector *vector, size_t new_size) {
   return VECTOR_SUCCESS;
 }
 
-int aom_vector_reserve(Vector *vector, size_t minimum_capacity) {
+int eb_aom_vector_reserve(Vector *vector, size_t minimum_capacity) {
   if (minimum_capacity > vector->capacity) {
     if (_vector_reallocate(vector, minimum_capacity) == VECTOR_ERROR)
       return VECTOR_ERROR;
@@ -310,18 +310,18 @@ int aom_vector_reserve(Vector *vector, size_t minimum_capacity) {
   return VECTOR_SUCCESS;
 }
 
-int aom_vector_shrink_to_fit(Vector *vector) {
+int eb_aom_vector_shrink_to_fit(Vector *vector) {
   return _vector_reallocate(vector, vector->size);
 }
 
 /* Iterators */
-Iterator aom_vector_begin(Vector *vector) { return aom_vector_iterator(vector, 0); }
+Iterator eb_aom_vector_begin(Vector *vector) { return eb_aom_vector_iterator(vector, 0); }
 
-Iterator aom_vector_end(Vector *vector) {
-  return aom_vector_iterator(vector, vector->size);
+Iterator eb_aom_vector_end(Vector *vector) {
+  return eb_aom_vector_iterator(vector, vector->size);
 }
 
-Iterator aom_vector_iterator(Vector *vector, size_t index) {
+Iterator eb_aom_vector_iterator(Vector *vector, size_t index) {
   Iterator iterator = { NULL, 0 };
 
   assert(vector != NULL);
@@ -342,9 +342,9 @@ void *iterator_get(Iterator *iterator) { return iterator->pointer; }
 int iterator_erase(Vector *vector, Iterator *iterator) {
   size_t index = iterator_index(vector, iterator);
 
-  if (aom_vector_erase(vector, index) == VECTOR_ERROR)
+  if (eb_aom_vector_erase(vector, index) == VECTOR_ERROR)
     return VECTOR_ERROR;
-  *iterator = aom_vector_iterator(vector, index);
+  *iterator = eb_aom_vector_iterator(vector, index);
 
   return VECTOR_SUCCESS;
 }
@@ -413,7 +413,7 @@ bool _vector_should_shrink(Vector *vector) {
 }
 
 size_t _vector_free_bytes(const Vector *vector) {
-  return aom_vector_free_space(vector) * vector->element_size;
+  return eb_aom_vector_free_space(vector) * vector->element_size;
 }
 
 void *_vector_offset(Vector *vector, size_t index) {
@@ -508,12 +508,12 @@ int _vector_reallocate(Vector *vector, size_t new_capacity) {
     if (memcpy_s(vector->data,
                              new_capacity_in_bytes,
                              old,
-                             aom_vector_byte_size(vector)) != 0) {
+                             eb_aom_vector_byte_size(vector)) != 0) {
         return VECTOR_ERROR;
     }
 /* clang-format on */
 #else
-  memcpy(vector->data, old, aom_vector_byte_size(vector));
+  memcpy(vector->data, old, eb_aom_vector_byte_size(vector));
 #endif
 
   vector->capacity = new_capacity;

--- a/Source/Lib/Common/Codec/vector.h
+++ b/Source/Lib/Common/Codec/vector.h
@@ -57,60 +57,60 @@ typedef struct Iterator {
 /***** METHODS *****/
 
 /* Constructor */
-int aom_vector_setup(Vector *vector, size_t capacity, size_t element_size);
+int eb_aom_vector_setup(Vector *vector, size_t capacity, size_t element_size);
 
 /* Copy Constructor */
-int aom_vector_copy(Vector *destination, Vector *source);
+int eb_aom_vector_copy(Vector *destination, Vector *source);
 
 /* Copy Assignment */
-int aom_vector_copy_assign(Vector *destination, Vector *source);
+int eb_aom_vector_copy_assign(Vector *destination, Vector *source);
 
 /* Move Constructor */
-int aom_vector_move(Vector *destination, Vector *source);
+int eb_aom_vector_move(Vector *destination, Vector *source);
 
 /* Move Assignment */
-int aom_vector_move_assign(Vector *destination, Vector *source);
+int eb_aom_vector_move_assign(Vector *destination, Vector *source);
 
-int aom_vector_swap(Vector *destination, Vector *source);
+int eb_aom_vector_swap(Vector *destination, Vector *source);
 
 /* Destructor */
-int aom_vector_destroy(Vector *vector);
+int eb_aom_vector_destroy(Vector *vector);
 
 /* Insertion */
-int aom_vector_push_back(Vector *vector, void *element);
-int aom_vector_push_front(Vector *vector, void *element);
-int aom_vector_insert(Vector *vector, size_t index, void *element);
-int aom_vector_assign(Vector *vector, size_t index, void *element);
+int eb_aom_vector_push_back(Vector *vector, void *element);
+int eb_aom_vector_push_front(Vector *vector, void *element);
+int eb_aom_vector_insert(Vector *vector, size_t index, void *element);
+int eb_aom_vector_assign(Vector *vector, size_t index, void *element);
 
 /* Deletion */
-int aom_vector_pop_back(Vector *vector);
-int aom_vector_pop_front(Vector *vector);
-int aom_vector_erase(Vector *vector, size_t index);
-int aom_vector_clear(Vector *vector);
+int eb_aom_vector_pop_back(Vector *vector);
+int eb_aom_vector_pop_front(Vector *vector);
+int eb_aom_vector_erase(Vector *vector, size_t index);
+int eb_aom_vector_clear(Vector *vector);
 
 /* Lookup */
-void *aom_vector_get(Vector *vector, size_t index);
-const void *aom_vector_const_get(const Vector *vector, size_t index);
-void *aom_vector_front(Vector *vector);
-void *aom_vector_back(Vector *vector);
+void *eb_aom_vector_get(Vector *vector, size_t index);
+const void *eb_aom_vector_const_get(const Vector *vector, size_t index);
+void *eb_aom_vector_front(Vector *vector);
+void *eb_aom_vector_back(Vector *vector);
 #define VECTOR_GET_AS(type, aom_vector_pointer, index) \
-  *((type *)aom_vector_get((aom_vector_pointer), (index)))
+  *((type *)eb_aom_vector_get((aom_vector_pointer), (index)))
 
 /* Information */
-bool aom_vector_is_initialized(const Vector *vector);
-size_t aom_vector_byte_size(const Vector *vector);
-size_t aom_vector_free_space(const Vector *vector);
-bool aom_vector_is_empty(const Vector *vector);
+bool eb_aom_vector_is_initialized(const Vector *vector);
+size_t eb_aom_vector_byte_size(const Vector *vector);
+size_t eb_aom_vector_free_space(const Vector *vector);
+bool eb_aom_vector_is_empty(const Vector *vector);
 
 /* Memory management */
-int aom_vector_resize(Vector *vector, size_t new_size);
-int aom_vector_reserve(Vector *vector, size_t minimum_capacity);
-int aom_vector_shrink_to_fit(Vector *vector);
+int eb_aom_vector_resize(Vector *vector, size_t new_size);
+int eb_aom_vector_reserve(Vector *vector, size_t minimum_capacity);
+int eb_aom_vector_shrink_to_fit(Vector *vector);
 
 /* Iterators */
-Iterator aom_vector_begin(Vector *vector);
-Iterator aom_vector_end(Vector *vector);
-Iterator aom_vector_iterator(Vector *vector, size_t index);
+Iterator eb_aom_vector_begin(Vector *vector);
+Iterator eb_aom_vector_end(Vector *vector);
+Iterator eb_aom_vector_iterator(Vector *vector, size_t index);
 
 void *iterator_get(Iterator *iterator);
 #define ITERATOR_GET_AS(type, iterator) *((type *)iterator_get((iterator)))
@@ -130,8 +130,8 @@ bool iterator_is_after(Iterator *first, Iterator *second);
 size_t iterator_index(Vector *vector, Iterator *iterator);
 
 #define VECTOR_FOR_EACH(aom_vector_pointer, iterator_name)           \
-  for (Iterator(iterator_name) = aom_vector_begin((aom_vector_pointer)), \
-      end = aom_vector_end((aom_vector_pointer));                        \
+  for (Iterator(iterator_name) = eb_aom_vector_begin((aom_vector_pointer)), \
+      end = eb_aom_vector_end((aom_vector_pointer));                        \
        !iterator_equals(&(iterator_name), &end);                 \
        iterator_increment(&(iterator_name)))
 

--- a/Source/Lib/Decoder/Codec/EbDecInterPrediction.c
+++ b/Source/Lib/Decoder/Codec/EbDecInterPrediction.c
@@ -191,7 +191,7 @@ void svtav1_predict_inter_block_plane(
 
                 wm_params = (mi->motion_mode == WARPED_CAUSAL) ? wm_local : wm_global;
 
-                av1_warp_plane((EbWarpedMotionParams *)wm_params,
+                eb_av1_warp_plane((EbWarpedMotionParams *)wm_params,
                     highbd, bit_depth,
                     src, ref_buf->ps_pic_buf->width >> ss_x,
                     ref_buf->ps_pic_buf->height >> ss_y,

--- a/Source/Lib/Decoder/Codec/EbDecIntraPrediction.c
+++ b/Source/Lib/Decoder/Codec/EbDecIntraPrediction.c
@@ -247,13 +247,13 @@ void cfl_predict_block(PartitionInfo_t *xd, CflCtx *cfl_ctx, uint8_t *dst,
         CFL_BUF_SQUARE);
 
     if (cc->bit_depth != AOM_BITS_8) {
-        cfl_predict_hbd(cfl_ctx->recon_buf_q3, (uint16_t *)dst, dst_stride,
+        eb_cfl_predict_hbd(cfl_ctx->recon_buf_q3, (uint16_t *)dst, dst_stride,
             (uint16_t *)dst, dst_stride, alpha_q3, cc->bit_depth,
             tx_size_wide[tx_size], tx_size_high[tx_size]);
         return;
     }
 
-    cfl_predict_lbd(cfl_ctx->recon_buf_q3, dst, dst_stride, dst, dst_stride,
+    eb_cfl_predict_lbd(cfl_ctx->recon_buf_q3, dst, dst_stride, dst, dst_stride,
         alpha_q3, cc->bit_depth,
         tx_size_wide[tx_size], tx_size_high[tx_size]);
 }
@@ -462,7 +462,7 @@ static void decode_build_intra_predictors(
     }
 
       if (use_filter_intra) {
-          av1_filter_intra_predictor(dst, dst_stride, tx_size, above_row, left_col,
+          eb_av1_filter_intra_predictor(dst, dst_stride, tx_size, above_row, left_col,
                filter_intra_mode);
            return;
        }
@@ -484,13 +484,13 @@ static void decode_build_intra_predictors(
                     const int32_t strength =
                         intra_edge_filter_strength(txwpx, txhpx, p_angle - 90, filt_type);
                     const int32_t n_px = n_top_px + ab_le + (need_right ? txhpx : 0);
-                    av1_filter_intra_edge(above_row - ab_le, n_px, strength);
+                    eb_av1_filter_intra_edge(above_row - ab_le, n_px, strength);
                 }
                 if (need_left && n_left_px > 0) {
                     const int32_t strength = intra_edge_filter_strength(
                         txhpx, txwpx, p_angle - 180, filt_type);
                     const int32_t n_px = n_left_px + ab_le + (need_bottom ? txwpx : 0);
-                    av1_filter_intra_edge(left_col - ab_le, n_px, strength);
+                    eb_av1_filter_intra_edge(left_col - ab_le, n_px, strength);
                 }
             }
             upsample_above =
@@ -498,14 +498,14 @@ static void decode_build_intra_predictors(
             if (need_above && upsample_above) {
                 const int32_t n_px = txwpx + (need_right ? txhpx : 0);
 
-                av1_upsample_intra_edge(above_row, n_px);
+                eb_av1_upsample_intra_edge(above_row, n_px);
             }
             upsample_left =
                 use_intra_edge_upsample(txhpx, txwpx, p_angle - 180, filt_type);
             if (need_left && upsample_left) {
                 const int32_t n_px = txhpx + (need_bottom ? txwpx : 0);
 
-                av1_upsample_intra_edge(left_col, n_px);
+                eb_av1_upsample_intra_edge(left_col, n_px);
             }
         }
         dr_predictor(dst, dst_stride, tx_size, above_row, left_col, upsample_above,
@@ -583,7 +583,7 @@ static void decode_build_intra_predictors_high(
         else
             val = (n_left_px > 0) ? left_ref[0] : base - 1;
         for (i = 0; i < txhpx; ++i) {
-            aom_memset16(dst, val, txwpx);
+            eb_aom_memset16(dst, val, txwpx);
             dst += dst_stride;
         }
         return;
@@ -604,13 +604,13 @@ static void decode_build_intra_predictors_high(
                     left_col[i] = left_ref[i * ref_stride];
             }
             if (i < num_left_pixels_needed)
-                aom_memset16(&left_col[i], left_col[i - 1], num_left_pixels_needed - i);
+                eb_aom_memset16(&left_col[i], left_col[i - 1], num_left_pixels_needed - i);
         }
         else {
             if (n_top_px > 0)
-                aom_memset16(left_col, above_ref[0], num_left_pixels_needed);
+                eb_aom_memset16(left_col, above_ref[0], num_left_pixels_needed);
             else
-                aom_memset16(left_col, base + 1, num_left_pixels_needed);
+                eb_aom_memset16(left_col, base + 1, num_left_pixels_needed);
         }
     }
 
@@ -630,14 +630,14 @@ static void decode_build_intra_predictors_high(
                 i += n_topright_px;
             }
             if (i < num_top_pixels_needed)
-                aom_memset16(&above_row[i], above_row[i - 1],
+                eb_aom_memset16(&above_row[i], above_row[i - 1],
                     num_top_pixels_needed - i);
         }
         else {
             if (n_left_px > 0)
-                aom_memset16(above_row, left_ref[0], num_top_pixels_needed);
+                eb_aom_memset16(above_row, left_ref[0], num_top_pixels_needed);
             else
-                aom_memset16(above_row, base - 1, num_top_pixels_needed);
+                eb_aom_memset16(above_row, base - 1, num_top_pixels_needed);
         }
     }
 
@@ -674,14 +674,14 @@ static void decode_build_intra_predictors_high(
                     const int32_t strength =
                         intra_edge_filter_strength(txwpx, txhpx, p_angle - 90, filt_type);
                     const int32_t n_px = n_top_px + ab_le + (need_right ? txhpx : 0);
-                    av1_filter_intra_edge_high(above_row - ab_le, n_px, strength);
+                    eb_av1_filter_intra_edge_high(above_row - ab_le, n_px, strength);
                 }
                 if (need_left && n_left_px > 0) {
                     const int32_t strength = intra_edge_filter_strength(
                         txhpx, txwpx, p_angle - 180, filt_type);
                     const int32_t n_px = n_left_px + ab_le + (need_bottom ? txwpx : 0);
 
-                    av1_filter_intra_edge_high(left_col - ab_le, n_px, strength);
+                    eb_av1_filter_intra_edge_high(left_col - ab_le, n_px, strength);
                 }
             }
             upsample_above =
@@ -689,14 +689,14 @@ static void decode_build_intra_predictors_high(
             if (need_above && upsample_above) {
                 const int32_t n_px = txwpx + (need_right ? txhpx : 0);
                 //av1_upsample_intra_edge_high(above_row, n_px, bd);// AMIR : to be replaced by optimized code
-                av1_upsample_intra_edge_high_c(above_row, n_px, bd);
+                eb_av1_upsample_intra_edge_high_c(above_row, n_px, bd);
             }
             upsample_left =
                 use_intra_edge_upsample(txhpx, txwpx, p_angle - 180, filt_type);
             if (need_left && upsample_left) {
                 const int32_t n_px = txhpx + (need_bottom ? txwpx : 0);
                 //av1_upsample_intra_edge_high(left_col, n_px, bd);// AMIR: to be replaced by optimized code
-                av1_upsample_intra_edge_high_c(left_col, n_px, bd);
+                eb_av1_upsample_intra_edge_high_c(left_col, n_px, bd);
             }
         }
         highbd_dr_predictor(dst, dst_stride, tx_size, above_row, left_col,

--- a/Source/Lib/Decoder/Codec/EbDecInverseQuantize.c
+++ b/Source/Lib/Decoder/Codec/EbDecInverseQuantize.c
@@ -29,12 +29,12 @@
 // Same wrapper(av1_ac/dc_quant_QTX) available in .c file of encoder
 int16_t get_dc_quant(int32_t qindex, int32_t delta, AomBitDepth bit_depth)
 {
-    return av1_dc_quant_Q3(qindex, delta, bit_depth);
+    return eb_av1_dc_quant_Q3(qindex, delta, bit_depth);
 }
 
 int16_t get_ac_quant(int32_t qindex, int32_t delta, AomBitDepth bit_depth)
 {
-    return av1_ac_quant_Q3(qindex, delta, bit_depth);
+    return eb_av1_ac_quant_Q3(qindex, delta, bit_depth);
 }
 
 // Called in read_frame_header_obu() -> av1_decode_frame_headers_and_setup() -> read_uncompressed_header()

--- a/Source/Lib/Decoder/Codec/EbDecInverseQuantize.h
+++ b/Source/Lib/Decoder/Codec/EbDecInverseQuantize.h
@@ -10,8 +10,8 @@ static INLINE int av1_num_planes(EbColorConfig   *color_info) {
     return color_info->mono_chrome ? 1 : MAX_MB_PLANE;
 }
 
-int16_t av1_dc_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth);
-int16_t av1_ac_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth);
+int16_t eb_av1_dc_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth);
+int16_t eb_av1_ac_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth);
 int16_t get_dc_quant(int32_t qindex, int32_t delta, AomBitDepth bit_depth);
 int16_t get_ac_quant(int32_t qindex, int32_t delta, AomBitDepth bit_depth);
 void setup_segmentation_dequant(EbDecHandle *dec_handle_ptr, EbColorConfig *color_config);

--- a/Source/Lib/Decoder/Codec/EbDecParseBlock.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseBlock.c
@@ -49,46 +49,46 @@ typedef struct txb_ctx {
     int dc_sign_ctx;
 } TXB_CTX;
 
-static const int16_t k_eob_group_start[12] = { 0,  1,  2,  3,   5,   9,
+static const int16_t eb_k_eob_group_start[12] = { 0,  1,  2,  3,   5,   9,
                                         17, 33, 65, 129, 257, 513 };
-static const int16_t k_eob_offset_bits[12] = { 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+static const int16_t eb_k_eob_offset_bits[12] = { 0, 0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-extern const int8_t av1_nz_map_ctx_offset_4x4[16];
-extern const int8_t av1_nz_map_ctx_offset_8x8[64];
-extern const int8_t av1_nz_map_ctx_offset_16x16[256];
-extern const int8_t av1_nz_map_ctx_offset_32x32[1024];
-extern const int8_t av1_nz_map_ctx_offset_8x4[32];
-extern const int8_t av1_nz_map_ctx_offset_8x16[128];
-extern const int8_t av1_nz_map_ctx_offset_16x8[128];
-extern const int8_t av1_nz_map_ctx_offset_16x32[512];
-extern const int8_t av1_nz_map_ctx_offset_32x16[512];
-extern const int8_t av1_nz_map_ctx_offset_32x64[1024];
-extern const int8_t av1_nz_map_ctx_offset_64x32[1024];
-extern const int8_t av1_nz_map_ctx_offset_4x16[64];
-extern const int8_t av1_nz_map_ctx_offset_16x4[64];
-extern const int8_t av1_nz_map_ctx_offset_8x32[256];
-extern const int8_t av1_nz_map_ctx_offset_32x8[256];
+extern const int8_t eb_av1_nz_map_ctx_offset_4x4[16];
+extern const int8_t eb_av1_nz_map_ctx_offset_8x8[64];
+extern const int8_t eb_av1_nz_map_ctx_offset_16x16[256];
+extern const int8_t eb_av1_nz_map_ctx_offset_32x32[1024];
+extern const int8_t eb_av1_nz_map_ctx_offset_8x4[32];
+extern const int8_t eb_av1_nz_map_ctx_offset_8x16[128];
+extern const int8_t eb_av1_nz_map_ctx_offset_16x8[128];
+extern const int8_t eb_av1_nz_map_ctx_offset_16x32[512];
+extern const int8_t eb_av1_nz_map_ctx_offset_32x16[512];
+extern const int8_t eb_av1_nz_map_ctx_offset_32x64[1024];
+extern const int8_t eb_av1_nz_map_ctx_offset_64x32[1024];
+extern const int8_t eb_av1_nz_map_ctx_offset_4x16[64];
+extern const int8_t eb_av1_nz_map_ctx_offset_16x4[64];
+extern const int8_t eb_av1_nz_map_ctx_offset_8x32[256];
+extern const int8_t eb_av1_nz_map_ctx_offset_32x8[256];
 
-static const int8_t *av1_nz_map_ctx_offset[19] = {
-  av1_nz_map_ctx_offset_4x4,    // TX_4x4
-  av1_nz_map_ctx_offset_8x8,    // TX_8x8
-  av1_nz_map_ctx_offset_16x16,  // TX_16x16
-  av1_nz_map_ctx_offset_32x32,  // TX_32x32
-  av1_nz_map_ctx_offset_32x32,  // TX_32x32
-  av1_nz_map_ctx_offset_4x16,   // TX_4x8
-  av1_nz_map_ctx_offset_8x4,    // TX_8x4
-  av1_nz_map_ctx_offset_8x32,   // TX_8x16
-  av1_nz_map_ctx_offset_16x8,   // TX_16x8
-  av1_nz_map_ctx_offset_16x32,  // TX_16x32
-  av1_nz_map_ctx_offset_32x16,  // TX_32x16
-  av1_nz_map_ctx_offset_32x64,  // TX_32x64
-  av1_nz_map_ctx_offset_64x32,  // TX_64x32
-  av1_nz_map_ctx_offset_4x16,   // TX_4x16
-  av1_nz_map_ctx_offset_16x4,   // TX_16x4
-  av1_nz_map_ctx_offset_8x32,   // TX_8x32
-  av1_nz_map_ctx_offset_32x8,   // TX_32x8
-  av1_nz_map_ctx_offset_16x32,  // TX_16x64
-  av1_nz_map_ctx_offset_64x32,  // TX_64x16
+static const int8_t *eb_av1_nz_map_ctx_offset[19] = {
+  eb_av1_nz_map_ctx_offset_4x4,    // TX_4x4
+  eb_av1_nz_map_ctx_offset_8x8,    // TX_8x8
+  eb_av1_nz_map_ctx_offset_16x16,  // TX_16x16
+  eb_av1_nz_map_ctx_offset_32x32,  // TX_32x32
+  eb_av1_nz_map_ctx_offset_32x32,  // TX_32x32
+  eb_av1_nz_map_ctx_offset_4x16,   // TX_4x8
+  eb_av1_nz_map_ctx_offset_8x4,    // TX_8x4
+  eb_av1_nz_map_ctx_offset_8x32,   // TX_8x16
+  eb_av1_nz_map_ctx_offset_16x8,   // TX_16x8
+  eb_av1_nz_map_ctx_offset_16x32,  // TX_16x32
+  eb_av1_nz_map_ctx_offset_32x16,  // TX_32x16
+  eb_av1_nz_map_ctx_offset_32x64,  // TX_32x64
+  eb_av1_nz_map_ctx_offset_64x32,  // TX_64x32
+  eb_av1_nz_map_ctx_offset_4x16,   // TX_4x16
+  eb_av1_nz_map_ctx_offset_16x4,   // TX_16x4
+  eb_av1_nz_map_ctx_offset_8x32,   // TX_8x32
+  eb_av1_nz_map_ctx_offset_32x8,   // TX_32x8
+  eb_av1_nz_map_ctx_offset_16x32,  // TX_16x64
+  eb_av1_nz_map_ctx_offset_64x32,  // TX_64x16
 };
 
 #define NZ_MAP_CTX_0 SIG_COEF_CONTEXTS_2D
@@ -150,7 +150,7 @@ static INLINE int get_nz_map_ctx_from_stats(
     switch (tx_class)
     {
     case TX_CLASS_2D:
-        return ctx + av1_nz_map_ctx_offset[tx_size][coeff_idx];
+        return ctx + eb_av1_nz_map_ctx_offset[tx_size][coeff_idx];
     case TX_CLASS_HORIZ: {
         const int row = coeff_idx >> bwl;
         const int col = coeff_idx - (row << bwl);
@@ -1469,7 +1469,7 @@ void update_coeff_ctx(EbDecHandle *dec_handle, int plane, PartitionInfo_t *pi,
 }
 
 static INLINE int rec_eob_pos(const int eob_token, const int extra) {
-    int eob = k_eob_group_start[eob_token];
+    int eob = eb_k_eob_group_start[eob_token];
     if (eob > 2)
         eob += extra;
     return eob;
@@ -1488,7 +1488,7 @@ static INLINE int get_lower_levels_ctx_2d(const uint8_t *levels,
     mag += AOMMIN(levels[(2 << bwl) + (2 << TX_PAD_HOR_LOG2)], 3);  // { 2, 0 }
 
     const int ctx = AOMMIN((mag + 1) >> 1, 4);
-    return ctx + av1_nz_map_ctx_offset[tx_size][coeff_idx];
+    return ctx + eb_av1_nz_map_ctx_offset[tx_size][coeff_idx];
 }
 static INLINE int get_lower_levels_ctx(const uint8_t *levels,
     int coeff_idx, int bwl, TxSize tx_size, TxClass tx_class)
@@ -1712,7 +1712,7 @@ uint16_t parse_coeffs(EbDecHandle *dec_handle, PartitionInfo_t *xd, SvtReader *r
         break;
     }
 
-    int eob_shift = k_eob_offset_bits[eob_pt];
+    int eob_shift = eb_k_eob_offset_bits[eob_pt];
     if (eob_shift > 0) {
         const int eob_ctx = eob_pt;
         int bit = svt_read_symbol(

--- a/Source/Lib/Decoder/Codec/EbDecParseObu.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseObu.c
@@ -1259,7 +1259,7 @@ void read_global_motion_params(bitstrm_t *bs, EbDecHandle *dec_handle,
             wm_global->wmtype = cur_buf->global_motion[ref].gm_type;
             memcpy(wm_global->wmmat, cur_buf->global_motion[ref].gm_params,
                 sizeof(cur_buf->global_motion[ref].gm_params));
-            int return_val = get_shear_params(wm_global);
+            int return_val = eb_get_shear_params(wm_global);
             assert(1 == return_val);
             (void)return_val;
         }
@@ -1516,7 +1516,7 @@ int get_qindex(SegmentationParams *seg_params, int segment_id, int base_q_idx)
 EbErrorType reset_parse_ctx(FRAME_CONTEXT *frm_ctx, uint8_t base_qp) {
     EbErrorType return_error = EB_ErrorNone;
 
-    av1_default_coef_probs(frm_ctx, base_qp);
+    eb_av1_default_coef_probs(frm_ctx, base_qp);
     init_mode_probs(frm_ctx);
 
     return return_error;
@@ -2340,7 +2340,7 @@ EbErrorType read_tile_group_obu(bitstrm_t *bs, EbDecHandle *dec_handle_ptr,
         {
             dec_handle_ptr->cur_pic_buf[0]->final_frm_ctx =
                                         parse_ctxt->cur_tile_ctx;
-            av1_reset_cdf_symbol_counters(&dec_handle_ptr->cur_pic_buf[0]->final_frm_ctx);
+            eb_av1_reset_cdf_symbol_counters(&dec_handle_ptr->cur_pic_buf[0]->final_frm_ctx);
         }
 
         dec_bits_init(bs, (uint8_t *)parse_ctxt->r.ec.bptr, obu_header->payload_size);

--- a/Source/Lib/Decoder/Codec/EbDecProcessBlock.c
+++ b/Source/Lib/Decoder/Codec/EbDecProcessBlock.c
@@ -263,7 +263,7 @@ void decode_block(DecModCtxt *dec_mod_ctxt, int32_t mi_row, int32_t mi_col,
 
         part_info.num_samples = nsamples;
 
-        apply_wm = !find_projection(
+        apply_wm = !eb_find_projection(
             nsamples,
             pts,
             pts_inref,

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -345,7 +345,7 @@ void asmSetConvolveAsmTable(void);
 void asmSetConvolveHbdAsmTable(void);
 void init_intra_dc_predictors_c_internal(void);
 void init_intra_predictors_internal(void);
-void av1_init_me_luts(void);
+void eb_av1_init_me_luts(void);
 
 void SwitchToRealTime(){
 #if defined(__linux__) || defined(__APPLE__)
@@ -910,7 +910,7 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
 
     build_blk_geom(scs_init.sb_size == 128);
 
-    av1_init_me_luts();
+    eb_av1_init_me_luts();
     init_fn_ptr();
 
     /************************************

--- a/test/BitstreamWriterTest.cc
+++ b/test/BitstreamWriterTest.cc
@@ -208,7 +208,7 @@ TEST(Entropy_BitstreamWriter, write_symbol_no_update) {
     const int base_qindex = 20;
     FRAME_CONTEXT fc;
     memset(&fc, 0, sizeof(fc));
-    av1_default_coef_probs(&fc, base_qindex);
+    eb_av1_default_coef_probs(&fc, base_qindex);
 
     // write random bit sequences and expect read out
     // the same random sequences.
@@ -249,7 +249,7 @@ TEST(Entropy_BitstreamWriter, write_symbol_with_update) {
     FRAME_CONTEXT fc;
     memset(&fc, 0, sizeof(fc));
 
-    av1_default_coef_probs(&fc, base_qindex);
+    eb_av1_default_coef_probs(&fc, base_qindex);
 
     // write random bit sequences and expect read out
     // the same random sequences.
@@ -270,7 +270,7 @@ TEST(Entropy_BitstreamWriter, write_symbol_with_update) {
     SvtReader br;
     svt_reader_init(&br, stream_buffer, bw.pos);
     br.allow_update_cdf = 1;
-    av1_default_coef_probs(&fc, base_qindex);  // reset cdf
+    eb_av1_default_coef_probs(&fc, base_qindex);  // reset cdf
     for (int i = 0; i < 500; i++) {
         ASSERT_EQ(svt_read_symbol(&br, fc.txb_skip_cdf[0][0], 2, nullptr),
                   rnd(gen));

--- a/test/CdefTest.cc
+++ b/test/CdefTest.cc
@@ -7,8 +7,8 @@
  * @file CdefTest.cc
  *
  * @brief Unit test for cdef tools:
- * * cdef_find_dir_avx2
- * * cdef_filter_block_avx2
+ * * eb_cdef_find_dir_avx2
+ * * eb_cdef_filter_block_avx2
  * * compute_cdef_dist_avx2
  * * copy_rect8_8bit_to_16bit_avx2
  * * search_one_dual_avx2
@@ -43,7 +43,7 @@ using cdef_dir_param_t =
                      int, int>;
 
 /**
- * @brief Unit test for cdef_filter_block_avx2
+ * @brief Unit test for eb_cdef_filter_block_avx2
  *
  * Test strategy:
  * Feed src data generated randomly and all possible input,
@@ -232,8 +232,8 @@ TEST_P(CDEFBlockTest, MatchTest) {
 
 INSTANTIATE_TEST_CASE_P(
     Cdef, CDEFBlockTest,
-    ::testing::Combine(::testing::Values(&cdef_filter_block_avx2),
-                       ::testing::Values(&cdef_filter_block_c),
+    ::testing::Combine(::testing::Values(&eb_cdef_filter_block_avx2),
+                       ::testing::Values(&eb_cdef_filter_block_c),
                        ::testing::Values(BLOCK_4X4, BLOCK_4X8, BLOCK_8X4,
                                          BLOCK_8X8),
                        ::testing::Range(0, 16), ::testing::Range(8, 13, 2)));
@@ -245,7 +245,7 @@ using FindDirFunc = int (*)(const uint16_t *img, int stride, int32_t *var,
 using TestFindDirParam = ::testing::tuple<FindDirFunc, FindDirFunc>;
 
 /**
- * @brief Unit test for cdef_find_dir_avx2
+ * @brief Unit test for eb_cdef_find_dir_avx2
  *
  * Test strategy:
  * Feed src data generated randomly, and check the best mse and
@@ -331,8 +331,8 @@ TEST_P(CDEFFindDirTest, MatchTest) {
 #if defined(_WIN64) || !defined(_MSC_VER) || defined(__clang__)
 
 INSTANTIATE_TEST_CASE_P(Cdef, CDEFFindDirTest,
-                        ::testing::Values(make_tuple(&cdef_find_dir_avx2,
-                                                     &cdef_find_dir_c)));
+                        ::testing::Values(make_tuple(&eb_cdef_find_dir_avx2,
+                                                     &eb_cdef_find_dir_c)));
 
 #endif  // defined(_WIN64) || !defined(_MSC_VER)
 }  // namespace
@@ -376,9 +376,9 @@ TEST(CdefToolTest, CopyRectMatchTest) {
             uint16_t *dst_ref_ =
                 dst_data_ref_ + CDEF_VBORDER * CDEF_BSTRIDE + CDEF_HBORDER;
 
-            copy_rect8_8bit_to_16bit_c(
+            eb_copy_rect8_8bit_to_16bit_c(
                 dst_ref_, CDEF_BSTRIDE, src_, CDEF_BSTRIDE, vsize, hsize);
-            copy_rect8_8bit_to_16bit_avx2(
+            eb_copy_rect8_8bit_to_16bit_avx2(
                 dst_tst_, CDEF_BSTRIDE, src_, CDEF_BSTRIDE, vsize, hsize);
 
             for (int i = 0; i < vsize; ++i) {
@@ -499,8 +499,8 @@ TEST(CdefToolTest, SearchOneDualMatchTest) {
     int lvl_luma_ref[CDEF_MAX_STRENGTHS], lvl_chroma_ref[CDEF_MAX_STRENGTHS];
     int lvl_luma_tst[CDEF_MAX_STRENGTHS], lvl_chroma_tst[CDEF_MAX_STRENGTHS];
     uint64_t(*mse[2])[TOTAL_STRENGTHS];
-    mse[0] = (uint64_t(*)[64])aom_memalign(32, sizeof(**mse) * sb_count);
-    mse[1] = (uint64_t(*)[64])aom_memalign(32, sizeof(**mse) * sb_count);
+    mse[0] = (uint64_t(*)[64])eb_aom_memalign(32, sizeof(**mse) * sb_count);
+    mse[1] = (uint64_t(*)[64])eb_aom_memalign(32, sizeof(**mse) * sb_count);
 
     SVTRandom rnd_(10, false);
     for (int k = 0; k < 100; ++k) {
@@ -553,6 +553,6 @@ TEST(CdefToolTest, SearchOneDualMatchTest) {
         }
     }
 
-    aom_free(mse[0]);
-    aom_free(mse[1]);
+    eb_aom_free(mse[0]);
+    eb_aom_free(mse[1]);
 }

--- a/test/EncodeTxbAsmTest.cc
+++ b/test/EncodeTxbAsmTest.cc
@@ -6,7 +6,7 @@
 /******************************************************************************
  * @file EncodeTxbAsmTest.cc
  *
- * @brief Unit test for av1_txb_init_levels_avx2:
+ * @brief Unit test for eb_av1_txb_init_levels_avx2:
  *
  * @author Cidana-Wenyao
  *
@@ -42,12 +42,12 @@ static INLINE uint8_t *set_levels(uint8_t *const levels_buf,
     return levels_buf + TX_PAD_TOP * (width + TX_PAD_HOR);
 }
 
-// test assembly code of av1_txb_init_levels
+// test assembly code of eb_av1_txb_init_levels
 using TxbInitLevelsFunc = void (*)(const TranLow *const coeff, const int width,
                                    const int height, uint8_t *const levels);
 using TxbInitLevelParam = std::tuple<TxbInitLevelsFunc, int>;
 /**
- * @brief Unit test for av1_txb_init_levels_avx2:
+ * @brief Unit test for eb_av1_txb_init_levels_avx2:
  *
  * Test strategy:
  * Verify this assembly code by comparing with reference c implementation.
@@ -66,7 +66,7 @@ using TxbInitLevelParam = std::tuple<TxbInitLevelsFunc, int>;
 class EncodeTxbInitLevelTest
     : public ::testing::TestWithParam<TxbInitLevelParam> {
   public:
-    EncodeTxbInitLevelTest() : ref_func_(&av1_txb_init_levels_c) {
+    EncodeTxbInitLevelTest() : ref_func_(&eb_av1_txb_init_levels_c) {
         // fill input_coeff_ with 16bit signed random
         // The random is only used in prepare_data function, however
         // we should not declare in that function, otherwise
@@ -141,6 +141,6 @@ TEST_P(EncodeTxbInitLevelTest, txb_init_levels_assmbly) {
 
 INSTANTIATE_TEST_CASE_P(
     Entropy, EncodeTxbInitLevelTest,
-    ::testing::Combine(::testing::Values(&av1_txb_init_levels_avx2),
+    ::testing::Combine(::testing::Values(&eb_av1_txb_init_levels_avx2),
                        ::testing::Range(0, static_cast<int>(TX_SIZES_ALL), 1)));
 }  // namespace

--- a/test/FwdTxfm1dTest.cc
+++ b/test/FwdTxfm1dTest.cc
@@ -73,20 +73,20 @@ class AV1FwdTxfm1dTest : public ::testing::TestWithParam<FwdTxfm1dParam> {
 
     void SetUp() override {
         input_test_ = reinterpret_cast<int32_t *>(
-            aom_memalign(32, MAX_TX_SIZE * sizeof(int32_t)));
+            eb_aom_memalign(32, MAX_TX_SIZE * sizeof(int32_t)));
         output_test_ = reinterpret_cast<int32_t *>(
-            aom_memalign(32, MAX_TX_SIZE * sizeof(int32_t)));
+            eb_aom_memalign(32, MAX_TX_SIZE * sizeof(int32_t)));
         input_ref_ = reinterpret_cast<double *>(
-            aom_memalign(32, MAX_TX_SIZE * sizeof(double)));
+            eb_aom_memalign(32, MAX_TX_SIZE * sizeof(double)));
         output_ref_ = reinterpret_cast<double *>(
-            aom_memalign(32, MAX_TX_SIZE * sizeof(double)));
+            eb_aom_memalign(32, MAX_TX_SIZE * sizeof(double)));
     }
 
     void TearDown() override {
-        aom_free(input_test_);
-        aom_free(output_test_);
-        aom_free(input_ref_);
-        aom_free(output_ref_);
+        eb_aom_free(input_test_);
+        eb_aom_free(output_test_);
+        eb_aom_free(input_ref_);
+        eb_aom_free(output_ref_);
         aom_clear_system_state();
     }
 

--- a/test/FwdTxfm2dAsmTest.cc
+++ b/test/FwdTxfm2dAsmTest.cc
@@ -7,7 +7,7 @@
  * @file FwdTxfm2dAsmTest.c
  *
  * @brief Unit test for forward 2d transform functions written in assembly code:
- * - av1_fwd_txfm2d_{4, 8, 16, 32, 64}x{4, 8, 16, 32, 64}_avx2
+ * - eb_av1_fwd_txfm2d_{4, 8, 16, 32, 64}x{4, 8, 16, 32, 64}_avx2
  *
  * @author Cidana-Wenyao
  *
@@ -40,21 +40,21 @@ using svt_av1_test_tool::SVTRandom;
 namespace {
 using FwdTxfm2dAsmParam = std::tuple<int, int>;
 static const FwdTxfm2dFunc fwd_txfm_2d_asm_func[TX_SIZES_ALL] = {
-    av1_fwd_txfm2d_4x4_sse4_1, av1_fwd_txfm2d_8x8_avx2,
-    av1_fwd_txfm2d_16x16_avx2, av1_fwd_txfm2d_32x32_avx2,
-    av1_fwd_txfm2d_64x64_avx2, av1_fwd_txfm2d_4x8_avx2,
-    av1_fwd_txfm2d_8x4_avx2,   av1_fwd_txfm2d_8x16_avx2,
-    av1_fwd_txfm2d_16x8_avx2,  av1_fwd_txfm2d_16x32_avx2,
-    av1_fwd_txfm2d_32x16_avx2, av1_fwd_txfm2d_32x64_avx2,
-    av1_fwd_txfm2d_64x32_avx2, av1_fwd_txfm2d_4x16_avx2,
-    av1_fwd_txfm2d_16x4_avx2,  av1_fwd_txfm2d_8x32_avx2,
-    av1_fwd_txfm2d_32x8_avx2,  av1_fwd_txfm2d_16x64_avx2,
-    av1_fwd_txfm2d_64x16_avx2,
+    eb_av1_fwd_txfm2d_4x4_sse4_1, eb_av1_fwd_txfm2d_8x8_avx2,
+    eb_av1_fwd_txfm2d_16x16_avx2, eb_av1_fwd_txfm2d_32x32_avx2,
+    eb_av1_fwd_txfm2d_64x64_avx2, eb_av1_fwd_txfm2d_4x8_avx2,
+    eb_av1_fwd_txfm2d_8x4_avx2,   eb_av1_fwd_txfm2d_8x16_avx2,
+    eb_av1_fwd_txfm2d_16x8_avx2,  eb_av1_fwd_txfm2d_16x32_avx2,
+    eb_av1_fwd_txfm2d_32x16_avx2, eb_av1_fwd_txfm2d_32x64_avx2,
+    eb_av1_fwd_txfm2d_64x32_avx2, eb_av1_fwd_txfm2d_4x16_avx2,
+    eb_av1_fwd_txfm2d_16x4_avx2,  eb_av1_fwd_txfm2d_8x32_avx2,
+    eb_av1_fwd_txfm2d_32x8_avx2,  eb_av1_fwd_txfm2d_16x64_avx2,
+    eb_av1_fwd_txfm2d_64x16_avx2,
 };
 
 /**
  * @brief Unit test for fwd tx 2d avx2 functions:
- * - av1_fwd_txfm2d_{4, 8, 16, 32, 64}x{4, 8, 16, 32, 64}_avx2
+ * - eb_av1_fwd_txfm2d_{4, 8, 16, 32, 64}x{4, 8, 16, 32, 64}_avx2
  *
  * Test strategy:
  * Verify this assembly code by comparing with reference c implementation.

--- a/test/FwdTxfm2dTest.cc
+++ b/test/FwdTxfm2dTest.cc
@@ -73,20 +73,20 @@ class AV1FwdTxfm2dTest : public ::testing::TestWithParam<FwdTxfm2dParam> {
 
     void SetUp() override {
         input_test_ = reinterpret_cast<int16_t *>(
-            aom_memalign(32, MAX_TX_SQUARE * sizeof(int16_t)));
+            eb_aom_memalign(32, MAX_TX_SQUARE * sizeof(int16_t)));
         output_test_ = reinterpret_cast<int32_t *>(
-            aom_memalign(32, MAX_TX_SQUARE * sizeof(int32_t)));
+            eb_aom_memalign(32, MAX_TX_SQUARE * sizeof(int32_t)));
         input_ref_ = reinterpret_cast<double *>(
-            aom_memalign(32, MAX_TX_SQUARE * sizeof(double)));
+            eb_aom_memalign(32, MAX_TX_SQUARE * sizeof(double)));
         output_ref_ = reinterpret_cast<double *>(
-            aom_memalign(32, MAX_TX_SQUARE * sizeof(double)));
+            eb_aom_memalign(32, MAX_TX_SQUARE * sizeof(double)));
     }
 
     void TearDown() override {
-        aom_free(input_test_);
-        aom_free(output_test_);
-        aom_free(input_ref_);
-        aom_free(output_ref_);
+        eb_aom_free(input_test_);
+        eb_aom_free(output_test_);
+        eb_aom_free(input_ref_);
+        eb_aom_free(output_ref_);
         aom_clear_system_state();
     }
 

--- a/test/InvTxfm1dTest.cc
+++ b/test/InvTxfm1dTest.cc
@@ -72,17 +72,17 @@ class AV1InvTxfm1dTest : public ::testing::TestWithParam<InvTxfm1dParam> {
 
     void SetUp() override {
         input_ = reinterpret_cast<int32_t *>(
-            aom_memalign(32, MAX_TX_SIZE * sizeof(int32_t)));
+            eb_aom_memalign(32, MAX_TX_SIZE * sizeof(int32_t)));
         output_ = reinterpret_cast<int32_t *>(
-            aom_memalign(32, MAX_TX_SIZE * sizeof(int32_t)));
+            eb_aom_memalign(32, MAX_TX_SIZE * sizeof(int32_t)));
         inv_output_ = reinterpret_cast<int32_t *>(
-            aom_memalign(32, MAX_TX_SIZE * sizeof(int32_t)));
+            eb_aom_memalign(32, MAX_TX_SIZE * sizeof(int32_t)));
     }
 
     void TearDown() override {
-        aom_free(input_);
-        aom_free(output_);
-        aom_free(inv_output_);
+        eb_aom_free(input_);
+        eb_aom_free(output_);
+        eb_aom_free(inv_output_);
         aom_clear_system_state();
     }
 

--- a/test/InvTxfm2dAsmTest.cc
+++ b/test/InvTxfm2dAsmTest.cc
@@ -8,7 +8,7 @@
  *
  * @brief Unit test for forward 2d transform functions:
  * - Av1TransformTwoD_{4x4, 8x8, 16x16, 32x32, 64x64}
- * - av1_fwd_txfm2d_{rectangle}
+ * - eb_av1_fwd_txfm2d_{rectangle}
  *
  * @author Cidana-Wenyao
  *
@@ -89,19 +89,19 @@ static bool is_tx_type_imp_64x64_sse4(const TxType tx_type) {
 }
 
 static const InvSqrTxfmFuncPair inv_txfm_c_avx2_func_pairs[TX_64X64 + 1] = {
-    SQR_FUNC_PAIRS(av1_inv_txfm2d_add_4x4, avx2, all_txtype_imp),
-    SQR_FUNC_PAIRS(av1_inv_txfm2d_add_8x8, avx2, all_txtype_imp),
-    SQR_FUNC_PAIRS(av1_inv_txfm2d_add_16x16, avx2, all_txtype_imp),
-    SQR_FUNC_PAIRS(av1_inv_txfm2d_add_32x32, avx2, is_tx_type_imp_32x32_avx2),
-    EMPTY_FUNC_PAIRS(av1_inv_txfm2d_add_64x64),
+    SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_4x4, avx2, all_txtype_imp),
+    SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_8x8, avx2, all_txtype_imp),
+    SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_16x16, avx2, all_txtype_imp),
+    SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_32x32, avx2, is_tx_type_imp_32x32_avx2),
+    EMPTY_FUNC_PAIRS(eb_av1_inv_txfm2d_add_64x64),
 };
 
 static const InvSqrTxfmFuncPair inv_txfm_c_sse4_1_func_pairs[TX_64X64 + 1] = {
-    SQR_FUNC_PAIRS(av1_inv_txfm2d_add_4x4, sse4_1, dct_adst_combine_imp),
-    SQR_FUNC_PAIRS(av1_inv_txfm2d_add_8x8, sse4_1, dct_adst_combine_imp),
-    SQR_FUNC_PAIRS(av1_inv_txfm2d_add_16x16, sse4_1, dct_adst_combine_imp),
-    EMPTY_FUNC_PAIRS(av1_inv_txfm2d_add_32x32),
-    SQR_FUNC_PAIRS(av1_inv_txfm2d_add_64x64, sse4_1, is_tx_type_imp_64x64_sse4),
+    SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_4x4, sse4_1, dct_adst_combine_imp),
+    SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_8x8, sse4_1, dct_adst_combine_imp),
+    SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_16x16, sse4_1, dct_adst_combine_imp),
+    EMPTY_FUNC_PAIRS(eb_av1_inv_txfm2d_add_32x32),
+    SQR_FUNC_PAIRS(eb_av1_inv_txfm2d_add_64x64, sse4_1, is_tx_type_imp_64x64_sse4),
 };
 
 // from TX_4X8 to TX_SIZES_ALL
@@ -114,27 +114,27 @@ static const InvRectTxfm2dType1Func rect_type1_ref_funcs[TX_SIZES_ALL] = {
     nullptr,
     nullptr,
     nullptr,  // 4x8 and 8x4
-    av1_inv_txfm2d_add_8x16_c,
-    av1_inv_txfm2d_add_16x8_c,
-    av1_inv_txfm2d_add_16x32_c,
-    av1_inv_txfm2d_add_32x16_c,
-    av1_inv_txfm2d_add_32x64_c,
-    av1_inv_txfm2d_add_64x32_c,
+    eb_av1_inv_txfm2d_add_8x16_c,
+    eb_av1_inv_txfm2d_add_16x8_c,
+    eb_av1_inv_txfm2d_add_16x32_c,
+    eb_av1_inv_txfm2d_add_32x16_c,
+    eb_av1_inv_txfm2d_add_32x64_c,
+    eb_av1_inv_txfm2d_add_64x32_c,
     nullptr,
     nullptr,  // 4x16 and 16x4
-    av1_inv_txfm2d_add_8x32_c,
-    av1_inv_txfm2d_add_32x8_c,
-    av1_inv_txfm2d_add_16x64_c,
-    av1_inv_txfm2d_add_64x16_c};
+    eb_av1_inv_txfm2d_add_8x32_c,
+    eb_av1_inv_txfm2d_add_32x8_c,
+    eb_av1_inv_txfm2d_add_16x64_c,
+    eb_av1_inv_txfm2d_add_64x16_c};
 
-static const InvRectType2TxfmFuncPair inv_4x8{av1_inv_txfm2d_add_4x8_c,
-                                              av1_inv_txfm2d_add_4x8_sse4_1};
-static const InvRectType2TxfmFuncPair inv_8x4{av1_inv_txfm2d_add_8x4_c,
-                                              av1_inv_txfm2d_add_8x4_sse4_1};
-static const InvRectType2TxfmFuncPair inv_4x16{av1_inv_txfm2d_add_4x16_c,
-                                               av1_inv_txfm2d_add_4x16_sse4_1};
-static const InvRectType2TxfmFuncPair inv_16x4{av1_inv_txfm2d_add_16x4_c,
-                                               av1_inv_txfm2d_add_16x4_sse4_1};
+static const InvRectType2TxfmFuncPair inv_4x8{eb_av1_inv_txfm2d_add_4x8_c,
+                                              eb_av1_inv_txfm2d_add_4x8_sse4_1};
+static const InvRectType2TxfmFuncPair inv_8x4{eb_av1_inv_txfm2d_add_8x4_c,
+                                              eb_av1_inv_txfm2d_add_8x4_sse4_1};
+static const InvRectType2TxfmFuncPair inv_4x16{eb_av1_inv_txfm2d_add_4x16_c,
+                                               eb_av1_inv_txfm2d_add_4x16_sse4_1};
+static const InvRectType2TxfmFuncPair inv_16x4{eb_av1_inv_txfm2d_add_16x4_c,
+                                               eb_av1_inv_txfm2d_add_16x4_sse4_1};
 static const InvRectType2TxfmFuncPair *get_rect_type2_func_pair(
     const TxSize tx_size) {
     switch (tx_size) {
@@ -148,7 +148,7 @@ static const InvRectType2TxfmFuncPair *get_rect_type2_func_pair(
 
 /**
  * @brief Unit test for inverse tx 2d avx2/sse4_1 functions:
- * - av1_inv_txfm2d_{4, 8, 16, 32, 64}x{4, 8, 16, 32, 64}_avx2
+ * - eb_av1_inv_txfm2d_{4, 8, 16, 32, 64}x{4, 8, 16, 32, 64}_avx2
  *
  * Test strategy:
  * Verify this assembly code by comparing with reference c implementation.
@@ -187,23 +187,23 @@ class InvTxfm2dAsmTest : public ::testing::TestWithParam<InvTxfm2dParam> {
 
     void SetUp() override {
         pixel_input_ = reinterpret_cast<int16_t *>(
-            aom_memalign(32, MAX_TX_SQUARE * sizeof(int16_t)));
+            eb_aom_memalign(32, MAX_TX_SQUARE * sizeof(int16_t)));
         input_ = reinterpret_cast<int32_t *>(
-            aom_memalign(32, MAX_TX_SQUARE * sizeof(int32_t)));
+            eb_aom_memalign(32, MAX_TX_SQUARE * sizeof(int32_t)));
         output_test_ = reinterpret_cast<uint16_t *>(
-            aom_memalign(32, MAX_TX_SQUARE * sizeof(uint16_t)));
+            eb_aom_memalign(32, MAX_TX_SQUARE * sizeof(uint16_t)));
         output_ref_ = reinterpret_cast<uint16_t *>(
-            aom_memalign(32, MAX_TX_SQUARE * sizeof(uint16_t)));
+            eb_aom_memalign(32, MAX_TX_SQUARE * sizeof(uint16_t)));
         lowbd_output_test_ = reinterpret_cast<uint8_t *>(
-            aom_memalign(32, MAX_TX_SQUARE * sizeof(uint8_t)));
+            eb_aom_memalign(32, MAX_TX_SQUARE * sizeof(uint8_t)));
     }
 
     void TearDown() override {
-        aom_free(pixel_input_);
-        aom_free(input_);
-        aom_free(output_test_);
-        aom_free(output_ref_);
-        aom_free(lowbd_output_test_);
+        eb_aom_free(pixel_input_);
+        eb_aom_free(input_);
+        eb_aom_free(output_test_);
+        eb_aom_free(output_ref_);
+        eb_aom_free(lowbd_output_test_);
         aom_clear_system_state();
     }
 
@@ -248,7 +248,7 @@ class InvTxfm2dAsmTest : public ::testing::TestWithParam<InvTxfm2dParam> {
         const int height = tx_size_high[tx_size];
         const int max_eob = av1_get_max_eob(tx_size);
 
-        const InvRectTxfm2dType1Func test_func = av1_highbd_inv_txfm_add_avx2;
+        const InvRectTxfm2dType1Func test_func = eb_av1_highbd_inv_txfm_add_avx2;
         const InvRectTxfm2dType1Func ref_func = rect_type1_ref_funcs[tx_size];
         if (ref_func == nullptr)
             return;
@@ -334,11 +334,11 @@ class InvTxfm2dAsmTest : public ::testing::TestWithParam<InvTxfm2dParam> {
                                                 TxType tx_type,
                                                 int32_t bd);
         const LowbdInvSqrTxfmRefFunc lowbd_sqr_ref_funcs[TX_SIZES] = {
-            av1_inv_txfm2d_add_4x4_c,
-            av1_inv_txfm2d_add_8x8_c,
-            av1_inv_txfm2d_add_16x16_c,
-            av1_inv_txfm2d_add_32x32_c,
-            av1_inv_txfm2d_add_64x64_c};
+            eb_av1_inv_txfm2d_add_4x4_c,
+            eb_av1_inv_txfm2d_add_8x8_c,
+            eb_av1_inv_txfm2d_add_16x16_c,
+            eb_av1_inv_txfm2d_add_32x32_c,
+            eb_av1_inv_txfm2d_add_64x64_c};
         const LowbdInvRectTxfmRefFunc lowbd_rect_ref_funcs[TX_SIZES_ALL] = {
             nullptr,
             nullptr,
@@ -347,18 +347,18 @@ class InvTxfm2dAsmTest : public ::testing::TestWithParam<InvTxfm2dParam> {
             nullptr,
             nullptr,
             nullptr,
-            av1_inv_txfm2d_add_8x16_c,
-            av1_inv_txfm2d_add_16x8_c,
-            av1_inv_txfm2d_add_16x32_c,
-            av1_inv_txfm2d_add_32x16_c,
-            av1_inv_txfm2d_add_32x64_c,
-            av1_inv_txfm2d_add_64x32_c,
+            eb_av1_inv_txfm2d_add_8x16_c,
+            eb_av1_inv_txfm2d_add_16x8_c,
+            eb_av1_inv_txfm2d_add_16x32_c,
+            eb_av1_inv_txfm2d_add_32x16_c,
+            eb_av1_inv_txfm2d_add_32x64_c,
+            eb_av1_inv_txfm2d_add_64x32_c,
             nullptr,
             nullptr,
-            av1_inv_txfm2d_add_8x32_c,
-            av1_inv_txfm2d_add_32x8_c,
-            av1_inv_txfm2d_add_16x64_c,
-            av1_inv_txfm2d_add_64x16_c};
+            eb_av1_inv_txfm2d_add_8x32_c,
+            eb_av1_inv_txfm2d_add_32x8_c,
+            eb_av1_inv_txfm2d_add_16x64_c,
+            eb_av1_inv_txfm2d_add_64x16_c};
 
         if (tx_size >= TX_SIZES && lowbd_rect_ref_funcs[tx_size] == nullptr)
             return;
@@ -556,14 +556,14 @@ class InvTxfm2dAsmTest : public ::testing::TestWithParam<InvTxfm2dParam> {
         const FwdTxfm2dFunc fwd_txfm_func[TX_SIZES_ALL] = {
             Av1TransformTwoD_4x4_c,   Av1TransformTwoD_8x8_c,
             Av1TransformTwoD_16x16_c, Av1TransformTwoD_32x32_c,
-            Av1TransformTwoD_64x64_c, av1_fwd_txfm2d_4x8_c,
-            av1_fwd_txfm2d_8x4_c,     av1_fwd_txfm2d_8x16_c,
-            av1_fwd_txfm2d_16x8_c,    av1_fwd_txfm2d_16x32_c,
-            av1_fwd_txfm2d_32x16_c,   av1_fwd_txfm2d_32x64_c,
-            av1_fwd_txfm2d_64x32_c,   av1_fwd_txfm2d_4x16_c,
-            av1_fwd_txfm2d_16x4_c,    av1_fwd_txfm2d_8x32_c,
-            av1_fwd_txfm2d_32x8_c,    av1_fwd_txfm2d_16x64_c,
-            av1_fwd_txfm2d_64x16_c,
+            Av1TransformTwoD_64x64_c, eb_av1_fwd_txfm2d_4x8_c,
+            eb_av1_fwd_txfm2d_8x4_c,     eb_av1_fwd_txfm2d_8x16_c,
+            eb_av1_fwd_txfm2d_16x8_c,    eb_av1_fwd_txfm2d_16x32_c,
+            eb_av1_fwd_txfm2d_32x16_c,   eb_av1_fwd_txfm2d_32x64_c,
+            eb_av1_fwd_txfm2d_64x32_c,   eb_av1_fwd_txfm2d_4x16_c,
+            eb_av1_fwd_txfm2d_16x4_c,    eb_av1_fwd_txfm2d_8x32_c,
+            eb_av1_fwd_txfm2d_32x8_c,    eb_av1_fwd_txfm2d_16x64_c,
+            eb_av1_fwd_txfm2d_64x16_c,
         };
 
         memset(output_ref_, 0, MAX_TX_SQUARE * sizeof(uint16_t));
@@ -648,17 +648,17 @@ TEST_P(InvTxfm2dAsmTest, DISABLED_HandleTransform_speed_test) {
 
 INSTANTIATE_TEST_CASE_P(
     TX, InvTxfm2dAsmTest,
-    ::testing::Combine(::testing::Values(av1_lowbd_inv_txfm2d_add_ssse3),
+    ::testing::Combine(::testing::Values(eb_av1_lowbd_inv_txfm2d_add_ssse3),
                        ::testing::Values(static_cast<int>(AOM_BITS_8),
                                          static_cast<int>(AOM_BITS_10))));
 
-extern "C" void av1_lowbd_inv_txfm2d_add_avx2(const int32_t *input,
+extern "C" void eb_av1_lowbd_inv_txfm2d_add_avx2(const int32_t *input,
     uint8_t *output, int32_t stride, TxType tx_type, TxSize tx_size,
     int32_t eob);
 
 INSTANTIATE_TEST_CASE_P(
     TX_AVX2, InvTxfm2dAsmTest,
-    ::testing::Combine(::testing::Values(av1_lowbd_inv_txfm2d_add_avx2),
+    ::testing::Combine(::testing::Values(eb_av1_lowbd_inv_txfm2d_add_avx2),
                        ::testing::Values(static_cast<int>(AOM_BITS_8),
                                          static_cast<int>(AOM_BITS_10))));
 

--- a/test/QuantAsmTest.cc
+++ b/test/QuantAsmTest.cc
@@ -7,9 +7,9 @@
  * @file QuantAsmTest.c
  *
  * @brief Unit test for quantize avx2 functions:
- * - aom_highbd_quantize_b_avx2
- * - aom_highbd_quantize_b_32x32_avx2
- * - aom_highbd_quantize_b_64x64_avx2
+ * - eb_aom_highbd_quantize_b_avx2
+ * - eb_aom_highbd_quantize_b_32x32_avx2
+ * - eb_aom_highbd_quantize_b_64x64_avx2
  *
  * @author Cidana-Zhengwen
  *
@@ -39,7 +39,7 @@
 #include "random.h"
 
 namespace QuantizeAsmTest {
-extern "C" void av1_build_quantizer(AomBitDepth bit_depth, int32_t y_dc_delta_q,
+extern "C" void eb_av1_build_quantizer(AomBitDepth bit_depth, int32_t y_dc_delta_q,
                                     int32_t u_dc_delta_q, int32_t u_ac_delta_q,
                                     int32_t v_dc_delta_q, int32_t v_ac_delta_q,
                                     Quants *const quants, Dequants *const deq);
@@ -58,9 +58,9 @@ using QuantizeParam = std::tuple<int, int>;
 using svt_av1_test_tool::SVTRandom;  // to generate the random
 /**
  * @brief Unit test for quantize avx2 functions:
- * - aom_highbd_quantize_b_avx2
- * - aom_highbd_quantize_b_32x32_avx2
- * - aom_highbd_quantize_b_64x64_avx2
+ * - eb_aom_highbd_quantize_b_avx2
+ * - eb_aom_highbd_quantize_b_32x32_avx2
+ * - eb_aom_highbd_quantize_b_64x64_avx2
  *
  * Test strategy:
  * These tests use quantize C function as reference, input the same data and
@@ -89,7 +89,7 @@ class QuantizeBTest : public ::testing::TestWithParam<QuantizeParam> {
         coeff_max_ = (1 << (7 + bd_)) - 1;
         rnd_ = new SVTRandom(coeff_min_, coeff_max_);
 
-        av1_build_quantizer(bd_, 0, 0, 0, 0, 0, &qtab_quants_, &qtab_deq_);
+        eb_av1_build_quantizer(bd_, 0, 0, 0, 0, 0, &qtab_quants_, &qtab_deq_);
         setup_func_ptrs();
     }
 
@@ -100,23 +100,23 @@ class QuantizeBTest : public ::testing::TestWithParam<QuantizeParam> {
 
     void SetUp() override {
         coeff_in_ = reinterpret_cast<TranLow *>(
-            aom_memalign(32, MAX_TX_SQUARE * sizeof(TranLow)));
+            eb_aom_memalign(32, MAX_TX_SQUARE * sizeof(TranLow)));
         qcoeff_ref_ = reinterpret_cast<TranLow *>(
-            aom_memalign(32, MAX_TX_SQUARE * sizeof(TranLow)));
+            eb_aom_memalign(32, MAX_TX_SQUARE * sizeof(TranLow)));
         dqcoeff_ref_ = reinterpret_cast<TranLow *>(
-            aom_memalign(32, MAX_TX_SQUARE * sizeof(TranLow)));
+            eb_aom_memalign(32, MAX_TX_SQUARE * sizeof(TranLow)));
         qcoeff_test_ = reinterpret_cast<TranLow *>(
-            aom_memalign(32, MAX_TX_SQUARE * sizeof(TranLow)));
+            eb_aom_memalign(32, MAX_TX_SQUARE * sizeof(TranLow)));
         dqcoeff_test_ = reinterpret_cast<TranLow *>(
-            aom_memalign(32, MAX_TX_SQUARE * sizeof(TranLow)));
+            eb_aom_memalign(32, MAX_TX_SQUARE * sizeof(TranLow)));
     }
 
     void TearDown() override {
-        aom_free(coeff_in_);
-        aom_free(qcoeff_ref_);
-        aom_free(dqcoeff_ref_);
-        aom_free(qcoeff_test_);
-        aom_free(dqcoeff_test_);
+        eb_aom_free(coeff_in_);
+        eb_aom_free(qcoeff_ref_);
+        eb_aom_free(dqcoeff_ref_);
+        eb_aom_free(qcoeff_test_);
+        eb_aom_free(dqcoeff_test_);
         aom_clear_system_state();
     }
 
@@ -127,25 +127,25 @@ class QuantizeBTest : public ::testing::TestWithParam<QuantizeParam> {
     void setup_func_ptrs() {
         if (bd_ == AOM_BITS_8) {
             if (tx_size_ == TX_32X32) {
-                quant_ref_ = aom_quantize_b_32x32_c_II;
-                quant_test_ = aom_highbd_quantize_b_32x32_avx2;
+                quant_ref_ = eb_aom_quantize_b_32x32_c_II;
+                quant_test_ = eb_aom_highbd_quantize_b_32x32_avx2;
             } else if (tx_size_ == TX_64X64) {
-                quant_ref_ = aom_quantize_b_64x64_c_II;
-                quant_test_ = aom_highbd_quantize_b_64x64_avx2;
+                quant_ref_ = eb_aom_quantize_b_64x64_c_II;
+                quant_test_ = eb_aom_highbd_quantize_b_64x64_avx2;
             } else {
-                quant_ref_ = aom_quantize_b_c_II;
-                quant_test_ = aom_highbd_quantize_b_avx2;
+                quant_ref_ = eb_aom_quantize_b_c_II;
+                quant_test_ = eb_aom_highbd_quantize_b_avx2;
             }
         } else {
             if (tx_size_ == TX_32X32) {
-                quant_ref_ = aom_highbd_quantize_b_32x32_c;
-                quant_test_ = aom_highbd_quantize_b_32x32_avx2;
+                quant_ref_ = eb_aom_highbd_quantize_b_32x32_c;
+                quant_test_ = eb_aom_highbd_quantize_b_32x32_avx2;
             } else if (tx_size_ == TX_64X64) {
-                quant_ref_ = aom_highbd_quantize_b_64x64_c;
-                quant_test_ = aom_highbd_quantize_b_64x64_avx2;
+                quant_ref_ = eb_aom_highbd_quantize_b_64x64_c;
+                quant_test_ = eb_aom_highbd_quantize_b_64x64_avx2;
             } else {
-                quant_ref_ = aom_highbd_quantize_b_c;
-                quant_test_ = aom_highbd_quantize_b_avx2;
+                quant_ref_ = eb_aom_highbd_quantize_b_c;
+                quant_test_ = eb_aom_highbd_quantize_b_avx2;
             }
         }
     }

--- a/test/RestorationPickTest.cc
+++ b/test/RestorationPickTest.cc
@@ -192,7 +192,7 @@ TEST(EbRestorationPick, compute_stats) {
                             const int32_t v_end =
                                 RESTORATION_UNITSIZE_MAX * 3 / 2 + end;
 
-                            av1_compute_stats_c(wiener_win,
+                            eb_av1_compute_stats_c(wiener_win,
                                                 d,
                                                 s,
                                                 h_start,
@@ -203,7 +203,7 @@ TEST(EbRestorationPick, compute_stats) {
                                                 src_stride,
                                                 M_org,
                                                 H_org);
-                            av1_compute_stats_avx2(wiener_win,
+                            eb_av1_compute_stats_avx2(wiener_win,
                                                    d,
                                                    s,
                                                    h_start,
@@ -301,7 +301,7 @@ TEST(EbRestorationPick, compute_stats_highbd) {
                                     const int32_t v_end =
                                         sizes[size_mode] + end;
 
-                                    av1_compute_stats_highbd_c(wiener_win,
+                                    eb_av1_compute_stats_highbd_c(wiener_win,
                                                                dgd8,
                                                                src8,
                                                                h_start,
@@ -313,7 +313,7 @@ TEST(EbRestorationPick, compute_stats_highbd) {
                                                                M_org,
                                                                H_org,
                                                                bit_depth);
-                                    av1_compute_stats_highbd_avx2(wiener_win,
+                                    eb_av1_compute_stats_highbd_avx2(wiener_win,
                                                                   dgd8,
                                                                   src8,
                                                                   h_start,
@@ -401,7 +401,7 @@ TEST(EbRestorationPick, DISABLED_compute_stats_speed) {
         EbStartTime(&start_time_seconds, &start_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
-            av1_compute_stats_c(wiener_win,
+            eb_av1_compute_stats_c(wiener_win,
                                 d,
                                 s,
                                 h_start,
@@ -417,7 +417,7 @@ TEST(EbRestorationPick, DISABLED_compute_stats_speed) {
         EbStartTime(&middle_time_seconds, &middle_time_useconds);
 
         for (uint64_t i = 0; i < num_loop; i++) {
-            av1_compute_stats_avx2(wiener_win,
+            eb_av1_compute_stats_avx2(wiener_win,
                                    d,
                                    s,
                                    h_start,
@@ -450,11 +450,11 @@ TEST(EbRestorationPick, DISABLED_compute_stats_speed) {
         }
 
         printf("Average Nanoseconds per Function Call\n");
-        printf("    av1_compute_stats_avx2(%d)   : %6.2f\n",
+        printf("    eb_av1_compute_stats_avx2(%d)   : %6.2f\n",
                wiener_win,
                1000000 * time_c / num_loop);
         printf(
-            "    av1_compute_stats_avx512(%d) : %6.2f   (Comparison: "
+            "    eb_av1_compute_stats_avx512(%d) : %6.2f   (Comparison: "
             "%5.2fx)\n",
             wiener_win,
             1000000 * time_o / num_loop,
@@ -493,7 +493,7 @@ TEST(EbRestorationPick, DISABLED_compute_stats_highbd_speed) {
             EbStartTime(&start_time_seconds, &start_time_useconds);
 
             for (uint64_t i = 0; i < num_loop; i++) {
-                av1_compute_stats_highbd_c(wiener_win,
+                eb_av1_compute_stats_highbd_c(wiener_win,
                                            dgd8,
                                            src8,
                                            h_start,
@@ -510,7 +510,7 @@ TEST(EbRestorationPick, DISABLED_compute_stats_highbd_speed) {
             EbStartTime(&middle_time_seconds, &middle_time_useconds);
 
             for (uint64_t i = 0; i < num_loop; i++) {
-                av1_compute_stats_highbd_avx2(wiener_win,
+                eb_av1_compute_stats_highbd_avx2(wiener_win,
                                               dgd8,
                                               src8,
                                               h_start,
@@ -544,7 +544,7 @@ TEST(EbRestorationPick, DISABLED_compute_stats_highbd_speed) {
             }
 
             printf("Average Nanoseconds per Function Call\n");
-            printf("    av1_compute_stats_highbd_avx2(%d)   : %6.2f\n",
+            printf("    eb_av1_compute_stats_highbd_avx2(%d)   : %6.2f\n",
                    wiener_win,
                    1000000 * time_c / num_loop);
             printf(

--- a/test/SadTest.cc
+++ b/test/SadTest.cc
@@ -85,9 +85,9 @@ class SADTestBase : public ::testing::Test {
     }
 
     void SetUp() override {
-        src_aligned_ = (uint8_t *)aom_memalign(32, MAX_BLOCK_SIZE);
-        ref1_aligned_ = (uint8_t *)aom_memalign(32, MAX_BLOCK_SIZE);
-        ref2_aligned_ = (uint8_t *)aom_memalign(32, MAX_BLOCK_SIZE);
+        src_aligned_ = (uint8_t * )eb_aom_memalign(32, MAX_BLOCK_SIZE);
+        ref1_aligned_ = (uint8_t * )eb_aom_memalign(32, MAX_BLOCK_SIZE);
+        ref2_aligned_ = (uint8_t * )eb_aom_memalign(32, MAX_BLOCK_SIZE);
         ASSERT_NE(src_aligned_, nullptr);
         ASSERT_NE(ref1_aligned_, nullptr);
         ASSERT_NE(ref2_aligned_, nullptr);
@@ -95,11 +95,11 @@ class SADTestBase : public ::testing::Test {
 
     void TearDown() override {
         if (src_aligned_)
-            aom_free(src_aligned_);
+            eb_aom_free(src_aligned_);
         if (ref1_aligned_)
-            aom_free(ref1_aligned_);
+            eb_aom_free(ref1_aligned_);
         if (ref2_aligned_)
-            aom_free(ref2_aligned_);
+            eb_aom_free(ref2_aligned_);
     }
 
     void prepare_data() {

--- a/test/TxfmCommon.h
+++ b/test/TxfmCommon.h
@@ -26,61 +26,61 @@ static const int8_t test_txfm_range[12] = {
     20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20};
 
 // export forward transform functions
-void av1_fdct4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fdct4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                    const int8_t *stage_range);
-void av1_fdct8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fdct8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                    const int8_t *stage_range);
-void av1_fdct16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fdct16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                     const int8_t *stage_range);
-void av1_fdct32_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fdct32_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                     const int8_t *stage_range);
-void av1_fdct64_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fdct64_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                     const int8_t *stage_range);
-void av1_fadst4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fadst4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                     const int8_t *stage_range);
-void av1_fadst8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fadst8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                     const int8_t *stage_range);
-void av1_fadst16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fadst16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                      const int8_t *stage_range);
 void av1_fadst32_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                      const int8_t *stage_range);
-void av1_fidentity4_c(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fidentity4_c(const int32_t *input, int32_t *output, int8_t cos_bit,
                       const int8_t *stage_range);
-void av1_fidentity8_c(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fidentity8_c(const int32_t *input, int32_t *output, int8_t cos_bit,
                       const int8_t *stage_range);
-void av1_fidentity16_c(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fidentity16_c(const int32_t *input, int32_t *output, int8_t cos_bit,
                        const int8_t *stage_range);
-void av1_fidentity32_c(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_fidentity32_c(const int32_t *input, int32_t *output, int8_t cos_bit,
                        const int8_t *stage_range);
 void av1_fidentity64_c(const int32_t *input, int32_t *output, int8_t cos_bit,
                        const int8_t *stage_range);
 
 // export inverse transform functions
-void av1_idct4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_idct4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                    const int8_t *stage_range);
-void av1_idct8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_idct8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                    const int8_t *stage_range);
-void av1_idct16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_idct16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                     const int8_t *stage_range);
-void av1_idct32_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_idct32_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                     const int8_t *stage_range);
-void av1_idct64_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_idct64_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                     const int8_t *stage_range);
-void av1_iadst4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_iadst4_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                     const int8_t *stage_range);
-void av1_iadst8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_iadst8_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                     const int8_t *stage_range);
-void av1_iadst16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_iadst16_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                      const int8_t *stage_range);
 void av1_iadst32_new(const int32_t *input, int32_t *output, int8_t cos_bit,
                      const int8_t *stage_range);
-void av1_iidentity4_c(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_iidentity4_c(const int32_t *input, int32_t *output, int8_t cos_bit,
                       const int8_t *stage_range);
-void av1_iidentity8_c(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_iidentity8_c(const int32_t *input, int32_t *output, int8_t cos_bit,
                       const int8_t *stage_range);
-void av1_iidentity16_c(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_iidentity16_c(const int32_t *input, int32_t *output, int8_t cos_bit,
                        const int8_t *stage_range);
-void av1_iidentity32_c(const int32_t *input, int32_t *output, int8_t cos_bit,
+void eb_av1_iidentity32_c(const int32_t *input, int32_t *output, int8_t cos_bit,
                        const int8_t *stage_range);
 void av1_iidentity64_c(const int32_t *input, int32_t *output, int8_t cos_bit,
                        const int8_t *stage_range);
@@ -96,19 +96,19 @@ typedef void (*TxfmFwd2dFunc)(int16_t *input, int32_t *output,
 
 static INLINE Txfm1dFunc fwd_txfm_type_to_func(TxfmType txfm_type) {
     switch (txfm_type) {
-    case TXFM_TYPE_DCT4: return av1_fdct4_new;
-    case TXFM_TYPE_DCT8: return av1_fdct8_new;
-    case TXFM_TYPE_DCT16: return av1_fdct16_new;
-    case TXFM_TYPE_DCT32: return av1_fdct32_new;
-    case TXFM_TYPE_DCT64: return av1_fdct64_new;
-    case TXFM_TYPE_ADST4: return av1_fadst4_new;
-    case TXFM_TYPE_ADST8: return av1_fadst8_new;
-    case TXFM_TYPE_ADST16: return av1_fadst16_new;
+    case TXFM_TYPE_DCT4: return eb_av1_fdct4_new;
+    case TXFM_TYPE_DCT8: return eb_av1_fdct8_new;
+    case TXFM_TYPE_DCT16: return eb_av1_fdct16_new;
+    case TXFM_TYPE_DCT32: return eb_av1_fdct32_new;
+    case TXFM_TYPE_DCT64: return eb_av1_fdct64_new;
+    case TXFM_TYPE_ADST4: return eb_av1_fadst4_new;
+    case TXFM_TYPE_ADST8: return eb_av1_fadst8_new;
+    case TXFM_TYPE_ADST16: return eb_av1_fadst16_new;
     case TXFM_TYPE_ADST32: return av1_fadst32_new;
-    case TXFM_TYPE_IDENTITY4: return av1_fidentity4_c;
-    case TXFM_TYPE_IDENTITY8: return av1_fidentity8_c;
-    case TXFM_TYPE_IDENTITY16: return av1_fidentity16_c;
-    case TXFM_TYPE_IDENTITY32: return av1_fidentity32_c;
+    case TXFM_TYPE_IDENTITY4: return eb_av1_fidentity4_c;
+    case TXFM_TYPE_IDENTITY8: return eb_av1_fidentity8_c;
+    case TXFM_TYPE_IDENTITY16: return eb_av1_fidentity16_c;
+    case TXFM_TYPE_IDENTITY32: return eb_av1_fidentity32_c;
     case TXFM_TYPE_IDENTITY64: return av1_fidentity64_c;
     default: assert(0); return NULL;
     }
@@ -116,19 +116,19 @@ static INLINE Txfm1dFunc fwd_txfm_type_to_func(TxfmType txfm_type) {
 
 static INLINE Txfm1dFunc inv_txfm_type_to_func(TxfmType txfm_type) {
     switch (txfm_type) {
-    case TXFM_TYPE_DCT4: return av1_idct4_new;
-    case TXFM_TYPE_DCT8: return av1_idct8_new;
-    case TXFM_TYPE_DCT16: return av1_idct16_new;
-    case TXFM_TYPE_DCT32: return av1_idct32_new;
-    case TXFM_TYPE_DCT64: return av1_idct64_new;
-    case TXFM_TYPE_ADST4: return av1_iadst4_new;
-    case TXFM_TYPE_ADST8: return av1_iadst8_new;
-    case TXFM_TYPE_ADST16: return av1_iadst16_new;
+    case TXFM_TYPE_DCT4: return eb_av1_idct4_new;
+    case TXFM_TYPE_DCT8: return eb_av1_idct8_new;
+    case TXFM_TYPE_DCT16: return eb_av1_idct16_new;
+    case TXFM_TYPE_DCT32: return eb_av1_idct32_new;
+    case TXFM_TYPE_DCT64: return eb_av1_idct64_new;
+    case TXFM_TYPE_ADST4: return eb_av1_iadst4_new;
+    case TXFM_TYPE_ADST8: return eb_av1_iadst8_new;
+    case TXFM_TYPE_ADST16: return eb_av1_iadst16_new;
     case TXFM_TYPE_ADST32: return av1_iadst32_new;
-    case TXFM_TYPE_IDENTITY4: return av1_iidentity4_c;
-    case TXFM_TYPE_IDENTITY8: return av1_iidentity8_c;
-    case TXFM_TYPE_IDENTITY16: return av1_iidentity16_c;
-    case TXFM_TYPE_IDENTITY32: return av1_iidentity32_c;
+    case TXFM_TYPE_IDENTITY4: return eb_av1_iidentity4_c;
+    case TXFM_TYPE_IDENTITY8: return eb_av1_iidentity8_c;
+    case TXFM_TYPE_IDENTITY16: return eb_av1_iidentity16_c;
+    case TXFM_TYPE_IDENTITY32: return eb_av1_iidentity32_c;
     case TXFM_TYPE_IDENTITY64: return av1_iidentity64_c;
     default: assert(0); return NULL;
     }
@@ -139,14 +139,14 @@ using FwdTxfm2dFunc = void (*)(int16_t *input, int32_t *output, uint32_t stride,
 static const FwdTxfm2dFunc fwd_txfm_2d_c_func[TX_SIZES_ALL] = {
     Av1TransformTwoD_4x4_c,   Av1TransformTwoD_8x8_c,
     Av1TransformTwoD_16x16_c, Av1TransformTwoD_32x32_c,
-    Av1TransformTwoD_64x64_c, av1_fwd_txfm2d_4x8_c,
-    av1_fwd_txfm2d_8x4_c,     av1_fwd_txfm2d_8x16_c,
-    av1_fwd_txfm2d_16x8_c,    av1_fwd_txfm2d_16x32_c,
-    av1_fwd_txfm2d_32x16_c,   av1_fwd_txfm2d_32x64_c,
-    av1_fwd_txfm2d_64x32_c,   av1_fwd_txfm2d_4x16_c,
-    av1_fwd_txfm2d_16x4_c,    av1_fwd_txfm2d_8x32_c,
-    av1_fwd_txfm2d_32x8_c,    av1_fwd_txfm2d_16x64_c,
-    av1_fwd_txfm2d_64x16_c,
+    Av1TransformTwoD_64x64_c, eb_av1_fwd_txfm2d_4x8_c,
+    eb_av1_fwd_txfm2d_8x4_c,     eb_av1_fwd_txfm2d_8x16_c,
+    eb_av1_fwd_txfm2d_16x8_c,    eb_av1_fwd_txfm2d_16x32_c,
+    eb_av1_fwd_txfm2d_32x16_c,   eb_av1_fwd_txfm2d_32x64_c,
+    eb_av1_fwd_txfm2d_64x32_c,   eb_av1_fwd_txfm2d_4x16_c,
+    eb_av1_fwd_txfm2d_16x4_c,    eb_av1_fwd_txfm2d_8x32_c,
+    eb_av1_fwd_txfm2d_32x8_c,    eb_av1_fwd_txfm2d_16x64_c,
+    eb_av1_fwd_txfm2d_64x16_c,
 };
 
 static INLINE int get_txfm1d_size(TxfmType txfm_type) {

--- a/test/VarianceTest.cc
+++ b/test/VarianceTest.cc
@@ -7,8 +7,8 @@
  * @file VarianceTest.cc
  *
  * @brief Unit test for variance, mse, sum square functions:
- * - aom_variance{4-128}x{4-128}_{c,sse2,avx2}
- * - aom_get_mb_ss_sse2
+ * - eb_aom_variance{4-128}x{4-128}_{c,sse2,avx2}
+ * - eb_aom_get_mb_ss_sse2
  * - aom_mse16x16_{c,avx2}
  *
  * @author Cidana-Ryan
@@ -84,15 +84,15 @@ class MseTest : public ::testing::TestWithParam<TestMseParam> {
           height_(TEST_GET_PARAM(1)),
           mse_tst_(TEST_GET_PARAM(2)) {
         src_data_ =
-            reinterpret_cast<uint8_t *>(aom_memalign(32, MAX_BLOCK_SIZE));
+            reinterpret_cast<uint8_t *>(eb_aom_memalign(32, MAX_BLOCK_SIZE));
         ref_data_ =
-            reinterpret_cast<uint8_t *>(aom_memalign(32, MAX_BLOCK_SIZE));
+            reinterpret_cast<uint8_t *>(eb_aom_memalign(32, MAX_BLOCK_SIZE));
     }
 
     ~MseTest() {
-        aom_free(src_data_);
+        eb_aom_free(src_data_);
         src_data_ = nullptr;
-        aom_free(ref_data_);
+        eb_aom_free(ref_data_);
         ref_data_ = nullptr;
     }
 
@@ -145,7 +145,7 @@ TEST_P(MseTest, MaxTest) {
 
 INSTANTIATE_TEST_CASE_P(Variance, MseTest,
                         ::testing::Values(TestMseParam(16, 16,
-                                                       &aom_mse16x16_avx2)));
+                                                       &eb_aom_mse16x16_avx2)));
 
 // sum of squares test
 static uint32_t mb_ss_ref(const int16_t *src) {
@@ -214,9 +214,9 @@ TEST_P(SumSquareTest, MatchTest) {
     run_match_test();
 };
 
-extern "C" uint32_t aom_get_mb_ss_sse2(const int16_t *src);
+extern "C" uint32_t eb_aom_get_mb_ss_sse2(const int16_t *src);
 INSTANTIATE_TEST_CASE_P(Variance, SumSquareTest,
-                        ::testing::Values(aom_get_mb_ss_sse2));
+                        ::testing::Values(eb_aom_get_mb_ss_sse2));
 
 // Variance test
 using VARIANCE_NXM_FUNC = uint32_t (*)(const uint8_t *src_ptr,
@@ -229,7 +229,7 @@ using VarianceParam =
 
 /**
  * @brief Unit test for variance functions, target functions include:
- *  - - aom_variance{4-128}x{4-128}_{c,avx2}
+ *  - - eb_aom_variance{4-128}x{4-128}_{c,avx2}
  *
  * Test strategy:
  *  This test case contains zero test, random value test, one quarter test as
@@ -253,15 +253,15 @@ class VarianceTest : public ::testing::TestWithParam<VarianceParam> {
           func_c_(TEST_GET_PARAM(2)),
           func_asm_(TEST_GET_PARAM(3)) {
         src_data_ =
-            reinterpret_cast<uint8_t *>(aom_memalign(32, MAX_BLOCK_SIZE));
+            reinterpret_cast<uint8_t *>(eb_aom_memalign(32, MAX_BLOCK_SIZE));
         ref_data_ =
-            reinterpret_cast<uint8_t *>(aom_memalign(32, MAX_BLOCK_SIZE));
+            reinterpret_cast<uint8_t *>(eb_aom_memalign(32, MAX_BLOCK_SIZE));
     }
 
     ~VarianceTest() {
-        aom_free(src_data_);
+        eb_aom_free(src_data_);
         src_data_ = nullptr;
-        aom_free(ref_data_);
+        eb_aom_free(ref_data_);
         ref_data_ = nullptr;
     }
 
@@ -332,28 +332,28 @@ TEST_P(VarianceTest, OneQuarterTest) {
 INSTANTIATE_TEST_CASE_P(
     Variance, VarianceTest,
     ::testing::Values(
-        VarianceParam(4, 4, &aom_variance4x4_c, &aom_variance4x4_sse2),
-        VarianceParam(4, 8, &aom_variance4x8_c, &aom_variance4x8_sse2),
-        VarianceParam(4, 16, &aom_variance4x16_c, &aom_variance4x16_sse2),
-        VarianceParam(8, 4, &aom_variance8x4_c, &aom_variance8x4_sse2),
-        VarianceParam(8, 8, &aom_variance8x8_c, &aom_variance8x8_sse2),
-        VarianceParam(8, 16, &aom_variance8x16_c, &aom_variance8x16_sse2),
-        VarianceParam(8, 32, &aom_variance8x32_c, &aom_variance8x32_sse2),
-        VarianceParam(16, 4, &aom_variance16x4_c, &aom_variance16x4_avx2),
-        VarianceParam(16, 8, &aom_variance16x8_c, &aom_variance16x8_avx2),
-        VarianceParam(16, 16, &aom_variance16x16_c, &aom_variance16x16_avx2),
-        VarianceParam(16, 32, &aom_variance16x32_c, &aom_variance16x32_avx2),
-        VarianceParam(16, 64, &aom_variance16x64_c, &aom_variance16x64_avx2),
-        VarianceParam(32, 8, &aom_variance32x8_c, &aom_variance32x8_avx2),
-        VarianceParam(32, 16, &aom_variance32x16_c, &aom_variance32x16_avx2),
-        VarianceParam(32, 32, &aom_variance32x32_c, &aom_variance32x32_avx2),
-        VarianceParam(32, 64, &aom_variance32x64_c, &aom_variance32x64_avx2),
-        VarianceParam(64, 16, &aom_variance64x16_c, &aom_variance64x16_avx2),
-        VarianceParam(64, 32, &aom_variance64x32_c, &aom_variance64x32_avx2),
-        VarianceParam(64, 64, &aom_variance64x64_c, &aom_variance64x64_avx2),
-        VarianceParam(64, 128, &aom_variance64x128_c, &aom_variance64x128_avx2),
-        VarianceParam(128, 64, &aom_variance128x64_c, &aom_variance128x64_avx2),
-        VarianceParam(128, 128, &aom_variance128x128_c,
-                      &aom_variance128x128_avx2)));
+        VarianceParam(4, 4, &eb_aom_variance4x4_c, &eb_aom_variance4x4_sse2),
+        VarianceParam(4, 8, &eb_aom_variance4x8_c, &eb_aom_variance4x8_sse2),
+        VarianceParam(4, 16, &eb_aom_variance4x16_c, &eb_aom_variance4x16_sse2),
+        VarianceParam(8, 4, &eb_aom_variance8x4_c, &eb_aom_variance8x4_sse2),
+        VarianceParam(8, 8, &eb_aom_variance8x8_c, &eb_aom_variance8x8_sse2),
+        VarianceParam(8, 16, &eb_aom_variance8x16_c, &eb_aom_variance8x16_sse2),
+        VarianceParam(8, 32, &eb_aom_variance8x32_c, &eb_aom_variance8x32_sse2),
+        VarianceParam(16, 4, &eb_aom_variance16x4_c, &eb_aom_variance16x4_avx2),
+        VarianceParam(16, 8, &eb_aom_variance16x8_c, &eb_aom_variance16x8_avx2),
+        VarianceParam(16, 16, &eb_aom_variance16x16_c, &eb_aom_variance16x16_avx2),
+        VarianceParam(16, 32, &eb_aom_variance16x32_c, &eb_aom_variance16x32_avx2),
+        VarianceParam(16, 64, &eb_aom_variance16x64_c, &eb_aom_variance16x64_avx2),
+        VarianceParam(32, 8, &eb_aom_variance32x8_c, &eb_aom_variance32x8_avx2),
+        VarianceParam(32, 16, &eb_aom_variance32x16_c, &eb_aom_variance32x16_avx2),
+        VarianceParam(32, 32, &eb_aom_variance32x32_c, &eb_aom_variance32x32_avx2),
+        VarianceParam(32, 64, &eb_aom_variance32x64_c, &eb_aom_variance32x64_avx2),
+        VarianceParam(64, 16, &eb_aom_variance64x16_c, &eb_aom_variance64x16_avx2),
+        VarianceParam(64, 32, &eb_aom_variance64x32_c, &eb_aom_variance64x32_avx2),
+        VarianceParam(64, 64, &eb_aom_variance64x64_c, &eb_aom_variance64x64_avx2),
+        VarianceParam(64, 128, &eb_aom_variance64x128_c, &eb_aom_variance64x128_avx2),
+        VarianceParam(128, 64, &eb_aom_variance128x64_c, &eb_aom_variance128x64_avx2),
+        VarianceParam(128, 128, &eb_aom_variance128x128_c,
+                      &eb_aom_variance128x128_avx2)));
 
 }  // namespace

--- a/test/convolve_2d_funcs.h
+++ b/test/convolve_2d_funcs.h
@@ -6,14 +6,14 @@
  * @file Convolve2dTest.cc
  *
  * @brief Function declaration for interpolation in inter prediction:
- * - av1_highbd_convolve_2d_copy_sr_avx2
- * - av1_highbd_jnt_convolve_2d_copy_avx2
- * - av1_highbd_convolve_x_sr_avx2
- * - av1_highbd_convolve_y_sr_avx2
- * - av1_highbd_convolve_2d_sr_avx2
- * - av1_highbd_jnt_convolve_x_avx2
- * - av1_highbd_jnt_convolve_y_avx2
- * - av1_highbd_jnt_convolve_2d_avx2
+ * - eb_av1_highbd_convolve_2d_copy_sr_avx2
+ * - eb_av1_highbd_jnt_convolve_2d_copy_avx2
+ * - eb_av1_highbd_convolve_x_sr_avx2
+ * - eb_av1_highbd_convolve_y_sr_avx2
+ * - eb_av1_highbd_convolve_2d_sr_avx2
+ * - eb_av1_highbd_jnt_convolve_x_avx2
+ * - eb_av1_highbd_jnt_convolve_y_avx2
+ * - eb_av1_highbd_jnt_convolve_2d_avx2
  * @author Cidana-Wenyao
  *
  ******************************************************************************/
@@ -24,84 +24,84 @@ extern "C" {
 InterpFilterParams av1_get_interp_filter_params_with_block_size(
     const InterpFilter interp_filter, const int32_t w);
 // higbbd sr version
-void av1_highbd_convolve_x_sr_avx2(
+void eb_av1_highbd_convolve_x_sr_avx2(
     const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride,
     int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
     const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-void av1_highbd_convolve_y_sr_avx2(
+void eb_av1_highbd_convolve_y_sr_avx2(
     const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride,
     int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
     const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-void av1_highbd_convolve_2d_sr_avx2(
+void eb_av1_highbd_convolve_2d_sr_avx2(
     const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride,
     int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
     const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-void av1_highbd_convolve_2d_copy_sr_avx2(
+void eb_av1_highbd_convolve_2d_copy_sr_avx2(
     const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride,
     int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
     const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-void av1_highbd_convolve_2d_sr_c(
+void eb_av1_highbd_convolve_2d_sr_c(
     const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride,
     int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
     const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
 // highbd jnt version
-void av1_highbd_jnt_convolve_x_avx2(
+void eb_av1_highbd_jnt_convolve_x_avx2(
     const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride,
     int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
     const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-void av1_highbd_jnt_convolve_y_avx2(
+void eb_av1_highbd_jnt_convolve_y_avx2(
     const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride,
     int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
     const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-void av1_highbd_jnt_convolve_2d_avx2(
+void eb_av1_highbd_jnt_convolve_2d_avx2(
     const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride,
     int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
     const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-void av1_highbd_jnt_convolve_2d_copy_avx2(
+void eb_av1_highbd_jnt_convolve_2d_copy_avx2(
     const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride,
     int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
     const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
-void av1_highbd_jnt_convolve_2d_c(
+void eb_av1_highbd_jnt_convolve_2d_c(
     const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride,
     int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
     const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
     const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
 // Lowbd sr version
-void av1_convolve_2d_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst,
+void eb_av1_convolve_2d_sr_c(const uint8_t *src, int32_t src_stride, uint8_t *dst,
                           int32_t dst_stride, int32_t w, int32_t h,
                           InterpFilterParams *filter_params_x,
                           InterpFilterParams *filter_params_y,
                           const int32_t subpel_x_q4, const int32_t subpel_y_q4,
                           ConvolveParams *conv_params);
-void av1_convolve_x_sr_avx2(const uint8_t *src, int32_t src_stride,
+void eb_av1_convolve_x_sr_avx2(const uint8_t *src, int32_t src_stride,
                             uint8_t *dst, int32_t dst_stride, int32_t w,
                             int32_t h, InterpFilterParams *filter_params_x,
                             InterpFilterParams *filter_params_y,
                             const int32_t subpel_x_q4,
                             const int32_t subpel_y_q4,
                             ConvolveParams *conv_params);
-void av1_convolve_y_sr_avx2(const uint8_t *src, int32_t src_stride,
+void eb_av1_convolve_y_sr_avx2(const uint8_t *src, int32_t src_stride,
                             uint8_t *dst, int32_t dst_stride, int32_t w,
                             int32_t h, InterpFilterParams *filter_params_x,
                             InterpFilterParams *filter_params_y,
                             const int32_t subpel_x_q4,
                             const int32_t subpel_y_q4,
                             ConvolveParams *conv_params);
-void av1_convolve_2d_copy_sr_avx2(
+void eb_av1_convolve_2d_copy_sr_avx2(
     const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride,
     int32_t w, int32_t h, InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
     const int32_t subpel_y_q4, ConvolveParams *conv_params);
-void av1_convolve_2d_sr_avx2(const uint8_t *src, int32_t src_stride,
+void eb_av1_convolve_2d_sr_avx2(const uint8_t *src, int32_t src_stride,
                              uint8_t *dst, int32_t dst_stride, int32_t w,
                              int32_t h, InterpFilterParams *filter_params_x,
                              InterpFilterParams *filter_params_y,
@@ -109,33 +109,33 @@ void av1_convolve_2d_sr_avx2(const uint8_t *src, int32_t src_stride,
                              const int32_t subpel_y_q4,
                              ConvolveParams *conv_params);
 // Lowbd jnt version
-void av1_jnt_convolve_x_avx2(const uint8_t *src, int32_t src_stride,
+void eb_av1_jnt_convolve_x_avx2(const uint8_t *src, int32_t src_stride,
                              uint8_t *dst, int32_t dst_stride, int32_t w,
                              int32_t h, InterpFilterParams *filter_params_x,
                              InterpFilterParams *filter_params_y,
                              const int32_t subpel_x_q4,
                              const int32_t subpel_y_q4,
                              ConvolveParams *conv_params);
-void av1_jnt_convolve_y_avx2(const uint8_t *src, int32_t src_stride,
+void eb_av1_jnt_convolve_y_avx2(const uint8_t *src, int32_t src_stride,
                              uint8_t *dst, int32_t dst_stride, int32_t w,
                              int32_t h, InterpFilterParams *filter_params_x,
                              InterpFilterParams *filter_params_y,
                              const int32_t subpel_x_q4,
                              const int32_t subpel_y_q4,
                              ConvolveParams *conv_params);
-void av1_jnt_convolve_2d_avx2(const uint8_t *src, int32_t src_stride,
+void eb_av1_jnt_convolve_2d_avx2(const uint8_t *src, int32_t src_stride,
                               uint8_t *dst, int32_t dst_stride, int32_t w,
                               int32_t h, InterpFilterParams *filter_params_x,
                               InterpFilterParams *filter_params_y,
                               const int32_t subpel_x_q4,
                               const int32_t subpel_y_q4,
                               ConvolveParams *conv_params);
-void av1_jnt_convolve_2d_copy_avx2(
+void eb_av1_jnt_convolve_2d_copy_avx2(
     const uint8_t *src, int32_t src_stride, uint8_t *dst, int32_t dst_stride,
     int32_t w, int32_t h, InterpFilterParams *filter_params_x,
     InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
     const int32_t subpel_y_q4, ConvolveParams *conv_params);
-void av1_jnt_convolve_2d_c(const uint8_t *src, int32_t src_stride, uint8_t *dst,
+void eb_av1_jnt_convolve_2d_c(const uint8_t *src, int32_t src_stride, uint8_t *dst,
                            int32_t dst_stride, int32_t w, int32_t h,
                            InterpFilterParams *filter_params_x,
                            InterpFilterParams *filter_params_y,

--- a/test/convolve_2d_test.cc
+++ b/test/convolve_2d_test.cc
@@ -7,22 +7,22 @@
  * @file Convolve2dTest.cc
  *
  * @brief Unit test for interpolation in inter prediction:
- * - av1_highbd_convolve_2d_copy_sr_avx2
- * - av1_highbd_jnt_convolve_2d_copy_avx2
- * - av1_highbd_convolve_x_sr_avx2
- * - av1_highbd_convolve_y_sr_avx2
- * - av1_highbd_convolve_2d_sr_avx2
- * - av1_highbd_jnt_convolve_x_avx2
- * - av1_highbd_jnt_convolve_y_avx2
- * - av1_highbd_jnt_convolve_2d_avx2
- * - av1_convolve_2d_copy_sr_avx2
- * - av1_jnt_convolve_2d_copy_avx2
- * - av1_convolve_x_sr_avx2
- * - av1_convolve_y_sr_avx2
- * - av1_convolve_2d_sr_avx2
- * - av1_jnt_convolve_x_avx2
- * - av1_jnt_convolve_y_avx2
- * - av1_jnt_convolve_2d_avx2
+ * - eb_av1_highbd_convolve_2d_copy_sr_avx2
+ * - eb_av1_highbd_jnt_convolve_2d_copy_avx2
+ * - eb_av1_highbd_convolve_x_sr_avx2
+ * - eb_av1_highbd_convolve_y_sr_avx2
+ * - eb_av1_highbd_convolve_2d_sr_avx2
+ * - eb_av1_highbd_jnt_convolve_x_avx2
+ * - eb_av1_highbd_jnt_convolve_y_avx2
+ * - eb_av1_highbd_jnt_convolve_2d_avx2
+ * - eb_av1_convolve_2d_copy_sr_avx2
+ * - eb_av1_jnt_convolve_2d_copy_avx2
+ * - eb_av1_convolve_x_sr_avx2
+ * - eb_av1_convolve_y_sr_avx2
+ * - eb_av1_convolve_2d_sr_avx2
+ * - eb_av1_jnt_convolve_x_avx2
+ * - eb_av1_jnt_convolve_y_avx2
+ * - eb_av1_jnt_convolve_2d_avx2
  *
  * @author Cidana-Wenyao
  *
@@ -89,20 +89,20 @@ class AV1Convolve2DTest : public ::testing::TestWithParam<Convolve2DParam> {
     // make the address algined to 32.
     void SetUp() override {
         conv_buf_ref_ = reinterpret_cast<ConvBufType *>(
-            aom_memalign(32, MAX_SB_SQUARE * sizeof(ConvBufType)));
+            eb_aom_memalign(32, MAX_SB_SQUARE * sizeof(ConvBufType)));
         conv_buf_tst_ = reinterpret_cast<ConvBufType *>(
-            aom_memalign(32, MAX_SB_SQUARE * sizeof(ConvBufType)));
+            eb_aom_memalign(32, MAX_SB_SQUARE * sizeof(ConvBufType)));
         output_ref_ = reinterpret_cast<Sample *>(
-            aom_memalign(32, MAX_SB_SQUARE * sizeof(Sample)));
+            eb_aom_memalign(32, MAX_SB_SQUARE * sizeof(Sample)));
         output_tst_ = reinterpret_cast<Sample *>(
-            aom_memalign(32, MAX_SB_SQUARE * sizeof(Sample)));
+            eb_aom_memalign(32, MAX_SB_SQUARE * sizeof(Sample)));
     }
 
     void TearDown() override {
-        aom_free(conv_buf_ref_);
-        aom_free(conv_buf_tst_);
-        aom_free(output_ref_);
-        aom_free(output_tst_);
+        eb_aom_free(conv_buf_ref_);
+        eb_aom_free(conv_buf_tst_);
+        eb_aom_free(output_ref_);
+        eb_aom_free(output_tst_);
         aom_clear_system_state();
     }
 
@@ -387,17 +387,17 @@ class AV1LbdJntConvolve2DTest : public AV1LbdConvolve2DTest {
   public:
     AV1LbdJntConvolve2DTest() {
         is_jnt_ = 1;
-        func_ref_ = av1_jnt_convolve_2d_c;
+        func_ref_ = eb_av1_jnt_convolve_2d_c;
         const int has_subx = TEST_GET_PARAM(1);
         const int has_suby = TEST_GET_PARAM(2);
         if (has_subx == 1 && has_suby == 1)
-            func_tst_ = av1_jnt_convolve_2d_avx2;
+            func_tst_ = eb_av1_jnt_convolve_2d_avx2;
         else if (has_subx == 1)
-            func_tst_ = av1_jnt_convolve_x_avx2;
+            func_tst_ = eb_av1_jnt_convolve_x_avx2;
         else if (has_suby == 1)
-            func_tst_ = av1_jnt_convolve_y_avx2;
+            func_tst_ = eb_av1_jnt_convolve_y_avx2;
         else
-            func_tst_ = av1_jnt_convolve_2d_copy_avx2;
+            func_tst_ = eb_av1_jnt_convolve_2d_copy_avx2;
         bd_ = TEST_GET_PARAM(0);
     }
     virtual ~AV1LbdJntConvolve2DTest() {
@@ -420,17 +420,17 @@ class AV1LbdSrConvolve2DTest : public AV1LbdConvolve2DTest {
   public:
     AV1LbdSrConvolve2DTest() {
         is_jnt_ = 0;
-        func_ref_ = av1_convolve_2d_sr_c;
+        func_ref_ = eb_av1_convolve_2d_sr_c;
         const int has_subx = TEST_GET_PARAM(1);
         const int has_suby = TEST_GET_PARAM(2);
         if (has_subx == 1 && has_suby == 1)
-            func_tst_ = av1_convolve_2d_sr_avx2;
+            func_tst_ = eb_av1_convolve_2d_sr_avx2;
         else if (has_subx == 1)
-            func_tst_ = av1_convolve_x_sr_avx2;
+            func_tst_ = eb_av1_convolve_x_sr_avx2;
         else if (has_suby == 1)
-            func_tst_ = av1_convolve_y_sr_avx2;
+            func_tst_ = eb_av1_convolve_y_sr_avx2;
         else
-            func_tst_ = av1_convolve_2d_copy_sr_avx2;
+            func_tst_ = eb_av1_convolve_2d_copy_sr_avx2;
         bd_ = TEST_GET_PARAM(0);
     }
     virtual ~AV1LbdSrConvolve2DTest() {
@@ -494,17 +494,17 @@ class AV1HbdJntConvolve2DTest : public AV1HbdConvolve2DTest {
   public:
     AV1HbdJntConvolve2DTest() {
         is_jnt_ = 1;
-        func_ref_ = av1_highbd_jnt_convolve_2d_c;
+        func_ref_ = eb_av1_highbd_jnt_convolve_2d_c;
         const int has_subx = TEST_GET_PARAM(1);
         const int has_suby = TEST_GET_PARAM(2);
         if (has_subx == 1 && has_suby == 1)
-            func_tst_ = av1_highbd_jnt_convolve_2d_avx2;
+            func_tst_ = eb_av1_highbd_jnt_convolve_2d_avx2;
         else if (has_subx == 1)
-            func_tst_ = av1_highbd_jnt_convolve_x_avx2;
+            func_tst_ = eb_av1_highbd_jnt_convolve_x_avx2;
         else if (has_suby == 1)
-            func_tst_ = av1_highbd_jnt_convolve_y_avx2;
+            func_tst_ = eb_av1_highbd_jnt_convolve_y_avx2;
         else
-            func_tst_ = av1_highbd_jnt_convolve_2d_copy_avx2;
+            func_tst_ = eb_av1_highbd_jnt_convolve_2d_copy_avx2;
 
         bd_ = TEST_GET_PARAM(0);
     }
@@ -528,17 +528,17 @@ class AV1HbdSrConvolve2DTest : public AV1HbdConvolve2DTest {
   public:
     AV1HbdSrConvolve2DTest() {
         is_jnt_ = 0;
-        func_ref_ = av1_highbd_convolve_2d_sr_c;
+        func_ref_ = eb_av1_highbd_convolve_2d_sr_c;
         const int has_subx = TEST_GET_PARAM(1);
         const int has_suby = TEST_GET_PARAM(2);
         if (has_subx == 1 && has_suby == 1)
-            func_tst_ = av1_highbd_convolve_2d_sr_avx2;
+            func_tst_ = eb_av1_highbd_convolve_2d_sr_avx2;
         else if (has_subx == 1)
-            func_tst_ = av1_highbd_convolve_x_sr_avx2;
+            func_tst_ = eb_av1_highbd_convolve_x_sr_avx2;
         else if (has_suby == 1)
-            func_tst_ = av1_highbd_convolve_y_sr_avx2;
+            func_tst_ = eb_av1_highbd_convolve_y_sr_avx2;
         else
-            func_tst_ = av1_highbd_convolve_2d_copy_sr_avx2;
+            func_tst_ = eb_av1_highbd_convolve_2d_copy_sr_avx2;
         bd_ = TEST_GET_PARAM(0);
     }
     virtual ~AV1HbdSrConvolve2DTest() {

--- a/test/frame_error_test.cc
+++ b/test/frame_error_test.cc
@@ -64,9 +64,9 @@ void AV1FrameErrorTest::RandomValues(frame_error_func test_impl, int width,
     const int stride = (((width * 3) / 2) + 15) & ~15;
     const int max_blk_size = stride * height;
     uint8_t *const dst =
-        static_cast<uint8_t *>(aom_memalign(16, max_blk_size * sizeof(*dst)));
+        static_cast<uint8_t *>(eb_aom_memalign(16, max_blk_size * sizeof(*dst)));
     uint8_t *const ref =
-        static_cast<uint8_t *>(aom_memalign(16, max_blk_size * sizeof(*ref)));
+        static_cast<uint8_t *>(eb_aom_memalign(16, max_blk_size * sizeof(*ref)));
     ASSERT_TRUE(dst != NULL);
     ASSERT_TRUE(ref != NULL);
     for (int i = 0; i < max_blk_size; ++i) {
@@ -74,12 +74,12 @@ void AV1FrameErrorTest::RandomValues(frame_error_func test_impl, int width,
         ref[i] = rnd_->Rand8();
     }
     const int64_t ref_error =
-        av1_calc_frame_error_c(ref, stride, dst, width, height, stride);
+        eb_av1_calc_frame_error_c(ref, stride, dst, width, height, stride);
     const int64_t test_error =
         test_impl(ref, stride, dst, width, height, stride);
     ASSERT_EQ(test_error, ref_error) << width << "x" << height;
-    aom_free(dst);
-    aom_free(ref);
+    eb_aom_free(dst);
+    eb_aom_free(ref);
 }
 
 void AV1FrameErrorTest::ExtremeValues(frame_error_func test_impl, int width,
@@ -87,9 +87,9 @@ void AV1FrameErrorTest::ExtremeValues(frame_error_func test_impl, int width,
     const int stride = (((width * 3) / 2) + 15) & ~15;
     const int max_blk_size = stride * height;
     uint8_t *const dst =
-        static_cast<uint8_t *>(aom_memalign(16, max_blk_size * sizeof(*dst)));
+        static_cast<uint8_t *>(eb_aom_memalign(16, max_blk_size * sizeof(*dst)));
     uint8_t *const ref =
-        static_cast<uint8_t *>(aom_memalign(16, max_blk_size * sizeof(*ref)));
+        static_cast<uint8_t *>(eb_aom_memalign(16, max_blk_size * sizeof(*ref)));
     ASSERT_TRUE(dst != NULL);
     ASSERT_TRUE(ref != NULL);
     for (int r = 0; r < 2; r++) {
@@ -101,13 +101,13 @@ void AV1FrameErrorTest::ExtremeValues(frame_error_func test_impl, int width,
             memset(ref, 0, max_blk_size);
         }
         const int64_t ref_error =
-            av1_calc_frame_error_c(ref, stride, dst, width, height, stride);
+            eb_av1_calc_frame_error_c(ref, stride, dst, width, height, stride);
         const int64_t test_error =
             test_impl(ref, stride, dst, width, height, stride);
         ASSERT_EQ(test_error, ref_error) << width << "x" << height;
     }
-    aom_free(dst);
-    aom_free(ref);
+    eb_aom_free(dst);
+    eb_aom_free(ref);
 }
 
 void AV1FrameErrorTest::RunSpeedTest(frame_error_func test_impl, int width,
@@ -115,16 +115,16 @@ void AV1FrameErrorTest::RunSpeedTest(frame_error_func test_impl, int width,
     const int stride = (((width * 3) / 2) + 15) & ~15;
     const int max_blk_size = stride * height;
     uint8_t *const dst =
-        static_cast<uint8_t *>(aom_memalign(16, max_blk_size * sizeof(*dst)));
+        static_cast<uint8_t *>(eb_aom_memalign(16, max_blk_size * sizeof(*dst)));
     uint8_t *const ref =
-        static_cast<uint8_t *>(aom_memalign(16, max_blk_size * sizeof(*ref)));
+        static_cast<uint8_t *>(eb_aom_memalign(16, max_blk_size * sizeof(*ref)));
     ASSERT_TRUE(dst != NULL);
     ASSERT_TRUE(ref != NULL);
     for (int i = 0; i < max_blk_size; ++i) {
         dst[i] = ref[i] = rnd_->Rand8();
     }
     const int num_loops = 10000000 / (width + height);
-    frame_error_func funcs[2] = {av1_calc_frame_error_c, test_impl};
+    frame_error_func funcs[2] = {eb_av1_calc_frame_error_c, test_impl};
     double elapsed_time[2] = {0};
     for (int i = 0; i < 2; ++i) {
         double time;
@@ -144,8 +144,8 @@ void AV1FrameErrorTest::RunSpeedTest(frame_error_func test_impl, int width,
                                       &time);
         elapsed_time[i] = 1000.0 * time / num_loops;
     }
-    aom_free(dst);
-    aom_free(ref);
+    eb_aom_free(dst);
+    eb_aom_free(ref);
     printf("av1_calc_frame_error %3dx%-3d: %7.2f/%7.2fns",
            width,
            height,
@@ -165,7 +165,7 @@ TEST_P(AV1FrameErrorTest, DISABLED_Speed) {
 
 INSTANTIATE_TEST_CASE_P(
     AVX2, AV1FrameErrorTest,
-    ::testing::Combine(::testing::Values(&av1_calc_frame_error_avx2),
+    ::testing::Combine(::testing::Values(&eb_av1_calc_frame_error_avx2),
                        ::testing::ValuesIn(kBlockWidth),
                        ::testing::ValuesIn(kBlockHeight)));
 

--- a/test/intrapred_cfl_test.cc
+++ b/test/intrapred_cfl_test.cc
@@ -7,8 +7,8 @@
  * @file intrapred_edge_filter_test.cc
  *
  * @brief Unit test for chroma from luma prediction:
- * - cfl_predict_hbd_avx2
- * - cfl_predict_lbd_avx2
+ * - eb_cfl_predict_hbd_avx2
+ * - eb_cfl_predict_lbd_avx2
  *
  * @author Cidana-Wenyao
  *
@@ -31,8 +31,8 @@ using CFL_PRED_LBD = void (*)(const int16_t *pred_buf_q3, uint8_t *pred,
                               int32_t bit_depth, int32_t width, int32_t height);
 /**
  * @brief Unit test for chroma from luma prediction:
- * - cfl_predict_hbd_avx2
- * - cfl_predict_lbd_avx2
+ * - eb_cfl_predict_hbd_avx2
+ * - eb_cfl_predict_lbd_avx2
  *
  * Test strategy:
  * Verify this assembly code by comparing with reference c implementation.
@@ -143,8 +143,8 @@ class LbdCflPredTest : public CflPredTest<uint8_t, CFL_PRED_LBD> {
   public:
     LbdCflPredTest() {
         bd_ = 8;
-        ref_func_ = cfl_predict_lbd_c;
-        tst_func_ = cfl_predict_lbd_avx2;
+        ref_func_ = eb_cfl_predict_lbd_c;
+        tst_func_ = eb_cfl_predict_lbd_avx2;
         common_init();
     }
 };
@@ -153,8 +153,8 @@ class HbdCflPredTest : public CflPredTest<uint16_t, CFL_PRED_HBD> {
   public:
     HbdCflPredTest() {
         bd_ = 10;
-        ref_func_ = cfl_predict_hbd_c;
-        tst_func_ = cfl_predict_hbd_avx2;
+        ref_func_ = eb_cfl_predict_hbd_c;
+        tst_func_ = eb_cfl_predict_hbd_avx2;
         common_init();
     }
 };

--- a/test/intrapred_dr_test.cc
+++ b/test/intrapred_dr_test.cc
@@ -7,8 +7,8 @@
  * @file intrapred_dr_test.cc
  *
  * @brief Unit test for intra directional prediction :
- * - av1_highbd_dr_prediction_z{1, 2, 3}_avx2
- * - av1_dr_prediction_z{1, 2, 3}_avx2
+ * - eb_av1_highbd_dr_prediction_z{1, 2, 3}_avx2
+ * - eb_av1_dr_prediction_z{1, 2, 3}_avx2
  *
  * @author Cidana-Wenyao
  *
@@ -110,8 +110,8 @@ using Z3_HBD = void (*)(uint16_t *dst, ptrdiff_t stride, int bw, int bh,
                         int upsample_left, int dx, int dy, int bd);
 /**
  * @brief Unit test for intra directional prediction:
- * - av1_highbd_dr_prediction_z{1, 2, 3}_avx2
- * - av1_dr_prediction_z{1, 2, 3}_avx2
+ * - eb_av1_highbd_dr_prediction_z{1, 2, 3}_avx2
+ * - eb_av1_dr_prediction_z{1, 2, 3}_avx2
  *
  * Test strategy:
  * Verify this assembly code by comparing with reference c implementation.
@@ -254,8 +254,8 @@ class LowbdZ1PredTest : public DrPredTest<uint8_t, Z1_LBD> {
     LowbdZ1PredTest() {
         start_angle_ = z1_start_angle;
         stop_angle_ = start_angle_ + 90;
-        ref_func_ = av1_dr_prediction_z1_c;
-        tst_func_ = av1_dr_prediction_z1_avx2;
+        ref_func_ = eb_av1_dr_prediction_z1_c;
+        tst_func_ = eb_av1_dr_prediction_z1_avx2;
         bd_ = 8;
 
         common_init();
@@ -289,8 +289,8 @@ class LowbdZ2PredTest : public DrPredTest<uint8_t, Z2_LBD> {
     LowbdZ2PredTest() {
         start_angle_ = z2_start_angle;
         stop_angle_ = start_angle_ + 90;
-        ref_func_ = av1_dr_prediction_z2_c;
-        tst_func_ = av1_dr_prediction_z2_avx2;
+        ref_func_ = eb_av1_dr_prediction_z2_c;
+        tst_func_ = eb_av1_dr_prediction_z2_avx2;
         bd_ = 8;
 
         common_init();
@@ -326,8 +326,8 @@ class LowbdZ3PredTest : public DrPredTest<uint8_t, Z3_LBD> {
     LowbdZ3PredTest() {
         start_angle_ = z3_start_angle;
         stop_angle_ = start_angle_ + 90;
-        ref_func_ = av1_dr_prediction_z3_c;
-        tst_func_ = av1_dr_prediction_z3_avx2;
+        ref_func_ = eb_av1_dr_prediction_z3_c;
+        tst_func_ = eb_av1_dr_prediction_z3_avx2;
         bd_ = 8;
 
         common_init();
@@ -372,8 +372,8 @@ class HighbdZ1PredTest : public DrPredTest<uint16_t, Z1_HBD> {
     HighbdZ1PredTest() {
         start_angle_ = z1_start_angle;
         stop_angle_ = start_angle_ + 90;
-        ref_func_ = av1_highbd_dr_prediction_z1_c;
-        tst_func_ = av1_highbd_dr_prediction_z1_avx2;
+        ref_func_ = eb_av1_highbd_dr_prediction_z1_c;
+        tst_func_ = eb_av1_highbd_dr_prediction_z1_avx2;
         bd_ = 10;
 
         common_init();
@@ -409,8 +409,8 @@ class HighbdZ2PredTest : public DrPredTest<uint16_t, Z2_HBD> {
     HighbdZ2PredTest() {
         start_angle_ = z2_start_angle;
         stop_angle_ = start_angle_ + 90;
-        ref_func_ = av1_highbd_dr_prediction_z2_c;
-        tst_func_ = av1_highbd_dr_prediction_z2_avx2;
+        ref_func_ = eb_av1_highbd_dr_prediction_z2_c;
+        tst_func_ = eb_av1_highbd_dr_prediction_z2_avx2;
         bd_ = 10;
 
         common_init();
@@ -448,8 +448,8 @@ class HighbdZ3PredTest : public DrPredTest<uint16_t, Z3_HBD> {
     HighbdZ3PredTest() {
         start_angle_ = z3_start_angle;
         stop_angle_ = start_angle_ + 90;
-        ref_func_ = av1_highbd_dr_prediction_z3_c;
-        tst_func_ = av1_highbd_dr_prediction_z3_avx2;
+        ref_func_ = eb_av1_highbd_dr_prediction_z3_c;
+        tst_func_ = eb_av1_highbd_dr_prediction_z3_avx2;
         bd_ = 10;
 
         common_init();

--- a/test/intrapred_edge_filter_test.cc
+++ b/test/intrapred_edge_filter_test.cc
@@ -7,9 +7,9 @@
  * @file intrapred_edge_filter_test.cc
  *
  * @brief Unit test for upsample and edge filter:
- * - av1_upsample_intra_edge_sse4_1
- * - av1_filter_intra_edge_sse4_1
- * - av1_filter_intra_edge_high_sse4_1
+ * - eb_av1_upsample_intra_edge_sse4_1
+ * - eb_av1_filter_intra_edge_sse4_1
+ * - eb_av1_filter_intra_edge_high_sse4_1
  *
  * @author Cidana-Wenyao
  *
@@ -30,7 +30,7 @@ using UPSAMPLE_LBD = void (*)(uint8_t *p, int size);
 /**
  * @brief Unit test for upsample in intra prediction specified in
  * spec 7.11.2.11:
- * - av1_upsample_intra_edge_sse4_1
+ * - eb_av1_upsample_intra_edge_sse4_1
  *
  * Test strategy:
  * Verify this assembly code by comparing with reference c implementation.
@@ -118,8 +118,8 @@ class UpsampleTest {
 class LowbdUpsampleTest : public UpsampleTest<uint8_t, UPSAMPLE_LBD> {
   public:
     LowbdUpsampleTest() {
-        ref_func_ = av1_upsample_intra_edge_c;
-        tst_func_ = av1_upsample_intra_edge_sse4_1;
+        ref_func_ = eb_av1_upsample_intra_edge_c;
+        tst_func_ = eb_av1_upsample_intra_edge_sse4_1;
         bd_ = 8;
         common_init();
     }
@@ -146,7 +146,7 @@ TEST_CLASS(UpsampleTestLBD, LowbdUpsampleTest)
 #define INTRA_EDGE_FILT 3
 #define INTRA_EDGE_TAPS 5
 #define MAX_UPSAMPLE_SZ 16
-static void av1_filter_intra_edge_c(uint8_t *p, int sz, int strength) {
+static void eb_av1_filter_intra_edge_c(uint8_t *p, int sz, int strength) {
     if (!strength)
         return;
 
@@ -174,8 +174,8 @@ using FILTER_EDGE_HBD = void (*)(uint16_t *p, int size, int strength);
 
 /**
  * @brief Unit test for edge filter in intra prediction:
- * - av1_filter_intra_edge_sse4_1
- * - av1_filter_intra_edge_high_sse4_1
+ * - eb_av1_filter_intra_edge_sse4_1
+ * - eb_av1_filter_intra_edge_high_sse4_1
  *
  * Test strategy:
  * Verify this assembly code by comparing with reference c implementation.
@@ -260,8 +260,8 @@ class FilterEdgeTest {
 class LowbdFilterEdgeTest : public FilterEdgeTest<uint8_t, FILTER_EDGE_LBD> {
   public:
     LowbdFilterEdgeTest() {
-        ref_func_ = av1_filter_intra_edge_c;
-        tst_func_ = av1_filter_intra_edge_sse4_1;
+        ref_func_ = eb_av1_filter_intra_edge_c;
+        tst_func_ = eb_av1_filter_intra_edge_sse4_1;
         bd_ = 8;
         common_init();
     }
@@ -270,8 +270,8 @@ class LowbdFilterEdgeTest : public FilterEdgeTest<uint8_t, FILTER_EDGE_LBD> {
 class HighbdFilterEdgeTest : public FilterEdgeTest<uint16_t, FILTER_EDGE_HBD> {
   public:
     HighbdFilterEdgeTest() {
-        ref_func_ = av1_filter_intra_edge_high_c;
-        tst_func_ = av1_filter_intra_edge_high_sse4_1;
+        ref_func_ = eb_av1_filter_intra_edge_high_c;
+        tst_func_ = eb_av1_filter_intra_edge_high_sse4_1;
         bd_ = 10;
         common_init();
     }

--- a/test/intrapred_test.cc
+++ b/test/intrapred_test.cc
@@ -110,20 +110,20 @@ class AV1IntraPredTest : public ::testing::TestWithParam<TupleType> {
         stride_ = 64 * 3;
         mask_ = (1 << bd_) - 1;
         above_row_data_ = reinterpret_cast<Sample *>(
-            aom_memalign(32, 3 * 64 * sizeof(Sample)));
+            eb_aom_memalign(32, 3 * 64 * sizeof(Sample)));
         above_row_ = above_row_data_ + 16;
         left_col_ = reinterpret_cast<Sample *>(
-            aom_memalign(32, 2 * 64 * sizeof(Sample)));
+            eb_aom_memalign(32, 2 * 64 * sizeof(Sample)));
         dst_tst_ = reinterpret_cast<Sample *>(
-            aom_memalign(32, 3 * 64 * 64 * sizeof(Sample)));
+            eb_aom_memalign(32, 3 * 64 * 64 * sizeof(Sample)));
         dst_ref_ = reinterpret_cast<Sample *>(
-            aom_memalign(32, 3 * 64 * 64 * sizeof(Sample)));
+            eb_aom_memalign(32, 3 * 64 * 64 * sizeof(Sample)));
     }
     void TearDown() override {
-        aom_free(above_row_data_);
-        aom_free(left_col_);
-        aom_free(dst_tst_);
-        aom_free(dst_ref_);
+        eb_aom_free(above_row_data_);
+        eb_aom_free(left_col_);
+        eb_aom_free(dst_tst_);
+        eb_aom_free(dst_ref_);
     }
 
     virtual void Predict() = 0;
@@ -175,8 +175,8 @@ TEST_P(LowbdIntraPredTest, match_test) {
 // -----------------------------------------------------------------------------
 // High Bit Depth Tests
 #define hbd_entry(type, width, height, opt)                               \
-    make_tuple(&aom_highbd_##type##_predictor_##width##x##height##_##opt, \
-               &aom_highbd_##type##_predictor_##width##x##height##_c,     \
+    make_tuple(&eb_aom_highbd_##type##_predictor_##width##x##height##_##opt, \
+               &eb_aom_highbd_##type##_predictor_##width##x##height##_c,     \
                width,                                                     \
                height,                                                    \
                10)
@@ -275,8 +275,8 @@ INSTANTIATE_TEST_CASE_P(intrapred, HighbdIntraPredTest,
 // ---------------------------------------------------------------------------
 // Low Bit Depth Tests
 #define lbd_entry(type, width, height, opt)                        \
-    LBD_PARAMS(&aom_##type##_predictor_##width##x##height##_##opt, \
-               &aom_##type##_predictor_##width##x##height##_c,     \
+    LBD_PARAMS(&eb_aom_##type##_predictor_##width##x##height##_##opt, \
+               &eb_aom_##type##_predictor_##width##x##height##_c,     \
                width,                                              \
                height,                                             \
                8)

--- a/test/quantize_func_test.cc
+++ b/test/quantize_func_test.cc
@@ -31,7 +31,7 @@
 namespace {
 using svt_av1_test_tool::SVTRandom;
 
-extern "C" void av1_build_quantizer(AomBitDepth bit_depth, int32_t y_dc_delta_q,
+extern "C" void eb_av1_build_quantizer(AomBitDepth bit_depth, int32_t y_dc_delta_q,
                                     int32_t u_dc_delta_q, int32_t u_ac_delta_q,
                                     int32_t v_dc_delta_q, int32_t v_ac_delta_q,
                                     Quants *const quants, Dequants *const deq);
@@ -73,22 +73,22 @@ class QuantizeTest : public ::testing::TestWithParam<QuantizeParam> {
     }
 
     virtual void SetUp() {
-        qtab_ = reinterpret_cast<QuanTable *>(aom_memalign(32, sizeof(*qtab_)));
+        qtab_ = reinterpret_cast<QuanTable *>(eb_aom_memalign(32, sizeof(*qtab_)));
         const int n_coeffs = coeff_num();
         coeff_ = reinterpret_cast<TranLow *>(
-            aom_memalign(32, 6 * n_coeffs * sizeof(TranLow)));
+            eb_aom_memalign(32, 6 * n_coeffs * sizeof(TranLow)));
         InitQuantizer();
     }
 
     virtual void TearDown() {
-        aom_free(qtab_);
+        eb_aom_free(qtab_);
         qtab_ = NULL;
-        aom_free(coeff_);
+        eb_aom_free(coeff_);
         coeff_ = NULL;
     }
 
     void InitQuantizer() {
-        av1_build_quantizer(bd_, 0, 0, 0, 0, 0, &qtab_->quant, &qtab_->dequant);
+        eb_av1_build_quantizer(bd_, 0, 0, 0, 0, 0, &qtab_->quant, &qtab_->dequant);
     }
 
     void QuantizeRun(bool is_loop, int q = 0, int test_num = 1) {
@@ -372,23 +372,23 @@ using std::make_tuple;
 
 #if HAS_AVX2
 const QuantizeParam kQParamArrayAvx2[] = {
-    make_tuple(&av1_quantize_fp_c, &av1_quantize_fp_avx2,
+    make_tuple(&eb_av1_quantize_fp_c, &eb_av1_quantize_fp_avx2,
                static_cast<TxSize>(TX_16X16), TYPE_FP, AOM_BITS_8),
-    make_tuple(&av1_quantize_fp_c, &av1_quantize_fp_avx2,
+    make_tuple(&eb_av1_quantize_fp_c, &eb_av1_quantize_fp_avx2,
                static_cast<TxSize>(TX_4X16), TYPE_FP, AOM_BITS_8),
-    make_tuple(&av1_quantize_fp_c, &av1_quantize_fp_avx2,
+    make_tuple(&eb_av1_quantize_fp_c, &eb_av1_quantize_fp_avx2,
                static_cast<TxSize>(TX_16X4), TYPE_FP, AOM_BITS_8),
-    make_tuple(&av1_quantize_fp_c, &av1_quantize_fp_avx2,
+    make_tuple(&eb_av1_quantize_fp_c, &eb_av1_quantize_fp_avx2,
                static_cast<TxSize>(TX_32X8), TYPE_FP, AOM_BITS_8),
-    make_tuple(&av1_quantize_fp_c, &av1_quantize_fp_avx2,
+    make_tuple(&eb_av1_quantize_fp_c, &eb_av1_quantize_fp_avx2,
                static_cast<TxSize>(TX_8X32), TYPE_FP, AOM_BITS_8),
-    make_tuple(&av1_quantize_fp_32x32_c, &av1_quantize_fp_32x32_avx2,
+    make_tuple(&eb_av1_quantize_fp_32x32_c, &eb_av1_quantize_fp_32x32_avx2,
                static_cast<TxSize>(TX_32X32), TYPE_FP, AOM_BITS_8),
-    make_tuple(&av1_quantize_fp_32x32_c, &av1_quantize_fp_32x32_avx2,
+    make_tuple(&eb_av1_quantize_fp_32x32_c, &eb_av1_quantize_fp_32x32_avx2,
                static_cast<TxSize>(TX_16X64), TYPE_FP, AOM_BITS_8),
-    make_tuple(&av1_quantize_fp_32x32_c, &av1_quantize_fp_32x32_avx2,
+    make_tuple(&eb_av1_quantize_fp_32x32_c, &eb_av1_quantize_fp_32x32_avx2,
                static_cast<TxSize>(TX_64X16), TYPE_FP, AOM_BITS_8),
-    make_tuple(&av1_quantize_fp_64x64_c, &av1_quantize_fp_64x64_avx2,
+    make_tuple(&eb_av1_quantize_fp_64x64_c, &eb_av1_quantize_fp_64x64_avx2,
                static_cast<TxSize>(TX_64X64), TYPE_FP, AOM_BITS_8)};
 
 INSTANTIATE_TEST_CASE_P(AVX2, QuantizeTest,

--- a/test/ref/TxfmRef.h
+++ b/test/ref/TxfmRef.h
@@ -54,7 +54,7 @@ using Txfm1dFuncRef = void (*)(const double *in, double *out, int size);
 
 void reference_dct_1d(const double *in, double *out, int size);
 
-// TODO(any): Copied from the old 'fadst4' (same as the new 'av1_fadst4_new'
+// TODO(any): Copied from the old 'fadst4' (same as the new 'eb_av1_fadst4_new'
 // function). Should be replaced by a proper reference function that takes
 // 'double' input & output.
 void fadst4_ref(const TranLow *input, TranLow *output);

--- a/test/selfguided_filter_test.cc
+++ b/test/selfguided_filter_test.cc
@@ -57,11 +57,11 @@ class AV1SelfguidedFilterTest
         const int NUM_ITERS = 2000;
         int i, j, k;
 
-        uint8_t *input_ = (uint8_t *)aom_memalign(
+        uint8_t *input_ = (uint8_t *)eb_aom_memalign(
             32, stride * (height + 32) * sizeof(uint8_t));
-        uint8_t *output_ = (uint8_t *)aom_memalign(
+        uint8_t *output_ = (uint8_t *)eb_aom_memalign(
             32, out_stride * (height + 32) * sizeof(uint8_t));
-        int32_t *tmpbuf = (int32_t *)aom_memalign(32, RESTORATION_TMPBUF_SIZE);
+        int32_t *tmpbuf = (int32_t *)eb_aom_memalign(32, RESTORATION_TMPBUF_SIZE);
         uint8_t *input = input_ + stride * 16 + 16;
         uint8_t *output = output_ + out_stride * 16 + 16;
 
@@ -92,7 +92,7 @@ class AV1SelfguidedFilterTest
                     int32_t h = AOMMIN(pu_height, height - k);
                     uint8_t *input_p = input + k * stride + j;
                     uint8_t *output_p = output + k * out_stride + j;
-                    apply_selfguided_restoration_c(input_p,
+                    eb_apply_selfguided_restoration_c(input_p,
                                                    w,
                                                    h,
                                                    stride,
@@ -148,9 +148,9 @@ class AV1SelfguidedFilterTest
             << "C time: " << ref_time << " us\n"
             << "SIMD time: " << tst_time << " us\n";
 
-        aom_free(input_);
-        aom_free(output_);
-        aom_free(tmpbuf);
+        eb_aom_free(input_);
+        eb_aom_free(output_);
+        eb_aom_free(tmpbuf);
     }
 
     void RunCorrectnessTest() {
@@ -164,13 +164,13 @@ class AV1SelfguidedFilterTest
         const int NUM_ITERS = 81;
         int i, j, k;
 
-        uint8_t *input_ = (uint8_t *)aom_memalign(
+        uint8_t *input_ = (uint8_t *)eb_aom_memalign(
             32, stride * (max_h + 32) * sizeof(uint8_t));
-        uint8_t *output_ = (uint8_t *)aom_memalign(
+        uint8_t *output_ = (uint8_t *)eb_aom_memalign(
             32, out_stride * (max_h + 32) * sizeof(uint8_t));
-        uint8_t *output2_ = (uint8_t *)aom_memalign(
+        uint8_t *output2_ = (uint8_t *)eb_aom_memalign(
             32, out_stride * (max_h + 32) * sizeof(uint8_t));
-        int32_t *tmpbuf = (int32_t *)aom_memalign(32, RESTORATION_TMPBUF_SIZE);
+        int32_t *tmpbuf = (int32_t *)eb_aom_memalign(32, RESTORATION_TMPBUF_SIZE);
 
         uint8_t *input = input_ + stride * 16 + 16;
         uint8_t *output = output_ + out_stride * 16 + 16;
@@ -212,7 +212,7 @@ class AV1SelfguidedFilterTest
                              tmpbuf,
                              8,
                              0);
-                    apply_selfguided_restoration_c(input_p,
+                    eb_apply_selfguided_restoration_c(input_p,
                                                    w,
                                                    h,
                                                    stride,
@@ -232,10 +232,10 @@ class AV1SelfguidedFilterTest
                 }
         }
 
-        aom_free(input_);
-        aom_free(output_);
-        aom_free(output2_);
-        aom_free(tmpbuf);
+        eb_aom_free(input_);
+        eb_aom_free(output_);
+        eb_aom_free(output2_);
+        eb_aom_free(tmpbuf);
     }
 
   private:
@@ -251,7 +251,7 @@ TEST_P(AV1SelfguidedFilterTest, CorrectnessTest) {
 
 INSTANTIATE_TEST_CASE_P(
     AVX2, AV1SelfguidedFilterTest,
-    ::testing::Values(make_tuple(apply_selfguided_restoration_avx2)));
+    ::testing::Values(make_tuple(eb_apply_selfguided_restoration_avx2)));
 
 // Test parameter list:
 //  <tst_fun_, bit_depth>
@@ -280,11 +280,11 @@ class AV1HighbdSelfguidedFilterTest
         int32_t bit_depth = TEST_GET_PARAM(1);
         int mask = (1 << bit_depth) - 1;
 
-        uint16_t *input_ = (uint16_t *)aom_memalign(
+        uint16_t *input_ = (uint16_t *)eb_aom_memalign(
             32, stride * (height + 32) * sizeof(uint16_t));
-        uint16_t *output_ = (uint16_t *)aom_memalign(
+        uint16_t *output_ = (uint16_t *)eb_aom_memalign(
             32, out_stride * (height + 32) * sizeof(uint16_t));
-        int32_t *tmpbuf = (int32_t *)aom_memalign(32, RESTORATION_TMPBUF_SIZE);
+        int32_t *tmpbuf = (int32_t *)eb_aom_memalign(32, RESTORATION_TMPBUF_SIZE);
         uint16_t *input = input_ + stride * 16 + 16;
         uint16_t *output = output_ + out_stride * 16 + 16;
 
@@ -315,7 +315,7 @@ class AV1HighbdSelfguidedFilterTest
                     int32_t h = AOMMIN(pu_height, height - k);
                     uint16_t *input_p = input + k * stride + j;
                     uint16_t *output_p = output + k * out_stride + j;
-                    apply_selfguided_restoration_c(CONVERT_TO_BYTEPTR(input_p),
+                    eb_apply_selfguided_restoration_c(CONVERT_TO_BYTEPTR(input_p),
                                                    w,
                                                    h,
                                                    stride,
@@ -373,9 +373,9 @@ class AV1HighbdSelfguidedFilterTest
             << "C time: " << ref_time << " us\n"
             << "SIMD time: " << tst_time << " us\n";
 
-        aom_free(input_);
-        aom_free(output_);
-        aom_free(tmpbuf);
+        eb_aom_free(input_);
+        eb_aom_free(output_);
+        eb_aom_free(tmpbuf);
     }
 
     void RunCorrectnessTest() {
@@ -391,13 +391,13 @@ class AV1HighbdSelfguidedFilterTest
         int32_t bit_depth = TEST_GET_PARAM(1);
         int mask = (1 << bit_depth) - 1;
 
-        uint16_t *input_ = (uint16_t *)aom_memalign(
+        uint16_t *input_ = (uint16_t *)eb_aom_memalign(
             32, stride * (max_h + 32) * sizeof(uint16_t));
-        uint16_t *output_ = (uint16_t *)aom_memalign(
+        uint16_t *output_ = (uint16_t *)eb_aom_memalign(
             32, out_stride * (max_h + 32) * sizeof(uint16_t));
-        uint16_t *output2_ = (uint16_t *)aom_memalign(
+        uint16_t *output2_ = (uint16_t *)eb_aom_memalign(
             32, out_stride * (max_h + 32) * sizeof(uint16_t));
-        int32_t *tmpbuf = (int32_t *)aom_memalign(32, RESTORATION_TMPBUF_SIZE);
+        int32_t *tmpbuf = (int32_t *)eb_aom_memalign(32, RESTORATION_TMPBUF_SIZE);
 
         uint16_t *input = input_ + stride * 16 + 16;
         uint16_t *output = output_ + out_stride * 16 + 16;
@@ -439,7 +439,7 @@ class AV1HighbdSelfguidedFilterTest
                              tmpbuf,
                              bit_depth,
                              1);
-                    apply_selfguided_restoration_c(
+                    eb_apply_selfguided_restoration_c(
                         CONVERT_TO_BYTEPTR(input_p),
                         w,
                         h,
@@ -459,10 +459,10 @@ class AV1HighbdSelfguidedFilterTest
                               output2[j * out_stride + k]);
         }
 
-        aom_free(input_);
-        aom_free(output_);
-        aom_free(output2_);
-        aom_free(tmpbuf);
+        eb_aom_free(input_);
+        eb_aom_free(output_);
+        eb_aom_free(output2_);
+        eb_aom_free(tmpbuf);
     }
 
   private:
@@ -479,7 +479,7 @@ TEST_P(AV1HighbdSelfguidedFilterTest, CorrectnessTest) {
 const int32_t highbd_params_avx2[] = {8, 10, 12};
 INSTANTIATE_TEST_CASE_P(
     AVX2, AV1HighbdSelfguidedFilterTest,
-    ::testing::Combine(::testing::Values(apply_selfguided_restoration_avx2),
+    ::testing::Combine(::testing::Values(eb_apply_selfguided_restoration_avx2),
                        ::testing::ValuesIn(highbd_params_avx2)));
 
 #if 0
@@ -569,8 +569,8 @@ TEST(IntegralImagesTest, integral_images) {
     const int32_t buf_elts = ALIGN_POWER_OF_TWO(RESTORATION_PROC_UNIT_PELS, 3);
     int32_t *buf_c, *buf_o;
 
-    buf_c = (int32_t *)aom_memalign(32, sizeof(*buf_c) * 4 * buf_elts);
-    buf_o = (int32_t *)aom_memalign(32, sizeof(*buf_o) * 4 * buf_elts);
+    buf_c = (int32_t *)eb_aom_memalign(32, sizeof(*buf_c) * 4 * buf_elts);
+    buf_o = (int32_t *)eb_aom_memalign(32, sizeof(*buf_o) * 4 * buf_elts);
 
     for (int i = 0; i < 10; i++) {
         init_data_integral_images(&src8, &src16, &src_stride);
@@ -690,8 +690,8 @@ TEST(IntegralImagesTest, integral_images) {
         uninit_data_integral_images(src8, src16);
     }
 
-    aom_free(buf_c);
-    aom_free(buf_o);
+    eb_aom_free(buf_c);
+    eb_aom_free(buf_o);
 }
 
 TEST(IntegralImagesTest, DISABLED_integral_images_speed) {
@@ -708,8 +708,8 @@ TEST(IntegralImagesTest, DISABLED_integral_images_speed) {
     const int32_t buf_elts = ALIGN_POWER_OF_TWO(RESTORATION_PROC_UNIT_PELS, 3);
     int32_t *buf_c, *buf_o;
 
-    buf_c = (int32_t *)aom_memalign(32, sizeof(*buf_c) * 4 * buf_elts);
-    buf_o = (int32_t *)aom_memalign(32, sizeof(*buf_o) * 4 * buf_elts);
+    buf_c = (int32_t *)eb_aom_memalign(32, sizeof(*buf_c) * 4 * buf_elts);
+    buf_o = (int32_t *)eb_aom_memalign(32, sizeof(*buf_o) * 4 * buf_elts);
 
     init_data_integral_images(&src8, &src16, &src_stride);
     const int32_t width = 32;
@@ -859,8 +859,8 @@ TEST(IntegralImagesTest, DISABLED_integral_images_speed) {
            time_c / time_o);
 
     uninit_data_integral_images(src8, src16);
-    aom_free(buf_c);
-    aom_free(buf_o);
+    eb_aom_free(buf_c);
+    eb_aom_free(buf_o);
 }
 #endif
 

--- a/test/subtract_avg_cfl_test.cc
+++ b/test/subtract_avg_cfl_test.cc
@@ -80,8 +80,8 @@ class CflSubAvgTest : public ::testing::TestWithParam<TxSize> {
         memset(data_ref_, 0, sizeof(data_ref_));
 
         /** get test and reference function */
-        sub_avg_tst_ = get_subtract_average_fn_avx2(tx_size_);
-        sub_avg_ref_ = get_subtract_average_fn_c(tx_size_);
+        sub_avg_tst_ = eb_get_subtract_average_fn_avx2(tx_size_);
+        sub_avg_ref_ = eb_get_subtract_average_fn_c(tx_size_);
     }
 
     virtual ~CflSubAvgTest() {

--- a/test/warp_filter_test.cc
+++ b/test/warp_filter_test.cc
@@ -27,7 +27,7 @@ TEST_P(AV1WarpFilterTest, DISABLED_Speed) {
 
 INSTANTIATE_TEST_CASE_P(
     C, AV1WarpFilterTest,
-    libaom_test::AV1WarpFilter::BuildParams(av1_warp_affine_c));
+    libaom_test::AV1WarpFilter::BuildParams(eb_av1_warp_affine_c));
 
 TEST_P(AV1HighbdWarpFilterTest, CheckOutput) {
     RunCheckOutput(std::get<4>(TEST_GET_PARAM(0)));
@@ -38,6 +38,6 @@ TEST_P(AV1HighbdWarpFilterTest, DISABLED_Speed) {
 
 INSTANTIATE_TEST_CASE_P(
     AVX2, AV1WarpFilterTest,
-    libaom_test::AV1WarpFilter::BuildParams(av1_warp_affine_avx2));
+    libaom_test::AV1WarpFilter::BuildParams(eb_av1_warp_affine_avx2));
 
 }  // namespace

--- a/test/warp_filter_test_util.cc
+++ b/test/warp_filter_test_util.cc
@@ -312,7 +312,7 @@ void AV1WarpFilterTest::RunCheckOutput(warp_affine_func test_impl) {
                                 conv_params.bck_offset =
                                     quant_dist_lookup_table[ii][jj][1];
                             }
-                            av1_warp_affine_c(mat,
+                            eb_av1_warp_affine_c(mat,
                                               input,
                                               w,
                                               h,
@@ -609,7 +609,7 @@ void AV1HighbdWarpFilterTest::RunCheckOutput(
                                     quant_dist_lookup_table[ii][jj][1];
                             }
 
-                            av1_highbd_warp_affine_c(mat,
+                            eb_av1_highbd_warp_affine_c(mat,
                                                      input,
                                                      w,
                                                      h,

--- a/test/weiner_convolve_test.cc
+++ b/test/weiner_convolve_test.cc
@@ -32,8 +32,8 @@
 
 /**
  * @brief Unit test of weiner convolbe add source:
- * - av1_wiener_convolve_add_src_avx2
- * - av1_highbd_wiener_convolve_add_src_avx2
+ * - eb_av1_wiener_convolve_add_src_avx2
+ * - eb_av1_highbd_wiener_convolve_add_src_avx2
  *
  * Test strategy:
  * Verify this assembly code by comparing with reference c implementation.
@@ -234,7 +234,7 @@ class AV1WienerConvolveLbdTest
         // Choose random locations within the source block
         int offset_r = 3 + pseudo_uniform(h - out_h_ - 7);
         int offset_c = 3 + pseudo_uniform(w - out_w_ - 7);
-        av1_wiener_convolve_add_src_c(input + offset_r * w + offset_c,
+        eb_av1_wiener_convolve_add_src_c(input + offset_r * w + offset_c,
                                       w,
                                       output_ref_,
                                       out_w_,
@@ -304,7 +304,7 @@ class AV1WienerConvolveHbdTest
         // Choose random locations within the source block
         int offset_r = 3 + pseudo_uniform(h - out_h_ - 7);
         int offset_c = 3 + pseudo_uniform(w - out_w_ - 7);
-        av1_highbd_wiener_convolve_add_src_c(input + offset_r * w + offset_c,
+        eb_av1_highbd_wiener_convolve_add_src_c(input + offset_r * w + offset_c,
                                              w,
                                              out_ref,
                                              out_w_,
@@ -357,7 +357,7 @@ TEST_P(AV1WienerConvolveLbdTest, run_random_test) {
 
 INSTANTIATE_TEST_CASE_P(
     AV1, AV1WienerConvolveLbdTest,
-    AV1WienerConvolveLbdTest::BuildParams(av1_wiener_convolve_add_src_avx2));
+    AV1WienerConvolveLbdTest::BuildParams(eb_av1_wiener_convolve_add_src_avx2));
 
 TEST_P(AV1WienerConvolveHbdTest, run_random_test) {
     run_random_test(1000);
@@ -365,6 +365,6 @@ TEST_P(AV1WienerConvolveHbdTest, run_random_test) {
 
 INSTANTIATE_TEST_CASE_P(AV1, AV1WienerConvolveHbdTest,
                         AV1WienerConvolveHbdTest::BuildParams(
-                            av1_highbd_wiener_convolve_add_src_avx2));
+                            eb_av1_highbd_wiener_convolve_add_src_avx2));
 
 }  // namespace

--- a/third_party/aom/inc/aom/aom_integer.h
+++ b/third_party/aom/inc/aom/aom_integer.h
@@ -79,7 +79,7 @@ extern "C" {
 #endif  // __cplusplus
 
 // Returns size of uint64_t when encoded using LEB128.
-size_t aom_uleb_size_in_bytes(uint64_t value);
+size_t eb_aom_uleb_size_in_bytes(uint64_t value);
 
 // Returns 0 on success, -1 on decode failure.
 // On success, 'value' stores the decoded LEB128 value and 'length' stores
@@ -88,7 +88,7 @@ int aom_uleb_decode(const uint8_t *buffer, size_t available, uint64_t *value,
                     size_t *length);
 
 // Encodes LEB128 integer. Returns 0 when successful, and -1 upon failure.
-int aom_uleb_encode(uint64_t value, size_t available, uint8_t *coded_value,
+int eb_aom_uleb_encode(uint64_t value, size_t available, uint8_t *coded_value,
                     size_t *coded_size);
 
 // Encodes LEB128 integer to size specified. Returns 0 when successful, and -1


### PR DESCRIPTION
We use many functions from liboam. We will see many duplicate define errors
if we enable liboam static library + svtav1.
this will fix #453


@jsunintel , @hassount @kylophone 
please help review this meet the requirement or not
thanks