### PR TITLE
Use a GCC version that is still maintained in unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,7 @@ before_install:
 install:
   - pip install --user cpp-coveralls
   - export PATH=/Users/travis/Library/Python/2.7/bin:${PATH}
-  - |
-    if [ "$TRAVIS_OS_NAME" != "osx" ]; then
-      export CFLAGS="-Werror"
-      if [ "$CC" = "clang" ]; then export CFLAGS+=" -Wno-error=array-bounds"; fi
-    fi
+  - export CFLAGS="-Werror"
   #- if [ $TRAVIS_OS_NAME = osx ]; then brew install --HEAD valgrind; fi
 base_script: &base_script |
   cd $TRAVIS_BUILD_DIR/Build/linux/${build_type:-Release}


### PR DESCRIPTION
Upgrades GCC to 7.4.

Fails because #511 is needed.

**EDIT**: Also needs #550 