### PR TITLE
Me sub_pel refinement optimization

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -51,9 +51,12 @@ extern "C" {
 #define EIGTH_PEL_MV                      0
 #define ALTREF_TF_EIGHTH_PEL_SEARCH       1 // Add 1/8 sub-pel search/compensation @ Temporal Filtering
 #define ALTREF_TF_ADAPTIVE_WINDOW_SIZE    1 // Add the ability to use dynamic/asymmetric window for AltRef temporal filtering, add the ability to derive the activity within past and future frames @ picture decision, and add a logic to derive window size from activity
-
+#define TF_KEY                            1 // Temporal Filtering  for Key frames. OFF for Screen Content.
+#define TFK_ALTREF_DYNAMIC_WINDOW         1 // Applying Dynamic window to key frame temporal filtering
+#define TFK_QPS_TUNING                    1 // QP scaling tuning of temporally filtered key frames.
 #define COMP_MODE                         1 // Add inter-inter compound modes
 #define PREDICTIVE_ME                     1 // Perform ME search around MVP @ MD
+
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC                         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch
 
@@ -62,12 +65,13 @@ extern "C" {
 #define NFL_IT_TH                                       2 // To be tuned
 #define NSQ_TAB_SIZE                                    6
 #define AOM_INTERP_EXTEND                               4
+#define OPTIMISED_EX_SUBPEL                             1
 
-
-
-
-
+#if OPTIMISED_EX_SUBPEL
+#define H_PEL_SEARCH_WIND 3  // 1/2-pel serach window
+#else
 #define H_PEL_SEARCH_WIND 4  // 1/2-pel serach window
+#endif
 #define Q_PEL_SEARCH_WIND 2  // 1/4-pel serach window
 #define HP_REF_OPT        1  // Remove redundant positions.
 typedef enum ME_HP_MODE {

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -53,8 +53,7 @@ extern "C" {
 #define ALTREF_TF_ADAPTIVE_WINDOW_SIZE    1 // Add the ability to use dynamic/asymmetric window for AltRef temporal filtering, add the ability to derive the activity within past and future frames @ picture decision, and add a logic to derive window size from activity
 
 #define COMP_MODE                         1 // Add inter-inter compound modes
-
-
+#define PREDICTIVE_ME                     1 // Perform ME search around MVP @ MD
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC                         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch
 

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1336,6 +1336,25 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     else
         context_ptr->bipred3x3_injection = 0;
 
+#if PREDICTIVE_ME
+    // Level                Settings
+    // 0                    Level 0: OFF
+    // 1                    Level 1: 7x5 full-pel search + sub-pel refinement off
+    // 2                    Level 2: 7x5 full-pel search +  (H + V) sub-pel refinement only = 4 half-pel + 4 quarter-pel = 8 positions + pred_me_distortion to pa_me_distortion deviation on
+    // 3                    Level 3: 7x5 full-pel search +  (H + V + D only ~ the best) sub-pel refinement = up to 6 half-pel + up to 6  quarter-pel = up to 12 positions + pred_me_distortion to pa_me_distortion deviation on
+    // 4                    Level 4: 7x5 full-pel search +  (H + V + D) sub-pel refinement = 8 half-pel + 8 quarter-pel = 16 positions + pred_me_distortion to pa_me_distortion deviation on
+    // 5                    Level 5: 7x5 full-pel search +  (H + V + D) sub-pel refinement = 8 half-pel + 8 quarter-pel = 16 positions + pred_me_distortion to pa_me_distortion deviation off
+    if (picture_control_set_ptr->slice_type != I_SLICE)
+        if (picture_control_set_ptr->enc_mode <= ENC_M1)
+            context_ptr->predictive_me_level = 4;
+        else if (picture_control_set_ptr->enc_mode <= ENC_M4)
+            context_ptr->predictive_me_level = 2;
+        else
+            context_ptr->predictive_me_level = 0;
+    else
+        context_ptr->predictive_me_level = 0;
+#endif
+
     // Set interpolation filter search blk size
     // Level                Settings
     // 0                    ON for 8x8 and above

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -2400,10 +2400,6 @@ void inject_new_candidates(
             MD_COMP_TYPE tot_comp_types = (bsize >= BLOCK_8X8 && bsize <= BLOCK_32X32) ? compound_types_to_try :
                 (compound_types_to_try == MD_COMP_WEDGE) ? MD_COMP_DIFF0 :
                 picture_control_set_ptr->parent_pcs_ptr->compound_types_to_try;//MD_COMP_DIST;// MD_COMP_AVG;//
-#if 0//N0_COMP
-            tot_comp_types = picture_control_set_ptr->enc_mode == ENC_M0 ? MD_COMP_AVG : tot_comp_types;
-#endif
-
 #endif
 
             uint8_t listIndex;

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -25,7 +25,11 @@ extern "C" {
      * Defines
      **************************************/
 #if COMP_MODE
+#if PREDICTIVE_ME
+#define MODE_DECISION_CANDIDATE_MAX_COUNT               1855
+#else
 #define MODE_DECISION_CANDIDATE_MAX_COUNT               1800
+#endif
 #else
 #define IBC_CAND 2 //two intra bc candidates
 #if EIGTH_PEL_MV
@@ -213,7 +217,10 @@ extern "C" {
         uint8_t                         tx_depth;
         uint8_t                         txb_itr;
         uint32_t                        me_sb_addr;
-
+#if PREDICTIVE_ME
+        uint32_t                        geom_offset_x;
+        uint32_t                        geom_offset_y;
+#endif
         int16_t                         luma_txb_skip_context;
         int16_t                         luma_dc_sign_context;
         int16_t                         cb_txb_skip_context;
@@ -237,6 +244,9 @@ extern "C" {
         uint8_t                         warped_motion_injection;
         uint8_t                         unipred3x3_injection;
         uint8_t                         bipred3x3_injection;
+#if PREDICTIVE_ME
+        uint8_t                         predictive_me_level;
+#endif
         uint8_t                         interpolation_filter_search_blk_size;
         uint8_t                         redundant_blk;
         uint8_t                         *cfl_temp_luma_recon;
@@ -244,6 +254,10 @@ extern "C" {
         EbBool                          spatial_sse_full_loop;
         EbBool                          blk_skip_decision;
         EbBool                          trellis_quant_coeff_optimization;
+#if PREDICTIVE_ME
+        int16_t                         best_spatial_pred_mv[2][4][2];
+        int8_t                          valid_refined_mv[2][4];
+#endif
         EbPictureBufferDesc                 *input_sample16bit_buffer;
 #if COMP_MODE
         DECLARE_ALIGNED(16, uint8_t, pred0[2 * MAX_SB_SQUARE]);

--- a/Source/Lib/Common/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimation.c
@@ -4198,7 +4198,316 @@ static void FullPelSearch_LCU(MeContext *context_ptr, uint32_t listIndex,
         }
     }
 }
-
+#if OPTIMISED_EX_SUBPEL
+/*******************************************
+ * PU_HalfPelRefinement
+ *   performs Half Pel refinement for one PU
+ *******************************************/
+static void half_pel_refinement_block(
+    MeContext
+    *context_ptr,  // input parameter, ME context Ptr, used to get SB Ptr
+    uint8_t *ref_buffer, uint32_t ref_stride, uint32_t *p_best_ssd,
+    uint32_t src_block_index,  // input parameter, PU origin, used to point to
+                               // source samples
+    uint8_t *pos_b_buffer,  // input parameter, position "b" interpolated search
+                            // area Ptr
+    uint8_t *pos_h_buffer,  // input parameter, position "h" interpolated search
+                            // area Ptr
+    uint8_t *pos_j_buffer,  // input parameter, position "j" interpolated search
+                            // area Ptr
+    uint32_t pu_width,      // input parameter, PU width
+    uint32_t pu_height,     // input parameter, PU height
+    int16_t x_search_area_origin,  // input parameter, search area origin in the
+                                   // horizontal direction, used to point to
+                                   // reference samples
+    int16_t y_search_area_origin,  // input parameter, search area origin in the
+                                   // vertical direction, used to point to
+                                   // reference samples
+#if OPTIMISED_EX_SUBPEL
+    uint32_t search_area_height,  // input parameter, search area height
+    uint32_t search_area_width,  // input parameter, search area width
+#endif
+    EbAsm asm_type, uint32_t *p_best_sad, uint32_t *p_best_mv,
+    uint8_t *p_sub_pel_direction, uint32_t *best_pervious_stage_mv,
+    uint32_t ineteger_mv) {
+    int32_t search_region_index;
+    uint64_t distortion_left_position = 0;
+    uint64_t distortion_top_position = 0;
+    uint64_t distortion_topleft_position = 0;
+    uint64_t distortion_topright_position = 0;
+    int16_t half_mv_x[8];
+    int16_t half_mv_y[8];
+    int16_t x_best_mv;
+    int16_t y_best_mv;
+    int16_t x_mv;
+    int16_t y_mv;
+    int16_t search_index_x;
+    int16_t search_index_y;
+    (void)p_sub_pel_direction;
+    (void)ineteger_mv;
+    // copute distance between best mv and the integer mv candidate
+    int16_t offset_x, offset_y;
+    for (offset_x = -H_PEL_SEARCH_WIND; offset_x <= H_PEL_SEARCH_WIND; offset_x++) {
+        for (offset_y = -H_PEL_SEARCH_WIND; offset_y <= H_PEL_SEARCH_WIND; offset_y++) {
+            x_best_mv = _MVXT(*best_pervious_stage_mv);
+            y_best_mv = _MVYT(*best_pervious_stage_mv);
+            x_mv = x_best_mv + (offset_x * 4);
+            y_mv = y_best_mv + (offset_y * 4);
+            search_index_x = (x_mv >> 2) - x_search_area_origin;
+            search_index_y = (y_mv >> 2) - y_search_area_origin;
+            uint32_t integer_mv1 = (((uint16_t)(y_mv >> 2)) << 18);
+            uint16_t integer_mv2 = (((uint16_t)(x_mv >> 2) << 2));
+            uint32_t integer_mv = integer_mv1 | integer_mv2;
+            if (search_index_x < 0 || search_index_x >(int16_t)(search_area_width - 1)) {
+                continue;
+            }
+            if (search_index_y < 0 || search_index_y >(int16_t)(search_area_height - 1)) {
+                continue;
+            }
+            half_mv_x[0] = x_mv - 2;  // L  position
+            half_mv_x[1] = x_mv + 2;  // R  position
+            half_mv_x[2] = x_mv;      // T  position
+            half_mv_x[3] = x_mv;      // B  position
+            half_mv_x[4] = x_mv - 2;  // TL position
+            half_mv_x[5] = x_mv + 2;  // TR position
+            half_mv_x[6] = x_mv + 2;  // BR position
+            half_mv_x[7] = x_mv - 2;  // BL position
+            half_mv_y[0] = y_mv;      // L  position
+            half_mv_y[1] = y_mv;      // R  position
+            half_mv_y[2] = y_mv - 2;  // T  position
+            half_mv_y[3] = y_mv + 2;  // B  position
+            half_mv_y[4] = y_mv - 2;  // TL position
+            half_mv_y[5] = y_mv - 2;  // TR position
+            half_mv_y[6] = y_mv + 2;  // BR position
+            half_mv_y[7] = y_mv + 2;  // BL position
+            // Compute SSD for the best full search candidate
+            if (context_ptr->fractional_search_method == SSD_SEARCH) {
+                uint32_t integer_sse =
+                    (uint32_t)spatial_full_distortion_kernel_func_ptr_array[asm_type](
+                        context_ptr->sb_src_ptr,
+                        src_block_index,
+                        context_ptr->sb_src_stride,
+                        ref_buffer,
+                        search_index_y * ref_stride + search_index_x,
+                        ref_stride,
+                        pu_width,
+                        pu_height);
+                if (integer_sse < *p_best_ssd) {
+                    *p_best_ssd = integer_sse;
+                    *p_best_mv = integer_mv;
+                }
+            }
+            // L position
+            search_region_index =
+                search_index_x +
+                (int16_t)context_ptr->interpolated_stride * search_index_y;
+            if (context_ptr->fractional_search_method == SSD_SEARCH)
+                distortion_left_position = spatial_full_distortion_kernel_func_ptr_array[asm_type](
+                    context_ptr->sb_src_ptr,
+                    src_block_index,
+                    context_ptr->sb_src_stride,
+                    pos_b_buffer,
+                    search_region_index,
+                    context_ptr->interpolated_stride,
+                    pu_width,
+                    pu_height);
+            else if (context_ptr->fractional_search_method == SUB_SAD_SEARCH)
+                distortion_left_position = (nxm_sad_kernel_func_ptr_array[asm_type][pu_width >> 3](
+                    &(context_ptr->sb_src_ptr[src_block_index]),
+                    context_ptr->sb_src_stride << 1,
+                    &(pos_b_buffer[search_region_index]),
+                    context_ptr->interpolated_stride << 1,
+                    pu_height >> 1,
+                    pu_width)) << 1;
+            else
+                distortion_left_position = nxm_sad_kernel_func_ptr_array[asm_type][pu_width >> 3](
+                    &(context_ptr->sb_src_ptr[src_block_index]),
+                    context_ptr->sb_src_stride,
+                    &(pos_b_buffer[search_region_index]),
+                    context_ptr->interpolated_stride,
+                    pu_height,
+                    pu_width);
+            if (context_ptr->fractional_search_method == SSD_SEARCH) {
+                if (distortion_left_position < *p_best_ssd) {
+                    *p_best_sad = (uint32_t)
+                        nxm_sad_kernel_func_ptr_array[asm_type][pu_width >> 3](
+                            &(context_ptr->sb_src_ptr[src_block_index]),
+                            context_ptr->sb_src_stride,
+                            &(pos_b_buffer[search_region_index]),
+                            context_ptr->interpolated_stride,
+                            pu_height,
+                            pu_width);
+                    *p_best_mv =
+                        ((uint16_t)half_mv_y[0] << 16) | ((uint16_t)half_mv_x[0]);
+                    *p_best_ssd = (uint32_t)distortion_left_position;
+                }
+            }
+            else {
+                if (distortion_left_position < *p_best_sad) {
+                    *p_best_sad = (uint32_t)distortion_left_position;
+                    *p_best_mv =
+                        ((uint16_t)half_mv_y[0] << 16) | ((uint16_t)half_mv_x[0]);
+                }
+            }
+            // T position
+            search_region_index =
+                search_index_x +
+                (int16_t)context_ptr->interpolated_stride * search_index_y;
+            if (context_ptr->fractional_search_method == SSD_SEARCH)
+                distortion_top_position = spatial_full_distortion_kernel_func_ptr_array[asm_type](
+                    context_ptr->sb_src_ptr,
+                    src_block_index,
+                    context_ptr->sb_src_stride,
+                    pos_h_buffer,
+                    search_region_index,
+                    context_ptr->interpolated_stride,
+                    pu_width,
+                    pu_height);
+            else if (context_ptr->fractional_search_method == SUB_SAD_SEARCH)
+                distortion_top_position = (nxm_sad_kernel_func_ptr_array[asm_type][pu_width >> 3](
+                    &(context_ptr->sb_src_ptr[src_block_index]),
+                    context_ptr->sb_src_stride << 1,
+                    &(pos_h_buffer[search_region_index]),
+                    context_ptr->interpolated_stride << 1,
+                    pu_height >> 1,
+                    pu_width)) << 1;
+            else
+                distortion_top_position = nxm_sad_kernel_func_ptr_array[asm_type][pu_width >> 3](
+                    &(context_ptr->sb_src_ptr[src_block_index]),
+                    context_ptr->sb_src_stride,
+                    &(pos_h_buffer[search_region_index]),
+                    context_ptr->interpolated_stride,
+                    pu_height,
+                    pu_width);
+            if (context_ptr->fractional_search_method == SSD_SEARCH) {
+                if (distortion_top_position < *p_best_ssd) {
+                    *p_best_sad = (uint32_t)
+                        nxm_sad_kernel_func_ptr_array[asm_type][pu_width >> 3](
+                            &(context_ptr->sb_src_ptr[src_block_index]),
+                            context_ptr->sb_src_stride,
+                            &(pos_h_buffer[search_region_index]),
+                            context_ptr->interpolated_stride,
+                            pu_height,
+                            pu_width);
+                    *p_best_mv =
+                        ((uint16_t)half_mv_y[2] << 16) | ((uint16_t)half_mv_x[2]);
+                    *p_best_ssd = (uint32_t)distortion_top_position;
+                }
+            }
+            else {
+                if (distortion_top_position < *p_best_sad) {
+                    *p_best_sad = (uint32_t)distortion_top_position;
+                    *p_best_mv =
+                        ((uint16_t)half_mv_y[2] << 16) | ((uint16_t)half_mv_x[2]);
+                }
+            }
+            // TL position
+            search_region_index =
+                search_index_x +
+                (int16_t)context_ptr->interpolated_stride * search_index_y;
+            if (context_ptr->fractional_search_method == SSD_SEARCH)
+                distortion_topleft_position = spatial_full_distortion_kernel_func_ptr_array[asm_type](
+                    context_ptr->sb_src_ptr,
+                    src_block_index,
+                    context_ptr->sb_src_stride,
+                    pos_j_buffer,
+                    search_region_index,
+                    context_ptr->interpolated_stride,
+                    pu_width,
+                    pu_height);
+            else if (context_ptr->fractional_search_method == SUB_SAD_SEARCH)
+                distortion_topleft_position = (nxm_sad_kernel_func_ptr_array[asm_type][pu_width >> 3](
+                    &(context_ptr->sb_src_ptr[src_block_index]),
+                    context_ptr->sb_src_stride << 1,
+                    &(pos_j_buffer[search_region_index]),
+                    context_ptr->interpolated_stride << 1,
+                    pu_height >> 1,
+                    pu_width)) << 1;
+            else
+                distortion_topleft_position = nxm_sad_kernel_func_ptr_array[asm_type][pu_width >> 3](
+                    &(context_ptr->sb_src_ptr[src_block_index]),
+                    context_ptr->sb_src_stride,
+                    &(pos_j_buffer[search_region_index]),
+                    context_ptr->interpolated_stride,
+                    pu_height,
+                    pu_width);
+            if (context_ptr->fractional_search_method == SSD_SEARCH) {
+                if (distortion_topleft_position < *p_best_ssd) {
+                    *p_best_sad = (uint32_t)
+                        nxm_sad_kernel_func_ptr_array[asm_type][pu_width >> 3](
+                            &(context_ptr->sb_src_ptr[src_block_index]),
+                            context_ptr->sb_src_stride,
+                            &(pos_j_buffer[search_region_index]),
+                            context_ptr->interpolated_stride,
+                            pu_height,
+                            pu_width);
+                    *p_best_mv =
+                        ((uint16_t)half_mv_y[4] << 16) | ((uint16_t)half_mv_x[4]);
+                    *p_best_ssd = (uint32_t)distortion_topleft_position;
+                }
+            }
+            else {
+                if (distortion_topleft_position < *p_best_sad) {
+                    *p_best_sad = (uint32_t)distortion_topleft_position;
+                    *p_best_mv =
+                        ((uint16_t)half_mv_y[4] << 16) | ((uint16_t)half_mv_x[4]);
+                }
+            }
+            // TR position
+            search_region_index++;
+            if (context_ptr->fractional_search_method == SSD_SEARCH)
+                distortion_topright_position = spatial_full_distortion_kernel_func_ptr_array[asm_type](
+                    context_ptr->sb_src_ptr,
+                    src_block_index,
+                    context_ptr->sb_src_stride,
+                    pos_j_buffer,
+                    search_region_index,
+                    context_ptr->interpolated_stride,
+                    pu_width,
+                    pu_height);
+            else if (context_ptr->fractional_search_method == SUB_SAD_SEARCH)
+                distortion_topright_position = (nxm_sad_kernel_func_ptr_array[asm_type][pu_width >> 3](
+                    &(context_ptr->sb_src_ptr[src_block_index]),
+                    context_ptr->sb_src_stride << 1,
+                    &(pos_j_buffer[search_region_index]),
+                    context_ptr->interpolated_stride << 1,
+                    pu_height >> 1,
+                    pu_width)) << 1;
+            else
+                distortion_topright_position = nxm_sad_kernel_func_ptr_array[asm_type][pu_width >> 3](
+                    &(context_ptr->sb_src_ptr[src_block_index]),
+                    context_ptr->sb_src_stride,
+                    &(pos_j_buffer[search_region_index]),
+                    context_ptr->interpolated_stride,
+                    pu_height,
+                    pu_width);
+            if (context_ptr->fractional_search_method == SSD_SEARCH) {
+                if (distortion_topright_position < *p_best_ssd) {
+                    *p_best_sad = (uint32_t)
+                        nxm_sad_kernel_func_ptr_array[asm_type][pu_width >> 3](
+                            &(context_ptr->sb_src_ptr[src_block_index]),
+                            context_ptr->sb_src_stride,
+                            &(pos_j_buffer[search_region_index]),
+                            context_ptr->interpolated_stride,
+                            pu_height,
+                            pu_width);
+                    *p_best_mv =
+                        ((uint16_t)half_mv_y[5] << 16) | ((uint16_t)half_mv_x[5]);
+                    *p_best_ssd = (uint32_t)distortion_topright_position;
+                }
+            }
+            else {
+                if (distortion_topright_position < *p_best_sad) {
+                    *p_best_sad = (uint32_t)distortion_topright_position;
+                    *p_best_mv =
+                        ((uint16_t)half_mv_y[5] << 16) | ((uint16_t)half_mv_x[5]);
+                }
+            }
+        }
+    }
+    return;
+}
+#else
 /*******************************************
  * PU_HalfPelRefinement
  *   performs Half Pel refinement for one PU
@@ -4697,6 +5006,7 @@ static void half_pel_refinement_block(
 #endif
     return;
 }
+#endif
 /*******************************************
  * HalfPelSearch_LCU
  *   performs Half Pel refinement for the 85 PUs
@@ -4718,6 +5028,10 @@ void half_pel_refinement_sb(
     int16_t y_search_area_origin,  // input parameter, search area origin in the
                                    // vertical direction, used to point to
                                    // reference samples
+#if OPTIMISED_EX_SUBPEL
+    uint32_t search_area_height,  // input parameter, search area height
+    uint32_t search_area_width,  // input parameter, search area width
+#endif
     uint32_t inetger_mv, EbAsm asm_type) {
     uint32_t idx;
     uint32_t pu_index;
@@ -4740,6 +5054,10 @@ void half_pel_refinement_sb(
                                   64,
                                   x_search_area_origin,
                                   y_search_area_origin,
+#if OPTIMISED_EX_SUBPEL
+                                  search_area_height,
+                                  search_area_width,
+#endif
                                   asm_type,
                                   context_ptr->p_best_sad64x64,
                                   context_ptr->p_best_mv64x64,
@@ -4775,6 +5093,10 @@ void half_pel_refinement_sb(
             32,
             x_search_area_origin,
             y_search_area_origin,
+#if OPTIMISED_EX_SUBPEL
+            search_area_height,
+            search_area_width,
+#endif
             asm_type,
             &context_ptr->p_best_sad32x32[pu_index],
             &context_ptr->p_best_mv32x32[pu_index],
@@ -4811,6 +5133,10 @@ void half_pel_refinement_sb(
                                   16,
                                   x_search_area_origin,
                                   y_search_area_origin,
+#if OPTIMISED_EX_SUBPEL
+                                  search_area_height,
+                                  search_area_width,
+#endif
                                   asm_type,
                                   &context_ptr->p_best_sad16x16[idx],
                                   &context_ptr->p_best_mv16x16[idx],
@@ -4847,6 +5173,10 @@ void half_pel_refinement_sb(
                                   8,
                                   x_search_area_origin,
                                   y_search_area_origin,
+#if OPTIMISED_EX_SUBPEL
+                                  search_area_height,
+                                  search_area_width,
+#endif
                                   asm_type,
                                   &context_ptr->p_best_sad8x8[idx],
                                   &context_ptr->p_best_mv8x8[idx],
@@ -4884,6 +5214,10 @@ void half_pel_refinement_sb(
                 32,
                 x_search_area_origin,
                 y_search_area_origin,
+#if OPTIMISED_EX_SUBPEL
+                search_area_height,
+                search_area_width,
+#endif
                 asm_type,
                 &context_ptr->p_best_sad64x32[pu_index],
                 &context_ptr->p_best_mv64x32[pu_index],
@@ -4921,6 +5255,10 @@ void half_pel_refinement_sb(
                 16,
                 x_search_area_origin,
                 y_search_area_origin,
+#if OPTIMISED_EX_SUBPEL
+                search_area_height,
+                search_area_width,
+#endif
                 asm_type,
                 &context_ptr->p_best_sad32x16[idx],
                 &context_ptr->p_best_mv32x16[idx],
@@ -4958,6 +5296,10 @@ void half_pel_refinement_sb(
                 8,
                 x_search_area_origin,
                 y_search_area_origin,
+#if OPTIMISED_EX_SUBPEL
+                search_area_height,
+                search_area_width,
+#endif
                 asm_type,
                 &context_ptr->p_best_sad16x8[idx],
                 &context_ptr->p_best_mv16x8[idx],
@@ -4994,6 +5336,10 @@ void half_pel_refinement_sb(
                 64,
                 x_search_area_origin,
                 y_search_area_origin,
+#if OPTIMISED_EX_SUBPEL
+                search_area_height,
+                search_area_width,
+#endif
                 asm_type,
                 &context_ptr->p_best_sad32x64[pu_index],
                 &context_ptr->p_best_mv32x64[pu_index],
@@ -5031,6 +5377,10 @@ void half_pel_refinement_sb(
                 32,
                 x_search_area_origin,
                 y_search_area_origin,
+#if OPTIMISED_EX_SUBPEL
+                search_area_height,
+                search_area_width,
+#endif
                 asm_type,
                 &context_ptr->p_best_sad16x32[idx],
                 &context_ptr->p_best_mv16x32[idx],
@@ -5068,6 +5418,10 @@ void half_pel_refinement_sb(
                 16,
                 x_search_area_origin,
                 y_search_area_origin,
+#if OPTIMISED_EX_SUBPEL
+                search_area_height,
+                search_area_width,
+#endif
                 asm_type,
                 &context_ptr->p_best_sad8x16[idx],
                 &context_ptr->p_best_mv8x16[idx],
@@ -5105,6 +5459,10 @@ void half_pel_refinement_sb(
                 8,
                 x_search_area_origin,
                 y_search_area_origin,
+#if OPTIMISED_EX_SUBPEL
+                search_area_height,
+                search_area_width,
+#endif
                 asm_type,
                 &context_ptr->p_best_sad32x8[idx],
                 &context_ptr->p_best_mv32x8[idx],
@@ -5141,6 +5499,10 @@ void half_pel_refinement_sb(
                 32,
                 x_search_area_origin,
                 y_search_area_origin,
+#if OPTIMISED_EX_SUBPEL
+                search_area_height,
+                search_area_width,
+#endif
                 asm_type,
                 &context_ptr->p_best_sad8x32[idx],
                 &context_ptr->p_best_mv8x32[idx],
@@ -5177,6 +5539,10 @@ void half_pel_refinement_sb(
                 16,
                 x_search_area_origin,
                 y_search_area_origin,
+#if OPTIMISED_EX_SUBPEL
+                search_area_height,
+                search_area_width,
+#endif
                 asm_type,
                 &context_ptr->p_best_sad64x16[idx],
                 &context_ptr->p_best_mv64x16[idx],
@@ -5213,6 +5579,10 @@ void half_pel_refinement_sb(
                 64,
                 x_search_area_origin,
                 y_search_area_origin,
+#if OPTIMISED_EX_SUBPEL
+                search_area_height,
+                search_area_width,
+#endif
                 asm_type,
                 &context_ptr->p_best_sad16x64[idx],
                 &context_ptr->p_best_mv16x64[idx],
@@ -5226,6 +5596,49 @@ void half_pel_refinement_sb(
 /*******************************************
  * open_loop_me_half_pel_search_sblock
  *******************************************/
+#if OPTIMISED_EX_SUBPEL
+static void open_loop_me_half_pel_search_sblock(
+    PictureParentControlSet *picture_control_set_ptr, MeContext *context_ptr,
+    uint32_t list_index, uint32_t ref_pic_index, int16_t x_search_area_origin,
+    int16_t y_search_area_origin, uint32_t search_area_width,
+    uint32_t search_area_height, EbAsm asm_type) {
+
+    half_pel_refinement_sb(
+        picture_control_set_ptr,
+        context_ptr,
+#if M0_HIGH_PRECISION_INTERPOLATION
+        context_ptr->integer_buffer_ptr[list_index][ref_pic_index] +
+        (ME_FILTER_PAD_DISTANCE >> 1) +
+        ((ME_FILTER_PAD_DISTANCE >> 1) *
+            context_ptr
+            ->interpolated_full_stride[listIndex][ref_pic_index]),
+        context_ptr
+        ->interpolated_full_stride[list_index][ref_pic_index],
+        &(context_ptr->pos_b_buffer[list_index][ref_pic_index]
+            [(ME_FILTER_PAD_DISTANCE >> 1) *
+            context_ptr->interpolated_stride]),
+#else
+        context_ptr->integer_buffer_ptr[list_index][ref_pic_index] +
+        (ME_FILTER_TAP >> 1) +
+        ((ME_FILTER_TAP >> 1) *
+            context_ptr
+            ->interpolated_full_stride[list_index][ref_pic_index]),
+        context_ptr
+        ->interpolated_full_stride[list_index][ref_pic_index],
+        &(context_ptr->pos_b_buffer[list_index][ref_pic_index]
+            [(ME_FILTER_TAP >> 1) *
+            context_ptr->interpolated_stride]),
+#endif
+        &(context_ptr->pos_h_buffer[list_index][ref_pic_index][1]),
+        &(context_ptr->pos_j_buffer[list_index][ref_pic_index][0]),
+        x_search_area_origin,
+        y_search_area_origin,
+        search_area_height,
+        search_area_width,
+        0,
+        asm_type);
+}
+#else
 static void open_loop_me_half_pel_search_sblock(
     PictureParentControlSet *picture_control_set_ptr, MeContext *context_ptr,
     uint32_t list_index, uint32_t ref_pic_index, int16_t x_search_area_origin,
@@ -5276,7 +5689,7 @@ static void open_loop_me_half_pel_search_sblock(
         }
     }
 }
-
+#endif
 static void quarter_pel_refinement_sb(
     MeContext
         *context_ptr,  //[IN/OUT]  ME context Ptr, used to get/update ME results

--- a/Source/Lib/Common/Codec/EbMotionEstimation.h
+++ b/Source/Lib/Common/Codec/EbMotionEstimation.h
@@ -1575,6 +1575,10 @@ void interpolate_search_region_AVC_chroma(
                                        // the vertical direction, used to point
                                        // to reference samples
         uint32_t integer_mv,           // input parameter, integer MV
+#if OPTIMISED_EX_SUBPEL
+        uint32_t search_area_height,  // input parameter, search area height
+        uint32_t search_area_width,  // input parameter, search area width
+#endif
         EbAsm asm_type);
 
 #ifdef __cplusplus

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -32,7 +32,16 @@
 #include "aom_dsp_rtcd.h"
 #include "EbCodingLoop.h"
 
+#if PREDICTIVE_ME
+#define PREDICTIVE_ME_MAX_MVP_CANIDATES  4
+#define PREDICTIVE_ME_DEVIATION_TH      50
+#define FULL_PEL_REF_WINDOW_WIDTH        7
+#define FULL_PEL_REF_WINDOW_HEIGHT       5
+#define HALF_PEL_REF_WINDOW              3
+#define QUARTER_PEL_REF_WINDOW           3
+#else
 #define TH_NFL_BIAS             7
+#endif
 
 EbErrorType ProductGenerateMdCandidatesCu(
     LargestCodingUnit             *sb_ptr,
@@ -1711,6 +1720,512 @@ void perform_fast_loop(
         MAX_CU_COST :
         *(candidateBufferPtrArrayBase[highestCostIndex]->fast_cost_ptr);
 }
+#if PREDICTIVE_ME
+void predictive_me_full_pel_search(
+    const SequenceControlSet     *sequence_control_set_ptr,
+    PictureControlSet            *picture_control_set_ptr,
+    ModeDecisionContext          *context_ptr,
+    EbPictureBufferDesc          *input_picture_ptr,
+    uint32_t                      inputOriginIndex,
+    EbBool                        use_ssd,
+    uint8_t                       list_idx,
+    int8_t                        ref_idx,
+    int16_t                       mvx,
+    int16_t                       mvy,
+    int16_t                       search_position_start_x,
+    int16_t                       search_position_end_x,
+    int16_t                       search_position_start_y,
+    int16_t                       search_position_end_y,
+    int16_t                       search_step,
+    int16_t                      *best_mvx,
+    int16_t                      *best_mvy,
+    uint32_t                     *best_distortion)
+{
+    EbAsm asm_type = sequence_control_set_ptr->encode_context_ptr->asm_type;
+    uint32_t  distortion;
+    ModeDecisionCandidateBuffer  *candidateBuffer = &(context_ptr->candidate_buffer_ptr_array[0][0]);
+    candidateBuffer->candidate_ptr = &(context_ptr->fast_candidate_array[0]);
+    EbPictureBufferDesc *ref_pic = ((EbReferenceObject*)picture_control_set_ptr->ref_pic_ptr_array[list_idx][ref_idx]->object_ptr)->reference_picture;
+    for (int32_t refinement_pos_x = search_position_start_x; refinement_pos_x <= search_position_end_x; ++refinement_pos_x) {
+        for (int32_t refinement_pos_y = search_position_start_y; refinement_pos_y <= search_position_end_y; ++refinement_pos_y) {
+
+            uint32_t ref_origin_index = ref_pic->origin_x + (context_ptr->cu_origin_x + (mvx >> 3) + refinement_pos_x) + (context_ptr->cu_origin_y + (mvy >> 3) + ref_pic->origin_y + refinement_pos_y) * ref_pic->stride_y;
+            if (use_ssd) {
+                distortion = (uint32_t)spatial_full_distortion_kernel_func_ptr_array[asm_type](
+                    input_picture_ptr->buffer_y,
+                    inputOriginIndex,
+                    input_picture_ptr->stride_y,
+                    ref_pic->buffer_y,
+                    ref_origin_index,
+                    ref_pic->stride_y,
+                    context_ptr->blk_geom->bwidth,
+                    context_ptr->blk_geom->bheight);
+            }
+            else {
+                assert((context_ptr->blk_geom->bwidth >> 3) < 17);
+                distortion = nxm_sad_kernel_sub_sampled_func_ptr_array[asm_type][context_ptr->blk_geom->bwidth >> 3](
+                    input_picture_ptr->buffer_y + inputOriginIndex,
+                    input_picture_ptr->stride_y,
+                    ref_pic->buffer_y + ref_origin_index,
+                    ref_pic->stride_y,
+                    context_ptr->blk_geom->bheight,
+                    context_ptr->blk_geom->bwidth);
+            }
+
+            if (distortion < *best_distortion) {
+                *best_mvx = mvx + (refinement_pos_x * search_step);
+                *best_mvy = mvy + (refinement_pos_y * search_step);
+                *best_distortion = distortion;
+            }
+        }
+    }
+}
+
+void predictive_me_sub_pel_search(
+    const SequenceControlSet     *sequence_control_set_ptr,
+    PictureControlSet            *picture_control_set_ptr,
+    ModeDecisionContext          *context_ptr,
+    EbPictureBufferDesc          *input_picture_ptr,
+    uint32_t                      inputOriginIndex,
+    uint32_t                      cuOriginIndex,
+    EbBool                        use_ssd,
+    uint8_t                       list_idx,
+    int8_t                        ref_idx,
+    int16_t                       mvx,
+    int16_t                       mvy,
+    int16_t                       search_position_start_x,
+    int16_t                       search_position_end_x,
+    int16_t                       search_position_start_y,
+    int16_t                       search_position_end_y,
+    int16_t                       search_step,
+    int16_t                      *best_mvx,
+    int16_t                      *best_mvy,
+    uint32_t                     *best_distortion,
+    uint8_t                       search_pattern)
+{
+    EbAsm asm_type = sequence_control_set_ptr->encode_context_ptr->asm_type;
+    uint32_t  distortion;
+    ModeDecisionCandidateBuffer  *candidateBuffer = &(context_ptr->candidate_buffer_ptr_array[0][0]);
+    candidateBuffer->candidate_ptr = &(context_ptr->fast_candidate_array[0]);
+
+    for (int32_t refinement_pos_x = search_position_start_x; refinement_pos_x <= search_position_end_x; ++refinement_pos_x) {
+        for (int32_t refinement_pos_y = search_position_start_y; refinement_pos_y <= search_position_end_y; ++refinement_pos_y) {
+
+            if (refinement_pos_x == 0 && refinement_pos_y == 0)
+                continue;
+
+            if (search_pattern == 1 && refinement_pos_x != 0 && refinement_pos_y != 0)
+                continue;
+
+            if (search_pattern == 2 && refinement_pos_y != 0)
+                continue;
+
+            if (search_pattern == 3 && refinement_pos_x != 0)
+                continue;
+
+            ModeDecisionCandidate *candidate_ptr = candidateBuffer->candidate_ptr;
+            EbPictureBufferDesc   *prediction_ptr = candidateBuffer->prediction_ptr;
+
+            candidate_ptr->type = INTER_MODE;
+            candidate_ptr->distortion_ready = 0;
+            candidate_ptr->use_intrabc = 0;
+            candidate_ptr->merge_flag = EB_FALSE;
+            candidate_ptr->prediction_direction[0] = (EbPredDirection)list_idx;
+            candidate_ptr->inter_mode = NEWMV;
+            candidate_ptr->pred_mode = NEWMV;
+            candidate_ptr->motion_mode = SIMPLE_TRANSLATION;
+            candidate_ptr->is_compound = 0;
+            candidate_ptr->is_new_mv = 1;
+            candidate_ptr->is_zero_mv = 0;
+            candidate_ptr->drl_index = 0;
+            candidate_ptr->ref_mv_index = 0;
+            candidate_ptr->pred_mv_weight = 0;
+            candidate_ptr->ref_frame_type = svt_get_ref_frame_type(list_idx, ref_idx);
+            candidate_ptr->transform_type[PLANE_TYPE_Y] = DCT_DCT;
+            candidate_ptr->transform_type[PLANE_TYPE_UV] = DCT_DCT;
+            candidate_ptr->motion_vector_xl0 = list_idx == 0 ? mvx + (refinement_pos_x * search_step) : 0;
+            candidate_ptr->motion_vector_yl0 = list_idx == 0 ? mvy + (refinement_pos_y * search_step) : 0;
+            candidate_ptr->motion_vector_xl1 = list_idx == 1 ? mvx + (refinement_pos_x * search_step) : 0;
+            candidate_ptr->motion_vector_yl1 = list_idx == 1 ? mvy + (refinement_pos_y * search_step) : 0;
+            candidate_ptr->ref_frame_index_l0 = list_idx == 0 ? ref_idx : -1;
+            candidate_ptr->ref_frame_index_l1 = list_idx == 1 ? ref_idx : -1;
+            candidate_ptr->interp_filters = 0;
+
+            // Prediction
+            uint8_t default_skip_interpolation_search = context_ptr->skip_interpolation_search;
+            context_ptr->skip_interpolation_search = 1;
+
+            ProductPredictionFunTable[INTER_MODE](
+                context_ptr,
+                picture_control_set_ptr,
+                candidateBuffer,
+                asm_type);
+
+            context_ptr->skip_interpolation_search = default_skip_interpolation_search;
+
+            // Distortion
+            if (use_ssd) {
+                distortion = (uint32_t)spatial_full_distortion_kernel_func_ptr_array[asm_type](
+                    input_picture_ptr->buffer_y,
+                    inputOriginIndex,
+                    input_picture_ptr->stride_y,
+                    prediction_ptr->buffer_y,
+                    cuOriginIndex,
+                    prediction_ptr->stride_y,
+                    context_ptr->blk_geom->bwidth,
+                    context_ptr->blk_geom->bheight);
+            }
+            else {
+                assert((context_ptr->blk_geom->bwidth >> 3) < 17);
+                distortion = nxm_sad_kernel_sub_sampled_func_ptr_array[asm_type][context_ptr->blk_geom->bwidth >> 3](
+                    input_picture_ptr->buffer_y + inputOriginIndex,
+                    input_picture_ptr->stride_y,
+                    prediction_ptr->buffer_y + cuOriginIndex,
+                    prediction_ptr->stride_y,
+                    context_ptr->blk_geom->bheight,
+                    context_ptr->blk_geom->bwidth);
+            }
+            if (distortion < *best_distortion) {
+                *best_mvx = mvx + (refinement_pos_x * search_step);
+                *best_mvy = mvy + (refinement_pos_y * search_step);
+                *best_distortion = distortion;
+            }
+        }
+    }
+}
+
+void av1_set_ref_frame(MvReferenceFrame *rf, int8_t ref_frame_type);
+uint8_t GetMaxDrlIndex(uint8_t  refmvCnt, PredictionMode   mode);
+
+void predictive_me_search(
+    PictureControlSet            *picture_control_set_ptr,
+    ModeDecisionContext          *context_ptr,
+    EbPictureBufferDesc          *input_picture_ptr,
+    uint32_t                      inputOriginIndex,
+    uint32_t                      cuOriginIndex) {
+
+    const SequenceControlSet *sequence_control_set_ptr = (SequenceControlSet*)picture_control_set_ptr->sequence_control_set_wrapper_ptr->object_ptr;
+    EbAsm asm_type = sequence_control_set_ptr->encode_context_ptr->asm_type;
+
+    EbBool use_ssd = EB_TRUE;
+
+    // Reset valid_refined_mv
+    for (uint8_t listIndex = REF_LIST_0; listIndex < 2; ++listIndex) {
+        for (uint8_t ref_pic_index = 0; ref_pic_index < 4; ++ref_pic_index) {
+            context_ptr->valid_refined_mv[listIndex][ref_pic_index] = 0;
+        }
+    }
+
+    for (uint32_t refIt = 0; refIt < picture_control_set_ptr->parent_pcs_ptr->tot_ref_frame_types; ++refIt) {
+        MvReferenceFrame ref_pair = picture_control_set_ptr->parent_pcs_ptr->ref_frame_type_arr[refIt];
+
+        MacroBlockD  *xd = context_ptr->cu_ptr->av1xd;
+        uint8_t drli, maxDrlIndex;
+        IntMv    nearestmv[2], nearmv[2], ref_mv[2];
+
+        MvReferenceFrame rf[2];
+        av1_set_ref_frame(rf, ref_pair);
+
+        // Reset search variable(s)
+        uint32_t best_mvp_distortion = (int32_t)~0;
+        uint32_t mvp_distortion;
+
+        int16_t  best_search_mvx = (int16_t)~0;
+        int16_t  best_search_mvy = (int16_t)~0;
+        uint32_t best_search_distortion = (int32_t)~0;
+
+        // Step 0: derive the MVP list; 1 nearest and up to 3 near
+        int16_t mvp_x_array[PREDICTIVE_ME_MAX_MVP_CANIDATES];
+        int16_t mvp_y_array[PREDICTIVE_ME_MAX_MVP_CANIDATES];
+        int8_t mvp_count = 0;
+        if (rf[1] == NONE_FRAME)
+        {
+
+
+            MvReferenceFrame frame_type = rf[0];
+            uint8_t list_idx = get_list_idx(rf[0]);
+            uint8_t ref_idx = get_ref_frame_idx(rf[0]);
+
+            // Get the ME MV
+            const MeLcuResults *me_results = picture_control_set_ptr->parent_pcs_ptr->me_results[context_ptr->me_sb_addr];
+            int16_t me_mv_x;
+            int16_t me_mv_y;
+
+            if (list_idx == 0) {
+                me_mv_x = (me_results->me_mv_array[context_ptr->me_block_offset][ref_idx].x_mv) << 1;
+                me_mv_y = (me_results->me_mv_array[context_ptr->me_block_offset][ref_idx].y_mv) << 1;
+            }
+            else {
+                me_mv_x = (me_results->me_mv_array[context_ptr->me_block_offset][((sequence_control_set_ptr->mrp_mode == 0) ? 4 : 2) + ref_idx].x_mv) << 1;
+                me_mv_y = (me_results->me_mv_array[context_ptr->me_block_offset][((sequence_control_set_ptr->mrp_mode == 0) ? 4 : 2) + ref_idx].y_mv) << 1;
+            }
+
+            // Round-up to the closest integer the ME MV
+            me_mv_x = (me_mv_x + 4)&~0x07;
+            me_mv_y = (me_mv_y + 4)&~0x07;
+
+            uint32_t pa_me_distortion;
+            EbPictureBufferDesc *ref_pic = ((EbReferenceObject*)picture_control_set_ptr->ref_pic_ptr_array[list_idx][ref_idx]->object_ptr)->reference_picture;
+
+            uint32_t ref_origin_index = ref_pic->origin_x + (context_ptr->cu_origin_x + (me_mv_x >> 3)) + (context_ptr->cu_origin_y + (me_mv_y >> 3) + ref_pic->origin_y) * ref_pic->stride_y;
+            if (use_ssd) {
+                pa_me_distortion = (uint32_t)spatial_full_distortion_kernel_func_ptr_array[asm_type](
+                    input_picture_ptr->buffer_y,
+                    inputOriginIndex,
+                    input_picture_ptr->stride_y,
+                    ref_pic->buffer_y,
+                    ref_origin_index,
+                    ref_pic->stride_y,
+                    context_ptr->blk_geom->bwidth,
+                    context_ptr->blk_geom->bheight);
+            }
+            else {
+                assert((context_ptr->blk_geom->bwidth >> 3) < 17);
+                pa_me_distortion = nxm_sad_kernel_sub_sampled_func_ptr_array[asm_type][context_ptr->blk_geom->bwidth >> 3](
+                    input_picture_ptr->buffer_y + inputOriginIndex,
+                    input_picture_ptr->stride_y,
+                    ref_pic->buffer_y + ref_origin_index,
+                    ref_pic->stride_y,
+                    context_ptr->blk_geom->bheight,
+                    context_ptr->blk_geom->bwidth);
+            }
+
+            if (pa_me_distortion != 0 || context_ptr->predictive_me_level >= 5) {
+
+                //NEAREST
+                mvp_x_array[mvp_count] = (context_ptr->cu_ptr->ref_mvs[frame_type][0].as_mv.col + 4)&~0x07;
+                mvp_y_array[mvp_count] = (context_ptr->cu_ptr->ref_mvs[frame_type][0].as_mv.row + 4)&~0x07;
+
+                mvp_count++;
+
+                //NEAR
+                maxDrlIndex = GetMaxDrlIndex(xd->ref_mv_count[frame_type], NEARMV);
+
+                for (drli = 0; drli < maxDrlIndex; drli++) {
+                    get_av1_mv_pred_drl(
+                        context_ptr,
+                        context_ptr->cu_ptr,
+                        frame_type,
+                        0,
+                        NEARMV,
+                        drli,
+                        nearestmv,
+                        nearmv,
+                        ref_mv);
+
+                    if (((nearmv[0].as_mv.col + 4)&~0x07) != mvp_x_array[0] && ((nearmv[0].as_mv.row + 4)&~0x07) != mvp_y_array[0]) {
+                        mvp_x_array[mvp_count] = (nearmv[0].as_mv.col + 4)&~0x07;
+                        mvp_y_array[mvp_count] = (nearmv[0].as_mv.row + 4)&~0x07;
+                        mvp_count++;
+                    }
+
+                }
+                // Step 1: derive the best MVP in term of distortion
+                int16_t best_mvp_x = 0;
+                int16_t best_mvp_y = 0;
+
+                for (int8_t mvp_index = 0; mvp_index < mvp_count; mvp_index++) {
+
+                    // MVP Distortion
+                    EbPictureBufferDesc *ref_pic = ((EbReferenceObject*)picture_control_set_ptr->ref_pic_ptr_array[list_idx][ref_idx]->object_ptr)->reference_picture;
+                    uint32_t ref_origin_index = ref_pic->origin_x + (context_ptr->cu_origin_x + (mvp_x_array[mvp_index] >> 3)) + (context_ptr->cu_origin_y + (mvp_y_array[mvp_index] >> 3) + ref_pic->origin_y) * ref_pic->stride_y;
+                    if (use_ssd) {
+                        mvp_distortion = (uint32_t)spatial_full_distortion_kernel_func_ptr_array[asm_type](
+                            input_picture_ptr->buffer_y,
+                            inputOriginIndex,
+                            input_picture_ptr->stride_y,
+                            ref_pic->buffer_y,
+                            ref_origin_index,
+                            ref_pic->stride_y,
+                            context_ptr->blk_geom->bwidth,
+                            context_ptr->blk_geom->bheight);
+                    }
+                    else {
+                        assert((context_ptr->blk_geom->bwidth >> 3) < 17);
+                        mvp_distortion = nxm_sad_kernel_sub_sampled_func_ptr_array[asm_type][context_ptr->blk_geom->bwidth >> 3](
+                            input_picture_ptr->buffer_y + inputOriginIndex,
+                            input_picture_ptr->stride_y,
+                            ref_pic->buffer_y + ref_origin_index,
+                            ref_pic->stride_y,
+                            context_ptr->blk_geom->bheight,
+                            context_ptr->blk_geom->bwidth);
+                    }
+
+                    if (mvp_distortion < best_mvp_distortion) {
+                        best_mvp_distortion = mvp_distortion;
+                        best_mvp_x = mvp_x_array[mvp_index];
+                        best_mvp_y = mvp_y_array[mvp_index];
+                    }
+                }
+
+                // Step 2: perform full pel search around the best MVP
+                best_mvp_x = (best_mvp_x + 4)&~0x07;
+                best_mvp_y = (best_mvp_y + 4)&~0x07;
+
+                predictive_me_full_pel_search(
+                    sequence_control_set_ptr,
+                    picture_control_set_ptr,
+                    context_ptr,
+                    input_picture_ptr,
+                    inputOriginIndex,
+                    use_ssd,
+                    list_idx,
+                    ref_idx,
+                    best_mvp_x,
+                    best_mvp_y,
+                    -(FULL_PEL_REF_WINDOW_WIDTH >> 1),
+                    +(FULL_PEL_REF_WINDOW_WIDTH >> 1),
+                    -(FULL_PEL_REF_WINDOW_HEIGHT >> 1),
+                    +(FULL_PEL_REF_WINDOW_HEIGHT >> 1),
+                    8,
+                    &best_search_mvx,
+                    &best_search_mvy,
+                    &best_search_distortion);
+
+                EbBool exit_predictive_me_sub_pel;
+
+                if (pa_me_distortion == 0)
+                    exit_predictive_me_sub_pel = EB_TRUE;
+                else if (best_search_distortion <= pa_me_distortion)
+                    exit_predictive_me_sub_pel = EB_FALSE;
+                else {
+                    exit_predictive_me_sub_pel = ((((best_search_distortion - pa_me_distortion) * 100) / pa_me_distortion) < PREDICTIVE_ME_DEVIATION_TH) ?
+                        EB_FALSE :
+                        EB_TRUE;
+                }
+
+                if (exit_predictive_me_sub_pel == EB_FALSE || context_ptr->predictive_me_level >= 5) {
+
+                    if (context_ptr->predictive_me_level >= 2) {
+
+                        uint8_t search_pattern;
+                        // 0: all possible position(s): horizontal, vertical, diagonal
+                        // 1: horizontal, vertical
+                        // 2: horizontal only
+                        // 3: vertical only
+
+                        // Step 3: perform half pel search around the best full pel position
+                        search_pattern = (context_ptr->predictive_me_level >= 4) ? 0 : 1;
+
+                        predictive_me_sub_pel_search(
+                            sequence_control_set_ptr,
+                            picture_control_set_ptr,
+                            context_ptr,
+                            input_picture_ptr,
+                            inputOriginIndex,
+                            cuOriginIndex,
+                            use_ssd,
+                            list_idx,
+                            ref_idx,
+                            best_search_mvx,
+                            best_search_mvy,
+                            -(HALF_PEL_REF_WINDOW >> 1),
+                            +(HALF_PEL_REF_WINDOW >> 1),
+                            -(HALF_PEL_REF_WINDOW >> 1),
+                            +(HALF_PEL_REF_WINDOW >> 1),
+                            4,
+                            &best_search_mvx,
+                            &best_search_mvy,
+                            &best_search_distortion,
+                            search_pattern);
+
+                        if (context_ptr->predictive_me_level == 3) {
+                            if ((best_search_mvx & 0x07) != 0 || (best_search_mvy & 0x07) != 0) {
+
+                                if ((best_search_mvx & 0x07) == 0)
+                                    search_pattern = 2;
+                                else // if(best_search_mvy & 0x07 == 0)
+                                    search_pattern = 3;
+
+                                predictive_me_sub_pel_search(
+                                    sequence_control_set_ptr,
+                                    picture_control_set_ptr,
+                                    context_ptr,
+                                    input_picture_ptr,
+                                    inputOriginIndex,
+                                    cuOriginIndex,
+                                    use_ssd,
+                                    list_idx,
+                                    ref_idx,
+                                    best_search_mvx,
+                                    best_search_mvy,
+                                    -(HALF_PEL_REF_WINDOW >> 1),
+                                    +(HALF_PEL_REF_WINDOW >> 1),
+                                    -(HALF_PEL_REF_WINDOW >> 1),
+                                    +(HALF_PEL_REF_WINDOW >> 1),
+                                    4,
+                                    &best_search_mvx,
+                                    &best_search_mvy,
+                                    &best_search_distortion,
+                                    search_pattern);
+                            }
+                        }
+
+                        // Step 4: perform quarter pel search around the best half pel position
+                        search_pattern = (context_ptr->predictive_me_level >= 4) ? 0 : 1;
+                        predictive_me_sub_pel_search(
+                            sequence_control_set_ptr,
+                            picture_control_set_ptr,
+                            context_ptr,
+                            input_picture_ptr,
+                            inputOriginIndex,
+                            cuOriginIndex,
+                            use_ssd,
+                            list_idx,
+                            ref_idx,
+                            best_search_mvx,
+                            best_search_mvy,
+                            -(QUARTER_PEL_REF_WINDOW >> 1),
+                            +(QUARTER_PEL_REF_WINDOW >> 1),
+                            -(QUARTER_PEL_REF_WINDOW >> 1),
+                            +(QUARTER_PEL_REF_WINDOW >> 1),
+                            2,
+                            &best_search_mvx,
+                            &best_search_mvy,
+                            &best_search_distortion,
+                            search_pattern);
+
+                        if (context_ptr->predictive_me_level == 3) {
+                            if ((best_search_mvx & 0x03) != 0 || (best_search_mvy & 0x03) != 0) {
+
+                                if ((best_search_mvx & 0x03) == 0)
+                                    search_pattern = 2;
+                                else // if(best_search_mvy & 0x03 == 0)
+                                    search_pattern = 3;
+
+                                predictive_me_sub_pel_search(
+                                    sequence_control_set_ptr,
+                                    picture_control_set_ptr,
+                                    context_ptr,
+                                    input_picture_ptr,
+                                    inputOriginIndex,
+                                    cuOriginIndex,
+                                    use_ssd,
+                                    list_idx,
+                                    ref_idx,
+                                    best_search_mvx,
+                                    best_search_mvy,
+                                    -(QUARTER_PEL_REF_WINDOW >> 1),
+                                    +(QUARTER_PEL_REF_WINDOW >> 1),
+                                    -(QUARTER_PEL_REF_WINDOW >> 1),
+                                    +(QUARTER_PEL_REF_WINDOW >> 1),
+                                    2,
+                                    &best_search_mvx,
+                                    &best_search_mvy,
+                                    &best_search_distortion,
+                                    search_pattern);
+                            }
+                        }
+                    }
+                    context_ptr->best_spatial_pred_mv[list_idx][ref_idx][0] = best_search_mvx;
+                    context_ptr->best_spatial_pred_mv[list_idx][ref_idx][1] = best_search_mvy;
+                    context_ptr->valid_refined_mv[list_idx][ref_idx] = 1;
+                }
+            }
+        }
+    }
+}
+#endif
 void AV1CostCalcCfl(
     PictureControlSet                *picture_control_set_ptr,
     ModeDecisionCandidateBuffer      *candidateBuffer,
@@ -5231,6 +5746,62 @@ void md_encode_block(
                 }
             }
         }
+
+#if PREDICTIVE_ME
+        FrameHeader *frm_hdr = &picture_control_set_ptr->parent_pcs_ptr->frm_hdr;
+        context_ptr->geom_offset_x = 0;
+        context_ptr->geom_offset_y = 0;
+
+        if (sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128) {
+            uint32_t me_sb_size = sequence_control_set_ptr->sb_sz;
+            uint32_t me_pic_width_in_sb = (sequence_control_set_ptr->seq_header.max_frame_width + sequence_control_set_ptr->sb_sz - 1) / me_sb_size;
+            uint32_t me_sb_x = (context_ptr->cu_origin_x / me_sb_size);
+            uint32_t me_sb_y = (context_ptr->cu_origin_y / me_sb_size);
+            context_ptr->me_sb_addr = me_sb_x + me_sb_y * me_pic_width_in_sb;
+            context_ptr->geom_offset_x = (me_sb_x & 0x1) * me_sb_size;
+            context_ptr->geom_offset_y = (me_sb_y & 0x1) * me_sb_size;
+        }
+        else
+            context_ptr->me_sb_addr = lcuAddr;
+
+        context_ptr->me_block_offset =
+            (context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4 || context_ptr->blk_geom->bwidth == 128 || context_ptr->blk_geom->bheight == 128) ?
+            0 :
+            get_me_info_index(picture_control_set_ptr->parent_pcs_ptr->max_number_of_pus_per_sb, context_ptr->blk_geom, context_ptr->geom_offset_x, context_ptr->geom_offset_y);
+
+        // Generate MVP(s)
+        if (frm_hdr->allow_intrabc) // picture_control_set_ptr->slice_type == I_SLICE
+            generate_av1_mvp_table(
+                &context_ptr->sb_ptr->tile_info,
+                context_ptr,
+                context_ptr->cu_ptr,
+                context_ptr->blk_geom,
+                context_ptr->cu_origin_x,
+                context_ptr->cu_origin_y,
+                picture_control_set_ptr->parent_pcs_ptr->ref_frame_type_arr,
+                1,
+                picture_control_set_ptr);
+        else if (picture_control_set_ptr->slice_type != I_SLICE)
+            generate_av1_mvp_table(
+                &context_ptr->sb_ptr->tile_info,
+                context_ptr,
+                context_ptr->cu_ptr,
+                context_ptr->blk_geom,
+                context_ptr->cu_origin_x,
+                context_ptr->cu_origin_y,
+                picture_control_set_ptr->parent_pcs_ptr->ref_frame_type_arr,
+                picture_control_set_ptr->parent_pcs_ptr->tot_ref_frame_types,
+                picture_control_set_ptr);
+
+        // Perform ME search around the best MVP
+        if (context_ptr->predictive_me_level)
+            predictive_me_search(
+                picture_control_set_ptr,
+                context_ptr,
+                input_picture_ptr,
+                inputOriginIndex,
+                cuOriginIndex);
+#endif
 
         ProductGenerateMdCandidatesCu(
             context_ptr->sb_ptr,

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -1910,11 +1910,7 @@ void predictive_me_search(
     EbBool use_ssd = EB_TRUE;
 
     // Reset valid_refined_mv
-    for (uint8_t listIndex = REF_LIST_0; listIndex < 2; ++listIndex) {
-        for (uint8_t ref_pic_index = 0; ref_pic_index < 4; ++ref_pic_index) {
-            context_ptr->valid_refined_mv[listIndex][ref_pic_index] = 0;
-        }
-    }
+    memset(context_ptr->valid_refined_mv, 0, 8); // [2][4]
 
     for (uint32_t refIt = 0; refIt < picture_control_set_ptr->parent_pcs_ptr->tot_ref_frame_types; ++refIt) {
         MvReferenceFrame ref_pair = picture_control_set_ptr->parent_pcs_ptr->ref_frame_type_arr[refIt];
@@ -1940,17 +1936,13 @@ void predictive_me_search(
         int8_t mvp_count = 0;
         if (rf[1] == NONE_FRAME)
         {
-
-
             MvReferenceFrame frame_type = rf[0];
             uint8_t list_idx = get_list_idx(rf[0]);
             uint8_t ref_idx = get_ref_frame_idx(rf[0]);
-
             // Get the ME MV
             const MeLcuResults *me_results = picture_control_set_ptr->parent_pcs_ptr->me_results[context_ptr->me_sb_addr];
             int16_t me_mv_x;
             int16_t me_mv_y;
-
             if (list_idx == 0) {
                 me_mv_x = (me_results->me_mv_array[context_ptr->me_block_offset][ref_idx].x_mv) << 1;
                 me_mv_y = (me_results->me_mv_array[context_ptr->me_block_offset][ref_idx].y_mv) << 1;
@@ -1959,7 +1951,6 @@ void predictive_me_search(
                 me_mv_x = (me_results->me_mv_array[context_ptr->me_block_offset][((sequence_control_set_ptr->mrp_mode == 0) ? 4 : 2) + ref_idx].x_mv) << 1;
                 me_mv_y = (me_results->me_mv_array[context_ptr->me_block_offset][((sequence_control_set_ptr->mrp_mode == 0) ? 4 : 2) + ref_idx].y_mv) << 1;
             }
-
             // Round-up to the closest integer the ME MV
             me_mv_x = (me_mv_x + 4)&~0x07;
             me_mv_y = (me_mv_y + 4)&~0x07;


### PR DESCRIPTION
Restructure the Sub_pel refinement to be done in an NxM window around the best integer-pel and where NxM is set to 3x3 by default.

The recorded data on the 360p clips is 11% speedup in encoding time for 0.1% bdrate gain and no impact on the memory.

Please note that this PR replaces the #464 one.