### PR TITLE
Add AVX512 code for high bd forward transform

### DIFF
--- a/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
@@ -7,6 +7,11 @@
 const int32_t *cospi_arr(int32_t n);
 const int32_t *sinpi_arr(int32_t n);
 
+#define ZERO (uint8_t)0U 
+#define ONE  (uint8_t)1U
+#define TWO  (uint8_t)2U
+#define THREE (uint8_t)3U
+
 void Av1TransformConfig(
     TxType tx_type,
     TxSize tx_size,
@@ -65,121 +70,121 @@ static INLINE void transpose_16x16_avx512(int32_t stride, const __m512i *in, __m
     TRANSPOSE_4X4_AVX512(in[12 * stride], in[13 * stride], in[14 * stride], in[15 * stride], out1[12], out1[13], out1[14], out1[15]);
 
     __m128i * outptr = (__m128i *)(out + 0 * stride);
-
+    
     //will get first row of transpose matrix from corresponding 4 vectors in out1
-    outptr[0] = _mm512_extracti32x4_epi32(out1[0], 0);
-    outptr[1] = _mm512_extracti32x4_epi32(out1[4], 0);
-    outptr[2] = _mm512_extracti32x4_epi32(out1[8], 0);
-    outptr[3] = _mm512_extracti32x4_epi32(out1[12], 0);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[0], ZERO);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[4], ZERO);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[8], ZERO);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[12], ZERO);
 
     //will get second row of transpose matrix from corresponding 4 vectors in out1
     outptr = (__m128i *)(out + 1 * stride);
-    outptr[0] = _mm512_extracti32x4_epi32(out1[1], 0);
-    outptr[1] = _mm512_extracti32x4_epi32(out1[5], 0);
-    outptr[2] = _mm512_extracti32x4_epi32(out1[9], 0);
-    outptr[3] = _mm512_extracti32x4_epi32(out1[13], 0);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[1], ZERO);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[5], ZERO);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[9], ZERO);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[13], ZERO);
 
     //will get 3rd row of transpose matrix from corresponding 4 vectors in out1
     outptr = (__m128i *)(out + 2 * stride);
-    outptr[0] = _mm512_extracti32x4_epi32(out1[2], 0);
-    outptr[1] = _mm512_extracti32x4_epi32(out1[6], 0);
-    outptr[2] = _mm512_extracti32x4_epi32(out1[10], 0);
-    outptr[3] = _mm512_extracti32x4_epi32(out1[14], 0);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[2], ZERO);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[6], ZERO);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[10], ZERO);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[14], ZERO);
 
     //will get 4th row of transpose matrix from corresponding 4 vectors in out1
     outptr = (__m128i *)(out + 3 * stride);
-    outptr[0] = _mm512_extracti32x4_epi32(out1[3], 0);
-    outptr[1] = _mm512_extracti32x4_epi32(out1[7], 0);
-    outptr[2] = _mm512_extracti32x4_epi32(out1[11], 0);
-    outptr[3] = _mm512_extracti32x4_epi32(out1[15], 0);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[3], ZERO);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[7], ZERO);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[11], ZERO);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[15], ZERO);
 
     //will get 5th row of transpose matrix from corresponding 4 vectors in out1
     outptr = (__m128i *)(out + 4 * stride);
-    outptr[0] = _mm512_extracti32x4_epi32(out1[0], 1);
-    outptr[1] = _mm512_extracti32x4_epi32(out1[4], 1);
-    outptr[2] = _mm512_extracti32x4_epi32(out1[8], 1);
-    outptr[3] = _mm512_extracti32x4_epi32(out1[12], 1);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[0], ONE);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[4], ONE);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[8], ONE);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[12], ONE);
 
     //will get 6th row of transpose matrix from corresponding 4 vectors in out1
     outptr = (__m128i *)(out + 5 * stride);
-    outptr[0] = _mm512_extracti32x4_epi32(out1[1], 1);
-    outptr[1] = _mm512_extracti32x4_epi32(out1[5], 1);
-    outptr[2] = _mm512_extracti32x4_epi32(out1[9], 1);
-    outptr[3] = _mm512_extracti32x4_epi32(out1[13], 1);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[1], ONE);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[5], ONE);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[9], ONE);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[13], ONE);
 
     //will get 7th row of transpose matrix from corresponding 4 vectors in out1
     outptr = (__m128i *)(out + 6 * stride);
-    outptr[0] = _mm512_extracti32x4_epi32(out1[2], 1);
-    outptr[1] = _mm512_extracti32x4_epi32(out1[6], 1);
-    outptr[2] = _mm512_extracti32x4_epi32(out1[10], 1);
-    outptr[3] = _mm512_extracti32x4_epi32(out1[14], 1);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[2], ONE);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[6], ONE);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[10], ONE);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[14], ONE);
 
     //will get 8th row of transpose matrix from corresponding 4 vectors in out1
     outptr = (__m128i *)(out + 7 * stride);
-    outptr[0] = _mm512_extracti32x4_epi32(out1[3], 1);
-    outptr[1] = _mm512_extracti32x4_epi32(out1[7], 1);
-    outptr[2] = _mm512_extracti32x4_epi32(out1[11], 1);
-    outptr[3] = _mm512_extracti32x4_epi32(out1[15], 1);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[3], ONE);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[7], ONE);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[11], ONE);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[15], ONE);
 
     //will get 9th row of transpose matrix from corresponding 4 vectors in out1
     outptr = (__m128i *)(out + 8 * stride);
-    outptr[0] = _mm512_extracti32x4_epi32(out1[0], 2);
-    outptr[1] = _mm512_extracti32x4_epi32(out1[4], 2);
-    outptr[2] = _mm512_extracti32x4_epi32(out1[8], 2);
-    outptr[3] = _mm512_extracti32x4_epi32(out1[12], 2);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[0], TWO);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[4], TWO);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[8], TWO);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[12], TWO);
 
     //will get 10th row of transpose matrix from corresponding 4 vectors in out1
     outptr = (__m128i *)(out + 9 * stride);
-    outptr[0] = _mm512_extracti32x4_epi32(out1[1], 2);
-    outptr[1] = _mm512_extracti32x4_epi32(out1[5], 2);
-    outptr[2] = _mm512_extracti32x4_epi32(out1[9], 2);
-    outptr[3] = _mm512_extracti32x4_epi32(out1[13], 2);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[1], TWO);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[5], TWO);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[9], TWO);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[13], TWO);
 
     //will get 11th row of transpose matrix from corresponding 4 vectors in out1
     outptr = (__m128i *)(out + 10 * stride);
-    outptr[0] = _mm512_extracti32x4_epi32(out1[2], 2);
-    outptr[1] = _mm512_extracti32x4_epi32(out1[6], 2);
-    outptr[2] = _mm512_extracti32x4_epi32(out1[10], 2);
-    outptr[3] = _mm512_extracti32x4_epi32(out1[14], 2);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[2], TWO);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[6], TWO);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[10], TWO);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[14], TWO);
 
     //will get 12th row of transpose matrix from corresponding 4 vectors in out1
     outptr = (__m128i *)(out + 11 * stride);
-    outptr[0] = _mm512_extracti32x4_epi32(out1[3], 2);
-    outptr[1] = _mm512_extracti32x4_epi32(out1[7], 2);
-    outptr[2] = _mm512_extracti32x4_epi32(out1[11], 2);
-    outptr[3] = _mm512_extracti32x4_epi32(out1[15], 2);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[3], TWO);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[7], TWO);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[11], TWO);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[15], TWO);
 
     //will get 13th row of transpose matrix from corresponding 4 vectors in out1
     outptr = (__m128i *)(out + 12 * stride);
-    outptr[0] = _mm512_extracti32x4_epi32(out1[0], 3);
-    outptr[1] = _mm512_extracti32x4_epi32(out1[4], 3);
-    outptr[2] = _mm512_extracti32x4_epi32(out1[8], 3);
-    outptr[3] = _mm512_extracti32x4_epi32(out1[12], 3);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[0], THREE);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[4], THREE);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[8], THREE);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[12], THREE);
 
     //will get 14th row of transpose matrix from corresponding 4 vectors in out1
     outptr = (__m128i *)(out + 13 * stride);
-    outptr[0] = _mm512_extracti32x4_epi32(out1[1], 3);
-    outptr[1] = _mm512_extracti32x4_epi32(out1[5], 3);
-    outptr[2] = _mm512_extracti32x4_epi32(out1[9], 3);
-    outptr[3] = _mm512_extracti32x4_epi32(out1[13], 3);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[1], THREE);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[5], THREE);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[9], THREE);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[13], THREE);
 
     //will get 15th row of transpose matrix from corresponding 4 vectors in out1
     outptr = (__m128i *)(out + 14 * stride);
-    outptr[0] = _mm512_extracti32x4_epi32(out1[2], 3);
-    outptr[1] = _mm512_extracti32x4_epi32(out1[6], 3);
-    outptr[2] = _mm512_extracti32x4_epi32(out1[10], 3);
-    outptr[3] = _mm512_extracti32x4_epi32(out1[14], 3);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[2], THREE);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[6], THREE);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[10], THREE);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[14], THREE);
 
     //will get 16th row of transpose matrix from corresponding 4 vectors in out1
     outptr = (__m128i *)(out + 15 * stride);
-    outptr[0] = _mm512_extracti32x4_epi32(out1[3], 3);
-    outptr[1] = _mm512_extracti32x4_epi32(out1[7], 3);
-    outptr[2] = _mm512_extracti32x4_epi32(out1[11], 3);
-    outptr[3] = _mm512_extracti32x4_epi32(out1[15], 3);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[3], THREE);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[7], THREE);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[11], THREE);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[15], THREE);
 }
 
 static INLINE void load_buffer_16x16_avx512(const int16_t *input, __m512i *out,
-    int32_t stride, int32_t flipud, int32_t fliplr, int32_t shift) {
+    int32_t stride, int32_t flipud, int32_t fliplr, const int8_t shift) {
     __m256i temp[16];
     uint8_t ushift = (uint8_t)shift;
     if (flipud) {
@@ -227,7 +232,7 @@ static void fidtx16x16_avx512(const __m512i *in, __m512i *out, const int8_t bit,
     }
 }
 
-static INLINE void col_txfm_16x16_rounding_avx512(__m512i *in, int32_t shift) {
+static INLINE void col_txfm_16x16_rounding_avx512(__m512i *in, const int8_t shift) {
     uint8_t ushift = (uint8_t)shift;
     const __m512i rounding = _mm512_set1_epi32(1 << (ushift - 1));
     for (int32_t i = 0; i < 16; i++) {
@@ -248,14 +253,14 @@ static INLINE void write_buffer_16x16(const __m512i *res, int32_t *output) {
 
 static INLINE __m512i half_btf_avx512(const __m512i *w0, const __m512i *n0,
     const __m512i *w1, const __m512i *n1,
-    const __m512i *rounding, int32_t bit) {
+    const __m512i *rounding, uint8_t bit) {
     __m512i x, y;
 
     x = _mm512_mullo_epi32(*w0, *n0);
     y = _mm512_mullo_epi32(*w1, *n1);
     x = _mm512_add_epi32(x, y);
     x = _mm512_add_epi32(x, *rounding);
-    x = _mm512_srai_epi32(x, (uint8_t)bit);
+    x = _mm512_srai_epi32(x, bit);
     return x;
 }
 
@@ -299,7 +304,7 @@ static void fadst16x16_avx512(const __m512i *in, __m512i *out, const int8_t bit,
     const __m512i cospi6 = _mm512_set1_epi32(cospi[6]);
     const __m512i cospim58 = _mm512_set1_epi32(-cospi[58]);
     const __m512i rnding = _mm512_set1_epi32(1 << (bit - 1));
-    const __m512i zero = _mm512_setzero_si512();
+    const __m512i zeroes = _mm512_setzero_si512();
 
     __m512i u[16], v[16], x, y;
     int32_t col;
@@ -308,20 +313,20 @@ static void fadst16x16_avx512(const __m512i *in, __m512i *out, const int8_t bit,
         // stage 0
         // stage 1
         u[0] = in[0 * col_num + col];
-        u[1] = _mm512_sub_epi32(zero, in[15 * col_num + col]);
-        u[2] = _mm512_sub_epi32(zero, in[7 * col_num + col]);
+        u[1] = _mm512_sub_epi32(zeroes, in[15 * col_num + col]);
+        u[2] = _mm512_sub_epi32(zeroes, in[7 * col_num + col]);
         u[3] = in[8 * col_num + col];
-        u[4] = _mm512_sub_epi32(zero, in[3 * col_num + col]);
+        u[4] = _mm512_sub_epi32(zeroes, in[3 * col_num + col]);
         u[5] = in[12 * col_num + col];
         u[6] = in[4 * col_num + col];
-        u[7] = _mm512_sub_epi32(zero, in[11 * col_num + col]);
-        u[8] = _mm512_sub_epi32(zero, in[1 * col_num + col]);
+        u[7] = _mm512_sub_epi32(zeroes, in[11 * col_num + col]);
+        u[8] = _mm512_sub_epi32(zeroes, in[1 * col_num + col]);
         u[9] = in[14 * col_num + col];
         u[10] = in[6 * col_num + col];
-        u[11] = _mm512_sub_epi32(zero, in[9 * col_num + col]);
+        u[11] = _mm512_sub_epi32(zeroes, in[9 * col_num + col]);
         u[12] = in[2 * col_num + col];
-        u[13] = _mm512_sub_epi32(zero, in[13 * col_num + col]);
-        u[14] = _mm512_sub_epi32(zero, in[5 * col_num + col]);
+        u[13] = _mm512_sub_epi32(zeroes, in[13 * col_num + col]);
+        u[14] = _mm512_sub_epi32(zeroes, in[5 * col_num + col]);
         u[15] = in[10 * col_num + col];
 
         // stage 2
@@ -332,11 +337,11 @@ static void fadst16x16_avx512(const __m512i *in, __m512i *out, const int8_t bit,
         y = _mm512_mullo_epi32(u[3], cospi32);
         v[2] = _mm512_add_epi32(x, y);
         v[2] = _mm512_add_epi32(v[2], rnding);
-        v[2] = _mm512_srai_epi32(v[2], bit);
+        v[2] = _mm512_srai_epi32(v[2], (uint8_t)bit);
 
         v[3] = _mm512_sub_epi32(x, y);
         v[3] = _mm512_add_epi32(v[3], rnding);
-        v[3] = _mm512_srai_epi32(v[3], bit);
+        v[3] = _mm512_srai_epi32(v[3], (uint8_t)bit);
 
         v[4] = u[4];
         v[5] = u[5];
@@ -345,11 +350,11 @@ static void fadst16x16_avx512(const __m512i *in, __m512i *out, const int8_t bit,
         y = _mm512_mullo_epi32(u[7], cospi32);
         v[6] = _mm512_add_epi32(x, y);
         v[6] = _mm512_add_epi32(v[6], rnding);
-        v[6] = _mm512_srai_epi32(v[6], bit);
+        v[6] = _mm512_srai_epi32(v[6], (uint8_t)bit);
 
         v[7] = _mm512_sub_epi32(x, y);
         v[7] = _mm512_add_epi32(v[7], rnding);
-        v[7] = _mm512_srai_epi32(v[7], bit);
+        v[7] = _mm512_srai_epi32(v[7], (uint8_t)bit);
 
         v[8] = u[8];
         v[9] = u[9];
@@ -358,11 +363,11 @@ static void fadst16x16_avx512(const __m512i *in, __m512i *out, const int8_t bit,
         y = _mm512_mullo_epi32(u[11], cospi32);
         v[10] = _mm512_add_epi32(x, y);
         v[10] = _mm512_add_epi32(v[10], rnding);
-        v[10] = _mm512_srai_epi32(v[10], bit);
+        v[10] = _mm512_srai_epi32(v[10], (uint8_t)bit);
 
         v[11] = _mm512_sub_epi32(x, y);
         v[11] = _mm512_add_epi32(v[11], rnding);
-        v[11] = _mm512_srai_epi32(v[11], bit);
+        v[11] = _mm512_srai_epi32(v[11], (uint8_t)bit);
 
         v[12] = u[12];
         v[13] = u[13];
@@ -371,11 +376,11 @@ static void fadst16x16_avx512(const __m512i *in, __m512i *out, const int8_t bit,
         y = _mm512_mullo_epi32(u[15], cospi32);
         v[14] = _mm512_add_epi32(x, y);
         v[14] = _mm512_add_epi32(v[14], rnding);
-        v[14] = _mm512_srai_epi32(v[14], bit);
+        v[14] = _mm512_srai_epi32(v[14], (uint8_t)bit);
 
         v[15] = _mm512_sub_epi32(x, y);
         v[15] = _mm512_add_epi32(v[15], rnding);
-        v[15] = _mm512_srai_epi32(v[15], bit);
+        v[15] = _mm512_srai_epi32(v[15], (uint8_t)bit);
 
         // stage 3
         u[0] = _mm512_add_epi32(v[0], v[2]);
@@ -564,25 +569,25 @@ static void fdct16x16_avx512(const __m512i *in, __m512i *out, const int8_t bit, 
         x = _mm512_mullo_epi32(u[13], cospi32);
         v[10] = _mm512_add_epi32(v[10], x);
         v[10] = _mm512_add_epi32(v[10], rnding);
-        v[10] = _mm512_srai_epi32(v[10], bit);
+        v[10] = _mm512_srai_epi32(v[10], (uint8_t)bit);
 
         v[13] = _mm512_mullo_epi32(u[10], cospi32);
         x = _mm512_mullo_epi32(u[13], cospim32);
         v[13] = _mm512_sub_epi32(v[13], x);
         v[13] = _mm512_add_epi32(v[13], rnding);
-        v[13] = _mm512_srai_epi32(v[13], bit);
+        v[13] = _mm512_srai_epi32(v[13], (uint8_t)bit);
 
         v[11] = _mm512_mullo_epi32(u[11], cospim32);
         x = _mm512_mullo_epi32(u[12], cospi32);
         v[11] = _mm512_add_epi32(v[11], x);
         v[11] = _mm512_add_epi32(v[11], rnding);
-        v[11] = _mm512_srai_epi32(v[11], bit);
+        v[11] = _mm512_srai_epi32(v[11], (uint8_t)bit);
 
         v[12] = _mm512_mullo_epi32(u[11], cospi32);
         x = _mm512_mullo_epi32(u[12], cospim32);
         v[12] = _mm512_sub_epi32(v[12], x);
         v[12] = _mm512_add_epi32(v[12], rnding);
-        v[12] = _mm512_srai_epi32(v[12], bit);
+        v[12] = _mm512_srai_epi32(v[12], (uint8_t)bit);
         v[14] = u[14];
         v[15] = u[15];
 
@@ -597,13 +602,13 @@ static void fdct16x16_avx512(const __m512i *in, __m512i *out, const int8_t bit, 
         x = _mm512_mullo_epi32(v[6], cospi32);
         u[5] = _mm512_add_epi32(u[5], x);
         u[5] = _mm512_add_epi32(u[5], rnding);
-        u[5] = _mm512_srai_epi32(u[5], bit);
+        u[5] = _mm512_srai_epi32(u[5], (uint8_t)bit);
 
         u[6] = _mm512_mullo_epi32(v[5], cospi32);
         x = _mm512_mullo_epi32(v[6], cospim32);
         u[6] = _mm512_sub_epi32(u[6], x);
         u[6] = _mm512_add_epi32(u[6], rnding);
-        u[6] = _mm512_srai_epi32(u[6], bit);
+        u[6] = _mm512_srai_epi32(u[6], (uint8_t)bit);
 
         u[7] = v[7];
         u[8] = _mm512_add_epi32(v[8], v[11]);
@@ -620,23 +625,23 @@ static void fdct16x16_avx512(const __m512i *in, __m512i *out, const int8_t bit, 
         u[1] = _mm512_mullo_epi32(u[1], cospi32);
         v[0] = _mm512_add_epi32(u[0], u[1]);
         v[0] = _mm512_add_epi32(v[0], rnding);
-        v[0] = _mm512_srai_epi32(v[0], bit);
+        v[0] = _mm512_srai_epi32(v[0], (uint8_t)bit);
 
         v[1] = _mm512_sub_epi32(u[0], u[1]);
         v[1] = _mm512_add_epi32(v[1], rnding);
-        v[1] = _mm512_srai_epi32(v[1], bit);
+        v[1] = _mm512_srai_epi32(v[1], (uint8_t)bit);
 
         v[2] = _mm512_mullo_epi32(u[2], cospi48);
         x = _mm512_mullo_epi32(u[3], cospi16);
         v[2] = _mm512_add_epi32(v[2], x);
         v[2] = _mm512_add_epi32(v[2], rnding);
-        v[2] = _mm512_srai_epi32(v[2], bit);
+        v[2] = _mm512_srai_epi32(v[2], (uint8_t)bit);
 
         v[3] = _mm512_mullo_epi32(u[2], cospi16);
         x = _mm512_mullo_epi32(u[3], cospi48);
         v[3] = _mm512_sub_epi32(x, v[3]);
         v[3] = _mm512_add_epi32(v[3], rnding);
-        v[3] = _mm512_srai_epi32(v[3], bit);
+        v[3] = _mm512_srai_epi32(v[3], (uint8_t)bit);
 
         v[4] = _mm512_add_epi32(u[4], u[5]);
         v[5] = _mm512_sub_epi32(u[4], u[5]);
@@ -648,25 +653,25 @@ static void fdct16x16_avx512(const __m512i *in, __m512i *out, const int8_t bit, 
         x = _mm512_mullo_epi32(u[14], cospi48);
         v[9] = _mm512_add_epi32(v[9], x);
         v[9] = _mm512_add_epi32(v[9], rnding);
-        v[9] = _mm512_srai_epi32(v[9], bit);
+        v[9] = _mm512_srai_epi32(v[9], (uint8_t)bit);
 
         v[14] = _mm512_mullo_epi32(u[9], cospi48);
         x = _mm512_mullo_epi32(u[14], cospim16);
         v[14] = _mm512_sub_epi32(v[14], x);
         v[14] = _mm512_add_epi32(v[14], rnding);
-        v[14] = _mm512_srai_epi32(v[14], bit);
+        v[14] = _mm512_srai_epi32(v[14], (uint8_t)bit);
 
         v[10] = _mm512_mullo_epi32(u[10], cospim48);
         x = _mm512_mullo_epi32(u[13], cospim16);
         v[10] = _mm512_add_epi32(v[10], x);
         v[10] = _mm512_add_epi32(v[10], rnding);
-        v[10] = _mm512_srai_epi32(v[10], bit);
+        v[10] = _mm512_srai_epi32(v[10], (uint8_t)bit);
 
         v[13] = _mm512_mullo_epi32(u[10], cospim16);
         x = _mm512_mullo_epi32(u[13], cospim48);
         v[13] = _mm512_sub_epi32(v[13], x);
         v[13] = _mm512_add_epi32(v[13], rnding);
-        v[13] = _mm512_srai_epi32(v[13], bit);
+        v[13] = _mm512_srai_epi32(v[13], (uint8_t)bit);
 
         v[11] = u[11];
         v[12] = u[12];
@@ -682,25 +687,25 @@ static void fdct16x16_avx512(const __m512i *in, __m512i *out, const int8_t bit, 
         x = _mm512_mullo_epi32(v[7], cospi8);
         u[4] = _mm512_add_epi32(u[4], x);
         u[4] = _mm512_add_epi32(u[4], rnding);
-        u[4] = _mm512_srai_epi32(u[4], bit);
+        u[4] = _mm512_srai_epi32(u[4], (uint8_t)bit);
 
         u[7] = _mm512_mullo_epi32(v[4], cospi8);
         x = _mm512_mullo_epi32(v[7], cospi56);
         u[7] = _mm512_sub_epi32(x, u[7]);
         u[7] = _mm512_add_epi32(u[7], rnding);
-        u[7] = _mm512_srai_epi32(u[7], bit);
+        u[7] = _mm512_srai_epi32(u[7], (uint8_t)bit);
 
         u[5] = _mm512_mullo_epi32(v[5], cospi24);
         x = _mm512_mullo_epi32(v[6], cospi40);
         u[5] = _mm512_add_epi32(u[5], x);
         u[5] = _mm512_add_epi32(u[5], rnding);
-        u[5] = _mm512_srai_epi32(u[5], bit);
+        u[5] = _mm512_srai_epi32(u[5], (uint8_t)bit);
 
         u[6] = _mm512_mullo_epi32(v[5], cospi40);
         x = _mm512_mullo_epi32(v[6], cospi24);
         u[6] = _mm512_sub_epi32(x, u[6]);
         u[6] = _mm512_add_epi32(u[6], rnding);
-        u[6] = _mm512_srai_epi32(u[6], bit);
+        u[6] = _mm512_srai_epi32(u[6], (uint8_t)bit);
 
         u[8] = _mm512_add_epi32(v[8], v[9]);
         u[9] = _mm512_sub_epi32(v[8], v[9]);
@@ -725,49 +730,49 @@ static void fdct16x16_avx512(const __m512i *in, __m512i *out, const int8_t bit, 
         x = _mm512_mullo_epi32(u[15], cospi4);
         v[8] = _mm512_add_epi32(v[8], x);
         v[8] = _mm512_add_epi32(v[8], rnding);
-        v[8] = _mm512_srai_epi32(v[8], bit);
+        v[8] = _mm512_srai_epi32(v[8], (uint8_t)bit);
 
         v[15] = _mm512_mullo_epi32(u[8], cospi4);
         x = _mm512_mullo_epi32(u[15], cospi60);
         v[15] = _mm512_sub_epi32(x, v[15]);
         v[15] = _mm512_add_epi32(v[15], rnding);
-        v[15] = _mm512_srai_epi32(v[15], bit);
+        v[15] = _mm512_srai_epi32(v[15], (uint8_t)bit);
 
         v[9] = _mm512_mullo_epi32(u[9], cospi28);
         x = _mm512_mullo_epi32(u[14], cospi36);
         v[9] = _mm512_add_epi32(v[9], x);
         v[9] = _mm512_add_epi32(v[9], rnding);
-        v[9] = _mm512_srai_epi32(v[9], bit);
+        v[9] = _mm512_srai_epi32(v[9], (uint8_t)bit);
 
         v[14] = _mm512_mullo_epi32(u[9], cospi36);
         x = _mm512_mullo_epi32(u[14], cospi28);
         v[14] = _mm512_sub_epi32(x, v[14]);
         v[14] = _mm512_add_epi32(v[14], rnding);
-        v[14] = _mm512_srai_epi32(v[14], bit);
+        v[14] = _mm512_srai_epi32(v[14], (uint8_t)bit);
 
         v[10] = _mm512_mullo_epi32(u[10], cospi44);
         x = _mm512_mullo_epi32(u[13], cospi20);
         v[10] = _mm512_add_epi32(v[10], x);
         v[10] = _mm512_add_epi32(v[10], rnding);
-        v[10] = _mm512_srai_epi32(v[10], bit);
+        v[10] = _mm512_srai_epi32(v[10], (uint8_t)bit);
 
         v[13] = _mm512_mullo_epi32(u[10], cospi20);
         x = _mm512_mullo_epi32(u[13], cospi44);
         v[13] = _mm512_sub_epi32(x, v[13]);
         v[13] = _mm512_add_epi32(v[13], rnding);
-        v[13] = _mm512_srai_epi32(v[13], bit);
+        v[13] = _mm512_srai_epi32(v[13], (uint8_t)bit);
 
         v[11] = _mm512_mullo_epi32(u[11], cospi12);
         x = _mm512_mullo_epi32(u[12], cospi52);
         v[11] = _mm512_add_epi32(v[11], x);
         v[11] = _mm512_add_epi32(v[11], rnding);
-        v[11] = _mm512_srai_epi32(v[11], bit);
+        v[11] = _mm512_srai_epi32(v[11], (uint8_t)bit);
 
         v[12] = _mm512_mullo_epi32(u[11], cospi52);
         x = _mm512_mullo_epi32(u[12], cospi12);
         v[12] = _mm512_sub_epi32(x, v[12]);
         v[12] = _mm512_add_epi32(v[12], rnding);
-        v[12] = _mm512_srai_epi32(v[12], bit);
+        v[12] = _mm512_srai_epi32(v[12], (uint8_t)bit);
 
         out[0 * col_num + col] = v[0];
         out[1 * col_num + col] = v[8];
@@ -1375,7 +1380,7 @@ static INLINE void load_buffer_32x32_avx512(const int16_t *input,
 static INLINE void av1_round_shift_array_avx512(__m512i *input,
     __m512i *output,
     const int32_t size,
-    const int32_t bit) {
+    const int8_t bit) {
     if (bit > 0) {
         __m512i round = _mm512_set1_epi32(1 << (bit - 1));
         int32_t i;
@@ -2335,124 +2340,124 @@ static INLINE void transpose_16nx16m_avx512(const __m512i *in,
                 out1[12], out1[13], out1[14], out1[15]);
 
             __m128i * outptr = (__m128i *)(out + (j * height + i + (numcol * 0)));
-
+            
             //will get first row of transpose matrix from corresponding 4 vectors in out1
-            outptr[0] = _mm512_extracti32x4_epi32(out1[0], 0);
-            outptr[1] = _mm512_extracti32x4_epi32(out1[4], 0);
-            outptr[2] = _mm512_extracti32x4_epi32(out1[8], 0);
-            outptr[3] = _mm512_extracti32x4_epi32(out1[12], 0);
+            outptr[0] = _mm512_extracti32x4_epi32(out1[0], ZERO);
+            outptr[1] = _mm512_extracti32x4_epi32(out1[4], ZERO);
+            outptr[2] = _mm512_extracti32x4_epi32(out1[8], ZERO);
+            outptr[3] = _mm512_extracti32x4_epi32(out1[12], ZERO);
 
             //will get second row of transpose matrix from corresponding 4 vectors in out1
             outptr = (__m128i *)(out + (j * height + i + (numcol * 1)));
-            outptr[0] = _mm512_extracti32x4_epi32(out1[1], 0);
-            outptr[1] = _mm512_extracti32x4_epi32(out1[5], 0);
-            outptr[2] = _mm512_extracti32x4_epi32(out1[9], 0);
-            outptr[3] = _mm512_extracti32x4_epi32(out1[13], 0);
+            outptr[0] = _mm512_extracti32x4_epi32(out1[1], ZERO);
+            outptr[1] = _mm512_extracti32x4_epi32(out1[5], ZERO);
+            outptr[2] = _mm512_extracti32x4_epi32(out1[9], ZERO);
+            outptr[3] = _mm512_extracti32x4_epi32(out1[13], ZERO);
 
             //will get 3rd row of transpose matrix from corresponding 4 vectors in out1
             outptr = (__m128i *)(out + (j * height + i + (numcol * 2)));
-            outptr[0] = _mm512_extracti32x4_epi32(out1[2], 0);
-            outptr[1] = _mm512_extracti32x4_epi32(out1[6], 0);
-            outptr[2] = _mm512_extracti32x4_epi32(out1[10], 0);
-            outptr[3] = _mm512_extracti32x4_epi32(out1[14], 0);
+            outptr[0] = _mm512_extracti32x4_epi32(out1[2], ZERO);
+            outptr[1] = _mm512_extracti32x4_epi32(out1[6], ZERO);
+            outptr[2] = _mm512_extracti32x4_epi32(out1[10], ZERO);
+            outptr[3] = _mm512_extracti32x4_epi32(out1[14], ZERO);
 
             //will get 4th row of transpose matrix from corresponding 4 vectors in out1
             outptr = (__m128i *)(out + (j * height + i + (numcol * 3)));
-            outptr[0] = _mm512_extracti32x4_epi32(out1[3], 0);
-            outptr[1] = _mm512_extracti32x4_epi32(out1[7], 0);
-            outptr[2] = _mm512_extracti32x4_epi32(out1[11], 0);
-            outptr[3] = _mm512_extracti32x4_epi32(out1[15], 0);
+            outptr[0] = _mm512_extracti32x4_epi32(out1[3], ZERO);
+            outptr[1] = _mm512_extracti32x4_epi32(out1[7], ZERO);
+            outptr[2] = _mm512_extracti32x4_epi32(out1[11], ZERO);
+            outptr[3] = _mm512_extracti32x4_epi32(out1[15], ZERO);
 
             //will get 5th row of transpose matrix from corresponding 4 vectors in out1
             outptr = (__m128i *)(out + (j * height + i + (numcol * 4)));
-            outptr[0] = _mm512_extracti32x4_epi32(out1[0], 1);
-            outptr[1] = _mm512_extracti32x4_epi32(out1[4], 1);
-            outptr[2] = _mm512_extracti32x4_epi32(out1[8], 1);
-            outptr[3] = _mm512_extracti32x4_epi32(out1[12], 1);
+            outptr[0] = _mm512_extracti32x4_epi32(out1[0], ONE);
+            outptr[1] = _mm512_extracti32x4_epi32(out1[4], ONE);
+            outptr[2] = _mm512_extracti32x4_epi32(out1[8], ONE);
+            outptr[3] = _mm512_extracti32x4_epi32(out1[12], ONE);
 
             //will get 6th row of transpose matrix from corresponding 4 vectors in out1
             outptr = (__m128i *)(out + (j * height + i + (numcol * 5)));
-            outptr[0] = _mm512_extracti32x4_epi32(out1[1], 1);
-            outptr[1] = _mm512_extracti32x4_epi32(out1[5], 1);
-            outptr[2] = _mm512_extracti32x4_epi32(out1[9], 1);
-            outptr[3] = _mm512_extracti32x4_epi32(out1[13], 1);
+            outptr[0] = _mm512_extracti32x4_epi32(out1[1], ONE);
+            outptr[1] = _mm512_extracti32x4_epi32(out1[5], ONE);
+            outptr[2] = _mm512_extracti32x4_epi32(out1[9], ONE);
+            outptr[3] = _mm512_extracti32x4_epi32(out1[13], ONE);
 
             //will get 7th row of transpose matrix from corresponding 4 vectors in out1
             outptr = (__m128i *)(out + (j * height + i + (numcol * 6)));
-            outptr[0] = _mm512_extracti32x4_epi32(out1[2], 1);
-            outptr[1] = _mm512_extracti32x4_epi32(out1[6], 1);
-            outptr[2] = _mm512_extracti32x4_epi32(out1[10], 1);
-            outptr[3] = _mm512_extracti32x4_epi32(out1[14], 1);
+            outptr[0] = _mm512_extracti32x4_epi32(out1[2], ONE);
+            outptr[1] = _mm512_extracti32x4_epi32(out1[6], ONE);
+            outptr[2] = _mm512_extracti32x4_epi32(out1[10], ONE);
+            outptr[3] = _mm512_extracti32x4_epi32(out1[14], ONE);
 
             //will get 8th row of transpose matrix from corresponding 4 vectors in out1
             outptr = (__m128i *)(out + (j * height + i + (numcol * 7)));
-            outptr[0] = _mm512_extracti32x4_epi32(out1[3], 1);
-            outptr[1] = _mm512_extracti32x4_epi32(out1[7], 1);
-            outptr[2] = _mm512_extracti32x4_epi32(out1[11], 1);
-            outptr[3] = _mm512_extracti32x4_epi32(out1[15], 1);
+            outptr[0] = _mm512_extracti32x4_epi32(out1[3], ONE);
+            outptr[1] = _mm512_extracti32x4_epi32(out1[7], ONE);
+            outptr[2] = _mm512_extracti32x4_epi32(out1[11], ONE);
+            outptr[3] = _mm512_extracti32x4_epi32(out1[15], ONE);
 
             //will get 9th row of transpose matrix from corresponding 4 vectors in out1
             outptr = (__m128i *)(out + (j * height + i + (numcol * 8)));
-            outptr[0] = _mm512_extracti32x4_epi32(out1[0], 2);
-            outptr[1] = _mm512_extracti32x4_epi32(out1[4], 2);
-            outptr[2] = _mm512_extracti32x4_epi32(out1[8], 2);
-            outptr[3] = _mm512_extracti32x4_epi32(out1[12], 2);
+            outptr[0] = _mm512_extracti32x4_epi32(out1[0], TWO);
+            outptr[1] = _mm512_extracti32x4_epi32(out1[4], TWO);
+            outptr[2] = _mm512_extracti32x4_epi32(out1[8], TWO);
+            outptr[3] = _mm512_extracti32x4_epi32(out1[12], TWO);
 
             //will get 10th row of transpose matrix from corresponding 4 vectors in out1
             outptr = (__m128i *)(out + (j * height + i + (numcol * 9)));
-            outptr[0] = _mm512_extracti32x4_epi32(out1[1], 2);
-            outptr[1] = _mm512_extracti32x4_epi32(out1[5], 2);
-            outptr[2] = _mm512_extracti32x4_epi32(out1[9], 2);
-            outptr[3] = _mm512_extracti32x4_epi32(out1[13], 2);
+            outptr[0] = _mm512_extracti32x4_epi32(out1[1], TWO);
+            outptr[1] = _mm512_extracti32x4_epi32(out1[5], TWO);
+            outptr[2] = _mm512_extracti32x4_epi32(out1[9], TWO);
+            outptr[3] = _mm512_extracti32x4_epi32(out1[13], TWO);
 
             //will get 11th row of transpose matrix from corresponding 4 vectors in out1
             outptr = (__m128i *)(out + (j * height + i + (numcol * 10)));
-            outptr[0] = _mm512_extracti32x4_epi32(out1[2], 2);
-            outptr[1] = _mm512_extracti32x4_epi32(out1[6], 2);
-            outptr[2] = _mm512_extracti32x4_epi32(out1[10], 2);
-            outptr[3] = _mm512_extracti32x4_epi32(out1[14], 2);
+            outptr[0] = _mm512_extracti32x4_epi32(out1[2], TWO);
+            outptr[1] = _mm512_extracti32x4_epi32(out1[6], TWO);
+            outptr[2] = _mm512_extracti32x4_epi32(out1[10], TWO);
+            outptr[3] = _mm512_extracti32x4_epi32(out1[14], TWO);
 
             //will get 12th row of transpose matrix from corresponding 4 vectors in out1
             outptr = (__m128i *)(out + (j * height + i + (numcol * 11)));
-            outptr[0] = _mm512_extracti32x4_epi32(out1[3], 2);
-            outptr[1] = _mm512_extracti32x4_epi32(out1[7], 2);
-            outptr[2] = _mm512_extracti32x4_epi32(out1[11], 2);
-            outptr[3] = _mm512_extracti32x4_epi32(out1[15], 2);
+            outptr[0] = _mm512_extracti32x4_epi32(out1[3], TWO);
+            outptr[1] = _mm512_extracti32x4_epi32(out1[7], TWO);
+            outptr[2] = _mm512_extracti32x4_epi32(out1[11], TWO);
+            outptr[3] = _mm512_extracti32x4_epi32(out1[15], TWO);
 
             //will get 13th row of transpose matrix from corresponding 4 vectors in out1
             outptr = (__m128i *)(out + (j * height + i + (numcol * 12)));
-            outptr[0] = _mm512_extracti32x4_epi32(out1[0], 3);
-            outptr[1] = _mm512_extracti32x4_epi32(out1[4], 3);
-            outptr[2] = _mm512_extracti32x4_epi32(out1[8], 3);
-            outptr[3] = _mm512_extracti32x4_epi32(out1[12], 3);
+            outptr[0] = _mm512_extracti32x4_epi32(out1[0], THREE);
+            outptr[1] = _mm512_extracti32x4_epi32(out1[4], THREE);
+            outptr[2] = _mm512_extracti32x4_epi32(out1[8], THREE);
+            outptr[3] = _mm512_extracti32x4_epi32(out1[12], THREE);
 
             //will get 14th row of transpose matrix from corresponding 4 vectors in out1
             outptr = (__m128i *)(out + (j * height + i + (numcol * 13)));
-            outptr[0] = _mm512_extracti32x4_epi32(out1[1], 3);
-            outptr[1] = _mm512_extracti32x4_epi32(out1[5], 3);
-            outptr[2] = _mm512_extracti32x4_epi32(out1[9], 3);
-            outptr[3] = _mm512_extracti32x4_epi32(out1[13], 3);
+            outptr[0] = _mm512_extracti32x4_epi32(out1[1], THREE);
+            outptr[1] = _mm512_extracti32x4_epi32(out1[5], THREE);
+            outptr[2] = _mm512_extracti32x4_epi32(out1[9], THREE);
+            outptr[3] = _mm512_extracti32x4_epi32(out1[13], THREE);
 
             //will get 15th row of transpose matrix from corresponding 4 vectors in out1
             outptr = (__m128i *)(out + (j * height + i + (numcol * 14)));
-            outptr[0] = _mm512_extracti32x4_epi32(out1[2], 3);
-            outptr[1] = _mm512_extracti32x4_epi32(out1[6], 3);
-            outptr[2] = _mm512_extracti32x4_epi32(out1[10], 3);
-            outptr[3] = _mm512_extracti32x4_epi32(out1[14], 3);
+            outptr[0] = _mm512_extracti32x4_epi32(out1[2], THREE);
+            outptr[1] = _mm512_extracti32x4_epi32(out1[6], THREE);
+            outptr[2] = _mm512_extracti32x4_epi32(out1[10], THREE);
+            outptr[3] = _mm512_extracti32x4_epi32(out1[14], THREE);
 
             //will get 16th row of transpose matrix from corresponding 4 vectors in out1
             outptr = (__m128i *)(out + (j * height + i + (numcol * 15)));
-            outptr[0] = _mm512_extracti32x4_epi32(out1[3], 3);
-            outptr[1] = _mm512_extracti32x4_epi32(out1[7], 3);
-            outptr[2] = _mm512_extracti32x4_epi32(out1[11], 3);
-            outptr[3] = _mm512_extracti32x4_epi32(out1[15], 3);
+            outptr[0] = _mm512_extracti32x4_epi32(out1[3], THREE);
+            outptr[1] = _mm512_extracti32x4_epi32(out1[7], THREE);
+            outptr[2] = _mm512_extracti32x4_epi32(out1[11], THREE);
+            outptr[3] = _mm512_extracti32x4_epi32(out1[15], THREE);
         }
     }
 }
 
 static INLINE void load_buffer_16_avx512(const int16_t *input, __m512i *in,
     int32_t stride, int32_t flipud, int32_t fliplr,
-    int32_t shift) {
+    const int8_t shift) {
     (void)flipud;
     (void)fliplr;
     __m256i temp;
@@ -2465,7 +2470,7 @@ static INLINE void load_buffer_16_avx512(const int16_t *input, __m512i *in,
 
 static INLINE void load_buffer_32_avx512(const int16_t *input, __m512i *in,
     int32_t stride, int32_t flipud, int32_t fliplr,
-    int32_t shift) {
+    const int8_t shift) {
     (void)flipud;
     (void)fliplr;
     __m256i temp[2];
@@ -2482,7 +2487,7 @@ static INLINE void load_buffer_32_avx512(const int16_t *input, __m512i *in,
 
 static INLINE void load_buffer_32x16n(const int16_t *input, __m512i *out,
     int32_t stride, int32_t flipud, int32_t fliplr,
-    int32_t shift, const int32_t height) {
+    const int8_t shift, const int32_t height) {
     const int16_t *in = input;
     __m512i *output = out;
     for (int32_t col = 0; col < height; col++) {
@@ -2495,7 +2500,7 @@ static INLINE void load_buffer_32x16n(const int16_t *input, __m512i *out,
 static INLINE void av1_round_shift_rect_array_32_avx512(__m512i *input,
     __m512i *output,
     const int32_t size,
-    const int32_t bit,
+    const int8_t bit,
     const int32_t val) {
     const __m512i sqrt2 = _mm512_set1_epi32(val);
     const __m512i round2 = _mm512_set1_epi32(1 << (12 - 1));
@@ -2514,7 +2519,7 @@ static INLINE void av1_round_shift_rect_array_32_avx512(__m512i *input,
     else {
         __m512i r0, r1, r2;
         for (i = 0; i < size; i++) {
-            r0 = _mm512_slli_epi32(input[i], -bit);
+            r0 = _mm512_slli_epi32(input[i], (uint8_t)-bit);
             r1 = _mm512_mullo_epi32(sqrt2, r0);
             r2 = _mm512_add_epi32(r1, round2);
             output[i] = _mm512_srai_epi32(r2, (uint8_t)12);

--- a/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
@@ -4,6 +4,7 @@
 #include "EbTransforms.h"
 #include <immintrin.h>
 
+#ifndef NON_AVX512_SUPPORT
 const int32_t *cospi_arr(int32_t n);
 const int32_t *sinpi_arr(int32_t n);
 
@@ -2768,3 +2769,4 @@ void av1_fwd_txfm2d_32x16_avx512(int16_t *input, int32_t *output, uint32_t strid
         5793);
     (void)bd;
 }
+#endif

--- a/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
@@ -7,7 +7,7 @@
 const int32_t *cospi_arr(int32_t n);
 const int32_t *sinpi_arr(int32_t n);
 
-#define ZERO (uint8_t)0U 
+#define ZERO (uint8_t)0U
 #define ONE  (uint8_t)1U
 #define TWO  (uint8_t)2U
 #define THREE (uint8_t)3U
@@ -70,7 +70,7 @@ static INLINE void transpose_16x16_avx512(int32_t stride, const __m512i *in, __m
     TRANSPOSE_4X4_AVX512(in[12 * stride], in[13 * stride], in[14 * stride], in[15 * stride], out1[12], out1[13], out1[14], out1[15]);
 
     __m128i * outptr = (__m128i *)(out + 0 * stride);
-    
+
     //will get first row of transpose matrix from corresponding 4 vectors in out1
     outptr[0] = _mm512_extracti32x4_epi32(out1[0], ZERO);
     outptr[1] = _mm512_extracti32x4_epi32(out1[4], ZERO);
@@ -247,7 +247,6 @@ static INLINE void write_buffer_16x16(const __m512i *res, int32_t *output) {
     {
         _mm512_storeu_si512((__m512i *)(output + (++fact) * 32), res[++index]);
         _mm512_storeu_si512((__m512i *)(output + (fact) * 32 + 16), res[++index]);
-      
     }
 }
 
@@ -2340,7 +2339,7 @@ static INLINE void transpose_16nx16m_avx512(const __m512i *in,
                 out1[12], out1[13], out1[14], out1[15]);
 
             __m128i * outptr = (__m128i *)(out + (j * height + i + (numcol * 0)));
-            
+
             //will get first row of transpose matrix from corresponding 4 vectors in out1
             outptr[0] = _mm512_extracti32x4_epi32(out1[0], ZERO);
             outptr[1] = _mm512_extracti32x4_epi32(out1[4], ZERO);

--- a/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
@@ -1,0 +1,911 @@
+#include <assert.h>
+#include "EbDefinitions.h"
+#include "aom_dsp_rtcd.h"
+#include "EbTransforms.h"
+#include <immintrin.h>
+
+const int32_t *cospi_arr(int32_t n);
+const int32_t *sinpi_arr(int32_t n);
+
+#define TRANSPOSE_4X4_AVX512(x0, x1, x2, x3, y0, y1, y2, y3) \
+  do {                                                \
+    __m512i u0, u1, u2, u3;                           \
+    u0 = _mm512_unpacklo_epi32(x0, x1);                  \
+    u1 = _mm512_unpackhi_epi32(x0, x1);                  \
+    u2 = _mm512_unpacklo_epi32(x2, x3);                  \
+    u3 = _mm512_unpackhi_epi32(x2, x3);                  \
+    y0 = _mm512_unpacklo_epi64(u0, u2);                  \
+    y1 = _mm512_unpackhi_epi64(u0, u2);                  \
+    y2 = _mm512_unpacklo_epi64(u1, u3);                  \
+    y3 = _mm512_unpackhi_epi64(u1, u3);                  \
+    } while (0)
+
+static const int8_t *fwd_txfm_shift_ls[TX_SIZES_ALL] = {
+    fwd_shift_4x4, fwd_shift_8x8, fwd_shift_16x16, fwd_shift_32x32,
+    fwd_shift_64x64, fwd_shift_4x8, fwd_shift_8x4, fwd_shift_8x16,
+    fwd_shift_16x8, fwd_shift_16x32, fwd_shift_32x16, fwd_shift_32x64,
+    fwd_shift_64x32, fwd_shift_4x16, fwd_shift_16x4, fwd_shift_8x32,
+    fwd_shift_32x8, fwd_shift_16x64, fwd_shift_64x16,
+};
+
+static INLINE void transpose_16x16_avx512(int32_t stride, const __m512i *in, __m512i *out) {
+    __m512i out1[16];
+    TRANSPOSE_4X4_AVX512(in[0 * stride], in[1 * stride], in[2 * stride], in[3 * stride], out1[0], out1[1], out1[2], out1[3]);
+    TRANSPOSE_4X4_AVX512(in[4 * stride], in[5 * stride], in[6 * stride], in[7 * stride], out1[4], out1[5], out1[6], out1[7]);
+    TRANSPOSE_4X4_AVX512(in[8 * stride], in[9 * stride], in[10 * stride], in[11 * stride], out1[8], out1[9], out1[10], out1[11]);
+    TRANSPOSE_4X4_AVX512(in[12 * stride], in[13 * stride], in[14 * stride], in[15 * stride], out1[12], out1[13], out1[14], out1[15]);
+
+    __m128i * outptr = (__m128i *)(out + 0 * stride);
+
+    //will get first row of transpose matrix from corresponding 4 vectors in out1
+    outptr[0] = _mm512_extracti32x4_epi32(out1[0], 0);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[4], 0);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[8], 0);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[12], 0);
+
+    //will get second row of transpose matrix from corresponding 4 vectors in out1
+    outptr = (__m128i *)(out + 1 * stride);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[1], 0);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[5], 0);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[9], 0);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[13], 0);
+
+    //will get 3rd row of transpose matrix from corresponding 4 vectors in out1
+    outptr = (__m128i *)(out + 2 * stride);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[2], 0);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[6], 0);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[10], 0);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[14], 0);
+
+    //will get 4th row of transpose matrix from corresponding 4 vectors in out1
+    outptr = (__m128i *)(out + 3 * stride);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[3], 0);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[7], 0);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[11], 0);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[15], 0);
+
+    //will get 5th row of transpose matrix from corresponding 4 vectors in out1
+    outptr = (__m128i *)(out + 4 * stride);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[0], 1);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[4], 1);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[8], 1);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[12], 1);
+
+    //will get 6th row of transpose matrix from corresponding 4 vectors in out1
+    outptr = (__m128i *)(out + 5 * stride);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[1], 1);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[5], 1);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[9], 1);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[13], 1);
+
+    //will get 7th row of transpose matrix from corresponding 4 vectors in out1
+    outptr = (__m128i *)(out + 6 * stride);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[2], 1);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[6], 1);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[10], 1);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[14], 1);
+
+    //will get 8th row of transpose matrix from corresponding 4 vectors in out1
+    outptr = (__m128i *)(out + 7 * stride);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[3], 1);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[7], 1);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[11], 1);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[15], 1);
+
+    //will get 9th row of transpose matrix from corresponding 4 vectors in out1
+    outptr = (__m128i *)(out + 8 * stride);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[0], 2);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[4], 2);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[8], 2);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[12], 2);
+
+    //will get 10th row of transpose matrix from corresponding 4 vectors in out1
+    outptr = (__m128i *)(out + 9 * stride);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[1], 2);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[5], 2);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[9], 2);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[13], 2);
+
+    //will get 11th row of transpose matrix from corresponding 4 vectors in out1
+    outptr = (__m128i *)(out + 10 * stride);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[2], 2);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[6], 2);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[10], 2);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[14], 2);
+
+    //will get 12th row of transpose matrix from corresponding 4 vectors in out1
+    outptr = (__m128i *)(out + 11 * stride);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[3], 2);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[7], 2);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[11], 2);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[15], 2);
+
+    //will get 13th row of transpose matrix from corresponding 4 vectors in out1
+    outptr = (__m128i *)(out + 12 * stride);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[0], 3);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[4], 3);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[8], 3);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[12], 3);
+
+    //will get 14th row of transpose matrix from corresponding 4 vectors in out1
+    outptr = (__m128i *)(out + 13 * stride);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[1], 3);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[5], 3);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[9], 3);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[13], 3);
+
+    //will get 15th row of transpose matrix from corresponding 4 vectors in out1
+    outptr = (__m128i *)(out + 14 * stride);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[2], 3);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[6], 3);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[10], 3);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[14], 3);
+
+    //will get 16th row of transpose matrix from corresponding 4 vectors in out1
+    outptr = (__m128i *)(out + 15 * stride);
+    outptr[0] = _mm512_extracti32x4_epi32(out1[3], 3);
+    outptr[1] = _mm512_extracti32x4_epi32(out1[7], 3);
+    outptr[2] = _mm512_extracti32x4_epi32(out1[11], 3);
+    outptr[3] = _mm512_extracti32x4_epi32(out1[15], 3);
+}
+
+static INLINE void load_buffer_16x16_avx512(const int16_t *input, __m512i *out,
+    int32_t stride, int32_t flipud, int32_t fliplr, int32_t shift) {
+    __m256i temp[16];
+    uint8_t ushift = (uint8_t)shift;
+    if (flipud) {
+        /* load rows upside down (bottom to top) */
+        for (int32_t i = 0; i < 16; i++) {
+            int idx = 15 - i;
+            temp[idx] = _mm256_loadu_si256((const __m256i *)(input + i * stride));
+            out[idx] = _mm512_cvtepi16_epi32(temp[idx]);
+            out[idx] = _mm512_slli_epi32(out[idx], ushift);
+        }
+    }
+    else {
+        /* load rows normally */
+        for (int32_t i = 0; i < 16; i++) {
+            temp[i] = _mm256_loadu_si256((const __m256i *)(input + i * stride));
+            out[i] = _mm512_cvtepi16_epi32(temp[i]);
+            out[i] = _mm512_slli_epi32(out[i], ushift);
+        }
+    }
+
+    if (fliplr) {
+      /*flip columns left to right*/
+        uint32_t idx[] = { 15 , 14 , 13 , 12 , 11 , 10 , 9 , 8 , 7 , 6 , 5 , 4 , 3 , 2 , 1 , 0 };
+        __m512i index = _mm512_loadu_si512(idx);
+
+        for (int32_t i = 0; i < 16; i++) {
+            out[i] = _mm512_permutexvar_epi32(index, out[i]);
+        }
+    }
+
+}
+
+static void fidtx16x16_avx512(const __m512i *in, __m512i *out, int8_t bit, int32_t col_num) {
+    (void)bit;
+    const uint8_t bits = 12;       // NewSqrt2Bits = 12
+    const int32_t sqrt = 2 * 5793; // 2 * NewSqrt2
+    const __m512i newsqrt = _mm512_set1_epi32(sqrt);
+    const __m512i rounding = _mm512_set1_epi32(1 << (bits - 1));
+    __m512i temp;
+    int32_t num_iters = 16 * col_num;
+    for (int32_t i = 0; i < num_iters; i++) {
+        temp = _mm512_mullo_epi32(in[i], newsqrt);
+        temp = _mm512_add_epi32(temp, rounding);
+        out[i] = _mm512_srai_epi32(temp, bits);
+    }
+}
+
+static INLINE void col_txfm_16x16_rounding_avx512(__m512i *in, int32_t shift) {
+    uint8_t ushift = (uint8_t)shift;
+    const __m512i rounding = _mm512_set1_epi32(1 << (ushift - 1));
+    for (int32_t i = 0; i < 16; i++) {
+        in[i] = _mm512_add_epi32(in[i], rounding);
+        in[i] = _mm512_srai_epi32(in[i], ushift);
+    }
+}
+
+static INLINE void write_buffer_16x16(const __m512i *res, int32_t *output) {
+    int32_t fact = -1, index = -1;
+    for (int32_t i = 0; i < 8; i++)
+    {
+        _mm512_storeu_si512((__m512i *)(output + (++fact) * 32), res[++index]);
+        _mm512_storeu_si512((__m512i *)(output + (fact) * 32 + 16), res[++index]);
+      
+    }
+}
+
+static INLINE __m512i half_btf_avx512(const __m512i *w0, const __m512i *n0,
+    const __m512i *w1, const __m512i *n1,
+    const __m512i *rounding, int32_t bit) {
+    __m512i x, y;
+
+    x = _mm512_mullo_epi32(*w0, *n0);
+    y = _mm512_mullo_epi32(*w1, *n1);
+    x = _mm512_add_epi32(x, y);
+    x = _mm512_add_epi32(x, *rounding);
+    x = _mm512_srai_epi32(x, (uint8_t)bit);
+    return x;
+}
+
+static void fadst16x16_avx512(const __m512i *in, __m512i *out, int8_t bit, const int32_t col_num) {
+    const int32_t *cospi = cospi_arr(bit);
+    const __m512i cospi32 = _mm512_set1_epi32(cospi[32]);
+    const __m512i cospi48 = _mm512_set1_epi32(cospi[48]);
+    const __m512i cospi16 = _mm512_set1_epi32(cospi[16]);
+    const __m512i cospim16 = _mm512_set1_epi32(-cospi[16]);
+    const __m512i cospim48 = _mm512_set1_epi32(-cospi[48]);
+    const __m512i cospi8 = _mm512_set1_epi32(cospi[8]);
+    const __m512i cospi56 = _mm512_set1_epi32(cospi[56]);
+    const __m512i cospim56 = _mm512_set1_epi32(-cospi[56]);
+    const __m512i cospim8 = _mm512_set1_epi32(-cospi[8]);
+    const __m512i cospi24 = _mm512_set1_epi32(cospi[24]);
+    const __m512i cospim24 = _mm512_set1_epi32(-cospi[24]);
+    const __m512i cospim40 = _mm512_set1_epi32(-cospi[40]);
+    const __m512i cospi40 = _mm512_set1_epi32(cospi[40]);
+    const __m512i cospi2 = _mm512_set1_epi32(cospi[2]);
+    const __m512i cospi62 = _mm512_set1_epi32(cospi[62]);
+    const __m512i cospim2 = _mm512_set1_epi32(-cospi[2]);
+    const __m512i cospi10 = _mm512_set1_epi32(cospi[10]);
+    const __m512i cospi54 = _mm512_set1_epi32(cospi[54]);
+    const __m512i cospim10 = _mm512_set1_epi32(-cospi[10]);
+    const __m512i cospi18 = _mm512_set1_epi32(cospi[18]);
+    const __m512i cospi46 = _mm512_set1_epi32(cospi[46]);
+    const __m512i cospim18 = _mm512_set1_epi32(-cospi[18]);
+    const __m512i cospi26 = _mm512_set1_epi32(cospi[26]);
+    const __m512i cospi38 = _mm512_set1_epi32(cospi[38]);
+    const __m512i cospim26 = _mm512_set1_epi32(-cospi[26]);
+    const __m512i cospi34 = _mm512_set1_epi32(cospi[34]);
+    const __m512i cospi30 = _mm512_set1_epi32(cospi[30]);
+    const __m512i cospim34 = _mm512_set1_epi32(-cospi[34]);
+    const __m512i cospi42 = _mm512_set1_epi32(cospi[42]);
+    const __m512i cospi22 = _mm512_set1_epi32(cospi[22]);
+    const __m512i cospim42 = _mm512_set1_epi32(-cospi[42]);
+    const __m512i cospi50 = _mm512_set1_epi32(cospi[50]);
+    const __m512i cospi14 = _mm512_set1_epi32(cospi[14]);
+    const __m512i cospim50 = _mm512_set1_epi32(-cospi[50]);
+    const __m512i cospi58 = _mm512_set1_epi32(cospi[58]);
+    const __m512i cospi6 = _mm512_set1_epi32(cospi[6]);
+    const __m512i cospim58 = _mm512_set1_epi32(-cospi[58]);
+    const __m512i rnding = _mm512_set1_epi32(1 << (bit - 1));
+    const __m512i zero = _mm512_setzero_si512();
+
+    __m512i u[16], v[16], x, y;
+    int32_t col;
+
+    for (col = 0; col < col_num; ++col) {
+        // stage 0
+        // stage 1
+        u[0] = in[0 * col_num + col];
+        u[1] = _mm512_sub_epi32(zero, in[15 * col_num + col]);
+        u[2] = _mm512_sub_epi32(zero, in[7 * col_num + col]);
+        u[3] = in[8 * col_num + col];
+        u[4] = _mm512_sub_epi32(zero, in[3 * col_num + col]);
+        u[5] = in[12 * col_num + col];
+        u[6] = in[4 * col_num + col];
+        u[7] = _mm512_sub_epi32(zero, in[11 * col_num + col]);
+        u[8] = _mm512_sub_epi32(zero, in[1 * col_num + col]);
+        u[9] = in[14 * col_num + col];
+        u[10] = in[6 * col_num + col];
+        u[11] = _mm512_sub_epi32(zero, in[9 * col_num + col]);
+        u[12] = in[2 * col_num + col];
+        u[13] = _mm512_sub_epi32(zero, in[13 * col_num + col]);
+        u[14] = _mm512_sub_epi32(zero, in[5 * col_num + col]);
+        u[15] = in[10 * col_num + col];
+
+        // stage 2
+        v[0] = u[0];
+        v[1] = u[1];
+
+        x = _mm512_mullo_epi32(u[2], cospi32);
+        y = _mm512_mullo_epi32(u[3], cospi32);
+        v[2] = _mm512_add_epi32(x, y);
+        v[2] = _mm512_add_epi32(v[2], rnding);
+        v[2] = _mm512_srai_epi32(v[2], bit);
+
+        v[3] = _mm512_sub_epi32(x, y);
+        v[3] = _mm512_add_epi32(v[3], rnding);
+        v[3] = _mm512_srai_epi32(v[3], bit);
+
+        v[4] = u[4];
+        v[5] = u[5];
+
+        x = _mm512_mullo_epi32(u[6], cospi32);
+        y = _mm512_mullo_epi32(u[7], cospi32);
+        v[6] = _mm512_add_epi32(x, y);
+        v[6] = _mm512_add_epi32(v[6], rnding);
+        v[6] = _mm512_srai_epi32(v[6], bit);
+
+        v[7] = _mm512_sub_epi32(x, y);
+        v[7] = _mm512_add_epi32(v[7], rnding);
+        v[7] = _mm512_srai_epi32(v[7], bit);
+
+        v[8] = u[8];
+        v[9] = u[9];
+
+        x = _mm512_mullo_epi32(u[10], cospi32);
+        y = _mm512_mullo_epi32(u[11], cospi32);
+        v[10] = _mm512_add_epi32(x, y);
+        v[10] = _mm512_add_epi32(v[10], rnding);
+        v[10] = _mm512_srai_epi32(v[10], bit);
+
+        v[11] = _mm512_sub_epi32(x, y);
+        v[11] = _mm512_add_epi32(v[11], rnding);
+        v[11] = _mm512_srai_epi32(v[11], bit);
+
+        v[12] = u[12];
+        v[13] = u[13];
+
+        x = _mm512_mullo_epi32(u[14], cospi32);
+        y = _mm512_mullo_epi32(u[15], cospi32);
+        v[14] = _mm512_add_epi32(x, y);
+        v[14] = _mm512_add_epi32(v[14], rnding);
+        v[14] = _mm512_srai_epi32(v[14], bit);
+
+        v[15] = _mm512_sub_epi32(x, y);
+        v[15] = _mm512_add_epi32(v[15], rnding);
+        v[15] = _mm512_srai_epi32(v[15], bit);
+
+        // stage 3
+        u[0] = _mm512_add_epi32(v[0], v[2]);
+        u[1] = _mm512_add_epi32(v[1], v[3]);
+        u[2] = _mm512_sub_epi32(v[0], v[2]);
+        u[3] = _mm512_sub_epi32(v[1], v[3]);
+        u[4] = _mm512_add_epi32(v[4], v[6]);
+        u[5] = _mm512_add_epi32(v[5], v[7]);
+        u[6] = _mm512_sub_epi32(v[4], v[6]);
+        u[7] = _mm512_sub_epi32(v[5], v[7]);
+        u[8] = _mm512_add_epi32(v[8], v[10]);
+        u[9] = _mm512_add_epi32(v[9], v[11]);
+        u[10] = _mm512_sub_epi32(v[8], v[10]);
+        u[11] = _mm512_sub_epi32(v[9], v[11]);
+        u[12] = _mm512_add_epi32(v[12], v[14]);
+        u[13] = _mm512_add_epi32(v[13], v[15]);
+        u[14] = _mm512_sub_epi32(v[12], v[14]);
+        u[15] = _mm512_sub_epi32(v[13], v[15]);
+
+        // stage 4
+        v[0] = u[0];
+        v[1] = u[1];
+        v[2] = u[2];
+        v[3] = u[3];
+        v[4] = half_btf_avx512(&cospi16, &u[4], &cospi48, &u[5], &rnding, bit);
+        v[5] = half_btf_avx512(&cospi48, &u[4], &cospim16, &u[5], &rnding, bit);
+        v[6] = half_btf_avx512(&cospim48, &u[6], &cospi16, &u[7], &rnding, bit);
+        v[7] = half_btf_avx512(&cospi16, &u[6], &cospi48, &u[7], &rnding, bit);
+        v[8] = u[8];
+        v[9] = u[9];
+        v[10] = u[10];
+        v[11] = u[11];
+        v[12] = half_btf_avx512(&cospi16, &u[12], &cospi48, &u[13], &rnding, bit);
+        v[13] = half_btf_avx512(&cospi48, &u[12], &cospim16, &u[13], &rnding, bit);
+        v[14] = half_btf_avx512(&cospim48, &u[14], &cospi16, &u[15], &rnding, bit);
+        v[15] = half_btf_avx512(&cospi16, &u[14], &cospi48, &u[15], &rnding, bit);
+
+        // stage 5
+        u[0] = _mm512_add_epi32(v[0], v[4]);
+        u[1] = _mm512_add_epi32(v[1], v[5]);
+        u[2] = _mm512_add_epi32(v[2], v[6]);
+        u[3] = _mm512_add_epi32(v[3], v[7]);
+        u[4] = _mm512_sub_epi32(v[0], v[4]);
+        u[5] = _mm512_sub_epi32(v[1], v[5]);
+        u[6] = _mm512_sub_epi32(v[2], v[6]);
+        u[7] = _mm512_sub_epi32(v[3], v[7]);
+        u[8] = _mm512_add_epi32(v[8], v[12]);
+        u[9] = _mm512_add_epi32(v[9], v[13]);
+        u[10] = _mm512_add_epi32(v[10], v[14]);
+        u[11] = _mm512_add_epi32(v[11], v[15]);
+        u[12] = _mm512_sub_epi32(v[8], v[12]);
+        u[13] = _mm512_sub_epi32(v[9], v[13]);
+        u[14] = _mm512_sub_epi32(v[10], v[14]);
+        u[15] = _mm512_sub_epi32(v[11], v[15]);
+
+        // stage 6
+        v[0] = u[0];
+        v[1] = u[1];
+        v[2] = u[2];
+        v[3] = u[3];
+        v[4] = u[4];
+        v[5] = u[5];
+        v[6] = u[6];
+        v[7] = u[7];
+        v[8] = half_btf_avx512(&cospi8, &u[8], &cospi56, &u[9], &rnding, bit);
+        v[9] = half_btf_avx512(&cospi56, &u[8], &cospim8, &u[9], &rnding, bit);
+        v[10] = half_btf_avx512(&cospi40, &u[10], &cospi24, &u[11], &rnding, bit);
+        v[11] = half_btf_avx512(&cospi24, &u[10], &cospim40, &u[11], &rnding, bit);
+        v[12] = half_btf_avx512(&cospim56, &u[12], &cospi8, &u[13], &rnding, bit);
+        v[13] = half_btf_avx512(&cospi8, &u[12], &cospi56, &u[13], &rnding, bit);
+        v[14] = half_btf_avx512(&cospim24, &u[14], &cospi40, &u[15], &rnding, bit);
+        v[15] = half_btf_avx512(&cospi40, &u[14], &cospi24, &u[15], &rnding, bit);
+
+        // stage 7
+        u[0] = _mm512_add_epi32(v[0], v[8]);
+        u[1] = _mm512_add_epi32(v[1], v[9]);
+        u[2] = _mm512_add_epi32(v[2], v[10]);
+        u[3] = _mm512_add_epi32(v[3], v[11]);
+        u[4] = _mm512_add_epi32(v[4], v[12]);
+        u[5] = _mm512_add_epi32(v[5], v[13]);
+        u[6] = _mm512_add_epi32(v[6], v[14]);
+        u[7] = _mm512_add_epi32(v[7], v[15]);
+        u[8] = _mm512_sub_epi32(v[0], v[8]);
+        u[9] = _mm512_sub_epi32(v[1], v[9]);
+        u[10] = _mm512_sub_epi32(v[2], v[10]);
+        u[11] = _mm512_sub_epi32(v[3], v[11]);
+        u[12] = _mm512_sub_epi32(v[4], v[12]);
+        u[13] = _mm512_sub_epi32(v[5], v[13]);
+        u[14] = _mm512_sub_epi32(v[6], v[14]);
+        u[15] = _mm512_sub_epi32(v[7], v[15]);
+
+        // stage 8
+        v[0] = half_btf_avx512(&cospi2, &u[0], &cospi62, &u[1], &rnding, bit);
+        v[1] = half_btf_avx512(&cospi62, &u[0], &cospim2, &u[1], &rnding, bit);
+        v[2] = half_btf_avx512(&cospi10, &u[2], &cospi54, &u[3], &rnding, bit);
+        v[3] = half_btf_avx512(&cospi54, &u[2], &cospim10, &u[3], &rnding, bit);
+        v[4] = half_btf_avx512(&cospi18, &u[4], &cospi46, &u[5], &rnding, bit);
+        v[5] = half_btf_avx512(&cospi46, &u[4], &cospim18, &u[5], &rnding, bit);
+        v[6] = half_btf_avx512(&cospi26, &u[6], &cospi38, &u[7], &rnding, bit);
+        v[7] = half_btf_avx512(&cospi38, &u[6], &cospim26, &u[7], &rnding, bit);
+        v[8] = half_btf_avx512(&cospi34, &u[8], &cospi30, &u[9], &rnding, bit);
+        v[9] = half_btf_avx512(&cospi30, &u[8], &cospim34, &u[9], &rnding, bit);
+        v[10] = half_btf_avx512(&cospi42, &u[10], &cospi22, &u[11], &rnding, bit);
+        v[11] = half_btf_avx512(&cospi22, &u[10], &cospim42, &u[11], &rnding, bit);
+        v[12] = half_btf_avx512(&cospi50, &u[12], &cospi14, &u[13], &rnding, bit);
+        v[13] = half_btf_avx512(&cospi14, &u[12], &cospim50, &u[13], &rnding, bit);
+        v[14] = half_btf_avx512(&cospi58, &u[14], &cospi6, &u[15], &rnding, bit);
+        v[15] = half_btf_avx512(&cospi6, &u[14], &cospim58, &u[15], &rnding, bit);
+
+        // stage 9
+        out[0 * col_num + col] = v[1];
+        out[1 * col_num + col] = v[14];
+        out[2 * col_num + col] = v[3];
+        out[3 * col_num + col] = v[12];
+        out[4 * col_num + col] = v[5];
+        out[5 * col_num + col] = v[10];
+        out[6 * col_num + col] = v[7];
+        out[7 * col_num + col] = v[8];
+        out[8 * col_num + col] = v[9];
+        out[9 * col_num + col] = v[6];
+        out[10 * col_num + col] = v[11];
+        out[11 * col_num + col] = v[4];
+        out[12 * col_num + col] = v[13];
+        out[13 * col_num + col] = v[2];
+        out[14 * col_num + col] = v[15];
+        out[15 * col_num + col] = v[0];
+    }
+}
+static void fdct16x16_avx512(const __m512i *in, __m512i *out, int8_t bit, const int32_t col_num) {
+    const int32_t *cospi = cospi_arr(bit);
+    const __m512i cospi32 = _mm512_set1_epi32(cospi[32]);
+    const __m512i cospim32 = _mm512_set1_epi32(-cospi[32]);
+    const __m512i cospi48 = _mm512_set1_epi32(cospi[48]);
+    const __m512i cospi16 = _mm512_set1_epi32(cospi[16]);
+    const __m512i cospim48 = _mm512_set1_epi32(-cospi[48]);
+    const __m512i cospim16 = _mm512_set1_epi32(-cospi[16]);
+    const __m512i cospi56 = _mm512_set1_epi32(cospi[56]);
+    const __m512i cospi8 = _mm512_set1_epi32(cospi[8]);
+    const __m512i cospi24 = _mm512_set1_epi32(cospi[24]);
+    const __m512i cospi40 = _mm512_set1_epi32(cospi[40]);
+    const __m512i cospi60 = _mm512_set1_epi32(cospi[60]);
+    const __m512i cospi4 = _mm512_set1_epi32(cospi[4]);
+    const __m512i cospi28 = _mm512_set1_epi32(cospi[28]);
+    const __m512i cospi36 = _mm512_set1_epi32(cospi[36]);
+    const __m512i cospi44 = _mm512_set1_epi32(cospi[44]);
+    const __m512i cospi20 = _mm512_set1_epi32(cospi[20]);
+    const __m512i cospi12 = _mm512_set1_epi32(cospi[12]);
+    const __m512i cospi52 = _mm512_set1_epi32(cospi[52]);
+    const __m512i rnding = _mm512_set1_epi32(1 << (bit - 1));
+    __m512i u[16], v[16], x;
+    int32_t col;
+
+    for (col = 0; col < col_num; ++col) {
+        // stage 0
+        // stage 1
+        u[0] = _mm512_add_epi32(in[0 * col_num + col], in[15 * col_num + col]);
+        u[15] = _mm512_sub_epi32(in[0 * col_num + col], in[15 * col_num + col]);
+        u[1] = _mm512_add_epi32(in[1 * col_num + col], in[14 * col_num + col]);
+        u[14] = _mm512_sub_epi32(in[1 * col_num + col], in[14 * col_num + col]);
+        u[2] = _mm512_add_epi32(in[2 * col_num + col], in[13 * col_num + col]);
+        u[13] = _mm512_sub_epi32(in[2 * col_num + col], in[13 * col_num + col]);
+        u[3] = _mm512_add_epi32(in[3 * col_num + col], in[12 * col_num + col]);
+        u[12] = _mm512_sub_epi32(in[3 * col_num + col], in[12 * col_num + col]);
+        u[4] = _mm512_add_epi32(in[4 * col_num + col], in[11 * col_num + col]);
+        u[11] = _mm512_sub_epi32(in[4 * col_num + col], in[11 * col_num + col]);
+        u[5] = _mm512_add_epi32(in[5 * col_num + col], in[10 * col_num + col]);
+        u[10] = _mm512_sub_epi32(in[5 * col_num + col], in[10 * col_num + col]);
+        u[6] = _mm512_add_epi32(in[6 * col_num + col], in[9 * col_num + col]);
+        u[9] = _mm512_sub_epi32(in[6 * col_num + col], in[9 * col_num + col]);
+        u[7] = _mm512_add_epi32(in[7 * col_num + col], in[8 * col_num + col]);
+        u[8] = _mm512_sub_epi32(in[7 * col_num + col], in[8 * col_num + col]);
+
+        // stage 2
+        v[0] = _mm512_add_epi32(u[0], u[7]);
+        v[7] = _mm512_sub_epi32(u[0], u[7]);
+        v[1] = _mm512_add_epi32(u[1], u[6]);
+        v[6] = _mm512_sub_epi32(u[1], u[6]);
+        v[2] = _mm512_add_epi32(u[2], u[5]);
+        v[5] = _mm512_sub_epi32(u[2], u[5]);
+        v[3] = _mm512_add_epi32(u[3], u[4]);
+        v[4] = _mm512_sub_epi32(u[3], u[4]);
+        v[8] = u[8];
+        v[9] = u[9];
+
+        v[10] = _mm512_mullo_epi32(u[10], cospim32);
+        x = _mm512_mullo_epi32(u[13], cospi32);
+        v[10] = _mm512_add_epi32(v[10], x);
+        v[10] = _mm512_add_epi32(v[10], rnding);
+        v[10] = _mm512_srai_epi32(v[10], bit);
+
+        v[13] = _mm512_mullo_epi32(u[10], cospi32);
+        x = _mm512_mullo_epi32(u[13], cospim32);
+        v[13] = _mm512_sub_epi32(v[13], x);
+        v[13] = _mm512_add_epi32(v[13], rnding);
+        v[13] = _mm512_srai_epi32(v[13], bit);
+
+        v[11] = _mm512_mullo_epi32(u[11], cospim32);
+        x = _mm512_mullo_epi32(u[12], cospi32);
+        v[11] = _mm512_add_epi32(v[11], x);
+        v[11] = _mm512_add_epi32(v[11], rnding);
+        v[11] = _mm512_srai_epi32(v[11], bit);
+
+        v[12] = _mm512_mullo_epi32(u[11], cospi32);
+        x = _mm512_mullo_epi32(u[12], cospim32);
+        v[12] = _mm512_sub_epi32(v[12], x);
+        v[12] = _mm512_add_epi32(v[12], rnding);
+        v[12] = _mm512_srai_epi32(v[12], bit);
+        v[14] = u[14];
+        v[15] = u[15];
+
+        // stage 3
+        u[0] = _mm512_add_epi32(v[0], v[3]);
+        u[3] = _mm512_sub_epi32(v[0], v[3]);
+        u[1] = _mm512_add_epi32(v[1], v[2]);
+        u[2] = _mm512_sub_epi32(v[1], v[2]);
+        u[4] = v[4];
+
+        u[5] = _mm512_mullo_epi32(v[5], cospim32);
+        x = _mm512_mullo_epi32(v[6], cospi32);
+        u[5] = _mm512_add_epi32(u[5], x);
+        u[5] = _mm512_add_epi32(u[5], rnding);
+        u[5] = _mm512_srai_epi32(u[5], bit);
+
+        u[6] = _mm512_mullo_epi32(v[5], cospi32);
+        x = _mm512_mullo_epi32(v[6], cospim32);
+        u[6] = _mm512_sub_epi32(u[6], x);
+        u[6] = _mm512_add_epi32(u[6], rnding);
+        u[6] = _mm512_srai_epi32(u[6], bit);
+
+        u[7] = v[7];
+        u[8] = _mm512_add_epi32(v[8], v[11]);
+        u[11] = _mm512_sub_epi32(v[8], v[11]);
+        u[9] = _mm512_add_epi32(v[9], v[10]);
+        u[10] = _mm512_sub_epi32(v[9], v[10]);
+        u[12] = _mm512_sub_epi32(v[15], v[12]);
+        u[15] = _mm512_add_epi32(v[15], v[12]);
+        u[13] = _mm512_sub_epi32(v[14], v[13]);
+        u[14] = _mm512_add_epi32(v[14], v[13]);
+
+        // stage 4
+        u[0] = _mm512_mullo_epi32(u[0], cospi32);
+        u[1] = _mm512_mullo_epi32(u[1], cospi32);
+        v[0] = _mm512_add_epi32(u[0], u[1]);
+        v[0] = _mm512_add_epi32(v[0], rnding);
+        v[0] = _mm512_srai_epi32(v[0], bit);
+
+        v[1] = _mm512_sub_epi32(u[0], u[1]);
+        v[1] = _mm512_add_epi32(v[1], rnding);
+        v[1] = _mm512_srai_epi32(v[1], bit);
+
+        v[2] = _mm512_mullo_epi32(u[2], cospi48);
+        x = _mm512_mullo_epi32(u[3], cospi16);
+        v[2] = _mm512_add_epi32(v[2], x);
+        v[2] = _mm512_add_epi32(v[2], rnding);
+        v[2] = _mm512_srai_epi32(v[2], bit);
+
+        v[3] = _mm512_mullo_epi32(u[2], cospi16);
+        x = _mm512_mullo_epi32(u[3], cospi48);
+        v[3] = _mm512_sub_epi32(x, v[3]);
+        v[3] = _mm512_add_epi32(v[3], rnding);
+        v[3] = _mm512_srai_epi32(v[3], bit);
+
+        v[4] = _mm512_add_epi32(u[4], u[5]);
+        v[5] = _mm512_sub_epi32(u[4], u[5]);
+        v[6] = _mm512_sub_epi32(u[7], u[6]);
+        v[7] = _mm512_add_epi32(u[7], u[6]);
+        v[8] = u[8];
+
+        v[9] = _mm512_mullo_epi32(u[9], cospim16);
+        x = _mm512_mullo_epi32(u[14], cospi48);
+        v[9] = _mm512_add_epi32(v[9], x);
+        v[9] = _mm512_add_epi32(v[9], rnding);
+        v[9] = _mm512_srai_epi32(v[9], bit);
+
+        v[14] = _mm512_mullo_epi32(u[9], cospi48);
+        x = _mm512_mullo_epi32(u[14], cospim16);
+        v[14] = _mm512_sub_epi32(v[14], x);
+        v[14] = _mm512_add_epi32(v[14], rnding);
+        v[14] = _mm512_srai_epi32(v[14], bit);
+
+        v[10] = _mm512_mullo_epi32(u[10], cospim48);
+        x = _mm512_mullo_epi32(u[13], cospim16);
+        v[10] = _mm512_add_epi32(v[10], x);
+        v[10] = _mm512_add_epi32(v[10], rnding);
+        v[10] = _mm512_srai_epi32(v[10], bit);
+
+        v[13] = _mm512_mullo_epi32(u[10], cospim16);
+        x = _mm512_mullo_epi32(u[13], cospim48);
+        v[13] = _mm512_sub_epi32(v[13], x);
+        v[13] = _mm512_add_epi32(v[13], rnding);
+        v[13] = _mm512_srai_epi32(v[13], bit);
+
+        v[11] = u[11];
+        v[12] = u[12];
+        v[15] = u[15];
+
+        // stage 5
+        u[0] = v[0];
+        u[1] = v[1];
+        u[2] = v[2];
+        u[3] = v[3];
+
+        u[4] = _mm512_mullo_epi32(v[4], cospi56);
+        x = _mm512_mullo_epi32(v[7], cospi8);
+        u[4] = _mm512_add_epi32(u[4], x);
+        u[4] = _mm512_add_epi32(u[4], rnding);
+        u[4] = _mm512_srai_epi32(u[4], bit);
+
+        u[7] = _mm512_mullo_epi32(v[4], cospi8);
+        x = _mm512_mullo_epi32(v[7], cospi56);
+        u[7] = _mm512_sub_epi32(x, u[7]);
+        u[7] = _mm512_add_epi32(u[7], rnding);
+        u[7] = _mm512_srai_epi32(u[7], bit);
+
+        u[5] = _mm512_mullo_epi32(v[5], cospi24);
+        x = _mm512_mullo_epi32(v[6], cospi40);
+        u[5] = _mm512_add_epi32(u[5], x);
+        u[5] = _mm512_add_epi32(u[5], rnding);
+        u[5] = _mm512_srai_epi32(u[5], bit);
+
+        u[6] = _mm512_mullo_epi32(v[5], cospi40);
+        x = _mm512_mullo_epi32(v[6], cospi24);
+        u[6] = _mm512_sub_epi32(x, u[6]);
+        u[6] = _mm512_add_epi32(u[6], rnding);
+        u[6] = _mm512_srai_epi32(u[6], bit);
+
+        u[8] = _mm512_add_epi32(v[8], v[9]);
+        u[9] = _mm512_sub_epi32(v[8], v[9]);
+        u[10] = _mm512_sub_epi32(v[11], v[10]);
+        u[11] = _mm512_add_epi32(v[11], v[10]);
+        u[12] = _mm512_add_epi32(v[12], v[13]);
+        u[13] = _mm512_sub_epi32(v[12], v[13]);
+        u[14] = _mm512_sub_epi32(v[15], v[14]);
+        u[15] = _mm512_add_epi32(v[15], v[14]);
+
+        // stage 6
+        v[0] = u[0];
+        v[1] = u[1];
+        v[2] = u[2];
+        v[3] = u[3];
+        v[4] = u[4];
+        v[5] = u[5];
+        v[6] = u[6];
+        v[7] = u[7];
+
+        v[8] = _mm512_mullo_epi32(u[8], cospi60);
+        x = _mm512_mullo_epi32(u[15], cospi4);
+        v[8] = _mm512_add_epi32(v[8], x);
+        v[8] = _mm512_add_epi32(v[8], rnding);
+        v[8] = _mm512_srai_epi32(v[8], bit);
+
+        v[15] = _mm512_mullo_epi32(u[8], cospi4);
+        x = _mm512_mullo_epi32(u[15], cospi60);
+        v[15] = _mm512_sub_epi32(x, v[15]);
+        v[15] = _mm512_add_epi32(v[15], rnding);
+        v[15] = _mm512_srai_epi32(v[15], bit);
+
+        v[9] = _mm512_mullo_epi32(u[9], cospi28);
+        x = _mm512_mullo_epi32(u[14], cospi36);
+        v[9] = _mm512_add_epi32(v[9], x);
+        v[9] = _mm512_add_epi32(v[9], rnding);
+        v[9] = _mm512_srai_epi32(v[9], bit);
+
+        v[14] = _mm512_mullo_epi32(u[9], cospi36);
+        x = _mm512_mullo_epi32(u[14], cospi28);
+        v[14] = _mm512_sub_epi32(x, v[14]);
+        v[14] = _mm512_add_epi32(v[14], rnding);
+        v[14] = _mm512_srai_epi32(v[14], bit);
+
+        v[10] = _mm512_mullo_epi32(u[10], cospi44);
+        x = _mm512_mullo_epi32(u[13], cospi20);
+        v[10] = _mm512_add_epi32(v[10], x);
+        v[10] = _mm512_add_epi32(v[10], rnding);
+        v[10] = _mm512_srai_epi32(v[10], bit);
+
+        v[13] = _mm512_mullo_epi32(u[10], cospi20);
+        x = _mm512_mullo_epi32(u[13], cospi44);
+        v[13] = _mm512_sub_epi32(x, v[13]);
+        v[13] = _mm512_add_epi32(v[13], rnding);
+        v[13] = _mm512_srai_epi32(v[13], bit);
+
+        v[11] = _mm512_mullo_epi32(u[11], cospi12);
+        x = _mm512_mullo_epi32(u[12], cospi52);
+        v[11] = _mm512_add_epi32(v[11], x);
+        v[11] = _mm512_add_epi32(v[11], rnding);
+        v[11] = _mm512_srai_epi32(v[11], bit);
+
+        v[12] = _mm512_mullo_epi32(u[11], cospi52);
+        x = _mm512_mullo_epi32(u[12], cospi12);
+        v[12] = _mm512_sub_epi32(x, v[12]);
+        v[12] = _mm512_add_epi32(v[12], rnding);
+        v[12] = _mm512_srai_epi32(v[12], bit);
+
+        out[0 * col_num + col] = v[0];
+        out[1 * col_num + col] = v[8];
+        out[2 * col_num + col] = v[4];
+        out[3 * col_num + col] = v[12];
+        out[4 * col_num + col] = v[2];
+        out[5 * col_num + col] = v[10];
+        out[6 * col_num + col] = v[6];
+        out[7 * col_num + col] = v[14];
+        out[8 * col_num + col] = v[1];
+        out[9 * col_num + col] = v[9];
+        out[10 * col_num + col] = v[5];
+        out[11 * col_num + col] = v[13];
+        out[12 * col_num + col] = v[3];
+        out[13 * col_num + col] = v[11];
+        out[14 * col_num + col] = v[7];
+        out[15 * col_num + col] = v[15];
+    }
+}
+
+void av1_fwd_txfm2d_16x16_avx512(int16_t *input, int32_t *coeff, uint32_t stride, TxType tx_type, uint8_t  bd)
+{
+    __m512i in[16], out[16];
+    const int8_t *shift = fwd_txfm_shift_ls[TX_16X16];
+    const int32_t txw_idx = get_txw_idx(TX_16X16);
+    const int32_t txh_idx = get_txh_idx(TX_16X16);
+    const int32_t col_num = 1;
+    switch (tx_type) {
+    case IDTX:
+        load_buffer_16x16_avx512(input, in, stride, 0, 0, shift[0]);
+        fidtx16x16_avx512(in, out, fwd_cos_bit_col[txw_idx][txh_idx], col_num);
+        col_txfm_16x16_rounding_avx512(out, -shift[1]);
+        fidtx16x16_avx512(out, out, fwd_cos_bit_row[txw_idx][txh_idx], col_num);
+        write_buffer_16x16(out, coeff);
+        break;
+    case DCT_DCT:
+        load_buffer_16x16_avx512(input, in, stride, 0, 0, shift[0]);
+        fdct16x16_avx512(in, out, fwd_cos_bit_col[txw_idx][txh_idx], col_num);
+        col_txfm_16x16_rounding_avx512(out, -shift[1]);
+        transpose_16x16_avx512(1, out, in);
+        fdct16x16_avx512(in, out, fwd_cos_bit_row[txw_idx][txh_idx], col_num);
+        transpose_16x16_avx512(1, out, in);
+        write_buffer_16x16(in, coeff);
+        break;
+    case ADST_DCT:
+        load_buffer_16x16_avx512(input, in, stride, 0, 0, shift[0]);
+        fadst16x16_avx512(in, out, fwd_cos_bit_col[txw_idx][txh_idx], col_num);
+        col_txfm_16x16_rounding_avx512(out, -shift[1]);
+        transpose_16x16_avx512(1, out, in);
+        fdct16x16_avx512(in, out, fwd_cos_bit_row[txw_idx][txh_idx], col_num);
+        transpose_16x16_avx512(1, out, in);
+        write_buffer_16x16(in, coeff);
+        break;
+    case DCT_ADST:
+        load_buffer_16x16_avx512(input, in, stride, 0, 0, shift[0]);
+        fdct16x16_avx512(in, out, fwd_cos_bit_col[txw_idx][txh_idx], col_num);
+        col_txfm_16x16_rounding_avx512(out, -shift[1]);
+        transpose_16x16_avx512(1, out, in);
+        fadst16x16_avx512(in, out, fwd_cos_bit_row[txw_idx][txh_idx], col_num);
+        transpose_16x16_avx512(1, out, in);
+        write_buffer_16x16(in, coeff);
+        break;
+    case ADST_ADST:
+        load_buffer_16x16_avx512(input, in, stride, 0, 0, shift[0]);
+        fadst16x16_avx512(in, out, fwd_cos_bit_col[txw_idx][txh_idx], col_num);
+        col_txfm_16x16_rounding_avx512(out, -shift[1]);
+        transpose_16x16_avx512(1, out, in);
+        fadst16x16_avx512(in, out, fwd_cos_bit_row[txw_idx][txh_idx], col_num);
+        transpose_16x16_avx512(1, out, in);
+        write_buffer_16x16(in, coeff);
+        break;
+    case DCT_FLIPADST:
+        load_buffer_16x16_avx512(input, in, stride, 0, 1, shift[0]);
+        fdct16x16_avx512(in, out, fwd_cos_bit_col[txw_idx][txh_idx], col_num);
+        col_txfm_16x16_rounding_avx512(out, -shift[1]);
+        transpose_16x16_avx512(1, out, in);
+        fadst16x16_avx512(in, out, fwd_cos_bit_row[txw_idx][txh_idx], col_num);
+        transpose_16x16_avx512(1, out, in);
+        write_buffer_16x16(in, coeff);
+        break;
+    case FLIPADST_DCT:
+        load_buffer_16x16_avx512(input, in, stride, 1, 0, shift[0]);
+        fadst16x16_avx512(in, out, fwd_cos_bit_col[txw_idx][txh_idx], col_num);
+        col_txfm_16x16_rounding_avx512(out, -shift[1]);
+        transpose_16x16_avx512(1, out, in);
+        fdct16x16_avx512(in, out, fwd_cos_bit_row[txw_idx][txh_idx], col_num);
+        transpose_16x16_avx512(1, out, in);
+        write_buffer_16x16(in, coeff);
+        break;
+    case FLIPADST_FLIPADST:
+        load_buffer_16x16_avx512(input, in, stride, 1, 1, shift[0]);
+        fadst16x16_avx512(in, out, fwd_cos_bit_col[txw_idx][txh_idx], col_num);
+        col_txfm_16x16_rounding_avx512(out, -shift[1]);
+        transpose_16x16_avx512(1, out, in);
+        fadst16x16_avx512(in, out, fwd_cos_bit_row[txw_idx][txh_idx], col_num);
+        transpose_16x16_avx512(1, out, in);
+        write_buffer_16x16(in, coeff);
+        break;
+    case ADST_FLIPADST:
+        load_buffer_16x16_avx512(input, in, stride, 0, 1, shift[0]);
+        fadst16x16_avx512(in, out, fwd_cos_bit_col[txw_idx][txh_idx], col_num);
+        col_txfm_16x16_rounding_avx512(out, -shift[1]);
+        transpose_16x16_avx512(1, out, in);
+        fadst16x16_avx512(in, out, fwd_cos_bit_row[txw_idx][txh_idx], col_num);
+        transpose_16x16_avx512(1, out, in);
+        write_buffer_16x16(in, coeff);
+        break;
+    case FLIPADST_ADST:
+        load_buffer_16x16_avx512(input, in, stride, 1, 0, shift[0]);
+        fadst16x16_avx512(in, out, fwd_cos_bit_col[txw_idx][txh_idx], col_num);
+        col_txfm_16x16_rounding_avx512(out, -shift[1]);
+        transpose_16x16_avx512(1, out, in);
+        fadst16x16_avx512(in, out, fwd_cos_bit_row[txw_idx][txh_idx], col_num);
+        transpose_16x16_avx512(1, out, in);
+        write_buffer_16x16(in, coeff);
+        break;
+    case V_DCT:
+        load_buffer_16x16_avx512(input, in, stride, 0, 0, shift[0]);
+        fdct16x16_avx512(in, out, fwd_cos_bit_col[txw_idx][txh_idx], col_num);
+        col_txfm_16x16_rounding_avx512(out, -shift[1]);
+        fidtx16x16_avx512(out, out, fwd_cos_bit_row[txw_idx][txh_idx], col_num);
+        write_buffer_16x16(out, coeff);
+        break;
+    case H_DCT:
+        load_buffer_16x16_avx512(input, in, stride, 0, 0, shift[0]);
+        fidtx16x16_avx512(in, in, fwd_cos_bit_col[txw_idx][txh_idx], col_num);
+        col_txfm_16x16_rounding_avx512(in, -shift[1]);
+        transpose_16x16_avx512(1, in, out);
+        fdct16x16_avx512(out, in, fwd_cos_bit_row[txw_idx][txh_idx], col_num);
+        transpose_16x16_avx512(1, in, out);
+        write_buffer_16x16(out, coeff);
+        break;
+    case V_ADST:
+        load_buffer_16x16_avx512(input, in, stride, 0, 0, shift[0]);
+        fadst16x16_avx512(in, out, fwd_cos_bit_col[txw_idx][txh_idx], col_num);
+        col_txfm_16x16_rounding_avx512(out, -shift[1]);
+        fidtx16x16_avx512(out, out, fwd_cos_bit_row[txw_idx][txh_idx], col_num);
+        write_buffer_16x16(out, coeff);
+        break;
+    case H_ADST:
+        load_buffer_16x16_avx512(input, in, stride, 0, 0, shift[0]);
+        fidtx16x16_avx512(in, in, fwd_cos_bit_col[txw_idx][txh_idx], col_num);
+        col_txfm_16x16_rounding_avx512(in, -shift[1]);
+        transpose_16x16_avx512(1, in, out);
+        fadst16x16_avx512(out, in, fwd_cos_bit_row[txw_idx][txh_idx], col_num);
+        transpose_16x16_avx512(1, in, out);
+        write_buffer_16x16(out, coeff);
+        break;
+    case V_FLIPADST:
+        load_buffer_16x16_avx512(input, in, stride, 1, 0, shift[0]);
+        fadst16x16_avx512(in, out, fwd_cos_bit_col[txw_idx][txh_idx], col_num);
+        col_txfm_16x16_rounding_avx512(out, -shift[1]);
+        fidtx16x16_avx512(out, out, fwd_cos_bit_row[txw_idx][txh_idx], col_num);
+        write_buffer_16x16(out, coeff);
+        break;
+    case H_FLIPADST:
+        load_buffer_16x16_avx512(input, in, stride, 0, 1, shift[0]);
+        fidtx16x16_avx512(in, in, fwd_cos_bit_col[txw_idx][txh_idx], col_num);
+        col_txfm_16x16_rounding_avx512(in, -shift[1]);
+        transpose_16x16_avx512(1, in, out);
+        fadst16x16_avx512(out, in, fwd_cos_bit_row[txw_idx][txh_idx], col_num);
+        transpose_16x16_avx512(1, in, out);
+        write_buffer_16x16(out, coeff);
+        break;
+    default: assert(0);
+    }
+    (void)bd;
+
+}
+

--- a/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
@@ -1423,7 +1423,7 @@ static INLINE void fwd_txfm2d_32x32_avx512(const int16_t *input, int32_t *output
 void av1_fwd_txfm2d_32x32_avx512(int16_t *input, int32_t *output,
     uint32_t stride, TxType tx_type, uint8_t  bd)
 {
-    DECLARE_ALIGNED(32, int32_t, txfm_buf[1024]);
+    DECLARE_ALIGNED(64, int32_t, txfm_buf[1024]);
     Txfm2DFlipCfg cfg;
     Av1TransformConfig(tx_type, TX_32X32, &cfg);
     (void)bd;

--- a/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
@@ -788,8 +788,7 @@ static void fdct16x16_avx512(const __m512i *in, __m512i *out, int8_t bit, const 
     }
 }
 
-void av1_fwd_txfm2d_16x16_avx512(int16_t *input, int32_t *coeff, uint32_t stride, TxType tx_type, uint8_t  bd)
-{
+void av1_fwd_txfm2d_16x16_avx512(int16_t *input, int32_t *coeff, uint32_t stride, TxType tx_type, uint8_t  bd) {
     __m512i in[16], out[16];
     const int8_t *shift = fwd_txfm_shift_ls[TX_16X16];
     const int32_t txw_idx = get_txw_idx(TX_16X16);
@@ -1424,8 +1423,7 @@ static INLINE void fwd_txfm2d_32x32_avx512(const int16_t *input, int32_t *output
 }
 
 void av1_fwd_txfm2d_32x32_avx512(int16_t *input, int32_t *output,
-    uint32_t stride, TxType tx_type, uint8_t  bd)
-{
+    uint32_t stride, TxType tx_type, uint8_t  bd) {
     DECLARE_ALIGNED(64, int32_t, txfm_buf[1024]);
     Txfm2DFlipCfg cfg;
     Av1TransformConfig(tx_type, TX_32X32, &cfg);
@@ -2524,8 +2522,7 @@ static INLINE void av1_round_shift_rect_array_32_avx512(__m512i *input,
     }
 }
 
-void av1_fwd_txfm2d_32x64_avx512(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
-{
+void av1_fwd_txfm2d_32x64_avx512(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd) {
     (void)tx_type;
     __m512i in[128];
     __m512i *outcoef512 = (__m512i *)output;
@@ -2556,8 +2553,7 @@ void av1_fwd_txfm2d_32x64_avx512(int16_t *input, int32_t *output, uint32_t strid
     (void)bd;
 }
 
-void av1_fwd_txfm2d_64x32_avx512(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
-{
+void av1_fwd_txfm2d_64x32_avx512(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd) {
     (void)tx_type;
     __m512i in[128];
     __m512i *outcoef512 = (__m512i *)output;
@@ -2593,8 +2589,7 @@ void av1_fwd_txfm2d_64x32_avx512(int16_t *input, int32_t *output, uint32_t strid
     (void)bd;
 }
 
-void av1_fwd_txfm2d_16x64_avx512(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
-{
+void av1_fwd_txfm2d_16x64_avx512(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd) {
     __m512i in[64];
     __m512i *outcoeff512 = (__m512i *)output;
     const int8_t *shift = fwd_txfm_shift_ls[TX_16X64];
@@ -2626,8 +2621,7 @@ void av1_fwd_txfm2d_16x64_avx512(int16_t *input, int32_t *output, uint32_t strid
     (void)bd;
 }
 
-void av1_fwd_txfm2d_64x16_avx512(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
-{
+void av1_fwd_txfm2d_64x16_avx512(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd) {
     __m512i in[64];
     __m512i *outcoeff512 = (__m512i *)output;
     const int8_t *shift = fwd_txfm_shift_ls[TX_64X16];
@@ -2707,8 +2701,7 @@ static const fwd_transform_1d_avx512 row_fwdtxfm_16x32_arr[TX_TYPES] = {
 };
 
 /* call this function only for DCT_DCT, IDTX */
-void av1_fwd_txfm2d_16x32_avx512(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
-{
+void av1_fwd_txfm2d_16x32_avx512(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd) {
     __m512i in[32];
     __m512i *outcoef512 = (__m512i *)output;
     const int8_t *shift = fwd_txfm_shift_ls[TX_16X32];
@@ -2741,8 +2734,7 @@ void av1_fwd_txfm2d_16x32_avx512(int16_t *input, int32_t *output, uint32_t strid
 }
 
 /* call this function only for DCT_DCT, IDTX */
-void av1_fwd_txfm2d_32x16_avx512(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd)
-{
+void av1_fwd_txfm2d_32x16_avx512(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd) {
     __m512i in[32];
     __m512i *outcoef512 = (__m512i *)output;
     const int8_t *shift = fwd_txfm_shift_ls[TX_32X16];

--- a/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
 #include <assert.h>
 #include "EbDefinitions.h"
 #include "aom_dsp_rtcd.h"

--- a/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
@@ -1330,7 +1330,6 @@ static INLINE void fdct32x32_avx512(const __m512i *input, __m512i *output,
     const int32_t txfm_size = 32;
     const int32_t num_per_512 = 16;
     int32_t col_num = txfm_size / num_per_512;
-    int32_t col;
     (void)stage_range;
     av1_fdct32_new_avx512(input, output, cos_bit, txfm_size, col_num);
 }
@@ -1392,7 +1391,7 @@ static INLINE void av1_round_shift_array_avx512(__m512i *input,
         for (i = 0; i < size; i++) {
             output[i] = _mm512_srai_epi32(
                 _mm512_add_epi32(input[i], round), (uint8_t)bit);
-
+        }
     }
     else {
         int32_t i;

--- a/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/highbd_fwd_txfm_AVX512.c
@@ -2628,6 +2628,7 @@ void av1_fwd_txfm2d_16x64_avx512(int16_t *input, int32_t *output, uint32_t strid
     fdct16x16_avx512(in, in, bitrow, num_row);
     transpose_16nx16m_avx512(in, outcoeff512, txfm_size_row, txfm_size_col);
     (void)bd;
+    (void)tx_type;
 }
 
 void av1_fwd_txfm2d_64x16_avx512(int16_t *input, int32_t *output, uint32_t stride, TxType tx_type, uint8_t  bd) {
@@ -2664,6 +2665,7 @@ void av1_fwd_txfm2d_64x16_avx512(int16_t *input, int32_t *output, uint32_t strid
     av1_fdct64_new_avx512(in, in, bitrow, txfm_size_row, num_row);
     transpose_16nx16m_avx512(in, outcoeff512, txfm_size_row, txfm_size_col);
     (void)bd;
+    (void)tx_type;
 }
 
 static void av1_fdct32_new_line_wraper_avx512(const __m512i *input,

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -2218,7 +2218,7 @@ extern    uint32_t                   lib_mutex_count;
 
 extern    uint32_t                   app_malloc_count;
 
-#define ALVALUE 32
+#define ALVALUE 64
 
 #define EB_ADD_APP_MEM(pointer, size, pointer_class, count, release, return_type) \
     do { \
@@ -2243,7 +2243,7 @@ extern    uint32_t                   app_malloc_count;
     pointer = (type)malloc(n_elements); \
     EB_ADD_APP_MEM(pointer, n_elements, pointer_class, app_malloc_count, return_type);
 
-#define ALVALUE 32
+#define ALVALUE 64
 
 #define EB_CREATE_SEMAPHORE(pointer, initial_count, max_count) \
     do { \

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -40,7 +40,7 @@ extern "C" {
 #endif
 
 // Internal Marcos
-//#define NON_AVX512_SUPPORT
+#define NON_AVX512_SUPPORT
 
 #define INCOMPLETE_SB_FIX                 1 // Handle the incomplete SBs properly based on the standard and consider all allowed blocks
 #define QPS_TUNING                        1 // Tune the QPS algorithm to consider ALR_REF filtering and movement of the pictures

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -40,7 +40,7 @@ extern "C" {
 #endif
 
 // Internal Marcos
-#define NON_AVX512_SUPPORT
+//#define NON_AVX512_SUPPORT
 
 #define INCOMPLETE_SB_FIX                 1 // Handle the incomplete SBs properly based on the standard and consider all allowed blocks
 #define QPS_TUNING                        1 // Tune the QPS algorithm to consider ALR_REF filtering and movement of the pictures

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -199,6 +199,7 @@ extern "C" {
 
     void eb_av1_fwd_txfm2d_32x16_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     void eb_av1_fwd_txfm2d_32x16_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void av1_fwd_txfm2d_32x16_avx512(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     RTCD_EXTERN void(*eb_av1_fwd_txfm2d_32x16)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
     void eb_av1_fwd_txfm2d_32x8_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
@@ -211,6 +212,7 @@ extern "C" {
 
     void eb_av1_fwd_txfm2d_16x32_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     void eb_av1_fwd_txfm2d_16x32_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void av1_fwd_txfm2d_16x32_avx512(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     RTCD_EXTERN void(*eb_av1_fwd_txfm2d_16x32)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
     void eb_av1_fwd_txfm2d_32x64_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
@@ -3230,13 +3232,11 @@ extern "C" {
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_4x8 = eb_av1_fwd_txfm2d_4x8_avx2;
 
         eb_av1_fwd_txfm2d_32x16 = eb_av1_fwd_txfm2d_32x16_c;
-        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x16 = eb_av1_fwd_txfm2d_32x16_avx2;
         eb_av1_fwd_txfm2d_32x8 = eb_av1_fwd_txfm2d_32x8_c;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x8 = eb_av1_fwd_txfm2d_32x8_avx2;
         eb_av1_fwd_txfm2d_8x32 = eb_av1_fwd_txfm2d_8x32_c;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_8x32 = eb_av1_fwd_txfm2d_8x32_avx2;
         eb_av1_fwd_txfm2d_16x32 = eb_av1_fwd_txfm2d_16x32_c;
-        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x32 = eb_av1_fwd_txfm2d_16x32_avx2;
         eb_av1_fwd_txfm2d_32x64 = eb_av1_fwd_txfm2d_32x64_c;
         eb_av1_fwd_txfm2d_64x32 = eb_av1_fwd_txfm2d_64x32_c;
         eb_av1_fwd_txfm2d_16x64 = eb_av1_fwd_txfm2d_16x64_c;
@@ -3252,6 +3252,8 @@ extern "C" {
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x32 = av1_fwd_txfm2d_64x32_avx512;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x64 = av1_fwd_txfm2d_16x64_avx512;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x16 = av1_fwd_txfm2d_64x16_avx512;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x16 = av1_fwd_txfm2d_32x16_avx512;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x32 = av1_fwd_txfm2d_16x32_avx512;
 #else
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x64 = eb_av1_fwd_txfm2d_64x64_avx2;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x32 = eb_av1_fwd_txfm2d_32x32_avx2;
@@ -3260,6 +3262,8 @@ extern "C" {
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x32 = eb_av1_fwd_txfm2d_64x32_avx2;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x64 = eb_av1_fwd_txfm2d_16x64_avx2;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x16 = eb_av1_fwd_txfm2d_64x16_avx2;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x16 = eb_av1_fwd_txfm2d_32x16_avx2;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x32 = eb_av1_fwd_txfm2d_16x32_avx2;
 #endif       
         eb_av1_fwd_txfm2d_8x8 = Av1TransformTwoD_8x8_c;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_8x8 = eb_av1_fwd_txfm2d_8x8_avx2;

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -215,18 +215,22 @@ extern "C" {
 
     void eb_av1_fwd_txfm2d_32x64_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     void eb_av1_fwd_txfm2d_32x64_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void av1_fwd_txfm2d_32x64_avx512(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     RTCD_EXTERN void(*eb_av1_fwd_txfm2d_32x64)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
     void eb_av1_fwd_txfm2d_64x32_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     void eb_av1_fwd_txfm2d_64x32_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void av1_fwd_txfm2d_64x32_avx512(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     RTCD_EXTERN void(*eb_av1_fwd_txfm2d_64x32)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
     void eb_av1_fwd_txfm2d_16x64_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     void eb_av1_fwd_txfm2d_16x64_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void av1_fwd_txfm2d_16x64_avx512(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     RTCD_EXTERN void(*eb_av1_fwd_txfm2d_16x64)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
     void eb_av1_fwd_txfm2d_64x16_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     void eb_av1_fwd_txfm2d_64x16_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void av1_fwd_txfm2d_64x16_avx512(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     RTCD_EXTERN void(*eb_av1_fwd_txfm2d_64x16)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
     void Av1TransformTwoD_64x64_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
@@ -3234,13 +3238,9 @@ extern "C" {
         eb_av1_fwd_txfm2d_16x32 = eb_av1_fwd_txfm2d_16x32_c;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x32 = eb_av1_fwd_txfm2d_16x32_avx2;
         eb_av1_fwd_txfm2d_32x64 = eb_av1_fwd_txfm2d_32x64_c;
-        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x64 = eb_av1_fwd_txfm2d_32x64_avx2;
         eb_av1_fwd_txfm2d_64x32 = eb_av1_fwd_txfm2d_64x32_c;
-        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x32 = eb_av1_fwd_txfm2d_64x32_avx2;
         eb_av1_fwd_txfm2d_16x64 = eb_av1_fwd_txfm2d_16x64_c;
-        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x64 = eb_av1_fwd_txfm2d_16x64_avx2;
         eb_av1_fwd_txfm2d_64x16 = eb_av1_fwd_txfm2d_64x16_c;
-        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x16 = eb_av1_fwd_txfm2d_64x16_avx2;
         eb_av1_fwd_txfm2d_64x64 = Av1TransformTwoD_64x64_c;
         eb_av1_fwd_txfm2d_32x32 = Av1TransformTwoD_32x32_c;
         eb_av1_fwd_txfm2d_16x16 = Av1TransformTwoD_16x16_c;
@@ -3248,10 +3248,18 @@ extern "C" {
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x64 = av1_fwd_txfm2d_64x64_avx512;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x32 = av1_fwd_txfm2d_32x32_avx512;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x16 = av1_fwd_txfm2d_16x16_avx512;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x64 = av1_fwd_txfm2d_32x64_avx512;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x32 = av1_fwd_txfm2d_64x32_avx512;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x64 = av1_fwd_txfm2d_16x64_avx512;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x16 = av1_fwd_txfm2d_64x16_avx512;
 #else
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x64 = eb_av1_fwd_txfm2d_64x64_avx2;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x32 = eb_av1_fwd_txfm2d_32x32_avx2;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x16 = eb_av1_fwd_txfm2d_16x16_avx2;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x64 = eb_av1_fwd_txfm2d_32x64_avx2;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x32 = eb_av1_fwd_txfm2d_64x32_avx2;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x64 = eb_av1_fwd_txfm2d_16x64_avx2;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x16 = eb_av1_fwd_txfm2d_64x16_avx2;
 #endif       
         eb_av1_fwd_txfm2d_8x8 = Av1TransformTwoD_8x8_c;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_8x8 = eb_av1_fwd_txfm2d_8x8_avx2;

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -3264,7 +3264,7 @@ extern "C" {
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x16 = eb_av1_fwd_txfm2d_64x16_avx2;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x16 = eb_av1_fwd_txfm2d_32x16_avx2;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x32 = eb_av1_fwd_txfm2d_16x32_avx2;
-#endif       
+#endif
         eb_av1_fwd_txfm2d_8x8 = Av1TransformTwoD_8x8_c;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_8x8 = eb_av1_fwd_txfm2d_8x8_avx2;
         eb_av1_fwd_txfm2d_4x4 = Av1TransformTwoD_4x4_c;

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -3245,8 +3245,8 @@ extern "C" {
         eb_av1_fwd_txfm2d_32x32 = Av1TransformTwoD_32x32_c;
         eb_av1_fwd_txfm2d_16x16 = Av1TransformTwoD_16x16_c;
 #ifndef NON_AVX512_SUPPORT
-        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x64 = eb_av1_fwd_txfm2d_64x64_avx2;
-        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x32 = eb_av1_fwd_txfm2d_32x32_avx2;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x64 = av1_fwd_txfm2d_64x64_avx512;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x32 = av1_fwd_txfm2d_32x32_avx512;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x16 = av1_fwd_txfm2d_16x16_avx512;
 #else
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x64 = eb_av1_fwd_txfm2d_64x64_avx2;

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -235,6 +235,7 @@ extern "C" {
 
     void Av1TransformTwoD_32x32_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     void eb_av1_fwd_txfm2d_32x32_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void av1_fwd_txfm2d_32x32_avx512(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     RTCD_EXTERN void(*eb_av1_fwd_txfm2d_32x32)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
     void eb_av1_fwd_txfm2d_pf_32x32_c(int16_t *input, int32_t *output, uint32_t inputStride, TxType transform_type, uint8_t  bit_depth);
@@ -3242,11 +3243,12 @@ extern "C" {
         eb_av1_fwd_txfm2d_64x64 = Av1TransformTwoD_64x64_c;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x64 = eb_av1_fwd_txfm2d_64x64_avx2;
         eb_av1_fwd_txfm2d_32x32 = Av1TransformTwoD_32x32_c;
-        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x32 = eb_av1_fwd_txfm2d_32x32_avx2;
         eb_av1_fwd_txfm2d_16x16 = Av1TransformTwoD_16x16_c;
 #ifndef NON_AVX512_SUPPORT
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x32 = av1_fwd_txfm2d_32x32_avx512;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x16 = av1_fwd_txfm2d_16x16_avx512;
 #else
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x32 = eb_av1_fwd_txfm2d_32x32_avx2;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x16 = eb_av1_fwd_txfm2d_16x16_avx2;
 #endif       
         eb_av1_fwd_txfm2d_8x8 = Av1TransformTwoD_8x8_c;

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -231,6 +231,7 @@ extern "C" {
 
     void Av1TransformTwoD_64x64_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     void eb_av1_fwd_txfm2d_64x64_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void av1_fwd_txfm2d_64x64_avx512(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     RTCD_EXTERN void(*eb_av1_fwd_txfm2d_64x64)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
     void Av1TransformTwoD_32x32_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
@@ -3241,13 +3242,14 @@ extern "C" {
         eb_av1_fwd_txfm2d_64x16 = eb_av1_fwd_txfm2d_64x16_c;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x16 = eb_av1_fwd_txfm2d_64x16_avx2;
         eb_av1_fwd_txfm2d_64x64 = Av1TransformTwoD_64x64_c;
-        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x64 = eb_av1_fwd_txfm2d_64x64_avx2;
         eb_av1_fwd_txfm2d_32x32 = Av1TransformTwoD_32x32_c;
         eb_av1_fwd_txfm2d_16x16 = Av1TransformTwoD_16x16_c;
 #ifndef NON_AVX512_SUPPORT
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x64 = av1_fwd_txfm2d_64x64_avx512;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x32 = av1_fwd_txfm2d_32x32_avx512;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x16 = av1_fwd_txfm2d_16x16_avx512;
 #else
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x64 = eb_av1_fwd_txfm2d_64x64_avx2;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x32 = eb_av1_fwd_txfm2d_32x32_avx2;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x16 = eb_av1_fwd_txfm2d_16x16_avx2;
 #endif       

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -243,6 +243,7 @@ extern "C" {
 
     void Av1TransformTwoD_16x16_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     void eb_av1_fwd_txfm2d_16x16_avx2(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
+    void av1_fwd_txfm2d_16x16_avx512(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
     RTCD_EXTERN void(*eb_av1_fwd_txfm2d_16x16)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 
     void Av1TransformTwoD_8x8_c(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
@@ -3243,7 +3244,11 @@ extern "C" {
         eb_av1_fwd_txfm2d_32x32 = Av1TransformTwoD_32x32_c;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x32 = eb_av1_fwd_txfm2d_32x32_avx2;
         eb_av1_fwd_txfm2d_16x16 = Av1TransformTwoD_16x16_c;
+#ifndef NON_AVX512_SUPPORT
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x16 = av1_fwd_txfm2d_16x16_avx512;
+#else
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x16 = eb_av1_fwd_txfm2d_16x16_avx2;
+#endif       
         eb_av1_fwd_txfm2d_8x8 = Av1TransformTwoD_8x8_c;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_8x8 = eb_av1_fwd_txfm2d_8x8_avx2;
         eb_av1_fwd_txfm2d_4x4 = Av1TransformTwoD_4x4_c;

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -3245,8 +3245,8 @@ extern "C" {
         eb_av1_fwd_txfm2d_32x32 = Av1TransformTwoD_32x32_c;
         eb_av1_fwd_txfm2d_16x16 = Av1TransformTwoD_16x16_c;
 #ifndef NON_AVX512_SUPPORT
-        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x64 = av1_fwd_txfm2d_64x64_avx512;
-        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x32 = av1_fwd_txfm2d_32x32_avx512;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x64 = eb_av1_fwd_txfm2d_64x64_avx2;
+        if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x32 = eb_av1_fwd_txfm2d_32x32_avx2;
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x16 = av1_fwd_txfm2d_16x16_avx512;
 #else
         if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x64 = eb_av1_fwd_txfm2d_64x64_avx2;

--- a/test/EbUnitTest.h
+++ b/test/EbUnitTest.h
@@ -23,4 +23,18 @@ extern const char eb_unit_test_result_str[2][25];
 }
 #endif
 
-#endif  // EbUnitTest_h
+#ifdef _MSC_VER
+#define TEST_ALLIGN_MALLOC(type, pointer, n_elements) \
+pointer = (type) _aligned_malloc(n_elements, ALVALUE); \
+
+#define TEST_ALLIGN_FREE(pointer) _aligned_free(pointer);
+
+#else
+#define TEST_ALLIGN_MALLOC(type, pointer, n_elements) \
+posix_memalign((void**)(&(pointer)), ALVALUE, n_elements); \
+
+#define TEST_ALLIGN_FREE(pointer) free(pointer);
+
+#endif
+
+#endif // EbUnitTest_h

--- a/test/EbUnitTest.h
+++ b/test/EbUnitTest.h
@@ -23,7 +23,7 @@ extern const char eb_unit_test_result_str[2][25];
 }
 #endif
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #define TEST_ALLIGN_MALLOC(type, pointer, n_elements) \
 pointer = (type) _aligned_malloc(n_elements, ALVALUE); \
 

--- a/test/ForwardtransformTests.cc
+++ b/test/ForwardtransformTests.cc
@@ -7,6 +7,8 @@
 #include "EbUnitTest.h"
 #include <immintrin.h>
 
+#ifndef NON_AVX512_SUPPORT
+
 typedef void(*av1_frwd_txfm_func)(int16_t *input, int32_t *coeff, uint32_t stride, TxType tx_type, uint8_t bitDepth);
 av1_frwd_txfm_func av1_frwd_txfm_func_ptr_array_base[9] = { av1_fwd_txfm2d_16x16_avx2, av1_fwd_txfm2d_32x32_avx2 , av1_fwd_txfm2d_64x64_avx2 , av1_fwd_txfm2d_16x64_avx2, av1_fwd_txfm2d_64x16_avx2 , av1_fwd_txfm2d_32x64_avx2 , av1_fwd_txfm2d_64x32_avx2 , av1_fwd_txfm2d_16x32_avx2 , av1_fwd_txfm2d_32x16_avx2 };
 av1_frwd_txfm_func av1_frwd_txfm_func_ptr_array_opt[9] = { av1_fwd_txfm2d_16x16_avx512, av1_fwd_txfm2d_32x32_avx512, av1_fwd_txfm2d_64x64_avx512 , av1_fwd_txfm2d_16x64_avx512, av1_fwd_txfm2d_64x16_avx512 , av1_fwd_txfm2d_32x64_avx512 , av1_fwd_txfm2d_64x32_avx512 , av1_fwd_txfm2d_16x32_avx512 , av1_fwd_txfm2d_32x16_avx512 };
@@ -163,3 +165,4 @@ TEST(ForwardTransformTest, av1_frwd_txfm_kernels)
     }
     uninit_coeff(coeff, coeff_opt);
 }
+#endif

--- a/test/ForwardtransformTests.cc
+++ b/test/ForwardtransformTests.cc
@@ -7,11 +7,11 @@
 #include <immintrin.h>
 
 typedef void(*av1_frwd_txfm_func)(int16_t *input, int32_t *coeff, uint32_t stride, TxType tx_type, uint8_t bitDepth);
-av1_frwd_txfm_func av1_frwd_txfm_func_ptr_array_base[3] = { av1_fwd_txfm2d_16x16_avx2, av1_fwd_txfm2d_32x32_avx2 , av1_fwd_txfm2d_64x64_avx2 };
-av1_frwd_txfm_func av1_frwd_txfm_func_ptr_array_opt[3] = { av1_fwd_txfm2d_16x16_avx512, av1_fwd_txfm2d_32x32_avx512, av1_fwd_txfm2d_64x64_avx512 };
+av1_frwd_txfm_func av1_frwd_txfm_func_ptr_array_base[9] = { av1_fwd_txfm2d_16x16_avx2, av1_fwd_txfm2d_32x32_avx2 , av1_fwd_txfm2d_64x64_avx2 , av1_fwd_txfm2d_16x64_avx2, av1_fwd_txfm2d_64x16_avx2 , av1_fwd_txfm2d_32x64_avx2 , av1_fwd_txfm2d_64x32_avx2 , av1_fwd_txfm2d_16x32_avx2 , av1_fwd_txfm2d_32x16_avx2 };
+av1_frwd_txfm_func av1_frwd_txfm_func_ptr_array_opt[9] = { av1_fwd_txfm2d_16x16_avx512, av1_fwd_txfm2d_32x32_avx512, av1_fwd_txfm2d_64x64_avx512 , av1_fwd_txfm2d_16x64_avx512, av1_fwd_txfm2d_64x16_avx512 , av1_fwd_txfm2d_32x64_avx512 , av1_fwd_txfm2d_64x32_avx512 , av1_fwd_txfm2d_16x32_avx512 , av1_fwd_txfm2d_32x16_avx512 };
 int tx_16[] = { 0 , 1 , 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 int tx_32[] = { 0 , 9 };
-int tx_64[] = { 0 };
+int tx_64[] = { 0 , 9 };
 int bitDepth[] = { 8, 10, 12 };
 
 static void init_data(int16_t **input, int16_t **input_opt, uint32_t input_stride) {
@@ -39,14 +39,14 @@ static void init_coeff(int32_t **coeff, int32_t **coeff_opt, uint32_t *stride) {
     *coeff_opt = (int32_t*)malloc(sizeof(**coeff_opt) * MAX_SB_SIZE * *stride);
 }
 
-TEST(ForwardTransformTest, av1_frwd_txfm_square_kernels)
+TEST(ForwardTransformTest, av1_frwd_txfm_kernels)
 {
     int16_t *input, *input_opt;
     int32_t* coeff, *coeff_opt;
     uint32_t stride;
     init_coeff(&coeff, &coeff_opt, &stride);
     ASSERT(eb_buf_compare_s32(coeff, coeff_opt, MAX_SB_SIZE * stride) == 1);
-    for (int loop = 0; loop < 3; loop++) {         //Function Pairs
+    for (int loop = 0; loop < 9; loop++) {         //Function Pairs
         for (int i = 0; i < 10; i++) {             //Number of Test Runs
             for (int x = 0; x < AOM_BITS_12; x++) {//Bit Depth
                 switch (loop) {
@@ -56,9 +56,7 @@ TEST(ForwardTransformTest, av1_frwd_txfm_square_kernels)
                         ASSERT(eb_buf_compare_s16(input, input_opt, MAX_SB_SIZE * stride) == 1);
                         av1_frwd_txfm_func_ptr_array_base[loop](input,coeff,stride, (TxType)tx_16[j], bitDepth[x]);
                         av1_frwd_txfm_func_ptr_array_opt[loop](input_opt, coeff_opt, stride, (TxType)tx_16[j], bitDepth[x]);
-                        for (int idx = 0; idx < 16; idx++) {
-                            EXPECT_EQ(coeff[idx], coeff_opt[idx]);
-                        }
+                        EXPECT_EQ(eb_buf_compare_s32(coeff, coeff_opt, MAX_SB_SIZE * stride), 1);
                         uninit_data(input, input_opt);
                     }
                 break;
@@ -68,9 +66,7 @@ TEST(ForwardTransformTest, av1_frwd_txfm_square_kernels)
                         ASSERT(eb_buf_compare_s16(input, input_opt, MAX_SB_SIZE * stride) == 1);
                         av1_frwd_txfm_func_ptr_array_base[loop](input, coeff, stride, (TxType)tx_32[j], bitDepth[x]);
                         av1_frwd_txfm_func_ptr_array_opt[loop](input_opt, coeff_opt, stride, (TxType)tx_32[j], bitDepth[x]);
-                        for (int idx = 0; idx < 16; idx++) {
-                            EXPECT_EQ(coeff[idx], coeff_opt[idx]);
-                        }
+                        EXPECT_EQ(eb_buf_compare_s32(coeff, coeff_opt, MAX_SB_SIZE * stride), 1);
                         uninit_data(input, input_opt);
                     }
                 break;
@@ -80,12 +76,70 @@ TEST(ForwardTransformTest, av1_frwd_txfm_square_kernels)
                         ASSERT(eb_buf_compare_s16(input, input_opt, MAX_SB_SIZE * stride) == 1);
                         av1_frwd_txfm_func_ptr_array_base[loop](input, coeff, stride, (TxType)tx_64[j], bitDepth[x]);
                         av1_frwd_txfm_func_ptr_array_opt[loop](input_opt, coeff_opt, stride, (TxType)tx_64[j], bitDepth[x]);
-                        for (int idx = 0; idx < 16; idx++) {
-                            EXPECT_EQ(coeff[idx], coeff_opt[idx]);
-                        }
+                        EXPECT_EQ(eb_buf_compare_s32(coeff, coeff_opt, MAX_SB_SIZE * stride), 1);
                         uninit_data(input, input_opt);
                     }
                 break;
+                case 3://16x64
+                    for (int j = 0; j < 1; j++) {
+                        init_data(&input, &input_opt, stride);
+                        ASSERT(eb_buf_compare_s16(input, input_opt, MAX_SB_SIZE * stride) == 1);
+                        av1_frwd_txfm_func_ptr_array_base[loop](input, coeff, stride, (TxType)tx_64[j], bitDepth[x]);
+                        av1_frwd_txfm_func_ptr_array_opt[loop](input_opt, coeff_opt, stride, (TxType)tx_64[j], bitDepth[x]);
+                        EXPECT_EQ(eb_buf_compare_s32(coeff, coeff_opt, MAX_SB_SIZE * stride), 1);
+                        uninit_data(input, input_opt);
+                    }
+                    break;
+                case 4://64x16
+                    for (int j = 0; j < 1; j++) {
+                        init_data(&input, &input_opt, stride);
+                        ASSERT(eb_buf_compare_s16(input, input_opt, MAX_SB_SIZE * stride) == 1);
+                        av1_frwd_txfm_func_ptr_array_base[loop](input, coeff, stride, (TxType)tx_64[j], bitDepth[x]);
+                        av1_frwd_txfm_func_ptr_array_opt[loop](input_opt, coeff_opt, stride, (TxType)tx_64[j], bitDepth[x]);
+                        EXPECT_EQ(eb_buf_compare_s32(coeff, coeff_opt, MAX_SB_SIZE * stride), 1);
+                        uninit_data(input, input_opt);
+                    }
+                    break;
+                case 5://32x64
+                    for (int j = 0; j < 1; j++) {
+                        init_data(&input, &input_opt, stride);
+                        ASSERT(eb_buf_compare_s16(input, input_opt, MAX_SB_SIZE * stride) == 1);
+                        av1_frwd_txfm_func_ptr_array_base[loop](input, coeff, stride, (TxType)tx_64[j], bitDepth[x]);
+                        av1_frwd_txfm_func_ptr_array_opt[loop](input_opt, coeff_opt, stride, (TxType)tx_64[j], bitDepth[x]);
+                        EXPECT_EQ(eb_buf_compare_s32(coeff, coeff_opt, MAX_SB_SIZE * stride), 1);
+                        uninit_data(input, input_opt);
+                    }
+                    break;
+                case 6://64x32
+                    for (int j = 0; j < 1; j++) {
+                        init_data(&input, &input_opt, stride);
+                        ASSERT(eb_buf_compare_s16(input, input_opt, MAX_SB_SIZE * stride) == 1);
+                        av1_frwd_txfm_func_ptr_array_base[loop](input, coeff, stride, (TxType)tx_64[j], bitDepth[x]);
+                        av1_frwd_txfm_func_ptr_array_opt[loop](input_opt, coeff_opt, stride, (TxType)tx_64[j], bitDepth[x]);
+                        EXPECT_EQ(eb_buf_compare_s32(coeff, coeff_opt, MAX_SB_SIZE * stride), 1);
+                        uninit_data(input, input_opt);
+                    }
+                    break;
+                case 7://16x32
+                    for (int j = 0; j < 2; j++) {
+                        init_data(&input, &input_opt, stride);
+                        ASSERT(eb_buf_compare_s16(input, input_opt, MAX_SB_SIZE * stride) == 1);
+                        av1_frwd_txfm_func_ptr_array_base[loop](input, coeff, stride, (TxType)tx_32[j], bitDepth[x]);
+                        av1_frwd_txfm_func_ptr_array_opt[loop](input_opt, coeff_opt, stride, (TxType)tx_32[j], bitDepth[x]);
+                        EXPECT_EQ(eb_buf_compare_s32(coeff, coeff_opt, MAX_SB_SIZE * stride), 1);
+                        uninit_data(input, input_opt);
+                    }
+                    break;
+                case 8://32x16
+                    for (int j = 0; j < 2; j++) {
+                        init_data(&input, &input_opt, stride);
+                        ASSERT(eb_buf_compare_s16(input, input_opt, MAX_SB_SIZE * stride) == 1);
+                        av1_frwd_txfm_func_ptr_array_base[loop](input, coeff, stride, (TxType)tx_32[j], bitDepth[x]);
+                        av1_frwd_txfm_func_ptr_array_opt[loop](input_opt, coeff_opt, stride, (TxType)tx_32[j], bitDepth[x]);
+                        EXPECT_EQ(eb_buf_compare_s32(coeff, coeff_opt, MAX_SB_SIZE * stride), 1);
+                        uninit_data(input, input_opt);
+                    }
+                    break;
                 default:
                     ASSERT(0);
                 }

--- a/test/ForwardtransformTests.cc
+++ b/test/ForwardtransformTests.cc
@@ -14,8 +14,7 @@ int tx_32[] = { 0 , 9 };
 int tx_64[] = { 0 };
 int bitDepth[] = { 8, 10, 12 };
 
-static void init_data(int16_t **input, int16_t **input_opt, uint32_t input_stride)
-{
+static void init_data(int16_t **input, int16_t **input_opt, uint32_t input_stride) {
     *input = (int16_t*)malloc(sizeof(**input) * MAX_SB_SIZE * input_stride);
     *input_opt = (int16_t*)malloc(sizeof(**input_opt) * MAX_SB_SIZE * input_stride);
     memset(*input, 0, MAX_SB_SIZE * input_stride);
@@ -24,20 +23,17 @@ static void init_data(int16_t **input, int16_t **input_opt, uint32_t input_strid
     memcpy(*input_opt, *input, sizeof(**input) * MAX_SB_SIZE * input_stride);
 }
 
-static void uninit_data(int16_t *input, int16_t *input_opt)
-{
+static void uninit_data(int16_t *input, int16_t *input_opt) {
     free(input);
     free(input_opt);
 }
 
-static void uninit_coeff(int32_t *coeff, int32_t *coeff_opt)
-{
+static void uninit_coeff(int32_t *coeff, int32_t *coeff_opt) {
     free(coeff);
     free(coeff_opt);
 }
 
-static void init_coeff(int32_t **coeff, int32_t **coeff_opt, uint32_t *stride)
-{
+static void init_coeff(int32_t **coeff, int32_t **coeff_opt, uint32_t *stride) {
     *stride = eb_create_random_aligned_stride(MAX_SB_SIZE, 64);
     *coeff = (int32_t*)malloc(sizeof(**coeff) * MAX_SB_SIZE * *stride);
     *coeff_opt = (int32_t*)malloc(sizeof(**coeff_opt) * MAX_SB_SIZE * *stride);
@@ -50,14 +46,11 @@ TEST(ForwardTransformTest, av1_frwd_txfm_square_kernels)
     uint32_t stride;
     init_coeff(&coeff, &coeff_opt, &stride);
     ASSERT(eb_buf_compare_s32(coeff, coeff_opt, MAX_SB_SIZE * stride) == 1);
-    for (int loop = 0; loop < 3; loop++)//Function Pairs
-    {
-        for (int i = 0; i < 10; i++) {//Number of Test Runs
+    for (int loop = 0; loop < 3; loop++) {         //Function Pairs
+        for (int i = 0; i < 10; i++) {             //Number of Test Runs
             for (int x = 0; x < AOM_BITS_12; x++) {//Bit Depth
-                switch (loop)
-                {
+                switch (loop) {
                 case 0://16x16
-                {
                     for (int j = 0; j < 16; j++) {
                         init_data(&input, &input_opt, stride);
                         ASSERT(eb_buf_compare_s16(input, input_opt, MAX_SB_SIZE * stride) == 1);
@@ -68,26 +61,21 @@ TEST(ForwardTransformTest, av1_frwd_txfm_square_kernels)
                         }
                         uninit_data(input, input_opt);
                     }
-                }
                 break;
                 case 1://32x32
-                {
-                    for (int j = 0; j < 2; j++){
-                    init_data(&input, &input_opt, stride);
-                    ASSERT(eb_buf_compare_s16(input, input_opt, MAX_SB_SIZE * stride) == 1);
-                    av1_frwd_txfm_func_ptr_array_base[loop](input, coeff, stride, (TxType)tx_32[j], bitDepth[x]);
-                    av1_frwd_txfm_func_ptr_array_opt[loop](input_opt, coeff_opt, stride, (TxType)tx_32[j], bitDepth[x]);
-                    for (int idx = 0; idx < 16; idx++) {
-                        EXPECT_EQ(coeff[idx], coeff_opt[idx]);
+                    for (int j = 0; j < 2; j++) {
+                        init_data(&input, &input_opt, stride);
+                        ASSERT(eb_buf_compare_s16(input, input_opt, MAX_SB_SIZE * stride) == 1);
+                        av1_frwd_txfm_func_ptr_array_base[loop](input, coeff, stride, (TxType)tx_32[j], bitDepth[x]);
+                        av1_frwd_txfm_func_ptr_array_opt[loop](input_opt, coeff_opt, stride, (TxType)tx_32[j], bitDepth[x]);
+                        for (int idx = 0; idx < 16; idx++) {
+                            EXPECT_EQ(coeff[idx], coeff_opt[idx]);
+                        }
+                        uninit_data(input, input_opt);
                     }
-                    uninit_data(input, input_opt);
-                    }
-                }
                 break;
                 case 2://64x64
-                {
-                    for (int j = 0; j < 1; j++)
-                    {
+                    for (int j = 0; j < 1; j++) {
                         init_data(&input, &input_opt, stride);
                         ASSERT(eb_buf_compare_s16(input, input_opt, MAX_SB_SIZE * stride) == 1);
                         av1_frwd_txfm_func_ptr_array_base[loop](input, coeff, stride, (TxType)tx_64[j], bitDepth[x]);
@@ -97,8 +85,9 @@ TEST(ForwardTransformTest, av1_frwd_txfm_square_kernels)
                         }
                         uninit_data(input, input_opt);
                     }
-                }
                 break;
+                default:
+                    ASSERT(0);
                 }
             }
         }

--- a/test/ForwardtransformTests.cc
+++ b/test/ForwardtransformTests.cc
@@ -1,0 +1,107 @@
+#include "gtest/gtest.h"
+#include "EbDefinitions.h"
+#include "EbEncHandle.h"
+#include "aom_dsp_rtcd.h"
+#include "EbTransforms.h"
+#include "EbUnitTestUtility.h"
+#include <immintrin.h>
+
+typedef void(*av1_frwd_txfm_func)(int16_t *input, int32_t *coeff, uint32_t stride, TxType tx_type, uint8_t bitDepth);
+av1_frwd_txfm_func av1_frwd_txfm_func_ptr_array_base[3] = { av1_fwd_txfm2d_16x16_avx2, av1_fwd_txfm2d_32x32_avx2 , av1_fwd_txfm2d_64x64_avx2 };
+av1_frwd_txfm_func av1_frwd_txfm_func_ptr_array_opt[3] = { av1_fwd_txfm2d_16x16_avx512, av1_fwd_txfm2d_32x32_avx512, av1_fwd_txfm2d_64x64_avx512 };
+int tx_16[] = { 0 , 1 , 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+int tx_32[] = { 0 , 9 };
+int tx_64[] = { 0 };
+int bitDepth[] = { 8, 10, 12 };
+
+static void init_data(int16_t **input, int16_t **input_opt, uint32_t input_stride)
+{
+    *input = (int16_t*)malloc(sizeof(**input) * MAX_SB_SIZE * input_stride);
+    *input_opt = (int16_t*)malloc(sizeof(**input_opt) * MAX_SB_SIZE * input_stride);
+    memset(*input, 0, MAX_SB_SIZE * input_stride);
+    memset(*input_opt, 0, MAX_SB_SIZE * input_stride);
+    eb_buf_random_s16(*input, MAX_SB_SIZE * input_stride);
+    memcpy(*input_opt, *input, sizeof(**input) * MAX_SB_SIZE * input_stride);
+}
+
+static void uninit_data(int16_t *input, int16_t *input_opt)
+{
+    free(input);
+    free(input_opt);
+}
+
+static void uninit_coeff(int32_t *coeff, int32_t *coeff_opt)
+{
+    free(coeff);
+    free(coeff_opt);
+}
+
+static void init_coeff(int32_t **coeff, int32_t **coeff_opt, uint32_t *stride)
+{
+    *stride = eb_create_random_aligned_stride(MAX_SB_SIZE, 64);
+    *coeff = (int32_t*)malloc(sizeof(**coeff) * MAX_SB_SIZE * *stride);
+    *coeff_opt = (int32_t*)malloc(sizeof(**coeff_opt) * MAX_SB_SIZE * *stride);
+}
+
+TEST(ForwardTransformTest, av1_frwd_txfm_square_kernels)
+{
+    int16_t *input, *input_opt;
+    int32_t* coeff, *coeff_opt;
+    uint32_t stride;
+    init_coeff(&coeff, &coeff_opt, &stride);
+    ASSERT(eb_buf_compare_s32(coeff, coeff_opt, MAX_SB_SIZE * stride) == 1);
+    for (int loop = 0; loop < 3; loop++)//Function Pairs
+    {
+        for (int i = 0; i < 10; i++) {//Number of Test Runs
+            for (int x = 0; x < AOM_BITS_12; x++) {//Bit Depth
+                switch (loop)
+                {
+                case 0://16x16
+                {
+                    for (int j = 0; j < 16; j++) {
+                        init_data(&input, &input_opt, stride);
+                        ASSERT(eb_buf_compare_s16(input, input_opt, MAX_SB_SIZE * stride) == 1);
+                        av1_frwd_txfm_func_ptr_array_base[loop](input,coeff,stride, (TxType)tx_16[j], bitDepth[x]);
+                        av1_frwd_txfm_func_ptr_array_opt[loop](input_opt, coeff_opt, stride, (TxType)tx_16[j], bitDepth[x]);
+                        for (int idx = 0; idx < 16; idx++) {
+                            EXPECT_EQ(coeff[idx], coeff_opt[idx]);
+                        }
+                        uninit_data(input, input_opt);
+                    }
+                }
+                break;
+                case 1://32x32
+                {
+                    for (int j = 0; j < 2; j++){
+                    init_data(&input, &input_opt, stride);
+                    ASSERT(eb_buf_compare_s16(input, input_opt, MAX_SB_SIZE * stride) == 1);
+                    av1_frwd_txfm_func_ptr_array_base[loop](input, coeff, stride, (TxType)tx_32[j], bitDepth[x]);
+                    av1_frwd_txfm_func_ptr_array_opt[loop](input_opt, coeff_opt, stride, (TxType)tx_32[j], bitDepth[x]);
+                    for (int idx = 0; idx < 16; idx++) {
+                        EXPECT_EQ(coeff[idx], coeff_opt[idx]);
+                    }
+                    uninit_data(input, input_opt);
+                    }
+                }
+                break;
+                case 2://64x64
+                {
+                    for (int j = 0; j < 1; j++)
+                    {
+                        init_data(&input, &input_opt, stride);
+                        ASSERT(eb_buf_compare_s16(input, input_opt, MAX_SB_SIZE * stride) == 1);
+                        av1_frwd_txfm_func_ptr_array_base[loop](input, coeff, stride, (TxType)tx_64[j], bitDepth[x]);
+                        av1_frwd_txfm_func_ptr_array_opt[loop](input_opt, coeff_opt, stride, (TxType)tx_64[j], bitDepth[x]);
+                        for (int idx = 0; idx < 16; idx++) {
+                            EXPECT_EQ(coeff[idx], coeff_opt[idx]);
+                        }
+                        uninit_data(input, input_opt);
+                    }
+                }
+                break;
+                }
+            }
+        }
+    }
+    uninit_coeff(coeff, coeff_opt);
+}

--- a/test/ForwardtransformTests.cc
+++ b/test/ForwardtransformTests.cc
@@ -4,6 +4,7 @@
 #include "aom_dsp_rtcd.h"
 #include "EbTransforms.h"
 #include "EbUnitTestUtility.h"
+#include "EbUnitTest.h"
 #include <immintrin.h>
 
 typedef void(*av1_frwd_txfm_func)(int16_t *input, int32_t *coeff, uint32_t stride, TxType tx_type, uint8_t bitDepth);
@@ -15,8 +16,8 @@ int tx_64[] = { 0 , 9 };
 int bitDepth[] = { 8, 10, 12 };
 
 static void init_data(int16_t **input, int16_t **input_opt, uint32_t input_stride) {
-    *input = (int16_t*)malloc(sizeof(**input) * MAX_SB_SIZE * input_stride);
-    *input_opt = (int16_t*)malloc(sizeof(**input_opt) * MAX_SB_SIZE * input_stride);
+    TEST_ALLIGN_MALLOC(int16_t*, *input, sizeof(int16_t) * MAX_SB_SIZE * input_stride);
+    TEST_ALLIGN_MALLOC(int16_t*, *input_opt, sizeof(int16_t) * MAX_SB_SIZE * input_stride);
     memset(*input, 0, MAX_SB_SIZE * input_stride);
     memset(*input_opt, 0, MAX_SB_SIZE * input_stride);
     eb_buf_random_s16(*input, MAX_SB_SIZE * input_stride);
@@ -24,19 +25,19 @@ static void init_data(int16_t **input, int16_t **input_opt, uint32_t input_strid
 }
 
 static void uninit_data(int16_t *input, int16_t *input_opt) {
-    free(input);
-    free(input_opt);
+    TEST_ALLIGN_FREE(input);
+    TEST_ALLIGN_FREE(input_opt);
 }
 
 static void uninit_coeff(int32_t *coeff, int32_t *coeff_opt) {
-    free(coeff);
-    free(coeff_opt);
+    TEST_ALLIGN_FREE(coeff);
+    TEST_ALLIGN_FREE(coeff_opt);
 }
 
 static void init_coeff(int32_t **coeff, int32_t **coeff_opt, uint32_t *stride) {
     *stride = eb_create_random_aligned_stride(MAX_SB_SIZE, 64);
-    *coeff = (int32_t*)malloc(sizeof(**coeff) * MAX_SB_SIZE * *stride);
-    *coeff_opt = (int32_t*)malloc(sizeof(**coeff_opt) * MAX_SB_SIZE * *stride);
+    TEST_ALLIGN_MALLOC(int32_t*, *coeff, sizeof(int32_t) * MAX_SB_SIZE * *stride);
+    TEST_ALLIGN_MALLOC(int32_t*, *coeff_opt, sizeof(int32_t) * MAX_SB_SIZE * *stride);
 }
 
 TEST(ForwardTransformTest, av1_frwd_txfm_kernels)

--- a/test/ForwardtransformTests.cc
+++ b/test/ForwardtransformTests.cc
@@ -1,3 +1,8 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
 #include "gtest/gtest.h"
 #include "EbDefinitions.h"
 #include "EbEncHandle.h"

--- a/test/ForwardtransformTests.cc
+++ b/test/ForwardtransformTests.cc
@@ -5,12 +5,9 @@
 
 #include "gtest/gtest.h"
 #include "EbDefinitions.h"
-#include "EbEncHandle.h"
 #include "aom_dsp_rtcd.h"
-#include "EbTransforms.h"
 #include "EbUnitTestUtility.h"
 #include "EbUnitTest.h"
-#include <immintrin.h>
 
 #ifndef NON_AVX512_SUPPORT
 

--- a/test/ForwardtransformTests.cc
+++ b/test/ForwardtransformTests.cc
@@ -9,9 +9,9 @@
 
 #ifndef NON_AVX512_SUPPORT
 
-typedef void(*av1_frwd_txfm_func)(int16_t *input, int32_t *coeff, uint32_t stride, TxType tx_type, uint8_t bitDepth);
-av1_frwd_txfm_func av1_frwd_txfm_func_ptr_array_base[9] = { av1_fwd_txfm2d_16x16_avx2, av1_fwd_txfm2d_32x32_avx2 , av1_fwd_txfm2d_64x64_avx2 , av1_fwd_txfm2d_16x64_avx2, av1_fwd_txfm2d_64x16_avx2 , av1_fwd_txfm2d_32x64_avx2 , av1_fwd_txfm2d_64x32_avx2 , av1_fwd_txfm2d_16x32_avx2 , av1_fwd_txfm2d_32x16_avx2 };
-av1_frwd_txfm_func av1_frwd_txfm_func_ptr_array_opt[9] = { av1_fwd_txfm2d_16x16_avx512, av1_fwd_txfm2d_32x32_avx512, av1_fwd_txfm2d_64x64_avx512 , av1_fwd_txfm2d_16x64_avx512, av1_fwd_txfm2d_64x16_avx512 , av1_fwd_txfm2d_32x64_avx512 , av1_fwd_txfm2d_64x32_avx512 , av1_fwd_txfm2d_16x32_avx512 , av1_fwd_txfm2d_32x16_avx512 };
+typedef void(*eb_av1_frwd_txfm_func)(int16_t *input, int32_t *coeff, uint32_t stride, TxType tx_type, uint8_t bitDepth);
+eb_av1_frwd_txfm_func av1_frwd_txfm_func_ptr_array_base[9] = { eb_av1_fwd_txfm2d_16x16_avx2, eb_av1_fwd_txfm2d_32x32_avx2 , eb_av1_fwd_txfm2d_64x64_avx2 , eb_av1_fwd_txfm2d_16x64_avx2, eb_av1_fwd_txfm2d_64x16_avx2 , eb_av1_fwd_txfm2d_32x64_avx2 , eb_av1_fwd_txfm2d_64x32_avx2 , eb_av1_fwd_txfm2d_16x32_avx2 , eb_av1_fwd_txfm2d_32x16_avx2 };
+eb_av1_frwd_txfm_func av1_frwd_txfm_func_ptr_array_opt[9] = { av1_fwd_txfm2d_16x16_avx512, av1_fwd_txfm2d_32x32_avx512, av1_fwd_txfm2d_64x64_avx512 , av1_fwd_txfm2d_16x64_avx512, av1_fwd_txfm2d_64x16_avx512 , av1_fwd_txfm2d_32x64_avx512 , av1_fwd_txfm2d_64x32_avx512 , av1_fwd_txfm2d_16x32_avx512 , av1_fwd_txfm2d_32x16_avx512 };
 int tx_16[] = { 0 , 1 , 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
 int tx_32[] = { 0 , 9 };
 int tx_64[] = { 0 , 9 };


### PR DESCRIPTION
This PR has AVX512 high bd forward transform kernels for sizes 16x16,32x32,64x64,64x32,32x64,64x16,16x64,32x16,16x32 and their unit tests.The performance numbers are given in the commit messages,