### PR TITLE
Added WARP_UPDATE flag and modified when warping is active

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -43,6 +43,8 @@ extern "C" {
 #endif
 
 #define MR_MODE                           0
+
+#define WARP_UPDATE                       1 // Modified Warp settings: ON for MR mode. ON for ref frames in M0
 #define EIGTH_PEL_MV                      1
 #define EIGHT_PEL_PREDICTIVE_ME           1
 #define COMP_INTERINTRA                   1 // InterIntra mode support

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.c
@@ -463,8 +463,16 @@ void reset_mode_decision(
     if (picture_control_set_ptr->parent_pcs_ptr->sc_content_detected)
         enable_wm = EB_FALSE;
     else
+#if WARP_UPDATE
+        enable_wm = (MR_MODE ||
+        (picture_control_set_ptr->parent_pcs_ptr->enc_mode == ENC_M0 && picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ||
+        (picture_control_set_ptr->parent_pcs_ptr->enc_mode <= ENC_M5 && picture_control_set_ptr->parent_pcs_ptr->temporal_layer_index == 0)) ? EB_TRUE : EB_FALSE;
+#else
         enable_wm = (picture_control_set_ptr->parent_pcs_ptr->enc_mode <= ENC_M5) || MR_MODE ? EB_TRUE : EB_FALSE;
+#endif
+
     enable_wm = picture_control_set_ptr->parent_pcs_ptr->temporal_layer_index > 0 ? EB_FALSE : enable_wm;
+
     frm_hdr->allow_warped_motion = enable_wm
         && !(frm_hdr->frame_type == KEY_FRAME || frm_hdr->frame_type == INTRA_ONLY_FRAME)
         && !frm_hdr->error_resilient_mode;


### PR DESCRIPTION
### Description
Modified when warp is active: 
MR: ON always
M0: ON for the ref frames
M1-M5: ON for the base layer
else: OFF

### Authors
@anaghdin

### Type of change
Feature enhancement

### Tests and performance:
Expected Average PSNR-SSIM BD-rate gain in the range of -0.2% on the AOM test set, using 4 QP values: {20, 32, 43 and 55}.

### Speed impact:
Speed drop of ~3% for M0

