### PR TITLE
Speed Optimization(s)

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -36,7 +36,7 @@ extern "C" {
 #define II_COMP_FLAG 1
 #define PRED_CHANGE                  1 // Change the MRP in 4L Pictures 3, 5 , 7 and 9 use 1 as the reference
 #define PRED_CHANGE_5L               1 // Change the MRP in 5L Pictures 3, 5 , 7 and 9 use 1 as the reference, 11, 13, 15 and 17 use 9 as the reference
-#define SPEED_OPT                    1 // Speed optimizations
+#define SPEED_OPT                    1 // Speed optimization(s)
 
 #ifndef NON_AVX512_SUPPORT
 #define NON_AVX512_SUPPORT

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -36,6 +36,7 @@ extern "C" {
 #define II_COMP_FLAG 1
 #define PRED_CHANGE                  1 // Change the MRP in 4L Pictures 3, 5 , 7 and 9 use 1 as the reference
 #define PRED_CHANGE_5L               1 // Change the MRP in 5L Pictures 3, 5 , 7 and 9 use 1 as the reference, 11, 13, 15 and 17 use 9 as the reference
+#define SPEED_OPT                    1 // Speed optimizations
 
 #ifndef NON_AVX512_SUPPORT
 #define NON_AVX512_SUPPORT
@@ -467,9 +468,9 @@ typedef enum MD_STAGE {
 #define MAX_REF_TYPE_CAND   30
 #define PRUNE_REC_TH         5
 #define PRUNE_REF_ME_TH      2
-
+#if !SPEED_OPT
 #define MD_EXIT_THSL         0 // MD_EXIT_THSL -->0 is lossless 100 is maximum. Increase with a step of 10-20.
-
+#endif
 typedef enum
 {
     EIGHTTAP_REGULAR,

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1442,6 +1442,27 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         context_ptr->prune_ref_frame_for_rec_partitions = 0;
     else
         context_ptr->prune_ref_frame_for_rec_partitions = 1;
+
+#if SPEED_OPT
+    // Derive INTER/INTER WEDGE variance TH
+    if (MR_MODE)
+        context_ptr->inter_inter_wedge_variance_th = 0;
+    else //if (picture_control_set_ptr->enc_mode == ENC_M0)
+        context_ptr->inter_inter_wedge_variance_th = 100;
+
+    // Derive MD Exit TH
+    if (MR_MODE)
+        context_ptr->md_exit_th = 0;
+    else //if (picture_control_set_ptr->enc_mode == ENC_M0)
+        context_ptr->md_exit_th = 10;
+
+    // Derive distortion-based md_stage_0_count proning
+    if (MR_MODE)
+        context_ptr->dist_base_md_stage_0_count_th = (uint64_t)~0;
+    else //if (picture_control_set_ptr->enc_mode == ENC_M0)
+        context_ptr->dist_base_md_stage_0_count_th = 75;
+#endif
+
     return return_error;
 }
 

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1447,19 +1447,19 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     // Derive INTER/INTER WEDGE variance TH
     if (MR_MODE)
         context_ptr->inter_inter_wedge_variance_th = 0;
-    else //if (picture_control_set_ptr->enc_mode == ENC_M0)
+    else
         context_ptr->inter_inter_wedge_variance_th = 100;
 
     // Derive MD Exit TH
     if (MR_MODE)
         context_ptr->md_exit_th = 0;
-    else //if (picture_control_set_ptr->enc_mode == ENC_M0)
+    else
         context_ptr->md_exit_th = 10;
 
     // Derive distortion-based md_stage_0_count proning
     if (MR_MODE)
         context_ptr->dist_base_md_stage_0_count_th = (uint64_t)~0;
-    else //if (picture_control_set_ptr->enc_mode == ENC_M0)
+    else
         context_ptr->dist_base_md_stage_0_count_th = 75;
 #endif
 

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -1168,6 +1168,10 @@ void Bipred3x3CandidatesInjection(
     MD_COMP_TYPE cur_type; //BIP 3x3
     MD_COMP_TYPE tot_comp_types = picture_control_set_ptr->parent_pcs_ptr->compound_mode == 1 ? MD_COMP_AVG :
         picture_control_set_ptr->parent_pcs_ptr->compound_types_to_try;
+#if SPEED_OPT
+    if (context_ptr->source_variance < context_ptr->inter_inter_wedge_variance_th)
+        tot_comp_types = MIN(tot_comp_types, MD_COMP_DIFF0);
+#endif
     if (isCompoundEnabled) {
         /**************
        NEW_NEWMV
@@ -1837,6 +1841,10 @@ void inject_mvp_candidates_II(
     av1_set_ref_frame(rf, ref_pair);
     MD_COMP_TYPE cur_type; //MVP
     MD_COMP_TYPE tot_comp_types = picture_control_set_ptr->parent_pcs_ptr->compound_types_to_try;
+#if SPEED_OPT
+    if (context_ptr->source_variance < context_ptr->inter_inter_wedge_variance_th)
+        tot_comp_types = MIN(tot_comp_types, MD_COMP_DIFF0);
+#endif
  #if II_COMP_FLAG
     BlockSize bsize = context_ptr->blk_geom->bsize;                       // bloc size
 #endif
@@ -2240,6 +2248,10 @@ void inject_new_nearest_new_comb_candidates(
     av1_set_ref_frame(rf, ref_pair);
     MD_COMP_TYPE cur_type; //N_NR N_NRST
     MD_COMP_TYPE tot_comp_types = picture_control_set_ptr->parent_pcs_ptr->compound_types_to_try;
+#if SPEED_OPT
+    if (context_ptr->source_variance < context_ptr->inter_inter_wedge_variance_th)
+        tot_comp_types = MIN(tot_comp_types, MD_COMP_DIFF0);
+#endif
 
     {
         uint8_t ref_idx_0 = get_ref_frame_idx(rf[0]);
@@ -2706,6 +2718,10 @@ void inject_new_candidates(
     MD_COMP_TYPE cur_type; //NN
     MD_COMP_TYPE tot_comp_types = picture_control_set_ptr->parent_pcs_ptr->compound_mode == 1 ? MD_COMP_AVG :
         picture_control_set_ptr->parent_pcs_ptr->compound_types_to_try;
+#if SPEED_OPT
+    if (context_ptr->source_variance < context_ptr->inter_inter_wedge_variance_th)
+        tot_comp_types = MIN(tot_comp_types, MD_COMP_DIFF0);
+#endif
  #if II_COMP_FLAG
     BlockSize bsize = context_ptr->blk_geom->bsize;                       // bloc size
 #endif
@@ -3089,7 +3105,10 @@ void inject_new_candidates(
             MD_COMP_TYPE tot_comp_types = (bsize >= BLOCK_8X8 && bsize <= BLOCK_32X32) ? compound_types_to_try :
                 (compound_types_to_try == MD_COMP_WEDGE) ? MD_COMP_DIFF0 :
                 picture_control_set_ptr->parent_pcs_ptr->compound_types_to_try;//MD_COMP_DIST;// MD_COMP_AVG;//
-
+#if SPEED_OPT
+            if (context_ptr->source_variance < context_ptr->inter_inter_wedge_variance_th)
+                tot_comp_types = MIN(tot_comp_types, MD_COMP_DIFF0);
+#endif
             uint8_t listIndex;
             uint8_t ref_pic_index;
             listIndex = REF_LIST_0;
@@ -3359,6 +3378,10 @@ void  inject_inter_candidates(
     MD_COMP_TYPE cur_type; //GG
     MD_COMP_TYPE tot_comp_types = picture_control_set_ptr->parent_pcs_ptr->compound_mode == 1 ? MD_COMP_AVG :
         picture_control_set_ptr->parent_pcs_ptr->compound_types_to_try;
+#if SPEED_OPT
+    if (context_ptr->source_variance < context_ptr->inter_inter_wedge_variance_th)
+        tot_comp_types = MIN(tot_comp_types, MD_COMP_DIFF0);
+#endif
 #if II_COMP_FLAG
     BlockSize bsize = context_ptr->blk_geom->bsize;                       // bloc size
 #endif

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -285,6 +285,13 @@ extern "C" {
     uint8_t                             edge_based_skip_angle_intra;
     EbBool                              coeff_based_skip_atb;
     uint8_t                             prune_ref_frame_for_rec_partitions;
+#if SPEED_OPT
+    unsigned int                        source_variance; // input block variance
+    unsigned int                        inter_inter_wedge_variance_th;
+    uint64_t                            md_exit_th;
+    uint64_t                            dist_base_md_stage_0_count_th;
+#endif
+
     } ModeDecisionContext;
 
     typedef void(*EbAv1LambdaAssignFunc)(

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -1193,7 +1193,11 @@ EbErrorType signal_derivation_multi_processes_oq(
         // Set skip atb                          Settings
         // 0                                     OFF
         // 1                                     ON
+#if SPEED_OPT
+        if (MR_MODE || picture_control_set_ptr->sc_content_detected)
+#else
         if (MR_MODE || picture_control_set_ptr->enc_mode == ENC_M0 || picture_control_set_ptr->sc_content_detected)
+#endif
             picture_control_set_ptr->coeff_based_skip_atb = 0;
         else
             picture_control_set_ptr->coeff_based_skip_atb = 1;

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -1182,7 +1182,11 @@ EbErrorType signal_derivation_multi_processes_oq(
         // 0                 OFF: no transform partitioning
         // 1                 ON for INTRA blocks
         if (picture_control_set_ptr->enc_mode <= ENC_M1 && sequence_control_set_ptr->static_config.encoder_bit_depth == EB_8BIT)
+#if SPEED_OPT
+            picture_control_set_ptr->atb_mode = (MR_MODE || picture_control_set_ptr->temporal_layer_index == 0) ? 1 : 0;
+#else
             picture_control_set_ptr->atb_mode = 1;
+#endif
         else
             picture_control_set_ptr->atb_mode = 0;
 

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -1750,9 +1750,11 @@ void sort_stage0_fast_candidates(
 )
 {
     ModeDecisionCandidateBuffer **buffer_ptr_array = context_ptr->candidate_buffer_ptr_array;
+#if !SPEED_OPT
     //  fill cand_buff_indices with surviving buffer indices ; move the scratch candidates (MAX_CU_COST) to the last spots (if any)
     uint32_t ordered_start_idx = 0;
     uint32_t ordered_end_idx = input_buffer_count - 1;
+#endif
 
     uint32_t input_buffer_end_idx = input_buffer_start_idx + input_buffer_count - 1;
 #if SPEED_OPT
@@ -5939,7 +5941,6 @@ void search_best_independent_uv_mode(
 }
 #if SPEED_OPT
 void inter_class_decision_count_1(
-    PictureControlSet *picture_control_set_ptr,
     struct ModeDecisionContext   *context_ptr
 )
 {
@@ -6195,7 +6196,7 @@ void md_encode_block(
 
 #if SPEED_OPT
         //after completing stage0, we might shorten cand count for some classes.
-        inter_class_decision_count_1(picture_control_set_ptr, context_ptr);
+        inter_class_decision_count_1(context_ptr);
 #endif
         context_ptr->md_stage = MD_STAGE_1;
         for (cand_class_it = CAND_CLASS_0; cand_class_it < CAND_CLASS_TOTAL; cand_class_it++) {

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -5945,17 +5945,11 @@ void inter_class_decision_count_1(
 )
 {
     ModeDecisionCandidateBuffer **buffer_ptr_array = context_ptr->candidate_buffer_ptr_array;
-
     // Distortion-based NIC proning not applied to INTRA clases: CLASS_0 and CLASS
     for (CAND_CLASS cand_class_it = CAND_CLASS_1; cand_class_it <= CAND_CLASS_3; cand_class_it++) {
-
         if (context_ptr->md_stage_0_count[cand_class_it] > 0 && context_ptr->md_stage_1_count[cand_class_it] > 0) {
-
             uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
-
             if (*(buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr) < *(buffer_ptr_array[context_ptr->cand_buff_indices[CAND_CLASS_0][0]]->fast_cost_ptr)) {
-
-
                 uint32_t fast1_cand_count = 1;
                 while (fast1_cand_count < context_ptr->md_stage_1_count[cand_class_it] && ((((*(buffer_ptr_array[cand_buff_indices[fast1_cand_count]]->fast_cost_ptr) - *(buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr)) * 100) / (*(buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr))) < context_ptr->dist_base_md_stage_0_count_th)) {
                     fast1_cand_count++;
@@ -6020,9 +6014,7 @@ void md_encode_block(
 
 #if SPEED_OPT
         const aom_variance_fn_ptr_t *fn_ptr = &mefn_ptr[context_ptr->blk_geom->bsize];
-        context_ptr->source_variance = // use_hbd ?
-            //eb_av1_high_get_sby_perpixel_variance(fn_ptr, (input_picture_ptr->buffer_y + inputOriginIndex), input_picture_ptr->stride_y, context_ptr->blk_geom->bsize :
-            eb_av1_get_sby_perpixel_variance(fn_ptr, (input_picture_ptr->buffer_y + inputOriginIndex), input_picture_ptr->stride_y, context_ptr->blk_geom->bsize);
+        context_ptr->source_variance = eb_av1_get_sby_perpixel_variance(fn_ptr, (input_picture_ptr->buffer_y + inputOriginIndex), input_picture_ptr->stride_y, context_ptr->blk_geom->bsize);
 #endif
 
         ProductCodingLoopInitFastLoop(


### PR DESCRIPTION
## Description
Added the following lossy speed optimizations:
- Variance-based compound skip, 
- Distortion based md-stage-1 count pruning.
- Lossy inter depth decision exit.
- ATB=f(layer) and enabled coef-based ATB skip.

Closes #643   

## Author

@hguermaz 

## Type of change

New feature/Tool

## Tests and performance
* BD-Rate to aom cpu0-2pass on 360p/720p: 0.189%.
* Speed on a 4-core machine for M0 on 360p: ~22% faster.
* Memory footprint on a 4-core machine: negligible.