### PR TITLE
Remove verbose warning message during build

### DIFF
--- a/Build/linux/build.sh
+++ b/Build/linux/build.sh
@@ -31,10 +31,10 @@ function build {
     fi
     PATH=$PATH:/usr/local/bin/
     cmake ${verbose:+"-v"} ../../.. ${cmake_env}
-    
+
     if [ "${verbose}" = "1" ]; then
         VERBOSE_MAKE="VERBOSE=1"
-    else 
+    else
         VERBOSE_MAKE=""
     fi
 

--- a/Build/linux/build.sh
+++ b/Build/linux/build.sh
@@ -31,11 +31,18 @@ function build {
     fi
     PATH=$PATH:/usr/local/bin/
     cmake ${verbose:+"-v"} ../../.. ${cmake_env}
+    
+    if [ "${verbose}" = "1" ]; then
+        VERBOSE_MAKE="VERBOSE=1"
+    else 
+        VERBOSE_MAKE=""
+    fi
 
     # Compile the Library
-    make VERBOSE=${verbose} -j ${make_threads} SvtAv1EncApp SvtAv1DecApp
+    make ${VERBOSE_MAKE} -j ${make_threads} SvtAv1EncApp SvtAv1DecApp
+
     if [ "$2" = "test" ]; then
-        make VERBOSE=${verbose} -j ${make_threads} SvtAv1UnitTests SvtAv1ApiTests SvtAv1E2ETests TestVectors
+        make ${VERBOSE_MAKE} -j ${make_threads} SvtAv1UnitTests SvtAv1ApiTests SvtAv1E2ETests TestVectors
     fi
     cd ..
 }


### PR DESCRIPTION
Removes verbose warning message when -v option is used in the linux/osx build script. 

Example of message:
```
Dependee "SVT-AV1/Build/linux/release/Source/App/DecApp/CMakeFiles/SvtAv1DecApp.dir/DependInfo.cmake" is newer than depender "SVT-AV1/Build/linux/release/Source/App/DecApp/CMakeFiles/SvtAv1DecApp.dir/depend.internal".
```