### PR TITLE
EbMalloc: return EB_ErrorInsufficientResources for thread/semaphore/mutex create fail

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -2314,8 +2314,11 @@ extern    uint32_t                   app_malloc_count;
 
 #define EB_DESTROY_SEMAPHORE(pointer) \
     do { \
-        eb_destroy_semaphore(pointer); \
-        EB_REMOVE_MEM_ENTRY(pointer, EB_SEMAPHORE); \
+        if (pointer) { \
+            eb_destroy_semaphore(pointer); \
+            EB_REMOVE_MEM_ENTRY(pointer, EB_SEMAPHORE); \
+            pointer = NULL; \
+        } \
     }while (0)
 
 #define EB_CREATE_MUTEX(pointer) \
@@ -2329,6 +2332,7 @@ extern    uint32_t                   app_malloc_count;
         if (pointer) { \
             eb_destroy_mutex(pointer); \
             EB_REMOVE_MEM_ENTRY(pointer, EB_MUTEX); \
+            pointer = NULL; \
         } \
     } while (0)
 

--- a/Source/Lib/Common/Codec/EbMalloc.h
+++ b/Source/Lib/Common/Codec/EbMalloc.h
@@ -31,7 +31,7 @@ void eb_remove_mem_entry(void* ptr, EbPtrType type);
 
 #endif //DEBUG_MEMORY_USAGE
 
-#define EB_ADD_MEM(p, size, type) \
+#define EB_NO_THROW_ADD_MEM(p, size, type) \
     do { \
         if (!p) { \
             fprintf(stderr,"allocate memory failed, at %s, L%d", __FILE__, __LINE__); \
@@ -40,32 +40,43 @@ void eb_remove_mem_entry(void* ptr, EbPtrType type);
         } \
     } while (0)
 
+#define EB_CHECK_MEM(p) \
+    do { \
+        if (!p) {\
+            return EB_ErrorInsufficientResources; \
+        } \
+    } while (0)
+
+#define EB_ADD_MEM(p, size, type) \
+    do { \
+        EB_NO_THROW_ADD_MEM(p, size, type); \
+        EB_CHECK_MEM(p); \
+    } while (0)
+
 #define EB_NO_THROW_MALLOC(pointer, size) \
     do { \
         void* p = malloc(size); \
-        EB_ADD_MEM(p, size, EB_N_PTR); \
+        EB_NO_THROW_ADD_MEM(p, size, EB_N_PTR); \
         *(void**)&(pointer) = p; \
     } while (0)
 
 #define EB_MALLOC(pointer, size) \
     do { \
         EB_NO_THROW_MALLOC(pointer, size); \
-        if (!(pointer)) \
-            return EB_ErrorInsufficientResources; \
+        EB_CHECK_MEM(pointer); \
     } while (0)
 
 #define EB_NO_THROW_CALLOC(pointer, count, size) \
     do { \
         void* p = calloc(count, size); \
-        EB_ADD_MEM(p, count * size, EB_C_PTR); \
+        EB_NO_THROW_ADD_MEM(p, count * size, EB_C_PTR); \
         *(void**)&(pointer) = p; \
     } while (0)
 
 #define EB_CALLOC(pointer, count, size) \
     do { \
         EB_NO_THROW_CALLOC(pointer, count, size); \
-        if (!(pointer)) \
-            return EB_ErrorInsufficientResources; \
+        EB_CHECK_MEM(pointer); \
     } while (0)
 
 #define EB_FREE(pointer) \

--- a/Source/Lib/Common/Codec/EbThreads.h
+++ b/Source/Lib/Common/Codec/EbThreads.h
@@ -114,9 +114,11 @@ extern    cpu_set_t                   group_affinity;
 
 #define EB_DESTROY_THREAD(pointer) \
     do { \
-        eb_destroy_thread(pointer); \
-        EB_REMOVE_MEM_ENTRY(pointer, EB_THREAD); \
-        pointer = NULL; \
+        if (pointer) { \
+            eb_destroy_thread(pointer); \
+            EB_REMOVE_MEM_ENTRY(pointer, EB_THREAD); \
+            pointer = NULL; \
+        } \
     } while (0);
 
 #define EB_CREATE_THREAD_ARRAY(pa, count, thread_function, thread_contexts) \


### PR DESCRIPTION
else it will crash ffmpeg when we create resource failed
this patch also do null check for EB_DESTORY_xxxx

This need to work with  https://github.com/OpenVisualCloud/SVT-AV1/pull/504