### PR TITLE
RDOQ for CHROMA

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -49,7 +49,7 @@ extern "C" {
 
 #define ENHANCE_ATB                       1
 
-
+#define RDOQ_CHROMA                       1
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC                         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch
 

--- a/Source/Lib/Common/Codec/EbFullLoop.c
+++ b/Source/Lib/Common/Codec/EbFullLoop.c
@@ -1918,7 +1918,11 @@ int32_t av1_quantize_inv_quantize(
 
 
     EbBool is_inter = (pred_mode >= NEARESTMV);
+#if RDOQ_CHROMA
+    EbBool perform_rdoq = ((md_context->md_staging_skip_rdoq == EB_FALSE || is_encode_pass) && md_context->trellis_quant_coeff_optimization && !is_intra_bc);
+#else
     EbBool perform_rdoq = ((md_context->md_staging_skip_rdoq == EB_FALSE || is_encode_pass) && md_context->trellis_quant_coeff_optimization && component_type == COMPONENT_LUMA && !is_intra_bc);
+#endif
     perform_rdoq = perform_rdoq && !picture_control_set_ptr->hbd_mode_decision && !bit_increment;
 
     // Hsan: set to FALSE until adding x86 quantize_fp
@@ -3130,9 +3134,15 @@ void full_loop_r(
                 picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 candidate_buffer->candidate_ptr->transform_type_uv,
                 candidate_buffer,
+#if RDOQ_CHROMA
+                context_ptr->cb_txb_skip_context,
+                context_ptr->cb_dc_sign_context,
+                candidate_buffer->candidate_ptr->pred_mode >= NEARESTMV,
+#else
                 0,
                 0,
                 0,
+#endif
                 candidate_buffer->candidate_ptr->use_intrabc,
                 EB_FALSE);
 
@@ -3215,9 +3225,15 @@ void full_loop_r(
                 picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 candidate_buffer->candidate_ptr->transform_type_uv,
                 candidate_buffer,
+#if RDOQ_CHROMA
+                context_ptr->cr_txb_skip_context,
+                context_ptr->cr_dc_sign_context,
+                candidate_buffer->candidate_ptr->pred_mode >= NEARESTMV,
+#else
                 0,
                 0,
                 0,
+#endif
                 candidate_buffer->candidate_ptr->use_intrabc,
                 EB_FALSE);
 

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -6762,7 +6762,9 @@ void search_best_independent_uv_mode(
 
         for (uint8_t uv_angleDeltaCounter = 0; uv_angleDeltaCounter < uv_angleDeltaCandidateCount; ++uv_angleDeltaCounter) {
             int32_t uv_angle_delta = CLIP(uv_angle_delta_shift * (uv_angleDeltaCandidateCount == 1 ? 0 : uv_angleDeltaCounter - (uv_angleDeltaCandidateCount >> 1)), -MAX_ANGLE_DELTA, MAX_ANGLE_DELTA);
-
+#if RDOQ_CHROMA
+            candidate_buffer->candidate_ptr->pred_mode = DC_PRED;
+#endif
             candidate_buffer->candidate_ptr->intra_chroma_mode = uv_mode;
             candidate_buffer->candidate_ptr->is_directional_chroma_mode_flag = (uint8_t)av1_is_directional_mode((PredictionMode)uv_mode);
             candidate_buffer->candidate_ptr->angle_delta[PLANE_TYPE_UV] = uv_angle_delta;


### PR DESCRIPTION
## Description
RDOQ for CHROMA

Closes #673

## Author

@hguermaz 

## Type of change

New feature/Tool

## Tests and performance
* BD-Rate to aom cpu0-2pass on the full list: ~0.6% Y gain and ~3.4% UV loss => YUV: ~0.075% loss (better distribution as currently UV to libaom is >> Y to libaom)
* Speed on a 4-core machine for M0 on 360p: ~1% slower
* Memory footprint on a 4-core machine: ~0%