### PR TITLE
Fix crash when using free() to release memory created by _aligned_mal…

### DIFF
--- a/Source/Lib/Common/Codec/EbMotionEstimationContext.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimationContext.c
@@ -22,7 +22,7 @@ static void me_context_dctor(EbPtr p)
     MeContext *obj = (MeContext*)p;
     uint32_t                   listIndex;
     uint32_t                   refPicIndex;
-    EB_FREE_ARRAY(obj->quarter_sb_buffer);
+    EB_FREE_ALIGNED_ARRAY(obj->quarter_sb_buffer);
 
     EB_FREE_ARRAY(obj->mvd_bits_array);
 

--- a/Source/Lib/Common/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.c
@@ -1116,7 +1116,7 @@ static void picture_parent_control_set_dctor(EbPtr p)
     }
 
     EB_FREE_ARRAY(obj->av1_cm->frame_to_show);
-    EB_FREE_ARRAY(obj->av1_cm->rst_tmpbuf);
+    EB_FREE_ALIGNED(obj->av1_cm->rst_tmpbuf);
     EB_FREE_ARRAY(obj->av1_cm);
     EB_FREE_ARRAY(obj->rusi_picture[0]);
     EB_FREE_ARRAY(obj->rusi_picture[1]);

--- a/Source/Lib/Common/Codec/EbRestProcess.c
+++ b/Source/Lib/Common/Codec/EbRestProcess.c
@@ -60,7 +60,7 @@ static void rest_context_dctor(EbPtr p)
     EB_DELETE(obj->temp_lf_recon_picture16bit_ptr);
     EB_DELETE(obj->trial_frame_rst);
     EB_DELETE(obj->org_rec_frame);
-    EB_FREE(obj->rst_tmpbuf);
+    EB_FREE_ALIGNED(obj->rst_tmpbuf);
 }
 
 /******************************************************


### PR DESCRIPTION
Bug was caused by PR #457 

By that time, there is no any _aligned_free() used.