### PR TITLE
Support arbitrary picture size (non multiple of 8)

### DIFF
--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -99,6 +99,9 @@ typedef struct EbSvtAv1EncConfiguration
      *
      * Default is 0. */
     uint32_t                 source_height;
+
+    uint32_t render_width, render_height;
+
     /* The frequecy of images being displayed. If the number is less than 1000,
      * the input frame rate is an integer number between 1 and 60, else the input
      * number is in Q16 format, shifted by 16 bits, where max allowed is 240 fps.

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -1234,8 +1234,8 @@ EbErrorType read_command_line(
 
                 // Assuming no errors, add padding to width and height
                 if (return_errors[index] == EB_ErrorNone) {
-                    configs[index]->input_padded_width  = configs[index]->source_width;
-                    configs[index]->input_padded_height = configs[index]->source_height;
+                    configs[index]->input_padded_width = configs[index]->source_width + configs[index]->source_width % 8;
+                    configs[index]->input_padded_height = configs[index]->source_height + configs[index]->source_width % 8;
                 }
 
                 // Assuming no errors, set the frames to be encoded to the number of frames in the input yuv

--- a/Source/Lib/Common/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Common/Codec/EbEntropyCoding.c
@@ -3586,6 +3586,23 @@ static void write_tile_info(const PictureParentControlSet *const pcs_ptr,
     }
 }
 
+static void write_render_size(struct AomWriteBitBuffer *wb,
+                              SequenceControlSet *scs)
+{
+    uint16_t width = scs->max_input_luma_width;
+    uint16_t render_width = width - scs->max_input_pad_right;
+    uint16_t height = scs->max_input_luma_height;
+    uint16_t render_height = height - scs->max_input_pad_bottom;
+    int render_and_frame_size_different =
+        (width != render_width) || (height != render_height);
+    eb_aom_wb_write_bit(wb, render_and_frame_size_different);
+    if (!render_and_frame_size_different) return;
+    uint32_t render_width_minus_1 = render_width - 1;
+    uint32_t render_height_minus_1 = render_height - 1;
+    eb_aom_wb_write_literal(wb, render_width_minus_1, 16);
+    eb_aom_wb_write_literal(wb, render_height_minus_1, 16);
+}
+
 static void write_frame_size(PictureParentControlSet *pcs_ptr,
     int32_t frame_size_override,
     struct AomWriteBitBuffer *wb) {
@@ -3607,8 +3624,7 @@ static void write_frame_size(PictureParentControlSet *pcs_ptr,
         //write_superres_scale(cm, wb);
     }
 
-    eb_aom_wb_write_bit(wb, 0);
-    //write_render_size(cm, wb);
+    write_render_size(wb, scs_ptr);
 }
 
 static void WriteProfile(BitstreamProfile profile,

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -1906,15 +1906,17 @@ void SetParamBasedOnInput(SequenceControlSet *sequence_control_set_ptr)
     if (sequence_control_set_ptr->max_input_luma_width % MIN_BLOCK_SIZE) {
         sequence_control_set_ptr->max_input_pad_right = MIN_BLOCK_SIZE - (sequence_control_set_ptr->max_input_luma_width % MIN_BLOCK_SIZE);
         sequence_control_set_ptr->max_input_luma_width = sequence_control_set_ptr->max_input_luma_width + sequence_control_set_ptr->max_input_pad_right;
-    }
-    else
+    } else {
         sequence_control_set_ptr->max_input_pad_right = 0;
+    }
+
     if (sequence_control_set_ptr->max_input_luma_height % MIN_BLOCK_SIZE) {
         sequence_control_set_ptr->max_input_pad_bottom = MIN_BLOCK_SIZE - (sequence_control_set_ptr->max_input_luma_height % MIN_BLOCK_SIZE);
         sequence_control_set_ptr->max_input_luma_height = sequence_control_set_ptr->max_input_luma_height + sequence_control_set_ptr->max_input_pad_bottom;
-    }
-    else
+    } else {
         sequence_control_set_ptr->max_input_pad_bottom = 0;
+    }
+
     sequence_control_set_ptr->max_input_chroma_width = sequence_control_set_ptr->max_input_luma_width >> subsampling_x;
     sequence_control_set_ptr->max_input_chroma_height = sequence_control_set_ptr->max_input_luma_height >> subsampling_y;
 
@@ -1979,8 +1981,9 @@ void CopyApiFromApp(
     EbSvtAv1EncConfiguration   *pComponentParameterStructure){
     uint32_t                  hmeRegionIndex = 0;
 
-    sequence_control_set_ptr->max_input_luma_width = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->source_width;
-    sequence_control_set_ptr->max_input_luma_height = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->source_height;
+    sequence_control_set_ptr->max_input_luma_width = pComponentParameterStructure->source_width;
+    sequence_control_set_ptr->max_input_luma_height = pComponentParameterStructure->source_height;
+
     sequence_control_set_ptr->frame_rate = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->frame_rate;
 
     sequence_control_set_ptr->general_frame_only_constraint_flag = 0;
@@ -2253,11 +2256,6 @@ static EbErrorType VerifySettings(
 
     if (sequence_control_set_ptr->max_input_luma_height % 2) {
         SVT_LOG("Error Instance %u: Source Height must be even for YUV_420 colorspace\n", channelNumber + 1);
-        return_error = EB_ErrorBadParameter;
-    }
-
-    if ((sequence_control_set_ptr->max_input_luma_height % 8) || (sequence_control_set_ptr->max_input_luma_width % 8)) {
-        SVT_LOG("Error Instance %u: Only multiple of 8 resolutions are supported \n", channelNumber + 1);
         return_error = EB_ErrorBadParameter;
     }
 


### PR DESCRIPTION
Hi,

The following PR removes the restriction for non multiple of 8 sized pictures. Please feel free to test.

After looking at this section of code, I would say that the current buffer allocation model should be reworked at some point. The onus of allocating, padding, aligning the input buffer happens in the app. Not ideal, this should really be something that is handled by the lib.

Thanks,
Kyle