### PR TITLE
Remove limitation of less than 16 Sockets

### DIFF
--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -1923,7 +1923,6 @@ EB_API EbErrorType eb_deinit_handle(
     #if  defined(__linux__)
         if(lp_group != NULL) {
             EB_FREE(lp_group);
-            lp_group = NULL;
         }
     #endif
     return return_error;

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -247,8 +247,8 @@ EbErrorType InitThreadManagmentParams() {
                 if (socket_id >= maxSize) {
                     maxSize = maxSize * 2;
                     lp_group = realloc(lp_group, maxSize * sizeof(processorGroup));
-                    if (lp_group == (processorGroup*) NULL) 
-                        return EB_ErrorInsufficientResources; 
+                    if (lp_group == (processorGroup*) NULL)
+                        return EB_ErrorInsufficientResources;
                 }
                 lp_group[socket_id].group[lp_group[socket_id].num++] = processor_id;
             }

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -1855,8 +1855,6 @@ EB_API EbErrorType eb_init_handle(
     #if defined(__linux__)
         if(lp_group == NULL) {
             EB_MALLOC(lp_group, INITIAL_PROCESSOR_GROUP * sizeof(processorGroup));
-            if (lp_group == NULL)
-                return EB_ErrorInsufficientResources;
         }
     #endif
 

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -1853,9 +1853,11 @@ EB_API EbErrorType eb_init_handle(
          return EB_ErrorBadParameter;
 
     #if defined(__linux__)
-        lp_group = (processorGroup*) malloc(INITIAL_PROCESSOR_GROUP * sizeof(processorGroup));
-        if (lp_group == (processorGroup*) NULL)
-            return EB_ErrorInsufficientResources;
+        if(lp_group == NULL) {
+            lp_group = (processorGroup*) malloc(INITIAL_PROCESSOR_GROUP * sizeof(processorGroup));
+            if (lp_group == (processorGroup*) NULL)
+                return EB_ErrorInsufficientResources;
+        }
     #endif
 
     *p_handle = (EbComponentType*)malloc(sizeof(EbComponentType));
@@ -1919,7 +1921,10 @@ EB_API EbErrorType eb_deinit_handle(
         return_error = EB_ErrorInvalidComponent;
 
     #if  defined(__linux__)
-        free(lp_group);
+        if(lp_group != NULL) {
+            free(lp_group);
+            lp_group = NULL;
+        }
     #endif
     return return_error;
 }

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -247,7 +247,7 @@ EbErrorType InitThreadManagmentParams() {
                 if (socket_id >= maxSize) {
                     maxSize = maxSize * 2;
                     lp_group = realloc(lp_group, maxSize * sizeof(processorGroup));
-                    if (lp_group == (processorGroup*) NULL)
+                    if (lp_group == NULL)
                         return EB_ErrorInsufficientResources;
                 }
                 lp_group[socket_id].group[lp_group[socket_id].num++] = processor_id;
@@ -1854,8 +1854,8 @@ EB_API EbErrorType eb_init_handle(
 
     #if defined(__linux__)
         if(lp_group == NULL) {
-            lp_group = (processorGroup*) malloc(INITIAL_PROCESSOR_GROUP * sizeof(processorGroup));
-            if (lp_group == (processorGroup*) NULL)
+            EB_MALLOC(lp_group, INITIAL_PROCESSOR_GROUP * sizeof(processorGroup));
+            if (lp_group == NULL)
                 return EB_ErrorInsufficientResources;
         }
     #endif
@@ -1922,7 +1922,7 @@ EB_API EbErrorType eb_deinit_handle(
 
     #if  defined(__linux__)
         if(lp_group != NULL) {
-            free(lp_group);
+            EB_FREE(lp_group);
             lp_group = NULL;
         }
     #endif


### PR DESCRIPTION
closes #517 

There was a socket_id > 15 clause that would cause it to throw an error on any machine with 16 or more sockets as soon as it was about to start the encoding process. While this would never occur with physical hardware it is possible to occur with virtual machines. Virtual machines can configure their systems to do 1 socket per core or really anything.  Here is the output of my validation. 

```
luis@clearlinux~/Desktop/SVT-AV1/Bin/Release $ sudo ./SvtAv1EncApp -i ../../output.y4m -enc-mode 8 -b ../../multisocket.mkv
-------------------------------------------
SVT-AV1 Encoder
SVT [version]:	SVT-AV1 Encoder Lib v0.6.0
SVT [build]  :	GCC 9.2.1 20190821 gcc-9-branch@274807	 64 bit
LIB Build date: Aug 22 2019 19:21:54
-------------------------------------------
Number of logical cores available: 32
Number of PPCS 88
------------------------------------------- 
SVT [config]: Main Profile	Tier (auto)	Level (auto)	
SVT [config]: EncoderMode 							: 8 
SVT [config]: EncoderBitDepth / EncoderColorFormat / CompressedTenBitFormat	: 8 / 1 / 0
SVT [config]: SourceWidth / SourceHeight					: 1920 / 1080 
SVT [config]: Fps_Numerator / Fps_Denominator / Gop Size / IntraRefreshType 	: 24000 / 1001 / 16 / 1
SVT [config]: HierarchicalLevels / BaseLayerSwitchMode / PredStructure		: 4 / 0 / 2 
SVT [config]: BRC Mode / QP  / LookaheadDistance / SceneChange			: CQP / 50 / 33 / 0 
------------------------------------------- 
Encoding      1000
SUMMARY --------------------------------- Channel 1  --------------------------------
Total Frames		Frame Rate		Byte Count		Bitrate
        1000		23.98 fps		   6888015		1321.18 kbps


Channel 1
Average Speed:		9.464 fps
Total Encoding Time:	105665 ms
Total Execution Time:	106855 ms
Average Latency:	9337 ms
Max Latency:		14911 ms
Encoder finished

luis@clearlinux~/Desktop/SVT-AV1 $ lscpu
Architecture:        x86_64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
Address sizes:       40 bits physical, 48 bits virtual
CPU(s):              32
On-line CPU(s) list: 0-31
Thread(s) per core:  1
Core(s) per socket:  1
Socket(s):           32
NUMA node(s):        1
Vendor ID:           AuthenticAMD
CPU family:          23
Model:               1
Model name:          AMD Ryzen 7 1700 Eight-Core Processor
Stepping:            1
CPU MHz:             2993.902
BogoMIPS:            5987.80
Virtualization:      AMD-V
L1d cache:           64K
L1i cache:           64K
L2 cache:            512K
L3 cache:            16384K
NUMA node0 CPU(s):   0-31
Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm rep_good nopl cpuid extd_apicid pni pclmulqdq ssse3 fma cx16 sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm cmp_legacy svm cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw perfctr_core ssbd ibpb vmmcall fsgsbase tsc_adjust bmi1 avx2 smep bmi2 rdseed adx smap clflushopt sha_ni xsaveopt xsavec xgetbv1 virt_ssbd arat npt nrip_save
```



Signed-off-by: Luis Garcia <luigi311.lg@gmail.com>