### PR TITLE
Add unit tests for utility functions in compound prediction

### DIFF
--- a/test/CompoundUtilTest.cc
+++ b/test/CompoundUtilTest.cc
@@ -1,0 +1,353 @@
+/*
+ * Copyright(c) 2019 Netflix, Inc.
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
+/******************************************************************************
+ * @file CompoundUtilTest.cc
+ *
+ * @brief Unit test for util functions in wedge prediction:
+ * - av1_build_compound_diffwtd_mask_{, d16}avx2
+ * - aom_blend_a64_mask_avx2/aom_lowbd_blend_a64_d16_mask_avx2
+ *
+ * @author Cidana-Wenyao
+ *
+ ******************************************************************************/
+#include "gtest/gtest.h"
+#include "EbDefinitions.h"
+#include "EbUtility.h"
+#include "aom_dsp_rtcd.h"
+#include "random.h"
+#include "convolve.h"
+#include "util.h"
+
+using svt_av1_test_tool::SVTRandom;
+namespace {
+extern "C" void aom_blend_a64_mask_c(uint8_t *dst, uint32_t dst_stride,
+                                     const uint8_t *src0, uint32_t src0_stride,
+                                     const uint8_t *src1, uint32_t src1_stride,
+                                     const uint8_t *mask, uint32_t mask_stride,
+                                     int w, int h, int subw, int subh);
+
+template <typename SrcSample, typename DstSample>
+class CompBlendTest : public ::testing::Test {
+  public:
+    void SetUp() override {
+        ref_dst_ =
+            (DstSample *)eb_aom_memalign(32, MAX_SB_SQUARE * sizeof(DstSample));
+        tst_dst_ =
+            (DstSample *)eb_aom_memalign(32, MAX_SB_SQUARE * sizeof(DstSample));
+        src0_ =
+            (SrcSample *)eb_aom_memalign(32, MAX_SB_SQUARE * sizeof(SrcSample));
+        src1_ =
+            (SrcSample *)eb_aom_memalign(32, MAX_SB_SQUARE * sizeof(SrcSample));
+        mask_ = (uint8_t *)eb_aom_memalign(32, MAX_SB_SQUARE);
+    }
+
+    void TearDown() override {
+        eb_aom_free(ref_dst_);
+        eb_aom_free(tst_dst_);
+        eb_aom_free(src0_);
+        eb_aom_free(src1_);
+        eb_aom_free(mask_);
+        aom_clear_system_state();
+    }
+
+    void run_test() {
+        const int loops = 10000;
+        SVTRandom rnd(0, (1 << bd_) - 1);
+        SVTRandom mask_rnd(0, 64);
+
+        // generate random mask
+        for (int i = 0; i < MAX_SB_SQUARE; ++i)
+            mask_[i] = mask_rnd.random();
+
+        for (int k = 0; k < loops; ++k) {
+            for (int block_size = BLOCK_4X4; block_size < BlockSizeS_ALL;
+                 block_size += 1) {
+                w_ = block_size_wide[block_size];
+                h_ = block_size_high[block_size];
+
+                // initial the input data
+                for (int i = 0; i < h_; ++i) {
+                    for (int j = 0; j < w_; ++j) {
+                        src0_[i * src_stride_ + j] = rnd.random();
+                        src1_[i * src_stride_ + j] = rnd.random();
+                    }
+                }
+
+                for (int subh = 0; subh < 2; ++subh) {
+                    for (int subw = 0; subw < 2; ++subw) {
+                        memset(ref_dst_, 0, MAX_SB_SQUARE * sizeof(DstSample));
+                        memset(tst_dst_, 0, MAX_SB_SQUARE * sizeof(DstSample));
+
+                        run_blend(subw, subh);
+
+                        // check output
+                        for (int i = 0; i < h_; ++i) {
+                            for (int j = 0; j < w_; ++j) {
+                                ASSERT_EQ(tst_dst_[i * dst_stride_ + j],
+                                          ref_dst_[i * dst_stride_ + j]);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    virtual void run_blend(int subw, int subh) = 0;
+
+  protected:
+    static const int src_stride_ = MAX_SB_SIZE;
+    static const int dst_stride_ = MAX_SB_SIZE;
+    static const int mask_stride_ = MAX_SB_SIZE;
+    DstSample *ref_dst_;
+    DstSample *tst_dst_;
+    SrcSample *src0_;
+    SrcSample *src1_;
+    uint8_t *mask_;
+    int w_, h_;
+    int bd_;
+};
+
+class LbdCompBlendTest : public CompBlendTest<uint8_t, uint8_t> {
+  public:
+    LbdCompBlendTest() {
+        bd_ = 8;
+    }
+
+    void run_blend(int subw, int subh) override {
+        aom_blend_a64_mask_c(ref_dst_,
+                             dst_stride_,
+                             src0_,
+                             src_stride_,
+                             src1_,
+                             src_stride_,
+                             mask_,
+                             mask_stride_,
+                             w_,
+                             h_,
+                             subw,
+                             subh);
+        aom_blend_a64_mask_avx2(tst_dst_,
+                                dst_stride_,
+                                src0_,
+                                src_stride_,
+                                src1_,
+                                src_stride_,
+                                mask_,
+                                mask_stride_,
+                                w_,
+                                h_,
+                                subw,
+                                subh);
+    }
+};
+
+TEST_F(LbdCompBlendTest, BlendA64Mask) {
+    run_test();
+}
+
+class LbdCompBlendD16Test : public CompBlendTest<uint16_t, uint8_t> {
+  public:
+    LbdCompBlendD16Test() {
+        bd_ = 10;
+    }
+
+    void run_blend(int subw, int subh) override {
+        ConvolveParams conv_params;
+        conv_params.round_0 = ROUND0_BITS;
+        conv_params.round_1 = COMPOUND_ROUND1_BITS;
+        aom_lowbd_blend_a64_d16_mask_avx2(tst_dst_,
+                                          dst_stride_,
+                                          src0_,
+                                          src_stride_,
+                                          src1_,
+                                          src_stride_,
+                                          mask_,
+                                          mask_stride_,
+                                          w_,
+                                          h_,
+                                          subw,
+                                          subh,
+                                          &conv_params);
+        aom_lowbd_blend_a64_d16_mask_c(ref_dst_,
+                                       dst_stride_,
+                                       src0_,
+                                       src_stride_,
+                                       src1_,
+                                       src_stride_,
+                                       mask_,
+                                       mask_stride_,
+                                       w_,
+                                       h_,
+                                       subw,
+                                       subh,
+                                       &conv_params);
+    }
+};
+
+TEST_F(LbdCompBlendD16Test, BlendA64MaskD16) {
+    run_test();
+}
+
+typedef void (*BuildCompDiffwtdMaskedFunc)(uint8_t *mask,
+                                           DIFFWTD_MASK_TYPE mask_type,
+                                           const uint8_t *src0, int src0_stride,
+                                           const uint8_t *src1, int src1_stride,
+                                           int h, int w);
+typedef ::testing::tuple<BlockSize, BuildCompDiffwtdMaskedFunc>
+    BuildCompDiffwtdMaskParam;
+
+class BuildCompDiffwtdMaskTest
+    : public ::testing::TestWithParam<BuildCompDiffwtdMaskParam> {
+  public:
+    BuildCompDiffwtdMaskTest() : rnd_(0, 255){};
+    virtual ~BuildCompDiffwtdMaskTest() {
+    }
+
+    void TearDown() override {
+        aom_clear_system_state();
+    }
+
+    void run_test(const DIFFWTD_MASK_TYPE type) {
+        const int block_size = TEST_GET_PARAM(0);
+        BuildCompDiffwtdMaskedFunc test_impl = TEST_GET_PARAM(1);
+        const int width = block_size_wide[block_size];
+        const int height = block_size_high[block_size];
+        DECLARE_ALIGNED(16, uint8_t, mask_ref[MAX_SB_SQUARE]);
+        DECLARE_ALIGNED(16, uint8_t, mask_test[MAX_SB_SQUARE]);
+        DECLARE_ALIGNED(16, uint8_t, src0[MAX_SB_SQUARE]);
+        DECLARE_ALIGNED(16, uint8_t, src1[MAX_SB_SQUARE]);
+        const int run_times = 100;
+        for (int i = 0; i < run_times; ++i) {
+            for (int i = 0; i < width * height; i++) {
+                src0[i] = rnd_.random();
+                src1[i] = rnd_.random();
+            }
+
+            av1_build_compound_diffwtd_mask_c(
+                mask_ref, type, src0, width, src1, width, height, width);
+
+            test_impl(mask_test, type, src0, width, src1, width, height, width);
+            for (int r = 0; r < height; ++r) {
+                for (int c = 0; c < width; ++c) {
+                    ASSERT_EQ(mask_ref[c + r * width], mask_test[c + r * width])
+                        << "[" << r << "," << c << "] " << i << " @ " << width
+                        << "x" << height << " inv " << type;
+                }
+            }
+        }
+    }
+
+  private:
+    SVTRandom rnd_;
+};
+
+TEST_P(BuildCompDiffwtdMaskTest, MatchTest) {
+    run_test(DIFFWTD_38);
+    run_test(DIFFWTD_38_INV);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    CompUtilTest, BuildCompDiffwtdMaskTest,
+    ::testing::Combine(
+        ::testing::Range(BLOCK_4X4, BlockSizeS_ALL),
+        ::testing::Values(av1_build_compound_diffwtd_mask_avx2)));
+
+// test av1_build_compound_diffwtd_mask_d16_avx2
+typedef void (*BuildCompDiffwtdMaskD16Func)(
+    uint8_t *mask, DIFFWTD_MASK_TYPE mask_type, const CONV_BUF_TYPE *src0,
+    int src0_stride, const CONV_BUF_TYPE *src1, int src1_stride, int h, int w,
+    ConvolveParams *conv_params, int bd);
+
+typedef ::testing::tuple<int, BuildCompDiffwtdMaskD16Func, BlockSize>
+    BuildCompDiffwtdMaskD16Param;
+
+class BuildCompDiffwtdMaskD16Test
+    : public ::testing::TestWithParam<BuildCompDiffwtdMaskD16Param> {
+  public:
+    BuildCompDiffwtdMaskD16Test() : rnd_(16, false) {
+    }
+
+    ~BuildCompDiffwtdMaskD16Test() {
+    }
+
+    void TearDown() override {
+        aom_clear_system_state();
+    }
+
+  protected:
+    void run_test() {
+        BuildCompDiffwtdMaskD16Func tst_func = TEST_GET_PARAM(1);
+        const int block_size = TEST_GET_PARAM(2);
+        const int bd = TEST_GET_PARAM(0);
+        const int width = block_size_wide[block_size];
+        const int height = block_size_high[block_size];
+        DECLARE_ALIGNED(16, uint8_t, mask_ref[2 * MAX_SB_SQUARE]);
+        DECLARE_ALIGNED(16, uint8_t, mask_test[2 * MAX_SB_SQUARE]);
+        DECLARE_ALIGNED(32, uint16_t, src0[MAX_SB_SQUARE]);
+        DECLARE_ALIGNED(32, uint16_t, src1[MAX_SB_SQUARE]);
+
+        ConvolveParams conv_params =
+            get_conv_params_no_round(0 /*unused*/, 0, 0, NULL, 0, 1, bd);
+
+        int in_precision = bd + 2 * FILTER_BITS - conv_params.round_0 -
+                           conv_params.round_1 + 2;
+
+        for (int i = 0; i < MAX_SB_SQUARE; i++) {
+            src0[i] = rnd_.random() & ((1 << in_precision) - 1);
+            src1[i] = rnd_.random() & ((1 << in_precision) - 1);
+        }
+
+        for (int mask_type = 0; mask_type < DIFFWTD_MASK_TYPES; mask_type++) {
+            av1_build_compound_diffwtd_mask_d16_c(mask_ref,
+                                                  (DIFFWTD_MASK_TYPE)mask_type,
+                                                  src0,
+                                                  width,
+                                                  src1,
+                                                  width,
+                                                  height,
+                                                  width,
+                                                  &conv_params,
+                                                  bd);
+
+            tst_func(mask_test,
+                     (DIFFWTD_MASK_TYPE)mask_type,
+                     src0,
+                     width,
+                     src1,
+                     width,
+                     height,
+                     width,
+                     &conv_params,
+                     bd);
+
+            for (int r = 0; r < height; ++r) {
+                for (int c = 0; c < width; ++c) {
+                    ASSERT_EQ(mask_ref[c + r * width], mask_test[c + r * width])
+                        << "Mismatch at unit tests for "
+                           "BuildCompDiffwtdMaskD16Test\n"
+                        << " Pixel mismatch at index "
+                        << "[" << r << "," << c << "] "
+                        << " @ " << width << "x" << height << " inv "
+                        << mask_type;
+                }
+            }
+        }
+    }
+    SVTRandom rnd_;
+};  // class BuildCompDiffwtdMaskD16Test
+
+TEST_P(BuildCompDiffwtdMaskD16Test, MatchTest) {
+    run_test();
+}
+
+INSTANTIATE_TEST_CASE_P(
+    SSE4_1, BuildCompDiffwtdMaskD16Test,
+    ::testing::Combine(
+        ::testing::Range(8, 13, 2),
+        ::testing::Values(av1_build_compound_diffwtd_mask_d16_avx2),
+        ::testing::Range(BLOCK_4X4, BlockSizeS_ALL)));
+}  // namespace

--- a/test/CompoundUtilTest.cc
+++ b/test/CompoundUtilTest.cc
@@ -9,11 +9,23 @@
  * @brief Unit test for util functions in wedge prediction:
  * - av1_build_compound_diffwtd_mask_{, d16}avx2
  * - aom_blend_a64_mask_avx2/aom_lowbd_blend_a64_d16_mask_avx2
+ * - aom_blend_a64_mask_sse4_1
+ * - aom_highbd_blend_a64_mask_sse4_1/aom_highbd_blend_a64_d16_mask_avx2
+ * - aom_blend_a64_hmask_sse4_1/aom_blend_a64_vmask_sse4_1
+ * - aom_highbd_blend_a64_hmask_sse4_1/aom_highbd_blend_a64_vmask_sse4_1
  *
  * @author Cidana-Wenyao
  *
  ******************************************************************************/
 #include "gtest/gtest.h"
+// workaround to eliminate the compiling warning on linux
+// The macro will conflict with definition in gtest.h
+#ifdef __USE_GNU
+#undef __USE_GNU  // defined in EbThreads.h
+#endif
+#ifdef _GNU_SOURCE
+#undef _GNU_SOURCE  // defined in EbThreads.h
+#endif
 #include "EbDefinitions.h"
 #include "EbUtility.h"
 #include "aom_dsp_rtcd.h"
@@ -21,19 +33,25 @@
 #include "convolve.h"
 #include "util.h"
 
+using std::make_tuple;
 using svt_av1_test_tool::SVTRandom;
-namespace {
-extern "C" void aom_blend_a64_mask_c(uint8_t *dst, uint32_t dst_stride,
-                                     const uint8_t *src0, uint32_t src0_stride,
-                                     const uint8_t *src1, uint32_t src1_stride,
-                                     const uint8_t *mask, uint32_t mask_stride,
-                                     int w, int h, int subw, int subh);
 
-template <typename SrcSample, typename DstSample>
-class CompBlendTest : public ::testing::Test {
+#define MAX_MASK_SQUARE (4 * MAX_SB_SQUARE)
+#define MAKE_PARAM(func_type) std::tuple<func_type, func_type, const char *>
+
+namespace {
+template <typename SrcSample, typename DstSample, typename BlendFunc,
+          typename BlendTestParam>
+class CompBlendTest : public ::testing::TestWithParam<BlendTestParam> {
   public:
-    void SetUp() override {
+    CompBlendTest() {
         tst_fn_name = "";
+        func_ref_ = nullptr;
+        func_tst_ = nullptr;
+        no_sub_ = false;
+    }
+
+    void SetUp() override {
         ref_dst_ =
             (DstSample *)eb_aom_memalign(32, MAX_SB_SQUARE * sizeof(DstSample));
         tst_dst_ =
@@ -42,7 +60,7 @@ class CompBlendTest : public ::testing::Test {
             (SrcSample *)eb_aom_memalign(32, MAX_SB_SQUARE * sizeof(SrcSample));
         src1_ =
             (SrcSample *)eb_aom_memalign(32, MAX_SB_SQUARE * sizeof(SrcSample));
-        mask_ = (uint8_t *)eb_aom_memalign(32, MAX_SB_SQUARE);
+        mask_ = (uint8_t *)eb_aom_memalign(32, MAX_MASK_SQUARE);
     }
 
     void TearDown() override {
@@ -55,12 +73,12 @@ class CompBlendTest : public ::testing::Test {
     }
 
     void run_test() {
-        const int iterations = 10000;
+        const int iterations = 1000;
         SVTRandom rnd(0, (1 << bd_) - 1);
         SVTRandom mask_rnd(0, 64);
 
         // generate random mask
-        for (int i = 0; i < MAX_SB_SQUARE; ++i)
+        for (int i = 0; i < MAX_MASK_SQUARE; ++i)
             mask_[i] = mask_rnd.random();
 
         for (int k = 0; k < iterations; ++k) {
@@ -77,8 +95,11 @@ class CompBlendTest : public ::testing::Test {
                     }
                 }
 
-                for (int subh = 0; subh < 2; ++subh) {
-                    for (int subw = 0; subw < 2; ++subw) {
+                int submax = 2;
+                if (no_sub_)
+                    submax = 1;
+                for (int subh = 0; subh < submax; ++subh) {
+                    for (int subw = 0; subw < submax; ++subw) {
                         memset(ref_dst_, 0, MAX_SB_SQUARE * sizeof(DstSample));
                         memset(tst_dst_, 0, MAX_SB_SQUARE * sizeof(DstSample));
 
@@ -93,8 +114,9 @@ class CompBlendTest : public ::testing::Test {
                                     << tst_fn_name << "\n"
                                     << " Pixel mismatch at index "
                                     << "[" << j << "x" << i
-                                    << "] block size: " << block_size
-                                    << "iterator: " << k;
+                                    << "]\nblock size: " << block_size
+                                    << "\nbit-depth: " << bd_
+                                    << "\niterator: " << k;
                             }
                         }
                     }
@@ -108,99 +130,484 @@ class CompBlendTest : public ::testing::Test {
   protected:
     static const int src_stride_ = MAX_SB_SIZE;
     static const int dst_stride_ = MAX_SB_SIZE;
-    static const int mask_stride_ = MAX_SB_SIZE;
+    static const int mask_stride_ = 2 * MAX_SB_SIZE;
     DstSample *ref_dst_;
     DstSample *tst_dst_;
     SrcSample *src0_;
     SrcSample *src1_;
+    BlendFunc func_ref_;
+    BlendFunc func_tst_;
     uint8_t *mask_;
     int w_, h_;
     int bd_;
     const char *tst_fn_name;  // test function name
+    bool no_sub_;
 };
 
-class LbdCompBlendTest : public CompBlendTest<uint8_t, uint8_t> {
+using LbdBlendA64MaskFunc = void (*)(uint8_t *, uint32_t, const uint8_t *,
+                                     uint32_t, const uint8_t *, uint32_t,
+                                     const uint8_t *, uint32_t, int, int, int,
+                                     int);
+
+class LbdCompBlendTest
+    : public CompBlendTest<uint8_t, uint8_t, LbdBlendA64MaskFunc,
+                           MAKE_PARAM(LbdBlendA64MaskFunc)> {
   public:
     LbdCompBlendTest() {
         bd_ = 8;
-        tst_fn_name = "aom_blend_a64_mask_avx2";
+        func_ref_ = TEST_GET_PARAM(0);
+        func_tst_ = TEST_GET_PARAM(1);
+        tst_fn_name = TEST_GET_PARAM(2);
     }
 
     void run_blend(int subw, int subh) override {
-        aom_blend_a64_mask_c(ref_dst_,
-                             dst_stride_,
-                             src0_,
-                             src_stride_,
-                             src1_,
-                             src_stride_,
-                             mask_,
-                             mask_stride_,
-                             w_,
-                             h_,
-                             subw,
-                             subh);
-        aom_blend_a64_mask_avx2(tst_dst_,
-                                dst_stride_,
-                                src0_,
-                                src_stride_,
-                                src1_,
-                                src_stride_,
-                                mask_,
-                                mask_stride_,
-                                w_,
-                                h_,
-                                subw,
-                                subh);
+        func_ref_(ref_dst_,
+                  dst_stride_,
+                  src0_,
+                  src_stride_,
+                  src1_,
+                  src_stride_,
+                  mask_,
+                  mask_stride_,
+                  w_,
+                  h_,
+                  subw,
+                  subh);
+        func_tst_(tst_dst_,
+                  dst_stride_,
+                  src0_,
+                  src_stride_,
+                  src1_,
+                  src_stride_,
+                  mask_,
+                  mask_stride_,
+                  w_,
+                  h_,
+                  subw,
+                  subh);
     }
 };
 
-TEST_F(LbdCompBlendTest, BlendA64Mask) {
+TEST_P(LbdCompBlendTest, BlendA64Mask) {
     run_test();
 }
 
-class LbdCompBlendD16Test : public CompBlendTest<uint16_t, uint8_t> {
+INSTANTIATE_TEST_CASE_P(
+    BLEND, LbdCompBlendTest,
+    ::testing::ValuesIn({
+        make_tuple(aom_blend_a64_mask_c, aom_blend_a64_mask_avx2,
+                   "aom_blend_a64_mask_avx2"),
+        make_tuple(aom_blend_a64_mask_c, aom_blend_a64_mask_sse4_1,
+                   "aom_blend_a64_mask_sse4_1"),
+    }));
+
+using LbdBlendA64D16MaskFunc = void (*)(uint8_t *, uint32_t,
+                                        const CONV_BUF_TYPE *, uint32_t,
+                                        const CONV_BUF_TYPE *, uint32_t,
+                                        const uint8_t *, uint32_t, int, int,
+                                        int, int, ConvolveParams *);
+
+class LbdCompBlendD16Test
+    : public CompBlendTest<uint16_t, uint8_t, LbdBlendA64D16MaskFunc,
+                           MAKE_PARAM(LbdBlendA64D16MaskFunc)> {
   public:
     LbdCompBlendD16Test() {
         bd_ = 10;
-        tst_fn_name = "aom_lowbd_blend_a64_d16_mask_avx2";
+        func_ref_ = TEST_GET_PARAM(0);
+        func_tst_ = TEST_GET_PARAM(1);
+        tst_fn_name = TEST_GET_PARAM(2);
     }
 
     void run_blend(int subw, int subh) override {
         ConvolveParams conv_params;
         conv_params.round_0 = ROUND0_BITS;
         conv_params.round_1 = COMPOUND_ROUND1_BITS;
-        aom_lowbd_blend_a64_d16_mask_avx2(tst_dst_,
-                                          dst_stride_,
-                                          src0_,
-                                          src_stride_,
-                                          src1_,
-                                          src_stride_,
-                                          mask_,
-                                          mask_stride_,
-                                          w_,
-                                          h_,
-                                          subw,
-                                          subh,
-                                          &conv_params);
-        aom_lowbd_blend_a64_d16_mask_c(ref_dst_,
-                                       dst_stride_,
-                                       src0_,
-                                       src_stride_,
-                                       src1_,
-                                       src_stride_,
-                                       mask_,
-                                       mask_stride_,
-                                       w_,
-                                       h_,
-                                       subw,
-                                       subh,
-                                       &conv_params);
+        func_tst_(tst_dst_,
+                  dst_stride_,
+                  src0_,
+                  src_stride_,
+                  src1_,
+                  src_stride_,
+                  mask_,
+                  mask_stride_,
+                  w_,
+                  h_,
+                  subw,
+                  subh,
+                  &conv_params);
+        func_ref_(ref_dst_,
+                  dst_stride_,
+                  src0_,
+                  src_stride_,
+                  src1_,
+                  src_stride_,
+                  mask_,
+                  mask_stride_,
+                  w_,
+                  h_,
+                  subw,
+                  subh,
+                  &conv_params);
     }
 };
 
-TEST_F(LbdCompBlendD16Test, BlendA64MaskD16) {
+TEST_P(LbdCompBlendD16Test, BlendA64MaskD16) {
     run_test();
 }
+
+INSTANTIATE_TEST_CASE_P(
+    BLEND, LbdCompBlendD16Test,
+    ::testing::ValuesIn({make_tuple(aom_lowbd_blend_a64_d16_mask_c,
+                                    aom_lowbd_blend_a64_d16_mask_avx2,
+                                    "aom_lowbd_blend_a64_d16_mask_avx2")}));
+
+using LbdBlendA64HMaskFunc = void (*)(uint8_t *, uint32_t, const uint8_t *,
+                                      uint32_t, const uint8_t *, uint32_t,
+                                      const uint8_t *, int, int);
+
+class LbdCompBlendHMaskTest
+    : public CompBlendTest<uint8_t, uint8_t, LbdBlendA64HMaskFunc,
+                           MAKE_PARAM(LbdBlendA64HMaskFunc)> {
+  public:
+    LbdCompBlendHMaskTest() {
+        bd_ = 8;
+        func_ref_ = TEST_GET_PARAM(0);
+        func_tst_ = TEST_GET_PARAM(1);
+        tst_fn_name = TEST_GET_PARAM(2);
+        no_sub_ = true;
+    }
+
+    void run_blend(int subw, int subh) override {
+        (void)subw;
+        (void)subh;
+        func_ref_(ref_dst_,
+                  dst_stride_,
+                  src0_,
+                  src_stride_,
+                  src1_,
+                  src_stride_,
+                  mask_,
+                  w_,
+                  h_);
+        func_tst_(tst_dst_,
+                  dst_stride_,
+                  src0_,
+                  src_stride_,
+                  src1_,
+                  src_stride_,
+                  mask_,
+                  w_,
+                  h_);
+    }
+};
+
+TEST_P(LbdCompBlendHMaskTest, BlendA64Mask) {
+    run_test();
+}
+
+INSTANTIATE_TEST_CASE_P(BLEND, LbdCompBlendHMaskTest,
+                        ::testing::ValuesIn({make_tuple(
+                            aom_blend_a64_hmask_c, aom_blend_a64_hmask_sse4_1,
+                            "aom_blend_a64_hmask_sse4_1")}));
+
+using LbdBlendA64VMaskFunc = void (*)(uint8_t *, uint32_t, const uint8_t *,
+                                      uint32_t, const uint8_t *, uint32_t,
+                                      const uint8_t *, int, int);
+
+class LbdCompBlendVMaskTest
+    : public CompBlendTest<uint8_t, uint8_t, LbdBlendA64VMaskFunc,
+                           MAKE_PARAM(LbdBlendA64VMaskFunc)> {
+  public:
+    LbdCompBlendVMaskTest() {
+        bd_ = 8;
+        func_ref_ = TEST_GET_PARAM(0);
+        func_tst_ = TEST_GET_PARAM(1);
+        tst_fn_name = TEST_GET_PARAM(2);
+        no_sub_ = true;
+    }
+
+    void run_blend(int subw, int subh) override {
+        (void)subw;
+        (void)subh;
+        func_ref_(ref_dst_,
+                  dst_stride_,
+                  src0_,
+                  src_stride_,
+                  src1_,
+                  src_stride_,
+                  mask_,
+                  w_,
+                  h_);
+        func_tst_(tst_dst_,
+                  dst_stride_,
+                  src0_,
+                  src_stride_,
+                  src1_,
+                  src_stride_,
+                  mask_,
+                  w_,
+                  h_);
+    }
+};
+
+TEST_P(LbdCompBlendVMaskTest, BlendA64Mask) {
+    run_test();
+}
+
+INSTANTIATE_TEST_CASE_P(BLEND, LbdCompBlendVMaskTest,
+                        ::testing::ValuesIn({make_tuple(
+                            aom_blend_a64_vmask_c, aom_blend_a64_vmask_sse4_1,
+                            "aom_blend_a64_vmask_sse4_1")}));
+
+using HbdBlendA64MaskFunc = void (*)(uint8_t *, uint32_t, const uint8_t *,
+                                     uint32_t, const uint8_t *, uint32_t,
+                                     const uint8_t *, uint32_t, int, int, int,
+                                     int, int);
+
+class HbdCompBlendTest
+    : public CompBlendTest<uint16_t, uint16_t, HbdBlendA64MaskFunc,
+                           MAKE_PARAM(HbdBlendA64MaskFunc)> {
+  public:
+    HbdCompBlendTest() {
+        bd_ = 8;
+        func_ref_ = TEST_GET_PARAM(0);
+        func_tst_ = TEST_GET_PARAM(1);
+        tst_fn_name = TEST_GET_PARAM(2);
+    }
+
+    void run_hbd_test(uint8_t bd) {
+        bd_ = bd;
+        run_test();
+    }
+
+    void run_blend(int subw, int subh) override {
+        func_ref_((uint8_t *)ref_dst_,
+                  dst_stride_,
+                  (uint8_t *)src0_,
+                  src_stride_,
+                  (uint8_t *)src1_,
+                  src_stride_,
+                  mask_,
+                  mask_stride_,
+                  w_,
+                  h_,
+                  subw,
+                  subh,
+                  bd_);
+        func_tst_((uint8_t *)tst_dst_,
+                  dst_stride_,
+                  (uint8_t *)src0_,
+                  src_stride_,
+                  (uint8_t *)src1_,
+                  src_stride_,
+                  mask_,
+                  mask_stride_,
+                  w_,
+                  h_,
+                  subw,
+                  subh,
+                  bd_);
+    }
+};
+
+TEST_P(HbdCompBlendTest, BlendA64Mask) {
+    run_hbd_test(8);
+    run_hbd_test(10);
+    run_hbd_test(12);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    BLEND, HbdCompBlendTest,
+    ::testing::ValuesIn({make_tuple(aom_highbd_blend_a64_mask_c,
+                                    aom_highbd_blend_a64_mask_sse4_1,
+                                    "aom_highbd_blend_a64_mask_sse4_1")}));
+
+using HbdBlendA64D16MaskFunc = void (*)(uint8_t *, uint32_t,
+                                        const CONV_BUF_TYPE *, uint32_t,
+                                        const CONV_BUF_TYPE *, uint32_t,
+                                        const uint8_t *, uint32_t, int, int,
+                                        int, int, ConvolveParams *, const int);
+
+class HbdCompBlendD16Test
+    : public CompBlendTest<uint16_t, uint16_t, HbdBlendA64D16MaskFunc,
+                           MAKE_PARAM(HbdBlendA64D16MaskFunc)> {
+  public:
+    HbdCompBlendD16Test() {
+        bd_ = 10;
+        func_ref_ = TEST_GET_PARAM(0);
+        func_tst_ = TEST_GET_PARAM(1);
+        tst_fn_name = TEST_GET_PARAM(2);
+    }
+
+    void run_hbd_test(uint8_t bd) {
+        bd_ = bd;
+        run_test();
+    }
+
+    void run_blend(int subw, int subh) override {
+        ConvolveParams conv_params;
+        conv_params.round_0 = ROUND0_BITS;
+        conv_params.round_1 = COMPOUND_ROUND1_BITS;
+        func_tst_((uint8_t *)tst_dst_,
+                  dst_stride_,
+                  src0_,
+                  src_stride_,
+                  src1_,
+                  src_stride_,
+                  mask_,
+                  mask_stride_,
+                  w_,
+                  h_,
+                  subw,
+                  subh,
+                  &conv_params,
+                  bd_);
+        func_ref_((uint8_t *)ref_dst_,
+                  dst_stride_,
+                  src0_,
+                  src_stride_,
+                  src1_,
+                  src_stride_,
+                  mask_,
+                  mask_stride_,
+                  w_,
+                  h_,
+                  subw,
+                  subh,
+                  &conv_params,
+                  bd_);
+    }
+};
+
+TEST_P(HbdCompBlendD16Test, BlendA64MaskD16) {
+    run_hbd_test(8);
+    run_hbd_test(10);
+    run_hbd_test(12);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    BLEND, HbdCompBlendD16Test,
+    ::testing::ValuesIn({make_tuple(aom_highbd_blend_a64_d16_mask_c,
+                                    aom_highbd_blend_a64_d16_mask_avx2,
+                                    "aom_highbd_blend_a64_d16_mask_avx2")}));
+
+using HbdBlendA64HMaskFunc = void (*)(uint8_t *, uint32_t, const uint8_t *,
+                                      uint32_t, const uint8_t *, uint32_t,
+                                      const uint8_t *, int, int, int);
+
+class HbdCompBlendHMaskTest
+    : public CompBlendTest<uint16_t, uint16_t, HbdBlendA64HMaskFunc,
+                           MAKE_PARAM(HbdBlendA64HMaskFunc)> {
+  public:
+    HbdCompBlendHMaskTest() {
+        bd_ = 8;
+        func_ref_ = TEST_GET_PARAM(0);
+        func_tst_ = TEST_GET_PARAM(1);
+        tst_fn_name = TEST_GET_PARAM(2);
+        no_sub_ = true;
+    }
+
+    void run_hbd_test(uint8_t bd) {
+        bd_ = bd;
+        run_test();
+    }
+
+    void run_blend(int subw, int subh) override {
+        (void)subw;
+        (void)subh;
+        func_ref_((uint8_t *)ref_dst_,
+                  dst_stride_,
+                  (uint8_t *)src0_,
+                  src_stride_,
+                  (uint8_t *)src1_,
+                  src_stride_,
+                  mask_,
+                  w_,
+                  h_,
+                  bd_);
+        func_tst_((uint8_t *)tst_dst_,
+                  dst_stride_,
+                  (uint8_t *)src0_,
+                  src_stride_,
+                  (uint8_t *)src1_,
+                  src_stride_,
+                  mask_,
+                  w_,
+                  h_,
+                  bd_);
+    }
+};
+
+TEST_P(HbdCompBlendHMaskTest, BlendA64Mask) {
+    run_hbd_test(8);
+    run_hbd_test(10);
+    run_hbd_test(12);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    BLEND, HbdCompBlendHMaskTest,
+    ::testing::ValuesIn({make_tuple(aom_highbd_blend_a64_hmask_c,
+                                    aom_highbd_blend_a64_hmask_sse4_1,
+                                    "aom_highbd_blend_a64_hmask_sse4_1")}));
+
+using HbdBlendA64VMaskFunc = void (*)(uint8_t *, uint32_t, const uint8_t *,
+                                      uint32_t, const uint8_t *, uint32_t,
+                                      const uint8_t *, int, int, int);
+
+class HbdCompBlendVMaskTest
+    : public CompBlendTest<uint16_t, uint16_t, HbdBlendA64VMaskFunc,
+                           MAKE_PARAM(HbdBlendA64VMaskFunc)> {
+  public:
+    HbdCompBlendVMaskTest() {
+        bd_ = 8;
+        func_ref_ = TEST_GET_PARAM(0);
+        func_tst_ = TEST_GET_PARAM(1);
+        tst_fn_name = TEST_GET_PARAM(2);
+        no_sub_ = true;
+    }
+
+    void run_hbd_test(uint8_t bd) {
+        bd_ = bd;
+        run_test();
+    }
+
+    void run_blend(int subw, int subh) override {
+        (void)subw;
+        (void)subh;
+        func_ref_((uint8_t *)ref_dst_,
+                  dst_stride_,
+                  (uint8_t *)src0_,
+                  src_stride_,
+                  (uint8_t *)src1_,
+                  src_stride_,
+                  mask_,
+                  w_,
+                  h_,
+                  bd_);
+        func_tst_((uint8_t *)tst_dst_,
+                  dst_stride_,
+                  (uint8_t *)src0_,
+                  src_stride_,
+                  (uint8_t *)src1_,
+                  src_stride_,
+                  mask_,
+                  w_,
+                  h_,
+                  bd_);
+    }
+};
+
+TEST_P(HbdCompBlendVMaskTest, BlendA64Mask) {
+    run_hbd_test(8);
+    run_hbd_test(10);
+    run_hbd_test(12);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    BLEND, HbdCompBlendVMaskTest,
+    ::testing::ValuesIn({make_tuple(aom_highbd_blend_a64_vmask_c,
+                                    aom_highbd_blend_a64_vmask_sse4_1,
+                                    "aom_highbd_blend_a64_vmask_sse4_1")}));
 
 typedef void (*BuildCompDiffwtdMaskedFunc)(uint8_t *mask,
                                            DIFFWTD_MASK_TYPE mask_type,

--- a/test/WedgeUtilTest.cc
+++ b/test/WedgeUtilTest.cc
@@ -1,0 +1,216 @@
+/*
+ * Copyright(c) 2019 Netflix, Inc.
+ * SPDX - License - Identifier: BSD - 2 - Clause - Patent
+ */
+
+/******************************************************************************
+ * @file WedgeUtilTest.cc
+ *
+ * @brief Unit test for util functions in wedge prediction:
+ * - av1_wedge_sign_from_residuals_avx2
+ * - av1_wedge_compute_delta_squares_avx2
+ * - av1_wedge_sse_from_residuals_avx2
+ *
+ * @author Cidana-Wenyao
+ *
+ ******************************************************************************/
+#include "gtest/gtest.h"
+#include "EbDefinitions.h"
+#include "EbUtility.h"
+#include "aom_dsp_rtcd.h"
+#include "random.h"
+
+using svt_av1_test_tool::SVTRandom;
+namespace {
+// test av1_wedge_sign_from_residuals_avx2
+// Choose the mask sign for a compound predictor.
+class WedgeUtilTest : public ::testing::Test {
+  public:
+    void SetUp() override {
+        r0 = (int16_t *)eb_aom_memalign(32, MAX_SB_SQUARE * sizeof(int16_t));
+        r1 = (int16_t *)eb_aom_memalign(32, MAX_SB_SQUARE * sizeof(int16_t));
+        m = (uint8_t *)eb_aom_memalign(32, MAX_SB_SQUARE);
+    }
+
+    void TearDown() override {
+        eb_aom_free(r0);
+        eb_aom_free(r1);
+        eb_aom_free(m);
+        aom_clear_system_state();
+    }
+
+  protected:
+    uint8_t *m;       /* mask */
+    int16_t *r0, *r1; /* two predicted residual */
+};
+
+extern "C" uint64_t aom_sum_squares_i16_c(const int16_t *src, uint32_t n);
+#define MAX_MASK_VALUE (1 << WEDGE_WEIGHT_BITS)
+TEST_F(WedgeUtilTest, MaskSignTest) {
+    const int loops = 10000;
+    const int int_13bit_max = (1 << 12) - 1;
+    SVTRandom rnd(13, true);             // max residual is 13-bit
+    SVTRandom m_rnd(0, MAX_MASK_VALUE);  // [0, MAX_MASK_VALUE]
+    SVTRandom n_rnd(1, 8191 / 64);       // required by assembly implementation
+    DECLARE_ALIGNED(32, int16_t, ds[MAX_SB_SQUARE]);
+
+    for (int k = 0; k < loops; ++k) {
+        if (k < 4) {  // extreme value test
+            switch (k) {
+            case 0:
+                for (int i = 0; i < MAX_SB_SQUARE; ++i) {
+                    r0[i] = 0;
+                    r1[i] = int_13bit_max;
+                }
+                break;
+            case 1:
+                for (int i = 0; i < MAX_SB_SQUARE; ++i) {
+                    r0[i] = int_13bit_max;
+                    r1[i] = 0;
+                }
+                break;
+            case 2:
+                for (int i = 0; i < MAX_SB_SQUARE; ++i) {
+                    r0[i] = -int_13bit_max;
+                    r1[i] = 0;
+                }
+                break;
+            case 3:
+                for (int i = 0; i < MAX_SB_SQUARE; ++i) {
+                    r0[i] = 0;
+                    r1[i] = -int_13bit_max;
+                }
+                break;
+            default: assert(0); break;
+            }
+
+            for (int i = 0; i < MAX_SB_SQUARE; ++i)
+                m[i] = MAX_MASK_VALUE;
+        } else {
+            // populate the residual buffer randomly
+            for (int i = 0; i < MAX_SB_SQUARE; ++i) {
+                r0[i] = rnd.random();
+                r1[i] = rnd.random();
+                m[i] = m_rnd.random();
+            }
+        }
+
+        // N should be multiple of 64, required by
+        // av1_wedge_sign_from_residuals_avx2
+        const int N = 64 * n_rnd.random();
+
+        // pre-compute limit
+        // MAX_MASK_VALUE/2 * (sum(r0**2) - sum(r1**2))
+        int64_t limit;
+        limit = (int64_t)aom_sum_squares_i16_c(r0, N);
+        limit -= (int64_t)aom_sum_squares_i16_c(r1, N);
+        limit *= (1 << WEDGE_WEIGHT_BITS) / 2;
+
+        // calculate ds: r0**2 - r1**2
+        for (int i = 0; i < N; ++i)
+            ds[i] = clamp(r0[i] * r0[i] - r1[i] * r1[i], INT16_MIN, INT16_MAX);
+        const int8_t ref_sign =
+            av1_wedge_sign_from_residuals_c(ds, m, N, limit);
+        const int8_t tst_sign =
+            av1_wedge_sign_from_residuals_avx2(ds, m, N, limit);
+        ASSERT_EQ(ref_sign, tst_sign)
+            << "av1_wedge_sign_from_residuals_avx2 fail at loop " << k;
+    }
+}
+
+// test av1_wedge_compute_delta_squares_avx2
+// element-by-element calculate the difference of square
+TEST_F(WedgeUtilTest, ComputeDeltaSquareTest) {
+    const int loops = 10000;
+    SVTRandom rnd(13, true);  // max residual is 13-bit
+    SVTRandom n_rnd(1, MAX_SB_SQUARE / 64);
+    DECLARE_ALIGNED(32, int16_t, ref_diff[MAX_SB_SQUARE]);
+    DECLARE_ALIGNED(32, int16_t, tst_diff[MAX_SB_SQUARE]);
+
+    for (int k = 0; k < loops; ++k) {
+        // populate the residual buffer randomly
+        for (int i = 0; i < MAX_SB_SQUARE; ++i) {
+            r0[i] = rnd.random();
+            r1[i] = rnd.random();
+        }
+        memset(ref_diff, 0, sizeof(ref_diff));
+        memset(tst_diff, 0, sizeof(ref_diff));
+
+        // N should be multiple of 64, required by
+        // av1_wedge_compute_delta_squares_avx2
+        const int N = 64 * n_rnd.random();
+
+        av1_wedge_compute_delta_squares_c(ref_diff, r0, r1, N);
+        av1_wedge_compute_delta_squares_avx2(tst_diff, r0, r1, N);
+
+        // check the output
+        for (int i = 0; i < N; ++i) {
+            ASSERT_EQ(ref_diff[i], tst_diff[i])
+                << "av1_wedge_compute_delta_squares_avx2 fail at loop " << k;
+        }
+    }
+}
+
+// test av1_wedge_sse_from_residuals_avx2
+// calculate the sse of two prediction combined with mask m
+TEST_F(WedgeUtilTest, SseFromResidualTest) {
+    const int loops = 10000;
+    const int int_13bit_max = (1 << 12) - 1;
+    SVTRandom rnd(13, true);             // max residual is 13-bit
+    SVTRandom m_rnd(0, MAX_MASK_VALUE);  // [0, MAX_MASK_VALUE]
+    SVTRandom n_rnd(1, MAX_SB_SQUARE / 64);
+
+    for (int k = 0; k < loops; ++k) {
+        if (k < 4) {
+            switch (k) {
+            case 0:
+                for (int i = 0; i < MAX_SB_SQUARE; ++i) {
+                    r0[i] = 0;
+                    r1[i] = int_13bit_max;
+                }
+                break;
+            case 1:
+                for (int i = 0; i < MAX_SB_SQUARE; ++i) {
+                    r0[i] = int_13bit_max;
+                    r1[i] = 0;
+                }
+                break;
+            case 2:
+                for (int i = 0; i < MAX_SB_SQUARE; ++i) {
+                    r0[i] = -int_13bit_max;
+                    r1[i] = 0;
+                }
+                break;
+            case 3:
+                for (int i = 0; i < MAX_SB_SQUARE; ++i) {
+                    r0[i] = 0;
+                    r1[i] = -int_13bit_max;
+                }
+                break;
+            default: assert(0); break;
+            }
+
+            for (int i = 0; i < MAX_SB_SQUARE; ++i)
+                m[i] = MAX_MASK_VALUE;
+        } else {
+            // populate the residual buffer randomly
+            for (int i = 0; i < MAX_SB_SQUARE; ++i) {
+                r0[i] = rnd.random();
+                r1[i] = rnd.random();
+                m[i] = m_rnd.random();
+            }
+        }
+
+        // N should be multiple of 64, required by
+        // av1_wedge_sse_from_residuals_avx2
+        const int N = 64 * n_rnd.random();
+
+        uint64_t ref_sse = av1_wedge_sse_from_residuals_c(r0, r1, m, N);
+        uint64_t tst_sse = av1_wedge_sse_from_residuals_avx2(r0, r1, m, N);
+
+        // check output
+        ASSERT_EQ(ref_sse, tst_sse)
+            << "av1_wedge_sse_from_residuals_avx2 fail at loop " << k;
+    }
+}
+}  // namespace

--- a/test/loopfilter_ref.h
+++ b/test/loopfilter_ref.h
@@ -432,22 +432,6 @@ static INLINE void highbd_filter14(int8_t mask, uint8_t thresh, int8_t flat,
     }
 }
 
-static void aom_lpf_vertical_6_c(uint8_t *s, int pitch, const uint8_t *blimit,
-                                 const uint8_t *limit, const uint8_t *thresh) {
-    int i;
-    int count = 4;
-
-    for (i = 0; i < count; ++i) {
-        const uint8_t p2 = s[-3], p1 = s[-2], p0 = s[-1];
-        const uint8_t q0 = s[0], q1 = s[1], q2 = s[2];
-        const int8_t mask =
-            filter_mask3_chroma(*limit, *blimit, p2, p1, p0, q0, q1, q2);
-        const int8_t flat = flat_mask3_chroma(1, p2, p1, p0, q0, q1, q2);
-        filter6(mask, *thresh, flat, s - 3, s - 2, s - 1, s, s + 1, s + 2);
-        s += pitch;
-    }
-}
-
 static void aom_highbd_lpf_horizontal_6_c(uint16_t *s, int p,
                                           const uint8_t *blimit,
                                           const uint8_t *limit,


### PR DESCRIPTION
1. add unit test for utility functions in wedge prediction, including:
   av1_wedge_sign_from_residuals_avx2,
   av1_wedge_compute_delta_squares_avx2,
   av1_wedge_sse_from_residuals_avx2
2. add unit tests for utility functions:
   av1_build_compound_diffwtd_mask_{, d16}avx2,
   aom_blend_a64_mask_avx2/aom_lowbd_blend_a64_d16_mask_avx2