### PR TITLE
Minor cleanup in unit test

### DIFF
--- a/test/FwdTxfm2dTest.cc
+++ b/test/FwdTxfm2dTest.cc
@@ -126,8 +126,8 @@ class AV1FwdTxfm2dTest : public ::testing::TestWithParam<FwdTxfm2dParam> {
             double test_max_error = 0;
             for (int ni = 0; ni < block_size; ++ni) {
                 test_max_error =
-                    max(test_max_error,
-                        fabs(output_test_[ni] - round(output_ref_[ni])));
+                    AOMMAX(test_max_error,
+                           fabs(output_test_[ni] - round(output_ref_[ni])));
             }
             test_max_error /= scale_factor_;
             ASSERT_GE(max_error_, test_max_error)

--- a/test/SelfGuidedUtilTest.cc
+++ b/test/SelfGuidedUtilTest.cc
@@ -163,7 +163,7 @@ class PixelProjErrorTest
 
     virtual void run_random_test(const int run_times,
                                  const bool is_fixed_size) {
-        const int iters = max(run_times, min_test_times);
+        const int iters = AOMMAX(run_times, min_test_times);
         for (int iter = 0; iter < iters && !HasFatalFailure(); ++iter) {
             prepare_random_data();
             run_and_check_data(iter, is_fixed_size ? 128 : 0);

--- a/test/random.h
+++ b/test/random.h
@@ -33,8 +33,10 @@ using std::mt19937;
 using std::uniform_int_distribution;
 using std::uniform_real_distribution;
 
-/** SVTRandom defines a tool class for generating random integer as uint test
- * samples*/
+/** SVTRandom defines a tool class for generating random integer as unit test
+ * samples and params, the tool can support a random 32-bit integer from
+ * [-2^31,2^31).
+ */
 class SVTRandom {
   public:
     /** contructor with given minimum and maximum bound of random integer*/
@@ -119,8 +121,9 @@ class SVTRandom {
 
     /** calculate and setup bounds of generator */
     void calculate_bounds(const int nbits, const bool is_signed) {
-        assert(is_signed ? nbits < 31 : nbits <= 31);
-        int set_bits = is_signed ? nbits - 1 : nbits;
+        assert(nbits <= 32);
+        int set_bits =
+            is_signed ? nbits - 1 : (nbits == 32 ? nbits - 1 : nbits);
         int min_bound = 0, max_bound = 0;
         for (int i = 0; i < set_bits; i++)
             max_bound |= (1 << i);

--- a/test/util.h
+++ b/test/util.h
@@ -28,13 +28,6 @@
 #define TEST_GET_PARAM(k) std::get<k>(GetParam())
 #endif
 
-#ifndef min
-#define min(a, b) ((((a) < (b)) ? (a) : (b)))
-#endif
-#ifndef max
-#define max(a, b) ((((a) > (b)) ? (a) : (b)))
-#endif
-
 #define ALIGNED_ADDR(T, alignment, buffer) \
     (T*)(((uintptr_t)buffer + (alignment - 1)) & ~(alignment - 1))
 


### PR DESCRIPTION
1. remove redundant min and max definition in util.h
2. fixed wrong assertion in random number generator.