### PR TITLE
Add AVX512 code for h and v predictors

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/EbHighbdIntraPrediction_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbHighbdIntraPrediction_AVX2.c
@@ -914,7 +914,7 @@ static INLINE void h_pred_32x8(uint16_t **dst, const ptrdiff_t stride,
     assert(!((intptr_t)*dst % 32));
     assert(!(stride % 32));
 
-    const __m128i left_u16 = _mm_load_si128((const __m128i *)left);
+    const __m128i left_u16 = _mm_loadu_si128((const __m128i *)left);
 
     h_pred_32(dst, stride, _mm_srli_si128(left_u16, 0));
     h_pred_32(dst, stride, _mm_srli_si128(left_u16, 2));
@@ -974,7 +974,7 @@ static INLINE void h_pred_64x8(uint16_t **dst, const ptrdiff_t stride,
     assert(!((intptr_t)*dst % 32));
     assert(!(stride % 32));
 
-    const __m128i left_u16 = _mm_load_si128((const __m128i *)left);
+    const __m128i left_u16 = _mm_loadu_si128((const __m128i *)left);
 
     h_pred_64(dst, stride, _mm_srli_si128(left_u16, 0));
     h_pred_64(dst, stride, _mm_srli_si128(left_u16, 2));

--- a/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
@@ -444,4 +444,377 @@ void aom_highbd_dc_predictor_64x64_avx512(uint16_t *dst, ptrdiff_t stride,
     sum = _mm_srli_epi32(sum, 7);
     dc_common_predictor_64xh(dst, stride, 64, sum);
 }
+
+// =============================================================================
+
+// H_PRED
+
+// -----------------------------------------------------------------------------
+
+// 32xN
+
+static INLINE void h_pred_32(uint16_t **const dst, const ptrdiff_t stride,
+    const __m128i left)
+{
+    // Broadcast the 16-bit left pixel to 256-bit register.
+    const __m512i row = _mm512_broadcastw_epi16(left);
+
+    _mm512_storeu_si512((__m512i *)(*dst + 0x00), row);
+    *dst += stride;
+}
+
+// Process 8 rows.
+static INLINE void h_pred_32x8(uint16_t **dst, const ptrdiff_t stride,
+    const uint16_t *const left)
+{
+    // dst and it's stride must be 32-byte aligned.
+    assert(!((intptr_t)*dst % 32));
+    assert(!(stride % 32));
+
+    const __m128i left_u16 = _mm_loadu_si128((const __m128i *)left);
+
+    h_pred_32(dst, stride, _mm_srli_si128(left_u16, 0));
+    h_pred_32(dst, stride, _mm_srli_si128(left_u16, 2));
+    h_pred_32(dst, stride, _mm_srli_si128(left_u16, 4));
+    h_pred_32(dst, stride, _mm_srli_si128(left_u16, 6));
+    h_pred_32(dst, stride, _mm_srli_si128(left_u16, 8));
+    h_pred_32(dst, stride, _mm_srli_si128(left_u16, 10));
+    h_pred_32(dst, stride, _mm_srli_si128(left_u16, 12));
+    h_pred_32(dst, stride, _mm_srli_si128(left_u16, 14));
+}
+
+// 32x8
+
+void aom_highbd_h_predictor_32x8_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    (void)above;
+    (void)bd;
+
+    h_pred_32x8(&dst, stride, left);
+}
+
+// 32x64
+
+void aom_highbd_h_predictor_32x64_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    (void)above;
+    (void)bd;
+
+    for (int32_t i = 0; i < 8; i++, left += 8) {
+        h_pred_32x8(&dst, stride, left);
+    }
+}
+
+//32x16 32x32
+static INLINE void h_store_32_unpacklo(uint16_t **dst, const ptrdiff_t stride,
+    const __m128i *row) {
+    const __m128i val = _mm_unpacklo_epi64(*row, *row);
+    const __m512i val2 = _mm512_broadcast_i32x4(val);
+    _mm512_storeu_si512((__m512i *)(*dst), val2);
+    *dst += stride;
+}
+
+static INLINE void h_store_32_unpackhi(uint16_t **dst, const ptrdiff_t stride,
+    const __m128i *row) {
+    const __m128i val = _mm_unpackhi_epi64(*row, *row);
+    const __m512i val2 = _mm512_broadcast_i32x4(val);
+    _mm512_storeu_si512((__m512i *)(*dst), val2);
+    *dst += stride;
+}
+
+static INLINE void h_predictor_32x8(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *left) {
+    const __m128i left_u16 = _mm_loadu_si128((const __m128i *)left);
+    const __m128i row0 = _mm_shufflelo_epi16(left_u16, 0x0);
+    const __m128i row1 = _mm_shufflelo_epi16(left_u16, 0x55);
+    const __m128i row2 = _mm_shufflelo_epi16(left_u16, 0xaa);
+    const __m128i row3 = _mm_shufflelo_epi16(left_u16, 0xff);
+    const __m128i row4 = _mm_shufflehi_epi16(left_u16, 0x0);
+    const __m128i row5 = _mm_shufflehi_epi16(left_u16, 0x55);
+    const __m128i row6 = _mm_shufflehi_epi16(left_u16, 0xaa);
+    const __m128i row7 = _mm_shufflehi_epi16(left_u16, 0xff);
+    h_store_32_unpacklo(&dst, stride, &row0);
+    h_store_32_unpacklo(&dst, stride, &row1);
+    h_store_32_unpacklo(&dst, stride, &row2);
+    h_store_32_unpacklo(&dst, stride, &row3);
+    h_store_32_unpackhi(&dst, stride, &row4);
+    h_store_32_unpackhi(&dst, stride, &row5);
+    h_store_32_unpackhi(&dst, stride, &row6);
+    h_store_32_unpackhi(&dst, stride, &row7);
+}
+
+void aom_highbd_h_predictor_32x16_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above,
+    const uint16_t *left, int32_t bd) {
+    int32_t i;
+    (void)above;
+    (void)bd;
+
+    for (i = 0; i < 2; i++, left += 8) {
+        h_predictor_32x8(dst, stride, left);
+        dst += stride << 3;
+    }
+}
+
+void aom_highbd_h_predictor_32x32_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above,
+    const uint16_t *left, int32_t bd) {
+    int32_t i;
+    (void)above;
+    (void)bd;
+
+    for (i = 0; i < 4; i++, left += 8) {
+        h_predictor_32x8(dst, stride, left);
+        dst += stride << 3;
+    }
+}
+
+// ---------------------------------------------------------------------------- -
+
+// 64xN
+
+static INLINE void h_pred_64(uint16_t **const dst, const ptrdiff_t stride,
+    const __m128i left)
+{
+    // Broadcast the 16-bit left pixel to 256-bit register.
+    const __m512i row = _mm512_broadcastw_epi16(left);
+
+    _mm512_store_si512((__m256i *)(*dst + 0x00), row);
+    _mm512_store_si512((__m256i *)(*dst + 0x20), row);
+
+    *dst += stride;
+}
+
+// Process 8 rows.
+static INLINE void h_pred_64x8(uint16_t **dst, const ptrdiff_t stride,
+    const uint16_t *const left)
+{
+    // dst and it's stride must be 32-byte aligned.
+    assert(!((intptr_t)*dst % 32));
+    assert(!(stride % 32));
+
+    __m128i left_u16 = _mm_loadu_si128((const __m128i *)left);
+
+    for (int16_t j = 0; j < 8; j++) {
+        h_pred_64(dst, stride, left_u16);
+        left_u16 = _mm_srli_si128(left_u16, 2);
+    }
+}
+
+// 64x16
+
+void aom_highbd_h_predictor_64x16_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    (void)above;
+    (void)bd;
+
+    for (int32_t i = 0; i < 2; i++, left += 8) {
+        h_pred_64x8(&dst, stride, left);
+    }
+}
+
+// 64x32
+
+void aom_highbd_h_predictor_64x32_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    (void)above;
+    (void)bd;
+
+    for (int32_t i = 0; i < 4; i++, left += 8) {
+        h_pred_64x8(&dst, stride, left);
+    }
+}
+
+// 64x64
+
+void aom_highbd_h_predictor_64x64_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    (void)above;
+    (void)bd;
+
+    for (int32_t i = 0; i < 8; i++, left += 8) {
+        h_pred_64x8(&dst, stride, left);
+    }
+}
+
+// =============================================================================
+
+// V_PRED
+
+// -----------------------------------------------------------------------------
+
+// 32xN
+
+static INLINE void v_pred_32(uint16_t **const dst, const ptrdiff_t stride,
+    const __m512i above01)
+{
+    _mm512_storeu_si512((__m512i *)(*dst + 0x00), above01);
+    *dst += stride;
+}
+
+// Process 8 rows.
+static INLINE void v_pred_32x8(uint16_t **const dst, const ptrdiff_t stride,
+    const __m512i above01)
+{
+    // dst and it's stride must be 32-byte aligned.
+    assert(!((intptr_t)*dst % 32));
+    assert(!(stride % 32));
+
+    v_pred_32(dst, stride, above01);
+    v_pred_32(dst, stride, above01);
+    v_pred_32(dst, stride, above01);
+    v_pred_32(dst, stride, above01);
+    v_pred_32(dst, stride, above01);
+    v_pred_32(dst, stride, above01);
+    v_pred_32(dst, stride, above01);
+    v_pred_32(dst, stride, above01);
+}
+
+// 32x8
+
+void aom_highbd_v_predictor_32x8_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    // Load all 32 pixels in a row into 256-bit registers.
+    const __m512i above01 = _mm512_loadu_si512((const __m512i *)(above + 0x00));
+
+    (void)left;
+    (void)bd;
+
+    v_pred_32x8(&dst, stride, above01);
+}
+
+// 32x16
+
+void aom_highbd_v_predictor_32x16_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    // Load all 32 pixels in a row into 512-bit registers.
+    const __m512i above01 = _mm512_loadu_si512((const __m512i *)(above + 0x00));
+
+    (void)left;
+    (void)bd;
+
+    for (int32_t i = 0; i < 2; i++) {
+        v_pred_32x8(&dst, stride, above01);
+    }
+}
+
+// 32x32
+
+void aom_highbd_v_predictor_32x32_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    // Load all 32 pixels in a row into 512-bit registers.
+    const __m512i above01 = _mm512_loadu_si512((const __m512i *)(above + 0x00));
+
+    (void)left;
+    (void)bd;
+
+    for (int32_t i = 0; i < 4; i++) {
+        v_pred_32x8(&dst, stride, above01);
+    }
+}
+
+// 32x64
+
+void aom_highbd_v_predictor_32x64_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    // Load all 32 pixels in a row into 512-bit registers.
+    const __m512i above01 = _mm512_loadu_si512((const __m512i *)(above + 0x00));
+
+    (void)left;
+    (void)bd;
+
+    for (int32_t i = 0; i < 8; i++) {
+        v_pred_32x8(&dst, stride, above01);
+    }
+}
+
+// -----------------------------------------------------------------------------
+
+// 64xN
+
+static INLINE void v_pred_64(uint16_t **const dst, const ptrdiff_t stride,
+    const __m512i above0, const __m512i above1)
+{
+    _mm512_storeu_si512((__m512i *)(*dst + 0x00), above0);
+    _mm512_storeu_si512((__m512i *)(*dst + 0x20), above1);
+    *dst += stride;
+}
+
+// Process 8 rows.
+static INLINE void v_pred_64x8(uint16_t **const dst, const ptrdiff_t stride,
+    const __m512i above0, const __m512i above1)
+{
+    // dst and it's stride must be 32-byte aligned.
+    assert(!((intptr_t)*dst % 32));
+    assert(!(stride % 32));
+
+    v_pred_64(dst, stride, above0, above1);
+    v_pred_64(dst, stride, above0, above1);
+    v_pred_64(dst, stride, above0, above1);
+    v_pred_64(dst, stride, above0, above1);
+    v_pred_64(dst, stride, above0, above1);
+    v_pred_64(dst, stride, above0, above1);
+    v_pred_64(dst, stride, above0, above1);
+    v_pred_64(dst, stride, above0, above1);
+}
+
+// 64x16
+
+void aom_highbd_v_predictor_64x16_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    // Load all 64 pixels in a row into 512-bit registers.
+    const __m512i above0 = _mm512_loadu_si512((const __m512i *)(above + 0x00));
+    const __m512i above1 = _mm512_loadu_si512((const __m512i *)(above + 0x20));
+
+    (void)left;
+    (void)bd;
+
+    for (int32_t i = 0; i < 2; i++) {
+        v_pred_64x8(&dst, stride, above0, above1);
+    }
+}
+
+// 64x32
+
+void aom_highbd_v_predictor_64x32_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    // Load all 64 pixels in a row into 512-bit registers.
+    const __m512i above0 = _mm512_loadu_si512((const __m512i *)(above + 0x00));
+    const __m512i above1 = _mm512_loadu_si512((const __m512i *)(above + 0x20));
+
+    (void)left;
+    (void)bd;
+
+    for (int32_t i = 0; i < 4; i++) {
+        v_pred_64x8(&dst, stride, above0, above1);
+    }
+}
+
+// 64x64
+
+void aom_highbd_v_predictor_64x64_avx512(uint16_t *dst, ptrdiff_t stride,
+    const uint16_t *above, const uint16_t *left, int32_t bd)
+{
+    // Load all 64 pixels in a row into 512-bit registers.
+    const __m512i above0 = _mm512_loadu_si512((const __m512i *)(above + 0x00));
+    const __m512i above1 = _mm512_loadu_si512((const __m512i *)(above + 0x20));
+
+    (void)left;
+    (void)bd;
+
+    for (int32_t i = 0; i < 8; i++) {
+        v_pred_64x8(&dst, stride, above0, above1);
+    }
+}
 #endif

--- a/Source/Lib/Common/ASM_SSE2/highbd_intrapred_sse2.c
+++ b/Source/Lib/Common/ASM_SSE2/highbd_intrapred_sse2.c
@@ -227,7 +227,7 @@ static INLINE void h_store_32_unpackhi(uint16_t **dst, const ptrdiff_t stride,
 
 static INLINE void h_predictor_32x8(uint16_t *dst, ptrdiff_t stride,
     const uint16_t *left) {
-    const __m128i left_u16 = _mm_load_si128((const __m128i *)left);
+    const __m128i left_u16 = _mm_loadu_si128((const __m128i *)left);
     const __m128i row0 = _mm_shufflelo_epi16(left_u16, 0x0);
     const __m128i row1 = _mm_shufflelo_epi16(left_u16, 0x55);
     const __m128i row2 = _mm_shufflelo_epi16(left_u16, 0xaa);

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -40,7 +40,7 @@ extern "C" {
 #endif
 
 // Internal Marcos
-#define NON_AVX512_SUPPORT
+//#define NON_AVX512_SUPPORT
 
 #define INCOMPLETE_SB_FIX                 1 // Handle the incomplete SBs properly based on the standard and consider all allowed blocks
 #define QPS_TUNING                        1 // Tune the QPS algorithm to consider ALR_REF filtering and movement of the pictures

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -1978,18 +1978,22 @@ extern "C" {
 
     void eb_aom_highbd_h_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_h_predictor_32x16_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_h_predictor_32x16_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_h_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_h_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_h_predictor_32x32_sse2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_h_predictor_32x32_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_h_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_h_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_h_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_h_predictor_32x64_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_h_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_h_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_h_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_h_predictor_32x8_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_h_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_h_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -2006,14 +2010,17 @@ extern "C" {
 
     void eb_aom_highbd_h_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_h_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_h_predictor_64x16_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_h_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_h_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_h_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_h_predictor_64x32_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_h_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_h_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_h_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_h_predictor_64x64_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_h_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_h_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -2294,18 +2301,22 @@ extern "C" {
 
     void eb_aom_highbd_v_predictor_32x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_v_predictor_32x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_v_predictor_32x16_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_v_predictor_32x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_v_predictor_32x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_v_predictor_32x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_v_predictor_32x32_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_v_predictor_32x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_v_predictor_32x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_v_predictor_32x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_v_predictor_32x64_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_v_predictor_32x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_v_predictor_32x8_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_v_predictor_32x8_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_v_predictor_32x8_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_v_predictor_32x8)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_v_predictor_4x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -2322,14 +2333,17 @@ extern "C" {
 
     void eb_aom_highbd_v_predictor_64x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_v_predictor_64x16_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_v_predictor_64x16_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_v_predictor_64x16)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_v_predictor_64x32_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_v_predictor_64x32_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_v_predictor_64x32_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_v_predictor_64x32)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_v_predictor_64x64_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     void eb_aom_highbd_v_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+    void aom_highbd_v_predictor_64x64_avx512(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
     RTCD_EXTERN void(*eb_aom_highbd_v_predictor_64x64)(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
 
     void eb_aom_highbd_v_predictor_8x16_c(uint16_t *dst, ptrdiff_t y_stride, const uint16_t *above, const uint16_t *left, int32_t bd);
@@ -3294,13 +3308,9 @@ extern "C" {
         if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_16x8 = eb_aom_highbd_v_predictor_16x8_avx2;
         eb_aom_highbd_v_predictor_2x2 = eb_aom_highbd_v_predictor_2x2_c;
         eb_aom_highbd_v_predictor_32x16 = eb_aom_highbd_v_predictor_32x16_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_32x16 = eb_aom_highbd_v_predictor_32x16_avx2;
         eb_aom_highbd_v_predictor_32x32 = eb_aom_highbd_v_predictor_32x32_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_32x32 = eb_aom_highbd_v_predictor_32x32_avx2;
         eb_aom_highbd_v_predictor_32x64 = eb_aom_highbd_v_predictor_32x64_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_32x64 = eb_aom_highbd_v_predictor_32x64_avx2;
         eb_aom_highbd_v_predictor_32x8 = eb_aom_highbd_v_predictor_32x8_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_32x8 = eb_aom_highbd_v_predictor_32x8_avx2;
         eb_aom_highbd_v_predictor_4x16 = eb_aom_highbd_v_predictor_4x16_c;
         if (flags & HAS_SSE2) eb_aom_highbd_v_predictor_4x16 = eb_aom_highbd_v_predictor_4x16_sse2;
         eb_aom_highbd_v_predictor_4x4 = eb_aom_highbd_v_predictor_4x4_c;
@@ -3308,19 +3318,34 @@ extern "C" {
         eb_aom_highbd_v_predictor_4x8 = eb_aom_highbd_v_predictor_4x8_c;
         if (flags & HAS_SSE2) eb_aom_highbd_v_predictor_4x8 = eb_aom_highbd_v_predictor_4x8_sse2;
         eb_aom_highbd_v_predictor_64x16 = eb_aom_highbd_v_predictor_64x16_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_64x16 = eb_aom_highbd_v_predictor_64x16_avx2;
         eb_aom_highbd_v_predictor_64x32 = eb_aom_highbd_v_predictor_64x32_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_64x32 = eb_aom_highbd_v_predictor_64x32_avx2;
         eb_aom_highbd_v_predictor_8x32 = eb_aom_highbd_v_predictor_8x32_c;
         if (flags & HAS_SSE2) eb_aom_highbd_v_predictor_8x32 = eb_aom_highbd_v_predictor_8x32_sse2;
         eb_aom_highbd_v_predictor_64x64 = eb_aom_highbd_v_predictor_64x64_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_64x64 = eb_aom_highbd_v_predictor_64x64_avx2;
         eb_aom_highbd_v_predictor_8x16 = eb_aom_highbd_v_predictor_8x16_c;
         if (flags & HAS_SSE2) eb_aom_highbd_v_predictor_8x16 = eb_aom_highbd_v_predictor_8x16_sse2;
         eb_aom_highbd_v_predictor_8x4 = eb_aom_highbd_v_predictor_8x4_c;
         if (flags & HAS_SSE2) eb_aom_highbd_v_predictor_8x4 = eb_aom_highbd_v_predictor_8x4_sse2;
         eb_aom_highbd_v_predictor_8x8 = eb_aom_highbd_v_predictor_8x8_c;
         if (flags & HAS_SSE2) eb_aom_highbd_v_predictor_8x8 = eb_aom_highbd_v_predictor_8x8_sse2;
+
+#ifndef NON_AVX512_SUPPORT
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_32x8 = aom_highbd_v_predictor_32x8_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_32x16 = aom_highbd_v_predictor_32x16_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_32x32 = aom_highbd_v_predictor_32x32_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_32x64 = aom_highbd_v_predictor_32x64_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_64x16 = aom_highbd_v_predictor_64x16_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_64x32 = aom_highbd_v_predictor_64x32_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_64x64 = aom_highbd_v_predictor_64x64_avx512;
+#else
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_32x8 = eb_aom_highbd_v_predictor_32x8_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_32x16 = eb_aom_highbd_v_predictor_32x16_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_32x32 = eb_aom_highbd_v_predictor_32x32_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_32x64 = eb_aom_highbd_v_predictor_32x64_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_64x16 = eb_aom_highbd_v_predictor_64x16_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_64x32 = eb_aom_highbd_v_predictor_64x32_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_v_predictor_64x64 = eb_aom_highbd_v_predictor_64x64_avx2;
+#endif // !NON_AVX512_SUPPORT
 
         //aom_highbd_smooth_predictor
         eb_aom_highbd_smooth_predictor_16x16 = eb_aom_highbd_smooth_predictor_16x16_c;
@@ -3606,13 +3631,9 @@ extern "C" {
         if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_16x8 = eb_aom_highbd_h_predictor_16x8_sse2;
         eb_aom_highbd_h_predictor_2x2 = eb_aom_highbd_h_predictor_2x2_c;
         eb_aom_highbd_h_predictor_32x16 = eb_aom_highbd_h_predictor_32x16_c;
-        if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_32x16 = eb_aom_highbd_h_predictor_32x16_sse2;
         eb_aom_highbd_h_predictor_32x32 = eb_aom_highbd_h_predictor_32x32_c;
-        if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_32x32 = eb_aom_highbd_h_predictor_32x32_sse2;
         eb_aom_highbd_h_predictor_32x64 = eb_aom_highbd_h_predictor_32x64_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_32x64 = eb_aom_highbd_h_predictor_32x64_avx2;
         eb_aom_highbd_h_predictor_32x8 = eb_aom_highbd_h_predictor_32x8_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_32x8 = eb_aom_highbd_h_predictor_32x8_avx2;
         eb_aom_highbd_h_predictor_4x16 = eb_aom_highbd_h_predictor_4x16_c;
         if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_4x16 = eb_aom_highbd_h_predictor_4x16_sse2;
         eb_aom_highbd_h_predictor_4x4 = eb_aom_highbd_h_predictor_4x4_c;
@@ -3620,13 +3641,10 @@ extern "C" {
         eb_aom_highbd_h_predictor_4x8 = eb_aom_highbd_h_predictor_4x8_c;
         if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_4x8 = eb_aom_highbd_h_predictor_4x8_sse2;
         eb_aom_highbd_h_predictor_64x16 = eb_aom_highbd_h_predictor_64x16_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_64x16 = eb_aom_highbd_h_predictor_64x16_avx2;
         eb_aom_highbd_h_predictor_64x32 = eb_aom_highbd_h_predictor_64x32_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_64x32 = eb_aom_highbd_h_predictor_64x32_avx2;
         eb_aom_highbd_h_predictor_8x32 = eb_aom_highbd_h_predictor_8x32_c;
         if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_8x32 = eb_aom_highbd_h_predictor_8x32_sse2;
         eb_aom_highbd_h_predictor_64x64 = eb_aom_highbd_h_predictor_64x64_c;
-        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_64x64 = eb_aom_highbd_h_predictor_64x64_avx2;
         eb_aom_highbd_h_predictor_8x16 = eb_aom_highbd_h_predictor_8x16_c;
         if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_8x16 = eb_aom_highbd_h_predictor_8x16_sse2;
         eb_aom_highbd_h_predictor_8x4 = eb_aom_highbd_h_predictor_8x4_c;
@@ -3637,6 +3655,24 @@ extern "C" {
         if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_16x16 = eb_aom_highbd_h_predictor_16x16_sse2;
         eb_aom_highbd_h_predictor_16x32 = eb_aom_highbd_h_predictor_16x32_c;
         if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_16x32 = eb_aom_highbd_h_predictor_16x32_sse2;
+
+#ifndef NON_AVX512_SUPPORT
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_32x16 = aom_highbd_h_predictor_32x16_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_32x32 = aom_highbd_h_predictor_32x32_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_32x64 = aom_highbd_h_predictor_32x64_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_32x8 = aom_highbd_h_predictor_32x8_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_64x16 = aom_highbd_h_predictor_64x16_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_64x32 = aom_highbd_h_predictor_64x32_avx512;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_64x64 = aom_highbd_h_predictor_64x64_avx512;
+#else
+        if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_32x16 = eb_aom_highbd_h_predictor_32x16_sse2;
+        if (flags & HAS_SSE2) eb_aom_highbd_h_predictor_32x32 = eb_aom_highbd_h_predictor_32x32_sse2;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_32x64 = eb_aom_highbd_h_predictor_32x64_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_32x8 = eb_aom_highbd_h_predictor_32x8_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_64x16 = eb_aom_highbd_h_predictor_64x16_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_64x32 = eb_aom_highbd_h_predictor_64x32_avx2;
+        if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_64x64 = eb_aom_highbd_h_predictor_64x64_avx2;
+#endif
 
         eb_aom_fft2x2_float = eb_aom_fft2x2_float_c;
         eb_aom_fft4x4_float = eb_aom_fft4x4_float_c;

--- a/test/EbHighbdIntraPredictionTests.cc
+++ b/test/EbHighbdIntraPredictionTests.cc
@@ -364,4 +364,213 @@ TEST(HighbdIntraPredictionTest, aom_dc_predictor_kernels)
     }
 
 }
+
+TEST(HighbdIntraPredictionTest, aom_h_predictor_kernels)
+{
+    uint16_t *input = NULL, *above = NULL, *left = NULL;
+    uint16_t* dc_coeff = NULL, *dc_coeff_opt = NULL;
+    ptrdiff_t stride = 0;
+
+    uint16_t no_of_pred_funcs = sizeof(aom_highbd_h_pred_funcptr_array_opt) / sizeof(aom_highbd_h_predictor_func);
+
+    for (uint16_t loop = 0; loop < no_of_pred_funcs; loop++) {         //Function Pairs
+        for (uint16_t i = 0; i < EB_UNIT_TEST_NUM; i++) {             //Number of Test Runs
+            for (uint16_t x = 0; x < 3; x++) {//Bit Depth
+                switch (loop) {
+                case 0://32x8
+                    for (uint16_t j = 0; j < 1; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_h_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_h_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 8, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 1://32x16
+                    for (uint16_t j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_h_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_h_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 16, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 2://32x32
+                    for (uint16_t j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_h_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_h_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 32, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 3://32x64
+                    for (uint16_t j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_h_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_h_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 64, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 4://64x16
+                    for (uint16_t j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_h_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_h_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 16, 64);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 5://64x32
+                    for (uint16_t j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_h_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_h_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 32, 64);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 6://64x64
+                    for (uint16_t j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_h_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_h_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 64, 64);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                default:
+                    ASSERT(0);
+                }
+            }
+        }
+    }
+
+}
+
+TEST(HighbdIntraPredictionTest, aom_v_predictor_kernels)
+{
+    uint16_t *input = NULL, *above = NULL, *left = NULL;
+    uint16_t* dc_coeff = NULL, *dc_coeff_opt = NULL;
+    ptrdiff_t stride = 0;
+
+    uint16_t no_of_pred_funcs = sizeof(aom_highbd_v_pred_funcptr_array_opt) / sizeof(aom_highbd_v_predictor_func);
+
+    for (uint16_t loop = 0; loop < no_of_pred_funcs; loop++) {         //Function Pairs
+        for (uint16_t i = 0; i < EB_UNIT_TEST_NUM; i++) {             //Number of Test Runs
+            for (uint16_t x = 0; x < 3; x++) {//Bit Depth
+                switch (loop) {
+                case 0://32x8
+                    for (uint16_t j = 0; j < 1; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_v_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_v_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 8, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 1://32x16
+                    for (uint16_t j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_v_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_v_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 16, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 2://32x32
+                    for (uint16_t j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_v_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_v_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 32, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 3://32x64
+                    for (uint16_t j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_v_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_v_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 64, 32);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 4://64x16
+                    for (uint16_t j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_v_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_v_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 16, 64);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 5://64x32
+                    for (uint16_t j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_v_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_v_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 32, 64);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                case 6://64x64
+                    for (uint16_t j = 0; j < 2; j++) {
+                        init_coeff(&dc_coeff, &dc_coeff_opt, &stride);
+                        ASSERT(eb_buf_compare_u16(dc_coeff, dc_coeff_opt, MAX_SB_SIZE * stride) == 1);
+                        init_data(&input, &above, &left, stride);
+                        aom_highbd_v_pred_funcptr_array_base[loop](dc_coeff, stride, above, left, bitdepth[x]);
+                        aom_highbd_v_pred_funcptr_array_opt[loop](dc_coeff_opt, stride, above, left, bitdepth[x]);
+                        dc_compare_u16(dc_coeff, dc_coeff_opt, stride, 64, 64);
+                        uninit_data(input);
+                        uninit_coeff(dc_coeff, dc_coeff_opt);
+                    }
+                    break;
+                default:
+                    ASSERT(0);
+                }
+            }
+        }
+    }
+}
 #endif

--- a/test/EbHighbdIntraPredictionTests.h
+++ b/test/EbHighbdIntraPredictionTests.h
@@ -97,5 +97,64 @@ static aom_highbd_dc_predictor_func aom_highbd_dc_pred_funcptr_array_naive[7] = 
                             eb_aom_highbd_dc_predictor_64x16_c,
                             eb_aom_highbd_dc_predictor_64x32_c,
                             eb_aom_highbd_dc_predictor_64x64_c };
+
+
+typedef void(*aom_highbd_h_predictor_func)(uint16_t *dst, ptrdiff_t stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+
+static aom_highbd_h_predictor_func aom_highbd_h_pred_funcptr_array_opt[7] = {
+                            aom_highbd_h_predictor_32x8_avx512,
+                            aom_highbd_h_predictor_32x16_avx512,
+                            aom_highbd_h_predictor_32x32_avx512,
+                            aom_highbd_h_predictor_32x64_avx512,
+                            aom_highbd_h_predictor_64x16_avx512,
+                            aom_highbd_h_predictor_64x32_avx512,
+                            aom_highbd_h_predictor_64x64_avx512 };
+
+static aom_highbd_h_predictor_func aom_highbd_h_pred_funcptr_array_base[7] = {
+                            eb_aom_highbd_h_predictor_32x8_avx2,
+                            eb_aom_highbd_h_predictor_32x16_sse2,
+                            eb_aom_highbd_h_predictor_32x32_sse2,
+                            eb_aom_highbd_h_predictor_32x64_avx2,
+                            eb_aom_highbd_h_predictor_64x16_avx2,
+                            eb_aom_highbd_h_predictor_64x32_avx2,
+                            eb_aom_highbd_h_predictor_64x64_avx2 };
+
+static aom_highbd_h_predictor_func aom_highbd_h_pred_funcptr_array_naive[7] = {
+                            eb_aom_highbd_h_predictor_32x8_c,
+                            eb_aom_highbd_h_predictor_32x16_c,
+                            eb_aom_highbd_h_predictor_32x32_c,
+                            eb_aom_highbd_h_predictor_32x64_c,
+                            eb_aom_highbd_h_predictor_64x16_c,
+                            eb_aom_highbd_h_predictor_64x32_c,
+                            eb_aom_highbd_h_predictor_64x64_c };
+
+typedef void(*aom_highbd_v_predictor_func)(uint16_t *dst, ptrdiff_t stride, const uint16_t *above, const uint16_t *left, int32_t bd);
+
+static aom_highbd_v_predictor_func aom_highbd_v_pred_funcptr_array_opt[7] = {
+                            aom_highbd_v_predictor_32x8_avx512,
+                            aom_highbd_v_predictor_32x16_avx512,
+                            aom_highbd_v_predictor_32x32_avx512,
+                            aom_highbd_v_predictor_32x64_avx512,
+                            aom_highbd_v_predictor_64x16_avx512,
+                            aom_highbd_v_predictor_64x32_avx512,
+                            aom_highbd_v_predictor_64x64_avx512 };
+
+static aom_highbd_v_predictor_func aom_highbd_v_pred_funcptr_array_base[7] = {
+                            eb_aom_highbd_v_predictor_32x8_avx2,
+                            eb_aom_highbd_v_predictor_32x16_avx2,
+                            eb_aom_highbd_v_predictor_32x32_avx2,
+                            eb_aom_highbd_v_predictor_32x64_avx2,
+                            eb_aom_highbd_v_predictor_64x16_avx2,
+                            eb_aom_highbd_v_predictor_64x32_avx2,
+                            eb_aom_highbd_v_predictor_64x64_avx2 };
+
+static aom_highbd_v_predictor_func aom_highbd_v_pred_funcptr_array_naive[7] = {
+                            eb_aom_highbd_v_predictor_32x8_c,
+                            eb_aom_highbd_v_predictor_32x16_c,
+                            eb_aom_highbd_v_predictor_32x32_c,
+                            eb_aom_highbd_v_predictor_32x64_c,
+                            eb_aom_highbd_v_predictor_64x16_c,
+                            eb_aom_highbd_v_predictor_64x32_c,
+                            eb_aom_highbd_v_predictor_64x64_c };
 #endif
 #endif


### PR DESCRIPTION
This PR has AVX512 code for aom highbd h and v pedictors and corresponding Unit tests.The performance numbers  are attached with the commit message.