### PR TITLE
hash_table_clear_all(): fix a crash caused by allocate and free mismatch

### DIFF
--- a/Source/Lib/Common/Codec/hash_motion.c
+++ b/Source/Lib/Common/Codec/hash_motion.c
@@ -27,7 +27,7 @@ static void hash_table_clear_all(HashTable *p_hash_table) {
   for (int i = 0; i < max_addr; i++) {
     if (p_hash_table->p_lookup_table[i] != NULL) {
       eb_aom_vector_destroy(p_hash_table->p_lookup_table[i]);
-      eb_aom_free(p_hash_table->p_lookup_table[i]);
+      free(p_hash_table->p_lookup_table[i]);
       p_hash_table->p_lookup_table[i] = NULL;
     }
   }


### PR DESCRIPTION
this will fix https://github.com/OpenVisualCloud/SVT-AV1/issues/605