### PR TITLE
Optimizing kernels construct_best_sorted_arrays_md_stage_2/3

### DIFF
--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -1817,23 +1817,192 @@ void sort_stage0_fast_candidates(
     }
 }
 
+static INLINE void heap_sort_stage_max_node_fast_cost_ptr(
+    ModeDecisionCandidateBuffer **buffer_ptr,
+    uint32_t* sort_index, uint32_t i, uint32_t num)
+{
+    uint32_t left, right, max;
+
+    /* Loop for removing recursion. */
+    while (1) {
+        left = 2 * i;
+        right = 2 * i + 1;
+        max = i;
+
+        if (left <= num && *(buffer_ptr[sort_index[left]]->fast_cost_ptr) >
+            *(buffer_ptr[sort_index[i]]->fast_cost_ptr)) {
+            max = left;
+        }
+
+        if (right <= num && *(buffer_ptr[sort_index[right]]->fast_cost_ptr) >
+            *(buffer_ptr[sort_index[max]]->fast_cost_ptr)) {
+            max = right;
+        }
+
+        if (max == i) {
+            break;
+        }
+
+        uint32_t swap = sort_index[i];
+        sort_index[i] = sort_index[max];
+        sort_index[max] = swap;
+        i = max;
+    }
+}
+
+static void qsort_stage_max_node_fast_cost_ptr(
+    ModeDecisionCandidateBuffer **buffer_ptr_array, uint32_t *dst,
+    uint32_t *a, uint32_t *b, int num)
+{
+    if (num < 4) {
+        if (num < 2) {
+            if (num) {
+                //num = 1
+                dst[0] = a[0];
+            }
+            return;
+        }
+        if (num > 2) {
+            //num = 3
+            uint32_t tmp_a = a[0];
+            uint32_t tmp_b = a[1];
+            uint32_t tmp_c = a[2];
+            uint64_t val_a = *(buffer_ptr_array[tmp_a]->fast_cost_ptr);
+            uint64_t val_b = *(buffer_ptr_array[tmp_b]->fast_cost_ptr);
+            uint64_t val_c = *(buffer_ptr_array[tmp_c]->fast_cost_ptr);
+
+            if (val_a < val_b) {
+                if (val_b < val_c) {
+                    //Sorted abc
+                    dst[0] = tmp_a;
+                    dst[1] = tmp_b;
+                    dst[2] = tmp_c;
+                }
+                else {
+                    //xcx
+                    if (val_a < val_c) {
+                        //Sorted 132
+                        dst[0] = tmp_a;
+                        dst[1] = tmp_c;
+                        dst[2] = tmp_b;
+                    }
+                    else {
+                        //Sorted 231
+                        dst[0] = tmp_c;
+                        dst[1] = tmp_a;
+                        dst[2] = tmp_b;
+                    }
+                }
+            }
+            else {
+                //a>b
+                if (val_b > val_c) {
+                    //Sorted cba
+                    dst[0] = tmp_c;
+                    dst[1] = tmp_b;
+                    dst[2] = tmp_a;
+                }
+                else {
+                    //bxx
+                    if (val_a < val_c) {
+                        //Sorted bac
+                        dst[0] = tmp_b;
+                        dst[1] = tmp_a;
+                        dst[2] = tmp_c;
+                    }
+                    else {
+                        //Sorted bca
+                        dst[0] = tmp_b;
+                        dst[1] = tmp_c;
+                        dst[2] = tmp_a;
+                    }
+                }
+            }
+            return;
+        }
+
+        /* bacuse a and dst can point on this same array, copy temporary values*/
+        uint32_t tmp_a = a[0];
+        uint32_t tmp_b = a[1];
+        if (*(buffer_ptr_array[tmp_a]->fast_cost_ptr) < *(buffer_ptr_array[tmp_b]->fast_cost_ptr)) {
+            dst[0] = tmp_a;
+            dst[1] = tmp_b;
+        }
+        else {
+            dst[0] = tmp_b;
+            dst[1] = tmp_a;
+        }
+        return;
+    }
+
+    int sorted_down = 0;
+    int sorted_up = num - 1;
+
+    uint64_t pivot_val = *(buffer_ptr_array[a[0]]->fast_cost_ptr);
+    for (int i = 1; i < num; ++i) {
+        if (pivot_val < *(buffer_ptr_array[a[i]]->fast_cost_ptr)) {
+            b[sorted_up] = a[i];
+            sorted_up--;
+        }
+        else {
+            b[sorted_down] = a[i];
+            sorted_down++;
+        }
+    }
+
+    dst[sorted_down] = a[0];
+
+    qsort_stage_max_node_fast_cost_ptr(buffer_ptr_array, dst,
+        b, a, sorted_down);
+
+    qsort_stage_max_node_fast_cost_ptr(buffer_ptr_array, dst + (sorted_down + 1),
+        b + (sorted_down + 1), a + (sorted_down + 1), num - (sorted_down)-1);
+}
+
+static INLINE void sort_array_index_fast_cost_ptr(
+    ModeDecisionCandidateBuffer** buffer_ptr,
+    uint32_t* sort_index, uint32_t num)
+{
+    if (num <= 60) {
+        //For small array uses 'quick sort', work much faster for small array,
+        //but required alloc temporary memory.
+        uint32_t  sorted_tmp[60];
+        qsort_stage_max_node_fast_cost_ptr(buffer_ptr, sort_index, sort_index, sorted_tmp, num);
+        return;
+    }
+
+    //For big arrays uses 'heap sort', not need allocate memory
+    //For small array less that 40 elements heap sort work slower than 'insertion sort'
+    uint32_t i;
+    for (i = (num - 1) / 2; i > 0; i--)
+    {
+        heap_sort_stage_max_node_fast_cost_ptr(
+            buffer_ptr, sort_index, i, num - 1);
+    }
+
+    heap_sort_stage_max_node_fast_cost_ptr(
+        buffer_ptr, sort_index, 0, num - 1);
+
+    for (i = num - 1; i > 0; i--)
+    {
+        uint32_t swap = sort_index[i];
+        sort_index[i] = sort_index[0];
+        sort_index[0] = swap;
+        heap_sort_stage_max_node_fast_cost_ptr(
+            buffer_ptr, sort_index, 0, i - 1);
+    }
+}
+
 void sort_stage1_fast_candidates(
     struct ModeDecisionContext   *context_ptr,
     uint32_t                      num_of_cand_to_sort,
     uint32_t                     *cand_buff_indices)
 {
-    uint32_t i, j, index;
     ModeDecisionCandidateBuffer **buffer_ptr_array = context_ptr->candidate_buffer_ptr_array;
-    for (i = 0; i < num_of_cand_to_sort - 1; ++i) {
-        for (j = i + 1; j < num_of_cand_to_sort; ++j) {
-            if (*(buffer_ptr_array[cand_buff_indices[j]]->fast_cost_ptr) < *(buffer_ptr_array[cand_buff_indices[i]]->fast_cost_ptr)) {
-                index = cand_buff_indices[i];
-                cand_buff_indices[i] = (uint32_t)cand_buff_indices[j];
-                cand_buff_indices[j] = (uint32_t)index;
 
-            }
-        }
-    }
+    //sorted best: *(buffer_ptr_array[sorted_candidate_index_array[?]]->fast_cost_ptr)
+    sort_array_index_fast_cost_ptr(buffer_ptr_array,
+        cand_buff_indices, num_of_cand_to_sort);
 }
 
 void sort_stage2_candidates(
@@ -1887,17 +2056,9 @@ void construct_best_sorted_arrays_md_stage_2(
         }
     }
 
-    uint32_t j, index;
-    for (i = 0; i < fullReconCandidateCount - 1; ++i) {
-        for (j = i + 1; j < fullReconCandidateCount; ++j) {
-            if (*(buffer_ptr_array[sorted_candidate_index_array[j]]->fast_cost_ptr) < *(buffer_ptr_array[sorted_candidate_index_array[i]]->fast_cost_ptr)) {
-                index = sorted_candidate_index_array[i];
-                sorted_candidate_index_array[i] = (uint32_t)sorted_candidate_index_array[j];
-                sorted_candidate_index_array[j] = (uint32_t)index;
-            }
-        }
-    }
-
+    //sorted best: *(buffer_ptr_array[sorted_candidate_index_array[?]]->fast_cost_ptr)
+    sort_array_index_fast_cost_ptr(buffer_ptr_array,
+        sorted_candidate_index_array, fullReconCandidateCount);
 
     // tx search
     *ref_fast_cost = *(buffer_ptr_array[sorted_candidate_index_array[0]]->fast_cost_ptr);
@@ -1936,18 +2097,11 @@ void construct_best_sorted_arrays_md_stage_3(
         }
     }
 
-    uint32_t j, index;
-    for (i = 0; i < fullReconCandidateCount - 1; ++i) {
-        for (j = i + 1; j < fullReconCandidateCount; ++j) {
-            if (*(buffer_ptr_array[sorted_candidate_index_array[j]]->fast_cost_ptr) < *(buffer_ptr_array[sorted_candidate_index_array[i]]->fast_cost_ptr)) {
-                index = sorted_candidate_index_array[i];
-                sorted_candidate_index_array[i] = (uint32_t)sorted_candidate_index_array[j];
-                sorted_candidate_index_array[j] = (uint32_t)index;
-
-            }
-        }
-    }
+    //sorted best: *(buffer_ptr_array[sorted_candidate_index_array[?]]->fast_cost_ptr)
+    sort_array_index_fast_cost_ptr(buffer_ptr_array,
+        sorted_candidate_index_array, fullReconCandidateCount);
 }
+
 void md_stage_0(
 #else
 void ProductMdFastPuPrediction(


### PR DESCRIPTION
Update info from commit message:
Kernels works 2.3 faster, with previous changes all works 4.3 faster

//OLD: Kernels work 2.7 faster on msvc and 4.3 faster on linux