### PR TITLE
Fix cfl unittest mismatch issue

### DIFF
--- a/test/intrapred_cfl_test.cc
+++ b/test/intrapred_cfl_test.cc
@@ -66,7 +66,7 @@ class CflPredTest {
     void RunAllTest() {
         // for pred_buf, after sampling and subtracted from average
         SVTRandom pred_rnd(bd_ + 3 + 1, true);
-        SVTRandom dst_rnd(4, false);
+        SVTRandom dst_rnd(8, false);
         for (int tx = TX_4X4; tx < TX_SIZES_ALL; ++tx) {
             const int c_w = tx_size_wide[tx] >> 1;
             const int c_h = tx_size_high[tx] >> 1;
@@ -77,13 +77,15 @@ class CflPredTest {
 
             for (int alpha_q3 = -16; alpha_q3 <= 16; ++alpha_q3) {
                 // prepare data
+                // Implicit assumption: The dst_buf is supposed to be populated
+                // by dc prediction before cfl prediction.
+                const Sample rnd_dc = dst_rnd.random();
                 for (int y = 0; y < c_h; ++y) {
                     for (int x = 0; x < c_w; ++x) {
                         pred_buf_q3[y * c_stride + x] =
                             (Sample)pred_rnd.random();
                         dst_buf_ref_[y * c_stride + x] =
-                            dst_buf_tst_[y * c_stride + x] =
-                                (Sample)dst_rnd.random();
+                            dst_buf_tst_[y * c_stride + x] = rnd_dc;
                     }
                 }
 


### PR DESCRIPTION
1. Populated the dst buffer using the same value instead of random
   value, because the pred buffer is supposed to be populated by
   dc prediction before cfl prediction.