### PR TITLE
ATB for INTER 

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -47,6 +47,9 @@ extern "C" {
 #define EIGHT_PEL_PREDICTIVE_ME           1
 #define COMP_INTERINTRA                   1 // InterIntra mode support
 
+#define ENHANCE_ATB                       1
+
+
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC                         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch
 
@@ -181,7 +184,11 @@ enum {
 // Maximum number of tile rows and tile columns
 #define MAX_TILE_ROWS 64
 #define MAX_TILE_COLS 64
+#if ENHANCE_ATB
+#define MAX_VARTX_DEPTH 2
+#else
 #define MAX_VARTX_DEPTH 1
+#endif
 #define MI_SIZE_64X64 (64 >> MI_SIZE_LOG2)
 #define MI_SIZE_128X128 (128 >> MI_SIZE_LOG2)
 #define MAX_PALETTE_SQUARE (64 * 64)
@@ -2453,9 +2460,11 @@ void(*ErrorHandler)(
 #define LOG2F_MAX_LCU_SIZE                          6u
 #define LOG2_64_SIZE                                6 // log2(BLOCK_SIZE_64)
 #define MAX_LEVEL_COUNT                             5 // log2(BLOCK_SIZE_64) - log2(MIN_BLOCK_SIZE)
+#if !ENHANCE_ATB
 #define MAX_TU_DEPTH                                2
-#define LOG_MIN_BLOCK_SIZE                             3
-#define MIN_BLOCK_SIZE                                 (1 << LOG_MIN_BLOCK_SIZE)
+#endif
+#define LOG_MIN_BLOCK_SIZE                          3
+#define MIN_BLOCK_SIZE                              (1 << LOG_MIN_BLOCK_SIZE)
 #define LOG_MIN_PU_SIZE                             2
 #define MIN_PU_SIZE                                 (1 << LOG_MIN_PU_SIZE)
 #define MAX_NUM_OF_PU_PER_CU                        1

--- a/Source/Lib/Common/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Common/Codec/EbEntropyCoding.c
@@ -615,7 +615,11 @@ int32_t  Av1WriteCoeffsTxb1D(
         // INTER. Chroma follows Luma in transform type
         if (cu_ptr->prediction_mode_flag == INTER_MODE) {
             txType = cu_ptr->transform_unit_array[tu_index].transform_type[PLANE_TYPE_Y] = DCT_DCT;
+#if ENHANCE_ATB
+            cu_ptr->transform_unit_array[tu_index].transform_type[PLANE_TYPE_UV] = DCT_DCT;
+#else
             cu_ptr->transform_unit_array[0].transform_type[PLANE_TYPE_UV] = DCT_DCT;
+#endif
         }
         else { // INTRA
             txType = cu_ptr->transform_unit_array[tu_index].transform_type[PLANE_TYPE_Y] = DCT_DCT;
@@ -1002,8 +1006,11 @@ static EbErrorType Av1EncodeCoeff1D(
     NeighborArrayUnit     *cb_dc_sign_level_coeff_neighbor_array)
 {
     EbErrorType return_error = EB_ErrorNone;
-
+#if ENHANCE_ATB
+    if (cu_ptr->tx_depth) {
+#else
     if (cu_ptr->prediction_mode_flag == INTRA_MODE && cu_ptr->tx_depth) {
+#endif
         av1_encode_tx_coef_y(
             pcs_ptr,
             context_ptr,

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -662,6 +662,19 @@ static void mode_decision_candidate_buffer_dctor(EbPtr p)
     EB_DELETE(obj->recon_coeff_ptr);
     EB_DELETE(obj->recon_ptr);
 }
+#if ENHANCE_ATB
+static void mode_decision_scratch_candidate_buffer_dctor(EbPtr p)
+{
+    ModeDecisionCandidateBuffer *obj = (ModeDecisionCandidateBuffer*)p;
+    EB_DELETE(obj->prediction_ptr);
+    EB_DELETE(obj->prediction_ptr_temp);
+    EB_DELETE(obj->cfl_temp_prediction_ptr);
+    EB_DELETE(obj->residual_ptr);
+    EB_DELETE(obj->residual_quant_coeff_ptr);
+    EB_DELETE(obj->recon_coeff_ptr);
+    EB_DELETE(obj->recon_ptr);
+}
+#endif
 /***************************************
 * Mode Decision Candidate Ctor
 ***************************************/
@@ -765,6 +778,94 @@ EbErrorType mode_decision_candidate_buffer_ctor(
     buffer_ptr->full_cost_merge_ptr = full_cost_merge_ptr;
     return EB_ErrorNone;
 }
+#if ENHANCE_ATB
+EbErrorType mode_decision_scratch_candidate_buffer_ctor(
+    ModeDecisionCandidateBuffer    *buffer_ptr,
+    EbBitDepthEnum                  max_bitdepth)
+{
+
+    EbPictureBufferDescInitData pictureBufferDescInitData;
+    EbPictureBufferDescInitData doubleWidthPictureBufferDescInitData;
+    EbPictureBufferDescInitData ThirtyTwoWidthPictureBufferDescInitData;
+
+
+    buffer_ptr->dctor = mode_decision_scratch_candidate_buffer_dctor;
+
+    // Init Picture Data
+    pictureBufferDescInitData.max_width = MAX_SB_SIZE;
+    pictureBufferDescInitData.max_height = MAX_SB_SIZE;
+    pictureBufferDescInitData.bit_depth = max_bitdepth;
+    pictureBufferDescInitData.color_format = EB_YUV420;
+    pictureBufferDescInitData.buffer_enable_mask = PICTURE_BUFFER_DESC_FULL_MASK;
+    pictureBufferDescInitData.left_padding = 0;
+    pictureBufferDescInitData.right_padding = 0;
+    pictureBufferDescInitData.top_padding = 0;
+    pictureBufferDescInitData.bot_padding = 0;
+    pictureBufferDescInitData.split_mode = EB_FALSE;
+    doubleWidthPictureBufferDescInitData.max_width = MAX_SB_SIZE;
+    doubleWidthPictureBufferDescInitData.max_height = MAX_SB_SIZE;
+    doubleWidthPictureBufferDescInitData.bit_depth = EB_16BIT;
+    doubleWidthPictureBufferDescInitData.color_format = EB_YUV420;
+    doubleWidthPictureBufferDescInitData.buffer_enable_mask = PICTURE_BUFFER_DESC_FULL_MASK;
+    doubleWidthPictureBufferDescInitData.left_padding = 0;
+    doubleWidthPictureBufferDescInitData.right_padding = 0;
+    doubleWidthPictureBufferDescInitData.top_padding = 0;
+    doubleWidthPictureBufferDescInitData.bot_padding = 0;
+    doubleWidthPictureBufferDescInitData.split_mode = EB_FALSE;
+
+    ThirtyTwoWidthPictureBufferDescInitData.max_width = MAX_SB_SIZE;
+    ThirtyTwoWidthPictureBufferDescInitData.max_height = MAX_SB_SIZE;
+    ThirtyTwoWidthPictureBufferDescInitData.bit_depth = EB_32BIT;
+    ThirtyTwoWidthPictureBufferDescInitData.color_format = EB_YUV420;
+    ThirtyTwoWidthPictureBufferDescInitData.buffer_enable_mask = PICTURE_BUFFER_DESC_FULL_MASK;
+    ThirtyTwoWidthPictureBufferDescInitData.left_padding = 0;
+    ThirtyTwoWidthPictureBufferDescInitData.right_padding = 0;
+    ThirtyTwoWidthPictureBufferDescInitData.top_padding = 0;
+    ThirtyTwoWidthPictureBufferDescInitData.bot_padding = 0;
+    ThirtyTwoWidthPictureBufferDescInitData.split_mode = EB_FALSE;
+
+    // Candidate Ptr
+    buffer_ptr->candidate_ptr = (ModeDecisionCandidate*)EB_NULL;
+
+    // Video Buffers
+    EB_NEW(
+        buffer_ptr->prediction_ptr,
+        eb_picture_buffer_desc_ctor,
+        (EbPtr)&pictureBufferDescInitData);
+
+    EB_NEW(
+        buffer_ptr->prediction_ptr_temp,
+        eb_picture_buffer_desc_ctor,
+        (EbPtr)&pictureBufferDescInitData);
+
+    EB_NEW(
+        buffer_ptr->cfl_temp_prediction_ptr,
+        eb_picture_buffer_desc_ctor,
+        (EbPtr)&pictureBufferDescInitData);
+
+    EB_NEW(
+        buffer_ptr->residual_ptr,
+        eb_picture_buffer_desc_ctor,
+        (EbPtr)&doubleWidthPictureBufferDescInitData);
+
+    EB_NEW(
+        buffer_ptr->residual_quant_coeff_ptr,
+        eb_picture_buffer_desc_ctor,
+        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData);
+
+    EB_NEW(
+        buffer_ptr->recon_coeff_ptr,
+        eb_picture_buffer_desc_ctor,
+        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData);
+
+    EB_NEW(
+        buffer_ptr->recon_ptr,
+        eb_picture_buffer_desc_ctor,
+        (EbPtr)&pictureBufferDescInitData);
+    return EB_ErrorNone;
+}
+#endif
+
 uint8_t check_ref_beackout(
     struct ModeDecisionContext *context_ptr,
     uint8_t                     ref_frame_type,

--- a/Source/Lib/Common/Codec/EbModeDecision.h
+++ b/Source/Lib/Common/Codec/EbModeDecision.h
@@ -270,6 +270,13 @@ extern "C" {
         uint64_t                       *full_cost_merge_ptr
     );
 
+#if ENHANCE_ATB
+    extern EbErrorType mode_decision_scratch_candidate_buffer_ctor(
+        ModeDecisionCandidateBuffer    *buffer_ptr,
+        EbBitDepthEnum                  max_bitdepth
+    );
+#endif
+
     uint32_t product_full_mode_decision(
          struct ModeDecisionContext  *context_ptr,
         CodingUnit                   *cu_ptr,

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -82,6 +82,9 @@ extern "C" {
         ModeDecisionCandidate       **fast_candidate_ptr_array;
         ModeDecisionCandidate        *fast_candidate_array;
         ModeDecisionCandidateBuffer **candidate_buffer_ptr_array;
+#if ENHANCE_ATB
+        ModeDecisionCandidateBuffer  *scratch_candidate_buffer;
+#endif
         MdRateEstimationContext      *md_rate_estimation_ptr;
         EbBool                        is_md_rate_estimation_ptr_owner;
         InterPredictionContext       *inter_prediction_context;
@@ -104,6 +107,9 @@ extern "C" {
         NeighborArrayUnit            *tx_search_luma_recon_neighbor_array16bit;
         NeighborArrayUnit            *skip_coeff_neighbor_array;
         NeighborArrayUnit            *luma_dc_sign_level_coeff_neighbor_array; // Stored per 4x4. 8 bit: lower 6 bits (COEFF_CONTEXT_BITS), shows if there is at least one Coef. Top 2 bit store the sign of DC as follow: 0->0,1->-1,2-> 1
+#if ENHANCE_ATB
+        NeighborArrayUnit            *full_loop_luma_dc_sign_level_coeff_neighbor_array; // Stored per 4x4. 8 bit: lower 6 bits (COEFF_CONTEXT_BITS), shows if there is at least one Coef. Top 2 bit store the sign of DC as follow: 0->0,1->-1,2-> 1
+#endif
         NeighborArrayUnit            *tx_search_luma_dc_sign_level_coeff_neighbor_array; // Stored per 4x4. 8 bit: lower 6 bits (COEFF_CONTEXT_BITS), shows if there is at least one Coef. Top 2 bit store the sign of DC as follow: 0->0,1->-1,2-> 1
         NeighborArrayUnit            *cr_dc_sign_level_coeff_neighbor_array; // Stored per 4x4. 8 bit: lower 6 bits(COEFF_CONTEXT_BITS), shows if there is at least one Coef. Top 2 bit store the sign of DC as follow: 0->0,1->-1,2-> 1
         NeighborArrayUnit            *cb_dc_sign_level_coeff_neighbor_array; // Stored per 4x4. 8 bit: lower 6 bits(COEFF_CONTEXT_BITS), shows if there is at least one Coef. Top 2 bit store the sign of DC as follow: 0->0,1->-1,2-> 1
@@ -166,6 +172,9 @@ extern "C" {
         EbBool                          hbd_mode_decision;
         uint16_t                        qp_index;
         uint64_t                        three_quad_energy;
+#if ENHANCE_ATB
+        uint32_t                        txb_1d_offset;
+#endif
         EbBool                          uv_search_path;
         UvPredictionMode                best_uv_mode    [UV_PAETH_PRED + 1][(MAX_ANGLE_DELTA << 1) + 1];
         int32_t                         best_uv_angle   [UV_PAETH_PRED + 1][(MAX_ANGLE_DELTA << 1) + 1];
@@ -285,13 +294,17 @@ extern "C" {
     uint8_t                             edge_based_skip_angle_intra;
     EbBool                              coeff_based_skip_atb;
     uint8_t                             prune_ref_frame_for_rec_partitions;
+
 #if SPEED_OPT
     unsigned int                        source_variance; // input block variance
     unsigned int                        inter_inter_wedge_variance_th;
     uint64_t                            md_exit_th;
     uint64_t                            dist_base_md_stage_0_count_th;
 #endif
-
+#if ENHANCE_ATB
+    uint8_t                            *above_txfm_context;
+    uint8_t                            *left_txfm_context;
+#endif
     } ModeDecisionContext;
 
     typedef void(*EbAv1LambdaAssignFunc)(

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -1182,6 +1182,7 @@ EbErrorType signal_derivation_multi_processes_oq(
         // 0                 OFF: no transform partitioning
         // 1                 ON for INTRA blocks
         if (picture_control_set_ptr->enc_mode <= ENC_M1 && sequence_control_set_ptr->static_config.encoder_bit_depth == EB_8BIT)
+
 #if SPEED_OPT
             picture_control_set_ptr->atb_mode = (MR_MODE || picture_control_set_ptr->temporal_layer_index == 0) ? 1 : 0;
 #else
@@ -1193,6 +1194,7 @@ EbErrorType signal_derivation_multi_processes_oq(
         // Set skip atb                          Settings
         // 0                                     OFF
         // 1                                     ON
+
 #if SPEED_OPT
         if (MR_MODE || picture_control_set_ptr->sc_content_detected)
 #else

--- a/Source/Lib/Common/Codec/EbRateDistortionCost.c
+++ b/Source/Lib/Common/Codec/EbRateDistortionCost.c
@@ -1892,10 +1892,25 @@ EbErrorType Av1FullCost(
         }
     }
 
+#if ENHANCE_ATB
+    uint64_t tx_size_bits = 0;
+    if (picture_control_set_ptr->parent_pcs_ptr->frm_hdr.tx_mode == TX_MODE_SELECT)
+        tx_size_bits = get_tx_size_bits(
+            candidate_buffer_ptr,
+            context_ptr,
+            picture_control_set_ptr,
+            candidate_buffer_ptr->candidate_ptr->tx_depth,
+            candidate_buffer_ptr->candidate_ptr->block_has_coeff);
+#endif
+
     // Coeff rate
 
     if (context_ptr->blk_skip_decision && candidate_buffer_ptr->candidate_ptr->type != INTRA_MODE) {
+#if ENHANCE_ATB
+        uint64_t non_skip_cost = RDCOST(lambda, (*y_coeff_bits + *cb_coeff_bits + *cr_coeff_bits + tx_size_bits + (uint64_t)candidate_buffer_ptr->candidate_ptr->md_rate_estimation_ptr->skip_fac_bits[cu_ptr->skip_coeff_context][0]), (y_distortion[0] + cb_distortion[0] + cr_distortion[0]));
+#else
         uint64_t non_skip_cost = RDCOST(lambda, (*y_coeff_bits + *cb_coeff_bits + *cr_coeff_bits + (uint64_t)candidate_buffer_ptr->candidate_ptr->md_rate_estimation_ptr->skip_fac_bits[cu_ptr->skip_coeff_context][0]), (y_distortion[0] + cb_distortion[0] + cr_distortion[0]));
+#endif
         uint64_t skip_cost = RDCOST(lambda, ((uint64_t)candidate_buffer_ptr->candidate_ptr->md_rate_estimation_ptr->skip_fac_bits[cu_ptr->skip_coeff_context][1]), (y_distortion[1] + cb_distortion[1] + cr_distortion[1]));
         if ((candidate_buffer_ptr->candidate_ptr->block_has_coeff == 0) || (skip_cost < non_skip_cost)) {
             y_distortion[0] = y_distortion[1];
@@ -1916,9 +1931,10 @@ EbErrorType Av1FullCost(
     totalDistortion = luma_sse + chromaSse;
 
     rate = lumaRate + chromaRate + coeffRate;
-
-    // To do: estimate the cost of tx size = tx_size_bits
-
+#if ENHANCE_ATB
+    if (candidate_buffer_ptr->candidate_ptr->block_has_coeff)
+        rate += tx_size_bits;
+#endif
     // Assign full cost
     *(candidate_buffer_ptr->full_cost_ptr) = RDCOST(lambda, rate, totalDistortion);
 
@@ -2027,8 +2043,17 @@ EbErrorType  Av1MergeSkipFullCost(
     mergeRate += candidate_buffer_ptr->candidate_ptr->fast_chroma_rate;
 
     mergeRate += coeffRate;
-
-    // To do: estimate the cost of tx size = tx_size_bits
+#if ENHANCE_ATB
+    uint64_t tx_size_bits = 0;
+    if (picture_control_set_ptr->parent_pcs_ptr->frm_hdr.tx_mode == TX_MODE_SELECT)
+        tx_size_bits = get_tx_size_bits(
+            candidate_buffer_ptr,
+            context_ptr,
+            picture_control_set_ptr,
+            candidate_buffer_ptr->candidate_ptr->tx_depth,
+            candidate_buffer_ptr->candidate_ptr->block_has_coeff);
+    mergeRate += tx_size_bits;
+#endif
 
     mergeDistortion = (mergeLumaSse + mergeChromaSse);
 

--- a/Source/Lib/Common/Codec/EbRateDistortionCost.h
+++ b/Source/Lib/Common/Codec/EbRateDistortionCost.h
@@ -220,6 +220,14 @@ extern "C" {
         uint64_t                                 *cr_coeff_bits,
         BlockSize                                bsize);
 
+#if ENHANCE_ATB
+    extern uint64_t get_tx_size_bits(
+        ModeDecisionCandidateBuffer          *candidateBuffer,
+        ModeDecisionContext                  *context_ptr,
+        PictureControlSet                    *picture_control_set_ptr,
+        uint8_t                               tx_depth,
+        EbBool                                block_has_coeff);
+#endif
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Description
- Enabled/fixed transform flag rate estimation. 
- Re-factor ATB path.
- Added ATB for INTER (Depth_1 only).

Closes #642 

## Author

@hguermaz 

## Type of change

New feature/Tool

## Tests and performance
* BD-Rate to aom cpu0-2pass on the full list: ~0.185% gain.
* Speed on a 4-core machine for M0 on 360p: ~8% slower.
* Memory footprint on a 4-core machine: ~1% increase.