### PR TITLE
Add AVX512 code for high_bd_dc predictor

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/EbHighbdIntraPrediction_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbHighbdIntraPrediction_AVX2.c
@@ -93,7 +93,7 @@ static INLINE __m128i dc_sum_8_16(const uint16_t *const src_8,
 
 static INLINE __m128i dc_sum_8_32(const uint16_t *const src_8,
     const uint16_t *const src_32) {
-    const __m128i s_8 = _mm_load_si128((const __m128i *)src_8);
+    const __m128i s_8 = _mm_loadu_si128((const __m128i *)src_8);
     const __m256i s_32_0 = _mm256_loadu_si256((const __m256i *)(src_32 + 0x00));
     const __m256i s_32_1 = _mm256_loadu_si256((const __m256i *)(src_32 + 0x10));
     const __m256i s_32 = _mm256_add_epi16(s_32_0, s_32_1);

--- a/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
@@ -24,8 +24,8 @@ static INLINE __m128i dc_sum_large(const __m256i src) {
 static INLINE void dc_common_predictor_32xh_kernel_avx512(uint16_t *dst,
     const ptrdiff_t stride, const int32_t h, const __m512i dc) {
     for (int32_t i = 0; i < h; i++) {
-    _mm512_store_si512((__m512i *)dst, dc);
-    dst += stride;
+        _mm512_store_si512((__m512i *)dst, dc);
+        dst += stride;
     }
 }
 
@@ -49,8 +49,6 @@ static INLINE void dc_common_predictor_64xh(uint16_t *const dst,
     const __m512i expected_dc = _mm512_broadcastw_epi16(dc);
     dc_common_predictor_64xh_kernel_avx512(dst, stride, h, expected_dc);
 }
-
-
 
 static INLINE __m128i dc_sum_16(const uint16_t *const src) {
     const __m256i s = _mm256_loadu_si256((const __m256i *) src);
@@ -171,3 +169,267 @@ void aom_highbd_dc_left_predictor_64x64_avx512(uint16_t *dst, ptrdiff_t stride,
     sum = _mm_srli_epi32(sum, 6);
     dc_common_predictor_64xh(dst, stride, 64, sum);
 }
+
+/*highbd dc top predictors */
+
+// 32xN
+
+static INLINE void dc_top_predictor_32xh(uint16_t *const dst,
+    const ptrdiff_t stride, const uint16_t *const above,
+    const int32_t h, const int32_t bd)
+{
+    const __m128i round = _mm_cvtsi32_si128(16);
+    __m128i sum;
+
+    sum = dc_sum_32(above);
+    sum = _mm_add_epi32(sum, round);
+    sum = _mm_srli_epi32(sum, 5);
+    dc_common_predictor_32xh(dst, stride, h, sum);
+}
+
+void aom_highbd_dc_top_predictor_32x8_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    (void)left;
+    dc_top_predictor_32xh(dst, stride, above, 8, bd);
+}
+
+void aom_highbd_dc_top_predictor_32x16_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    (void)left;
+    dc_top_predictor_32xh(dst, stride, above, 16, bd);
+}
+
+void aom_highbd_dc_top_predictor_32x32_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    (void)left;
+    dc_top_predictor_32xh(dst, stride, above, 32, bd);
+}
+
+void aom_highbd_dc_top_predictor_32x64_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    (void)left;
+    dc_top_predictor_32xh(dst, stride, above, 64, bd);
+}
+
+// 64xN
+
+static INLINE void dc_top_predictor_64xh(uint16_t *const dst,
+    const ptrdiff_t stride, const uint16_t *const above,
+    const int32_t h, const int32_t bd)
+{
+    const __m128i round = _mm_cvtsi32_si128(32);
+    __m128i sum;
+
+    sum = dc_sum_64(above);
+    sum = _mm_add_epi32(sum, round);
+    sum = _mm_srli_epi32(sum, 6);
+    dc_common_predictor_64xh(dst, stride, h, sum);
+}
+
+void aom_highbd_dc_top_predictor_64x16_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    (void)left;
+    dc_top_predictor_64xh(dst, stride, above, 16, bd);
+}
+
+void aom_highbd_dc_top_predictor_64x32_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    (void)left;
+    dc_top_predictor_64xh(dst, stride, above, 32, bd);
+}
+
+void aom_highbd_dc_top_predictor_64x64_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    (void)left;
+    dc_top_predictor_64xh(dst, stride, above, 64, bd);
+}
+
+/* highbd dc predictor */
+
+// 32xN
+
+static INLINE __m128i dc_sum_8_32(const uint16_t *const src_8,
+    const uint16_t *const src_32) {
+    const __m128i s_8 = _mm_load_si128((const __m128i *)src_8);
+    // need to change if single load avx512 and two extracts in dc left predictor 32x32 gives better performance than avx2 code.
+    const __m256i s_32_0 = _mm256_loadu_si256((const __m256i *)(src_32 + 0x00));
+    const __m256i s_32_1 = _mm256_loadu_si256((const __m256i *)(src_32 + 0x10));
+    const __m256i s_32 = _mm256_add_epi16(s_32_0, s_32_1);
+    const __m128i s_lo = _mm256_extracti128_si256(s_32, 0);
+    const __m128i s_hi = _mm256_extracti128_si256(s_32, 1);
+    const __m128i s_16_sum = _mm_add_epi16(s_lo, s_hi);
+    const __m128i sum = _mm_add_epi16(s_8, s_16_sum);
+    return dc_sum_8x16bit_large(sum);
+}
+
+static INLINE __m128i dc_sum_16_32(const uint16_t *const src_16,
+    const uint16_t *const src_32) {
+    const __m256i s_16 = _mm256_loadu_si256((const __m256i *)src_16);
+    // need to change if single load avx512 and two extracts in dc left predictor 32x32 gives better performance than avx2 code.
+    const __m256i s_32_0 = _mm256_loadu_si256((const __m256i *)(src_32 + 0x00));
+    const __m256i s_32_1 = _mm256_loadu_si256((const __m256i *)(src_32 + 0x20));
+    const __m256i sum0 = _mm256_add_epi16(s_16, s_32_0);
+    const __m256i sum = _mm256_add_epi16(sum0, s_32_1);
+    return dc_sum_large(sum);
+}
+
+// Handle number of elements: 65 to 128.
+static INLINE __m128i dc_sum_larger(const __m256i src) {
+    const __m128i s_lo = _mm256_extracti128_si256(src, 0);
+    const __m128i s_hi = _mm256_extracti128_si256(src, 1);
+    __m128i sum, sum_hi;
+    sum = _mm_add_epi16(s_lo, s_hi);
+    // Unpack to avoid 12-bit overflow.
+    sum_hi = _mm_unpackhi_epi16(sum, _mm_setzero_si128());
+    sum = _mm_unpacklo_epi16(sum, _mm_setzero_si128());
+    sum = _mm_add_epi32(sum, sum_hi);
+
+    return dc_sum_4x32bit(sum);
+}
+
+static INLINE __m128i dc_sum_32_32(const uint16_t *const src0,
+    const uint16_t *const src1) {
+    const __m512i s_32_0 = _mm512_loadu_si512((const __m512i *)(src0 + 0x00));
+    const __m512i s_32_1 = _mm512_loadu_si512((const __m512i *)(src1 + 0x00));
+    const __m512i sum_32_01 = _mm512_add_epi16(s_32_0, s_32_1);
+    const __m256i sum_16_0 = _mm512_extracti64x4_epi64(sum_32_01,0);
+    const __m256i sum_16_1 = _mm512_extracti64x4_epi64(sum_32_01,1);
+    const __m256i sum = _mm256_add_epi16(sum_16_0, sum_16_1);
+    return dc_sum_large(sum);
+}
+
+static INLINE __m128i dc_sum_16_64(const uint16_t *const src_16,
+    const uint16_t *const src_64)
+{
+    const __m256i s_16 = _mm256_loadu_si256((const __m256i *)src_16);
+    const __m512i s_64_0 = _mm512_loadu_si512((const __m512i *)(src_64 + 0x00));
+    const __m512i s_64_1 = _mm512_loadu_si512((const __m512i *)(src_64 + 0x20));
+    const __m512i sum_64_01 = _mm512_add_epi16(s_64_1, s_64_0);
+    const __m256i s1 = _mm512_extracti64x4_epi64(sum_64_01, 0);
+    const __m256i s2 = _mm512_extracti64x4_epi64(sum_64_01, 1);
+    const __m256i s3 = _mm256_add_epi16(s1, s_16);
+    const __m256i sum = _mm256_add_epi16(s2, s3);
+    return dc_sum_larger(sum);
+}
+
+
+static INLINE __m128i dc_sum_32_64(const uint16_t *const src_32,
+    const uint16_t *const src_64) {
+    const __m512i s_32_0 = _mm512_loadu_si512((const __m512i *)(src_32 + 0x00));
+    const __m512i s_64_0 = _mm512_loadu_si512((const __m256i *)(src_64 + 0x00));
+    const __m512i s_64_1 = _mm512_loadu_si512((const __m256i *)(src_64 + 0x20));
+
+    const __m512i sum0 = _mm512_add_epi16(s_32_0, s_64_0);
+    const __m512i sum1 = _mm512_add_epi16(sum0, s_64_1);
+
+    const __m256i sum2 = _mm512_extracti64x4_epi64(sum1, 0);
+    const __m256i sum3 = _mm512_extracti64x4_epi64(sum1, 1);
+    const __m256i sum = _mm256_add_epi16(sum2, sum3);
+    return dc_sum_larger(sum);
+}
+
+static INLINE __m128i dc_sum_64_64(const uint16_t *const src0,
+    const uint16_t *const src1) {
+    const __m512i s0 = _mm512_loadu_si512((const __m512i *)(src0 + 0x00));
+    const __m512i s1 = _mm512_loadu_si512((const __m256i *)(src0 + 0x20));
+    const __m512i s2 = _mm512_loadu_si512((const __m256i *)(src1 + 0x00));
+    const __m512i s3 = _mm512_loadu_si512((const __m256i *)(src1 + 0x20));
+  
+    const __m512i sum01 = _mm512_add_epi16(s0, s1);
+    const __m512i sum23 = _mm512_add_epi16(s2, s3);
+    const __m512i sum03 = _mm512_add_epi16(sum01, sum23);
+
+    const __m256i sum03_1 = _mm512_extracti64x4_epi64(sum03, 0);
+    const __m256i sum03_2 = _mm512_extracti64x4_epi64(sum03, 1);
+   
+    const __m256i sum = _mm256_add_epi16(sum03_1, sum03_2);
+    return dc_sum_larger(sum);
+}
+
+void aom_highbd_dc_predictor_32x8_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd) {
+    (void)bd;
+    __m128i sum = dc_sum_8_32(left, above);
+    uint32_t sum32 = _mm_cvtsi128_si32(sum);
+    sum32 += 20;
+    sum32 /= 40;
+    const __m512i dc = _mm512_set1_epi16((int16_t)sum32);
+
+    dc_common_predictor_32xh_kernel_avx512(dst, stride, 8, dc);
+}
+
+void aom_highbd_dc_predictor_32x16_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd) {
+    (void)bd;
+    __m128i sum = dc_sum_16_32(left, above);
+    uint32_t sum32 = _mm_cvtsi128_si32(sum);
+    sum32 += 24;
+    sum32 /= 48;
+    const __m512i dc = _mm512_set1_epi16((int16_t)sum32);
+
+    dc_common_predictor_32xh_kernel_avx512(dst, stride, 16, dc);
+}
+
+void aom_highbd_dc_predictor_32x32_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd) {
+    (void)bd;
+    __m128i sum = dc_sum_32_32(above, left);
+    sum = _mm_add_epi32(sum, _mm_set1_epi32(32));
+    sum = _mm_srli_epi32(sum, 6);
+    dc_common_predictor_32xh(dst, stride, 32, sum);
+}
+
+void aom_highbd_dc_predictor_32x64_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd) {
+    (void)bd;
+    __m128i sum = dc_sum_32_64(above, left);
+    uint32_t sum32 = _mm_cvtsi128_si32(sum);
+    sum32 += 48;
+    sum32 /= 96;
+    const __m512i dc = _mm512_set1_epi16((int16_t)sum32);
+
+    dc_common_predictor_32xh_kernel_avx512(dst, stride, 64, dc);
+}
+
+// 64xN
+
+void aom_highbd_dc_predictor_64x16_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd) {
+    (void)bd;
+    __m128i sum = dc_sum_16_64(left, above);
+    uint32_t sum32 = _mm_cvtsi128_si32(sum);
+    sum32 += 40;
+    sum32 /= 80;
+    const __m512i dc = _mm512_set1_epi16((int16_t)sum32);
+
+    dc_common_predictor_64xh_kernel_avx512(dst, stride, 16, dc);
+}
+
+void aom_highbd_dc_predictor_64x32_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd) {
+    (void)bd;
+    __m128i sum = dc_sum_32_64(left, above);
+    uint32_t sum32 = _mm_cvtsi128_si32(sum);
+    sum32 += 48;
+    sum32 /= 96;
+    const __m512i dc = _mm512_set1_epi16((int16_t)sum32);
+
+    dc_common_predictor_64xh_kernel_avx512(dst, stride, 32, dc);
+}
+
+void aom_highbd_dc_predictor_64x64_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd) {
+    (void)bd;
+    __m128i sum = dc_sum_64_64(above, left);
+    sum = _mm_add_epi32(sum, _mm_set1_epi32(64));
+    sum = _mm_srli_epi32(sum, 7);
+    dc_common_predictor_64xh(dst, stride, 64, sum);
+}
+

--- a/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
+#ifndef NON_AVX512_SUPPORT
 #include <immintrin.h>
 #include "EbHighbdIntraPrediction_SSE2.h"
 #include "EbDefinitions.h"
@@ -428,4 +434,4 @@ void aom_highbd_dc_predictor_64x64_avx512(uint16_t *dst, ptrdiff_t stride,
     sum = _mm_srli_epi32(sum, 7);
     dc_common_predictor_64xh(dst, stride, 64, sum);
 }
-
+#endif

--- a/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
@@ -24,7 +24,7 @@ static INLINE __m128i dc_sum_large(const __m256i src) {
 static INLINE void dc_common_predictor_32xh_kernel_avx512(uint16_t *dst,
     const ptrdiff_t stride, const int32_t h, const __m512i dc) {
     for (int32_t i = 0; i < h; i++) {
-        _mm512_store_si512((__m512i *)dst, dc);
+        _mm512_storeu_si512((__m512i *)dst, dc);
         dst += stride;
     }
 }
@@ -38,8 +38,8 @@ static INLINE void dc_common_predictor_32xh(uint16_t *const dst,
 static INLINE void dc_common_predictor_64xh_kernel_avx512(uint16_t *dst,
     const ptrdiff_t stride, const int32_t h, const __m512i dc) {
     for (int32_t i = 0; i < h; i++) {
-        _mm512_store_si512((__m512i *)(dst + 0x00), dc);
-        _mm512_store_si512((__m512i *)(dst + 0x20), dc);
+        _mm512_storeu_si512((__m512i *)(dst + 0x00), dc);
+        _mm512_storeu_si512((__m512i *)(dst + 0x20), dc);
         dst += stride;
     }
 }
@@ -59,10 +59,6 @@ static INLINE __m128i dc_sum_16(const uint16_t *const src) {
 }
 
 static INLINE __m128i dc_sum_32(const uint16_t *const src) {
-    /*const __m256i s0 = _mm256_loadu_si256((const __m256i *)(src + 0x00));
-    const __m256i s1 = _mm256_loadu_si256((const __m256i *)(src + 0x10));
-    const __m256i sum = _mm256_add_epi16(s0, s1); uncomment only if faster than avx512 code*/
-
     const __m512i s32 = _mm512_loadu_si512((const __m512i *) src);
     const __m256i s0 = _mm512_extracti64x4_epi64(s32, 0);
     const __m256i s1 = _mm512_extracti64x4_epi64(s32, 1);
@@ -257,10 +253,10 @@ void aom_highbd_dc_top_predictor_64x64_avx512(uint16_t *dst, ptrdiff_t stride,
 
 static INLINE __m128i dc_sum_8_32(const uint16_t *const src_8,
     const uint16_t *const src_32) {
-    const __m128i s_8 = _mm_load_si128((const __m128i *)src_8);
-    // need to change if single load avx512 and two extracts in dc left predictor 32x32 gives better performance than avx2 code.
-    const __m256i s_32_0 = _mm256_loadu_si256((const __m256i *)(src_32 + 0x00));
-    const __m256i s_32_1 = _mm256_loadu_si256((const __m256i *)(src_32 + 0x10));
+    const __m128i s_8 = _mm_loadu_si128((const __m128i *)src_8);
+    const __m512i s32_01 = _mm512_loadu_si512((const __m512i *)(src_32 + 0x00));
+    const __m256i s_32_0 = _mm512_extracti64x4_epi64(s32_01,0);
+    const __m256i s_32_1 = _mm512_extracti64x4_epi64(s32_01,1);
     const __m256i s_32 = _mm256_add_epi16(s_32_0, s_32_1);
     const __m128i s_lo = _mm256_extracti128_si256(s_32, 0);
     const __m128i s_hi = _mm256_extracti128_si256(s_32, 1);
@@ -272,9 +268,9 @@ static INLINE __m128i dc_sum_8_32(const uint16_t *const src_8,
 static INLINE __m128i dc_sum_16_32(const uint16_t *const src_16,
     const uint16_t *const src_32) {
     const __m256i s_16 = _mm256_loadu_si256((const __m256i *)src_16);
-    // need to change if single load avx512 and two extracts in dc left predictor 32x32 gives better performance than avx2 code.
-    const __m256i s_32_0 = _mm256_loadu_si256((const __m256i *)(src_32 + 0x00));
-    const __m256i s_32_1 = _mm256_loadu_si256((const __m256i *)(src_32 + 0x20));
+    const __m512i s32_01 = _mm512_loadu_si512((const __m512i *)(src_32 + 0x00));
+    const __m256i s_32_0 = _mm512_extracti64x4_epi64(s32_01, 0);
+    const __m256i s_32_1 = _mm512_extracti64x4_epi64(s32_01, 1);
     const __m256i sum0 = _mm256_add_epi16(s_16, s_32_0);
     const __m256i sum = _mm256_add_epi16(sum0, s_32_1);
     return dc_sum_large(sum);

--- a/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
@@ -91,6 +91,7 @@ void aom_highbd_dc_left_predictor_32x8_avx512(uint16_t *dst, ptrdiff_t stride,
     const __m128i round = _mm_cvtsi32_si128(4);
     __m128i sum;
     (void)above;
+    (void)bd;
 
     sum = dc_sum_8(left);
     sum = _mm_add_epi16(sum, round);
@@ -103,6 +104,7 @@ void aom_highbd_dc_left_predictor_32x16_avx512(uint16_t *dst, ptrdiff_t stride,
     const __m128i round = _mm_cvtsi32_si128(8);
     __m128i sum;
     (void)above;
+    (void)bd;
 
     sum = dc_sum_16(left);
     sum = _mm_add_epi16(sum, round);
@@ -115,6 +117,7 @@ void aom_highbd_dc_left_predictor_32x32_avx512(uint16_t *dst, ptrdiff_t stride,
     const __m128i round = _mm_cvtsi32_si128(16);
     __m128i sum;
     (void)above;
+    (void)bd;
 
     sum = dc_sum_32(left);
     sum = _mm_add_epi32(sum, round);
@@ -127,6 +130,7 @@ void aom_highbd_dc_left_predictor_32x64_avx512(uint16_t *dst, ptrdiff_t stride,
     const __m128i round = _mm_cvtsi32_si128(32);
     __m128i sum;
     (void)above;
+    (void)bd;
 
     sum = dc_sum_64(left);
     sum = _mm_add_epi32(sum, round);
@@ -141,6 +145,7 @@ void aom_highbd_dc_left_predictor_64x16_avx512(uint16_t *dst, ptrdiff_t stride,
     const __m128i round = _mm_cvtsi32_si128(8);
     __m128i sum;
     (void)above;
+    (void)bd;
 
     sum = dc_sum_16(left);
     sum = _mm_add_epi16(sum, round);
@@ -153,6 +158,7 @@ void aom_highbd_dc_left_predictor_64x32_avx512(uint16_t *dst, ptrdiff_t stride,
     const __m128i round = _mm_cvtsi32_si128(16);
     __m128i sum;
     (void)above;
+    (void)bd;
 
     sum = dc_sum_32(left);
     sum = _mm_add_epi32(sum, round);
@@ -165,6 +171,7 @@ void aom_highbd_dc_left_predictor_64x64_avx512(uint16_t *dst, ptrdiff_t stride,
     const __m128i round = _mm_cvtsi32_si128(32);
     __m128i sum;
     (void)above;
+    (void)bd;
 
     sum = dc_sum_64(left);
     sum = _mm_add_epi32(sum, round);
@@ -182,6 +189,7 @@ static INLINE void dc_top_predictor_32xh(uint16_t *const dst,
 {
     const __m128i round = _mm_cvtsi32_si128(16);
     __m128i sum;
+    (void)bd;
 
     sum = dc_sum_32(above);
     sum = _mm_add_epi32(sum, round);
@@ -193,6 +201,7 @@ void aom_highbd_dc_top_predictor_32x8_avx512(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *above, const uint16_t *left, int32_t bd)
 {
     (void)left;
+
     dc_top_predictor_32xh(dst, stride, above, 8, bd);
 }
 
@@ -225,6 +234,7 @@ static INLINE void dc_top_predictor_64xh(uint16_t *const dst,
 {
     const __m128i round = _mm_cvtsi32_si128(32);
     __m128i sum;
+    (void)bd;
 
     sum = dc_sum_64(above);
     sum = _mm_add_epi32(sum, round);

--- a/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
@@ -343,14 +343,14 @@ static INLINE __m128i dc_sum_64_64(const uint16_t *const src0,
     const __m512i s1 = _mm512_loadu_si512((const __m256i *)(src0 + 0x20));
     const __m512i s2 = _mm512_loadu_si512((const __m256i *)(src1 + 0x00));
     const __m512i s3 = _mm512_loadu_si512((const __m256i *)(src1 + 0x20));
-  
+
     const __m512i sum01 = _mm512_add_epi16(s0, s1);
     const __m512i sum23 = _mm512_add_epi16(s2, s3);
     const __m512i sum03 = _mm512_add_epi16(sum01, sum23);
 
     const __m256i sum03_1 = _mm512_extracti64x4_epi64(sum03, 0);
     const __m256i sum03_2 = _mm512_extracti64x4_epi64(sum03, 1);
-   
+
     const __m256i sum = _mm256_add_epi16(sum03_1, sum03_2);
     return dc_sum_larger(sum);
 }

--- a/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
@@ -1,0 +1,173 @@
+#include <immintrin.h>
+#include "EbHighbdIntraPrediction_SSE2.h"
+#include "EbDefinitions.h"
+#include "aom_dsp_rtcd.h"
+
+// =============================================================================
+
+// DC RELATED PRED
+
+// Handle number of elements: up to 64.
+static INLINE __m128i dc_sum_large(const __m256i src) {
+    const __m128i s_lo = _mm256_extracti128_si256(src, 0);
+    const __m128i s_hi = _mm256_extracti128_si256(src, 1);
+    __m128i sum, sum_hi;
+    sum = _mm_add_epi16(s_lo, s_hi);
+    sum_hi = _mm_srli_si128(sum, 8);
+    sum = _mm_add_epi16(sum, sum_hi);
+    // Unpack to avoid 12-bit overflow.
+    sum = _mm_unpacklo_epi16(sum, _mm_setzero_si128());
+
+    return dc_sum_4x32bit(sum);
+}
+
+static INLINE void dc_common_predictor_32xh_kernel_avx512(uint16_t *dst,
+    const ptrdiff_t stride, const int32_t h, const __m512i dc) {
+    for (int32_t i = 0; i < h; i++) {
+    _mm512_store_si512((__m512i *)dst, dc);
+    dst += stride;
+    }
+}
+
+static INLINE void dc_common_predictor_32xh(uint16_t *const dst,
+    const ptrdiff_t stride, const int32_t h, const __m128i dc) {
+    const __m512i expected_dc = _mm512_broadcastw_epi16(dc);
+    dc_common_predictor_32xh_kernel_avx512(dst, stride, h, expected_dc);
+}
+
+static INLINE void dc_common_predictor_64xh_kernel_avx512(uint16_t *dst,
+    const ptrdiff_t stride, const int32_t h, const __m512i dc) {
+    for (int32_t i = 0; i < h; i++) {
+        _mm512_store_si512((__m512i *)(dst + 0x00), dc);
+        _mm512_store_si512((__m512i *)(dst + 0x20), dc);
+        dst += stride;
+    }
+}
+
+static INLINE void dc_common_predictor_64xh(uint16_t *const dst,
+    const ptrdiff_t stride, const int32_t h, const __m128i dc) {
+    const __m512i expected_dc = _mm512_broadcastw_epi16(dc);
+    dc_common_predictor_64xh_kernel_avx512(dst, stride, h, expected_dc);
+}
+
+
+
+static INLINE __m128i dc_sum_16(const uint16_t *const src) {
+    const __m256i s = _mm256_loadu_si256((const __m256i *) src);
+    const __m128i s_lo = _mm256_extracti128_si256(s, 0);
+    const __m128i s_hi = _mm256_extracti128_si256(s, 1);
+    const __m128i sum = _mm_add_epi16(s_lo, s_hi);
+    return dc_sum_8x16bit(sum);
+}
+
+static INLINE __m128i dc_sum_32(const uint16_t *const src) {
+    /*const __m256i s0 = _mm256_loadu_si256((const __m256i *)(src + 0x00));
+    const __m256i s1 = _mm256_loadu_si256((const __m256i *)(src + 0x10));
+    const __m256i sum = _mm256_add_epi16(s0, s1); uncomment only if faster than avx512 code*/
+
+    const __m512i s32 = _mm512_loadu_si512((const __m512i *) src);
+    const __m256i s0 = _mm512_extracti64x4_epi64(s32, 0);
+    const __m256i s1 = _mm512_extracti64x4_epi64(s32, 1);
+    const __m256i sum = _mm256_add_epi16(s0, s1);
+    return dc_sum_large(sum);
+}
+
+static INLINE __m128i dc_sum_64(const uint16_t *const src) {
+    const __m512i s0 = _mm512_loadu_si512((const __m512i *)(src + 0x00));
+    const __m512i s1 = _mm512_loadu_si512((const __m512i *)(src + 0x20));
+    const __m512i s01 = _mm512_add_epi16(s0, s1);
+
+    const __m256i s2 = _mm512_extracti64x4_epi64(s01, 0);
+    const __m256i s3 = _mm512_extracti64x4_epi64(s01, 1);
+
+    const __m256i sum = _mm256_add_epi16(s2, s3);
+    return dc_sum_large(sum);
+}
+
+// 32xN
+
+void aom_highbd_dc_left_predictor_32x8_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd) {
+    const __m128i round = _mm_cvtsi32_si128(4);
+    __m128i sum;
+    (void)above;
+
+    sum = dc_sum_8(left);
+    sum = _mm_add_epi16(sum, round);
+    sum = _mm_srli_epi16(sum, 3);
+    dc_common_predictor_32xh(dst, stride, 8, sum);
+}
+
+void aom_highbd_dc_left_predictor_32x16_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd) {
+    const __m128i round = _mm_cvtsi32_si128(8);
+    __m128i sum;
+    (void)above;
+
+    sum = dc_sum_16(left);
+    sum = _mm_add_epi16(sum, round);
+    sum = _mm_srli_epi16(sum, 4);
+    dc_common_predictor_32xh(dst, stride, 16, sum);
+}
+
+void aom_highbd_dc_left_predictor_32x32_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd) {
+    const __m128i round = _mm_cvtsi32_si128(16);
+    __m128i sum;
+    (void)above;
+
+    sum = dc_sum_32(left);
+    sum = _mm_add_epi32(sum, round);
+    sum = _mm_srli_epi32(sum, 5);
+    dc_common_predictor_32xh(dst, stride, 32, sum);
+}
+
+void aom_highbd_dc_left_predictor_32x64_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd) {
+    const __m128i round = _mm_cvtsi32_si128(32);
+    __m128i sum;
+    (void)above;
+
+    sum = dc_sum_64(left);
+    sum = _mm_add_epi32(sum, round);
+    sum = _mm_srli_epi32(sum, 6);
+    dc_common_predictor_32xh(dst, stride, 64, sum);
+}
+
+// 64xN
+
+void aom_highbd_dc_left_predictor_64x16_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd) {
+    const __m128i round = _mm_cvtsi32_si128(8);
+    __m128i sum;
+    (void)above;
+
+    sum = dc_sum_16(left);
+    sum = _mm_add_epi16(sum, round);
+    sum = _mm_srli_epi16(sum, 4);
+    dc_common_predictor_64xh(dst, stride, 16, sum);
+}
+
+void aom_highbd_dc_left_predictor_64x32_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd) {
+    const __m128i round = _mm_cvtsi32_si128(16);
+    __m128i sum;
+    (void)above;
+
+    sum = dc_sum_32(left);
+    sum = _mm_add_epi32(sum, round);
+    sum = _mm_srli_epi32(sum, 5);
+    dc_common_predictor_64xh(dst, stride, 32, sum);
+}
+
+void aom_highbd_dc_left_predictor_64x64_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd) {
+    const __m128i round = _mm_cvtsi32_si128(32);
+    __m128i sum;
+    (void)above;
+
+    sum = dc_sum_64(left);
+    sum = _mm_add_epi32(sum, round);
+    sum = _mm_srli_epi32(sum, 6);
+    dc_common_predictor_64xh(dst, stride, 64, sum);
+}

--- a/Source/Lib/Common/ASM_SSE2/EbHighbdIntraPrediction_SSE2.h
+++ b/Source/Lib/Common/ASM_SSE2/EbHighbdIntraPrediction_SSE2.h
@@ -52,7 +52,7 @@ static INLINE __m128i dc_sum_4(const uint16_t *const src) {
 }
 
 static INLINE __m128i dc_sum_8(const uint16_t *const src) {
-    const __m128i s = _mm_load_si128((const __m128i *)src);
+    const __m128i s = _mm_loadu_si128((const __m128i *)src);
     return dc_sum_8x16bit(s);
 }
 

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -40,7 +40,7 @@ extern "C" {
 #endif
 
 // Internal Marcos
-//#define NON_AVX512_SUPPORT
+#define NON_AVX512_SUPPORT
 
 #define INCOMPLETE_SB_FIX                 1 // Handle the incomplete SBs properly based on the standard and consider all allowed blocks
 #define QPS_TUNING                        1 // Tune the QPS algorithm to consider ALR_REF filtering and movement of the pictures

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -40,7 +40,7 @@ extern "C" {
 #endif
 
 // Internal Marcos
-#define NON_AVX512_SUPPORT
+//#define NON_AVX512_SUPPORT
 
 #define INCOMPLETE_SB_FIX                 1 // Handle the incomplete SBs properly based on the standard and consider all allowed blocks
 #define QPS_TUNING                        1 // Tune the QPS algorithm to consider ALR_REF filtering and movement of the pictures

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -1721,18 +1721,22 @@ extern "C" {
 
     void eb_aom_highbd_dc_left_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_left_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_left_predictor_32x16_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_left_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_left_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_left_predictor_32x32_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_left_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_left_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_left_predictor_32x64_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_left_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_left_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_left_predictor_32x8_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_left_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1749,14 +1753,17 @@ extern "C" {
 
     void eb_aom_highbd_dc_left_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_left_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_left_predictor_64x16_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_left_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_left_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_left_predictor_64x32_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_left_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_left_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_left_predictor_64x64_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_left_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_left_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -3437,13 +3444,9 @@ extern "C" {
         if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_16x8 = eb_aom_highbd_dc_left_predictor_16x8_avx2;
         eb_aom_highbd_dc_left_predictor_2x2 = eb_aom_highbd_dc_left_predictor_2x2_c;
         eb_aom_highbd_dc_left_predictor_32x16 = eb_aom_highbd_dc_left_predictor_32x16_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_32x16 = eb_aom_highbd_dc_left_predictor_32x16_avx2;
         eb_aom_highbd_dc_left_predictor_32x32 = eb_aom_highbd_dc_left_predictor_32x32_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_32x32 = eb_aom_highbd_dc_left_predictor_32x32_avx2;
         eb_aom_highbd_dc_left_predictor_32x64 = eb_aom_highbd_dc_left_predictor_32x64_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_32x64 = eb_aom_highbd_dc_left_predictor_32x64_avx2;
         eb_aom_highbd_dc_left_predictor_32x8 = eb_aom_highbd_dc_left_predictor_32x8_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_32x8 = eb_aom_highbd_dc_left_predictor_32x8_avx2;
         eb_aom_highbd_dc_left_predictor_4x16 = eb_aom_highbd_dc_left_predictor_4x16_c;
         if (flags & HAS_SSE2) eb_aom_highbd_dc_left_predictor_4x16 = eb_aom_highbd_dc_left_predictor_4x16_sse2;
         eb_aom_highbd_dc_left_predictor_4x4 = eb_aom_highbd_dc_left_predictor_4x4_c;
@@ -3453,17 +3456,32 @@ extern "C" {
         eb_aom_highbd_dc_left_predictor_8x32 = eb_aom_highbd_dc_left_predictor_8x32_c;
         if (flags & HAS_SSE2) eb_aom_highbd_dc_left_predictor_8x32 = eb_aom_highbd_dc_left_predictor_8x32_sse2;
         eb_aom_highbd_dc_left_predictor_64x16 = eb_aom_highbd_dc_left_predictor_64x16_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_64x16 = eb_aom_highbd_dc_left_predictor_64x16_avx2;
         eb_aom_highbd_dc_left_predictor_64x32 = eb_aom_highbd_dc_left_predictor_64x32_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_64x32 = eb_aom_highbd_dc_left_predictor_64x32_avx2;
         eb_aom_highbd_dc_left_predictor_64x64 = eb_aom_highbd_dc_left_predictor_64x64_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_64x64 = eb_aom_highbd_dc_left_predictor_64x64_avx2;
         eb_aom_highbd_dc_left_predictor_8x16 = eb_aom_highbd_dc_left_predictor_8x16_c;
         if (flags & HAS_SSE2) eb_aom_highbd_dc_left_predictor_8x16 = eb_aom_highbd_dc_left_predictor_8x16_sse2;
         eb_aom_highbd_dc_left_predictor_8x4 = eb_aom_highbd_dc_left_predictor_8x4_c;
         if (flags & HAS_SSE2) eb_aom_highbd_dc_left_predictor_8x4 = eb_aom_highbd_dc_left_predictor_8x4_sse2;
         eb_aom_highbd_dc_left_predictor_8x8 = eb_aom_highbd_dc_left_predictor_8x8_c;
         if (flags & HAS_SSE2) eb_aom_highbd_dc_left_predictor_8x8 = eb_aom_highbd_dc_left_predictor_8x8_sse2;
+
+#ifndef NON_AVX512_SUPPORT
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_32x8 = aom_highbd_dc_left_predictor_32x8_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_32x16 = aom_highbd_dc_left_predictor_32x16_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_32x32 = aom_highbd_dc_left_predictor_32x32_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_32x64 = aom_highbd_dc_left_predictor_32x64_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_64x16 = aom_highbd_dc_left_predictor_64x16_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_64x32 = aom_highbd_dc_left_predictor_64x32_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_64x64 = aom_highbd_dc_left_predictor_64x64_avx512;
+#else
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_32x8 = eb_aom_highbd_dc_left_predictor_32x8_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_32x16 = eb_aom_highbd_dc_left_predictor_32x16_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_32x32 = eb_aom_highbd_dc_left_predictor_32x32_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_32x64 = eb_aom_highbd_dc_left_predictor_32x64_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_64x16 = eb_aom_highbd_dc_left_predictor_64x16_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_64x32 = eb_aom_highbd_dc_left_predictor_64x32_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_left_predictor_64x64 = eb_aom_highbd_dc_left_predictor_64x64_avx2;
+#endif // !NON_AVX512_SUPPORT
 
         eb_aom_highbd_dc_predictor_16x16 = eb_aom_highbd_dc_predictor_16x16_c;
         if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_16x16 = eb_aom_highbd_dc_predictor_16x16_avx2;

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -1807,18 +1807,22 @@ extern "C" {
 
     void eb_aom_highbd_dc_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_predictor_32x16_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_predictor_32x32_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_predictor_32x64_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_predictor_32x8_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1835,14 +1839,17 @@ extern "C" {
 
     void eb_aom_highbd_dc_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_predictor_64x16_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_predictor_64x32_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_predictor_64x64_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1886,18 +1893,22 @@ extern "C" {
 
     void eb_aom_highbd_dc_top_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_top_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_top_predictor_32x16_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_top_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_top_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_top_predictor_32x32_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_top_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_top_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_top_predictor_32x64_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_top_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_top_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_top_predictor_32x8_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_top_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -1914,14 +1925,17 @@ extern "C" {
 
     void eb_aom_highbd_dc_top_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_top_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_top_predictor_64x16_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_top_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_top_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_top_predictor_64x32_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_top_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_dc_top_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_dc_top_predictor_64x64_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_dc_top_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_dc_top_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -3495,13 +3509,9 @@ extern "C" {
         if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_16x8 = eb_aom_highbd_dc_predictor_16x8_avx2;
         eb_aom_highbd_dc_predictor_2x2 = eb_aom_highbd_dc_predictor_2x2_c;
         eb_aom_highbd_dc_predictor_32x16 = eb_aom_highbd_dc_predictor_32x16_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_32x16 = eb_aom_highbd_dc_predictor_32x16_avx2;
         eb_aom_highbd_dc_predictor_32x32 = eb_aom_highbd_dc_predictor_32x32_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_32x32 = eb_aom_highbd_dc_predictor_32x32_avx2;
         eb_aom_highbd_dc_predictor_32x64 = eb_aom_highbd_dc_predictor_32x64_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_32x64 = eb_aom_highbd_dc_predictor_32x64_avx2;
         eb_aom_highbd_dc_predictor_32x8 = eb_aom_highbd_dc_predictor_32x8_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_32x8 = eb_aom_highbd_dc_predictor_32x8_avx2;
         eb_aom_highbd_dc_predictor_4x16 = eb_aom_highbd_dc_predictor_4x16_c;
         if (flags & HAS_SSE2) eb_aom_highbd_dc_predictor_4x16 = eb_aom_highbd_dc_predictor_4x16_sse2;
         eb_aom_highbd_dc_predictor_4x4 = eb_aom_highbd_dc_predictor_4x4_c;
@@ -3509,11 +3519,8 @@ extern "C" {
         eb_aom_highbd_dc_predictor_4x8 = eb_aom_highbd_dc_predictor_4x8_c;
         if (flags & HAS_SSE2) eb_aom_highbd_dc_predictor_4x8 = eb_aom_highbd_dc_predictor_4x8_sse2;
         eb_aom_highbd_dc_predictor_64x16 = eb_aom_highbd_dc_predictor_64x16_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_64x16 = eb_aom_highbd_dc_predictor_64x16_avx2;
         eb_aom_highbd_dc_predictor_64x32 = eb_aom_highbd_dc_predictor_64x32_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_64x32 = eb_aom_highbd_dc_predictor_64x32_avx2;
         eb_aom_highbd_dc_predictor_64x64 = eb_aom_highbd_dc_predictor_64x64_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_64x64 = eb_aom_highbd_dc_predictor_64x64_avx2;
         eb_aom_highbd_dc_predictor_8x16 = eb_aom_highbd_dc_predictor_8x16_c;
         if (flags & HAS_SSE2) eb_aom_highbd_dc_predictor_8x16 = eb_aom_highbd_dc_predictor_8x16_sse2;
         eb_aom_highbd_dc_predictor_8x4 = eb_aom_highbd_dc_predictor_8x4_c;
@@ -3523,6 +3530,23 @@ extern "C" {
         eb_aom_highbd_dc_predictor_8x32 = eb_aom_highbd_dc_predictor_8x32_c;
         if (flags & HAS_SSE2) eb_aom_highbd_dc_predictor_8x32 = eb_aom_highbd_dc_predictor_8x32_sse2;
 
+#ifndef NON_AVX512_SUPPORT
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_32x8 = aom_highbd_dc_predictor_32x8_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_32x16 = aom_highbd_dc_predictor_32x16_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_32x32 = aom_highbd_dc_predictor_32x32_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_32x64 = aom_highbd_dc_predictor_32x64_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_64x16 = aom_highbd_dc_predictor_64x16_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_64x32 = aom_highbd_dc_predictor_64x32_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_64x64 = aom_highbd_dc_predictor_64x64_avx512;
+#else
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_32x8 = eb_aom_highbd_dc_predictor_32x8_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_32x16 = eb_aom_highbd_dc_predictor_32x16_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_32x32 = eb_aom_highbd_dc_predictor_32x32_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_32x64 = eb_aom_highbd_dc_predictor_32x64_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_64x16 = eb_aom_highbd_dc_predictor_64x16_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_64x32 = eb_aom_highbd_dc_predictor_64x32_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_predictor_64x64 = eb_aom_highbd_dc_predictor_64x64_avx2;
+#endif // !NON_AVX512_SUPPORT
         //aom_highbd_dc_top_predictor
         eb_aom_highbd_dc_top_predictor_16x16 = eb_aom_highbd_dc_top_predictor_16x16_c;
         if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_16x16 = eb_aom_highbd_dc_top_predictor_16x16_avx2;
@@ -3536,13 +3560,9 @@ extern "C" {
         if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_16x8 = eb_aom_highbd_dc_top_predictor_16x8_avx2;
         eb_aom_highbd_dc_top_predictor_2x2 = eb_aom_highbd_dc_top_predictor_2x2_c;
         eb_aom_highbd_dc_top_predictor_32x16 = eb_aom_highbd_dc_top_predictor_32x16_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_32x16 = eb_aom_highbd_dc_top_predictor_32x16_avx2;
         eb_aom_highbd_dc_top_predictor_32x32 = eb_aom_highbd_dc_top_predictor_32x32_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_32x32 = eb_aom_highbd_dc_top_predictor_32x32_avx2;
         eb_aom_highbd_dc_top_predictor_32x64 = eb_aom_highbd_dc_top_predictor_32x64_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_32x64 = eb_aom_highbd_dc_top_predictor_32x64_avx2;
         eb_aom_highbd_dc_top_predictor_32x8 = eb_aom_highbd_dc_top_predictor_32x8_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_32x8 = eb_aom_highbd_dc_top_predictor_32x8_avx2;
         eb_aom_highbd_dc_top_predictor_4x16 = eb_aom_highbd_dc_top_predictor_4x16_c;
         if (flags & HAS_SSE2) eb_aom_highbd_dc_top_predictor_4x16 = eb_aom_highbd_dc_top_predictor_4x16_sse2;
         eb_aom_highbd_dc_top_predictor_4x4 = eb_aom_highbd_dc_top_predictor_4x4_c;
@@ -3550,11 +3570,8 @@ extern "C" {
         eb_aom_highbd_dc_top_predictor_4x8 = eb_aom_highbd_dc_top_predictor_4x8_c;
         if (flags & HAS_SSE2) eb_aom_highbd_dc_top_predictor_4x8 = eb_aom_highbd_dc_top_predictor_4x8_sse2;
         eb_aom_highbd_dc_top_predictor_64x16 = eb_aom_highbd_dc_top_predictor_64x16_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_64x16 = eb_aom_highbd_dc_top_predictor_64x16_avx2;
         eb_aom_highbd_dc_top_predictor_64x32 = eb_aom_highbd_dc_top_predictor_64x32_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_64x32 = eb_aom_highbd_dc_top_predictor_64x32_avx2;
         eb_aom_highbd_dc_top_predictor_64x64 = eb_aom_highbd_dc_top_predictor_64x64_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_64x64 = eb_aom_highbd_dc_top_predictor_64x64_avx2;
         eb_aom_highbd_dc_top_predictor_8x16 = eb_aom_highbd_dc_top_predictor_8x16_c;
         if (flags & HAS_SSE2) eb_aom_highbd_dc_top_predictor_8x16 = eb_aom_highbd_dc_top_predictor_8x16_sse2;
         if (flags & HAS_SSE2) eb_aom_highbd_dc_top_predictor_8x32 = eb_aom_highbd_dc_top_predictor_8x32_c;
@@ -3563,6 +3580,23 @@ extern "C" {
         eb_aom_highbd_dc_top_predictor_8x8 = eb_aom_highbd_dc_top_predictor_8x8_c;
         if (flags & HAS_SSE2) eb_aom_highbd_dc_top_predictor_8x8 = eb_aom_highbd_dc_top_predictor_8x8_sse2;
 
+#ifndef NON_AVX512_SUPPORT
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_32x8 = aom_highbd_dc_top_predictor_32x8_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_32x16 = aom_highbd_dc_top_predictor_32x16_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_32x32 = aom_highbd_dc_top_predictor_32x32_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_32x64 = aom_highbd_dc_top_predictor_32x64_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_64x16 = aom_highbd_dc_top_predictor_64x16_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_64x32 = aom_highbd_dc_top_predictor_64x32_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_64x64 = aom_highbd_dc_top_predictor_64x64_avx512;
+#else
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_32x8 = eb_aom_highbd_dc_top_predictor_32x8_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_32x16 = eb_aom_highbd_dc_top_predictor_32x16_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_32x32 = eb_aom_highbd_dc_top_predictor_32x32_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_32x64 = eb_aom_highbd_dc_top_predictor_32x64_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_64x16 = eb_aom_highbd_dc_top_predictor_64x16_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_64x32 = eb_aom_highbd_dc_top_predictor_64x32_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_dc_top_predictor_64x64 = eb_aom_highbd_dc_top_predictor_64x64_avx2;
+#endif
         // eb_aom_highbd_h_predictor
         eb_aom_highbd_h_predictor_16x4 = eb_aom_highbd_h_predictor_16x4_c;
         if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_16x4 = eb_aom_highbd_h_predictor_16x4_avx2;

--- a/test/EbHighbdIntraPredictionTests.cc
+++ b/test/EbHighbdIntraPredictionTests.cc
@@ -1,0 +1,361 @@
+#include "gtest/gtest.h"
+#include "EbDefinitions.h"
+#include "EbUnitTest.h"
+#include "EbUnitTestUtility.h"
+#include "EbHighbdIntraPredictionTests.h"
+#include <immintrin.h>
+#include <iostream>
+
+using namespace std;
+int bitdepth[] = { 8, 10, 12 };
+
+static void init_data(uint16_t **input, uint16_t **above, uint16_t **left, ptrdiff_t input_stride) {
+    TEST_ALLIGN_MALLOC(uint16_t*, *input, sizeof(uint16_t) * MAX_SB_SIZE * input_stride);
+    memset(*input, 0, MAX_SB_SIZE * input_stride);
+    eb_buf_random_u16(*input, MAX_SB_SIZE * input_stride);
+    *above = *input + rand() % (MAX_SB_SIZE * input_stride / 2);
+    *left = *input + rand() % (MAX_SB_SIZE * input_stride / 4);
+}
+
+static void uninit_data(uint16_t *input) {
+    TEST_ALLIGN_FREE(input);
+}
+
+static void init_coeff(uint16_t **coeff, uint16_t **coeff_opt, ptrdiff_t *stride) {
+    *stride = eb_create_random_aligned_stride(MAX_SB_SIZE, 64);
+    TEST_ALLIGN_MALLOC(uint16_t*, *coeff, sizeof(uint16_t) * MAX_SB_SIZE * *stride);
+    TEST_ALLIGN_MALLOC(uint16_t*, *coeff_opt, sizeof(uint16_t) * MAX_SB_SIZE * *stride);
+    memset(*coeff, 0, MAX_SB_SIZE * *stride);
+    memset(*coeff_opt, 0, MAX_SB_SIZE * *stride);
+}
+
+static void uninit_coeff(uint16_t *coeff, uint16_t *coeff_opt) {
+    TEST_ALLIGN_FREE(coeff);
+    TEST_ALLIGN_FREE(coeff_opt);
+}
+
+void dc_compare_u16(uint16_t * output_base, uint16_t *output_opt,ptrdiff_t stride,int height, int width) {
+    for(int x = 0; x < height; x++) {
+        for(int y = 0; y < width; y++) {
+           EXPECT_EQ(output_base[y], output_opt[y]);
+        }
+        output_base += stride;
+        output_opt += stride;
+    }
+}
+
+TEST(HighbdIntraPredictionTest, aom_dc_top_predictor_kernels)
+{
+    uint16_t *input = NULL, *above = NULL, *left = NULL;
+    uint16_t* dc_coeff = NULL, *dc_coeff_opt = NULL;
+    ptrdiff_t stride = 0;
+
+    int no_of_pred_funcs = sizeof(aom_highbd_dc_top_funcptr_array_opt) / sizeof(aom_highbd_dc_top_predictor_func);
+    int no_of_bitdepths = sizeof(bitdepth)/sizeof(int);
+
+    for (int loop = 0; loop < no_of_pred_funcs; loop++) {         //Function Pairs
+        for (int i = 0; i < EB_UNIT_TEST_NUM; i++) {             //Number of Test Runs
+            for (int x = 0; x < no_of_bitdepths; x++) {//Bit Depth
+                switch (loop) {
+                case 0://32x8
+                    for (int j = 0; j < 10; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_top_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_top_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 8, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 1://32x16
+                    for (int j = 0; j < 10; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_top_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_top_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 16, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 2://32x32
+                    for (int j = 0; j < 10; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_top_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_top_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 32, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 3://32x64
+                    for (int j = 0; j < 10; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_top_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_top_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 64, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 4://64x16
+                    for (int j = 0; j < 10; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_top_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_top_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 16, 64);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 5://64x32
+                    for (int j = 0; j < 10; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_top_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_top_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 32, 64);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 6://64x64
+                    for (int j = 0; j < 10; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_top_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_top_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt,stride, 64, 64);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                default:
+                    ASSERT(0);
+                }
+            }
+        }
+    }
+   
+}
+
+TEST(HighbdIntraPredictionTest, aom_dc_left_predictor_kernels)
+{
+    uint16_t *input = NULL, *above = NULL, *left = NULL;
+    uint16_t* dc_coeff = NULL, *dc_coeff_opt = NULL;
+    ptrdiff_t stride = 0;
+
+    int no_of_pred_funcs = sizeof(aom_highbd_dc_left_funcptr_array_opt) / sizeof(aom_highbd_dc_left_predictor_func);
+
+    for (int loop = 0; loop < no_of_pred_funcs; loop++) {         //Function Pairs
+        for (int i = 0; i < EB_UNIT_TEST_NUM; i++) {             //Number of Test Runs
+            for (int x = 0; x < 3; x++) {//Bit Depth
+                switch (loop) {
+                case 0://32x8
+                    for (int j = 0; j < 1; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_left_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_left_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt,stride, 8, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 1://32x16
+                    for (int j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_left_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_left_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt,stride, 16, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 2://32x32
+                    for (int j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_left_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_left_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 32, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 3://32x64
+                    for (int j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_left_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_left_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 64, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 4://64x16
+                    for (int j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_left_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_left_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt,stride, 16, 64);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 5://64x32
+                    for (int j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_left_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_left_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 32, 64);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 6://64x64
+                    for (int j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_left_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_left_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 64, 64);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                default:
+                    ASSERT(0);
+                }
+            }
+        }
+    }
+
+}
+
+TEST(HighbdIntraPredictionTest, aom_dc_predictor_kernels)
+{
+    uint16_t *input = NULL, *above = NULL, *left = NULL;
+    uint16_t* dc_coeff = NULL, *dc_coeff_opt = NULL;
+    ptrdiff_t stride = 0;
+
+    int no_of_pred_funcs = sizeof(aom_highbd_dc_pred_funcptr_array_opt) / sizeof(aom_highbd_dc_predictor_func);
+
+    for (int loop = 0; loop < no_of_pred_funcs; loop++) {         //Function Pairs
+        for (int i = 0; i < EB_UNIT_TEST_NUM; i++) {             //Number of Test Runs
+            for (int x = 0; x < 3; x++) {//Bit Depth
+                switch (loop) {
+                case 0://32x8
+                    for (int j = 0; j < 1; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 8, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 1://32x16
+                    for (int j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 16, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 2://32x32
+                    for (int j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt,stride, 32, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 3://32x64
+                    for (int j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 64, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 4://64x16
+                    for (int j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 16, 64);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 5://64x32
+                    for (int j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 32, 64);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 6://64x64
+                    for (int j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_dc_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_dc_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 64, 64);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                default:
+                    ASSERT(0);
+                }
+            }
+        }
+    }
+
+}

--- a/test/EbHighbdIntraPredictionTests.cc
+++ b/test/EbHighbdIntraPredictionTests.cc
@@ -34,7 +34,7 @@ static void uninit_coeff(uint16_t *coeff, uint16_t *coeff_opt) {
     TEST_ALLIGN_FREE(coeff_opt);
 }
 
-void dc_compare_u16(uint16_t * output_base, uint16_t *output_opt,ptrdiff_t stride,int height, int width) {
+void dc_compare_u16(uint16_t * output_base, uint16_t *output_opt, ptrdiff_t stride, int height, int width) {
     for(int x = 0; x < height; x++) {
         for(int y = 0; y < width; y++) {
            EXPECT_EQ(output_base[y], output_opt[y]);

--- a/test/EbHighbdIntraPredictionTests.cc
+++ b/test/EbHighbdIntraPredictionTests.cc
@@ -17,7 +17,7 @@ int bitdepth[] = { 8, 10, 12 };
 static void init_data(uint16_t **input, uint16_t **above, uint16_t **left, ptrdiff_t input_stride) {
     TEST_ALLIGN_MALLOC(uint16_t*, *input, sizeof(uint16_t) * MAX_SB_SIZE * input_stride);
     memset(*input, 0, MAX_SB_SIZE * input_stride);
-    eb_buf_random_u16(*input, MAX_SB_SIZE * input_stride);
+    eb_buf_random_u16(*input, (uint32_t)(MAX_SB_SIZE * input_stride));
     *above = *input + rand() % (MAX_SB_SIZE * input_stride / 2);
     *left = *input + rand() % (MAX_SB_SIZE * input_stride / 4);
 }

--- a/test/EbHighbdIntraPredictionTests.cc
+++ b/test/EbHighbdIntraPredictionTests.cc
@@ -1,11 +1,16 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
 #include "gtest/gtest.h"
 #include "EbDefinitions.h"
 #include "EbUnitTest.h"
 #include "EbUnitTestUtility.h"
 #include "EbHighbdIntraPredictionTests.h"
 #include <immintrin.h>
-#include <iostream>
 
+#ifndef NON_AVX512_SUPPORT
 using namespace std;
 int bitdepth[] = { 8, 10, 12 };
 
@@ -359,3 +364,4 @@ TEST(HighbdIntraPredictionTest, aom_dc_predictor_kernels)
     }
 
 }
+#endif

--- a/test/EbHighbdIntraPredictionTests.cc
+++ b/test/EbHighbdIntraPredictionTests.cc
@@ -152,7 +152,7 @@ TEST(HighbdIntraPredictionTest, aom_dc_top_predictor_kernels)
             }
         }
     }
-   
+
 }
 
 TEST(HighbdIntraPredictionTest, aom_dc_left_predictor_kernels)

--- a/test/EbHighbdIntraPredictionTests.h
+++ b/test/EbHighbdIntraPredictionTests.h
@@ -1,0 +1,94 @@
+#pragma once
+#ifndef EbHighbdIntraPredictionTests_h
+#define EbHighbdIntraPredictionTests_h
+
+#include "aom_dsp_rtcd.h"
+
+typedef void(*aom_highbd_dc_top_predictor_func)(uint16_t *dst, ptrdiff_t stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+
+static aom_highbd_dc_top_predictor_func aom_highbd_dc_top_funcptr_array_opt[7] = {
+                            aom_highbd_dc_top_predictor_32x8_avx512,
+                            aom_highbd_dc_top_predictor_32x16_avx512,
+                            aom_highbd_dc_top_predictor_32x32_avx512,
+                            aom_highbd_dc_top_predictor_32x64_avx512,
+                            aom_highbd_dc_top_predictor_64x16_avx512,
+                            aom_highbd_dc_top_predictor_64x32_avx512,
+                            aom_highbd_dc_top_predictor_64x64_avx512 };
+
+static aom_highbd_dc_top_predictor_func aom_highbd_dc_top_funcptr_array_base[7] = {
+                            aom_highbd_dc_top_predictor_32x8_avx2,
+                            aom_highbd_dc_top_predictor_32x16_avx2,
+                            aom_highbd_dc_top_predictor_32x32_avx2,
+                            aom_highbd_dc_top_predictor_32x64_avx2,
+                            aom_highbd_dc_top_predictor_64x16_avx2,
+                            aom_highbd_dc_top_predictor_64x32_avx2,
+                            aom_highbd_dc_top_predictor_64x64_avx2 };
+
+static aom_highbd_dc_top_predictor_func aom_highbd_dc_top_funcptr_array_naive[7] = {
+                            aom_highbd_dc_top_predictor_32x8_c,
+                            aom_highbd_dc_top_predictor_32x16_c,
+                            aom_highbd_dc_top_predictor_32x32_c,
+                            aom_highbd_dc_top_predictor_32x64_c,
+                            aom_highbd_dc_top_predictor_64x16_c,
+                            aom_highbd_dc_top_predictor_64x32_c,
+                            aom_highbd_dc_top_predictor_64x64_c};
+
+typedef void(*aom_highbd_dc_left_predictor_func)(uint16_t *dst, ptrdiff_t stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+
+static aom_highbd_dc_left_predictor_func aom_highbd_dc_left_funcptr_array_opt[7] = {
+                            aom_highbd_dc_left_predictor_32x8_avx512,
+                            aom_highbd_dc_left_predictor_32x16_avx512,
+                            aom_highbd_dc_left_predictor_32x32_avx512,
+                            aom_highbd_dc_left_predictor_32x64_avx512,
+                            aom_highbd_dc_left_predictor_64x16_avx512,
+                            aom_highbd_dc_left_predictor_64x32_avx512,
+                            aom_highbd_dc_left_predictor_64x64_avx512 };
+
+static aom_highbd_dc_left_predictor_func aom_highbd_dc_left_funcptr_array_base[7] = {
+                            aom_highbd_dc_left_predictor_32x8_avx2,
+                            aom_highbd_dc_left_predictor_32x16_avx2,
+                            aom_highbd_dc_left_predictor_32x32_avx2,
+                            aom_highbd_dc_left_predictor_32x64_avx2,
+                            aom_highbd_dc_left_predictor_64x16_avx2,
+                            aom_highbd_dc_left_predictor_64x32_avx2,
+                            aom_highbd_dc_left_predictor_64x64_avx2 };
+
+static aom_highbd_dc_left_predictor_func aom_highbd_dc_left_funcptr_array_naive[7] = {
+                            aom_highbd_dc_left_predictor_32x8_c,
+                            aom_highbd_dc_left_predictor_32x16_c,
+                            aom_highbd_dc_left_predictor_32x32_c,
+                            aom_highbd_dc_left_predictor_32x64_c,
+                            aom_highbd_dc_left_predictor_64x16_c,
+                            aom_highbd_dc_left_predictor_64x32_c,
+                            aom_highbd_dc_left_predictor_64x64_c };
+
+
+typedef void(*aom_highbd_dc_predictor_func)(uint16_t *dst, ptrdiff_t stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+
+static aom_highbd_dc_predictor_func aom_highbd_dc_pred_funcptr_array_opt[7] = {
+                            aom_highbd_dc_predictor_32x8_avx512,
+                            aom_highbd_dc_predictor_32x16_avx512,
+                            aom_highbd_dc_predictor_32x32_avx512,
+                            aom_highbd_dc_predictor_32x64_avx512,
+                            aom_highbd_dc_predictor_64x16_avx512,
+                            aom_highbd_dc_predictor_64x32_avx512,
+                            aom_highbd_dc_predictor_64x64_avx512 };
+
+static aom_highbd_dc_predictor_func aom_highbd_dc_pred_funcptr_array_base[7] = {
+                            aom_highbd_dc_predictor_32x8_avx2,
+                            aom_highbd_dc_predictor_32x16_avx2,
+                            aom_highbd_dc_predictor_32x32_avx2,
+                            aom_highbd_dc_predictor_32x64_avx2,
+                            aom_highbd_dc_predictor_64x16_avx2,
+                            aom_highbd_dc_predictor_64x32_avx2,
+                            aom_highbd_dc_predictor_64x64_avx2 };
+
+static aom_highbd_dc_predictor_func aom_highbd_dc_pred_funcptr_array_naive[7] = {
+                            aom_highbd_dc_predictor_32x8_c,
+                            aom_highbd_dc_predictor_32x16_c,
+                            aom_highbd_dc_predictor_32x32_c,
+                            aom_highbd_dc_predictor_32x64_c,
+                            aom_highbd_dc_predictor_64x16_c,
+                            aom_highbd_dc_predictor_64x32_c,
+                            aom_highbd_dc_predictor_64x64_c };
+#endif

--- a/test/EbHighbdIntraPredictionTests.h
+++ b/test/EbHighbdIntraPredictionTests.h
@@ -16,22 +16,22 @@ static aom_highbd_dc_top_predictor_func aom_highbd_dc_top_funcptr_array_opt[7] =
                             aom_highbd_dc_top_predictor_64x64_avx512 };
 
 static aom_highbd_dc_top_predictor_func aom_highbd_dc_top_funcptr_array_base[7] = {
-                            aom_highbd_dc_top_predictor_32x8_avx2,
-                            aom_highbd_dc_top_predictor_32x16_avx2,
-                            aom_highbd_dc_top_predictor_32x32_avx2,
-                            aom_highbd_dc_top_predictor_32x64_avx2,
-                            aom_highbd_dc_top_predictor_64x16_avx2,
-                            aom_highbd_dc_top_predictor_64x32_avx2,
-                            aom_highbd_dc_top_predictor_64x64_avx2 };
+                            eb_aom_highbd_dc_top_predictor_32x8_avx2,
+                            eb_aom_highbd_dc_top_predictor_32x16_avx2,
+                            eb_aom_highbd_dc_top_predictor_32x32_avx2,
+                            eb_aom_highbd_dc_top_predictor_32x64_avx2,
+                            eb_aom_highbd_dc_top_predictor_64x16_avx2,
+                            eb_aom_highbd_dc_top_predictor_64x32_avx2,
+                            eb_aom_highbd_dc_top_predictor_64x64_avx2 };
 
 static aom_highbd_dc_top_predictor_func aom_highbd_dc_top_funcptr_array_naive[7] = {
-                            aom_highbd_dc_top_predictor_32x8_c,
-                            aom_highbd_dc_top_predictor_32x16_c,
-                            aom_highbd_dc_top_predictor_32x32_c,
-                            aom_highbd_dc_top_predictor_32x64_c,
-                            aom_highbd_dc_top_predictor_64x16_c,
-                            aom_highbd_dc_top_predictor_64x32_c,
-                            aom_highbd_dc_top_predictor_64x64_c};
+                            eb_aom_highbd_dc_top_predictor_32x8_c,
+                            eb_aom_highbd_dc_top_predictor_32x16_c,
+                            eb_aom_highbd_dc_top_predictor_32x32_c,
+                            eb_aom_highbd_dc_top_predictor_32x64_c,
+                            eb_aom_highbd_dc_top_predictor_64x16_c,
+                            eb_aom_highbd_dc_top_predictor_64x32_c,
+                            eb_aom_highbd_dc_top_predictor_64x64_c};
 
 typedef void(*aom_highbd_dc_left_predictor_func)(uint16_t *dst, ptrdiff_t stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
@@ -45,22 +45,22 @@ static aom_highbd_dc_left_predictor_func aom_highbd_dc_left_funcptr_array_opt[7]
                             aom_highbd_dc_left_predictor_64x64_avx512 };
 
 static aom_highbd_dc_left_predictor_func aom_highbd_dc_left_funcptr_array_base[7] = {
-                            aom_highbd_dc_left_predictor_32x8_avx2,
-                            aom_highbd_dc_left_predictor_32x16_avx2,
-                            aom_highbd_dc_left_predictor_32x32_avx2,
-                            aom_highbd_dc_left_predictor_32x64_avx2,
-                            aom_highbd_dc_left_predictor_64x16_avx2,
-                            aom_highbd_dc_left_predictor_64x32_avx2,
-                            aom_highbd_dc_left_predictor_64x64_avx2 };
+                            eb_aom_highbd_dc_left_predictor_32x8_avx2,
+                            eb_aom_highbd_dc_left_predictor_32x16_avx2,
+                            eb_aom_highbd_dc_left_predictor_32x32_avx2,
+                            eb_aom_highbd_dc_left_predictor_32x64_avx2,
+                            eb_aom_highbd_dc_left_predictor_64x16_avx2,
+                            eb_aom_highbd_dc_left_predictor_64x32_avx2,
+                            eb_aom_highbd_dc_left_predictor_64x64_avx2 };
 
 static aom_highbd_dc_left_predictor_func aom_highbd_dc_left_funcptr_array_naive[7] = {
-                            aom_highbd_dc_left_predictor_32x8_c,
-                            aom_highbd_dc_left_predictor_32x16_c,
-                            aom_highbd_dc_left_predictor_32x32_c,
-                            aom_highbd_dc_left_predictor_32x64_c,
-                            aom_highbd_dc_left_predictor_64x16_c,
-                            aom_highbd_dc_left_predictor_64x32_c,
-                            aom_highbd_dc_left_predictor_64x64_c };
+                            eb_aom_highbd_dc_left_predictor_32x8_c,
+                            eb_aom_highbd_dc_left_predictor_32x16_c,
+                            eb_aom_highbd_dc_left_predictor_32x32_c,
+                            eb_aom_highbd_dc_left_predictor_32x64_c,
+                            eb_aom_highbd_dc_left_predictor_64x16_c,
+                            eb_aom_highbd_dc_left_predictor_64x32_c,
+                            eb_aom_highbd_dc_left_predictor_64x64_c };
 
 
 typedef void(*aom_highbd_dc_predictor_func)(uint16_t *dst, ptrdiff_t stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -75,20 +75,20 @@ static aom_highbd_dc_predictor_func aom_highbd_dc_pred_funcptr_array_opt[7] = {
                             aom_highbd_dc_predictor_64x64_avx512 };
 
 static aom_highbd_dc_predictor_func aom_highbd_dc_pred_funcptr_array_base[7] = {
-                            aom_highbd_dc_predictor_32x8_avx2,
-                            aom_highbd_dc_predictor_32x16_avx2,
-                            aom_highbd_dc_predictor_32x32_avx2,
-                            aom_highbd_dc_predictor_32x64_avx2,
-                            aom_highbd_dc_predictor_64x16_avx2,
-                            aom_highbd_dc_predictor_64x32_avx2,
-                            aom_highbd_dc_predictor_64x64_avx2 };
+                            eb_aom_highbd_dc_predictor_32x8_avx2,
+                            eb_aom_highbd_dc_predictor_32x16_avx2,
+                            eb_aom_highbd_dc_predictor_32x32_avx2,
+                            eb_aom_highbd_dc_predictor_32x64_avx2,
+                            eb_aom_highbd_dc_predictor_64x16_avx2,
+                            eb_aom_highbd_dc_predictor_64x32_avx2,
+                            eb_aom_highbd_dc_predictor_64x64_avx2 };
 
 static aom_highbd_dc_predictor_func aom_highbd_dc_pred_funcptr_array_naive[7] = {
-                            aom_highbd_dc_predictor_32x8_c,
-                            aom_highbd_dc_predictor_32x16_c,
-                            aom_highbd_dc_predictor_32x32_c,
-                            aom_highbd_dc_predictor_32x64_c,
-                            aom_highbd_dc_predictor_64x16_c,
-                            aom_highbd_dc_predictor_64x32_c,
-                            aom_highbd_dc_predictor_64x64_c };
+                            eb_aom_highbd_dc_predictor_32x8_c,
+                            eb_aom_highbd_dc_predictor_32x16_c,
+                            eb_aom_highbd_dc_predictor_32x32_c,
+                            eb_aom_highbd_dc_predictor_32x64_c,
+                            eb_aom_highbd_dc_predictor_64x16_c,
+                            eb_aom_highbd_dc_predictor_64x32_c,
+                            eb_aom_highbd_dc_predictor_64x64_c };
 #endif

--- a/test/EbHighbdIntraPredictionTests.h
+++ b/test/EbHighbdIntraPredictionTests.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright(c) 2019 Intel Corporation
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
+#ifndef NON_AVX512_SUPPORT
 #pragma once
 #ifndef EbHighbdIntraPredictionTests_h
 #define EbHighbdIntraPredictionTests_h
@@ -91,4 +97,5 @@ static aom_highbd_dc_predictor_func aom_highbd_dc_pred_funcptr_array_naive[7] = 
                             eb_aom_highbd_dc_predictor_64x16_c,
                             eb_aom_highbd_dc_predictor_64x32_c,
                             eb_aom_highbd_dc_predictor_64x64_c };
+#endif
 #endif

--- a/test/EbUnitTest.h
+++ b/test/EbUnitTest.h
@@ -23,4 +23,18 @@ extern const char eb_unit_test_result_str[2][25];
 }
 #endif
 
-#endif  // EbUnitTest_h
+#ifdef _WIN32
+#define TEST_ALLIGN_MALLOC(type, pointer, n_elements) \
+pointer = (type) _aligned_malloc(n_elements, ALVALUE); \
+
+#define TEST_ALLIGN_FREE(pointer) _aligned_free(pointer);
+
+#else
+#define TEST_ALLIGN_MALLOC(type, pointer, n_elements) \
+posix_memalign((void**)(&(pointer)), ALVALUE, n_elements); \
+
+#define TEST_ALLIGN_FREE(pointer) free(pointer);
+
+#endif
+
+#endif // EbUnitTest_h


### PR DESCRIPTION
This PR has the AVX512 high_bd_dc_predictor,high_bd_dc_top_predictor and high_bd_dc_left_predictor kernels and their unit tests.The performance numbers are given with commit messages.