### PR TITLE
Ffmpeg plugin fixes and improvements

### DIFF
--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
@@ -1,4 +1,4 @@
-From 219ace9cc15ea37e0be8531b380fb97404654cee Mon Sep 17 00:00:00 2001
+From 3ffe1178f8866de55cc33b334f394ee15b85126f Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1 with svt-hevc
@@ -13,8 +13,8 @@ Signed-off-by: Zhong Li <zhong.li@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 507 ++++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 513 insertions(+)
+ libavcodec/libsvt_av1.c | 509 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 515 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index 5739d53..98f0c99 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..9473a08
+index 0000000..a63b7e6
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,507 @@
+@@ -0,0 +1,509 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -461,6 +461,8 @@ index 0000000..9473a08
 +
 +    if (headerPtr->flags & EB_BUFFERFLAG_EOS)
 +        svt_enc->eos_flag = EOS_RECEIVED;
++
++    ff_side_data_set_encoder_stats(pkt, headerPtr->qp * FF_QP2LAMBDA, NULL, 0, headerPtr->pic_type);
 +
 +    eb_svt_release_out_buffer(&headerPtr);
 +

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
@@ -1,4 +1,4 @@
-From 3ffe1178f8866de55cc33b334f394ee15b85126f Mon Sep 17 00:00:00 2001
+From ccc5b3450703506d7f2ceb87148bb149ae910897 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1 with svt-hevc
@@ -13,8 +13,8 @@ Signed-off-by: Zhong Li <zhong.li@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 509 ++++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 515 insertions(+)
+ libavcodec/libsvt_av1.c | 507 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 513 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index 5739d53..98f0c99 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..a63b7e6
+index 0000000..68da59b
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,509 @@
+@@ -0,0 +1,507 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -486,8 +486,6 @@ index 0000000..a63b7e6
 +static const AVOption options[] = {
 +    { "hielevel", "Hierarchical prediction levels setting", OFFSET(hierarchical_level),
 +      AV_OPT_TYPE_INT, { .i64 = 4 }, 3, 4, VE , "hielevel"},
-+        { "flat",   NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 },  INT_MIN, INT_MAX, VE, "hielevel" },
-+        { "2level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 2 },  INT_MIN, INT_MAX, VE, "hielevel" },
 +        { "3level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 3 },  INT_MIN, INT_MAX, VE, "hielevel" },
 +        { "4level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 4 },  INT_MIN, INT_MAX, VE, "hielevel" },
 +

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
@@ -1,4 +1,4 @@
-From bd562755450c284d480fcf987f94f12f17113be8 Mon Sep 17 00:00:00 2001
+From a7907975f7d1a23d6b3cc4b82a5a3fba718a0e89 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1 with svt-hevc
@@ -13,8 +13,8 @@ Signed-off-by: Zhong Li <zhong.li@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 512 ++++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 518 insertions(+)
+ libavcodec/libsvt_av1.c | 507 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 513 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index 5739d53..98f0c99 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..60b7df5
+index 0000000..7ecbfdd
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,512 @@
+@@ -0,0 +1,507 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -143,8 +143,6 @@ index 0000000..60b7df5
 +    int qp;
 +
 +    int forced_idr;
-+
-+    int aud;
 +
 +    int tier;
 +    int level;
@@ -484,9 +482,6 @@ index 0000000..60b7df5
 +#define OFFSET(x) offsetof(SvtContext, x)
 +#define VE AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_ENCODING_PARAM
 +static const AVOption options[] = {
-+    { "aud", "Include AUD", OFFSET(aud),
-+      AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VE },
-+
 +    { "hielevel", "Hierarchical prediction levels setting", OFFSET(hierarchical_level),
 +      AV_OPT_TYPE_INT, { .i64 = 4 }, 3, 4, VE , "hielevel"},
 +        { "flat",   NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 },  INT_MIN, INT_MAX, VE, "hielevel" },

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
@@ -1,4 +1,4 @@
-From 356196a32bfcaebe7c5793aa4c5f2745d341c4c0 Mon Sep 17 00:00:00 2001
+From 7365188dd74bdf988c7b0f93b64b74ca54292f3f Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1 with svt-hevc
@@ -13,8 +13,8 @@ Signed-off-by: Zhong Li <zhong.li@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 507 ++++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 513 insertions(+)
+ libavcodec/libsvt_av1.c | 508 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 514 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index 5739d53..98f0c99 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..0ddade8
+index 0000000..445ee25
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,507 @@
+@@ -0,0 +1,508 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -537,9 +537,10 @@ index 0000000..0ddade8
 +#undef LEVEL
 +
 +    { "rc", "Bit rate control mode", OFFSET(rc_mode),
-+      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 1, VE , "rc"},
++      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 3, VE , "rc"},
 +        { "cqp", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 0 },  INT_MIN, INT_MAX, VE, "rc" },
-+        { "vbr", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 },  INT_MIN, INT_MAX, VE, "rc" },
++        { "vbr", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 2 },  INT_MIN, INT_MAX, VE, "rc" },
++        { "cvbr", NULL, 0, AV_OPT_TYPE_CONST,{ .i64 = 3 },  INT_MIN, INT_MAX, VE, "rc" },
 +
 +    { "qp", "QP value for intra frames", OFFSET(qp),
 +      AV_OPT_TYPE_INT, { .i64 = 50 }, 0, 63, VE },

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
@@ -1,4 +1,4 @@
-From 42fffab2fc5518e67b1eba6e440ba76ccfc1e8b7 Mon Sep 17 00:00:00 2001
+From 2e2af59365be43324d3d8c0f0cd324b5d70423c9 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1 with svt-hevc
@@ -13,8 +13,8 @@ Signed-off-by: Zhong Li <zhong.li@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 505 ++++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 511 insertions(+)
+ libavcodec/libsvt_av1.c | 507 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 513 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index 5739d53..98f0c99 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..220657a
+index 0000000..772bb09
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,505 @@
+@@ -0,0 +1,507 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -113,6 +113,7 @@ index 0000000..220657a
 +#include "libavutil/frame.h"
 +#include "libavutil/opt.h"
 +#include "libavutil/pixdesc.h"
++#include "libavutil/avassert.h"
 +
 +#include "internal.h"
 +#include "avcodec.h"
@@ -151,42 +152,48 @@ index 0000000..220657a
 +    int base_layer_switch_mode;
 +} SvtContext;
 +
-+static int error_mapping(EbErrorType svt_ret)
++static const struct {
++    EbErrorType    eb_err;
++    int            av_err;
++    const char     *desc;
++} svt_errors[] = {
++    { EB_ErrorNone,                             0,              "success"                   },
++    { EB_ErrorInsufficientResources,      AVERROR(ENOMEM),      "insufficient resources"    },
++    { EB_ErrorUndefined,                  AVERROR(EINVAL),      "undefined error"           },
++    { EB_ErrorInvalidComponent,           AVERROR(EINVAL),      "invalid component"         },
++    { EB_ErrorBadParameter,               AVERROR(EINVAL),      "bad parameter"             },
++    { EB_ErrorDestroyThreadFailed,        AVERROR_EXTERNAL,     "failed to destory thread"  },
++    { EB_ErrorSemaphoreUnresponsive,      AVERROR_EXTERNAL,     "semaphore unresponsive"    },
++    { EB_ErrorDestroySemaphoreFailed,     AVERROR_EXTERNAL,     "semaphore unresponsive"    },
++    { EB_ErrorCreateMutexFailed,          AVERROR_EXTERNAL,     "failed to creat mutex"     },
++    { EB_ErrorMutexUnresponsive,          AVERROR_EXTERNAL,     "mutex unresponsive"        },
++    { EB_ErrorDestroyMutexFailed,         AVERROR_EXTERNAL,     "failed to destory muxtex"  },
++    { EB_NoErrorEmptyQueue,               AVERROR(EAGAIN),      "empty queue"               },
++};
++
++static int svt_map_error(EbErrorType eb_err, const char **desc)
 +{
-+    int err;
++    int i;
 +
-+    switch (svt_ret) {
-+    case EB_ErrorInsufficientResources:
-+        err = AVERROR(ENOMEM);
-+        break;
-+
-+    case EB_ErrorUndefined:
-+    case EB_ErrorInvalidComponent:
-+    case EB_ErrorBadParameter:
-+        err = AVERROR(EINVAL);
-+        break;
-+
-+    case EB_ErrorDestroyThreadFailed:
-+    case EB_ErrorSemaphoreUnresponsive:
-+    case EB_ErrorDestroySemaphoreFailed:
-+    case EB_ErrorCreateMutexFailed:
-+    case EB_ErrorMutexUnresponsive:
-+    case EB_ErrorDestroyMutexFailed:
-+        err = AVERROR_EXTERNAL;
-+            break;
-+
-+    case EB_NoErrorEmptyQueue:
-+        err = AVERROR(EAGAIN);
-+
-+    case EB_ErrorNone:
-+        err = 0;
-+        break;
-+
-+    default:
-+        err = AVERROR_UNKNOWN;
++    av_assert0(desc);
++    for (i = 0; i < FF_ARRAY_ELEMS(svt_errors); i++) {
++        if (svt_errors[i].eb_err == eb_err) {
++            *desc = svt_errors[i].desc;
++            return svt_errors[i].av_err;
++        }
 +    }
++    *desc = "unknown error";
++    return AVERROR_UNKNOWN;
++}
 +
-+    return err;
++static int svt_print_error(void *log_ctx, EbErrorType err,
++                           const char *error_string)
++{
++    const char *desc;
++    int ret;
++    ret = svt_map_error(err, &desc);
++    av_log(log_ctx, AV_LOG_ERROR, "%s: %s (0x%x)\n", error_string, desc, err);
++    return ret;
 +}
 +
 +static void free_buffer(SvtContext *svt_enc)
@@ -337,8 +344,7 @@ index 0000000..220657a
 +
 +    svt_ret = eb_init_handle(&svt_enc->svt_handle, svt_enc, &svt_enc->enc_params);
 +    if (svt_ret != EB_ErrorNone) {
-+        av_log(avctx, AV_LOG_ERROR, "Error init encoder handle\n");
-+        return error_mapping(svt_ret);
++        return svt_print_error(avctx, svt_ret, "Error init encoder handle");
 +    }
 +
 +    ret = config_enc_params(&svt_enc->enc_params, avctx);
@@ -349,16 +355,14 @@ index 0000000..220657a
 +
 +    svt_ret = eb_svt_enc_set_parameter(svt_enc->svt_handle, &svt_enc->enc_params);
 +    if (svt_ret != EB_ErrorNone) {
-+        av_log(avctx, AV_LOG_ERROR, "Error setting encoder parameters\n");
-+        return error_mapping(svt_ret);
++        return svt_print_error(avctx, svt_ret, "Error setting encoder parameters");
 +    }
 +
 +    svt_ret = eb_init_encoder(svt_enc->svt_handle);
 +    if (svt_ret != EB_ErrorNone) {
-+        av_log(avctx, AV_LOG_ERROR, "Error init encoder\n");
 +        eb_deinit_handle(svt_enc->svt_handle);
 +        svt_enc->svt_handle = NULL;
-+        return error_mapping(svt_ret);
++        return svt_print_error(avctx, svt_ret, "Error init encoder");
 +    }
 +
 +    if (avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER) {
@@ -366,8 +370,7 @@ index 0000000..220657a
 +
 +        svt_ret = eb_svt_enc_stream_header(svt_enc->svt_handle, &headerPtr);
 +        if (svt_ret != EB_ErrorNone) {
-+            av_log(avctx, AV_LOG_ERROR, "Error when build stream header.\n");
-+            return error_mapping(svt_ret);
++            return svt_print_error(avctx, svt_ret, "Error when build stream header");
 +        }
 +
 +        avctx->extradata_size = headerPtr->n_filled_len;
@@ -382,8 +385,7 @@ index 0000000..220657a
 +
 +        svt_ret = eb_svt_release_enc_stream_header(headerPtr);
 +        if (svt_ret != EB_ErrorNone) {
-+            av_log(avctx, AV_LOG_ERROR, "Error when destroy stream header.\n");
-+            return error_mapping(svt_ret);
++            return svt_print_error(avctx, svt_ret, "Error when destroy stream header");
 +        }
 +    }
 +

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
@@ -1,4 +1,4 @@
-From 2e2af59365be43324d3d8c0f0cd324b5d70423c9 Mon Sep 17 00:00:00 2001
+From 2119881b3c3c4e2386ac6acb28ef906d7a16c190 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1 with svt-hevc
@@ -13,8 +13,8 @@ Signed-off-by: Zhong Li <zhong.li@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 507 ++++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 513 insertions(+)
+ libavcodec/libsvt_av1.c | 515 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 521 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index 5739d53..98f0c99 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..772bb09
+index 0000000..1523542
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,507 @@
+@@ -0,0 +1,515 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -432,7 +432,7 @@ index 0000000..772bb09
 +    SvtContext  *svt_enc = avctx->priv_data;
 +    EbBufferHeaderType *headerPtr;
 +    EbErrorType svt_ret;
-+    int ret = 0;
++    int ret = 0, pict_type;
 +
 +    if (svt_enc->eos_flag == EOS_RECEIVED)
 +        return AVERROR_EOF;
@@ -449,15 +449,23 @@ index 0000000..772bb09
 +    pkt->size = headerPtr->n_filled_len;
 +    pkt->pts  = headerPtr->pts;
 +    pkt->dts  = headerPtr->dts;
-+    if (headerPtr->pic_type == EB_AV1_KEY_PICTURE)
++    if (headerPtr->pic_type == EB_AV1_KEY_PICTURE) {
 +        pkt->flags |= AV_PKT_FLAG_KEY;
++        pict_type = AV_PICTURE_TYPE_I;
++    } else if (headerPtr->pic_type == EB_AV1_INTRA_ONLY_PICTURE) {
++        pict_type = AV_PICTURE_TYPE_I;
++    } else if (headerPtr->pic_type == EB_AV1_INVALID_PICTURE) {
++        pict_type = AV_PICTURE_TYPE_NONE;
++    } else
++        pict_type = AV_PICTURE_TYPE_P;
++
 +    if (headerPtr->pic_type == EB_AV1_NON_REF_PICTURE)
 +        pkt->flags |= AV_PKT_FLAG_DISPOSABLE;
 +
 +    if (headerPtr->flags & EB_BUFFERFLAG_EOS)
 +        svt_enc->eos_flag = EOS_RECEIVED;
 +
-+    ff_side_data_set_encoder_stats(pkt, headerPtr->qp * FF_QP2LAMBDA, NULL, 0, headerPtr->pic_type);
++    ff_side_data_set_encoder_stats(pkt, headerPtr->qp * FF_QP2LAMBDA, NULL, 0, pict_type);
 +
 +    eb_svt_release_out_buffer(&headerPtr);
 +

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
@@ -1,4 +1,4 @@
-From 7365188dd74bdf988c7b0f93b64b74ca54292f3f Mon Sep 17 00:00:00 2001
+From 42fffab2fc5518e67b1eba6e440ba76ccfc1e8b7 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1 with svt-hevc
@@ -13,8 +13,8 @@ Signed-off-by: Zhong Li <zhong.li@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 508 ++++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 514 insertions(+)
+ libavcodec/libsvt_av1.c | 505 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 511 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index 5739d53..98f0c99 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..445ee25
+index 0000000..220657a
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,508 @@
+@@ -0,0 +1,505 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -214,11 +214,11 @@ index 0000000..445ee25
 +    // allocate buffer for in and out
 +    svt_enc->in_buf           = av_mallocz(sizeof(*svt_enc->in_buf));
 +    if (!svt_enc->in_buf)
-+        goto failed;
++        return AVERROR(ENOMEM);
 +
 +    in_data  = av_mallocz(sizeof(*in_data));
 +    if (!in_data)
-+        goto failed;
++        return AVERROR(ENOMEM);
 +    svt_enc->in_buf->p_buffer  = (unsigned char *)in_data;
 +
 +    svt_enc->in_buf->size        = sizeof(*svt_enc->in_buf);
@@ -226,9 +226,6 @@ index 0000000..445ee25
 +
 +    return 0;
 +
-+failed:
-+    free_buffer(svt_enc);
-+    return AVERROR(ENOMEM);
 +}
 +
 +static int config_enc_params(EbSvtAv1EncConfiguration *param,
@@ -301,9 +298,7 @@ index 0000000..445ee25
 +    if (svt_enc->la_depth != -1)
 +        param->look_ahead_distance  = svt_enc->la_depth;
 +
-+    ret = alloc_buffer(param, svt_enc);
-+
-+    return ret;
++    return 0;
 +}
 +
 +static void read_in_data(const AVFrame *frame,
@@ -336,31 +331,34 @@ index 0000000..445ee25
 +{
 +    SvtContext   *svt_enc = avctx->priv_data;
 +    EbErrorType svt_ret;
++    int ret;
 +
 +    svt_enc->eos_flag = EOS_NOT_REACHED;
 +
 +    svt_ret = eb_init_handle(&svt_enc->svt_handle, svt_enc, &svt_enc->enc_params);
 +    if (svt_ret != EB_ErrorNone) {
 +        av_log(avctx, AV_LOG_ERROR, "Error init encoder handle\n");
-+        goto failed;
++        return error_mapping(svt_ret);
 +    }
 +
-+    svt_ret = config_enc_params(&svt_enc->enc_params, avctx);
-+    if (svt_ret != EB_ErrorNone) {
++    ret = config_enc_params(&svt_enc->enc_params, avctx);
++    if (ret < 0) {
 +        av_log(avctx, AV_LOG_ERROR, "Error configure encoder parameters\n");
-+        goto failed_init_handle;
++        return ret;
 +    }
 +
 +    svt_ret = eb_svt_enc_set_parameter(svt_enc->svt_handle, &svt_enc->enc_params);
 +    if (svt_ret != EB_ErrorNone) {
 +        av_log(avctx, AV_LOG_ERROR, "Error setting encoder parameters\n");
-+        goto failed_init_handle;
++        return error_mapping(svt_ret);
 +    }
 +
 +    svt_ret = eb_init_encoder(svt_enc->svt_handle);
 +    if (svt_ret != EB_ErrorNone) {
 +        av_log(avctx, AV_LOG_ERROR, "Error init encoder\n");
-+        goto failed_init_handle;
++        eb_deinit_handle(svt_enc->svt_handle);
++        svt_enc->svt_handle = NULL;
++        return error_mapping(svt_ret);
 +    }
 +
 +    if (avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER) {
@@ -369,7 +367,7 @@ index 0000000..445ee25
 +        svt_ret = eb_svt_enc_stream_header(svt_enc->svt_handle, &headerPtr);
 +        if (svt_ret != EB_ErrorNone) {
 +            av_log(avctx, AV_LOG_ERROR, "Error when build stream header.\n");
-+            goto failed_init_enc;
++            return error_mapping(svt_ret);
 +        }
 +
 +        avctx->extradata_size = headerPtr->n_filled_len;
@@ -377,8 +375,7 @@ index 0000000..445ee25
 +        if (!avctx->extradata) {
 +            av_log(avctx, AV_LOG_ERROR,
 +                   "Cannot allocate AV1 header of size %d.\n", avctx->extradata_size);
-+            svt_ret = EB_ErrorInsufficientResources;
-+            goto failed_init_enc;
++            return AVERROR(ENOMEM);
 +        }
 +
 +        memcpy(avctx->extradata, headerPtr->p_buffer, avctx->extradata_size);
@@ -386,19 +383,15 @@ index 0000000..445ee25
 +        svt_ret = eb_svt_release_enc_stream_header(headerPtr);
 +        if (svt_ret != EB_ErrorNone) {
 +            av_log(avctx, AV_LOG_ERROR, "Error when destroy stream header.\n");
-+            goto failed_init_enc;
++            return error_mapping(svt_ret);
 +        }
 +    }
 +
++    ret = alloc_buffer(&svt_enc->enc_params, svt_enc);
++    if (ret < 0)
++        return ret;
 +    return 0;
 +
-+failed_init_enc:
-+    eb_deinit_encoder(svt_enc->svt_handle);
-+failed_init_handle:
-+    eb_deinit_handle(svt_enc->svt_handle);
-+failed:
-+    free_buffer(svt_enc);
-+    return error_mapping(svt_ret);
 +}
 +
 +static int eb_send_frame(AVCodecContext *avctx, const AVFrame *frame)
@@ -473,11 +466,15 @@ index 0000000..445ee25
 +{
 +    SvtContext *svt_enc = avctx->priv_data;
 +
-+    eb_deinit_encoder(svt_enc->svt_handle);
-+    eb_deinit_handle(svt_enc->svt_handle);
++    if (svt_enc) {
++        if (svt_enc->svt_handle) {
++            eb_deinit_encoder(svt_enc->svt_handle);
++            eb_deinit_handle(svt_enc->svt_handle);
++        }
 +
-+    free_buffer(svt_enc);
-+
++        free_buffer(svt_enc);
++        svt_enc = NULL;
++    }
 +    return 0;
 +}
 +

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
@@ -1,4 +1,4 @@
-From a7907975f7d1a23d6b3cc4b82a5a3fba718a0e89 Mon Sep 17 00:00:00 2001
+From 219ace9cc15ea37e0be8531b380fb97404654cee Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1 with svt-hevc
@@ -79,7 +79,7 @@ index 5739d53..98f0c99 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..7ecbfdd
+index 0000000..9473a08
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
 @@ -0,0 +1,507 @@
@@ -492,7 +492,7 @@ index 0000000..7ecbfdd
 +    { "la_depth", "Look ahead distance [0, 256]", OFFSET(la_depth),
 +      AV_OPT_TYPE_INT, { .i64 = -1 }, -1, 256, VE },
 +
-+    { "preset", "Encoding preset [0, 7]",
++    { "preset", "Encoding preset [0, 8]",
 +      OFFSET(enc_mode), AV_OPT_TYPE_INT, { .i64 = MAX_ENC_PRESET }, 0, MAX_ENC_PRESET, VE },
 +
 +    { "profile", "Set profile restrictions", OFFSET(profile), AV_OPT_TYPE_INT, { .i64 = MAIN_PROFILE}, MAIN_PROFILE, PROFESSIONAL_PROFILE, VE, "profile" },

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
@@ -1,22 +1,24 @@
-From 64932c76e3dd36f010b1643a70abcceae7fdfca8 Mon Sep 17 00:00:00 2001
+From bd562755450c284d480fcf987f94f12f17113be8 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
-Subject: [PATCH 1/1] Add ability for ffmpeg to run svt-av1 with svt-hevc
+Subject: [PATCH] Add ability for ffmpeg to run svt-av1 with svt-hevc
+Cc: zhong.li@intel.com
 
 Change-Id: I37ee5414fdd99e0b3f112a6e5ede166f3e48d819
 Signed-off-by: Daryl Seah <daryl.seah@intel.com>
 Signed-off-by: Jing SUN <jing.a.sun@intel.com>
 Signed-off-by: ZhiZhen Tang <zhizhen.tang@intel.com>
+Signed-off-by: Zhong Li <zhong.li@intel.com>
 ---
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 483 ++++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 489 insertions(+)
+ libavcodec/libsvt_av1.c | 512 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 518 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
-index 2f61c8296e..87e6696523 100755
+index 2f61c82..87e6696 100755
 --- a/configure
 +++ b/configure
 @@ -263,6 +263,7 @@ External library support:
@@ -52,7 +54,7 @@ index 2f61c8296e..87e6696523 100755
  enabled libtesseract      && require_pkg_config libtesseract tesseract tesseract/capi.h TessBaseAPICreate
  enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -ltheoraenc -ltheoradec -logg
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 728503be9c..a524f34d9c 100644
+index 728503b..a524f34 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
 @@ -982,6 +982,7 @@ OBJS-$(CONFIG_LIBSHINE_ENCODER)           += libshine.o
@@ -64,7 +66,7 @@ index 728503be9c..a524f34d9c 100644
  OBJS-$(CONFIG_LIBTWOLAME_ENCODER)         += libtwolame.o
  OBJS-$(CONFIG_LIBVO_AMRWBENC_ENCODER)     += libvo-amrwbenc.o
 diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
-index 5739d53329..98f0c99883 100644
+index 5739d53..98f0c99 100644
 --- a/libavcodec/allcodecs.c
 +++ b/libavcodec/allcodecs.c
 @@ -698,6 +698,7 @@ extern AVCodec ff_libshine_encoder;
@@ -77,10 +79,10 @@ index 5739d53329..98f0c99883 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..8f0e5a6
+index 0000000..60b7df5
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,483 @@
+@@ -0,0 +1,512 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -110,6 +112,7 @@ index 0000000..8f0e5a6
 +#include "libavutil/common.h"
 +#include "libavutil/frame.h"
 +#include "libavutil/opt.h"
++#include "libavutil/pixdesc.h"
 +
 +#include "internal.h"
 +#include "avcodec.h"
@@ -145,6 +148,7 @@ index 0000000..8f0e5a6
 +
 +    int tier;
 +    int level;
++    int profile;
 +
 +    int base_layer_switch_mode;
 +} SvtContext;
@@ -233,20 +237,38 @@ index 0000000..8f0e5a6
 +                             AVCodecContext *avctx)
 +{
 +    SvtContext *svt_enc = avctx->priv_data;
++    const AVPixFmtDescriptor *desc;
 +    int ret;
 +
 +    param->source_width     = avctx->width;
 +    param->source_height    = avctx->height;
 +
-+    if (avctx->pix_fmt == AV_PIX_FMT_YUV420P10) {
-+        av_log(avctx, AV_LOG_DEBUG, "Set 10 bits depth input\n");
-+        param->encoder_bit_depth = 10;
-+    } else {
-+        av_log(avctx, AV_LOG_DEBUG, "Set 8 bits depth input\n");
-+        param->encoder_bit_depth = 8;
-+    }
++    desc = av_pix_fmt_desc_get(avctx->pix_fmt);
++    param->encoder_bit_depth = desc->comp[0].depth;
++    av_log(avctx, AV_LOG_DEBUG , "Encoder %d bits depth input\n", param->encoder_bit_depth);
 +
-+    param->encoder_color_format = EB_YUV420;
++    if (desc->log2_chroma_w == 1 && desc->log2_chroma_h == 1)
++        param->encoder_color_format   = EB_YUV420;
++    else if (desc->log2_chroma_w == 1 && desc->log2_chroma_h == 0)
++        param->encoder_color_format   = EB_YUV422;
++    else if (!desc->log2_chroma_w && !desc->log2_chroma_h)
++        param->encoder_color_format   = EB_YUV444;
++    else {
++        av_log(avctx, AV_LOG_ERROR , "Unsupported pixel format\n");
++        return AVERROR(EINVAL);
++    }
++    av_log(avctx, AV_LOG_DEBUG , "Encoder color format is %d \n", param->encoder_color_format);
++
++    param->profile = svt_enc->profile;
++
++    if ((param->encoder_color_format == EB_YUV422 || param->encoder_bit_depth > 10)
++         && param->profile != PROFESSIONAL_PROFILE ) {
++        av_log(avctx, AV_LOG_WARNING, "Force to be professional profile \n");
++        param->profile = PROFESSIONAL_PROFILE;
++    } else if (param->encoder_color_format == EB_YUV444 && param->profile != HIGH_PROFILE) {
++        av_log(avctx, AV_LOG_WARNING, "Force to be high profile \n");
++        param->profile = HIGH_PROFILE;
++    }
 +
 +    // Update param from options
 +    param->hierarchical_levels     = svt_enc->hierarchical_level;
@@ -286,26 +308,30 @@ index 0000000..8f0e5a6
 +    return ret;
 +}
 +
-+static void read_in_data(EbSvtAv1EncConfiguration *config,
-+                         const AVFrame *frame,
-+                         EbBufferHeaderType *headerPtr)
++static void read_in_data(const AVFrame *frame,
++                         EbBufferHeaderType *header_ptr)
 +{
-+    uint8_t is16bit = config->encoder_bit_depth > 8;
-+    uint64_t luma_size =
-+        (uint64_t)config->source_width * config->source_height<< is16bit;
-+    EbSvtIOFormat *in_data = (EbSvtIOFormat *)headerPtr->p_buffer;
++    EbSvtIOFormat *in_data = (EbSvtIOFormat *)header_ptr->p_buffer;
++    const AVPixFmtDescriptor *desc;
++    int i, bytes_shift, plane_h;
 +
-+    // support yuv420p and yuv420p010
++    desc = av_pix_fmt_desc_get(frame->format);
++    bytes_shift = desc->comp[0].depth > 8 ? 1 : 0;
++
 +    in_data->luma = frame->data[0];
 +    in_data->cb   = frame->data[1];
 +    in_data->cr   = frame->data[2];
 +
-+    // stride info
-+    in_data->y_stride  = frame->linesize[0] >> is16bit;
-+    in_data->cb_stride = frame->linesize[1] >> is16bit;
-+    in_data->cr_stride = frame->linesize[2] >> is16bit;
++    in_data->y_stride  = AV_CEIL_RSHIFT(frame->linesize[0], bytes_shift);
++    in_data->cb_stride = AV_CEIL_RSHIFT(frame->linesize[1], bytes_shift);
++    in_data->cr_stride = AV_CEIL_RSHIFT(frame->linesize[2], bytes_shift);
 +
-+    headerPtr->n_filled_len   += luma_size * 3/2u;
++    for (i = 0; i < desc->nb_components; i++) {
++        plane_h = frame->height;
++        if (i > 0)
++            plane_h = AV_CEIL_RSHIFT(plane_h, desc->log2_chroma_h);
++        header_ptr->n_filled_len += frame->linesize[i] * plane_h;
++    }
 +}
 +
 +static av_cold int eb_enc_init(AVCodecContext *avctx)
@@ -397,7 +423,7 @@ index 0000000..8f0e5a6
 +        return 0;
 +    }
 +
-+    read_in_data(&svt_enc->enc_params, frame, headerPtr);
++    read_in_data(frame, headerPtr);
 +
 +    headerPtr->flags       = 0;
 +    headerPtr->p_app_private  = NULL;
@@ -473,6 +499,11 @@ index 0000000..8f0e5a6
 +
 +    { "preset", "Encoding preset [0, 7]",
 +      OFFSET(enc_mode), AV_OPT_TYPE_INT, { .i64 = MAX_ENC_PRESET }, 0, MAX_ENC_PRESET, VE },
++
++    { "profile", "Set profile restrictions", OFFSET(profile), AV_OPT_TYPE_INT, { .i64 = MAIN_PROFILE}, MAIN_PROFILE, PROFESSIONAL_PROFILE, VE, "profile" },
++    { "main" , NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MAIN_PROFILE}, INT_MIN, INT_MAX,     VE, "profile" },
++    { "high" , NULL, 0, AV_OPT_TYPE_CONST, { .i64 = HIGH_PROFILE}, INT_MIN, INT_MAX,     VE, "profile" },
++    { "professional", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = PROFESSIONAL_PROFILE }, INT_MIN, INT_MAX,     VE, "profile" },
 +
 +    { "tier", "Set tier (general_tier_flag)", OFFSET(tier),
 +      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 1, VE, "tier" },
@@ -565,5 +596,5 @@ index 0000000..8f0e5a6
 +    .wrapper_name   = "libsvt_av1",
 +};
 --
-1.8.3.1
+2.7.4
 

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
@@ -1,4 +1,4 @@
-From ccc5b3450703506d7f2ceb87148bb149ae910897 Mon Sep 17 00:00:00 2001
+From 356196a32bfcaebe7c5793aa4c5f2745d341c4c0 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1 with svt-hevc
@@ -79,7 +79,7 @@ index 5739d53..98f0c99 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..68da59b
+index 0000000..0ddade8
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
 @@ -0,0 +1,507 @@
@@ -489,8 +489,8 @@ index 0000000..68da59b
 +        { "3level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 3 },  INT_MIN, INT_MAX, VE, "hielevel" },
 +        { "4level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 4 },  INT_MIN, INT_MAX, VE, "hielevel" },
 +
-+    { "la_depth", "Look ahead distance [0, 256]", OFFSET(la_depth),
-+      AV_OPT_TYPE_INT, { .i64 = -1 }, -1, 256, VE },
++    { "la_depth", "Look ahead distance [0, 120]", OFFSET(la_depth),
++      AV_OPT_TYPE_INT, { .i64 = -1 }, -1, 120, VE },
 +
 +    { "preset", "Encoding preset [0, 8]",
 +      OFFSET(enc_mode), AV_OPT_TYPE_INT, { .i64 = MAX_ENC_PRESET }, 0, MAX_ENC_PRESET, VE },

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -1,4 +1,4 @@
-From 258d206c99f447ea70b5a27d1c0200ba8a93580b Mon Sep 17 00:00:00 2001
+From af2bb7f5b57dd9caf5706938eed47019e4e42e74 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1
@@ -79,7 +79,7 @@ index 1b8144a..f7df66c 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..7ecbfdd
+index 0000000..9473a08
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
 @@ -0,0 +1,507 @@
@@ -492,7 +492,7 @@ index 0000000..7ecbfdd
 +    { "la_depth", "Look ahead distance [0, 256]", OFFSET(la_depth),
 +      AV_OPT_TYPE_INT, { .i64 = -1 }, -1, 256, VE },
 +
-+    { "preset", "Encoding preset [0, 7]",
++    { "preset", "Encoding preset [0, 8]",
 +      OFFSET(enc_mode), AV_OPT_TYPE_INT, { .i64 = MAX_ENC_PRESET }, 0, MAX_ENC_PRESET, VE },
 +
 +    { "profile", "Set profile restrictions", OFFSET(profile), AV_OPT_TYPE_INT, { .i64 = MAIN_PROFILE}, MAIN_PROFILE, PROFESSIONAL_PROFILE, VE, "profile" },

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -1,4 +1,4 @@
-From 0af42e74b50ac64e38f5450d48c1b9538461f259 Mon Sep 17 00:00:00 2001
+From 1ef53753920407e647bb513084da8f25de01e029 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1
@@ -79,7 +79,7 @@ index 1b8144a..f7df66c 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..68da59b
+index 0000000..0ddade8
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
 @@ -0,0 +1,507 @@
@@ -489,8 +489,8 @@ index 0000000..68da59b
 +        { "3level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 3 },  INT_MIN, INT_MAX, VE, "hielevel" },
 +        { "4level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 4 },  INT_MIN, INT_MAX, VE, "hielevel" },
 +
-+    { "la_depth", "Look ahead distance [0, 256]", OFFSET(la_depth),
-+      AV_OPT_TYPE_INT, { .i64 = -1 }, -1, 256, VE },
++    { "la_depth", "Look ahead distance [0, 120]", OFFSET(la_depth),
++      AV_OPT_TYPE_INT, { .i64 = -1 }, -1, 120, VE },
 +
 +    { "preset", "Encoding preset [0, 8]",
 +      OFFSET(enc_mode), AV_OPT_TYPE_INT, { .i64 = MAX_ENC_PRESET }, 0, MAX_ENC_PRESET, VE },

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -1,4 +1,4 @@
-From af2bb7f5b57dd9caf5706938eed47019e4e42e74 Mon Sep 17 00:00:00 2001
+From a4984801582cdd13ad6345e3200054b7a07a7ed3 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1
@@ -13,8 +13,8 @@ Signed-off-by: Zhong Li <zhong.li@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 507 ++++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 513 insertions(+)
+ libavcodec/libsvt_av1.c | 509 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 515 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index 1b8144a..f7df66c 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..9473a08
+index 0000000..a63b7e6
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,507 @@
+@@ -0,0 +1,509 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -461,6 +461,8 @@ index 0000000..9473a08
 +
 +    if (headerPtr->flags & EB_BUFFERFLAG_EOS)
 +        svt_enc->eos_flag = EOS_RECEIVED;
++
++    ff_side_data_set_encoder_stats(pkt, headerPtr->qp * FF_QP2LAMBDA, NULL, 0, headerPtr->pic_type);
 +
 +    eb_svt_release_out_buffer(&headerPtr);
 +

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -1,4 +1,4 @@
-From a4984801582cdd13ad6345e3200054b7a07a7ed3 Mon Sep 17 00:00:00 2001
+From 0af42e74b50ac64e38f5450d48c1b9538461f259 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1
@@ -13,8 +13,8 @@ Signed-off-by: Zhong Li <zhong.li@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 509 ++++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 515 insertions(+)
+ libavcodec/libsvt_av1.c | 507 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 513 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index 1b8144a..f7df66c 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..a63b7e6
+index 0000000..68da59b
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,509 @@
+@@ -0,0 +1,507 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -486,8 +486,6 @@ index 0000000..a63b7e6
 +static const AVOption options[] = {
 +    { "hielevel", "Hierarchical prediction levels setting", OFFSET(hierarchical_level),
 +      AV_OPT_TYPE_INT, { .i64 = 4 }, 3, 4, VE , "hielevel"},
-+        { "flat",   NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 },  INT_MIN, INT_MAX, VE, "hielevel" },
-+        { "2level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 2 },  INT_MIN, INT_MAX, VE, "hielevel" },
 +        { "3level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 3 },  INT_MIN, INT_MAX, VE, "hielevel" },
 +        { "4level", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 4 },  INT_MIN, INT_MAX, VE, "hielevel" },
 +

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -1,4 +1,4 @@
-From c44430eec1ee8e933f1f0d868612d72adbc5df96 Mon Sep 17 00:00:00 2001
+From ae65d59029ba13665c833b318ca367f6a0dd758e Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1
@@ -13,8 +13,8 @@ Signed-off-by: Zhong Li <zhong.li@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 505 ++++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 511 insertions(+)
+ libavcodec/libsvt_av1.c | 507 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 513 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index 1b8144a..f7df66c 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..220657a
+index 0000000..772bb09
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,505 @@
+@@ -0,0 +1,507 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -113,6 +113,7 @@ index 0000000..220657a
 +#include "libavutil/frame.h"
 +#include "libavutil/opt.h"
 +#include "libavutil/pixdesc.h"
++#include "libavutil/avassert.h"
 +
 +#include "internal.h"
 +#include "avcodec.h"
@@ -151,42 +152,48 @@ index 0000000..220657a
 +    int base_layer_switch_mode;
 +} SvtContext;
 +
-+static int error_mapping(EbErrorType svt_ret)
++static const struct {
++    EbErrorType    eb_err;
++    int            av_err;
++    const char     *desc;
++} svt_errors[] = {
++    { EB_ErrorNone,                             0,              "success"                   },
++    { EB_ErrorInsufficientResources,      AVERROR(ENOMEM),      "insufficient resources"    },
++    { EB_ErrorUndefined,                  AVERROR(EINVAL),      "undefined error"           },
++    { EB_ErrorInvalidComponent,           AVERROR(EINVAL),      "invalid component"         },
++    { EB_ErrorBadParameter,               AVERROR(EINVAL),      "bad parameter"             },
++    { EB_ErrorDestroyThreadFailed,        AVERROR_EXTERNAL,     "failed to destory thread"  },
++    { EB_ErrorSemaphoreUnresponsive,      AVERROR_EXTERNAL,     "semaphore unresponsive"    },
++    { EB_ErrorDestroySemaphoreFailed,     AVERROR_EXTERNAL,     "semaphore unresponsive"    },
++    { EB_ErrorCreateMutexFailed,          AVERROR_EXTERNAL,     "failed to creat mutex"     },
++    { EB_ErrorMutexUnresponsive,          AVERROR_EXTERNAL,     "mutex unresponsive"        },
++    { EB_ErrorDestroyMutexFailed,         AVERROR_EXTERNAL,     "failed to destory muxtex"  },
++    { EB_NoErrorEmptyQueue,               AVERROR(EAGAIN),      "empty queue"               },
++};
++
++static int svt_map_error(EbErrorType eb_err, const char **desc)
 +{
-+    int err;
++    int i;
 +
-+    switch (svt_ret) {
-+    case EB_ErrorInsufficientResources:
-+        err = AVERROR(ENOMEM);
-+        break;
-+
-+    case EB_ErrorUndefined:
-+    case EB_ErrorInvalidComponent:
-+    case EB_ErrorBadParameter:
-+        err = AVERROR(EINVAL);
-+        break;
-+
-+    case EB_ErrorDestroyThreadFailed:
-+    case EB_ErrorSemaphoreUnresponsive:
-+    case EB_ErrorDestroySemaphoreFailed:
-+    case EB_ErrorCreateMutexFailed:
-+    case EB_ErrorMutexUnresponsive:
-+    case EB_ErrorDestroyMutexFailed:
-+        err = AVERROR_EXTERNAL;
-+            break;
-+
-+    case EB_NoErrorEmptyQueue:
-+        err = AVERROR(EAGAIN);
-+
-+    case EB_ErrorNone:
-+        err = 0;
-+        break;
-+
-+    default:
-+        err = AVERROR_UNKNOWN;
++    av_assert0(desc);
++    for (i = 0; i < FF_ARRAY_ELEMS(svt_errors); i++) {
++        if (svt_errors[i].eb_err == eb_err) {
++            *desc = svt_errors[i].desc;
++            return svt_errors[i].av_err;
++        }
 +    }
++    *desc = "unknown error";
++    return AVERROR_UNKNOWN;
++}
 +
-+    return err;
++static int svt_print_error(void *log_ctx, EbErrorType err,
++                           const char *error_string)
++{
++    const char *desc;
++    int ret;
++    ret = svt_map_error(err, &desc);
++    av_log(log_ctx, AV_LOG_ERROR, "%s: %s (0x%x)\n", error_string, desc, err);
++    return ret;
 +}
 +
 +static void free_buffer(SvtContext *svt_enc)
@@ -337,8 +344,7 @@ index 0000000..220657a
 +
 +    svt_ret = eb_init_handle(&svt_enc->svt_handle, svt_enc, &svt_enc->enc_params);
 +    if (svt_ret != EB_ErrorNone) {
-+        av_log(avctx, AV_LOG_ERROR, "Error init encoder handle\n");
-+        return error_mapping(svt_ret);
++        return svt_print_error(avctx, svt_ret, "Error init encoder handle");
 +    }
 +
 +    ret = config_enc_params(&svt_enc->enc_params, avctx);
@@ -349,16 +355,14 @@ index 0000000..220657a
 +
 +    svt_ret = eb_svt_enc_set_parameter(svt_enc->svt_handle, &svt_enc->enc_params);
 +    if (svt_ret != EB_ErrorNone) {
-+        av_log(avctx, AV_LOG_ERROR, "Error setting encoder parameters\n");
-+        return error_mapping(svt_ret);
++        return svt_print_error(avctx, svt_ret, "Error setting encoder parameters");
 +    }
 +
 +    svt_ret = eb_init_encoder(svt_enc->svt_handle);
 +    if (svt_ret != EB_ErrorNone) {
-+        av_log(avctx, AV_LOG_ERROR, "Error init encoder\n");
 +        eb_deinit_handle(svt_enc->svt_handle);
 +        svt_enc->svt_handle = NULL;
-+        return error_mapping(svt_ret);
++        return svt_print_error(avctx, svt_ret, "Error init encoder");
 +    }
 +
 +    if (avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER) {
@@ -366,8 +370,7 @@ index 0000000..220657a
 +
 +        svt_ret = eb_svt_enc_stream_header(svt_enc->svt_handle, &headerPtr);
 +        if (svt_ret != EB_ErrorNone) {
-+            av_log(avctx, AV_LOG_ERROR, "Error when build stream header.\n");
-+            return error_mapping(svt_ret);
++            return svt_print_error(avctx, svt_ret, "Error when build stream header");
 +        }
 +
 +        avctx->extradata_size = headerPtr->n_filled_len;
@@ -382,8 +385,7 @@ index 0000000..220657a
 +
 +        svt_ret = eb_svt_release_enc_stream_header(headerPtr);
 +        if (svt_ret != EB_ErrorNone) {
-+            av_log(avctx, AV_LOG_ERROR, "Error when destroy stream header.\n");
-+            return error_mapping(svt_ret);
++            return svt_print_error(avctx, svt_ret, "Error when destroy stream header");
 +        }
 +    }
 +

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -1,4 +1,4 @@
-From 1ef53753920407e647bb513084da8f25de01e029 Mon Sep 17 00:00:00 2001
+From 650d49a94f0b214ae47520904bb44a9f1801388e Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1
@@ -13,8 +13,8 @@ Signed-off-by: Zhong Li <zhong.li@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 507 ++++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 513 insertions(+)
+ libavcodec/libsvt_av1.c | 508 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 514 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index 1b8144a..f7df66c 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..0ddade8
+index 0000000..445ee25
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,507 @@
+@@ -0,0 +1,508 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -537,9 +537,10 @@ index 0000000..0ddade8
 +#undef LEVEL
 +
 +    { "rc", "Bit rate control mode", OFFSET(rc_mode),
-+      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 1, VE , "rc"},
++      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 3, VE , "rc"},
 +        { "cqp", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 0 },  INT_MIN, INT_MAX, VE, "rc" },
-+        { "vbr", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 },  INT_MIN, INT_MAX, VE, "rc" },
++        { "vbr", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 2 },  INT_MIN, INT_MAX, VE, "rc" },
++        { "cvbr", NULL, 0, AV_OPT_TYPE_CONST,{ .i64 = 3 },  INT_MIN, INT_MAX, VE, "rc" },
 +
 +    { "qp", "QP value for intra frames", OFFSET(qp),
 +      AV_OPT_TYPE_INT, { .i64 = 50 }, 0, 63, VE },

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -1,4 +1,4 @@
-From 650d49a94f0b214ae47520904bb44a9f1801388e Mon Sep 17 00:00:00 2001
+From c44430eec1ee8e933f1f0d868612d72adbc5df96 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1
@@ -13,8 +13,8 @@ Signed-off-by: Zhong Li <zhong.li@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 508 ++++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 514 insertions(+)
+ libavcodec/libsvt_av1.c | 505 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 511 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index 1b8144a..f7df66c 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..445ee25
+index 0000000..220657a
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,508 @@
+@@ -0,0 +1,505 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -214,11 +214,11 @@ index 0000000..445ee25
 +    // allocate buffer for in and out
 +    svt_enc->in_buf           = av_mallocz(sizeof(*svt_enc->in_buf));
 +    if (!svt_enc->in_buf)
-+        goto failed;
++        return AVERROR(ENOMEM);
 +
 +    in_data  = av_mallocz(sizeof(*in_data));
 +    if (!in_data)
-+        goto failed;
++        return AVERROR(ENOMEM);
 +    svt_enc->in_buf->p_buffer  = (unsigned char *)in_data;
 +
 +    svt_enc->in_buf->size        = sizeof(*svt_enc->in_buf);
@@ -226,9 +226,6 @@ index 0000000..445ee25
 +
 +    return 0;
 +
-+failed:
-+    free_buffer(svt_enc);
-+    return AVERROR(ENOMEM);
 +}
 +
 +static int config_enc_params(EbSvtAv1EncConfiguration *param,
@@ -301,9 +298,7 @@ index 0000000..445ee25
 +    if (svt_enc->la_depth != -1)
 +        param->look_ahead_distance  = svt_enc->la_depth;
 +
-+    ret = alloc_buffer(param, svt_enc);
-+
-+    return ret;
++    return 0;
 +}
 +
 +static void read_in_data(const AVFrame *frame,
@@ -336,31 +331,34 @@ index 0000000..445ee25
 +{
 +    SvtContext   *svt_enc = avctx->priv_data;
 +    EbErrorType svt_ret;
++    int ret;
 +
 +    svt_enc->eos_flag = EOS_NOT_REACHED;
 +
 +    svt_ret = eb_init_handle(&svt_enc->svt_handle, svt_enc, &svt_enc->enc_params);
 +    if (svt_ret != EB_ErrorNone) {
 +        av_log(avctx, AV_LOG_ERROR, "Error init encoder handle\n");
-+        goto failed;
++        return error_mapping(svt_ret);
 +    }
 +
-+    svt_ret = config_enc_params(&svt_enc->enc_params, avctx);
-+    if (svt_ret != EB_ErrorNone) {
++    ret = config_enc_params(&svt_enc->enc_params, avctx);
++    if (ret < 0) {
 +        av_log(avctx, AV_LOG_ERROR, "Error configure encoder parameters\n");
-+        goto failed_init_handle;
++        return ret;
 +    }
 +
 +    svt_ret = eb_svt_enc_set_parameter(svt_enc->svt_handle, &svt_enc->enc_params);
 +    if (svt_ret != EB_ErrorNone) {
 +        av_log(avctx, AV_LOG_ERROR, "Error setting encoder parameters\n");
-+        goto failed_init_handle;
++        return error_mapping(svt_ret);
 +    }
 +
 +    svt_ret = eb_init_encoder(svt_enc->svt_handle);
 +    if (svt_ret != EB_ErrorNone) {
 +        av_log(avctx, AV_LOG_ERROR, "Error init encoder\n");
-+        goto failed_init_handle;
++        eb_deinit_handle(svt_enc->svt_handle);
++        svt_enc->svt_handle = NULL;
++        return error_mapping(svt_ret);
 +    }
 +
 +    if (avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER) {
@@ -369,7 +367,7 @@ index 0000000..445ee25
 +        svt_ret = eb_svt_enc_stream_header(svt_enc->svt_handle, &headerPtr);
 +        if (svt_ret != EB_ErrorNone) {
 +            av_log(avctx, AV_LOG_ERROR, "Error when build stream header.\n");
-+            goto failed_init_enc;
++            return error_mapping(svt_ret);
 +        }
 +
 +        avctx->extradata_size = headerPtr->n_filled_len;
@@ -377,8 +375,7 @@ index 0000000..445ee25
 +        if (!avctx->extradata) {
 +            av_log(avctx, AV_LOG_ERROR,
 +                   "Cannot allocate AV1 header of size %d.\n", avctx->extradata_size);
-+            svt_ret = EB_ErrorInsufficientResources;
-+            goto failed_init_enc;
++            return AVERROR(ENOMEM);
 +        }
 +
 +        memcpy(avctx->extradata, headerPtr->p_buffer, avctx->extradata_size);
@@ -386,19 +383,15 @@ index 0000000..445ee25
 +        svt_ret = eb_svt_release_enc_stream_header(headerPtr);
 +        if (svt_ret != EB_ErrorNone) {
 +            av_log(avctx, AV_LOG_ERROR, "Error when destroy stream header.\n");
-+            goto failed_init_enc;
++            return error_mapping(svt_ret);
 +        }
 +    }
 +
++    ret = alloc_buffer(&svt_enc->enc_params, svt_enc);
++    if (ret < 0)
++        return ret;
 +    return 0;
 +
-+failed_init_enc:
-+    eb_deinit_encoder(svt_enc->svt_handle);
-+failed_init_handle:
-+    eb_deinit_handle(svt_enc->svt_handle);
-+failed:
-+    free_buffer(svt_enc);
-+    return error_mapping(svt_ret);
 +}
 +
 +static int eb_send_frame(AVCodecContext *avctx, const AVFrame *frame)
@@ -473,11 +466,15 @@ index 0000000..445ee25
 +{
 +    SvtContext *svt_enc = avctx->priv_data;
 +
-+    eb_deinit_encoder(svt_enc->svt_handle);
-+    eb_deinit_handle(svt_enc->svt_handle);
++    if (svt_enc) {
++        if (svt_enc->svt_handle) {
++            eb_deinit_encoder(svt_enc->svt_handle);
++            eb_deinit_handle(svt_enc->svt_handle);
++        }
 +
-+    free_buffer(svt_enc);
-+
++        free_buffer(svt_enc);
++        svt_enc = NULL;
++    }
 +    return 0;
 +}
 +

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -1,4 +1,4 @@
-From ae65d59029ba13665c833b318ca367f6a0dd758e Mon Sep 17 00:00:00 2001
+From 4bf9bdfa4044f1324a7871cb69855777ac85050e Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1
@@ -13,8 +13,8 @@ Signed-off-by: Zhong Li <zhong.li@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 507 ++++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 513 insertions(+)
+ libavcodec/libsvt_av1.c | 515 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 521 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index 1b8144a..f7df66c 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..772bb09
+index 0000000..1523542
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,507 @@
+@@ -0,0 +1,515 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -432,7 +432,7 @@ index 0000000..772bb09
 +    SvtContext  *svt_enc = avctx->priv_data;
 +    EbBufferHeaderType *headerPtr;
 +    EbErrorType svt_ret;
-+    int ret = 0;
++    int ret = 0, pict_type;
 +
 +    if (svt_enc->eos_flag == EOS_RECEIVED)
 +        return AVERROR_EOF;
@@ -449,15 +449,23 @@ index 0000000..772bb09
 +    pkt->size = headerPtr->n_filled_len;
 +    pkt->pts  = headerPtr->pts;
 +    pkt->dts  = headerPtr->dts;
-+    if (headerPtr->pic_type == EB_AV1_KEY_PICTURE)
++    if (headerPtr->pic_type == EB_AV1_KEY_PICTURE) {
 +        pkt->flags |= AV_PKT_FLAG_KEY;
++        pict_type = AV_PICTURE_TYPE_I;
++    } else if (headerPtr->pic_type == EB_AV1_INTRA_ONLY_PICTURE) {
++        pict_type = AV_PICTURE_TYPE_I;
++    } else if (headerPtr->pic_type == EB_AV1_INVALID_PICTURE) {
++        pict_type = AV_PICTURE_TYPE_NONE;
++    } else
++        pict_type = AV_PICTURE_TYPE_P;
++
 +    if (headerPtr->pic_type == EB_AV1_NON_REF_PICTURE)
 +        pkt->flags |= AV_PKT_FLAG_DISPOSABLE;
 +
 +    if (headerPtr->flags & EB_BUFFERFLAG_EOS)
 +        svt_enc->eos_flag = EOS_RECEIVED;
 +
-+    ff_side_data_set_encoder_stats(pkt, headerPtr->qp * FF_QP2LAMBDA, NULL, 0, headerPtr->pic_type);
++    ff_side_data_set_encoder_stats(pkt, headerPtr->qp * FF_QP2LAMBDA, NULL, 0, pict_type);
 +
 +    eb_svt_release_out_buffer(&headerPtr);
 +

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -1,4 +1,4 @@
-From 7241b092b8eff9bc24f61ebdf0a88e0fe08e55ea Mon Sep 17 00:00:00 2001
+From 258d206c99f447ea70b5a27d1c0200ba8a93580b Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1
@@ -13,8 +13,8 @@ Signed-off-by: Zhong Li <zhong.li@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 512 ++++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 518 insertions(+)
+ libavcodec/libsvt_av1.c | 507 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 513 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index 1b8144a..f7df66c 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..60b7df5
+index 0000000..7ecbfdd
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,512 @@
+@@ -0,0 +1,507 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -143,8 +143,6 @@ index 0000000..60b7df5
 +    int qp;
 +
 +    int forced_idr;
-+
-+    int aud;
 +
 +    int tier;
 +    int level;
@@ -484,9 +482,6 @@ index 0000000..60b7df5
 +#define OFFSET(x) offsetof(SvtContext, x)
 +#define VE AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_ENCODING_PARAM
 +static const AVOption options[] = {
-+    { "aud", "Include AUD", OFFSET(aud),
-+      AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VE },
-+
 +    { "hielevel", "Hierarchical prediction levels setting", OFFSET(hierarchical_level),
 +      AV_OPT_TYPE_INT, { .i64 = 4 }, 3, 4, VE , "hielevel"},
 +        { "flat",   NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 },  INT_MIN, INT_MAX, VE, "hielevel" },

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -1,25 +1,27 @@
-From 3864107fa3e0fb2f7a47a332222f1efe0088a487 Mon Sep 17 00:00:00 2001
+From 7241b092b8eff9bc24f61ebdf0a88e0fe08e55ea Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
-Subject: [PATCH 1/1] Add ability for ffmpeg to run svt-av1
+Subject: [PATCH] Add ability for ffmpeg to run svt-av1
+Cc: zhong.li@intel.com
 
 Change-Id: I37ee5414fdd99e0b3f112a6e5ede166f3e48d819
 Signed-off-by: Daryl Seah <daryl.seah@intel.com>
 Signed-off-by: Jing SUN <jing.a.sun@intel.com>
 Signed-off-by: ZhiZhen Tang <zhizhen.tang@intel.com>
+Signed-off-by: Zhong Li <zhong.li@intel.com>
 ---
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 483 ++++++++++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 489 insertions(+)
+ libavcodec/libsvt_av1.c | 512 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 518 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
-index 5a4f507..b7f73e3 100755
+index a9644e2..e500088 100755
 --- a/configure
 +++ b/configure
-@@ -264,6 +264,7 @@ External library support:
+@@ -262,6 +262,7 @@ External library support:
    --enable-libspeex        enable Speex de/encoding via libspeex [no]
    --enable-libsrt          enable Haivision SRT protocol via libsrt [no]
    --enable-libssh          enable SFTP protocol via libssh [no]
@@ -27,7 +29,7 @@ index 5a4f507..b7f73e3 100755
    --enable-libtensorflow   enable TensorFlow as a DNN module backend
                             for DNN based filters like sr [no]
    --enable-libtesseract    enable Tesseract, needed for ocr filter [no]
-@@ -1788,6 +1789,7 @@ EXTERNAL_LIBRARY_LIST="
+@@ -1743,6 +1744,7 @@ EXTERNAL_LIBRARY_LIST="
      libspeex
      libsrt
      libssh
@@ -35,7 +37,7 @@ index 5a4f507..b7f73e3 100755
      libtensorflow
      libtesseract
      libtheora
-@@ -3183,6 +3185,7 @@ libshine_encoder_select="audio_frame_queue"
+@@ -3125,6 +3127,7 @@ libshine_encoder_select="audio_frame_queue"
  libspeex_decoder_deps="libspeex"
  libspeex_encoder_deps="libspeex"
  libspeex_encoder_select="audio_frame_queue"
@@ -43,7 +45,7 @@ index 5a4f507..b7f73e3 100755
  libtheora_encoder_deps="libtheora"
  libtwolame_encoder_deps="libtwolame"
  libvo_amrwbenc_encoder_deps="libvo_amrwbenc"
-@@ -6230,6 +6233,7 @@ enabled libsoxr           && require libsoxr soxr.h soxr_create -lsoxr
+@@ -6135,6 +6138,7 @@ enabled libsoxr           && require libsoxr soxr.h soxr_create -lsoxr
  enabled libssh            && require_pkg_config libssh libssh libssh/sftp.h sftp_init
  enabled libspeex          && require_pkg_config libspeex speex speex/speex.h speex_decoder_init
  enabled libsrt            && require_pkg_config libsrt "srt >= 1.3.0" srt/srt.h srt_socket
@@ -52,10 +54,10 @@ index 5a4f507..b7f73e3 100755
  enabled libtesseract      && require_pkg_config libtesseract tesseract tesseract/capi.h TessBaseAPICreate
  enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -ltheoraenc -ltheoradec -logg
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 3cd73fb..5db4565 100644
+index 3e41497..9b2e663 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -991,6 +991,7 @@ OBJS-$(CONFIG_LIBOPUS_ENCODER)            += libopusenc.o libopus.o     \
+@@ -981,6 +981,7 @@ OBJS-$(CONFIG_LIBOPUS_ENCODER)            += libopusenc.o libopus.o     \
  OBJS-$(CONFIG_LIBSHINE_ENCODER)           += libshine.o
  OBJS-$(CONFIG_LIBSPEEX_DECODER)           += libspeexdec.o
  OBJS-$(CONFIG_LIBSPEEX_ENCODER)           += libspeexenc.o
@@ -64,10 +66,10 @@ index 3cd73fb..5db4565 100644
  OBJS-$(CONFIG_LIBTWOLAME_ENCODER)         += libtwolame.o
  OBJS-$(CONFIG_LIBVO_AMRWBENC_ENCODER)     += libvo-amrwbenc.o
 diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
-index d2f9a39..75759c7 100644
+index 1b8144a..f7df66c 100644
 --- a/libavcodec/allcodecs.c
 +++ b/libavcodec/allcodecs.c
-@@ -707,6 +707,7 @@ extern AVCodec ff_librsvg_decoder;
+@@ -697,6 +697,7 @@ extern AVCodec ff_librsvg_decoder;
  extern AVCodec ff_libshine_encoder;
  extern AVCodec ff_libspeex_encoder;
  extern AVCodec ff_libspeex_decoder;
@@ -77,10 +79,10 @@ index d2f9a39..75759c7 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000..8f0e5a6
+index 0000000..60b7df5
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,483 @@
+@@ -0,0 +1,512 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -110,6 +112,7 @@ index 0000000..8f0e5a6
 +#include "libavutil/common.h"
 +#include "libavutil/frame.h"
 +#include "libavutil/opt.h"
++#include "libavutil/pixdesc.h"
 +
 +#include "internal.h"
 +#include "avcodec.h"
@@ -145,6 +148,7 @@ index 0000000..8f0e5a6
 +
 +    int tier;
 +    int level;
++    int profile;
 +
 +    int base_layer_switch_mode;
 +} SvtContext;
@@ -233,20 +237,38 @@ index 0000000..8f0e5a6
 +                             AVCodecContext *avctx)
 +{
 +    SvtContext *svt_enc = avctx->priv_data;
++    const AVPixFmtDescriptor *desc;
 +    int ret;
 +
 +    param->source_width     = avctx->width;
 +    param->source_height    = avctx->height;
 +
-+    if (avctx->pix_fmt == AV_PIX_FMT_YUV420P10) {
-+        av_log(avctx, AV_LOG_DEBUG, "Set 10 bits depth input\n");
-+        param->encoder_bit_depth = 10;
-+    } else {
-+        av_log(avctx, AV_LOG_DEBUG, "Set 8 bits depth input\n");
-+        param->encoder_bit_depth = 8;
-+    }
++    desc = av_pix_fmt_desc_get(avctx->pix_fmt);
++    param->encoder_bit_depth = desc->comp[0].depth;
++    av_log(avctx, AV_LOG_DEBUG , "Encoder %d bits depth input\n", param->encoder_bit_depth);
 +
-+    param->encoder_color_format = EB_YUV420;
++    if (desc->log2_chroma_w == 1 && desc->log2_chroma_h == 1)
++        param->encoder_color_format   = EB_YUV420;
++    else if (desc->log2_chroma_w == 1 && desc->log2_chroma_h == 0)
++        param->encoder_color_format   = EB_YUV422;
++    else if (!desc->log2_chroma_w && !desc->log2_chroma_h)
++        param->encoder_color_format   = EB_YUV444;
++    else {
++        av_log(avctx, AV_LOG_ERROR , "Unsupported pixel format\n");
++        return AVERROR(EINVAL);
++    }
++    av_log(avctx, AV_LOG_DEBUG , "Encoder color format is %d \n", param->encoder_color_format);
++
++    param->profile = svt_enc->profile;
++
++    if ((param->encoder_color_format == EB_YUV422 || param->encoder_bit_depth > 10)
++         && param->profile != PROFESSIONAL_PROFILE ) {
++        av_log(avctx, AV_LOG_WARNING, "Force to be professional profile \n");
++        param->profile = PROFESSIONAL_PROFILE;
++    } else if (param->encoder_color_format == EB_YUV444 && param->profile != HIGH_PROFILE) {
++        av_log(avctx, AV_LOG_WARNING, "Force to be high profile \n");
++        param->profile = HIGH_PROFILE;
++    }
 +
 +    // Update param from options
 +    param->hierarchical_levels     = svt_enc->hierarchical_level;
@@ -286,26 +308,30 @@ index 0000000..8f0e5a6
 +    return ret;
 +}
 +
-+static void read_in_data(EbSvtAv1EncConfiguration *config,
-+                         const AVFrame *frame,
-+                         EbBufferHeaderType *headerPtr)
++static void read_in_data(const AVFrame *frame,
++                         EbBufferHeaderType *header_ptr)
 +{
-+    uint8_t is16bit = config->encoder_bit_depth > 8;
-+    uint64_t luma_size =
-+        (uint64_t)config->source_width * config->source_height<< is16bit;
-+    EbSvtIOFormat *in_data = (EbSvtIOFormat *)headerPtr->p_buffer;
++    EbSvtIOFormat *in_data = (EbSvtIOFormat *)header_ptr->p_buffer;
++    const AVPixFmtDescriptor *desc;
++    int i, bytes_shift, plane_h;
 +
-+    // support yuv420p and yuv420p010
++    desc = av_pix_fmt_desc_get(frame->format);
++    bytes_shift = desc->comp[0].depth > 8 ? 1 : 0;
++
 +    in_data->luma = frame->data[0];
 +    in_data->cb   = frame->data[1];
 +    in_data->cr   = frame->data[2];
 +
-+    // stride info
-+    in_data->y_stride  = frame->linesize[0] >> is16bit;
-+    in_data->cb_stride = frame->linesize[1] >> is16bit;
-+    in_data->cr_stride = frame->linesize[2] >> is16bit;
++    in_data->y_stride  = AV_CEIL_RSHIFT(frame->linesize[0], bytes_shift);
++    in_data->cb_stride = AV_CEIL_RSHIFT(frame->linesize[1], bytes_shift);
++    in_data->cr_stride = AV_CEIL_RSHIFT(frame->linesize[2], bytes_shift);
 +
-+    headerPtr->n_filled_len   += luma_size * 3/2u;
++    for (i = 0; i < desc->nb_components; i++) {
++        plane_h = frame->height;
++        if (i > 0)
++            plane_h = AV_CEIL_RSHIFT(plane_h, desc->log2_chroma_h);
++        header_ptr->n_filled_len += frame->linesize[i] * plane_h;
++    }
 +}
 +
 +static av_cold int eb_enc_init(AVCodecContext *avctx)
@@ -397,7 +423,7 @@ index 0000000..8f0e5a6
 +        return 0;
 +    }
 +
-+    read_in_data(&svt_enc->enc_params, frame, headerPtr);
++    read_in_data(frame, headerPtr);
 +
 +    headerPtr->flags       = 0;
 +    headerPtr->p_app_private  = NULL;
@@ -473,6 +499,11 @@ index 0000000..8f0e5a6
 +
 +    { "preset", "Encoding preset [0, 7]",
 +      OFFSET(enc_mode), AV_OPT_TYPE_INT, { .i64 = MAX_ENC_PRESET }, 0, MAX_ENC_PRESET, VE },
++
++    { "profile", "Set profile restrictions", OFFSET(profile), AV_OPT_TYPE_INT, { .i64 = MAIN_PROFILE}, MAIN_PROFILE, PROFESSIONAL_PROFILE, VE, "profile" },
++    { "main" , NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MAIN_PROFILE}, INT_MIN, INT_MAX,     VE, "profile" },
++    { "high" , NULL, 0, AV_OPT_TYPE_CONST, { .i64 = HIGH_PROFILE}, INT_MIN, INT_MAX,     VE, "profile" },
++    { "professional", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = PROFESSIONAL_PROFILE }, INT_MIN, INT_MAX,     VE, "profile" },
 +
 +    { "tier", "Set tier (general_tier_flag)", OFFSET(tier),
 +      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 1, VE, "tier" },
@@ -565,5 +596,5 @@ index 0000000..8f0e5a6
 +    .wrapper_name   = "libsvt_av1",
 +};
 --
-1.8.3.1
+2.7.4
 


### PR DESCRIPTION
This PR is to fix and improve FFmpeg plugin.

face854 is the top priority patch in the PR: we are setting a wrong value of vbr thus means vbr mode is totally broken now and we can only work on cqp mode, setting any bitrate is meaningless right now. 

31cdd39 is an small but important fix,  look like current look_ahead_depth is copied from ffmpeg svt-hevc plugin


df9574e can help user to know encoding quality  immediately with little calculation (since just expose qp, not PSNR), and also help developer to know some encoding parameters working correctly or not (such as max/min qp). 

85ef5a7 can provide more detail error message to know what happening in svt library. 

84bbb8c  is to follow an common way in FFmpeg project to support different pixel format, thus should be benefit to make this plugin more easily be accepted by FFmpeg community.