### PR TITLE
Fix build issues in unittest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -204,7 +204,7 @@ matrix:
       stage: unittest
       os: linux
       compiler: gcc
-      env: build_type=debug CMAKE_EFLAGS="-DBUILD_TESTING=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/
+      env: build_type=release CMAKE_EFLAGS="-DBUILD_TESTING=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/
       script:
         - *base_script
         - cd $TRAVIS_BUILD_DIR/Build/linux/${build_type:-Release}
@@ -217,7 +217,7 @@ matrix:
       stage: unittest
       os: osx
       compiler: clang
-      env: build_type=debug CMAKE_EFLAGS="-DBUILD_TESTING=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/
+      env: build_type=release CMAKE_EFLAGS="-DBUILD_TESTING=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/
       script:
         - *base_script
         - cd $TRAVIS_BUILD_DIR/Build/linux/${build_type:-Release}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,23 @@ add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING=1)
 
 enable_testing()
 
+# support avx2 compiling
+if(CMAKE_C_COMPILER_ID STREQUAL "Intel")
+    if(WIN32)
+        # Intel Windows (*Note - The Warning level /W0 should be made to /W4 at some point)
+        list(APPEND flags_to_test /Qdiag-disable:10010,10148,10157 /W0)
+    else()
+        list(APPEND flags_to_test -static-intel -w)
+    endif()
+endif()
+
+if(MSVC)
+    list(APPEND flags_to_test /arch:AVX2)
+else()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mavx2")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mavx2")
+endif()
+
 file(GLOB all_files
     "*.h"
     "*.c"

--- a/test/TransposeTest.cc
+++ b/test/TransposeTest.cc
@@ -7,6 +7,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+// workaround to eliminate the compiling warning on linux
+// The macro will conflict with definition in gtest.h
+#ifdef __USE_GNU
+#undef __USE_GNU  // defined in EbThreads.h
+#endif
+#ifdef _GNU_SOURCE
+#undef _GNU_SOURCE  // defined in EbThreads.h
+#endif
 #include "aom_dsp_rtcd.h"
 #include "EbDefinitions.h"
 #include "EbUnitTestUtility.h"


### PR DESCRIPTION
1. change build type to release from debug in unittest, as
   there is "unrecognizable insn" error when EbHighbdIntraPrediction_AVX512.c
   is compiled in debug mode on linux platform.
2. add avx2 flags in test building as TransposeTest.cc includes avx2
   functions, also remove the build warning in this file.