### PR TITLE
cfg->input_file: fix for reading from named pipe

### DIFF
--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -13,7 +13,7 @@
 #include "EbAppInputy4m.h"
 
 #ifdef _WIN32
-#include <Fileapi.h>
+#include <windows.h>
 #else
 #include <unistd.h>
 #endif

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -126,7 +126,7 @@
  **********************************/
 static void SetCfgInputFile(const char *filename, EbConfig *cfg)
 {
-    if (cfg->input_file && cfg->input_file_is_fifo)
+    if (cfg->input_file && !cfg->input_file_is_fifo)
         fclose(cfg->input_file);
 
     if (!filename) {

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -13,8 +13,8 @@
 #include "EbAppInputy4m.h"
 
 #ifdef _WIN32
-#else
 #include <Fileapi.h>
+#else
 #include <unistd.h>
 #endif
 

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -139,7 +139,7 @@ static void SetCfgInputFile(const char *filename, EbConfig *cfg)
     else
         FOPEN(cfg->input_file, filename, "rb");
 
-#if defined(_MSC_VER)
+#ifdef _WIN32
     cfg->input_file_is_fifo =
     GetFileType(cfg->input_file) == FILE_TYPE_PIPE;
 #else

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -142,7 +142,7 @@ static void SetCfgInputFile(const char *filename, EbConfig *cfg)
 #if defined(_MSC_VER)
     cfg->input_file_is_fifo =
     GetFileType(cfg->input_file) == FILE_TYPE_PIPE;
-#elif
+#else
     int fd = fileno(cfg->input_file);
     struct stat statbuf;
     fstat(fd, &statbuf);

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -166,6 +166,7 @@ typedef struct EbConfig
      ****************************************/
     FILE                    *config_file;
     FILE                    *input_file;
+    EbBool                  input_file_is_fifo;
     FILE                    *bitstream_file;
     FILE                    *recon_file;
     FILE                    *error_log_file;

--- a/Source/App/EncApp/EbAppInputy4m.c
+++ b/Source/App/EncApp/EbAppInputy4m.c
@@ -257,24 +257,20 @@ int32_t read_y4m_frame_delimiter(EbConfig *cfg){
 }
 
 /* check if the input file is in YUV4MPEG2 (y4m) format */
-EbBool check_if_y4m(EbConfig *cfg){
-    char buffer[YUV4MPEG2_IND_SIZE+1];
-    size_t headerReadLength;
-
-    /* Parse the header for the "YUV4MPEG2" string */
-    headerReadLength = fread(buffer, YUV4MPEG2_IND_SIZE, 1, cfg->input_file);
-    if(headerReadLength != 1)
+EbBool check_if_y4m(EbConfig *cfg)
+{
+    size_t len;
+    char buf[YUV4MPEG2_IND_SIZE+1];
+    len = fread(buf, YUV4MPEG2_IND_SIZE, 1, cfg->input_file);
+    if (len != 1)
         return EB_FALSE;
-    buffer[YUV4MPEG2_IND_SIZE] = 0;
 
-    if (EB_STRCMP(buffer, "YUV4MPEG2") == 0) {
-        return EB_TRUE; /* YUV4MPEG2 file */
-    }else{
-        if(cfg->input_file != stdin) {
-            fseek(cfg->input_file, 0, SEEK_SET);
-        }else{
-            memcpy(cfg->y4m_buf, buffer, YUV4MPEG2_IND_SIZE); /* TODO copy 9 bytes read to cfg->y4m_buf*/
-        }
-        return EB_FALSE; /* Not a YUV4MPEG2 file */
+    if (!cfg->input_file_is_fifo) {
+        fseek(cfg->input_file, 0, SEEK_SET);
+    } else {
+        memcpy(cfg->y4m_buf, buf, YUV4MPEG2_IND_SIZE);
     }
+
+    buf[YUV4MPEG2_IND_SIZE] = 0;
+    return (EB_STRCMP(buf, "YUV4MPEG2") == 0);
 }


### PR DESCRIPTION
This is a fix for reading from a named pipe. Tested for both yuv and y4m inputs. Should address #523.