### PR TITLE
Refactor & Fix all warnings

### DIFF
--- a/Source/App/DecApp/EbDecParamParser.h
+++ b/Source/App/DecApp/EbDecParamParser.h
@@ -5,6 +5,9 @@
 
 // Command line argument parsing
 
+#ifndef EbDecParamParser_h
+#define EbDecParamParser_h
+
 /***************************************
  * Includes
  ***************************************/
@@ -53,3 +56,5 @@ typedef struct ConfigEntry {
 } ConfigEntry;
 
 EbErrorType read_command_line(int32_t argc, char *const argv[], EbSvtAv1DecConfiguration *configs, CLInput *cli);
+
+#endif

--- a/Source/App/DecApp/EbFileUtils.h
+++ b/Source/App/DecApp/EbFileUtils.h
@@ -3,6 +3,9 @@
 * SPDX - License - Identifier: BSD - 2 - Clause - Patent
 */
 
+#ifndef EbFileUtils_h
+#define EbFileUtils_h
+
 #include <stdio.h>
 
 #include "EbSvtAv1Dec.h"
@@ -56,3 +59,5 @@ typedef struct CLInput{
 int file_is_ivf(CLInput *cli);
 int read_ivf_frame(FILE *infile, uint8_t **buffer, size_t *bytes_read,
     size_t *buffer_size, int64_t *pts);
+
+#endif

--- a/Source/App/DecApp/EbMD5Utility.h
+++ b/Source/App/DecApp/EbMD5Utility.h
@@ -25,6 +25,9 @@
  * Still in the public domain.
 */
 
+#ifndef EbMD_Utility_h
+#define EbMD_Utility_h
+
 typedef struct MD5Context {
     unsigned int buf[4];
     unsigned int bytes[2];
@@ -38,3 +41,5 @@ void md5_transform(unsigned int buf[4], unsigned int const in[16]);
 
 void print_md5(unsigned char digest[16]);
 void write_md5(EbBufferHeaderType *recon_buffer, CLInput *cli, MD5Context *md5);
+
+#endif

--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -115,8 +115,11 @@ int32_t main(int32_t argc, char* argv[])
         // Initialize config
         for (instanceCount = 0; instanceCount < num_channels; ++instanceCount) {
             configs[instanceCount] = (EbConfig*)malloc(sizeof(EbConfig));
-            if (!configs[instanceCount])
+            if (!configs[instanceCount]) {
+                while(instanceCount-- > 0)
+                    free(configs[instanceCount]);
                 return EB_ErrorInsufficientResources;
+            }
             eb_config_ctor(configs[instanceCount]);
             return_errors[instanceCount] = EB_ErrorNone;
         }
@@ -124,8 +127,11 @@ int32_t main(int32_t argc, char* argv[])
         // Initialize appCallback
         for (instanceCount = 0; instanceCount < num_channels; ++instanceCount) {
             appCallbacks[instanceCount] = (EbAppContext*)malloc(sizeof(EbAppContext));
-            if (!appCallbacks[instanceCount])
+            if (!appCallbacks[instanceCount]) {
+                while(instanceCount-- > 0)
+                    free(appCallbacks[instanceCount]);
                 return EB_ErrorInsufficientResources;
+            }
         }
 
         for (instanceCount = 0; instanceCount < MAX_CHANNEL_NUMBER; ++instanceCount) {

--- a/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
+++ b/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
@@ -1475,6 +1475,7 @@ void enc_pass_av1_mv_pred(
 
     (void)mode;
     IntMv    nearestmv[2], nearmv[2];
+    memset(nearestmv, 0, sizeof(nearestmv));
 
     generate_av1_mvp_table(
         tile,

--- a/Source/Lib/Common/Codec/EbComputeSAD.h
+++ b/Source/Lib/Common/Codec/EbComputeSAD.h
@@ -29,7 +29,41 @@ extern "C" {
         uint32_t  height,
         uint32_t  width);
 
-    static void nxm_sad_kernel_void_func() {}
+    static uint32_t nxm_sad_kernel_void_func(
+            const uint8_t  *src,
+            uint32_t  src_stride,
+            const uint8_t  *ref,
+            uint32_t  ref_stride,
+            uint32_t  height,
+            uint32_t  width) {
+        (void)src;
+        (void)src_stride;
+        (void)ref;
+        (void)ref_stride;
+        (void)height;
+        (void)width;
+        return 0;
+    }
+
+    static uint32_t nxm_sad_avg_kernel_void_func(
+            uint8_t  *src,
+            uint32_t  src_stride,
+            uint8_t  *ref1,
+            uint32_t  ref1_stride,
+            uint8_t  *ref2,
+            uint32_t  ref2_stride,
+            uint32_t  height,
+            uint32_t  width) {
+        (void)src;
+        (void)src_stride;
+        (void)ref1;
+        (void)ref1_stride;
+        (void)ref2;
+        (void)ref2_stride;
+        (void)height;
+        (void)width;
+        return 0;
+    }
 
     typedef void(*EbSadLoopKernelNxMType)(
         uint8_t  *src,                            // input parameter, source samples Ptr
@@ -151,9 +185,9 @@ extern "C" {
             /*2 16xM */ compute16x_m_sad_avx2_intrin,//compute16x_m_sad_avx2_intrin is slower than the SSE2 version
             /*3 24xM */ compute24x_m_sad_avx2_intrin,
             /*4 32xM */ compute32x_m_sad_avx2_intrin,
-            /*5      */ (EbSadKernelNxMType)nxm_sad_kernel_void_func,
+            /*5      */ nxm_sad_kernel_void_func,
             /*6 48xM */ compute48x_m_sad_avx2_intrin,
-            /*7      */ (EbSadKernelNxMType)nxm_sad_kernel_void_func,
+            /*7      */ nxm_sad_kernel_void_func,
             /*8 64xM */ compute64x_m_sad_avx2_intrin,
         },
     };
@@ -167,9 +201,9 @@ extern "C" {
             /*2 16xM */     combined_averaging_sad,
             /*3 24xM */     combined_averaging_sad,
             /*4 32xM */     combined_averaging_sad,
-            /*5      */     (EbSadAvgKernelNxMType)nxm_sad_kernel_void_func,
+            /*5      */     nxm_sad_avg_kernel_void_func,
             /*6 48xM */     combined_averaging_sad,
-            /*7      */     (EbSadAvgKernelNxMType)nxm_sad_kernel_void_func,
+            /*7      */     nxm_sad_avg_kernel_void_func,
             /*8 64xM */     combined_averaging_sad
         },
         // AVX2
@@ -179,9 +213,9 @@ extern "C" {
             /*2 16xM */     combined_averaging16x_msad_avx2_intrin,
             /*3 24xM */     combined_averaging24x_msad_avx2_intrin,
             /*4 32xM */     combined_averaging32x_msad_avx2_intrin,
-            /*5      */     (EbSadAvgKernelNxMType)nxm_sad_kernel_void_func,
+            /*5      */     nxm_sad_avg_kernel_void_func,
             /*6 48xM */     combined_averaging48x_msad_avx2_intrin,
-            /*7      */     (EbSadAvgKernelNxMType)nxm_sad_kernel_void_func,
+            /*7      */     nxm_sad_avg_kernel_void_func,
             /*8 64xM */     combined_averaging64x_msad_avx2_intrin
         },
     };

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1500,6 +1500,9 @@ void* enc_dec_kernel(void *input_ptr)
     uint32_t                                 segmentBandIndex;
     uint32_t                                 segmentBandSize;
     EncDecSegments                          *segments_ptr;
+
+    segment_index = 0;
+
     for (;;) {
         // Get Mode Decision Results
         eb_get_full_object(

--- a/Source/Lib/Common/Codec/EbFullLoop.c
+++ b/Source/Lib/Common/Codec/EbFullLoop.c
@@ -2306,8 +2306,8 @@ void product_full_loop_tx_search(
         txk_end = 2;
 
     for (int32_t tx_type_index = txk_start; tx_type_index < txk_end; ++tx_type_index) {
-    if (picture_control_set_ptr->parent_pcs_ptr->tx_search_reduced_set == 2)
-        tx_type_index = (tx_type_index  == 1) ? IDTX : tx_type_index;
+        if (picture_control_set_ptr->parent_pcs_ptr->tx_search_reduced_set == 2)
+            tx_type_index = (tx_type_index  == 1) ? IDTX : tx_type_index;
         tx_type = (TxType)tx_type_index;
         allowed_tx_mask[tx_type] = 1;
         if (plane == 0) {
@@ -2325,8 +2325,8 @@ void product_full_loop_tx_search(
         allowed_tx_mask[plane ? uv_tx_type : DCT_DCT] = 1;
     TxType best_tx_type = DCT_DCT;
     for (int32_t tx_type_index = txk_start; tx_type_index < txk_end; ++tx_type_index) {
-    if (picture_control_set_ptr->parent_pcs_ptr->tx_search_reduced_set == 2)
-        tx_type_index = (tx_type_index  == 1) ? IDTX : tx_type_index;
+        if (picture_control_set_ptr->parent_pcs_ptr->tx_search_reduced_set == 2)
+            tx_type_index = (tx_type_index  == 1) ? IDTX : tx_type_index;
         tx_type = (TxType)tx_type_index;
         if (!allowed_tx_mask[tx_type]) continue;
         if (picture_control_set_ptr->parent_pcs_ptr->tx_search_reduced_set)

--- a/Source/Lib/Common/Codec/EbInterPrediction.c
+++ b/Source/Lib/Common/Codec/EbInterPrediction.c
@@ -5374,36 +5374,36 @@ EbErrorType inter_pu_prediction_av1(
                 &skip_sse_sb);
         }
 
-        av1_inter_prediction(
-            picture_control_set_ptr,
-            candidate_buffer_ptr->candidate_ptr->interp_filters,
-            md_context_ptr->cu_ptr,
-            candidate_buffer_ptr->candidate_ptr->ref_frame_type,
-            &mv_unit,
-            candidate_buffer_ptr->candidate_ptr->use_intrabc,
-            candidate_buffer_ptr->candidate_ptr->compound_idx,
-            &candidate_buffer_ptr->candidate_ptr->interinter_comp,
+    av1_inter_prediction(
+        picture_control_set_ptr,
+        candidate_buffer_ptr->candidate_ptr->interp_filters,
+        md_context_ptr->cu_ptr,
+        candidate_buffer_ptr->candidate_ptr->ref_frame_type,
+        &mv_unit,
+        candidate_buffer_ptr->candidate_ptr->use_intrabc,
+        candidate_buffer_ptr->candidate_ptr->compound_idx,
+        &candidate_buffer_ptr->candidate_ptr->interinter_comp,
 #if II_COMP_FLAG
-            &md_context_ptr->sb_ptr->tile_info,
-            md_context_ptr->luma_recon_neighbor_array,
-            md_context_ptr->cb_recon_neighbor_array,
-            md_context_ptr->cr_recon_neighbor_array,
-            candidate_ptr->is_interintra_used,
-            candidate_ptr->interintra_mode,
-            candidate_ptr->use_wedge_interintra,
-            candidate_ptr->interintra_wedge_index,
+        &md_context_ptr->sb_ptr->tile_info,
+        md_context_ptr->luma_recon_neighbor_array,
+        md_context_ptr->cb_recon_neighbor_array,
+        md_context_ptr->cr_recon_neighbor_array,
+        candidate_ptr->is_interintra_used,
+        candidate_ptr->interintra_mode,
+        candidate_ptr->use_wedge_interintra,
+        candidate_ptr->interintra_wedge_index,
 #endif
-            md_context_ptr->cu_origin_x,
-            md_context_ptr->cu_origin_y,
-            md_context_ptr->blk_geom->bwidth,
-            md_context_ptr->blk_geom->bheight,
-            ref_pic_list0,
-            ref_pic_list1,
-            candidate_buffer_ptr->prediction_ptr,
-            md_context_ptr->blk_geom->origin_x,
-            md_context_ptr->blk_geom->origin_y,
-            md_context_ptr->chroma_level <= CHROMA_MODE_1 && md_context_ptr->md_staging_skip_inter_chroma_pred == EB_FALSE,
-            asm_type);
+        md_context_ptr->cu_origin_x,
+        md_context_ptr->cu_origin_y,
+        md_context_ptr->blk_geom->bwidth,
+        md_context_ptr->blk_geom->bheight,
+        ref_pic_list0,
+        ref_pic_list1,
+        candidate_buffer_ptr->prediction_ptr,
+        md_context_ptr->blk_geom->origin_x,
+        md_context_ptr->blk_geom->origin_y,
+        md_context_ptr->chroma_level <= CHROMA_MODE_1 && md_context_ptr->md_staging_skip_inter_chroma_pred == EB_FALSE,
+        asm_type);
     return return_error;
 }
 

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -36,7 +36,7 @@
 #include "EbRateDistortionCost.h"
 #endif
 #include "aom_dsp_rtcd.h"
-#define  INCRMENT_CAND_TOTAL_COUNT(cnt) cnt++; if(cnt>=MODE_DECISION_CANDIDATE_MAX_COUNT) printf(" ERROR: reaching limit for MODE_DECISION_CANDIDATE_MAX_COUNT %i\n",cnt);
+#define  INCRMENT_CAND_TOTAL_COUNT(cnt) MULTI_LINE_MACRO_BEGIN cnt++; if(cnt>=MODE_DECISION_CANDIDATE_MAX_COUNT) printf(" ERROR: reaching limit for MODE_DECISION_CANDIDATE_MAX_COUNT %i\n",cnt); MULTI_LINE_MACRO_END
 int8_t av1_ref_frame_type(const MvReferenceFrame *const rf);
 
 #if II_COMP_FLAG

--- a/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
@@ -161,51 +161,52 @@ EbErrorType signal_derivation_me_kernel_oq(
         set_me_hme_params_from_config(
             sequence_control_set_ptr,
             context_ptr->me_context_ptr);
-        if (picture_control_set_ptr->sc_content_detected)
-            context_ptr->me_context_ptr->fractional_search_method = SUB_SAD_SEARCH;
-        else
+    if (picture_control_set_ptr->sc_content_detected)
+        context_ptr->me_context_ptr->fractional_search_method = SUB_SAD_SEARCH;
+    else
         if (picture_control_set_ptr->enc_mode <= ENC_M6)
-        context_ptr->me_context_ptr->fractional_search_method = SSD_SEARCH ;
+            context_ptr->me_context_ptr->fractional_search_method = SSD_SEARCH ;
         else
-        context_ptr->me_context_ptr->fractional_search_method = FULL_SAD_SEARCH;
-        if (picture_control_set_ptr->sc_content_detected)
-            context_ptr->me_context_ptr->fractional_search64x64 = EB_FALSE;
-        else
-            context_ptr->me_context_ptr->fractional_search64x64 = EB_TRUE;
+            context_ptr->me_context_ptr->fractional_search_method = FULL_SAD_SEARCH;
+    if (picture_control_set_ptr->sc_content_detected)
+        context_ptr->me_context_ptr->fractional_search64x64 = EB_FALSE;
+    else
+        context_ptr->me_context_ptr->fractional_search64x64 = EB_TRUE;
 
         // Set HME flags
-        context_ptr->me_context_ptr->enable_hme_flag = picture_control_set_ptr->enable_hme_flag;
-        context_ptr->me_context_ptr->enable_hme_level0_flag = picture_control_set_ptr->enable_hme_level0_flag;
-        context_ptr->me_context_ptr->enable_hme_level1_flag = picture_control_set_ptr->enable_hme_level1_flag;
-        context_ptr->me_context_ptr->enable_hme_level2_flag = picture_control_set_ptr->enable_hme_level2_flag;
+    context_ptr->me_context_ptr->enable_hme_flag = picture_control_set_ptr->enable_hme_flag;
+    context_ptr->me_context_ptr->enable_hme_level0_flag = picture_control_set_ptr->enable_hme_level0_flag;
+    context_ptr->me_context_ptr->enable_hme_level1_flag = picture_control_set_ptr->enable_hme_level1_flag;
+    context_ptr->me_context_ptr->enable_hme_level2_flag = picture_control_set_ptr->enable_hme_level2_flag;
 
-        // Set the default settings of subpel
-        if (picture_control_set_ptr->sc_content_detected)
-            if (picture_control_set_ptr->enc_mode <= ENC_M1)
-                context_ptr->me_context_ptr->use_subpel_flag = 1;
-            else
-                context_ptr->me_context_ptr->use_subpel_flag = 0;
-        else
+    // Set the default settings of subpel
+    if (picture_control_set_ptr->sc_content_detected)
+        if (picture_control_set_ptr->enc_mode <= ENC_M1)
             context_ptr->me_context_ptr->use_subpel_flag = 1;
-        if (MR_MODE) {
-            context_ptr->me_context_ptr->half_pel_mode =
-                EX_HP_MODE;
-            context_ptr->me_context_ptr->quarter_pel_mode =
-                EX_QP_MODE;
-        }
-        else if (picture_control_set_ptr->enc_mode ==
-            ENC_M0) {
-            context_ptr->me_context_ptr->half_pel_mode =
-                EX_HP_MODE;
-            context_ptr->me_context_ptr->quarter_pel_mode =
-                REFINMENT_QP_MODE;
-        }
-        else {
-            context_ptr->me_context_ptr->half_pel_mode =
-                REFINMENT_HP_MODE;
-            context_ptr->me_context_ptr->quarter_pel_mode =
-                REFINMENT_QP_MODE;
-        }
+        else
+            context_ptr->me_context_ptr->use_subpel_flag = 0;
+    else
+        context_ptr->me_context_ptr->use_subpel_flag = 1;
+    if (MR_MODE) {
+        context_ptr->me_context_ptr->half_pel_mode =
+            EX_HP_MODE;
+        context_ptr->me_context_ptr->quarter_pel_mode =
+            EX_QP_MODE;
+    }
+    else if (picture_control_set_ptr->enc_mode ==
+        ENC_M0) {
+        context_ptr->me_context_ptr->half_pel_mode =
+            EX_HP_MODE;
+        context_ptr->me_context_ptr->quarter_pel_mode =
+            REFINMENT_QP_MODE;
+    }
+    else {
+        context_ptr->me_context_ptr->half_pel_mode =
+            REFINMENT_HP_MODE;
+        context_ptr->me_context_ptr->quarter_pel_mode =
+            REFINMENT_QP_MODE;
+    }
+
 
 
     // Set fractional search model
@@ -228,7 +229,7 @@ EbErrorType signal_derivation_me_kernel_oq(
         else
             context_ptr->me_context_ptr->hme_search_method = SUB_SAD_SEARCH;
     else
-    context_ptr->me_context_ptr->hme_search_method = FULL_SAD_SEARCH;
+        context_ptr->me_context_ptr->hme_search_method = FULL_SAD_SEARCH;
     // ME Search Method
     if (picture_control_set_ptr->sc_content_detected)
         if (picture_control_set_ptr->enc_mode <= ENC_M3)

--- a/Source/Lib/Common/Codec/EbPredictionStructure.c
+++ b/Source/Lib/Common/Codec/EbPredictionStructure.c
@@ -621,11 +621,6 @@ static void PredictionStructureDctor(EbPtr p)
     if (pe) {
         for (uint32_t i = 0; i < count; i++) {
             EB_FREE_ARRAY(pe[i]->ref_list0.reference_list);
-            EB_FREE_ARRAY(pe[i]->ref_list0.reference_list);
-            EB_FREE_ARRAY(pe[i]->ref_list1.reference_list);
-            EB_FREE_ARRAY(pe[i]->ref_list1.reference_list);
-            EB_FREE_ARRAY(pe[i]->ref_list0.reference_list);
-            EB_FREE_ARRAY(pe[i]->ref_list1.reference_list);
             EB_FREE_ARRAY(pe[i]->ref_list1.reference_list);
             EB_FREE_ARRAY(pe[i]->dep_list0.list);
             EB_FREE_ARRAY(pe[i]->dep_list1.list);

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -323,16 +323,16 @@ void mode_decision_update_neighbor_arrays(
                 context_ptr->blk_geom->bwidth,
                 context_ptr->blk_geom->bheight);
 
-            if (picture_control_set_ptr->parent_pcs_ptr->atb_mode) {
-                update_recon_neighbor_array16bit(
-                    picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
-                    context_ptr->cu_ptr->neigh_top_recon_16bit[0],
-                    context_ptr->cu_ptr->neigh_left_recon_16bit[0],
-                    origin_x,
-                    origin_y,
-                    context_ptr->blk_geom->bwidth,
-                    context_ptr->blk_geom->bheight);
-            }
+        if (picture_control_set_ptr->parent_pcs_ptr->atb_mode) {
+            update_recon_neighbor_array16bit(
+                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
+                context_ptr->cu_ptr->neigh_top_recon_16bit[0],
+                context_ptr->cu_ptr->neigh_left_recon_16bit[0],
+                origin_x,
+                origin_y,
+                context_ptr->blk_geom->bwidth,
+                context_ptr->blk_geom->bheight);
+        }
 
         if (intraMdOpenLoop == EB_FALSE &&
             context_ptr->blk_geom->has_uv &&

--- a/Source/Lib/Common/Codec/EbSegmentation.c
+++ b/Source/Lib/Common/Codec/EbSegmentation.c
@@ -145,7 +145,7 @@ void setup_segmentation(
     SegmentationParams *segmentation_params = &picture_control_set_ptr->parent_pcs_ptr->frm_hdr.segmentation_params;
     segmentation_params->segmentation_enabled = (EbBool)(sequence_control_set_ptr->static_config.enable_adaptive_quantization == 1);
     if (segmentation_params->segmentation_enabled) {
-        int32_t segment_qps[MAX_SEGMENTS];
+        int32_t segment_qps[MAX_SEGMENTS] = {0};
         segmentation_params->segmentation_update_data = 1; //always updating for now. Need to set this based on actual deltas
         segmentation_params->segmentation_update_map = 1;
         segmentation_params->segmentation_temporal_update = EB_FALSE; //!(picture_control_set_ptr->parent_pcs_ptr->av1FrameType == KEY_FRAME || picture_control_set_ptr->parent_pcs_ptr->av1FrameType == INTRA_ONLY_FRAME);
@@ -224,4 +224,3 @@ void temporally_update_qps(
         segment_qp_ptr[i] = temporal_update ? diff : segment_qp_ptr[i];
     }
 }
-

--- a/Source/Lib/Common/Codec/EbThreads.h
+++ b/Source/Lib/Common/Codec/EbThreads.h
@@ -93,8 +93,12 @@ extern "C" {
     } while (0)
 
 #elif defined(__linux__)
+#ifndef __USE_GNU
 #define __USE_GNU
+#endif
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 #include <sched.h>
 #include <pthread.h>
 extern    cpu_set_t                   group_affinity;

--- a/Source/Lib/Decoder/Codec/EbDecIntraPrediction.h
+++ b/Source/Lib/Decoder/Codec/EbDecIntraPrediction.h
@@ -19,11 +19,11 @@ extern "C" {
 void svt_av1_predict_intra(DecModCtxt *dec_mod_ctxt, PartitionInfo_t *part_info,
         int32_t plane,
         TxSize tx_size, TileInfo *td,
-        uint8_t *blk_recon_buf, int32_t recon_stride,
+        void *pv_blk_recon_buf, int32_t recon_stride,
         EbBitDepthEnum bit_depth, int32_t blk_mi_col_off, int32_t blk_mi_row_off);
 
 void cfl_store_tx(PartitionInfo_t *xd, CflCtx *cfl_ctx, int row, int col, TxSize tx_size,
-    BlockSize  bsize, EbColorConfig *cc, void *pv_dst_buff,
+    BlockSize  bsize, EbColorConfig *cc, uint8_t *dst_buff,
     uint32_t dst_stride);
 
 #ifdef __cplusplus

--- a/Source/Lib/Decoder/Codec/EbDecParseBlock.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseBlock.c
@@ -2730,11 +2730,13 @@ static INLINE void update_ext_partition_context(ParseCtxt *parse_ctx, int mi_row
         switch (partition) {
         case PARTITION_SPLIT:
             if (bsize != BLOCK_8X8) break;
+            goto PARTITIONS;
         case PARTITION_NONE:
         case PARTITION_HORZ:
         case PARTITION_VERT:
         case PARTITION_HORZ_4:
         case PARTITION_VERT_4:
+        PARTITIONS:
             update_partition_context(parse_ctx, mi_row, mi_col, subsize, bsize);
             break;
         case PARTITION_HORZ_A:

--- a/Source/Lib/Decoder/Codec/EbDecParseInterBlock.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseInterBlock.c
@@ -2327,6 +2327,7 @@ void inter_block_mode_info(EbDecHandle *dec_handle, PartitionInfo_t* pi,
 
     IntMvDec ref_mv[2];
     IntMvDec nearestmv[2], nearmv[2];
+    memset(nearestmv, 0, sizeof(nearestmv));
     if (!is_compound && mbmi->mode != GLOBALMV) {
         svt_find_best_ref_mvs(allow_hp, ref_mvs[mbmi->ref_frame[0]], &nearestmv[0],
             &nearmv[0], dec_handle->frame_header.force_integer_mv);

--- a/Source/Lib/Decoder/Codec/EbDecParseObu.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseObu.c
@@ -2584,8 +2584,10 @@ EbErrorType decode_multiple_obu(EbDecHandle *dec_handle_ptr, uint8_t **data, siz
             }*/
 
             if (obu_header.obu_type != OBU_FRAME) break; // For OBU_TILE_GROUP comes under OBU_FRAME
+            goto TITLE_GROUP;
 
         case OBU_TILE_GROUP:
+        TITLE_GROUP:
             PRINT_NAME("**************OBU_TILE_GROUP*******************");
             if (!dec_handle_ptr->seen_frame_header)
                 return EB_Corrupt_Frame;

--- a/Source/Lib/Decoder/Codec/EbDecPicMgr.c
+++ b/Source/Lib/Decoder/Codec/EbDecPicMgr.c
@@ -286,7 +286,7 @@ void generate_next_ref_frame_map(EbDecHandle *dec_handle_ptr) {
 // These functions take a reference frame label between LAST_FRAME and
 // EXTREF_FRAME inclusive.  Note that this is different to the indexing
 // previously used by the frame_refs[] array.
-static INLINE int32_t get_ref_frame_map_idx(EbDecHandle *dec_handle_ptr,
+static INLINE int32_t get_ref_frame_map_with_idx(EbDecHandle *dec_handle_ptr,
                                         const MvReferenceFrame ref_frame)
 {
     return (ref_frame >= LAST_FRAME && ref_frame <= REF_FRAMES)
@@ -297,7 +297,7 @@ static INLINE int32_t get_ref_frame_map_idx(EbDecHandle *dec_handle_ptr,
 EbDecPicBuf *get_ref_frame_buf(EbDecHandle *dec_handle_ptr,
                                const MvReferenceFrame ref_frame)
 {
-    const int32_t map_idx = get_ref_frame_map_idx(dec_handle_ptr, ref_frame);
+    const int32_t map_idx = get_ref_frame_map_with_idx(dec_handle_ptr, ref_frame);
     return (map_idx != INVALID_IDX) ? dec_handle_ptr->ref_frame_map[map_idx] : NULL;
 }
 

--- a/test/BitstreamWriterTest.cc
+++ b/test/BitstreamWriterTest.cc
@@ -153,10 +153,8 @@ class BitstreamWriterTest : public ::testing::Test {
 
         // setup test bits
         switch (bit_gen_method) {
-        case 0: memset(test_bits, 0, total_bits * sizeof(test_bits[0])); break;
-        case 1:
-            for (int i = 0; i < total_bits; ++i)
-                test_bits[i] = 1;
+        case 0:
+        case 1: memset(test_bits, bit_gen_method, total_bits * sizeof(test_bits[0])); break;
         default:
             for (int i = 0; i < total_bits; ++i)
                 test_bits[i] = bit_dist(gen_);

--- a/test/SadTest.cc
+++ b/test/SadTest.cc
@@ -359,16 +359,19 @@ class SADTestSubSample : public ::testing::WithParamInterface<TestSadParam>,
                                  height_,
                                  width_);
 
-        if (non_avx2_func != nullptr)
+        if (non_avx2_func != nullptr) {
             EXPECT_EQ(ref_sad, non_avx2_sad)
                 << "compare ref and non_avx2 error";
+        }
 
-        if (avx2_func != nullptr)
+        if (avx2_func != nullptr) {
             EXPECT_EQ(ref_sad, avx2_sad) << "compare ref and avx2 error";
+        }
 
-        if (non_avx2_func != nullptr && avx2_func != nullptr)
+        if (non_avx2_func != nullptr && avx2_func != nullptr) {
             EXPECT_EQ(non_avx2_sad, avx2_sad)
                 << "compare non_avx2 and non_avx2 error";
+        }
     }
 };
 
@@ -442,14 +445,17 @@ class SADTest : public ::testing::WithParamInterface<TestSadParam>,
                                  height_,
                                  width_);
 
-        if (non_avx2_func != nullptr)
+        if (non_avx2_func != nullptr) {
             EXPECT_EQ(ref_sad, non_avx2_sad)
                 << "compare ref and non_avx2 error";
-        if (avx2_func != nullptr)
+        }
+        if (avx2_func != nullptr) {
             EXPECT_EQ(ref_sad, avx2_sad) << "compare ref and avx2 error";
-        if (non_avx2_func != nullptr && avx2_func != nullptr)
+        }
+        if (non_avx2_func != nullptr && avx2_func != nullptr) {
             EXPECT_EQ(non_avx2_sad, avx2_sad)
                 << "compare non_avx2 and non_avx2 error";
+        }
     }
 };
 
@@ -525,14 +531,17 @@ class SADAvgTest : public ::testing::WithParamInterface<TestSadParam>,
                                  height_,
                                  width_);
 
-        if (non_avx2_func != nullptr)
+        if (non_avx2_func != nullptr) {
             EXPECT_EQ(ref_sad, non_avx2_sad)
                 << "compare ref and non_avx2 error";
-        if (avx2_func != nullptr)
+        }
+        if (avx2_func != nullptr) {
             EXPECT_EQ(ref_sad, avx2_sad) << "compare ref and avx2 error";
-        if (non_avx2_func != nullptr && avx2_func != nullptr)
+        }
+        if (non_avx2_func != nullptr && avx2_func != nullptr) {
             EXPECT_EQ(non_avx2_sad, avx2_sad)
                 << "compare non_avx2 and non_avx2 error";
+        }
     }
 };
 

--- a/test/e2e_test/RefDecoder.cc
+++ b/test/e2e_test/RefDecoder.cc
@@ -307,7 +307,7 @@ RefDecoder::RefDecoder(RefDecoder::RefDecoderErr& ret, bool enable_analyzer) {
     parser_ = nullptr;
     enc_bytes_ = 0;
     burst_bytes_ = 0;
-    memset(&video_param_, 0, sizeof(video_param_));
+    video_param_ = VideoFrameParam();
 
     codec_handle_ = new aom_codec_ctx_t();
     if (codec_handle_ == nullptr) {

--- a/test/e2e_test/SvtAv1E2EParamsTest.cc
+++ b/test/e2e_test/SvtAv1E2EParamsTest.cc
@@ -186,9 +186,10 @@ class CodingOptionTest : public SvtAv1E2ETestFramework {
         EXPECT_GE(config->max_qp_allowed, actual_max_qp)
             << "Max qp allowd " << config->max_qp_allowed << " actual "
             << actual_max_qp;
-        if (config->rate_control_mode == 0)
+        if (config->rate_control_mode == 0) {
             EXPECT_EQ(actual_min_qp, actual_max_qp)
                 << "QP fluctuate in const qp mode";
+        }
 
         // verify the bitrate
         if (config->rate_control_mode == 3) {

--- a/test/e2e_test/VideoFrame.h
+++ b/test/e2e_test/VideoFrame.h
@@ -68,9 +68,9 @@ typedef struct VideoFrame : public VideoFrameParam {
     VideoFrame() {
         disp_width = 0;
         disp_height = 0;
-        memset(&stride, 0, sizeof(stride));
-        memset(&planes, 0, sizeof(planes));
-        memset(&ext_planes, 0, sizeof(ext_planes));
+        memset(stride, 0, sizeof(stride));
+        memset(planes, 0, sizeof(planes));
+        memset(ext_planes, 0, sizeof(ext_planes));
         context = nullptr;
         timestamp = 0;
         buffer = nullptr;
@@ -83,9 +83,9 @@ typedef struct VideoFrame : public VideoFrameParam {
         *(VideoFrameParam *)this = param;
         disp_width = param.width;
         disp_height = param.height;
-        memset(&stride, 0, sizeof(stride));
-        memset(&planes, 0, sizeof(planes));
-        memset(&ext_planes, 0, sizeof(ext_planes));
+        memset(stride, 0, sizeof(stride));
+        memset(planes, 0, sizeof(planes));
+        memset(ext_planes, 0, sizeof(ext_planes));
         bits_per_sample = param.bits_per_sample;
         context = nullptr;
         timestamp = 0;

--- a/test/e2e_test/VideoFrame.h
+++ b/test/e2e_test/VideoFrame.h
@@ -114,8 +114,15 @@ typedef struct VideoFrame : public VideoFrameParam {
             printf("video frame buffer is out of memory!!\n");
     }
     VideoFrame(const VideoFrame &origin) {
-        // copy from origin
-        *this = origin;
+        // copy from origin except buffer, planes, buf_size
+        // which are calculated below
+        disp_width = origin.disp_width;
+        disp_height = origin.disp_height;
+        memcpy(stride, origin.stride, sizeof(stride));
+        bits_per_sample = origin.bits_per_sample;
+        context = origin.context;
+        timestamp = origin.timestamp;
+        qp = origin.qp;
         // maintain own buffer
         const uint32_t luma_len = stride[0] * height;
         /** create video frame buffer with maximun size in 4 planes */
@@ -176,9 +183,10 @@ typedef struct VideoFrame : public VideoFrameParam {
         case IMG_FMT_422P10_PACKED:
             strides[1] = strides[2] = param.width >> 1;
             break;
-        case IMG_FMT_444A: strides[3] = param.width;
+        case IMG_FMT_444A: strides[3] = param.width; goto IMG_FMT_444;
         case IMG_FMT_444:
         case IMG_FMT_444P10_PACKED:
+        IMG_FMT_444:
             strides[1] = strides[2] = param.width;
             break;
         default: assert(0); break;


### PR DESCRIPTION
This pull requests resolves **all** warnings issued during compilation by -Wall/-Wextra of the source code and the tests.

---

#497 is needed to enable unittests, as GCC 5.5 poorly supports AVX512. That pull request shows build failure, because there are too many warnings that made into the source code silently, which is the reason new warnings come regularly. Therefore first merging *this* then #497 would prevent new warnings from coming silently. (Though I'll rebase #497 after this one is merged, so please only merge this for now.)

**TL;DR** without this pull request, unit tests won't run properly on Travis!

---

I believe it'd be easier to review it [commit-by-commit](https://github.com/OpenVisualCloud/SVT-AV1/pull/511/commits). I've documented all changes. Forgive me for the mess below, there are actually five commits. I know that it's big pain to review 26 files changed, so let me know if there's something I can do to make it easier for you. 

The last repush only changes the commit date.