### PR TITLE
MFMV

### DIFF
--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -57,7 +57,7 @@ void LogErrorOutput(
     case EB_ENC_AMVP_ERROR5:
         fprintf(error_log_file, "Error: The availability parameter in GetSpatialMVPPosBx() function can not be > 7 !\n");
         break;
-
+#if !MFMV_SUPPORT // SVT-HEVC TMVP code
     case EB_ENC_AMVP_ERROR6:
         fprintf(error_log_file, "Error: GetTemporalMVP: tmvpMapLcuIndex must be either 0 or 1!\n");
         break;
@@ -69,7 +69,7 @@ void LogErrorOutput(
     case EB_ENC_AMVP_ERROR8:
         fprintf(error_log_file, "Error: GetTemporalMVP: tmvpMapLcuIndex must be either 0 or 1");
         break;
-
+#endif
     case EB_ENC_AMVP_NULL_REF_ERROR:
         fprintf(error_log_file, "Error: The referenceObject can not be NULL!\n");
         break;

--- a/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
+++ b/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
@@ -613,8 +613,195 @@ static INLINE int32_t find_valid_col_offset(const TileInfo *const tile, int32_t 
     return clamp(col_offset, tile->mi_col_start - mi_col,
         tile->mi_col_end - mi_col - 1);
 }
+#if MFMV_SUPPORT
+static INLINE void integer_mv_precision(MV *mv) {
+    int32_t mod = (mv->row % 8);
+    if (mod != 0) {
+        mv->row -= (int16_t)mod;
+        if (abs(mod) > 4) {
+            if (mod > 0)
+                mv->row += 8;
+            else
+                mv->row -= 8;
+        }
+    }
 
+    mod = (mv->col % 8);
+    if (mod != 0) {
+        mv->col -= (int16_t)mod;
+        if (abs(mod) > 4) {
+            if (mod > 0)
+                mv->col += 8;
+            else
+                mv->col -= 8;
+        }
+    }
+}
+static INLINE void lower_mv_precision(MV *mv, int allow_hp, int is_integer) {
+    if (is_integer)
+        integer_mv_precision(mv);
+    else {
+        if (!allow_hp) {
+            if (mv->row & 1) mv->row += (mv->row > 0 ? -1 : 1);
+            if (mv->col & 1) mv->col += (mv->col > 0 ? -1 : 1);
+        }
+    }
+}
+// Although we assign 32 bit integers, all the values are strictly under 14
+// bits.
+static int div_mult_[32] = { 0,    16384, 8192, 5461, 4096, 3276, 2730, 2340,
+                            2048, 1820,  1638, 1489, 1365, 1260, 1170, 1092,
+                            1024, 963,   910,  862,  819,  780,  744,  712,
+                            682,  655,   630,  606,  585,  564,  546,  528 };
+// TODO(jingning): Consider the use of lookup table for (num / den)
+// altogether.
+static void get_mv_projection(MV *output, MV ref, int num, int den) {
+    den = AOMMIN(den, MAX_FRAME_DISTANCE);
+    num = num > 0 ? AOMMIN(num, MAX_FRAME_DISTANCE)
+        : AOMMAX(num, -MAX_FRAME_DISTANCE);
+    const int mv_row =
+        ROUND_POWER_OF_TWO_SIGNED(ref.row * num * div_mult_[den], 14);
+    const int mv_col =
+        ROUND_POWER_OF_TWO_SIGNED(ref.col * num * div_mult_[den], 14);
+    const int clamp_max = MV_UPP - 1;
+    const int clamp_min = MV_LOW + 1;
+    output->row = (int16_t)clamp(mv_row, clamp_min, clamp_max);
+    output->col = (int16_t)clamp(mv_col, clamp_min, clamp_max);
+}
+static INLINE int get_relative_dist(const OrderHintInfo *oh, int a, int b) {
+    if (!oh->enable_order_hint) return 0;
+
+    const int bits = oh->order_hint_bits;
+
+    assert(bits >= 1);
+    assert(a >= 0 && a < (1 << bits));
+    assert(b >= 0 && b < (1 << bits));
+
+    int diff = a - b;
+    const int m = 1 << (bits - 1);
+    diff = (diff & (m - 1)) - (diff & m);
+    return diff;
+}
+static int add_tpl_ref_mv(const Av1Common *cm, PictureControlSet *picture_control_set_ptr, const MacroBlockD *xd,
+    int mi_row, int mi_col, MvReferenceFrame ref_frame,
+    int blk_row, int blk_col, IntMv *gm_mv_candidates,
+    uint8_t *const refmv_count,
+    CandidateMv ref_mv_stack[MAX_REF_MV_STACK_SIZE],
+    int16_t *mode_context) {
+    Position mi_pos;
+    mi_pos.row = (mi_row & 0x01) ? blk_row : blk_row + 1;
+    mi_pos.col = (mi_col & 0x01) ? blk_col : blk_col + 1;
+
+    if (!is_inside(&xd->tile, mi_col, mi_row, xd->tile.mi_row_end, &mi_pos)) return 0;
+
+    const TPL_MV_REF *prev_frame_mvs =
+        picture_control_set_ptr->tpl_mvs + ((mi_row + mi_pos.row) >> 1) * (cm->mi_stride >> 1) +
+        ((mi_col + mi_pos.col) >> 1);
+    if (prev_frame_mvs->mfmv0.as_int == INVALID_MV) return 0;
+
+    MvReferenceFrame rf[2];
+    av1_set_ref_frame(rf, ref_frame);
+
+    uint8_t list_idx0, list_idx1, ref_idx_l0, ref_idx_l1;
+    list_idx0 = get_list_idx(rf[0]);
+    ref_idx_l0 = get_ref_frame_idx(rf[0]);
+    if (rf[1] == NONE_FRAME) {
+        list_idx1 = get_list_idx(rf[0]);
+        ref_idx_l1 = get_ref_frame_idx(rf[0]);
+    }
+    else {
+        list_idx1 = get_list_idx(rf[1]);
+        ref_idx_l1 = get_ref_frame_idx(rf[1]);
+    }
+
+    const uint16_t weight_unit = 1;
+    const int cur_frame_index = picture_control_set_ptr->parent_pcs_ptr->cur_order_hint;
+    EbReferenceObject *buf_0 = (EbReferenceObject*)picture_control_set_ptr->ref_pic_ptr_array[list_idx0][ref_idx_l0]->object_ptr;
+
+    const int frame0_index = buf_0->order_hint;
+    const int cur_offset_0 = get_relative_dist(&picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.order_hint_info,
+        cur_frame_index, frame0_index);
+    int idx;
+
+    IntMv this_refmv;
+    get_mv_projection(&this_refmv.as_mv, prev_frame_mvs->mfmv0.as_mv,
+        cur_offset_0, prev_frame_mvs->ref_frame_offset);
+    lower_mv_precision(&this_refmv.as_mv, 0, 0);
+
+    if (rf[1] == NONE_FRAME) {
+        if (blk_row == 0 && blk_col == 0) {
+            if (abs(this_refmv.as_mv.row - gm_mv_candidates[0].as_mv.row) >= 16 ||
+                abs(this_refmv.as_mv.col - gm_mv_candidates[0].as_mv.col) >= 16)
+                mode_context[ref_frame] |= (1 << GLOBALMV_OFFSET);
+        }
+
+        for (idx = 0; idx < *refmv_count; ++idx)
+            if (this_refmv.as_int == ref_mv_stack[idx].this_mv.as_int) break;
+
+        if (idx < *refmv_count)  ref_mv_stack[idx].weight += 2 * weight_unit;
+
+        if (idx == *refmv_count && *refmv_count < MAX_REF_MV_STACK_SIZE) {
+            ref_mv_stack[idx].this_mv.as_int = this_refmv.as_int;
+            ref_mv_stack[idx].weight = 2 * weight_unit;
+            ++(*refmv_count);
+        }
+    }
+    else {
+        // Process compound inter mode
+        EbReferenceObject *buf_1 = (EbReferenceObject*)picture_control_set_ptr->ref_pic_ptr_array[list_idx1][ref_idx_l1]->object_ptr;
+
+        const int frame1_index = buf_1->order_hint;
+        const int cur_offset_1 = get_relative_dist(&picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->seq_header.order_hint_info,
+            cur_frame_index, frame1_index);
+        IntMv comp_refmv;
+        get_mv_projection(&comp_refmv.as_mv, prev_frame_mvs->mfmv0.as_mv,
+            cur_offset_1, prev_frame_mvs->ref_frame_offset);
+        lower_mv_precision(&comp_refmv.as_mv, 0, 0);
+
+        if (blk_row == 0 && blk_col == 0) {
+            if (abs(this_refmv.as_mv.row - gm_mv_candidates[0].as_mv.row) >= 16 ||
+                abs(this_refmv.as_mv.col - gm_mv_candidates[0].as_mv.col) >= 16 ||
+                abs(comp_refmv.as_mv.row - gm_mv_candidates[1].as_mv.row) >= 16 ||
+                abs(comp_refmv.as_mv.col - gm_mv_candidates[1].as_mv.col) >= 16)
+                mode_context[ref_frame] |= (1 << GLOBALMV_OFFSET);
+        }
+
+        for (idx = 0; idx < *refmv_count; ++idx) {
+            if (this_refmv.as_int == ref_mv_stack[idx].this_mv.as_int &&
+                comp_refmv.as_int == ref_mv_stack[idx].comp_mv.as_int)
+                break;
+        }
+
+        if (idx < *refmv_count)  ref_mv_stack[idx].weight += 2 * weight_unit;
+
+        if (idx == *refmv_count && *refmv_count < MAX_REF_MV_STACK_SIZE) {
+            ref_mv_stack[idx].this_mv.as_int = this_refmv.as_int;
+            ref_mv_stack[idx].comp_mv.as_int = comp_refmv.as_int;
+            ref_mv_stack[idx].weight = 2 * weight_unit;
+            ++(*refmv_count);
+        }
+    }
+
+    return 1;
+}
+
+static int check_sb_border(const int mi_row, const int mi_col,
+    const int row_offset, const int col_offset) {
+    const int sb_mi_size = mi_size_wide[BLOCK_64X64];
+    const int row = mi_row & (sb_mi_size - 1);
+    const int col = mi_col & (sb_mi_size - 1);
+
+    if (row + row_offset < 0 || row + row_offset >= sb_mi_size ||
+        col + col_offset < 0 || col + col_offset >= sb_mi_size)
+        return 0;
+
+    return 1;
+}
+#endif
 void setup_ref_mv_list(
+#if MFMV_SUPPORT
+    PictureControlSet *picture_control_set_ptr,
+#endif
     const Av1Common *cm, const MacroBlockD *xd, MvReferenceFrame ref_frame,
     uint8_t refmv_count[MODE_CTX_REF_FRAMES],
     CandidateMv ref_mv_stack[][MAX_REF_MV_STACK_SIZE],
@@ -705,6 +892,55 @@ void setup_ref_mv_list(
     for (int32_t idx = 0; idx < nearest_refmv_count[ref_frame]; ++idx)
         ref_mv_stack[ref_frame][idx].weight += REF_CAT_LEVEL;
 
+#if MFMV_SUPPORT
+    //CHKN  MFMV - get canididates from reference frames- orderHint has to be on, in order to scale the vectors.
+    if (picture_control_set_ptr->parent_pcs_ptr->frm_hdr.use_ref_frame_mvs)
+    {
+
+        int is_available = 0;
+        const int voffset = AOMMAX(mi_size_high[BLOCK_8X8], xd->n4_h);
+        const int hoffset = AOMMAX(mi_size_wide[BLOCK_8X8], xd->n4_w);
+        const int blk_row_end = AOMMIN(xd->n4_h, mi_size_high[BLOCK_64X64]);
+        const int blk_col_end = AOMMIN(xd->n4_w, mi_size_wide[BLOCK_64X64]);
+
+        const int tpl_sample_pos[3][2] = {
+          { voffset, -2 },
+          { voffset, hoffset },
+          { voffset - 2, hoffset },
+        };
+        const int allow_extension = (xd->n4_h >= mi_size_high[BLOCK_8X8]) &&
+            (xd->n4_h < mi_size_high[BLOCK_64X64]) &&
+            (xd->n4_w >= mi_size_wide[BLOCK_8X8]) &&
+            (xd->n4_w < mi_size_wide[BLOCK_64X64]);
+
+        const int step_h = (xd->n4_h >= mi_size_high[BLOCK_64X64])
+            ? mi_size_high[BLOCK_16X16]
+            : mi_size_high[BLOCK_8X8];
+        const int step_w = (xd->n4_w >= mi_size_wide[BLOCK_64X64])
+            ? mi_size_wide[BLOCK_16X16]
+            : mi_size_wide[BLOCK_8X8];
+
+        for (int blk_row = 0; blk_row < blk_row_end; blk_row += step_h) {
+            for (int blk_col = 0; blk_col < blk_col_end; blk_col += step_w) {
+                int ret = add_tpl_ref_mv(cm, picture_control_set_ptr, xd, mi_row, mi_col, ref_frame, blk_row,
+                    blk_col, gm_mv_candidates, &refmv_count[ref_frame],
+                    ref_mv_stack[ref_frame], mode_context);
+                if (blk_row == 0 && blk_col == 0) is_available = ret;
+            }
+        }
+
+        if (is_available == 0) mode_context[ref_frame] |= (1 << GLOBALMV_OFFSET);
+
+        for (int i = 0; i < 3 && allow_extension; ++i) {
+            const int blk_row = tpl_sample_pos[i][0];
+            const int blk_col = tpl_sample_pos[i][1];
+
+            if (!check_sb_border(mi_row, mi_col, blk_row, blk_col)) continue;
+            add_tpl_ref_mv(cm, picture_control_set_ptr, xd, mi_row, mi_col, ref_frame, blk_row, blk_col,
+                gm_mv_candidates, &refmv_count[ref_frame], ref_mv_stack[ref_frame], mode_context);
+        }
+    }
+#else
     //-------------------------- TMVP --------------------------
     //CHKN  TMVP - get canididates from reference frames- orderHint has to be on,
     // in order to scale the vectors.
@@ -712,7 +948,7 @@ void setup_ref_mv_list(
     // the mode context too.
 
     //-------------------------- TMVP --------------------------
-
+#endif
     //CHKN------------- TOP-LEFT
     uint8_t dummy_newmv_count[MODE_CTX_REF_FRAMES] = { 0 };
 
@@ -1042,7 +1278,7 @@ void setup_ref_mv_list(
     }
     (void)nearest_match;
 }
-
+#if !MFMV_SUPPORT
 static INLINE void integer_mv_precision(MV *mv) {
     int32_t mod = (mv->row % 8);
     if (mod != 0) {
@@ -1066,7 +1302,7 @@ static INLINE void integer_mv_precision(MV *mv) {
         }
     }
 }
-
+#endif
 static INLINE IntMv gm_get_motion_vector(
     const EbWarpedMotionParams *gm,
     int32_t allow_hp,
@@ -1195,7 +1431,11 @@ void generate_av1_mvp_table(
         }
         else
             zeromv[0].as_int = zeromv[1].as_int = 0;
-        setup_ref_mv_list(cm,
+        setup_ref_mv_list(
+#if MFMV_SUPPORT
+            picture_control_set_ptr,
+#endif
+            cm,
             xd,
             ref_frame,
             xd->ref_mv_count,
@@ -2124,7 +2364,7 @@ IntMv eb_av1_get_ref_mv_from_stack(int ref_idx,
     }
     return ref_mv;
 }
-
+#if !MFMV_SUPPORT
 static INLINE void lower_mv_precision(MV *mv, int allow_hp, int is_integer) {
     if (is_integer)
         integer_mv_precision(mv);
@@ -2135,6 +2375,7 @@ static INLINE void lower_mv_precision(MV *mv, int allow_hp, int is_integer) {
         }
     }
 }
+#endif
 void eb_av1_find_best_ref_mvs_from_stack(int allow_hp,
     //const MB_MODE_INFO_EXT *mbmi_ext,
     CandidateMv ref_mv_stack[][MAX_REF_MV_STACK_SIZE],

--- a/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
+++ b/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
@@ -726,8 +726,11 @@ static int add_tpl_ref_mv(const Av1Common *cm, PictureControlSet *picture_contro
     IntMv this_refmv;
     get_mv_projection(&this_refmv.as_mv, prev_frame_mvs->mfmv0.as_mv,
         cur_offset_0, prev_frame_mvs->ref_frame_offset);
+#if MFMV_SUPPORT
+    lower_mv_precision(&this_refmv.as_mv, picture_control_set_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv, 0);
+#else
     lower_mv_precision(&this_refmv.as_mv, 0, 0);
-
+#endif
     if (rf[1] == NONE_FRAME) {
         if (blk_row == 0 && blk_col == 0) {
             if (abs(this_refmv.as_mv.row - gm_mv_candidates[0].as_mv.row) >= 16 ||
@@ -756,8 +759,11 @@ static int add_tpl_ref_mv(const Av1Common *cm, PictureControlSet *picture_contro
         IntMv comp_refmv;
         get_mv_projection(&comp_refmv.as_mv, prev_frame_mvs->mfmv0.as_mv,
             cur_offset_1, prev_frame_mvs->ref_frame_offset);
+#if MFMV_SUPPORT
+        lower_mv_precision(&comp_refmv.as_mv, picture_control_set_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv, 0);
+#else
         lower_mv_precision(&comp_refmv.as_mv, 0, 0);
-
+#endif
         if (blk_row == 0 && blk_col == 0) {
             if (abs(this_refmv.as_mv.row - gm_mv_candidates[0].as_mv.row) >= 16 ||
                 abs(this_refmv.as_mv.col - gm_mv_candidates[0].as_mv.col) >= 16 ||

--- a/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.h
+++ b/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.h
@@ -20,7 +20,7 @@ extern "C" {
 
     struct ModeDecisionContext;
     struct InterPredictionContext;
-
+#if !MFMV_SUPPORT // SVT-HEVC TMVP code
     typedef enum TmvpPos
     {
         TmvpColocatedBottomRight = 0,
@@ -37,7 +37,7 @@ extern "C" {
 
         //*Note- list 1 motion info will be added when B-slices are ready
     } TmvpUnit;
-
+#endif
     extern EbErrorType clip_mv(
         uint32_t  cu_origin_x,
         uint32_t  cu_origin_y,

--- a/Source/Lib/Common/Codec/EbCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbCodingLoop.c
@@ -2186,7 +2186,42 @@ void perform_intra_coding_loop(
         }
     } // Transform Loop
 }
+#if MFMV_SUPPORT
+#define REFMVS_LIMIT ((1 << 12) - 1)
 
+void av1_copy_frame_mvs(PictureControlSet *picture_control_set_ptr, const Av1Common *const cm,
+    MbModeInfo  mi, int mi_row, int mi_col,
+    int x_mis, int y_mis, EbReferenceObject *object_ptr) {
+    const int frame_mvs_stride = ROUND_POWER_OF_TWO(cm->mi_cols, 1);
+    MV_REF *frame_mvs = object_ptr->mvs + (mi_row >> 1) * frame_mvs_stride + (mi_col >> 1);
+    x_mis = ROUND_POWER_OF_TWO(x_mis, 1);
+    y_mis = ROUND_POWER_OF_TWO(y_mis, 1);
+    int w, h;
+
+    for (h = 0; h < y_mis; h++) {
+        MV_REF *mv = frame_mvs;
+        for (w = 0; w < x_mis; w++) {
+            mv->ref_frame = NONE_FRAME;
+            mv->mv.as_int = 0;
+
+            for (int idx = 0; idx < 2; ++idx) {
+                MvReferenceFrame ref_frame = mi.ref_frame[idx];
+                if (ref_frame > INTRA_FRAME) {
+                    int8_t ref_idx = picture_control_set_ptr->ref_frame_side[ref_frame];
+                    if (ref_idx) continue;
+                    if ((abs(mi.mv[idx].as_mv.row) > REFMVS_LIMIT) ||
+                        (abs(mi.mv[idx].as_mv.col) > REFMVS_LIMIT))
+                        continue;
+                    mv->ref_frame = ref_frame;
+                    mv->mv.as_int = mi.mv[idx].as_int;
+                }
+            }
+            mv++;
+        }
+        frame_mvs += frame_mvs_stride;
+    }
+}
+#endif
 /*******************************************
 * Encode Pass
 *
@@ -3826,6 +3861,25 @@ EB_EXTERN void av1_encode_pass(
 
                     move_cu_data(src_cu, dst_cu);
                 }
+#if MFMV_SUPPORT
+                if (sequence_control_set_ptr->mfmv_enabled && picture_control_set_ptr->slice_type != I_SLICE && picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) {
+#if INCOMPLETE_SB_FIX
+                    uint32_t mi_stride = picture_control_set_ptr->mi_stride;
+#else
+                    uint32_t mi_stride = picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->picture_width_in_sb*(BLOCK_SIZE_64 >> MI_SIZE_LOG2);
+#endif
+                    int32_t mi_row = context_ptr->cu_origin_y >> MI_SIZE_LOG2;
+                    int32_t mi_col = context_ptr->cu_origin_x >> MI_SIZE_LOG2;
+                    const int32_t offset = mi_row * mi_stride + mi_col;
+                    ModeInfo *miPtr = *(picture_control_set_ptr->mi_grid_base + offset);
+                    const int x_mis = AOMMIN(context_ptr->blk_geom->bwidth, picture_control_set_ptr->parent_pcs_ptr->av1_cm->mi_cols - mi_col);
+                    const int y_mis = AOMMIN(context_ptr->blk_geom->bheight, picture_control_set_ptr->parent_pcs_ptr->av1_cm->mi_rows - mi_row);
+                    EbReferenceObject *obj_l0 = (EbReferenceObject*)picture_control_set_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr;
+
+                    av1_copy_frame_mvs(picture_control_set_ptr, picture_control_set_ptr->parent_pcs_ptr->av1_cm, miPtr->mbmi,
+                        mi_row, mi_col, x_mis, y_mis, obj_l0);
+                }
+#endif
             }
             blk_it += ns_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][context_ptr->blk_geom->depth];
         }

--- a/Source/Lib/Common/Codec/EbCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbCodingLoop.c
@@ -3863,11 +3863,7 @@ EB_EXTERN void av1_encode_pass(
                 }
 #if MFMV_SUPPORT
                 if (sequence_control_set_ptr->mfmv_enabled && picture_control_set_ptr->slice_type != I_SLICE && picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) {
-#if INCOMPLETE_SB_FIX
                     uint32_t mi_stride = picture_control_set_ptr->mi_stride;
-#else
-                    uint32_t mi_stride = picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->picture_width_in_sb*(BLOCK_SIZE_64 >> MI_SIZE_LOG2);
-#endif
                     int32_t mi_row = context_ptr->cu_origin_y >> MI_SIZE_LOG2;
                     int32_t mi_col = context_ptr->cu_origin_x >> MI_SIZE_LOG2;
                     const int32_t offset = mi_row * mi_stride + mi_col;

--- a/Source/Lib/Common/Codec/EbCodingUnit.h
+++ b/Source/Lib/Common/Codec/EbCodingUnit.h
@@ -199,6 +199,17 @@ extern "C" {
         uint8_t tx_depth;
     } MbModeInfo;
 
+#if MFMV_SUPPORT
+    typedef struct {
+        IntMv mfmv0;
+        uint8_t ref_frame_offset;
+    } TPL_MV_REF;
+    typedef struct {
+        IntMv mv;
+        MvReferenceFrame ref_frame;
+    } MV_REF;
+#endif
+
     typedef struct ModeInfo {
         MbModeInfo mbmi;
     } ModeInfo;

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -57,6 +57,9 @@ extern "C" {
 #define COMP_MODE                         1 // Add inter-inter compound modes
 #define PREDICTIVE_ME                     1 // Perform ME search around MVP @ MD
 
+
+#define MFMV_SUPPORT                      1// Temporal mvp support. aka. MFMV
+
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC                         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch
 
@@ -2451,7 +2454,7 @@ typedef enum DownSamplingMethod
 //***Segments***
 #define EB_SEGMENT_MIN_COUNT                        1
 #define EB_SEGMENT_MAX_COUNT                        64
-
+#if !MFMV_SUPPORT // SVT-HEVC TMVP code
 //***TMVP***
 #define LOG_MV_COMPRESS_UNIT_SIZE                   4
 #define MAX_TMVP_CAND_PER_LCU                       (BLOCK_SIZE_64 >> LOG_MV_COMPRESS_UNIT_SIZE)*(BLOCK_SIZE_64 >> LOG_MV_COMPRESS_UNIT_SIZE)
@@ -2466,7 +2469,7 @@ typedef enum DownSamplingMethod
 #define MAX_MODE_DECISION_CATEGORY_NUM              6
 #define LOG_MAX_AMVP_MODE_DECISION_CANDIDATE_NUM    2
 #define MAX_AMVP_MODE_DECISION_CANDIDATE_NUM        (1 << LOG_MAX_AMVP_MODE_DECISION_CANDIDATE_NUM)
-
+#endif
 #define CU_MAX_COUNT                                85
 
 #define EB_EVENT_MAX_COUNT                          20

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1157,6 +1157,13 @@ void CopyStatisticsToRefObject(
 
     Av1Common* cm = picture_control_set_ptr->parent_pcs_ptr->av1_cm;
     ((EbReferenceObject*)picture_control_set_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)->sg_frame_ep = cm->sg_frame_ep;
+#if MFMV_SUPPORT
+    if (sequence_control_set_ptr->mfmv_enabled) {
+        ((EbReferenceObject*)picture_control_set_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)->frame_type = picture_control_set_ptr->parent_pcs_ptr->frm_hdr.frame_type;
+        ((EbReferenceObject*)picture_control_set_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)->order_hint = picture_control_set_ptr->parent_pcs_ptr->cur_order_hint;
+        memcpy(((EbReferenceObject*)picture_control_set_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)->ref_order_hint, picture_control_set_ptr->parent_pcs_ptr->ref_order_hint, 7 * sizeof(uint32_t));
+    }
+#endif
 }
 
 /******************************************************

--- a/Source/Lib/Common/Codec/EbEncDecProcess.h
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.h
@@ -51,10 +51,10 @@ extern "C" {
         EbBool                               is_md_rate_estimation_ptr_owner;
         ModeDecisionContext                 *md_context;
         const BlockGeom                     *blk_geom;
-
+#if !MFMV_SUPPORT // SVT-HEVC TMVP code
         // TMVP
         EbReferenceObject                   *reference_object_write_ptr;
-
+#endif
         // MCP Context
         MotionCompensationPredictionContext *mcp_context;
         SsMeContext                         *ss_mecontext;
@@ -88,7 +88,9 @@ extern "C" {
         uint8_t                                sb_sz;
         uint32_t                               sb_index;
         MvUnit                               mv_unit;
+#if !MFMV_SUPPORT // SVT-HEVC TMVP code
         int16_t                                x_mv_amvp_candidate_array_list0[MAX_NUM_OF_AMVP_CANDIDATES];
+#endif
         uint8_t                                txb_itr;
         EbBool                                 is16bit; //enable 10 bit encode in CL
         EbColorFormat                          color_format;

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -419,7 +419,7 @@ EbBool mrp_is_already_injected_mv_bipred(
     }
     return(EB_FALSE);
 }
-
+#if !MFMV_SUPPORT // SVT-HEVC TMVP code
 EbErrorType SetMvpClipMVs(
     ModeDecisionCandidate  *candidate_ptr,
     uint32_t                    cu_origin_x,
@@ -521,7 +521,7 @@ void LimitMvOverBound(
     if ((int32_t)ctxtPtr->cu_origin_y + mvyF < 0)
         *mvy = -(int16_t)ctxtPtr->cu_origin_y;
 }
-
+#endif
 void sort_fast_loop_candidates(
     struct ModeDecisionContext   *context_ptr,
     uint32_t                        buffer_total_count,

--- a/Source/Lib/Common/Codec/EbPictureBufferDesc.h
+++ b/Source/Lib/Common/Codec/EbPictureBufferDesc.h
@@ -299,6 +299,9 @@ extern "C" {
         uint16_t          bot_padding;
         EbBool            split_mode;         //ON: allocate 8bit data seperately from nbit data
         EbBool            down_sampled_filtered;
+#if MFMV_SUPPORT
+        uint8_t           mfmv;
+#endif
     } EbPictureBufferDescInitData;
 
     /**************************************

--- a/Source/Lib/Common/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.c
@@ -1019,6 +1019,17 @@ EbErrorType picture_control_set_ctor(
         object_ptr->mi_grid_base[miIdx] = object_ptr->mip + miIdx;
     object_ptr->mi_stride = pictureLcuWidth * (BLOCK_SIZE_64 / 4);
 #endif
+#if MFMV_SUPPORT
+    if (initDataPtr->mfmv)
+    {
+        //MFMV: map is 8x8 based.
+        uint32_t mi_rows = initDataPtr->picture_height >> MI_SIZE_LOG2;
+        const int mem_size = ((mi_rows + MAX_MIB_SIZE) >> 1) * (object_ptr->mi_stride >> 1);
+
+        EB_MALLOC_ALIGNED_ARRAY(object_ptr->tpl_mvs, mem_size);
+        memset(object_ptr->tpl_mvs, 0, sizeof(TPL_MV_REF)*mem_size);
+    }
+#endif
     object_ptr->hash_table.p_lookup_table = NULL;
     av1_hash_table_create(&object_ptr->hash_table);
     return EB_ErrorNone;

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -13865,6 +13865,10 @@ extern "C" {
         EbWarpedMotionParams    ref_global_motion[TOTAL_REFS_PER_FRAME];
         struct MdRateEstimationContext *md_rate_estimation_array;
 #endif
+#if MFMV_SUPPORT
+        int8_t ref_frame_side[REF_FRAMES];
+        TPL_MV_REF  *tpl_mvs;
+#endif
     } PictureControlSet;
 
     // To optimize based on the max input size
@@ -14290,6 +14294,9 @@ extern "C" {
         uint8_t                            nsq_present;
 #if INCOMPLETE_SB_FIX
         uint8_t                            over_boundary_block_mode;
+#endif
+#if MFMV_SUPPORT
+        uint8_t                            mfmv;
 #endif
     } PictureControlSetInitData;
 

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -95,7 +95,11 @@ void eb_av1_setup_skip_mode_allowed(PictureParentControlSet  *parent_pcs_ptr) {
     skip_mode_info->skip_mode_allowed = 0;
     skip_mode_info->ref_frame_idx_0 = INVALID_IDX;
     skip_mode_info->ref_frame_idx_1 = INVALID_IDX;
-
+#if MFMV_SUPPORT
+    parent_pcs_ptr->cur_order_hint = parent_pcs_ptr->picture_number % (uint64_t)(1 << (parent_pcs_ptr->sequence_control_set_ptr->seq_header.order_hint_info.order_hint_bits));
+    for (uint8_t i = 0; i < 7; ++i)
+        parent_pcs_ptr->ref_order_hint[i] = (uint32_t)ref_frame_arr_single[i].poc;
+#endif
     if (/*!order_hint_info->enable_order_hint ||*/ parent_pcs_ptr->slice_type == I_SLICE /*frame_is_intra_only(cm)*/ ||
         frm_hdr->reference_mode == SINGLE_REFERENCE)
         return;
@@ -177,7 +181,7 @@ void eb_av1_setup_skip_mode_allowed(PictureParentControlSet  *parent_pcs_ptr) {
     //4 :BWD
     //5 :ALT2
     //6 :ALT
-#if COMP_MODE
+#if COMP_MODE && !MFMV_SUPPORT
     parent_pcs_ptr->cur_order_hint = parent_pcs_ptr->picture_number % (uint64_t)(1 << (parent_pcs_ptr->sequence_control_set_ptr->seq_header.order_hint_info.order_hint_bits));
     for (uint8_t i = 0; i < 7; ++i)
         parent_pcs_ptr->ref_order_hint[i] = (uint32_t)ref_frame_arr_single[i].poc;
@@ -1233,6 +1237,14 @@ EbErrorType signal_derivation_multi_processes_oq(
             picture_control_set_ptr->frame_end_cdf_update_mode = 1;
         else
             picture_control_set_ptr->frame_end_cdf_update_mode = 0;
+#endif
+#if MFMV_SUPPORT
+        //CHKN: Temporal MVP should be disabled for pictures beloning to 4L MiniGop preceeded by 5L miniGOP. in this case the RPS is wrong(known issue). check RPS construction for more info.
+        if ((sequence_control_set_ptr->static_config.hierarchical_levels == 4 && picture_control_set_ptr->hierarchical_levels == 3) ||
+            picture_control_set_ptr->slice_type == I_SLICE)
+            picture_control_set_ptr->frm_hdr.use_ref_frame_mvs = 0;
+        else
+            picture_control_set_ptr->frm_hdr.use_ref_frame_mvs = sequence_control_set_ptr->mfmv_enabled;
 #endif
     return return_error;
 }

--- a/Source/Lib/Common/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureManagerProcess.c
@@ -810,6 +810,16 @@ void* picture_manager_kernel(void *input_ptr)
                                         EB_ENC_PM_ERROR1);
                                 }
                             }
+#if MFMV_SUPPORT
+                            //fill the non used spots to be used in MFMV.
+                            for (refIdx = entryPictureControlSetPtr->ref_list0_count; refIdx < 4; ++refIdx)
+                                ChildPictureControlSetPtr->ref_pic_ptr_array[REF_LIST_0][refIdx] = ChildPictureControlSetPtr->ref_pic_ptr_array[REF_LIST_0][0];
+
+                            if (entryPictureControlSetPtr->ref_list1_count == 0) {
+                                for (refIdx = entryPictureControlSetPtr->ref_list1_count; refIdx < 3; ++refIdx)
+                                    ChildPictureControlSetPtr->ref_pic_ptr_array[REF_LIST_1][refIdx] = ChildPictureControlSetPtr->ref_pic_ptr_array[REF_LIST_0][0];
+                            }
+#endif
                         }
 
                         // Configure List1
@@ -854,6 +864,13 @@ void* picture_manager_kernel(void *input_ptr)
                                         EB_ENC_PM_ERROR1);
                                 }
                             }
+#if MFMV_SUPPORT
+                            //fill the non used spots to be used in MFMV.
+                            if (entryPictureControlSetPtr->ref_list1_count) {
+                                for (refIdx = entryPictureControlSetPtr->ref_list1_count; refIdx < 3; ++refIdx)
+                                    ChildPictureControlSetPtr->ref_pic_ptr_array[REF_LIST_1][refIdx] = ChildPictureControlSetPtr->ref_pic_ptr_array[REF_LIST_1][0];
+                            }
+#endif
                         }
 
                         // Adjust the Slice-type if the Lists are Empty, but don't reset the Prediction Structure

--- a/Source/Lib/Common/Codec/EbReferenceObject.c
+++ b/Source/Lib/Common/Codec/EbReferenceObject.c
@@ -178,6 +178,17 @@ EbErrorType eb_reference_object_ctor(
             pictureBufferDescInitDataPtr,
             pictureBufferDescInitData16BitPtr.bit_depth);
     }
+#if MFMV_SUPPORT
+    if (pictureBufferDescInitDataPtr->mfmv)
+    {
+        //MFMV map is 8x8 based.
+        uint32_t mi_rows = referenceObject->reference_picture->height >> MI_SIZE_LOG2;
+        uint32_t mi_cols = referenceObject->reference_picture->width >> MI_SIZE_LOG2;
+        const int mem_size = ((mi_rows + 1) >> 1) * ((mi_cols + 1) >> 1);
+        EB_MALLOC_ALIGNED_ARRAY(referenceObject->mvs, mem_size);
+        memset(referenceObject->mvs, 0, sizeof(MV_REF)*mem_size);
+    }
+#endif
     memset(&referenceObject->film_grain_params, 0, sizeof(referenceObject->film_grain_params));
 
     return EB_ErrorNone;

--- a/Source/Lib/Common/Codec/EbReferenceObject.h
+++ b/Source/Lib/Common/Codec/EbReferenceObject.h
@@ -38,6 +38,12 @@ typedef struct EbReferenceObject
     FRAME_CONTEXT                   frame_context;
     EbWarpedMotionParams            global_motion[TOTAL_REFS_PER_FRAME];
 #endif
+#if MFMV_SUPPORT
+    MV_REF                         *mvs;
+    FrameType                       frame_type;
+    uint32_t                        order_hint;
+    uint32_t                        ref_order_hint[7];
+#endif
 } EbReferenceObject;
 
 typedef struct EbReferenceObjectDescInitData {

--- a/Source/Lib/Common/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Common/Codec/EbResourceCoordinationProcess.c
@@ -308,8 +308,10 @@ void ResetPcsAv1(
     frm_hdr->quantization_params.qm_y = 5;
     frm_hdr->quantization_params.qm_u = 5;
     frm_hdr->quantization_params.qm_v = 5;
+#if ! MFMV_SUPPORT
     // Whether to use previous frame's motion vectors for prediction.
     frm_hdr->use_ref_frame_mvs = 0;
+#endif
     frm_hdr->is_motion_mode_switchable = 0;
     // Flag signaling how frame contexts should be updated at the end of
     // a frame decode

--- a/Source/Lib/Common/Codec/EbRestProcess.c
+++ b/Source/Lib/Common/Codec/EbRestProcess.c
@@ -310,7 +310,7 @@ void* rest_kernel(void *input_ptr)
                     picture_control_set_ptr,
                     sequence_control_set_ptr);
 
-            // Pad the reference picture and set up TMVP flag and ref POC
+            // Pad the reference picture and set ref POC
             if (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE)
                 PadRefAndSetFlags(
                     picture_control_set_ptr,

--- a/Source/Lib/Common/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Common/Codec/EbSequenceControlSet.c
@@ -96,10 +96,10 @@ EbErrorType eb_sequence_control_set_ctor(
     sequence_control_set_ptr->general_progressive_source_flag = 1;
     sequence_control_set_ptr->general_interlaced_source_flag = 0;
     sequence_control_set_ptr->general_frame_only_constraint_flag = 0;
-
+#if !MFMV_SUPPORT // SVT-HEVC TMVP code
     // temporal mvp enable flag
     sequence_control_set_ptr->enable_tmvp_sps = 1;
-
+#endif
     // Rate Control
     sequence_control_set_ptr->rate_control_mode = 0;
     sequence_control_set_ptr->target_bitrate = 0x1000;
@@ -107,10 +107,10 @@ EbErrorType eb_sequence_control_set_ctor(
 
     // Quantization
     sequence_control_set_ptr->qp = 20;
-
+#if !MFMV_SUPPORT // SVT-HEVC TMVP code
     // mv merge
     sequence_control_set_ptr->mv_merge_total_count = 5;
-
+#endif
     // Initialize SB params
     EB_MALLOC_ARRAY(sequence_control_set_ptr->sb_params_array,
         ((MAX_PICTURE_WIDTH_SIZE + sequence_control_set_ptr->sb_sz - 1) / sequence_control_set_ptr->sb_sz) *
@@ -248,8 +248,10 @@ EbErrorType copy_sequence_control_set(
     dst->target_bitrate = src->target_bitrate;                           writeCount += sizeof(uint32_t);
     dst->available_bandwidth = src->available_bandwidth;                      writeCount += sizeof(uint32_t);
     dst->qp = src->qp;                                      writeCount += sizeof(uint32_t);
+#if !MFMV_SUPPORT // SVT-HEVC TMVP code
     dst->enable_tmvp_sps = src->enable_tmvp_sps;                           writeCount += sizeof(uint32_t);
     dst->mv_merge_total_count = src->mv_merge_total_count;                       writeCount += sizeof(uint32_t);
+#endif
     dst->film_grain_denoise_strength = src->film_grain_denoise_strength;          writeCount += sizeof(int32_t);
     dst->seq_header.film_grain_params_present = src->seq_header.film_grain_params_present;              writeCount += sizeof(int32_t);
     dst->seq_header.film_grain_params_present = src->seq_header.film_grain_params_present;              writeCount += sizeof(int32_t);
@@ -305,6 +307,9 @@ EbErrorType copy_sequence_control_set(
     dst->tf_segment_row_count = src->tf_segment_row_count;
 #if INCOMPLETE_SB_FIX
     dst->over_boundary_block_mode = src->over_boundary_block_mode;
+#endif
+#if MFMV_SUPPORT
+    dst->mfmv_enabled = src->mfmv_enabled;
 #endif
     return EB_ErrorNone;
 }

--- a/Source/Lib/Common/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Common/Codec/EbSequenceControlSet.h
@@ -109,13 +109,13 @@ extern "C" {
 
         // Quantization
         uint32_t                                qp;
-
+#if !MFMV_SUPPORT // SVT-HEVC TMVP code
         // tmvp enable
         uint32_t                                enable_tmvp_sps;
 
         // MV merge
         uint32_t                                mv_merge_total_count;
-
+#endif
         // Picture Analysis
         uint32_t                                picture_analysis_number_of_regions_per_width;
         uint32_t                                picture_analysis_number_of_regions_per_height;
@@ -201,6 +201,9 @@ extern "C" {
         *
         * Default is 0. */
         uint8_t                                 down_sampling_method_me_search;
+#if MFMV_SUPPORT
+        uint8_t                                 mfmv_enabled; // 1:Enabled  0:Disabled
+#endif
         uint8_t                                 trans_coeff_shape_array[2][8][4];    // [componantTypeIndex][resolutionIndex][levelIndex][tuSizeIndex]
         EbBlockMeanPrec                         block_mean_calc_prec;
         BitstreamLevel                          level[MAX_NUM_OPERATING_POINTS];

--- a/Source/Lib/Decoder/Codec/EbDecBlock.h
+++ b/Source/Lib/Decoder/Codec/EbDecBlock.h
@@ -112,7 +112,6 @@ typedef struct CandidateMvDec {
     IntMvDec comp_mv;
     int32_t weight;
 } CandidateMvDec;
-
 #define MFMV_STACK_SIZE 3
 typedef struct TemporalMvRef {
     /* Motion Filed MV */

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -953,6 +953,9 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         inputData.max_depth = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->max_sb_depth;
         inputData.hbd_mode_decision = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->static_config.enable_hbd_mode_decision;
         inputData.cdf_mode = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->cdf_mode;
+#if MFMV_SUPPORT
+        inputData.mfmv = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->mfmv_enabled;
+#endif
         EB_NEW(
             enc_handle_ptr->picture_control_set_pool_ptr_array[instance_index],
             eb_system_resource_ctor,
@@ -1007,6 +1010,9 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         referencePictureBufferDescInitData.right_padding = PAD_VALUE;
         referencePictureBufferDescInitData.top_padding = PAD_VALUE;
         referencePictureBufferDescInitData.bot_padding = PAD_VALUE;
+#if MFMV_SUPPORT
+        referencePictureBufferDescInitData.mfmv = enc_handle_ptr->sequence_control_set_instance_array[instance_index]->sequence_control_set_ptr->mfmv_enabled;
+#endif
         // Hsan: split_mode is set @ eb_reference_object_ctor() as both unpacked reference and packed reference are needed for a 10BIT input; unpacked reference @ MD, and packed reference @ EP
 
         if (is16bit)
@@ -2003,6 +2009,9 @@ void SetParamBasedOnInput(SequenceControlSet *sequence_control_set_ptr)
         sequence_control_set_ptr->over_boundary_block_mode = 1;
     else
         sequence_control_set_ptr->over_boundary_block_mode = 0;
+#endif
+#if MFMV_SUPPORT
+    sequence_control_set_ptr->mfmv_enabled = (uint8_t)(sequence_control_set_ptr->static_config.enc_mode == ENC_M0) ? 1 : 0;
 #endif
 }
 


### PR DESCRIPTION
## Description

Added MFMV as MVP.
Removed TMVP code (SVT-HEVC unused code)

Closes #578

## Author

@hguermaz 

## Type of change

New feature/Tool

## Tests and performance
* BD-Rate to aom cpu0-2pass on a subset of 360p clips:  0.953% gain
* Speed on a 4-core machine:  3.5% decrease
* Memory footprint on a 4-core machine: 0.5% increase