### PR TITLE
Remove some MSVC build warnings

### DIFF
--- a/Source/Lib/Common/Codec/EbCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbCodingLoop.c
@@ -508,13 +508,13 @@ static void Av1EncodeLoop(
             residual16bit->stride_y,
             context_ptr->blk_geom->tx_width[cu_ptr->tx_depth][context_ptr->txb_itr],
             context_ptr->blk_geom->tx_height[cu_ptr->tx_depth][context_ptr->txb_itr]);
-        uint8_t  tx_search_skip_fag = (picture_control_set_ptr->parent_pcs_ptr->tx_search_level == TX_SEARCH_ENC_DEC && (picture_control_set_ptr->parent_pcs_ptr->atb_mode == 0 || cu_ptr->prediction_mode_flag == INTER_MODE)) ? get_skip_tx_search_flag(
+        uint8_t  tx_search_skip_flag = (picture_control_set_ptr->parent_pcs_ptr->tx_search_level == TX_SEARCH_ENC_DEC && (picture_control_set_ptr->parent_pcs_ptr->atb_mode == 0 || cu_ptr->prediction_mode_flag == INTER_MODE)) ? get_skip_tx_search_flag(
             context_ptr->blk_geom->sq_size,
             MAX_MODE_COST,
             0,
             1) : 1;
 
-        if (!tx_search_skip_fag) {
+        if (!tx_search_skip_flag) {
                 encode_pass_tx_search(
                     picture_control_set_ptr,
                     context_ptr,
@@ -929,13 +929,13 @@ static void Av1EncodeLoop16bit(
                 residual16bit->stride_y,
                 context_ptr->blk_geom->tx_width[cu_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height[cu_ptr->tx_depth][context_ptr->txb_itr]);
-            uint8_t  tx_search_skip_fag = (picture_control_set_ptr->parent_pcs_ptr->tx_search_level == TX_SEARCH_ENC_DEC && (picture_control_set_ptr->parent_pcs_ptr->atb_mode == 0 || cu_ptr->prediction_mode_flag == INTER_MODE)) ? get_skip_tx_search_flag(
+            uint8_t  tx_search_skip_flag = (picture_control_set_ptr->parent_pcs_ptr->tx_search_level == TX_SEARCH_ENC_DEC && (picture_control_set_ptr->parent_pcs_ptr->atb_mode == 0 || cu_ptr->prediction_mode_flag == INTER_MODE)) ? get_skip_tx_search_flag(
                 context_ptr->blk_geom->sq_size,
                 MAX_MODE_COST,
                 0,
                 1) : 1;
 
-            if (!tx_search_skip_fag) {
+            if (!tx_search_skip_flag) {
                     encode_pass_tx_search_hbd(
                         picture_control_set_ptr,
                         context_ptr,
@@ -1636,7 +1636,7 @@ void perform_intra_coding_loop(
         }
         // Encode Transform Unit -INTRA-
 
-        uint8_t cb_qp = cu_ptr->qp;
+        uint16_t cb_qp = cu_ptr->qp;
         Av1EncodeLoopFunctionTable[is16bit](
             picture_control_set_ptr,
             context_ptr,
@@ -1902,7 +1902,7 @@ void perform_intra_coding_loop(
         }
 
         // Encode Transform Unit -INTRA-
-        uint8_t cb_qp = cu_ptr->qp;
+        uint16_t cb_qp = cu_ptr->qp;
 
         Av1EncodeLoopFunctionTable[is16bit](
             picture_control_set_ptr,
@@ -2726,7 +2726,7 @@ EB_EXTERN void av1_encode_pass(
 
                             // Encode Transform Unit -INTRA-
                             {
-                                uint8_t             cb_qp = cu_ptr->qp;
+                                uint16_t             cb_qp = cu_ptr->qp;
 
                                 Av1EncodeLoopFunctionTable[is16bit](
                                     picture_control_set_ptr,
@@ -3091,7 +3091,7 @@ EB_EXTERN void av1_encode_pass(
 
                     uint32_t totTu = context_ptr->blk_geom->txb_count[cu_ptr->tx_depth];
                     uint8_t   tuIt;
-                    uint8_t   cb_qp = cu_ptr->qp;
+                    uint16_t   cb_qp = cu_ptr->qp;
                     uint32_t  component_mask = context_ptr->blk_geom->has_uv ? PICTURE_BUFFER_DESC_FULL_MASK : PICTURE_BUFFER_DESC_LUMA_MASK;
 
                     if (cu_ptr->prediction_unit_array[0].merge_flag == EB_FALSE) {

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -257,7 +257,7 @@ static void ResetEncDec(
 #endif
     // Asuming cb and cr offset to be the same for chroma QP in both slice and pps for lambda computation
 
-    context_ptr->chroma_qp = context_ptr->qp;
+    context_ptr->chroma_qp = (uint8_t)context_ptr->qp;
 
     // Lambda Assignement
     context_ptr->qp_index = (uint8_t)picture_control_set_ptr->
@@ -296,7 +296,7 @@ static void EncDecConfigureLcu(
     context_ptr->qp = sb_qp;
 
     // Asuming cb and cr offset to be the same for chroma QP in both slice and pps for lambda computation
-    context_ptr->chroma_qp = context_ptr->qp;
+    context_ptr->chroma_qp = (uint8_t)context_ptr->qp;
     /* Note(CHKN) : when Qp modulation varies QP on a sub-LCU(CU) basis,  Lamda has to change based on Cu->QP , and then this code has to move inside the CU loop in MD */
     (void)sb_ptr;
     context_ptr->qp_index = (uint8_t)picture_control_set_ptr->

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.c
@@ -396,7 +396,7 @@ void reset_mode_decision(
     context_ptr->qp = picture_control_set_ptr->picture_qp;
 #endif
     // Asuming cb and cr offset to be the same for chroma QP in both slice and pps for lambda computation
-    context_ptr->chroma_qp = context_ptr->qp;
+    context_ptr->chroma_qp = (uint8_t)context_ptr->qp;
     context_ptr->qp_index = (uint8_t)frm_hdr->quantization_params.base_q_idx;
     (*av1_lambda_assignment_function_table[picture_control_set_ptr->parent_pcs_ptr->pred_structure])(
         &context_ptr->fast_lambda,
@@ -454,7 +454,7 @@ void mode_decision_configure_lcu(
     context_ptr->qp = sb_qp;
     // Asuming cb and cr offset to be the same for chroma QP in both slice and pps for lambda computation
 
-    context_ptr->chroma_qp = context_ptr->qp;
+    context_ptr->chroma_qp = (uint8_t)context_ptr->qp;
 
     /* Note(CHKN) : when Qp modulation varies QP on a sub-LCU(CU) basis,  Lamda has to change based on Cu->QP , and then this code has to move inside the CU loop in MD */
 

--- a/Source/Lib/Common/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureManagerProcess.c
@@ -772,7 +772,7 @@ void* picture_manager_kernel(void *input_ptr)
                                     }
                                     // Set the Reference Object
                                     ChildPictureControlSetPtr->ref_pic_ptr_array[REF_LIST_0][refIdx] = referenceEntryPtr->reference_object_ptr;
-                                    ChildPictureControlSetPtr->ref_pic_qp_array[REF_LIST_0][refIdx] = ((EbReferenceObject*)referenceEntryPtr->reference_object_ptr->object_ptr)->qp;
+                                    ChildPictureControlSetPtr->ref_pic_qp_array[REF_LIST_0][refIdx] = (uint8_t)((EbReferenceObject*)referenceEntryPtr->reference_object_ptr->object_ptr)->qp;
                                     ChildPictureControlSetPtr->ref_slice_type_array[REF_LIST_0][refIdx] = ((EbReferenceObject*)referenceEntryPtr->reference_object_ptr->object_ptr)->slice_type;
                                     // Increment the Reference's liveCount by the number of tiles in the input picture
                                     eb_object_inc_live_count(


### PR DESCRIPTION
## Description
This PR addresses build warnings type C4244 seen when building SVT-AV1 on MSVC Visual Studio 2017

fixes #636

## Type of change
Code Cleanup

## Tests and performance
- Lossless; no impact on BD-Rate
- negligible speed impact
- no deviation in memory footprint