### PR TITLE
Add unit tests for spatial full distortion functions

### DIFF
--- a/test/SpatialFullDistortionTest.cc
+++ b/test/SpatialFullDistortionTest.cc
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright(c) 2019 Intel Corporation
  * SPDX - License - Identifier: BSD - 2 - Clause - Patent
  */
@@ -26,13 +26,13 @@
 
 namespace {
 
-typedef uint64_t (*spatial_full_distortion_kernel_func)(
+typedef uint64_t (*SpatialFullDistortionKernelFunc)(
     uint8_t *input, uint32_t input_offset, uint32_t input_stride,
     uint8_t *recon, uint32_t recon_offset, uint32_t recon_stride,
     uint32_t area_width, uint32_t area_height);
 
 class SpatialFullDistortionTest
-    : public ::testing::TestWithParam<spatial_full_distortion_kernel_func> {
+    : public ::testing::TestWithParam<SpatialFullDistortionKernelFunc> {
   public:
     SpatialFullDistortionTest() : func_(GetParam()) {
     }
@@ -42,10 +42,10 @@ class SpatialFullDistortionTest
     void SetUp() {
         input_stride_ = eb_create_random_aligned_stride(MAX_SB_SIZE, 64);
         recon_stride_ = eb_create_random_aligned_stride(MAX_SB_SIZE, 64);
-        input_ =
-            (uint8_t *)malloc(sizeof(*input_) * MAX_SB_SIZE * input_stride_);
-        recon_ =
-            (uint8_t *)malloc(sizeof(*recon_) * MAX_SB_SIZE * recon_stride_);
+        input_ = reinterpret_cast<uint8_t *>(
+            malloc(sizeof(*input_) * MAX_SB_SIZE * input_stride_));
+        recon_ = reinterpret_cast<uint8_t *>(
+            malloc(sizeof(*recon_) * MAX_SB_SIZE * recon_stride_));
     }
     void TearDown() {
         free(recon_);
@@ -62,7 +62,7 @@ class SpatialFullDistortionTest
         eb_buf_random_u8(recon_, MAX_SB_SIZE * recon_stride_);
     }
 
-    spatial_full_distortion_kernel_func func_;
+    SpatialFullDistortionKernelFunc func_;
     uint8_t *input_;
     uint8_t *recon_;
     uint32_t input_stride_;
@@ -186,4 +186,318 @@ INSTANTIATE_TEST_CASE_P(
     ::testing::Values(spatial_full_distortion_kernel_avx512));
 #endif
 
-};  // namespace
+typedef enum { VAL_MIN, VAL_MAX, VAL_RANDOM } TestPattern;
+TestPattern TEST_PATTERNS[] = {VAL_MIN, VAL_MAX, VAL_RANDOM};
+typedef std::tuple<uint32_t, uint32_t> AreaSize;
+
+/**
+ * @Brief Base class for SpatialFullDistortionFunc test.
+ */
+class SpatialFullDistortionFuncTestBase : public ::testing::Test {
+    void SetUp() override {
+        input_stride_ = eb_create_random_aligned_stride(MAX_SB_SIZE, 64);
+        recon_stride_ = eb_create_random_aligned_stride(MAX_SB_SIZE, 64);
+        input_test_size_ = MAX_SB_SIZE * input_stride_;
+        recon_test_size_ = MAX_SB_SIZE * recon_stride_;
+        input_ = reinterpret_cast<uint8_t *>(
+            malloc(sizeof(*input_) * input_test_size_));
+        recon_ = reinterpret_cast<uint8_t *>(
+            malloc(sizeof(*recon_) * recon_test_size_));
+    }
+    void TearDown() override {
+        free(recon_);
+        free(input_);
+        aom_clear_system_state();
+    }
+
+  protected:
+    virtual void RunCheckOutput() {
+    }
+
+    void init_data() {
+        const uint8_t mask = (1 << 8) - 1;
+        switch (test_pattern_) {
+        case VAL_MIN: {
+            memset(input_, 0, input_test_size_ * sizeof(input_[0]));
+            memset(recon_, 0, recon_test_size_ * sizeof(recon_[0]));
+            break;
+        }
+        case VAL_MAX: {
+            memset(input_, mask, input_test_size_ * sizeof(input_[0]));
+            memset(recon_, mask, recon_test_size_ * sizeof(recon_[0]));
+            break;
+        }
+        case VAL_RANDOM: {
+            eb_buf_random_u8(input_, input_test_size_);
+            eb_buf_random_u8(recon_, recon_test_size_);
+            break;
+        }
+        default: break;
+        }
+    }
+
+    int input_test_size_, recon_test_size_;
+    uint8_t *input_;
+    uint8_t *recon_;
+    uint32_t input_stride_;
+    uint32_t recon_stride_;
+    uint32_t area_width_, area_height_;
+    TestPattern test_pattern_;
+};
+
+typedef struct TestParam {
+    AreaSize area_size;
+    SpatialFullDistortionKernelFunc sse2_test_func;
+    SpatialFullDistortionKernelFunc avx2_test_func;
+    SpatialFullDistortionKernelFunc avx512_test_func;
+} TestParam;
+#ifndef NON_AVX512_SUPPORT
+TestParam spatial_test_param[] = {
+    {AreaSize(128, 128),
+     spatial_full_distortion_kernel128x_n_sse2_intrin,
+     spatial_full_distortion_kernel128x_n_avx2_intrin,
+     spatial_full_distortion_kernel128x_n_avx512_intrin},
+    {AreaSize(64, 64),
+     spatial_full_distortion_kernel64x_n_sse2_intrin,
+     spatial_full_distortion_kernel64x_n_avx2_intrin,
+     spatial_full_distortion_kernel64x_n_avx512_intrin},
+    {AreaSize(32, 32),
+     spatial_full_distortion_kernel32x_n_sse2_intrin,
+     spatial_full_distortion_kernel32x_n_avx2_intrin,
+     spatial_full_distortion_kernel32x_n_avx512_intrin},
+    {AreaSize(16, 16),
+     spatial_full_distortion_kernel16x_n_sse2_intrin,
+     spatial_full_distortion_kernel16x_n_avx2_intrin,
+     nullptr},
+    {AreaSize(8, 8),
+     spatial_full_distortion_kernel8x_n_sse2_intrin,
+     spatial_full_distortion_kernel8x_n_avx2_intrin,
+     nullptr},
+    {AreaSize(4, 4),
+     spatial_full_distortion_kernel4x_n_sse2_intrin,
+     spatial_full_distortion_kernel4x_n_avx2_intrin,
+     nullptr}};
+#else
+TestParam SPATIAL_TEST_PARAM[] = {
+    {AreaSize(128, 128),
+     spatial_full_distortion_kernel128x_n_sse2_intrin,
+     spatial_full_distortion_kernel128x_n_avx2_intrin,
+     nullptr},
+    {AreaSize(64, 64),
+     spatial_full_distortion_kernel64x_n_sse2_intrin,
+     spatial_full_distortion_kernel64x_n_avx2_intrin,
+     nullptr},
+    {AreaSize(32, 32),
+     spatial_full_distortion_kernel32x_n_sse2_intrin,
+     spatial_full_distortion_kernel32x_n_avx2_intrin,
+     nullptr},
+    {AreaSize(16, 16),
+     spatial_full_distortion_kernel16x_n_sse2_intrin,
+     spatial_full_distortion_kernel16x_n_avx2_intrin,
+     nullptr},
+    {AreaSize(8, 8),
+     spatial_full_distortion_kernel8x_n_sse2_intrin,
+     spatial_full_distortion_kernel8x_n_avx2_intrin,
+     nullptr},
+    {AreaSize(4, 4),
+     spatial_full_distortion_kernel4x_n_sse2_intrin,
+     spatial_full_distortion_kernel4x_n_avx2_intrin,
+     nullptr}};
+#endif
+typedef std::tuple<TestParam, TestPattern> SpatialTestParam;
+
+/**
+ * @brief Unit test for spatial distortion calculation functions include:
+ *  - spatial_full_distortion_kernel{4, 8, 16, 32, 64,
+      128}x_n_{sse2,avx2,avx512}_intrin
+ *
+ *
+ * Test strategy:
+ *  This test case combine different area width{4-128} x area
+ * height{4-128} and different test pattern(VAL_MIN, VAL_MAX, VAL_RANDOM). Check
+ * the result by compare result from reference function and avx2/sse2 function.
+ *
+ *
+ * Expect result:
+ *  Results from reference function and sse2/avx2/avx512 function are
+ * equal.
+ *
+ *
+ * Test cases:
+ *  Width {4, 8, 16, 32, 64, 128} x height{ 4, 8, 16, 32, 64, 128}
+ *  Test vector pattern {VAL_MIN, VAL_MIN, VAL_RANDOM}
+ *
+ */
+class SpatialFullDistortionFuncTest
+    : public SpatialFullDistortionFuncTestBase,
+      public ::testing::WithParamInterface<SpatialTestParam> {
+  public:
+    SpatialFullDistortionFuncTest() {
+        area_width_ = std::get<0>(TEST_GET_PARAM(0).area_size);
+        area_height_ = std::get<1>(TEST_GET_PARAM(0).area_size);
+        sse2_func_ = TEST_GET_PARAM(0).sse2_test_func;
+        avx2_func_ = TEST_GET_PARAM(0).avx2_test_func;
+        avx512_func_ = TEST_GET_PARAM(0).avx512_test_func;
+        test_pattern_ = TEST_GET_PARAM(1);
+    }
+
+    ~SpatialFullDistortionFuncTest() {
+    }
+
+  protected:
+    void RunCheckOutput();
+    SpatialFullDistortionKernelFunc sse2_func_, avx2_func_, avx512_func_;
+};
+
+void SpatialFullDistortionFuncTest::RunCheckOutput() {
+    for (int i = 0; i < 10; i++) {
+        init_data();
+        const uint64_t dist_sse2 = sse2_func_(input_,
+                                              0,
+                                              input_stride_,
+                                              recon_,
+                                              0,
+                                              recon_stride_,
+                                              area_width_,
+                                              area_height_);
+        const uint64_t dist_avx2 = avx2_func_(input_,
+                                              0,
+                                              input_stride_,
+                                              recon_,
+                                              0,
+                                              recon_stride_,
+                                              area_width_,
+                                              area_height_);
+        uint64_t dist_avx512 = 0;
+        if (avx512_func_)
+            dist_avx512 = avx512_func_(input_,
+                                       0,
+                                       input_stride_,
+                                       recon_,
+                                       0,
+                                       recon_stride_,
+                                       area_width_,
+                                       area_height_);
+        const uint64_t dist_c = spatial_full_distortion_kernel_c(input_,
+                                                                 0,
+                                                                 input_stride_,
+                                                                 recon_,
+                                                                 0,
+                                                                 recon_stride_,
+                                                                 area_width_,
+                                                                 area_height_);
+        EXPECT_EQ(dist_sse2, dist_c)
+            << "Compare sse2 vs c Spatial distortion result error";
+        EXPECT_EQ(dist_avx2, dist_c)
+            << "Compare avx2 vs c Spatial distortion result error";
+        if (avx512_func_)
+            EXPECT_EQ(dist_avx512, dist_c)
+                << "Compare avx512 vs c Spatial distortion result error";
+    }
+}
+
+TEST_P(SpatialFullDistortionFuncTest, SpatialFuncTest) {
+    RunCheckOutput();
+}
+
+INSTANTIATE_TEST_CASE_P(
+    SpatialFunc, SpatialFullDistortionFuncTest,
+    ::testing::Combine(::testing::ValuesIn(SPATIAL_TEST_PARAM),
+                       ::testing::ValuesIn(TEST_PATTERNS)));
+
+AreaSize TEST_AREA_SIZES[] = {
+    AreaSize(4, 4),    AreaSize(4, 8),    AreaSize(8, 4),   AreaSize(8, 8),
+    AreaSize(16, 16),  AreaSize(12, 16),  AreaSize(4, 16),  AreaSize(16, 4),
+    AreaSize(16, 8),   AreaSize(20, 16),  AreaSize(24, 16), AreaSize(28, 16),
+    AreaSize(8, 16),   AreaSize(32, 32),  AreaSize(32, 8),  AreaSize(16, 32),
+    AreaSize(8, 32),   AreaSize(32, 16),  AreaSize(16, 64), AreaSize(64, 16),
+    AreaSize(64, 64),  AreaSize(64, 32),  AreaSize(32, 64), AreaSize(128, 128),
+    AreaSize(96, 128), AreaSize(64, 128), AreaSize(128, 64)};
+typedef std::tuple<AreaSize, TestPattern, SpatialFullDistortionKernelFunc>
+    SpatialKernelTestParam;
+
+/**
+ * @brief Unit test for spatial distortion calculation functions include:
+ *  - spatial_full_distortion_kernel_{avx2,avx512}
+ *
+ *
+ * Test strategy:
+ *  This test case combine different area width{4-128} x area
+ * height{4-128} and different test pattern(VAL_MIN, VAL_MAX, VAL_RANDOM). Check
+ * the result by compare result from reference function and avx2/sse2 function.
+ *
+ *
+ * Expect result:
+ *  Results from reference function and avx2/avx512 function are
+ * equal.
+ *
+ *
+ * Test cases:
+ *  Width {4, 8, 12, 16, 20, 24, 28, 32, 64, 96, 128} x height{ 4, 8, 16, 32,
+ * 64, 128} Test vector pattern {VAL_MIN, VAL_MIN, VAL_RANDOM}
+ *
+ */
+class SpatialFullDistortionKernelFuncTest
+    : public SpatialFullDistortionFuncTestBase,
+      public ::testing::WithParamInterface<SpatialKernelTestParam> {
+  public:
+    SpatialFullDistortionKernelFuncTest() {
+        area_width_ = std::get<0>(TEST_GET_PARAM(0));
+        area_height_ = std::get<1>(TEST_GET_PARAM(0));
+        test_func_ = TEST_GET_PARAM(2);
+        test_pattern_ = TEST_GET_PARAM(1);
+    }
+
+    ~SpatialFullDistortionKernelFuncTest() {
+    }
+
+  protected:
+    void RunCheckOutput();
+    SpatialFullDistortionKernelFunc test_func_;
+};
+
+void SpatialFullDistortionKernelFuncTest::RunCheckOutput() {
+    for (int i = 0; i < 10; i++) {
+        init_data();
+        const uint64_t dist_test = test_func_(input_,
+                                              0,
+                                              input_stride_,
+                                              recon_,
+                                              0,
+                                              recon_stride_,
+                                              area_width_,
+                                              area_height_);
+        const uint64_t dist_c = spatial_full_distortion_kernel_c(input_,
+                                                                 0,
+                                                                 input_stride_,
+                                                                 recon_,
+                                                                 0,
+                                                                 recon_stride_,
+                                                                 area_width_,
+                                                                 area_height_);
+
+        EXPECT_EQ(dist_test, dist_c)
+            << "Compare Spatial distortion result error";
+    }
+}
+
+TEST_P(SpatialFullDistortionKernelFuncTest, SpatialKernelFuncTest) {
+    RunCheckOutput();
+}
+#ifndef NON_AVX512_SUPPORT
+INSTANTIATE_TEST_CASE_P(
+    SpatialKernelFunc, SpatialFullDistortionKernelFuncTest,
+    ::testing::Combine(
+        ::testing::ValuesIn(TEST_AREA_SIZES),
+        ::testing::ValuesIn(TEST_PATTERNS),
+        ::testing::Values(spatial_full_distortion_kernel_avx2,
+                          spatial_full_distortion_kernel_avx512)));
+#else
+INSTANTIATE_TEST_CASE_P(
+    SpatialKernelFunc, SpatialFullDistortionKernelFuncTest,
+    ::testing::Combine(::testing::ValuesIn(TEST_AREA_SIZES),
+                       ::testing::ValuesIn(TEST_PATTERNS),
+                       ::testing::Values(spatial_full_distortion_kernel_avx2)));
+#endif
+
+}  // namespace


### PR DESCRIPTION
1. add unit tests for spatial_full_distortion_kernel{4, 8, 16, 32, 64,
      128}x_n_{sse2,avx2}_intrin
2. add unit tests for spatial_full_distortion_kernel_{avx2,avx512}