### PR TITLE
Speed optimization

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/EbIntraPrediction_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbIntraPrediction_Intrinsic_AVX2.c
@@ -13,6 +13,311 @@
 #include "txfm_common_avx2.h"
 #include "aom_dsp_rtcd.h"
 
+#if EDGE_BASED_SKIP_ANGULAR_INTRA
+// Indices are sign, integer, and fractional part of the gradient value
+static const uint8_t gradient_to_angle_bin[2][7][16] = {
+  {
+      { 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0 },
+      { 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1 },
+      { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
+      { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
+      { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
+      { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 },
+      { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 },
+  },
+  {
+      { 6, 6, 6, 6, 5, 5, 5, 5, 5, 5, 5, 5, 4, 4, 4, 4 },
+      { 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 3, 3, 3, 3, 3 },
+      { 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 },
+      { 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 },
+      { 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 },
+      { 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2 },
+      { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 },
+  },
+};
+
+static INLINE __m256i __m256i_div_epi32(const __m256i *a, const __m256i *b)
+{
+    __m256 d_f = _mm256_div_ps(_mm256_cvtepi32_ps(*a), _mm256_cvtepi32_ps(*b));
+    //Integer devide round down
+    return _mm256_cvtps_epi32(_mm256_floor_ps(d_f));
+}
+
+static INLINE void get_gradient_hist_avx2_internal(const __m256i *src1,
+    const __m256i *src2, const __m256i *src3, int16_t *dy_mask_array,
+    int16_t *quot_array, int16_t *remd_array, int16_t * sn_array,
+    int32_t *temp_array) {
+
+    const __m256i zero = _mm256_setzero_si256();
+    const __m256i val_15_i16 = _mm256_set1_epi16(15);
+    const __m256i val_6_i16 = _mm256_set1_epi16(6);
+    __m256i dx, dy;
+    __m256i tmp1_32, tmp2_32;
+    __m256i dx1_32, dx2_32;
+    __m256i dy1_32, dy2_32;
+    __m256i sn;
+    __m256i remd;
+    __m256i quot;
+    __m256i dy_mask;
+
+    dx = _mm256_sub_epi16(*src1, *src2);
+    dy = _mm256_sub_epi16(*src1, *src3);
+
+    //sn = (dx > 0) ^ (dy > 0);
+    sn = _mm256_xor_si256(dx, dy);  //result is 0 or 0xFFFF
+    sn = _mm256_srli_epi16(sn, 15);  //change output from 0xFFFF to 1
+
+    //mask which shows where are zeros in dy register 0/1
+    dy_mask = _mm256_srli_epi16(_mm256_cmpeq_epi16(dy, zero), 15);
+
+    //dx = abs(dx); dy = abs(dy);
+    dx = _mm256_abs_epi16(dx);
+    dy = _mm256_abs_epi16(dy);
+
+    _mm256_add_epi16(dy, dy_mask);
+
+    //  temp = dx * dx + dy * dy;
+    dx1_32 = _mm256_cvtepi16_epi32(_mm256_castsi256_si128(dx)); //dx
+    dy1_32 = _mm256_cvtepi16_epi32(_mm256_castsi256_si128(dy)); //dy
+
+    tmp1_32 = _mm256_add_epi32(
+        _mm256_mullo_epi32(dx1_32, dx1_32),
+        _mm256_mullo_epi32(dy1_32, dy1_32));
+
+    dx2_32 = _mm256_cvtepi16_epi32(_mm256_extracti128_si256(dx, 1));
+    dy2_32 = _mm256_cvtepi16_epi32(_mm256_extracti128_si256(dy, 1));
+
+    tmp2_32 = _mm256_add_epi32(
+        _mm256_mullo_epi32(dx2_32, dx2_32),
+        _mm256_mullo_epi32(dy2_32, dy2_32));
+
+    /* Code:
+     quot16 = (dx << 4) / dy;
+     quot = quot16 >> 4;
+     remd = = (quot16 & (15));
+    Equivalent of:
+     quot = dx / dy;
+     remd = (dx % dy) * 16 / dy;*/
+
+     //quot16 = (dx << 4) / dy;
+    dx1_32 = _mm256_slli_epi32(dx1_32, 4);
+    dx2_32 = _mm256_slli_epi32(dx2_32, 4);
+    const __m256i d1_i32 = __m256i_div_epi32(&dx1_32, &dy1_32);
+    const __m256i d2_i32 = __m256i_div_epi32(&dx2_32, &dy2_32);
+    __m256i quot16 = _mm256_permute4x64_epi64(
+        _mm256_packs_epi32(d1_i32, d2_i32), 0xD8);
+
+    quot = _mm256_srli_epi16(quot16, 4);
+
+    //remd = (quot16 & (15));
+    remd = _mm256_and_si256(quot16, val_15_i16);
+
+    //AOMMIN(remdA, 15)
+    remd = _mm256_min_epi16(remd, val_15_i16);
+    //AOMMIN(quotA, 6)
+    quot = _mm256_min_epi16(quot, val_6_i16);
+
+    _mm256_store_si256((__m256i *)dy_mask_array, dy_mask);
+    _mm256_store_si256((__m256i *)quot_array, quot);
+    _mm256_store_si256((__m256i *)remd_array, remd);
+    _mm256_store_si256((__m256i *)sn_array, sn);
+    _mm256_store_si256((__m256i *)temp_array, tmp1_32);
+    _mm256_store_si256((__m256i *)&temp_array[8], tmp2_32);
+}
+
+void av1_get_gradient_hist_avx2(const uint8_t *src, int src_stride, int rows,
+    int cols, uint64_t *hist) {
+    src += src_stride;
+
+    __m128i tmp_src;
+    __m256i src1; //src[c]
+    __m256i src2; //src[c-1]
+    __m256i src3; //src[c - src_stride]
+
+    DECLARE_ALIGNED(64, int16_t, dy_mask_array[16]);
+    DECLARE_ALIGNED(64, int16_t, quot_array[16]);
+    DECLARE_ALIGNED(64, int16_t, remd_array[16]);
+    DECLARE_ALIGNED(64, int16_t, sn_array[16]);
+    DECLARE_ALIGNED(64, int32_t, temp_array[16]);
+
+    if (cols < 8) { //i.e cols ==4
+        for (int r = 1; r < rows; r += 4) {
+            if ((r + 3) >= rows) {
+                tmp_src = _mm_set_epi32(
+                    0,
+                    *(uint32_t*)(src + 1),
+                    *(uint32_t*)(src + 1 + src_stride),
+                    *(uint32_t*)(src + 1 + 2 * src_stride));
+                src1 = _mm256_cvtepu8_epi16(tmp_src);
+
+                tmp_src = _mm_set_epi32(
+                    0,
+                    *(uint32_t*)(src),
+                    *(uint32_t*)(src + src_stride),
+                    *(uint32_t*)(src + 2 * src_stride));
+                src2 = _mm256_cvtepu8_epi16(tmp_src);
+
+                tmp_src = _mm_set_epi32(
+                    0,
+                    *(uint32_t*)(src + 1 - src_stride),
+                    *(uint32_t*)(src + 1),
+                    *(uint32_t*)(src + 1 + src_stride));
+                src3 = _mm256_cvtepu8_epi16(tmp_src);
+            }
+            else {
+                tmp_src = _mm_set_epi32(
+                    *(uint32_t*)(src + 1),
+                    *(uint32_t*)(src + 1 + src_stride),
+                    *(uint32_t*)(src + 1 + 2 * src_stride),
+                    *(uint32_t*)(src + 1 + 3 * src_stride));
+                src1 = _mm256_cvtepu8_epi16(tmp_src);
+
+                tmp_src = _mm_set_epi32(
+                    *(uint32_t*)(src),
+                    *(uint32_t*)(src + src_stride),
+                    *(uint32_t*)(src + 2 * src_stride),
+                    *(uint32_t*)(src + 3 * src_stride));
+                src2 = _mm256_cvtepu8_epi16(tmp_src);
+
+                tmp_src = _mm_set_epi32(
+                    *(uint32_t*)(src + 1 - src_stride),
+                    *(uint32_t*)(src + 1),
+                    *(uint32_t*)(src + 1 + src_stride),
+                    *(uint32_t*)(src + 1 + 2 * src_stride));
+                src3 = _mm256_cvtepu8_epi16(tmp_src);
+            }
+
+            get_gradient_hist_avx2_internal(&src1, &src2, &src3, dy_mask_array,
+                quot_array, remd_array, sn_array, temp_array);
+
+            if ((r + 3) >= rows) {
+                for (int w = 0; w < 11; ++w) {
+                    if (w == 3 || w == 7)
+                        continue;
+                    if (dy_mask_array[w] != 1) {
+                        int index = gradient_to_angle_bin[sn_array[w]]
+                            [quot_array[w]][remd_array[w]];
+                        hist[index] += temp_array[w];
+                    }
+                    else {
+                        hist[2] += temp_array[w];
+                    }
+                }
+            }
+            else {
+                for (int w = 0; w < 15; ++w) {
+                    if (w == 3 || w == 7 || w == 11)
+                        continue;
+                    if (dy_mask_array[w] != 1) {
+                        int index = gradient_to_angle_bin[sn_array[w]]
+                            [quot_array[w]][remd_array[w]];
+                        hist[index] += temp_array[w];
+                    }
+                    else {
+                        hist[2] += temp_array[w];
+                    }
+                }
+            }
+            src += 4 * src_stride;
+        }
+    }
+    else if (cols < 16) { //i.e cols ==8
+        for (int r = 1; r < rows; r += 2) {
+            if ((r + 1) >= rows) {
+                tmp_src = _mm_set1_epi64x(*(uint64_t*)(src + 1));
+                src1 = _mm256_cvtepu8_epi16(tmp_src);
+
+                tmp_src = _mm_set1_epi64x(*(uint64_t*)(src));
+                src2 = _mm256_cvtepu8_epi16(tmp_src);
+
+                tmp_src = _mm_set1_epi64x(*(uint64_t*)(src + 1 - src_stride));
+                src3 = _mm256_cvtepu8_epi16(tmp_src);
+            }
+            else {
+                tmp_src = _mm_set_epi64x(*(uint64_t*)(src + 1 + src_stride),
+                    *(uint64_t*)(src + 1));
+                src1 = _mm256_cvtepu8_epi16(tmp_src);
+
+                tmp_src = _mm_set_epi64x(*(uint64_t*)(src + src_stride),
+                    *(uint64_t*)(src));
+                src2 = _mm256_cvtepu8_epi16(tmp_src);
+
+                tmp_src = _mm_set_epi64x(*(uint64_t*)(src + 1),
+                    *(uint64_t*)(src + 1 - src_stride));
+                src3 = _mm256_cvtepu8_epi16(tmp_src);
+            }
+
+            get_gradient_hist_avx2_internal(&src1, &src2, &src3, dy_mask_array,
+                quot_array, remd_array, sn_array, temp_array);
+
+            if ((r + 1) >= rows) {
+                for (int w = 0; w < 7; ++w) {
+                    if (dy_mask_array[w] != 1) {
+                        int index = gradient_to_angle_bin[sn_array[w]]
+                            [quot_array[w]][remd_array[w]];
+                        hist[index] += temp_array[w];
+                    }
+                    else {
+                        hist[2] += temp_array[w];
+                    }
+                }
+            }
+            else {
+                for (int w = 0; w < 15; ++w) {
+                    if (w == 7)
+                        continue;
+                    if (dy_mask_array[w] != 1) {
+                        int index = gradient_to_angle_bin[sn_array[w]]
+                            [quot_array[w]][remd_array[w]];
+                        hist[index] += temp_array[w];
+                    }
+                    else {
+                        hist[2] += temp_array[w];
+                    }
+                }
+            }
+            src += 2 * src_stride;
+        }
+    }
+    else {
+        for (int r = 1; r < rows; ++r) {
+            int c = 1;
+            for (; cols - c >= 15; c += 16) {
+
+                //read too many [1:16], while max is 15
+                src1 = _mm256_cvtepu8_epi16(
+                    _mm_loadu_si128((__m128i const*)&src[c]));
+                src2 = _mm256_cvtepu8_epi16(
+                    _mm_loadu_si128((__m128i const*)&src[c - 1]));
+                src3 = _mm256_cvtepu8_epi16(
+                    _mm_loadu_si128((__m128i const*)&src[c - src_stride]));
+
+                get_gradient_hist_avx2_internal(&src1, &src2, &src3,
+                    dy_mask_array, quot_array, remd_array, sn_array, temp_array);
+
+                int max = 16;
+                if (c + 16 > cols) {
+                    max = 15;
+                }
+
+                for (int w = 0; w < max; ++w) {
+
+                    if (dy_mask_array[w] != 1) {
+                        int index = gradient_to_angle_bin[sn_array[w]]
+                            [quot_array[w]][remd_array[w]];
+                        hist[index] += temp_array[w];
+                    }
+                    else {
+                        hist[2] += temp_array[w];
+                    }
+                }
+            }
+            src += src_stride;
+        }
+    }
+}
+
+#endif
 #ifndef _mm256_setr_m128i
 #define _mm256_setr_m128i(/* __m128i */ lo, /* __m128i */ hi) \
     _mm256_insertf128_si256(_mm256_castsi128_si256(lo), (hi), 0x1)

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -67,13 +67,13 @@ extern "C" {
 // Opt 0
 #define APPLY_3X3_FOR_BEST_ME             1 // Use the top 4 ME candidates @ 3x3 Unipred and 3x3 Bipred
 // Opt 1
-#define PRUNE_REF_FRAME_AT_ME             1 // Bipred candidates reduction @ ME
-// Opt 2
-#define PRUNE_REF_FRAME_FRO_REC_PARTITION 1 // MD candidates reduction @ MD
-// Opt 3
 #define COEFF_BASED_SKIP_ATB              1 // Skip ATB if parent block does not have coeff
-// Opt 4
+// Opt 2
 #define EDGE_BASED_SKIP_ANGULAR_INTRA     1 // Use edge detection to bypass some angular modes
+// Opt 3
+#define PRUNE_REF_FRAME_AT_ME             1 // Bipred candidates reduction @ ME
+// Opt 4
+#define PRUNE_REF_FRAME_FRO_REC_PARTITION 1 // MD candidates reduction @ MD
 
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC                         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -63,6 +63,17 @@ extern "C" {
 #define HME_ME_TUNING                     1 // HME/ME tuning
 #define MFMV_SUPPORT                      1// Temporal mvp support. aka. MFMV
 
+// Lossy optimizations -
+// Opt 0
+#define APPLY_3X3_FOR_BEST_ME             1 // Use the top 4 ME candidates @ 3x3 Unipred and 3x3 Bipred
+// Opt 1
+#define PRUNE_REF_FRAME_AT_ME             1 // Bipred candidates reduction @ ME
+// Opt 2
+#define PRUNE_REF_FRAME_FRO_REC_PARTITION 1 // MD candidates reduction @ MD
+// Opt 3
+#define COEFF_BASED_SKIP_ATB              1 // Skip ATB if parent block does not have coeff
+// Opt 4
+#define EDGE_BASED_SKIP_ANGULAR_INTRA     1 // Use edge detection to bypass some angular modes
 
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC                         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch
@@ -478,6 +489,17 @@ typedef enum MD_STAGE {
 #define INTER_NEW_NFL       16
 #define INTER_PRED_NFL      16
 
+#endif
+
+#if APPLY_3X3_FOR_BEST_ME
+#define BEST_CANDIDATE_COUNT 4
+#endif
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+#define MAX_REF_TYPE_CAND   30
+#define PRUNE_REC_TH         5
+#endif
+#if PRUNE_REF_FRAME_AT_ME
+#define PRUNE_REF_ME_TH      2
 #endif
 
 #define MD_EXIT_THSL         0 // MD_EXIT_THSL -->0 is lossless 100 is maximum. Increase with a step of 10-20.

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1531,10 +1531,13 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     else
         context_ptr->redundant_blk = EB_FALSE;
 #if EDGE_BASED_SKIP_ANGULAR_INTRA
-    if (MR_MODE || picture_control_set_ptr->enc_mode == ENC_M0)
-        context_ptr->edge_based_skip_angle_intra = 0;
+    if (sequence_control_set_ptr->static_config.encoder_bit_depth == EB_8BIT)
+        if (MR_MODE || picture_control_set_ptr->enc_mode == ENC_M0)
+            context_ptr->edge_based_skip_angle_intra = 0;
+        else
+            context_ptr->edge_based_skip_angle_intra = 1;
     else
-        context_ptr->edge_based_skip_angle_intra = 1;
+        context_ptr->edge_based_skip_angle_intra = 0;
 #endif
     return return_error;
 }

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1539,6 +1539,12 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     else
         context_ptr->edge_based_skip_angle_intra = 0;
 #endif
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+    if (picture_control_set_ptr->parent_pcs_ptr->sc_content_detected || picture_control_set_ptr->enc_mode == ENC_M0)
+        context_ptr->prune_ref_frame_for_rec_partitions = 0;
+    else
+        context_ptr->prune_ref_frame_for_rec_partitions = 1;
+#endif
     return return_error;
 }
 

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1530,7 +1530,12 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         context_ptr->redundant_blk = EB_TRUE;
     else
         context_ptr->redundant_blk = EB_FALSE;
-
+#if EDGE_BASED_SKIP_ANGULAR_INTRA
+    if (MR_MODE || picture_control_set_ptr->enc_mode == ENC_M0)
+        context_ptr->edge_based_skip_angle_intra = 0;
+    else
+        context_ptr->edge_based_skip_angle_intra = 1;
+#endif
     return return_error;
 }
 

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -356,7 +356,6 @@ EbErrorType mode_decision_candidate_buffer_ctor(
 }
 #if PRUNE_REF_FRAME_FRO_REC_PARTITION
 uint8_t check_ref_beackout(
-    PictureControlSet          *picture_control_set_ptr,
     struct ModeDecisionContext *context_ptr,
     uint8_t                     ref_frame_type,
     PART                        shape)
@@ -639,7 +638,6 @@ void Unipred3x3CandidatesInjection(
         uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_0, list0_ref_index);
 #if PRUNE_REF_FRAME_FRO_REC_PARTITION
         uint8_t skip_cand = check_ref_beackout(
-            picture_control_set_ptr,
             context_ptr,
             to_inject_ref_type,
             context_ptr->blk_geom->shape);
@@ -728,7 +726,6 @@ void Unipred3x3CandidatesInjection(
             uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_1, list1_ref_index);
 #if PRUNE_REF_FRAME_FRO_REC_PARTITION
             uint8_t skip_cand = check_ref_beackout(
-                picture_control_set_ptr,
                 context_ptr,
                 to_inject_ref_type,
                 context_ptr->blk_geom->shape);
@@ -854,7 +851,6 @@ void Bipred3x3CandidatesInjection(
         uint8_t to_inject_ref_type = av1_ref_frame_type(rf);
 #if PRUNE_REF_FRAME_FRO_REC_PARTITION
         uint8_t skip_cand = check_ref_beackout(
-            picture_control_set_ptr,
             context_ptr,
             to_inject_ref_type,
             context_ptr->blk_geom->shape);
@@ -962,7 +958,6 @@ void Bipred3x3CandidatesInjection(
             uint8_t to_inject_ref_type = av1_ref_frame_type(rf);
 #if PRUNE_REF_FRAME_FRO_REC_PARTITION
             uint8_t skip_cand = check_ref_beackout(
-                picture_control_set_ptr,
                 context_ptr,
                 to_inject_ref_type,
                 context_ptr->blk_geom->shape);
@@ -2212,7 +2207,6 @@ void inject_new_candidates(
             uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_0, list0_ref_index);
 #if PRUNE_REF_FRAME_FRO_REC_PARTITION
             uint8_t skip_cand = check_ref_beackout(
-                picture_control_set_ptr,
                 context_ptr,
                 to_inject_ref_type,
                 context_ptr->blk_geom->shape);
@@ -2288,7 +2282,6 @@ void inject_new_candidates(
                 uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_1, list1_ref_index);
 #if PRUNE_REF_FRAME_FRO_REC_PARTITION
                 uint8_t skip_cand = check_ref_beackout(
-                    picture_control_set_ptr,
                     context_ptr,
                     to_inject_ref_type,
                     context_ptr->blk_geom->shape);
@@ -2367,7 +2360,6 @@ void inject_new_candidates(
                     uint8_t to_inject_ref_type = av1_ref_frame_type(rf);
 #if PRUNE_REF_FRAME_FRO_REC_PARTITION
                     uint8_t skip_cand = check_ref_beackout(
-                        picture_control_set_ptr,
                         context_ptr,
                         to_inject_ref_type,
                         context_ptr->blk_geom->shape);

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -34,6 +34,9 @@
 #if COMP_MODE
 #include "EbInterPrediction.h"
 #endif
+#if EDGE_BASED_SKIP_ANGULAR_INTRA
+#include "aom_dsp_rtcd.h"
+#endif
 #define  INCRMENT_CAND_TOTAL_COUNT(cnt) cnt++; if(cnt>=MODE_DECISION_CANDIDATE_MAX_COUNT) printf(" ERROR: reaching limit for MODE_DECISION_CANDIDATE_MAX_COUNT %i\n",cnt);
 int8_t av1_ref_frame_type(const MvReferenceFrame *const rf);
 /********************************************
@@ -351,21 +354,32 @@ EbErrorType mode_decision_candidate_buffer_ctor(
     buffer_ptr->full_cost_merge_ptr = full_cost_merge_ptr;
     return EB_ErrorNone;
 }
-
-// Function Declarations
-void RoundMv(
-    ModeDecisionCandidate    *candidateArray,
-    uint32_t                   canTotalCnt)
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+uint8_t check_ref_beackout(
+    PictureControlSet          *picture_control_set_ptr,
+    struct ModeDecisionContext *context_ptr,
+    uint8_t                     ref_frame_type,
+    PART                        shape)
 {
-    candidateArray[canTotalCnt].motion_vector_xl0 = (candidateArray[canTotalCnt].motion_vector_xl0 + 2)&~0x03;
-    candidateArray[canTotalCnt].motion_vector_yl0 = (candidateArray[canTotalCnt].motion_vector_yl0 + 2)&~0x03;
-
-    candidateArray[canTotalCnt].motion_vector_xl1 = (candidateArray[canTotalCnt].motion_vector_xl1 + 2)&~0x03;
-    candidateArray[canTotalCnt].motion_vector_yl1 = (candidateArray[canTotalCnt].motion_vector_yl1 + 2)&~0x03;
-
-    return;
+    uint8_t skip_candidate = 0;
+    uint8_t ref_cnt = 0;
+    uint8_t allowed_nsq_ref_th = (uint8_t)PRUNE_REC_TH;
+    if (picture_control_set_ptr->parent_pcs_ptr->prune_ref_frame_for_rec_partitions) {
+        if (shape != PART_N) {
+            uint8_t ref_idx;
+            assert(ref_frame_type < 30);
+            ref_cnt = 0;
+            for (ref_idx = 0; ref_idx < allowed_nsq_ref_th; ref_idx++) {
+                if (ref_frame_type == context_ptr->ref_best_ref_sq_table[ref_idx]) {
+                    ref_cnt++;
+                }
+            }
+            skip_candidate = ref_cnt ? 0 : 1;
+        }
+    }
+    return skip_candidate;
 }
-
+#endif
 /***************************************
 * return true if the MV candidate is already injected
 ***************************************/
@@ -601,6 +615,9 @@ void Unipred3x3CandidatesInjection(
 
     // (8 Best_L0 neighbors)
     //const MeLcuResults_t *meResults = pictureControlSetPtr->ParentPcsPtr->meResultsPtr[lcuAddr];
+#if APPLY_3X3_FOR_BEST_ME
+    total_me_cnt = MIN(total_me_cnt, BEST_CANDIDATE_COUNT);
+#endif
     for (uint8_t me_candidate_index = 0; me_candidate_index < total_me_cnt; ++me_candidate_index)
     {
         const MeCandidate *me_block_results_ptr = &me_block_results[me_candidate_index];
@@ -620,7 +637,17 @@ void Unipred3x3CandidatesInjection(
         int16_t to_inject_mv_x = use_close_loop_me ? (inloop_me_context->inloop_me_mv[0][0][close_loop_me_index][0] + BIPRED_3x3_X_POS[bipredIndex]) << 1 : (me_results->me_mv_array[context_ptr->me_block_offset][list0_ref_index].x_mv + BIPRED_3x3_X_POS[bipredIndex]) << 1;
         int16_t to_inject_mv_y = use_close_loop_me ? (inloop_me_context->inloop_me_mv[0][0][close_loop_me_index][1] + BIPRED_3x3_Y_POS[bipredIndex]) << 1 : (me_results->me_mv_array[context_ptr->me_block_offset][list0_ref_index].y_mv + BIPRED_3x3_Y_POS[bipredIndex]) << 1;
         uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_0, list0_ref_index);
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+        uint8_t skip_cand = check_ref_beackout(
+            picture_control_set_ptr,
+            context_ptr,
+            to_inject_ref_type,
+            context_ptr->blk_geom->shape);
+
+        if (!skip_cand && (context_ptr->injected_mv_count_l0 == 0 || mrp_is_already_injected_mv_l0(context_ptr, to_inject_mv_x, to_inject_mv_y, to_inject_ref_type) == EB_FALSE)) {
+#else
         if (context_ptr->injected_mv_count_l0 == 0 || mrp_is_already_injected_mv_l0(context_ptr, to_inject_mv_x, to_inject_mv_y, to_inject_ref_type) == EB_FALSE) {
+#endif
             candidateArray[canTotalCnt].type = INTER_MODE;
             candidateArray[canTotalCnt].distortion_ready = 0;
             candidateArray[canTotalCnt].use_intrabc = 0;
@@ -677,6 +704,9 @@ void Unipred3x3CandidatesInjection(
 
     // (8 Best_L1 neighbors)
 //const MeLcuResults_t *meResults = pictureControlSetPtr->ParentPcsPtr->meResultsPtr[lcuAddr];
+#if APPLY_3X3_FOR_BEST_ME
+    total_me_cnt = MIN(total_me_cnt, BEST_CANDIDATE_COUNT);
+#endif
     for (uint8_t me_candidate_index = 0; me_candidate_index < total_me_cnt; ++me_candidate_index)
     {
         const MeCandidate *me_block_results_ptr = &me_block_results[me_candidate_index];
@@ -696,7 +726,17 @@ void Unipred3x3CandidatesInjection(
             int16_t to_inject_mv_x = use_close_loop_me ? (inloop_me_context->inloop_me_mv[1][0][close_loop_me_index][0] + BIPRED_3x3_X_POS[bipredIndex]) << 1 : (me_results->me_mv_array[context_ptr->me_block_offset][((sequence_control_set_ptr->mrp_mode == 0) ? 4 : 2) + list1_ref_index].x_mv + BIPRED_3x3_X_POS[bipredIndex]) << 1;
             int16_t to_inject_mv_y = use_close_loop_me ? (inloop_me_context->inloop_me_mv[1][0][close_loop_me_index][1] + BIPRED_3x3_Y_POS[bipredIndex]) << 1 : (me_results->me_mv_array[context_ptr->me_block_offset][((sequence_control_set_ptr->mrp_mode == 0) ? 4 : 2) + list1_ref_index].y_mv + BIPRED_3x3_Y_POS[bipredIndex]) << 1;
             uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_1, list1_ref_index);
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+            uint8_t skip_cand = check_ref_beackout(
+                picture_control_set_ptr,
+                context_ptr,
+                to_inject_ref_type,
+                context_ptr->blk_geom->shape);
+
+            if (!skip_cand && (context_ptr->injected_mv_count_l1 == 0 || mrp_is_already_injected_mv_l1(context_ptr, to_inject_mv_x, to_inject_mv_y, to_inject_ref_type) == EB_FALSE)) {
+#else
             if (context_ptr->injected_mv_count_l1 == 0 || mrp_is_already_injected_mv_l1(context_ptr, to_inject_mv_x, to_inject_mv_y, to_inject_ref_type) == EB_FALSE) {
+#endif
                 candidateArray[canTotalCnt].type = INTER_MODE;
                 candidateArray[canTotalCnt].distortion_ready = 0;
                 candidateArray[canTotalCnt].use_intrabc = 0;
@@ -785,6 +825,9 @@ void Bipred3x3CandidatesInjection(
        NEW_NEWMV
        ************* */
        //const MeLcuResults_t *meResults = pictureControlSetPtr->ParentPcsPtr->meResultsPtr[lcuAddr];
+#if APPLY_3X3_FOR_BEST_ME
+        total_me_cnt = MIN(total_me_cnt, BEST_CANDIDATE_COUNT);
+#endif
         for (uint8_t me_candidate_index = 0; me_candidate_index < total_me_cnt; ++me_candidate_index)
         {
             const MeCandidate *me_block_results_ptr = &me_block_results[me_candidate_index];
@@ -809,8 +852,17 @@ void Bipred3x3CandidatesInjection(
         rf[0] = svt_get_ref_frame_type(me_block_results_ptr->ref0_list, list0_ref_index);
         rf[1] = svt_get_ref_frame_type(me_block_results_ptr->ref1_list, list1_ref_index);
         uint8_t to_inject_ref_type = av1_ref_frame_type(rf);
-        if (context_ptr->injected_mv_count_bipred == 0 || mrp_is_already_injected_mv_bipred(context_ptr, to_inject_mv_x_l0, to_inject_mv_y_l0, to_inject_mv_x_l1, to_inject_mv_y_l1, to_inject_ref_type) == EB_FALSE) {
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+        uint8_t skip_cand = check_ref_beackout(
+            picture_control_set_ptr,
+            context_ptr,
+            to_inject_ref_type,
+            context_ptr->blk_geom->shape);
 
+        if (!skip_cand && (context_ptr->injected_mv_count_bipred == 0 || mrp_is_already_injected_mv_bipred(context_ptr, to_inject_mv_x_l0, to_inject_mv_y_l0, to_inject_mv_x_l1, to_inject_mv_y_l1, to_inject_ref_type) == EB_FALSE)) {
+#else
+        if (context_ptr->injected_mv_count_bipred == 0 || mrp_is_already_injected_mv_bipred(context_ptr, to_inject_mv_x_l0, to_inject_mv_y_l0, to_inject_mv_x_l1, to_inject_mv_y_l1, to_inject_ref_type) == EB_FALSE) {
+#endif
 #if COMP_MODE
             context_ptr->variance_ready = 0;
             for (cur_type = MD_COMP_AVG; cur_type <= tot_comp_types; cur_type++)
@@ -908,8 +960,17 @@ void Bipred3x3CandidatesInjection(
             rf[0] = svt_get_ref_frame_type(me_block_results_ptr->ref0_list, list0_ref_index);
             rf[1] = svt_get_ref_frame_type(me_block_results_ptr->ref1_list, list1_ref_index);
             uint8_t to_inject_ref_type = av1_ref_frame_type(rf);
-            if (context_ptr->injected_mv_count_bipred == 0 || mrp_is_already_injected_mv_bipred(context_ptr, to_inject_mv_x_l0, to_inject_mv_y_l0, to_inject_mv_x_l1, to_inject_mv_y_l1, to_inject_ref_type) == EB_FALSE) {
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+            uint8_t skip_cand = check_ref_beackout(
+                picture_control_set_ptr,
+                context_ptr,
+                to_inject_ref_type,
+                context_ptr->blk_geom->shape);
 
+            if (!skip_cand && (context_ptr->injected_mv_count_bipred == 0 || mrp_is_already_injected_mv_bipred(context_ptr, to_inject_mv_x_l0, to_inject_mv_y_l0, to_inject_mv_x_l1, to_inject_mv_y_l1, to_inject_ref_type) == EB_FALSE)) {
+#else
+            if (context_ptr->injected_mv_count_bipred == 0 || mrp_is_already_injected_mv_bipred(context_ptr, to_inject_mv_x_l0, to_inject_mv_y_l0, to_inject_mv_x_l1, to_inject_mv_y_l1, to_inject_ref_type) == EB_FALSE) {
+#endif
 #if COMP_MODE
                 context_ptr->variance_ready = 0;
                 for (cur_type = MD_COMP_AVG; cur_type <= tot_comp_types; cur_type++)
@@ -2149,8 +2210,17 @@ void inject_new_candidates(
             int16_t to_inject_mv_x = use_close_loop_me ? inloop_me_context->inloop_me_mv[0][0][close_loop_me_index][0] << 1 : me_results->me_mv_array[me_block_offset][list0_ref_index].x_mv << 1;
             int16_t to_inject_mv_y = use_close_loop_me ? inloop_me_context->inloop_me_mv[0][0][close_loop_me_index][1] << 1 : me_results->me_mv_array[me_block_offset][list0_ref_index].y_mv << 1;
             uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_0, list0_ref_index);
-            if (context_ptr->injected_mv_count_l0 == 0 || mrp_is_already_injected_mv_l0(context_ptr, to_inject_mv_x, to_inject_mv_y, to_inject_ref_type) == EB_FALSE) {
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+            uint8_t skip_cand = check_ref_beackout(
+                picture_control_set_ptr,
+                context_ptr,
+                to_inject_ref_type,
+                context_ptr->blk_geom->shape);
 
+            if (!skip_cand && (context_ptr->injected_mv_count_l0 == 0 || mrp_is_already_injected_mv_l0(context_ptr, to_inject_mv_x, to_inject_mv_y, to_inject_ref_type) == EB_FALSE)) {
+#else
+            if (context_ptr->injected_mv_count_l0 == 0 || mrp_is_already_injected_mv_l0(context_ptr, to_inject_mv_x, to_inject_mv_y, to_inject_ref_type) == EB_FALSE) {
+#endif
 
                 candidateArray[canTotalCnt].type = INTER_MODE;
                 candidateArray[canTotalCnt].distortion_ready = 0;
@@ -2216,8 +2286,17 @@ void inject_new_candidates(
                 int16_t to_inject_mv_x = use_close_loop_me ? inloop_me_context->inloop_me_mv[1][0][close_loop_me_index][0] << 1 : me_results->me_mv_array[me_block_offset][((sequence_control_set_ptr->mrp_mode == 0) ? 4 : 2) + list1_ref_index].x_mv << 1;
                 int16_t to_inject_mv_y = use_close_loop_me ? inloop_me_context->inloop_me_mv[1][0][close_loop_me_index][1] << 1 : me_results->me_mv_array[me_block_offset][((sequence_control_set_ptr->mrp_mode == 0) ? 4 : 2) + list1_ref_index].y_mv << 1;
                 uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_1, list1_ref_index);
-                if (context_ptr->injected_mv_count_l1 == 0 || mrp_is_already_injected_mv_l1(context_ptr, to_inject_mv_x, to_inject_mv_y, to_inject_ref_type) == EB_FALSE) {
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+                uint8_t skip_cand = check_ref_beackout(
+                    picture_control_set_ptr,
+                    context_ptr,
+                    to_inject_ref_type,
+                    context_ptr->blk_geom->shape);
 
+                if (!skip_cand && (context_ptr->injected_mv_count_l1 == 0 || mrp_is_already_injected_mv_l1(context_ptr, to_inject_mv_x, to_inject_mv_y, to_inject_ref_type) == EB_FALSE)) {
+#else
+                if (context_ptr->injected_mv_count_l1 == 0 || mrp_is_already_injected_mv_l1(context_ptr, to_inject_mv_x, to_inject_mv_y, to_inject_ref_type) == EB_FALSE) {
+#endif
                     candidateArray[canTotalCnt].type = INTER_MODE;
                     candidateArray[canTotalCnt].distortion_ready = 0;
                     candidateArray[canTotalCnt].use_intrabc = 0;
@@ -2286,7 +2365,17 @@ void inject_new_candidates(
                     rf[0] = svt_get_ref_frame_type(me_block_results_ptr->ref0_list, list0_ref_index);
                     rf[1] = svt_get_ref_frame_type(me_block_results_ptr->ref1_list, list1_ref_index);
                     uint8_t to_inject_ref_type = av1_ref_frame_type(rf);
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+                    uint8_t skip_cand = check_ref_beackout(
+                        picture_control_set_ptr,
+                        context_ptr,
+                        to_inject_ref_type,
+                        context_ptr->blk_geom->shape);
+
+                    if (!skip_cand && (context_ptr->injected_mv_count_bipred == 0 || mrp_is_already_injected_mv_bipred(context_ptr, to_inject_mv_x_l0, to_inject_mv_y_l0, to_inject_mv_x_l1, to_inject_mv_y_l1, to_inject_ref_type) == EB_FALSE)) {
+#else
                     if (context_ptr->injected_mv_count_bipred == 0 || mrp_is_already_injected_mv_bipred(context_ptr, to_inject_mv_x_l0, to_inject_mv_y_l0, to_inject_mv_x_l1, to_inject_mv_y_l1, to_inject_ref_type) == EB_FALSE) {
+#endif
 #if COMP_MODE
                         context_ptr->variance_ready = 0;
                         for (cur_type = MD_COMP_AVG; cur_type <= tot_comp_types; cur_type++)
@@ -3580,6 +3669,98 @@ void  inject_intra_bc_candidates(
         INCRMENT_CAND_TOTAL_COUNT( (*cand_cnt) );
     }
 }
+#if EDGE_BASED_SKIP_ANGULAR_INTRA
+// Indices are sign, integer, and fractional part of the gradient value
+static const uint8_t gradient_to_angle_bin[2][7][16] = {
+  {
+      { 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 0, 0, 0, 0 },
+      { 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1 },
+      { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
+      { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
+      { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 },
+      { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 },
+      { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 },
+  },
+  {
+      { 6, 6, 6, 6, 5, 5, 5, 5, 5, 5, 5, 5, 4, 4, 4, 4 },
+      { 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 3, 3, 3, 3, 3 },
+      { 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 },
+      { 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 },
+      { 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3 },
+      { 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2 },
+      { 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2 },
+  },
+};
+
+/* clang-format off */
+static const uint8_t mode_to_angle_bin[INTRA_MODES] = {
+  0, 2, 6, 0, 4, 3, 5, 7, 1, 0,
+  0,
+};
+void av1_get_gradient_hist_c(const uint8_t *src, int src_stride, int rows,
+    int cols, uint64_t *hist) {
+    src += src_stride;
+    for (int r = 1; r < rows; ++r) {
+        for (int c = 1; c < cols; ++c) {
+            int dx = src[c] - src[c - 1];
+            int dy = src[c] - src[c - src_stride];
+            int index;
+            const int temp = dx * dx + dy * dy;
+            if (dy == 0) {
+                index = 2;
+            }
+            else {
+                const int sn = (dx > 0) ^ (dy > 0);
+                dx = abs(dx);
+                dy = abs(dy);
+                const int remd = (dx % dy) * 16 / dy;
+                const int quot = dx / dy;
+                index = gradient_to_angle_bin[sn][AOMMIN(quot, 6)][AOMMIN(remd, 15)];
+            }
+            hist[index] += temp;
+        }
+        src += src_stride;
+    }
+}
+static void angle_estimation(
+    const uint8_t *src,
+    int src_stride,
+    int rows,
+    int cols,
+    //BLOCK_SIZE bsize,
+    uint8_t *directional_mode_skip_mask)
+{
+    // Check if angle_delta is used
+    //if (!av1_use_angle_delta(bsize)) return;
+
+    uint64_t hist[DIRECTIONAL_MODES] = { 0 };
+    //if (is_hbd)
+    //    get_highbd_gradient_hist(src, src_stride, rows, cols, hist);
+    //else
+    av1_get_gradient_hist(src, src_stride, rows, cols, hist);
+
+    int i;
+    uint64_t hist_sum = 0;
+    for (i = 0; i < DIRECTIONAL_MODES; ++i) hist_sum += hist[i];
+    for (i = 0; i < INTRA_MODES; ++i) {
+        if (av1_is_directional_mode(i)) {
+            const uint8_t angle_bin = mode_to_angle_bin[i];
+            uint64_t score = 2 * hist[angle_bin];
+            int weight = 2;
+            if (angle_bin > 0) {
+                score += hist[angle_bin - 1];
+                ++weight;
+            }
+            if (angle_bin < DIRECTIONAL_MODES - 1) {
+                score += hist[angle_bin + 1];
+                ++weight;
+            }
+            const int thresh = 10;
+            if (score * thresh < hist_sum * weight) directional_mode_skip_mask[i] = 1;
+        }
+    }
+}
+#endif
 // END of Function Declarations
 void  inject_intra_candidates(
     PictureControlSet            *picture_control_set_ptr,
@@ -3604,7 +3785,19 @@ void  inject_intra_candidates(
     uint8_t                     disable_z2_prediction;
     uint8_t                     disable_angle_refinement;
     uint8_t                     disable_angle_prediction;
-        uint8_t     angle_delta_shift = 1;
+#if EDGE_BASED_SKIP_ANGULAR_INTRA
+    uint8_t directional_mode_skip_mask[INTRA_MODES] = { 0 };
+
+    if (context_ptr->edge_based_skip_angle_intra && use_angle_delta)
+    {
+        EbPictureBufferDesc   *src_pic = picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
+        uint8_t               *src_buf = src_pic->buffer_y + (context_ptr->cu_origin_x + src_pic->origin_x) + (context_ptr->cu_origin_y + src_pic->origin_y) * src_pic->stride_y;
+        const int rows = block_size_high[context_ptr->blk_geom->bsize];
+        const int cols = block_size_wide[context_ptr->blk_geom->bsize];
+        angle_estimation(src_buf, src_pic->stride_y, rows, cols, /*context_ptr->blk_geom->bsize,*/directional_mode_skip_mask);
+    }
+#endif
+    uint8_t     angle_delta_shift = 1;
     if (picture_control_set_ptr->parent_pcs_ptr->intra_pred_mode == 4) {
         if (picture_control_set_ptr->slice_type == I_SLICE) {
             intra_mode_end = is16bit ? SMOOTH_H_PRED : PAETH_PRED;
@@ -3655,7 +3848,12 @@ void  inject_intra_candidates(
 #endif
     for (openLoopIntraCandidate = intra_mode_start; openLoopIntraCandidate <= intra_mode_end ; ++openLoopIntraCandidate) {
         if (av1_is_directional_mode((PredictionMode)openLoopIntraCandidate)) {
+#if EDGE_BASED_SKIP_ANGULAR_INTRA
+            if (!disable_angle_prediction &&
+                directional_mode_skip_mask[(PredictionMode)openLoopIntraCandidate] == 0) {
+#else
             if (!disable_angle_prediction) {
+#endif
                 for (angleDeltaCounter = 0; angleDeltaCounter < angleDeltaCandidateCount; ++angleDeltaCounter) {
                     int32_t angle_delta = CLIP( angle_delta_shift * (angleDeltaCandidateCount == 1 ? 0 : angleDeltaCounter - (angleDeltaCandidateCount >> 1)), -3 , 3);
                     int32_t  p_angle = mode_to_angle_map[(PredictionMode)openLoopIntraCandidate] + angle_delta * ANGLE_STEP;
@@ -3939,12 +4137,47 @@ uint32_t product_full_mode_decision(
     ModeDecisionCandidateBuffer **buffer_ptr_array,
     uint32_t                      candidate_total_count,
     uint32_t                     *best_candidate_index_array,
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+    uint8_t                       prune_ref_frame_for_rec_partitions,
+#endif
     uint32_t                     *best_intra_mode)
 {
     uint32_t                  candidateIndex;
     uint64_t                  lowestCost = 0xFFFFFFFFFFFFFFFFull;
     uint64_t                  lowestIntraCost = 0xFFFFFFFFFFFFFFFFull;
     uint32_t                  lowestCostIndex = 0;
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+    if (prune_ref_frame_for_rec_partitions) {
+        if (context_ptr->blk_geom->shape == PART_N) {
+            for (uint32_t i = 0; i < candidate_total_count; ++i) {
+                candidateIndex = best_candidate_index_array[i];
+                ModeDecisionCandidate *candidate_ptr = buffer_ptr_array[candidateIndex]->candidate_ptr;
+                EbBool is_inter = (candidate_ptr->pred_mode >= NEARESTMV) ? EB_TRUE : EB_FALSE;
+                EbBool is_simple_translation = (candidate_ptr->motion_mode != WARPED_CAUSAL) ? EB_TRUE : EB_FALSE;
+                if (is_inter && is_simple_translation) {
+                    uint8_t ref_frame_type = candidate_ptr->ref_frame_type;
+                    assert(ref_frame_type < MAX_REF_TYPE_CAND);
+                    context_ptr->ref_best_cost_sq_table[ref_frame_type] = *(buffer_ptr_array[candidateIndex]->full_cost_ptr);
+                }
+
+            }
+            //Sort ref_frame by sq cost.
+            uint32_t i, j, index;
+            for (i = 0; i < MAX_REF_TYPE_CAND; ++i) {
+                context_ptr->ref_best_ref_sq_table[i] = i;
+            }
+            for (i = 0; i < MAX_REF_TYPE_CAND - 1; ++i) {
+                for (j = i + 1; j < MAX_REF_TYPE_CAND; ++j) {
+                    if (context_ptr->ref_best_cost_sq_table[context_ptr->ref_best_ref_sq_table[j]] < context_ptr->ref_best_cost_sq_table[context_ptr->ref_best_ref_sq_table[i]]) {
+                        index = context_ptr->ref_best_ref_sq_table[i];
+                        context_ptr->ref_best_ref_sq_table[i] = context_ptr->ref_best_ref_sq_table[j];
+                        context_ptr->ref_best_ref_sq_table[j] = index;
+                    }
+                }
+            }
+        }
+    }
+#endif
 #else
 uint8_t product_full_mode_decision(
     struct ModeDecisionContext   *context_ptr,

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -364,7 +364,7 @@ uint8_t check_ref_beackout(
     uint8_t skip_candidate = 0;
     uint8_t ref_cnt = 0;
     uint8_t allowed_nsq_ref_th = (uint8_t)PRUNE_REC_TH;
-    if (picture_control_set_ptr->parent_pcs_ptr->prune_ref_frame_for_rec_partitions) {
+    if (context_ptr->prune_ref_frame_for_rec_partitions) {
         if (shape != PART_N) {
             uint8_t ref_idx;
             assert(ref_frame_type < 30);

--- a/Source/Lib/Common/Codec/EbModeDecision.h
+++ b/Source/Lib/Common/Codec/EbModeDecision.h
@@ -274,6 +274,9 @@ extern "C" {
         ModeDecisionCandidateBuffer **buffer_ptr_array,
         uint32_t                      candidate_total_count,
         uint32_t                     *best_candidate_index_array,
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+        uint8_t                       prune_ref_frame_for_rec_partitions,
+#endif
         uint32_t                     *best_intra_mode);
 #else
     uint8_t product_full_mode_decision(

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.c
@@ -213,6 +213,10 @@ EbErrorType mode_decision_context_ctor(
         }
 #endif
     }
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+    EB_MALLOC_ARRAY(context_ptr->ref_best_cost_sq_table, MAX_REF_TYPE_CAND);
+    EB_MALLOC_ARRAY(context_ptr->ref_best_ref_sq_table, MAX_REF_TYPE_CAND);
+#endif
     return EB_ErrorNone;
 }
 

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -312,6 +312,16 @@ extern "C" {
     EbBool                              md_staging_skip_full_chroma;
     EbBool                              md_staging_skip_rdoq;
 #endif
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+    uint64_t                           *ref_best_cost_sq_table;
+    uint32_t                           *ref_best_ref_sq_table;
+#endif
+#if EDGE_BASED_SKIP_ANGULAR_INTRA
+    uint8_t                             edge_based_skip_angle_intra;
+#endif
+#if COEFF_BASED_SKIP_ATB
+    EbBool                              coeff_based_skip_atb;
+#endif
     } ModeDecisionContext;
 
     typedef void(*EbAv1LambdaAssignFunc)(

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -322,6 +322,9 @@ extern "C" {
 #if COEFF_BASED_SKIP_ATB
     EbBool                              coeff_based_skip_atb;
 #endif
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+    uint8_t                             prune_ref_frame_for_rec_partitions;
+#endif
     } ModeDecisionContext;
 
     typedef void(*EbAv1LambdaAssignFunc)(

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -14261,8 +14261,17 @@ extern "C" {
 #endif
         FrameHeader                           frm_hdr;
 #if COMP_MODE
-        MD_COMP_TYPE                            compound_types_to_try;
-        uint8_t                                 compound_mode;
+        MD_COMP_TYPE                          compound_types_to_try;
+        uint8_t                               compound_mode;
+#endif
+#if PRUNE_REF_FRAME_AT_ME
+        uint8_t                               prune_unipred_at_me;
+#endif
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+        uint8_t                               prune_ref_frame_for_rec_partitions;
+#endif
+#if COEFF_BASED_SKIP_ATB
+        uint8_t                              coeff_based_skip_atb;
 #endif
     } PictureParentControlSet;
 

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -14267,9 +14267,6 @@ extern "C" {
 #if PRUNE_REF_FRAME_AT_ME
         uint8_t                               prune_unipred_at_me;
 #endif
-#if PRUNE_REF_FRAME_FRO_REC_PARTITION
-        uint8_t                               prune_ref_frame_for_rec_partitions;
-#endif
 #if COEFF_BASED_SKIP_ATB
         uint8_t                              coeff_based_skip_atb;
 #endif

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -1230,6 +1230,16 @@ EbErrorType signal_derivation_multi_processes_oq(
         else
             picture_control_set_ptr->atb_mode = 0;
 #endif
+#if COEFF_BASED_SKIP_ATB
+        // Set skip atb                          Settings
+        // 0                                     OFF
+        // 1                                     ON
+        if (MR_MODE || picture_control_set_ptr->enc_mode == ENC_M0 || picture_control_set_ptr->sc_content_detected)
+            picture_control_set_ptr->coeff_based_skip_atb = 0;
+        else
+            picture_control_set_ptr->coeff_based_skip_atb = 1;
+
+#endif
 #if COMP_MODE
         // Set Wedge mode      Settings
         // 0                 FULL: Full search
@@ -1265,6 +1275,18 @@ EbErrorType signal_derivation_multi_processes_oq(
             picture_control_set_ptr->frame_end_cdf_update_mode = 1;
         else
             picture_control_set_ptr->frame_end_cdf_update_mode = 0;
+#endif
+#if PRUNE_REF_FRAME_AT_ME
+        if (picture_control_set_ptr->sc_content_detected || picture_control_set_ptr->enc_mode == ENC_M0 || picture_control_set_ptr->enc_mode >= ENC_M4)
+            picture_control_set_ptr->prune_unipred_at_me = 0;
+        else
+            picture_control_set_ptr->prune_unipred_at_me = 1;
+#endif
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+        if (picture_control_set_ptr->sc_content_detected || picture_control_set_ptr->enc_mode == ENC_M0)
+            picture_control_set_ptr->prune_ref_frame_for_rec_partitions = 0;
+        else
+            picture_control_set_ptr->prune_ref_frame_for_rec_partitions = 1;
 #endif
 #if MFMV_SUPPORT
         //CHKN: Temporal MVP should be disabled for pictures beloning to 4L MiniGop preceeded by 5L miniGOP. in this case the RPS is wrong(known issue). check RPS construction for more info.

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -1282,12 +1282,6 @@ EbErrorType signal_derivation_multi_processes_oq(
         else
             picture_control_set_ptr->prune_unipred_at_me = 1;
 #endif
-#if PRUNE_REF_FRAME_FRO_REC_PARTITION
-        if (picture_control_set_ptr->sc_content_detected || picture_control_set_ptr->enc_mode == ENC_M0)
-            picture_control_set_ptr->prune_ref_frame_for_rec_partitions = 0;
-        else
-            picture_control_set_ptr->prune_ref_frame_for_rec_partitions = 1;
-#endif
 #if MFMV_SUPPORT
         //CHKN: Temporal MVP should be disabled for pictures beloning to 4L MiniGop preceeded by 5L miniGOP. in this case the RPS is wrong(known issue). check RPS construction for more info.
         if ((sequence_control_set_ptr->static_config.hierarchical_levels == 4 && picture_control_set_ptr->hierarchical_levels == 3) ||

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -5465,7 +5465,11 @@ void md_stage_3(
 
         // Set MD Staging full_loop_core settings
         context_ptr->md_staging_skip_full_pred = (context_ptr->md_staging_mode == MD_STAGING_MODE_3) ? EB_FALSE: EB_TRUE;
+#if COEFF_BASED_SKIP_ATB
+        context_ptr->md_staging_skip_atb = context_ptr->coeff_based_skip_atb;
+#else
         context_ptr->md_staging_skip_atb = EB_FALSE;
+#endif
         context_ptr->md_staging_tx_search = candidate_ptr->cand_class == CAND_CLASS_0 ? 2 : 1;
         context_ptr->md_staging_skip_full_chroma = EB_FALSE;
         context_ptr->md_staging_skip_rdoq = EB_FALSE;
@@ -6589,6 +6593,10 @@ void md_encode_block(
     const uint32_t cuChromaOriginIndex = ROUND_UV(blk_geom->origin_x) / 2 + ROUND_UV(blk_geom->origin_y) / 2 * SB_STRIDE_UV;
     CodingUnit *  cu_ptr = context_ptr->cu_ptr;
     candidate_buffer_ptr_array = &(candidate_buffer_ptr_array_base[0]);
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+    for (uint8_t ref_idx = 0; ref_idx < MAX_REF_TYPE_CAND; ref_idx++)
+        context_ptr->ref_best_cost_sq_table[ref_idx] = MAX_CU_COST;
+#endif
     EbBool is_nsq_table_used = (picture_control_set_ptr->slice_type == !I_SLICE &&
         picture_control_set_ptr->parent_pcs_ptr->pic_depth_mode <= PIC_ALL_C_DEPTH_MODE &&
         picture_control_set_ptr->parent_pcs_ptr->nsq_search_level >= NSQ_SEARCH_LEVEL1 &&
@@ -7017,6 +7025,9 @@ void md_encode_block(
             candidate_buffer_ptr_array,
             context_ptr->md_stage_3_total_count,
             (context_ptr->full_loop_escape == 2) ? context_ptr->sorted_candidate_index_array : context_ptr->best_candidate_index_array,
+#if PRUNE_REF_FRAME_FRO_REC_PARTITION
+            picture_control_set_ptr->parent_pcs_ptr->prune_ref_frame_for_rec_partitions,
+#endif
             &best_intra_mode);
         candidate_buffer = candidate_buffer_ptr_array[candidate_index];
 #else
@@ -7560,7 +7571,9 @@ EB_EXTERN EbErrorType mode_decision_sb(
                 context_ptr->full_lambda,
                 context_ptr->md_rate_estimation_ptr,
                 picture_control_set_ptr);
-
+#if COEFF_BASED_SKIP_ATB
+            context_ptr->coeff_based_skip_atb = picture_control_set_ptr->parent_pcs_ptr->coeff_based_skip_atb && context_ptr->md_cu_arr_nsq[lastCuIndex_mds].block_has_coeff == 0 ? 1 : 0;
+#endif
             if (context_ptr->md_cu_arr_nsq[lastCuIndex_mds].split_flag == EB_FALSE)
             {
                 md_update_all_neighbour_arrays_multiple(

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -7026,7 +7026,7 @@ void md_encode_block(
             context_ptr->md_stage_3_total_count,
             (context_ptr->full_loop_escape == 2) ? context_ptr->sorted_candidate_index_array : context_ptr->best_candidate_index_array,
 #if PRUNE_REF_FRAME_FRO_REC_PARTITION
-            picture_control_set_ptr->parent_pcs_ptr->prune_ref_frame_for_rec_partitions,
+            context_ptr->prune_ref_frame_for_rec_partitions,
 #endif
             &best_intra_mode);
         candidate_buffer = candidate_buffer_ptr_array[candidate_index];

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -2592,6 +2592,12 @@ extern "C" {
     void eb_av1_txb_init_levels_avx2(const TranLow *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
     RTCD_EXTERN void(*eb_av1_txb_init_levels)(const TranLow *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
 
+
+#if EDGE_BASED_SKIP_ANGULAR_INTRA
+    void av1_get_gradient_hist_c(const uint8_t *src, int src_stride, int rows, int cols, uint64_t *hist);
+    void av1_get_gradient_hist_avx2(const uint8_t *src, int src_stride, int rows, int cols, uint64_t *hist);
+    RTCD_EXTERN void(*av1_get_gradient_hist)(const uint8_t *src, int src_stride, int rows, int cols, uint64_t *hist);
+#endif
     void eb_aom_dsp_rtcd(void);
 
 #ifdef RTCD_C
@@ -3927,6 +3933,10 @@ extern "C" {
         /*if (flags & HAS_AVX2)*/ eb_aom_ifft8x8_float = eb_aom_ifft8x8_float_avx2;
         eb_aom_ifft2x2_float = eb_aom_ifft2x2_float_c;
         /*if (flags & HAS_SSE2)*/ eb_aom_ifft4x4_float = eb_aom_ifft4x4_float_sse2;
+#if EDGE_BASED_SKIP_ANGULAR_INTRA
+        av1_get_gradient_hist = av1_get_gradient_hist_c;
+        if (flags & HAS_AVX2) av1_get_gradient_hist = av1_get_gradient_hist_avx2;
+#endif
     }
 #endif
 

--- a/Source/Lib/Decoder/Codec/EbDecParseBlock.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseBlock.c
@@ -2532,7 +2532,7 @@ void parse_residual(EbDecHandle *dec_handle, PartitionInfo_t *pi, SvtReader *r,
 
                     assert(total_num_tu != 0);
                     assert(total_num_tu ==
-                        (parse_ctx->num_tus[plane][0] + parse_ctx->num_tus[plane][1] +
+                        (uint32_t)(parse_ctx->num_tus[plane][0] + parse_ctx->num_tus[plane][1] +
                             parse_ctx->num_tus[plane][2] + parse_ctx->num_tus[plane][3]));
                 }
                 assert(num_tu != 0);


### PR DESCRIPTION
## Description
Added the following lossy speed optimizations:
- Opt 0: Use the top 4 ME candidates only @ 3x3 Unipred and 3x3 Bipred.
- Opt 1: Skip ATB if parent block does not have coeff.
- Opt 2: Use edge detection to bypass some angular modes.
- Opt 3: Bipred candidates reduction @ ME.
- Opt 4: MD candidates reduction @ MD.

Closes #593  

## Author

@NaderMahdi 
@chkngit  
@hguermaz 

## Type of change

New feature/Tool

## Tests and performance
* BD-Rate to aom cpu0-2pass on the full list: Opt 0: 0.020% loss, Opt 1: 0.023%, Opt 2: 0.029%, Opt 3: M1 & higher tool , Opt 4: M1 & higher too.l 
* Speed on a 4-core machine:  Opt 0: 30% faster, Opt 1: 0.9% faster, Opt 2: 1.5% faster, Opt 3: M1 & higher tool , Opt 4: M1 & higher too.l 
* Memory footprint on a 4-core machine: negligible