### PR TITLE
Protect rate control queues from negative array indexing

### DIFF
--- a/Source/Lib/Common/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Common/Codec/EbInitialRateControlProcess.c
@@ -977,8 +977,8 @@ void GetHistogramQueueData(
     histogramQueueEntryIndex = (histogramQueueEntryIndex > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
         histogramQueueEntryIndex - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
         (histogramQueueEntryIndex < 0) ?
-            histogramQueueEntryIndex + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-            histogramQueueEntryIndex;
+        histogramQueueEntryIndex + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
+        histogramQueueEntryIndex;
     histogramQueueEntryPtr = encode_context_ptr->hl_rate_control_historgram_queue[histogramQueueEntryIndex];
 
     //histogramQueueEntryPtr->parent_pcs_wrapper_ptr  = inputResultsPtr->picture_control_set_wrapper_ptr;
@@ -1024,8 +1024,8 @@ void UpdateHistogramQueueEntry(
     histogramQueueEntryIndex = (histogramQueueEntryIndex > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
         histogramQueueEntryIndex - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
         (histogramQueueEntryIndex < 0) ?
-            histogramQueueEntryIndex + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-            histogramQueueEntryIndex;
+        histogramQueueEntryIndex + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
+        histogramQueueEntryIndex;
     histogramQueueEntryPtr = encode_context_ptr->hl_rate_control_historgram_queue[histogramQueueEntryIndex];
     histogramQueueEntryPtr->passed_to_hlrc = EB_TRUE;
     if (sequence_control_set_ptr->static_config.rate_control_mode == 3)

--- a/Source/Lib/Common/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Common/Codec/EbInitialRateControlProcess.c
@@ -976,7 +976,9 @@ void GetHistogramQueueData(
     histogramQueueEntryIndex += encode_context_ptr->hl_rate_control_historgram_queue_head_index;
     histogramQueueEntryIndex = (histogramQueueEntryIndex > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
         histogramQueueEntryIndex - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-        histogramQueueEntryIndex;
+        (histogramQueueEntryIndex < 0) ?
+            histogramQueueEntryIndex + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
+            histogramQueueEntryIndex;
     histogramQueueEntryPtr = encode_context_ptr->hl_rate_control_historgram_queue[histogramQueueEntryIndex];
 
     //histogramQueueEntryPtr->parent_pcs_wrapper_ptr  = inputResultsPtr->picture_control_set_wrapper_ptr;
@@ -1021,7 +1023,9 @@ void UpdateHistogramQueueEntry(
     histogramQueueEntryIndex += encode_context_ptr->hl_rate_control_historgram_queue_head_index;
     histogramQueueEntryIndex = (histogramQueueEntryIndex > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
         histogramQueueEntryIndex - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-        histogramQueueEntryIndex;
+        (histogramQueueEntryIndex < 0) ?
+            histogramQueueEntryIndex + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
+            histogramQueueEntryIndex;
     histogramQueueEntryPtr = encode_context_ptr->hl_rate_control_historgram_queue[histogramQueueEntryIndex];
     histogramQueueEntryPtr->passed_to_hlrc = EB_TRUE;
     if (sequence_control_set_ptr->static_config.rate_control_mode == 3)

--- a/Source/Lib/Common/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Common/Codec/EbRateControlProcess.c
@@ -446,7 +446,7 @@ void high_level_rc_input_picture_vbr(
                     queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
                     queue_entry_index_head_temp;
 
-            queue_entry_index_temp = queue_entry_index_head_temp;
+            queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
             {
                 hl_rate_control_histogram_ptr_temp = (encode_context_ptr->hl_rate_control_historgram_queue[queue_entry_index_temp]);
 
@@ -553,7 +553,7 @@ void high_level_rc_input_picture_vbr(
                         queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
                         queue_entry_index_head_temp;
 
-                queue_entry_index_temp = queue_entry_index_head_temp;
+                queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
                 // This is set to false, so the last frame would go inside the loop
                 end_of_sequence_flag = EB_FALSE;
 
@@ -632,7 +632,7 @@ void high_level_rc_input_picture_vbr(
                         queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
                         queue_entry_index_head_temp;
 
-                queue_entry_index_temp = queue_entry_index_head_temp;
+                queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
 
                 // This is set to false, so the last frame would go inside the loop
                 end_of_sequence_flag = EB_FALSE;
@@ -688,7 +688,7 @@ void high_level_rc_input_picture_vbr(
                         queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
                         queue_entry_index_head_temp;
 
-                queue_entry_index_temp = queue_entry_index_head_temp;
+                queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
 
                 // This is set to false, so the last frame would go inside the loop
                 end_of_sequence_flag = EB_FALSE;
@@ -1756,7 +1756,7 @@ void high_level_rc_input_picture_cvbr(
                     queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                     queue_entry_index_head_temp;
 
-            queue_entry_index_temp = queue_entry_index_head_temp;
+            queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
             {
                 hl_rate_control_histogram_ptr_temp = (encode_context_ptr->hl_rate_control_historgram_queue[queue_entry_index_temp]);
 
@@ -1866,7 +1866,7 @@ void high_level_rc_input_picture_cvbr(
                             queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                             queue_entry_index_head_temp;
 
-                    queue_entry_index_temp = queue_entry_index_head_temp;
+                    queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
                     // This is set to false, so the last frame would go inside the loop
                     end_of_sequence_flag = EB_FALSE;
 
@@ -1949,7 +1949,7 @@ void high_level_rc_input_picture_cvbr(
                         queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                         queue_entry_index_head_temp;
 
-                queue_entry_index_temp = queue_entry_index_head_temp;
+                queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
 
                 // This is set to false, so the last frame would go inside the loop
                 end_of_sequence_flag = EB_FALSE;
@@ -2003,7 +2003,7 @@ void high_level_rc_input_picture_cvbr(
                         queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                         queue_entry_index_head_temp;
 
-                queue_entry_index_temp = queue_entry_index_head_temp;
+                queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
 
                 // This is set to false, so the last frame would go inside the loop
                 end_of_sequence_flag = EB_FALSE;
@@ -2313,7 +2313,7 @@ void frame_level_rc_input_picture_cvbr(
                 ref_qp_table_index);
             high_level_rate_control_ptr->pred_bits_ref_qpPerSw[ref_qp_index] = 0;
 
-            queue_entry_index_temp = queue_entry_index_head_temp;
+            queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
             // This is set to false, so the last frame would go inside the loop
             end_of_sequence_flag = EB_FALSE;
 

--- a/Source/Lib/Common/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Common/Codec/EbRateControlProcess.c
@@ -443,7 +443,7 @@ void high_level_rc_input_picture_vbr(
             queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                 queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                 (queue_entry_index_head_temp < 0) ?
-                queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
+                queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                 queue_entry_index_head_temp;
 
             queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
@@ -550,7 +550,7 @@ void high_level_rc_input_picture_vbr(
                 queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                     queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                     (queue_entry_index_head_temp < 0) ?
-                    queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
+                    queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                     queue_entry_index_head_temp;
 
                 queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
@@ -629,7 +629,7 @@ void high_level_rc_input_picture_vbr(
                 queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                     queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                     (queue_entry_index_head_temp < 0) ?
-                    queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
+                    queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                     queue_entry_index_head_temp;
 
                 queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
@@ -685,7 +685,7 @@ void high_level_rc_input_picture_vbr(
                 queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                     queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                     (queue_entry_index_head_temp < 0) ?
-                    queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
+                    queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                     queue_entry_index_head_temp;
 
                 queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;

--- a/Source/Lib/Common/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Common/Codec/EbRateControlProcess.c
@@ -355,7 +355,7 @@ void high_level_rc_input_picture_vbr(
     // Queue variables
     uint32_t                     queue_entry_index_temp;
     uint32_t                     queue_entry_index_temp2;
-    uint32_t                     queue_entry_index_head_temp;
+    int64_t                      queue_entry_index_head_temp;
 
     uint64_t                     min_la_bit_distance;
     uint32_t                     selected_ref_qp_table_index;
@@ -442,7 +442,9 @@ void high_level_rc_input_picture_vbr(
             queue_entry_index_head_temp += encode_context_ptr->hl_rate_control_historgram_queue_head_index;
             queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                 queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-                queue_entry_index_head_temp;
+                (queue_entry_index_head_temp < 0) ?
+                    queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
+                    queue_entry_index_head_temp;
 
             queue_entry_index_temp = queue_entry_index_head_temp;
             {
@@ -547,7 +549,9 @@ void high_level_rc_input_picture_vbr(
                 queue_entry_index_head_temp += encode_context_ptr->hl_rate_control_historgram_queue_head_index;
                 queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                     queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-                    queue_entry_index_head_temp;
+                    (queue_entry_index_head_temp < 0) ?
+                        queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
+                        queue_entry_index_head_temp;
 
                 queue_entry_index_temp = queue_entry_index_head_temp;
                 // This is set to false, so the last frame would go inside the loop
@@ -624,7 +628,9 @@ void high_level_rc_input_picture_vbr(
                 queue_entry_index_head_temp += encode_context_ptr->hl_rate_control_historgram_queue_head_index;
                 queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                     queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-                    queue_entry_index_head_temp;
+                    (queue_entry_index_head_temp < 0) ?
+                        queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
+                        queue_entry_index_head_temp;
 
                 queue_entry_index_temp = queue_entry_index_head_temp;
 
@@ -678,7 +684,9 @@ void high_level_rc_input_picture_vbr(
                 queue_entry_index_head_temp += encode_context_ptr->hl_rate_control_historgram_queue_head_index;
                 queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                     queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-                    queue_entry_index_head_temp;
+                    (queue_entry_index_head_temp < 0) ?
+                        queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
+                        queue_entry_index_head_temp;
 
                 queue_entry_index_temp = queue_entry_index_head_temp;
 
@@ -1655,7 +1663,7 @@ void high_level_rc_input_picture_cvbr(
     // Queue variables
     uint32_t                     queue_entry_index_temp;
     uint32_t                     queue_entry_index_temp2;
-    uint32_t                     queue_entry_index_head_temp;
+    int64_t                      queue_entry_index_head_temp;
 
     uint64_t                     min_la_bit_distance;
     uint32_t                     selected_ref_qp_table_index;
@@ -1744,7 +1752,9 @@ void high_level_rc_input_picture_cvbr(
             queue_entry_index_head_temp += encode_context_ptr->hl_rate_control_historgram_queue_head_index;
             queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                 queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-                queue_entry_index_head_temp;
+                (queue_entry_index_head_temp < 0) ?
+                    queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
+                    queue_entry_index_head_temp;
 
             queue_entry_index_temp = queue_entry_index_head_temp;
             {
@@ -1852,7 +1862,9 @@ void high_level_rc_input_picture_cvbr(
                     queue_entry_index_head_temp += encode_context_ptr->hl_rate_control_historgram_queue_head_index;
                     queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                         queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-                        queue_entry_index_head_temp;
+                        (queue_entry_index_head_temp < 0) ?
+                            queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
+                            queue_entry_index_head_temp;
 
                     queue_entry_index_temp = queue_entry_index_head_temp;
                     // This is set to false, so the last frame would go inside the loop
@@ -1933,7 +1945,9 @@ void high_level_rc_input_picture_cvbr(
                 queue_entry_index_head_temp += encode_context_ptr->hl_rate_control_historgram_queue_head_index;
                 queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                     queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-                    queue_entry_index_head_temp;
+                    (queue_entry_index_head_temp < 0) ?
+                        queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
+                        queue_entry_index_head_temp;
 
                 queue_entry_index_temp = queue_entry_index_head_temp;
 
@@ -1985,7 +1999,9 @@ void high_level_rc_input_picture_cvbr(
                 queue_entry_index_head_temp += encode_context_ptr->hl_rate_control_historgram_queue_head_index;
                 queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                     queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-                    queue_entry_index_head_temp;
+                    (queue_entry_index_head_temp < 0) ?
+                        queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
+                        queue_entry_index_head_temp;
 
                 queue_entry_index_temp = queue_entry_index_head_temp;
 
@@ -2232,7 +2248,7 @@ void frame_level_rc_input_picture_cvbr(
         // Queue variables
         uint32_t                     queue_entry_index_temp;
         uint32_t                     queue_entry_index_temp2;
-        uint32_t                     queue_entry_index_head_temp;
+        int64_t                     queue_entry_index_head_temp;
 
         uint64_t                     min_la_bit_distance;
         uint32_t                     selected_ref_qp_table_index;
@@ -2271,7 +2287,9 @@ void frame_level_rc_input_picture_cvbr(
         queue_entry_index_head_temp += encode_context_ptr->hl_rate_control_historgram_queue_head_index;
         queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
             queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-            queue_entry_index_head_temp;
+            (queue_entry_index_head_temp < 0) ?
+                queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
+                queue_entry_index_head_temp;
 
         if (picture_control_set_ptr->parent_pcs_ptr->picture_number + picture_control_set_ptr->parent_pcs_ptr->frames_in_sw > rate_control_param_ptr->first_poc + sequence_control_set_ptr->static_config.intra_period_length + 1)
             bit_constraint_per_sw = high_level_rate_control_ptr->bit_constraint_per_sw;

--- a/Source/Lib/Common/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Common/Codec/EbRateControlProcess.c
@@ -443,8 +443,8 @@ void high_level_rc_input_picture_vbr(
             queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                 queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                 (queue_entry_index_head_temp < 0) ?
-                    queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
-                    queue_entry_index_head_temp;
+                queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
+                queue_entry_index_head_temp;
 
             queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
             {
@@ -550,8 +550,8 @@ void high_level_rc_input_picture_vbr(
                 queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                     queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                     (queue_entry_index_head_temp < 0) ?
-                        queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
-                        queue_entry_index_head_temp;
+                    queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
+                    queue_entry_index_head_temp;
 
                 queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
                 // This is set to false, so the last frame would go inside the loop
@@ -629,8 +629,8 @@ void high_level_rc_input_picture_vbr(
                 queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                     queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                     (queue_entry_index_head_temp < 0) ?
-                        queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
-                        queue_entry_index_head_temp;
+                    queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
+                    queue_entry_index_head_temp;
 
                 queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
 
@@ -685,8 +685,8 @@ void high_level_rc_input_picture_vbr(
                 queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                     queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                     (queue_entry_index_head_temp < 0) ?
-                        queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
-                        queue_entry_index_head_temp;
+                    queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH : 
+                    queue_entry_index_head_temp;
 
                 queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
 
@@ -1753,8 +1753,8 @@ void high_level_rc_input_picture_cvbr(
             queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                 queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                 (queue_entry_index_head_temp < 0) ?
-                    queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-                    queue_entry_index_head_temp;
+                queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
+                queue_entry_index_head_temp;
 
             queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
             {
@@ -1863,8 +1863,8 @@ void high_level_rc_input_picture_cvbr(
                     queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                         queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                         (queue_entry_index_head_temp < 0) ?
-                            queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-                            queue_entry_index_head_temp;
+                        queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
+                        queue_entry_index_head_temp;
 
                     queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
                     // This is set to false, so the last frame would go inside the loop
@@ -1946,8 +1946,8 @@ void high_level_rc_input_picture_cvbr(
                 queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                     queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                     (queue_entry_index_head_temp < 0) ?
-                        queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-                        queue_entry_index_head_temp;
+                    queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
+                    queue_entry_index_head_temp;
 
                 queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
 
@@ -2000,8 +2000,8 @@ void high_level_rc_input_picture_cvbr(
                 queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
                     queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
                     (queue_entry_index_head_temp < 0) ?
-                        queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-                        queue_entry_index_head_temp;
+                    queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
+                    queue_entry_index_head_temp;
 
                 queue_entry_index_temp = (uint32_t) queue_entry_index_head_temp;
 
@@ -2288,8 +2288,8 @@ void frame_level_rc_input_picture_cvbr(
         queue_entry_index_head_temp = (queue_entry_index_head_temp > HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH - 1) ?
             queue_entry_index_head_temp - HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
             (queue_entry_index_head_temp < 0) ?
-                queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
-                queue_entry_index_head_temp;
+            queue_entry_index_head_temp + HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH :
+            queue_entry_index_head_temp;
 
         if (picture_control_set_ptr->parent_pcs_ptr->picture_number + picture_control_set_ptr->parent_pcs_ptr->frames_in_sw > rate_control_param_ptr->first_poc + sequence_control_set_ptr->static_config.intra_period_length + 1)
             bit_constraint_per_sw = high_level_rate_control_ptr->bit_constraint_per_sw;


### PR DESCRIPTION
Closes #481 by preventing attempted access to negative queue indices. By adding, HIGH_LEVEL_RATE_CONTROL_HISTOGRAM_QUEUE_MAX_DEPTH to all negative index values, the queue indices are circularly represented as originally intended.