### PR TITLE
Fix for logical processors being ignored on macOS

### DIFF
--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -438,10 +438,10 @@ EbErrorType load_default_buffer_configuration_settings(
 #if defined(_WIN32) || defined(__linux__)
     if (sequence_control_set_ptr->static_config.target_socket != -1)
         core_count /= num_groups;
+#endif
     if (sequence_control_set_ptr->static_config.logical_processors != 0)
         core_count = sequence_control_set_ptr->static_config.logical_processors < core_count ?
             sequence_control_set_ptr->static_config.logical_processors: core_count;
-#endif
 
 #ifdef _WIN32
     //Handle special case on Windows


### PR DESCRIPTION
The enforcement of the -lp option for logical processor count was #ifdef'd to Windows and Linux only, causing the option to be ignored on macOS builds.

Fixes https://github.com/OpenVisualCloud/SVT-AV1/issues/483