### PR TITLE
appveyor: download yasm.exe from github instead of tortall.net

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ configuration: Release
 
 install:
     - git submodule update --init
-    - appveyor DownloadFile http://www.tortall.net/projects/yasm/releases/yasm-1.3.0-win64.exe -FileName yasm.exe
+    - appveyor DownloadFile https://github.com/yasm/yasm/releases/download/v1.3.0/yasm-1.3.0-win64.exe -FileName yasm.exe
     - set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%
     - cmake . -G "Visual Studio 16 2019" -A x64 -DCMAKE_ASM_NASM_COMPILER="yasm.exe" -DBUILD_TESTING=ON
 


### PR DESCRIPTION
www.tortall.net is down.We'd better use github to download the yasm file.
I updloaded the yasm 1.3 file here:
https://github.com/OpenVisualCloud/SVT-AV1/pull/463#issuecomment-514077315

Closes #490