### PR TITLE
Tile parallel

### DIFF
--- a/Source/Lib/Common/Codec/EbCodingUnit.h
+++ b/Source/Lib/Common/Codec/EbCodingUnit.h
@@ -206,6 +206,9 @@ extern "C" {
         int32_t tg_horz_boundary;
         int32_t tile_row;
         int32_t tile_col;
+#if TILES_PARALLEL
+        int32_t tile_rs_index; //tile index in raster order
+#endif
     } TileInfo;
 
     typedef struct MacroBlockDPlane

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -114,6 +114,7 @@ enum {
 /********************************************************/
 /****************** Pre-defined Values ******************/
 /********************************************************/
+#define TILES_PARALLEL 1
 
 #define ALTREF_MAX_NFRAMES 10 // maximum number of frames allowed for the Alt-ref picture computation
                               // this number can be increased by increasing the constant
@@ -181,6 +182,7 @@ enum {
 // Maximum number of tile rows and tile columns
 #define MAX_TILE_ROWS 64
 #define MAX_TILE_COLS 64
+#define MAX_TILE_CNTS 4096
 #define MAX_VARTX_DEPTH 1
 #define MI_SIZE_64X64 (64 >> MI_SIZE_LOG2)
 #define MI_SIZE_128X128 (128 >> MI_SIZE_LOG2)

--- a/Source/Lib/Common/Codec/EbDlfProcess.c
+++ b/Source/Lib/Common/Codec/EbDlfProcess.c
@@ -116,7 +116,15 @@ void* dlf_kernel(void *input_ptr)
         EbBool is16bit       = (EbBool)(sequence_control_set_ptr->static_config.encoder_bit_depth > EB_8BIT);
 
         EbBool dlfEnableFlag = (EbBool) picture_control_set_ptr->parent_pcs_ptr->loop_filter_mode;
+#if TILES_PARALLEL
+        uint16_t total_tile_cnt = picture_control_set_ptr->parent_pcs_ptr->av1_cm->tiles_info.tile_cols * picture_control_set_ptr->parent_pcs_ptr->av1_cm->tiles_info.tile_rows;
+        // Jing: Move sb level lf to here if tile_parallel
+        if ((dlfEnableFlag && picture_control_set_ptr->parent_pcs_ptr->loop_filter_mode >= 2 && total_tile_cnt == 1) ||
+                (dlfEnableFlag && picture_control_set_ptr->parent_pcs_ptr->loop_filter_mode == 1 && total_tile_cnt > 1)) {
+#else
         if (dlfEnableFlag && picture_control_set_ptr->parent_pcs_ptr->loop_filter_mode >= 2) {
+#endif
+
             EbPictureBufferDesc  *recon_buffer = is16bit ? picture_control_set_ptr->recon_picture16bit_ptr : picture_control_set_ptr->recon_picture_ptr;
 
             if (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE)

--- a/Source/Lib/Common/Codec/EbEncDecProcess.h
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.h
@@ -127,6 +127,11 @@ extern "C" {
         uint8_t                                reduced_tx_set_used;
         EbBool                                 evaluate_cfl_ep; // 0: CFL is evaluated @ mode decision, 1: CFL is evaluated @ encode pass
         uint8_t                                md_skip_blk;
+#if TILES_PARALLEL
+        uint16_t                               tile_row_index;
+        uint16_t                               tile_index;
+        uint32_t                               coded_sb_count;
+#endif
     } EncDecContext;
 
     /**************************************

--- a/Source/Lib/Common/Codec/EbEncDecResults.h
+++ b/Source/Lib/Common/Codec/EbEncDecResults.h
@@ -43,6 +43,9 @@ extern "C" {
         EbObjectWrapper *picture_control_set_wrapper_ptr;
         uint32_t         completed_lcu_row_index_start;
         uint32_t         completed_lcu_row_count;
+#if TILES_PARALLEL
+        uint16_t         tile_index;
+#endif
     } RestResults;
 
     typedef struct EncDecResultsInitData {

--- a/Source/Lib/Common/Codec/EbEncDecSegments.c
+++ b/Source/Lib/Common/Codec/EbEncDecSegments.c
@@ -71,7 +71,10 @@ void enc_dec_segments_init(
 {
     unsigned x, y, yLast;
     unsigned row_index, band_index, segment_index;
-
+#if TILES_PARALLEL
+    segColCount = (segColCount < pic_width_lcu) ? segColCount : pic_width_lcu;
+    segRowCount = (segRowCount < pic_height_lcu)? segRowCount : pic_height_lcu;
+#endif
     segments_ptr->lcu_row_count = pic_height_lcu;
     segments_ptr->lcu_band_count = BAND_TOTAL_COUNT(pic_height_lcu, pic_width_lcu);
     segments_ptr->segment_row_count = segRowCount;

--- a/Source/Lib/Common/Codec/EbEncDecTasks.h
+++ b/Source/Lib/Common/Codec/EbEncDecTasks.h
@@ -25,6 +25,9 @@ extern "C" {
         EbObjectWrapper            *picture_control_set_wrapper_ptr;
         uint32_t                        input_type;
         int16_t                        enc_dec_segment_row;
+#if TILES_PARALLEL
+        uint16_t                       tile_row_index;
+#endif
     } EncDecTasks;
 
     typedef struct EncDecTasksInitData {

--- a/Source/Lib/Common/Codec/EbEntropyCoding.h
+++ b/Source/Lib/Common/Codec/EbEntropyCoding.h
@@ -46,6 +46,9 @@ extern "C" {
     extern EbErrorType write_sb(
         struct EntropyCodingContext   *context_ptr,
         LargestCodingUnit     *tb_ptr,
+#if TILES_PARALLEL
+        uint16_t               tile_idx,
+#endif
         PictureControlSet     *picture_control_set_ptr,
         EntropyCoder          *entropy_coder_ptr,
         EbPictureBufferDesc   *coeff_ptr);

--- a/Source/Lib/Common/Codec/EbEntropyCodingObject.h
+++ b/Source/Lib/Common/Codec/EbEntropyCodingObject.h
@@ -28,6 +28,25 @@ extern "C" {
         uint64_t   ec_frame_size;
     } EntropyCoder;
 
+#if TILES_PARALLEL
+    typedef struct EntropyTileInfo
+    {
+        EbDctor           dctor;
+        EntropyCoder     *entropy_coder_ptr;
+        int8_t            entropy_coding_current_available_row;
+        EbBool            entropy_coding_row_array[MAX_LCU_ROWS];
+        int8_t            entropy_coding_current_row;
+        int8_t            entropy_coding_row_count;
+        EbHandle          entropy_coding_mutex;
+        EbBool            entropy_coding_in_progress;
+        EbBool            entropy_coding_tile_done;
+    } EntropyTileInfo;
+
+    extern EbErrorType entropy_tile_info_ctor(
+        EntropyTileInfo *entropy_tile_info_ptr,
+        uint32_t buf_size);
+#endif
+
     extern EbErrorType bitstream_ctor(
         Bitstream *bitstream_ptr,
         uint32_t buffer_size);
@@ -38,6 +57,7 @@ extern "C" {
 
     extern EbPtr entropy_coder_get_bitstream_ptr(
         EntropyCoder *entropy_coder_ptr);
+
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Common/Codec/EbFullLoop.c
+++ b/Source/Lib/Common/Codec/EbFullLoop.c
@@ -2374,7 +2374,11 @@ void product_full_loop_tx_search(
                 sequence_control_set_ptr,
 #endif
                 COMPONENT_LUMA,
+#if TILES_PARALLEL
+                picture_control_set_ptr->ep_luma_dc_sign_level_coeff_neighbor_array[context_ptr->tile_index],
+#else
                 picture_control_set_ptr->ep_luma_dc_sign_level_coeff_neighbor_array,
+#endif
                 context_ptr->sb_origin_x + txb_origin_x,
                 context_ptr->sb_origin_y + txb_origin_y,
                 //txb_origin_x,// context_ptr->cu_origin_x,

--- a/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
@@ -2057,6 +2057,21 @@ void* mode_decision_configuration_kernel(void *input_ptr)
             picture_control_set_ptr);
 
         // Post the results to the MD processes
+#if TILES_PARALLEL
+        for (int tile_row_idx = 0; tile_row_idx < picture_control_set_ptr->parent_pcs_ptr->av1_cm->tiles_info.tile_rows; tile_row_idx++) {
+            eb_get_empty_object(
+                    context_ptr->mode_decision_configuration_output_fifo_ptr,
+                    &encDecTasksWrapperPtr);
+
+            encDecTasksPtr = (EncDecTasks*)encDecTasksWrapperPtr->object_ptr;
+            encDecTasksPtr->picture_control_set_wrapper_ptr = rateControlResultsPtr->picture_control_set_wrapper_ptr;
+            encDecTasksPtr->input_type = ENCDEC_TASKS_MDC_INPUT;
+            encDecTasksPtr->tile_row_index = tile_row_idx;
+
+            // Post the Full Results Object
+            eb_post_full_object(encDecTasksWrapperPtr);
+        }
+#else
         eb_get_empty_object(
             context_ptr->mode_decision_configuration_output_fifo_ptr,
             &encDecTasksWrapperPtr);
@@ -2067,6 +2082,7 @@ void* mode_decision_configuration_kernel(void *input_ptr)
 
         // Post the Full Results Object
         eb_post_full_object(encDecTasksWrapperPtr);
+#endif
 
         // Release Rate Control Results
         eb_release_object(rateControlResultsWrapperPtr);

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -241,6 +241,9 @@ extern "C" {
         EbBool                          blk_skip_decision;
         EbBool                          trellis_quant_coeff_optimization;
         EbPictureBufferDesc                 *input_sample16bit_buffer;
+#if TILES_PARALLEL
+        uint16_t                        tile_index;
+#endif
     } ModeDecisionContext;
 
     typedef void(*EbAv1LambdaAssignFunc)(
@@ -272,8 +275,10 @@ extern "C" {
         EbFifo                    *mode_decision_output_fifo_ptr,
         EbBool                     enable_hbd_mode_decision);
 
+#if !TILES_PARALLEL
     extern void reset_mode_decision_neighbor_arrays(
         PictureControlSet *picture_control_set_ptr);
+#endif
 
     extern void lambda_assign_low_delay(
         uint32_t                    *fast_lambda,
@@ -312,6 +317,9 @@ extern "C" {
         PictureControlSet     *picture_control_set_ptr,
 #if !ENABLE_CDF_UPDATE
         SequenceControlSet    *sequence_control_set_ptr,
+#endif
+#if TILES_PARALLEL
+        uint16_t               tile_row_idx,
 #endif
         uint32_t                 segment_index);
 

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -13679,6 +13679,7 @@ extern "C" {
         MeshPattern mesh_patterns[MAX_MESH_STEP];
     } SpeedFeatures;
 
+
     typedef struct PictureControlSet
     {
         EbDctor                            dctor;
@@ -13693,7 +13694,9 @@ extern "C" {
 
         struct PictureParentControlSet     *parent_pcs_ptr;  //The parent of this PCS.
         EbObjectWrapper                    *picture_parent_control_set_wrapper_ptr;
+#if !TILES_PARALLEL
         EntropyCoder                       *entropy_coder_ptr;
+#endif
         // Packetization (used to encode SPS, PPS, etc)
         Bitstream                          *bitstream_ptr;
 
@@ -13710,9 +13713,19 @@ extern "C" {
 
         EbColorFormat                         color_format;
 
+#if TILES_PARALLEL
+        EncDecSegments                     **enc_dec_segment_ctrl;
+        uint32_t                             enc_dec_coded_sb_count;
+#else
         EncDecSegments                     *enc_dec_segment_ctrl;
+#endif
 
         // Entropy Process Rows
+#if TILES_PARALLEL
+        EntropyTileInfo                     **entropy_coding_info;
+        EbHandle                              entropy_coding_pic_mutex;
+        EbBool                                entropy_coding_pic_reset_flag;
+#else
         int8_t                                entropy_coding_current_available_row;
         EbBool                                entropy_coding_row_array[MAX_LCU_ROWS];
         int8_t                                entropy_coding_current_row;
@@ -13720,6 +13733,8 @@ extern "C" {
         EbHandle                              entropy_coding_mutex;
         EbBool                                entropy_coding_in_progress;
         EbBool                                entropy_coding_pic_done;
+#endif
+
         EbHandle                              intra_mutex;
         uint32_t                              intra_coded_area;
         uint32_t                              tot_seg_searched_cdef;
@@ -13769,6 +13784,35 @@ extern "C" {
         EntropyCoder                       *coeff_est_entropy_coder_ptr;
 
         // Mode Decision Neighbor Arrays
+#if TILES_PARALLEL
+        NeighborArrayUnit                  **md_intra_luma_mode_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_intra_chroma_mode_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_mv_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_skip_flag_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_mode_type_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_leaf_depth_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_luma_recon_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_tx_depth_1_luma_recon_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_cb_recon_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_cr_recon_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        EbBool                             hbd_mode_decision;
+        NeighborArrayUnit                  **md_luma_recon_neighbor_array16bit[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_tx_depth_1_luma_recon_neighbor_array16bit[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_cb_recon_neighbor_array16bit[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_cr_recon_neighbor_array16bit[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_skip_coeff_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_luma_dc_sign_level_coeff_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_cb_dc_sign_level_coeff_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_cr_dc_sign_level_coeff_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_txfm_context_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_inter_pred_dir_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+        NeighborArrayUnit                  **md_ref_frame_type_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+
+        NeighborArrayUnit32                **md_interpolation_type_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+
+        NeighborArrayUnit                  **mdleaf_partition_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+#else
         NeighborArrayUnit                  *md_intra_luma_mode_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
         NeighborArrayUnit                  *md_intra_chroma_mode_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
         NeighborArrayUnit                  *md_mv_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
@@ -13796,7 +13840,25 @@ extern "C" {
         NeighborArrayUnit32                *md_interpolation_type_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
 
         NeighborArrayUnit                  *mdleaf_partition_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
+#endif
         // Encode Pass Neighbor Arrays
+#if TILES_PARALLEL
+        NeighborArrayUnit                  **ep_intra_luma_mode_neighbor_array;
+        NeighborArrayUnit                  **ep_intra_chroma_mode_neighbor_array;
+        NeighborArrayUnit                  **ep_mv_neighbor_array;
+        NeighborArrayUnit                  **ep_skip_flag_neighbor_array;
+        NeighborArrayUnit                  **ep_mode_type_neighbor_array;
+        NeighborArrayUnit                  **ep_leaf_depth_neighbor_array;
+        NeighborArrayUnit                  **ep_luma_recon_neighbor_array;
+        NeighborArrayUnit                  **ep_cb_recon_neighbor_array;
+        NeighborArrayUnit                  **ep_cr_recon_neighbor_array;
+        NeighborArrayUnit                  **ep_luma_recon_neighbor_array16bit;
+        NeighborArrayUnit                  **ep_cb_recon_neighbor_array16bit;
+        NeighborArrayUnit                  **ep_cr_recon_neighbor_array16bit;
+        NeighborArrayUnit                  **ep_luma_dc_sign_level_coeff_neighbor_array;
+        NeighborArrayUnit                  **ep_cr_dc_sign_level_coeff_neighbor_array;
+        NeighborArrayUnit                  **ep_cb_dc_sign_level_coeff_neighbor_array;
+#else
         NeighborArrayUnit                  *ep_intra_luma_mode_neighbor_array;
         NeighborArrayUnit                  *ep_intra_chroma_mode_neighbor_array;
         NeighborArrayUnit                  *ep_mv_neighbor_array;
@@ -13812,7 +13874,24 @@ extern "C" {
         NeighborArrayUnit                  *ep_luma_dc_sign_level_coeff_neighbor_array;
         NeighborArrayUnit                  *ep_cr_dc_sign_level_coeff_neighbor_array;
         NeighborArrayUnit                  *ep_cb_dc_sign_level_coeff_neighbor_array;
+#endif
         // Entropy Coding Neighbor Arrays
+#if TILES_PARALLEL
+        NeighborArrayUnit                  **mode_type_neighbor_array;
+        NeighborArrayUnit                  **partition_context_neighbor_array;
+        NeighborArrayUnit                  **intra_luma_mode_neighbor_array;
+        NeighborArrayUnit                  **skip_flag_neighbor_array;
+        NeighborArrayUnit                  **skip_coeff_neighbor_array;
+        NeighborArrayUnit                  **luma_dc_sign_level_coeff_neighbor_array; // Stored per 4x4. 8 bit: lower 6 bits (COEFF_CONTEXT_BITS), shows if there is at least one Coef. Top 2 bit store the sign of DC as follow: 0->0,1->-1,2-> 1
+        NeighborArrayUnit                  **cr_dc_sign_level_coeff_neighbor_array; // Stored per 4x4. 8 bit: lower 6 bits(COEFF_CONTEXT_BITS), shows if there is at least one Coef. Top 2 bit store the sign of DC as follow: 0->0,1->-1,2-> 1
+        NeighborArrayUnit                  **cb_dc_sign_level_coeff_neighbor_array; // Stored per 4x4. 8 bit: lower 6 bits(COEFF_CONTEXT_BITS), shows if there is at least one Coef. Top 2 bit store the sign of DC as follow: 0->0,1->-1,2-> 1
+        NeighborArrayUnit                  **txfm_context_array;
+        NeighborArrayUnit                  **inter_pred_dir_neighbor_array;
+        NeighborArrayUnit                  **ref_frame_type_neighbor_array;
+        NeighborArrayUnit32                **interpolation_type_neighbor_array;
+
+        NeighborArrayUnit                  **segmentation_id_pred_array;
+#else
         NeighborArrayUnit                  *mode_type_neighbor_array;
         NeighborArrayUnit                  *partition_context_neighbor_array;
         NeighborArrayUnit                  *intra_luma_mode_neighbor_array;
@@ -13827,6 +13906,7 @@ extern "C" {
         NeighborArrayUnit32                *interpolation_type_neighbor_array;
 
         NeighborArrayUnit                  *segmentation_id_pred_array;
+#endif
         SegmentationNeighborMap              *segmentation_neighbor_map;
 
         ModeInfo                            **mi_grid_base; //2 SB Rows of mi Data are enough
@@ -13848,9 +13928,19 @@ extern "C" {
         EbEncMode                             enc_mode;
         EbBool                                intra_md_open_loop_flag;
         EbBool                                limit_intra;
+
+#if TILES_PARALLEL
+        //Jing:TODO
+        //re-calculate MAX_TILE_CNTS, currently 4K is too big
+        int32_t                               cdef_preset[MAX_TILE_CNTS][4];
+        WienerInfo                            wiener_info[MAX_TILE_CNTS][MAX_MB_PLANE];
+        SgrprojInfo                           sgrproj_info[MAX_TILE_CNTS][MAX_MB_PLANE];
+#else
         int32_t                               cdef_preset[4];
         WienerInfo                            wiener_info[MAX_MB_PLANE];
         SgrprojInfo                           sgrproj_info[MAX_MB_PLANE];
+#endif
+
         SpeedFeatures sf;
         SearchSiteConfig ss_cfg;//CHKN this might be a seq based
         HashTable hash_table;
@@ -13864,6 +13954,12 @@ extern "C" {
         FRAME_CONTEXT           ref_frame_context[REF_FRAMES];
         EbWarpedMotionParams    ref_global_motion[TOTAL_REFS_PER_FRAME];
         struct MdRateEstimationContext *md_rate_estimation_array;
+#endif
+
+#if TILES_PARALLEL
+        //Put it here for deinit, don't need to go pcs->ppcs->av1_cm which may already be released
+        uint16_t tile_row_count;
+        uint16_t tile_column_count;
 #endif
     } PictureControlSet;
 
@@ -13951,6 +14047,11 @@ extern "C" {
         EbLinkedListNode                     *app_out_data_ll_head_ptr;
 
         EbBufferHeaderType                   *input_ptr;            // input picture buffer
+#if TILES_PARALLEL
+        uint8_t                               log2_tile_rows;
+        uint8_t                               log2_tile_cols;
+        uint8_t                               log2_sb_sz;
+#endif
 
         EbBool                                idr_flag;
         EbBool                                cra_flag;
@@ -14280,6 +14381,17 @@ extern "C" {
         uint8_t                            nsq_present;
 #if INCOMPLETE_SB_FIX
         uint8_t                            over_boundary_block_mode;
+#endif
+#if TILES_PARALLEL
+        //init value for pcs
+        uint8_t                            tile_row_count;
+        uint8_t                            tile_column_count;
+
+        //Init value for ppcs
+        uint8_t                            log2_tile_rows; //from command line
+        uint8_t                            log2_tile_cols;
+        uint8_t                            log2_sb_sz; //in mi unit
+
 #endif
     } PictureControlSetInitData;
 

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -100,6 +100,9 @@ void mode_decision_update_neighbor_arrays(
     context_ptr->mv_unit.mv[REF_LIST_1].mv_union = context_ptr->md_cu_arr_nsq[index_mds].prediction_unit_array[0].mv[REF_LIST_1].mv_union;
     uint8_t                    inter_pred_direction_index = (uint8_t)context_ptr->cu_ptr->prediction_unit_array->inter_pred_direction_index;
     uint8_t                    ref_frame_type = (uint8_t)context_ptr->cu_ptr->prediction_unit_array[0].ref_frame_type;
+#if TILES_PARALLEL
+    uint16_t tile_idx = context_ptr->tile_index;
+#endif
 
     if (picture_control_set_ptr->parent_pcs_ptr->interpolation_search_level != IT_SEARCH_OFF)
     neighbor_array_unit_mode_write32(
@@ -169,7 +172,11 @@ void mode_decision_update_neighbor_arrays(
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
 
             neighbor_array_unit_mode_write(
+#if TILES_PARALLEL
+                picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
                 picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
+#endif
                 (uint8_t*)&dc_sign_level_coeff,
                 context_ptr->sb_origin_x + context_ptr->blk_geom->tx_org_x[context_ptr->cu_ptr->tx_depth][txb_itr],
                 context_ptr->sb_origin_y + context_ptr->blk_geom->tx_org_y[context_ptr->cu_ptr->tx_depth][txb_itr],
@@ -272,7 +279,11 @@ void mode_decision_update_neighbor_arrays(
                 context_ptr->blk_geom->bheight);
             if (picture_control_set_ptr->parent_pcs_ptr->atb_mode) {
                 update_recon_neighbor_array(
+#if TILES_PARALLEL
+                    picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
                     picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
+#endif
                     context_ptr->cu_ptr->neigh_top_recon[0],
                     context_ptr->cu_ptr->neigh_left_recon[0],
                     origin_x,
@@ -315,7 +326,11 @@ void mode_decision_update_neighbor_arrays(
 
             if (picture_control_set_ptr->parent_pcs_ptr->atb_mode) {
                 update_recon_neighbor_array16bit(
+#if TILES_PARALLEL
+                    picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
                     picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
+#endif
                     context_ptr->cu_ptr->neigh_top_recon_16bit[0],
                     context_ptr->cu_ptr->neigh_left_recon_16bit[0],
                     origin_x,
@@ -359,7 +374,11 @@ void copy_neighbour_arrays(
     uint32_t                            sb_org_x,
     uint32_t                            sb_org_y)
 {
+#if TILES_PARALLEL
+    uint16_t tile_idx = context_ptr->tile_index;
+#else
     (void)*context_ptr;
+#endif
 
     const BlockGeom * blk_geom = get_blk_geom_mds(blk_mds);
 
@@ -371,8 +390,13 @@ void copy_neighbour_arrays(
     uint32_t                            bheight_uv = blk_geom->bheight_uv;
 
     copy_neigh_arr(
+#if TILES_PARALLEL
+        picture_control_set_ptr->md_intra_luma_mode_neighbor_array[src_idx][tile_idx],
+        picture_control_set_ptr->md_intra_luma_mode_neighbor_array[dst_idx][tile_idx],
+#else
         picture_control_set_ptr->md_intra_luma_mode_neighbor_array[src_idx],
         picture_control_set_ptr->md_intra_luma_mode_neighbor_array[dst_idx],
+#endif
         blk_org_x,
         blk_org_y,
         blk_geom->bwidth,
@@ -381,8 +405,13 @@ void copy_neighbour_arrays(
 
     //neighbor_array_unit_reset(picture_control_set_ptr->md_intra_chroma_mode_neighbor_array[depth]);
     copy_neigh_arr(
+#if TILES_PARALLEL
+        picture_control_set_ptr->md_intra_chroma_mode_neighbor_array[src_idx][tile_idx],
+        picture_control_set_ptr->md_intra_chroma_mode_neighbor_array[dst_idx][tile_idx],
+#else
         picture_control_set_ptr->md_intra_chroma_mode_neighbor_array[src_idx],
         picture_control_set_ptr->md_intra_chroma_mode_neighbor_array[dst_idx],
+#endif
         blk_org_x_uv,
         blk_org_y_uv,
         bwidth_uv,
@@ -391,8 +420,13 @@ void copy_neighbour_arrays(
 
     //neighbor_array_unit_reset(picture_control_set_ptr->md_skip_flag_neighbor_array[depth]);
     copy_neigh_arr(
+#if TILES_PARALLEL
+        picture_control_set_ptr->md_skip_flag_neighbor_array[src_idx][tile_idx],
+        picture_control_set_ptr->md_skip_flag_neighbor_array[dst_idx][tile_idx],
+#else
         picture_control_set_ptr->md_skip_flag_neighbor_array[src_idx],
         picture_control_set_ptr->md_skip_flag_neighbor_array[dst_idx],
+#endif
         blk_org_x,
         blk_org_y,
         blk_geom->bwidth,
@@ -401,8 +435,13 @@ void copy_neighbour_arrays(
 
     //neighbor_array_unit_reset(picture_control_set_ptr->md_mode_type_neighbor_array[depth]);
     copy_neigh_arr(
+#if TILES_PARALLEL
+        picture_control_set_ptr->md_mode_type_neighbor_array[src_idx][tile_idx],
+        picture_control_set_ptr->md_mode_type_neighbor_array[dst_idx][tile_idx],
+#else
         picture_control_set_ptr->md_mode_type_neighbor_array[src_idx],
         picture_control_set_ptr->md_mode_type_neighbor_array[dst_idx],
+#endif
         blk_org_x,
         blk_org_y,
         blk_geom->bwidth,
@@ -411,16 +450,26 @@ void copy_neighbour_arrays(
 
     //neighbor_array_unit_reset(picture_control_set_ptr->md_leaf_depth_neighbor_array[depth]);
     copy_neigh_arr(
+#if TILES_PARALLEL
+        picture_control_set_ptr->md_leaf_depth_neighbor_array[src_idx][tile_idx],
+        picture_control_set_ptr->md_leaf_depth_neighbor_array[dst_idx][tile_idx],
+#else
         picture_control_set_ptr->md_leaf_depth_neighbor_array[src_idx],
         picture_control_set_ptr->md_leaf_depth_neighbor_array[dst_idx],
+#endif
         blk_org_x,
         blk_org_y,
         blk_geom->bwidth,
         blk_geom->bheight,
         NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
     copy_neigh_arr(
+#if TILES_PARALLEL
+        picture_control_set_ptr->mdleaf_partition_neighbor_array[src_idx][tile_idx],
+        picture_control_set_ptr->mdleaf_partition_neighbor_array[dst_idx][tile_idx],
+#else
         picture_control_set_ptr->mdleaf_partition_neighbor_array[src_idx],
         picture_control_set_ptr->mdleaf_partition_neighbor_array[dst_idx],
+#endif
         blk_org_x,
         blk_org_y,
         blk_geom->bwidth,
@@ -429,8 +478,13 @@ void copy_neighbour_arrays(
 
     if (!context_ptr->hbd_mode_decision) {
         copy_neigh_arr(
+#if TILES_PARALLEL
+            picture_control_set_ptr->md_luma_recon_neighbor_array[src_idx][tile_idx],
+            picture_control_set_ptr->md_luma_recon_neighbor_array[dst_idx][tile_idx],
+#else
             picture_control_set_ptr->md_luma_recon_neighbor_array[src_idx],
             picture_control_set_ptr->md_luma_recon_neighbor_array[dst_idx],
+#endif
             blk_org_x,
             blk_org_y,
             blk_geom->bwidth,
@@ -438,8 +492,13 @@ void copy_neighbour_arrays(
             NEIGHBOR_ARRAY_UNIT_FULL_MASK);
         if (picture_control_set_ptr->parent_pcs_ptr->atb_mode) {
             copy_neigh_arr(
+#if TILES_PARALLEL
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[src_idx][tile_idx],
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[dst_idx][tile_idx],
+#else
                 picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[src_idx],
                 picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[dst_idx],
+#endif
                 blk_org_x,
                 blk_org_y,
                 blk_geom->bwidth,
@@ -448,8 +507,13 @@ void copy_neighbour_arrays(
         }
         if (blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
             copy_neigh_arr(
+#if TILES_PARALLEL
+                picture_control_set_ptr->md_cb_recon_neighbor_array[src_idx][tile_idx],
+                picture_control_set_ptr->md_cb_recon_neighbor_array[dst_idx][tile_idx],
+#else
                 picture_control_set_ptr->md_cb_recon_neighbor_array[src_idx],
                 picture_control_set_ptr->md_cb_recon_neighbor_array[dst_idx],
+#endif
                 blk_org_x_uv,
                 blk_org_y_uv,
                 bwidth_uv,
@@ -457,8 +521,13 @@ void copy_neighbour_arrays(
                 NEIGHBOR_ARRAY_UNIT_FULL_MASK);
 
             copy_neigh_arr(
+#if TILES_PARALLEL
+                picture_control_set_ptr->md_cr_recon_neighbor_array[src_idx][tile_idx],
+                picture_control_set_ptr->md_cr_recon_neighbor_array[dst_idx][tile_idx],
+#else
                 picture_control_set_ptr->md_cr_recon_neighbor_array[src_idx],
                 picture_control_set_ptr->md_cr_recon_neighbor_array[dst_idx],
+#endif
                 blk_org_x_uv,
                 blk_org_y_uv,
                 bwidth_uv,
@@ -467,8 +536,13 @@ void copy_neighbour_arrays(
         }
     } else {
         copy_neigh_arr(
+#if TILES_PARALLEL
+            picture_control_set_ptr->md_luma_recon_neighbor_array16bit[src_idx][tile_idx],
+            picture_control_set_ptr->md_luma_recon_neighbor_array16bit[dst_idx][tile_idx],
+#else
             picture_control_set_ptr->md_luma_recon_neighbor_array16bit[src_idx],
             picture_control_set_ptr->md_luma_recon_neighbor_array16bit[dst_idx],
+#endif
             blk_org_x,
             blk_org_y,
             blk_geom->bwidth,
@@ -477,8 +551,13 @@ void copy_neighbour_arrays(
 
         if (picture_control_set_ptr->parent_pcs_ptr->atb_mode) {
             copy_neigh_arr(
+#if TILES_PARALLEL
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[src_idx][tile_idx],
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[dst_idx][tile_idx],
+#else
                 picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[src_idx],
                 picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[dst_idx],
+#endif
                 blk_org_x,
                 blk_org_y,
                 blk_geom->bwidth,
@@ -488,8 +567,13 @@ void copy_neighbour_arrays(
 
         if (blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
             copy_neigh_arr(
+#if TILES_PARALLEL
+                picture_control_set_ptr->md_cb_recon_neighbor_array16bit[src_idx][tile_idx],
+                picture_control_set_ptr->md_cb_recon_neighbor_array16bit[dst_idx][tile_idx],
+#else
                 picture_control_set_ptr->md_cb_recon_neighbor_array16bit[src_idx],
                 picture_control_set_ptr->md_cb_recon_neighbor_array16bit[dst_idx],
+#endif
                 blk_org_x_uv,
                 blk_org_y_uv,
                 bwidth_uv,
@@ -497,8 +581,13 @@ void copy_neighbour_arrays(
                 NEIGHBOR_ARRAY_UNIT_FULL_MASK);
 
             copy_neigh_arr(
+#if TILES_PARALLEL
+                picture_control_set_ptr->md_cr_recon_neighbor_array16bit[src_idx][tile_idx],
+                picture_control_set_ptr->md_cr_recon_neighbor_array16bit[dst_idx][tile_idx],
+#else
                 picture_control_set_ptr->md_cr_recon_neighbor_array16bit[src_idx],
                 picture_control_set_ptr->md_cr_recon_neighbor_array16bit[dst_idx],
+#endif
                 blk_org_x_uv,
                 blk_org_y_uv,
                 bwidth_uv,
@@ -509,8 +598,13 @@ void copy_neighbour_arrays(
 
     //neighbor_array_unit_reset(picture_control_set_ptr->md_skip_coeff_neighbor_array[depth]);
     copy_neigh_arr(
+#if TILES_PARALLEL
+        picture_control_set_ptr->md_skip_coeff_neighbor_array[src_idx][tile_idx],
+        picture_control_set_ptr->md_skip_coeff_neighbor_array[dst_idx][tile_idx],
+#else
         picture_control_set_ptr->md_skip_coeff_neighbor_array[src_idx],
         picture_control_set_ptr->md_skip_coeff_neighbor_array[dst_idx],
+#endif
         blk_org_x,
         blk_org_y,
         blk_geom->bwidth,
@@ -518,8 +612,13 @@ void copy_neighbour_arrays(
         NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
     //neighbor_array_unit_reset(picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[depth]);
     copy_neigh_arr(
+#if TILES_PARALLEL
+        picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[src_idx][tile_idx],
+        picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[dst_idx][tile_idx],
+#else
         picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[src_idx],
         picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[dst_idx],
+#endif
         blk_org_x,
         blk_org_y,
         blk_geom->bwidth,
@@ -527,8 +626,13 @@ void copy_neighbour_arrays(
         NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
 
     copy_neigh_arr(
+#if TILES_PARALLEL
+        picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[src_idx][tile_idx],
+        picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[dst_idx][tile_idx],
+#else
         picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[src_idx],
         picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[dst_idx],
+#endif
         blk_org_x,
         blk_org_y,
         blk_geom->bwidth,
@@ -537,8 +641,13 @@ void copy_neighbour_arrays(
 
     if (blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
         copy_neigh_arr(
+#if TILES_PARALLEL
+            picture_control_set_ptr->md_cb_dc_sign_level_coeff_neighbor_array[src_idx][tile_idx],
+            picture_control_set_ptr->md_cb_dc_sign_level_coeff_neighbor_array[dst_idx][tile_idx],
+#else
             picture_control_set_ptr->md_cb_dc_sign_level_coeff_neighbor_array[src_idx],
             picture_control_set_ptr->md_cb_dc_sign_level_coeff_neighbor_array[dst_idx],
+#endif
             blk_org_x_uv,
             blk_org_y_uv,
             bwidth_uv,
@@ -547,8 +656,13 @@ void copy_neighbour_arrays(
         //neighbor_array_unit_reset(picture_control_set_ptr->md_cr_dc_sign_level_coeff_neighbor_array[depth]);
 
         copy_neigh_arr(
+#if TILES_PARALLEL
+            picture_control_set_ptr->md_cr_dc_sign_level_coeff_neighbor_array[src_idx][tile_idx],
+            picture_control_set_ptr->md_cr_dc_sign_level_coeff_neighbor_array[dst_idx][tile_idx],
+#else
             picture_control_set_ptr->md_cr_dc_sign_level_coeff_neighbor_array[src_idx],
             picture_control_set_ptr->md_cr_dc_sign_level_coeff_neighbor_array[dst_idx],
+#endif
             blk_org_x_uv,
             blk_org_y_uv,
             bwidth_uv,
@@ -558,8 +672,13 @@ void copy_neighbour_arrays(
 
     //neighbor_array_unit_reset(picture_control_set_ptr->md_txfm_context_array[depth]);
     copy_neigh_arr(
+#if TILES_PARALLEL
+        picture_control_set_ptr->md_txfm_context_array[src_idx][tile_idx],
+        picture_control_set_ptr->md_txfm_context_array[dst_idx][tile_idx],
+#else
         picture_control_set_ptr->md_txfm_context_array[src_idx],
         picture_control_set_ptr->md_txfm_context_array[dst_idx],
+#endif
         blk_org_x,
         blk_org_y,
         blk_geom->bwidth,
@@ -567,8 +686,13 @@ void copy_neighbour_arrays(
         NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
     //neighbor_array_unit_reset(picture_control_set_ptr->md_inter_pred_dir_neighbor_array[depth]);
     copy_neigh_arr(
+#if TILES_PARALLEL
+        picture_control_set_ptr->md_inter_pred_dir_neighbor_array[src_idx][tile_idx],
+        picture_control_set_ptr->md_inter_pred_dir_neighbor_array[dst_idx][tile_idx],
+#else
         picture_control_set_ptr->md_inter_pred_dir_neighbor_array[src_idx],
         picture_control_set_ptr->md_inter_pred_dir_neighbor_array[dst_idx],
+#endif
         blk_org_x,
         blk_org_y,
         blk_geom->bwidth,
@@ -576,8 +700,13 @@ void copy_neighbour_arrays(
         NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
     //neighbor_array_unit_reset(picture_control_set_ptr->md_ref_frame_type_neighbor_array[depth]);
     copy_neigh_arr(
+#if TILES_PARALLEL
+        picture_control_set_ptr->md_ref_frame_type_neighbor_array[src_idx][tile_idx],
+        picture_control_set_ptr->md_ref_frame_type_neighbor_array[dst_idx][tile_idx],
+#else
         picture_control_set_ptr->md_ref_frame_type_neighbor_array[src_idx],
         picture_control_set_ptr->md_ref_frame_type_neighbor_array[dst_idx],
+#endif
         blk_org_x,
         blk_org_y,
         blk_geom->bwidth,
@@ -585,8 +714,13 @@ void copy_neighbour_arrays(
         NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
 
     copy_neigh_arr_32(
+#if TILES_PARALLEL
+        picture_control_set_ptr->md_interpolation_type_neighbor_array[src_idx][tile_idx],
+        picture_control_set_ptr->md_interpolation_type_neighbor_array[dst_idx][tile_idx],
+#else
         picture_control_set_ptr->md_interpolation_type_neighbor_array[src_idx],
         picture_control_set_ptr->md_interpolation_type_neighbor_array[dst_idx],
+#endif
         blk_org_x,
         blk_org_y,
         blk_geom->bwidth,
@@ -3097,12 +3231,21 @@ void perform_intra_tx_partitioning(
 
     TxType best_tx_type_depth_0 = DCT_DCT; // Track the best tx type @ depth 0 to be used @ the final stage (i.e. avoid redoing the tx type search).
 
+#if TILES_PARALLEL
+    uint16_t tile_idx = context_ptr->tile_index;
+#endif
+
     // Reset depth_1 neighbor arrays
     if (end_tx_depth) {
         if (!picture_control_set_ptr->hbd_mode_decision) {
             copy_neigh_arr(
+#if TILES_PARALLEL
+                picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
                 picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
                 picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
+#endif
                 context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x,
                 context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y,
                 context_ptr->blk_geom->bwidth,
@@ -3110,8 +3253,13 @@ void perform_intra_tx_partitioning(
                 NEIGHBOR_ARRAY_UNIT_FULL_MASK);
         } else {
             copy_neigh_arr(
+#if TILES_PARALLEL
+                picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
                 picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
                 picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
+#endif
                 context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x,
                 context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y,
                 context_ptr->blk_geom->bwidth,
@@ -3120,8 +3268,13 @@ void perform_intra_tx_partitioning(
         }
 
         copy_neigh_arr(
+#if TILES_PARALLEL
+            picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+            picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
             picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
             picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
+#endif
             context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x,
             context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y,
             context_ptr->blk_geom->bwidth,
@@ -3135,20 +3288,35 @@ void perform_intra_tx_partitioning(
         if (!context_ptr->hbd_mode_decision) {
             context_ptr->tx_search_luma_recon_neighbor_array =
                 (context_ptr->tx_depth) ?
+#if TILES_PARALLEL
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx] :
+                picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+#else
                 picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX] :
                 picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
+#endif
         } else {
             context_ptr->tx_search_luma_recon_neighbor_array16bit =
                 (context_ptr->tx_depth) ?
+#if TILES_PARALLEL
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx] :
+                picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+#else
                 picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX] :
                 picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX];
+#endif
         }
 
         // Set luma dc sign level coeff
         context_ptr->tx_search_luma_dc_sign_level_coeff_neighbor_array =
             (context_ptr->tx_depth) ?
+#if TILES_PARALLEL
+            picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx] :
+            picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+#else
             picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX] :
             picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
+#endif
 
         // Initialize TU Split
         y_full_distortion[DIST_CALC_RESIDUAL] = 0;
@@ -3530,7 +3698,11 @@ void perform_intra_tx_partitioning(
 
                 int8_t dc_sign_level_coeff = candidateBuffer->candidate_ptr->quantized_dc[0][context_ptr->txb_itr];
                 neighbor_array_unit_mode_write(
+#if TILES_PARALLEL
+                    picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
                     picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
+#endif
                     (uint8_t*)&dc_sign_level_coeff,
                     context_ptr->sb_origin_x + context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr],
                     context_ptr->sb_origin_y + context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr],
@@ -3567,9 +3739,17 @@ void perform_intra_tx_partitioning(
     if (context_ptr->tx_depth == 0) {
         // Set recon neighbor array to be used @ intra compensation
         if (context_ptr->hbd_mode_decision)
+#if TILES_PARALLEL
+            context_ptr->tx_search_luma_recon_neighbor_array16bit = picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+#else
             context_ptr->tx_search_luma_recon_neighbor_array16bit = picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX];
+#endif
         else
+#if TILES_PARALLEL
+            context_ptr->tx_search_luma_recon_neighbor_array = picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+#else
             context_ptr->tx_search_luma_recon_neighbor_array = picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
+#endif
 
         // Initialize TU Split
         y_full_distortion[DIST_CALC_RESIDUAL] = 0;
@@ -3591,7 +3771,11 @@ void perform_intra_tx_partitioning(
                 sequence_control_set_ptr,
 #endif
                 COMPONENT_LUMA,
+#if TILES_PARALLEL
+                picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
                 picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
+#endif
                 context_ptr->sb_origin_x + tx_org_x,
                 context_ptr->sb_origin_y + tx_org_y,
                 context_ptr->blk_geom->bsize,
@@ -5538,6 +5722,9 @@ EB_EXTERN EbErrorType mode_decision_sb(
     // Pre Intra Search
     uint32_t                               leaf_count = mdcResultTbPtr->leaf_count;
     const EbMdcLeafData *const           leaf_data_array = mdcResultTbPtr->leaf_data_array;
+#if TILES_PARALLEL
+    const uint16_t tile_idx = context_ptr->tile_index;
+#endif
     context_ptr->sb_ptr = sb_ptr;
     if (picture_control_set_ptr->parent_pcs_ptr->pic_depth_mode <= PIC_SQ_DEPTH_MODE) {
         init_nsq_block(
@@ -5549,6 +5736,33 @@ EB_EXTERN EbErrorType mode_decision_sb(
             context_ptr);
     }
     // Mode Decision Neighbor Arrays
+#if TILES_PARALLEL
+    context_ptr->intra_luma_mode_neighbor_array = picture_control_set_ptr->md_intra_luma_mode_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->intra_chroma_mode_neighbor_array = picture_control_set_ptr->md_intra_chroma_mode_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->mv_neighbor_array = picture_control_set_ptr->md_mv_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->skip_flag_neighbor_array = picture_control_set_ptr->md_skip_flag_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->mode_type_neighbor_array = picture_control_set_ptr->md_mode_type_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->leaf_depth_neighbor_array = picture_control_set_ptr->md_leaf_depth_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->leaf_partition_neighbor_array = picture_control_set_ptr->mdleaf_partition_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+
+    if (!context_ptr->hbd_mode_decision) {
+        context_ptr->luma_recon_neighbor_array = picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+        context_ptr->cb_recon_neighbor_array = picture_control_set_ptr->md_cb_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+        context_ptr->cr_recon_neighbor_array = picture_control_set_ptr->md_cr_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    } else {
+        context_ptr->luma_recon_neighbor_array16bit = picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+        context_ptr->cb_recon_neighbor_array16bit = picture_control_set_ptr->md_cb_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+        context_ptr->cr_recon_neighbor_array16bit = picture_control_set_ptr->md_cr_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    }
+    context_ptr->skip_coeff_neighbor_array = picture_control_set_ptr->md_skip_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->luma_dc_sign_level_coeff_neighbor_array = picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->cb_dc_sign_level_coeff_neighbor_array = picture_control_set_ptr->md_cb_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->cr_dc_sign_level_coeff_neighbor_array = picture_control_set_ptr->md_cr_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->txfm_context_array = picture_control_set_ptr->md_txfm_context_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->inter_pred_dir_neighbor_array = picture_control_set_ptr->md_inter_pred_dir_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->ref_frame_type_neighbor_array = picture_control_set_ptr->md_ref_frame_type_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->interpolation_type_neighbor_array = picture_control_set_ptr->md_interpolation_type_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+#else
     context_ptr->intra_luma_mode_neighbor_array = picture_control_set_ptr->md_intra_luma_mode_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
     context_ptr->intra_chroma_mode_neighbor_array = picture_control_set_ptr->md_intra_chroma_mode_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
     context_ptr->mv_neighbor_array = picture_control_set_ptr->md_mv_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
@@ -5574,6 +5788,7 @@ EB_EXTERN EbErrorType mode_decision_sb(
     context_ptr->inter_pred_dir_neighbor_array = picture_control_set_ptr->md_inter_pred_dir_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
     context_ptr->ref_frame_type_neighbor_array = picture_control_set_ptr->md_ref_frame_type_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
     context_ptr->interpolation_type_neighbor_array = picture_control_set_ptr->md_interpolation_type_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
+#endif
 
     EbPictureBufferDesc *input_picture_ptr = picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
     if (context_ptr->hbd_mode_decision) {

--- a/Source/Lib/Common/Codec/EbRestProcess.c
+++ b/Source/Lib/Common/Codec/EbRestProcess.c
@@ -228,7 +228,9 @@ void* rest_kernel(void *input_ptr)
         picture_control_set_ptr = (PictureControlSet*)cdef_results_ptr->picture_control_set_wrapper_ptr->object_ptr;
         sequence_control_set_ptr = (SequenceControlSet*)picture_control_set_ptr->sequence_control_set_wrapper_ptr->object_ptr;
         frm_hdr = &picture_control_set_ptr->parent_pcs_ptr->frm_hdr;
+#if !TILES_PARALLEL
         uint8_t lcuSizeLog2 = (uint8_t)Log2f(sequence_control_set_ptr->sb_size_pix);
+#endif
         EbBool  is16bit = (EbBool)(sequence_control_set_ptr->static_config.encoder_bit_depth > EB_8BIT);
         Av1Common* cm = picture_control_set_ptr->parent_pcs_ptr->av1_cm;
 
@@ -338,6 +340,28 @@ void* rest_kernel(void *input_ptr)
                 eb_post_full_object(picture_demux_results_wrapper_ptr);
             }
 
+#if TILES_PARALLEL
+            //Jing: TODO
+            //Consider to add parallelism here, sending line by line, not waiting for a full frame
+            for (int tile_row_idx = 0; tile_row_idx < picture_control_set_ptr->parent_pcs_ptr->av1_cm->tiles_info.tile_rows; tile_row_idx++) {
+                uint16_t tile_height_in_sb = cm->tiles_info.tile_row_start_sb[tile_row_idx + 1] - cm->tiles_info.tile_row_start_sb[tile_row_idx];
+                for (int tile_col_idx = 0; tile_col_idx < picture_control_set_ptr->parent_pcs_ptr->av1_cm->tiles_info.tile_cols; tile_col_idx++) {
+                    const int tile_idx = tile_row_idx * picture_control_set_ptr->parent_pcs_ptr->av1_cm->tiles_info.tile_cols + tile_col_idx;
+                    eb_get_empty_object(
+                            context_ptr->rest_output_fifo_ptr,
+                            &rest_results_wrapper_ptr);
+                    rest_results_ptr = (struct RestResults*)rest_results_wrapper_ptr->object_ptr;
+                    rest_results_ptr->picture_control_set_wrapper_ptr = cdef_results_ptr->picture_control_set_wrapper_ptr;
+                    rest_results_ptr->completed_lcu_row_index_start = 0;
+                    //rest_results_ptr->completed_lcu_row_count = ((sequence_control_set_ptr->seq_header.max_frame_height + sequence_control_set_ptr->sb_size_pix - 1) >> lcuSizeLog2);
+                    // Set to tile rows
+                    rest_results_ptr->completed_lcu_row_count = tile_height_in_sb;
+                    rest_results_ptr->tile_index = tile_idx;
+                    // Post Rest Results
+                    eb_post_full_object(rest_results_wrapper_ptr);
+                }
+            }
+#else
             // Get Empty rest Results to EC
             eb_get_empty_object(
                 context_ptr->rest_output_fifo_ptr,
@@ -348,6 +372,7 @@ void* rest_kernel(void *input_ptr)
             rest_results_ptr->completed_lcu_row_count = ((sequence_control_set_ptr->seq_header.max_frame_height + sequence_control_set_ptr->sb_size_pix - 1) >> lcuSizeLog2);
             // Post Rest Results
             eb_post_full_object(rest_results_wrapper_ptr);
+#endif
         }
         eb_release_mutex(picture_control_set_ptr->rest_search_mutex);
 


### PR DESCRIPTION
## Description
Currently in enc_dec_kernel, we are using segments to do the parallelism, and didn't leverage tiles (even if we enable multi-tiles, we just pack the bitstream to have tiles, but didn't really use tiles)
This PR will leverage tiles within enc_dec_kernel, and segments will be used within tiles.
For example, if input is a 4K yuv and we split it to 4 tiles(eg: split it to 4 1080P). then this 4 tiles will start spontaneously in encdec.
It will help to increase the parallelism and reduce the overall latency(ideally latency will drop from encoding 1 4K frame to encoding 1 1080P frame)