### PR TITLE
WIP Enhanced cdef

### DIFF
--- a/Source/Lib/Common/Codec/EbCdef.c
+++ b/Source/Lib/Common/Codec/EbCdef.c
@@ -18,6 +18,9 @@
 #include "EbCodingUnit.h"
 #include "EbEncDecProcess.h"
 #include "aom_dsp_rtcd.h"
+#if UPDATE_CDEF
+#include "EbRateDistortionCost.h"
+#endif
 
 extern int16_t eb_av1_ac_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth);
 
@@ -1432,7 +1435,9 @@ uint64_t compute_cdef_dist_8bit_c(const uint8_t *dst8, int32_t dstride, const ui
 
 void finish_cdef_search(
     EncDecContext                *context_ptr,
+#if !UPDATE_CDEF
     SequenceControlSet           *sequence_control_set_ptr,
+#endif
     PictureControlSet            *picture_control_set_ptr
     , int32_t                      selected_strength_cnt[64]
 )
@@ -1478,13 +1483,38 @@ void finish_cdef_search(
     int32_t i;
     int32_t nb_strengths;
     int32_t nb_strength_bits;
+#if !UPDATE_CDEF
     int32_t quantizer;
+#endif
+#if UPDATE_CDEF
+    uint64_t lambda;
+#else
     double lambda;
+#endif
     const int32_t num_planes = 3;
 
+#if UPDATE_CDEF
+    uint16_t qp_index = (uint8_t)picture_control_set_ptr->parent_pcs_ptr->frm_hdr.quantization_params.base_q_idx;
+    uint32_t fast_lambda;
+    uint32_t full_lambda;
+    uint32_t fast_chroma_lambda;
+    uint32_t full_chroma_lambda;
+    (*av1_lambda_assignment_function_table[picture_control_set_ptr->parent_pcs_ptr->pred_structure])(
+        &fast_lambda,
+        &full_lambda,
+        &fast_chroma_lambda,
+        &full_chroma_lambda,
+        (uint8_t)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
+        qp_index,
+        picture_control_set_ptr->hbd_mode_decision);
+    // Adjust lambda based on empirical data
+    lambda = (full_lambda * 120) / 100;
+#else
     quantizer =
-        eb_av1_ac_quant_Q3(frm_hdr->quantization_params.base_q_idx, 0, (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth) >> (sequence_control_set_ptr->static_config.encoder_bit_depth - 8);
+        eb_av1_ac_quant_Q3(pPcs->frm_hdr.quantization_params.base_q_idx, 0, (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth) >> (sequence_control_set_ptr->static_config.encoder_bit_depth - 8);
     lambda = .12 * quantizer * quantizer / 256.;
+
+#endif
 
     mse[0] = (uint64_t(*)[64])malloc(sizeof(**mse) * nvfb * nhfb);
     mse[1] = (uint64_t(*)[64])malloc(sizeof(**mse) * nvfb * nhfb);
@@ -1530,9 +1560,19 @@ void finish_cdef_search(
         else
             tot_mse = joint_strength_search(best_lev0, nb_strengths, mse[0], sb_count, fast, start_gi, end_gi);
         /* Count superblock signalling cost. */
+#if UPDATE_CDEF
+        const int total_bits = sb_count * i + nb_strengths * CDEF_STRENGTH_BITS *
+            (num_planes > 1 ? 2 : 1);
+        const int rate_cost = av1_cost_literal(total_bits);
+        const uint64_t dist = tot_mse * 16;
+        tot_mse = RDCOST(lambda, rate_cost, dist);
+#else
         tot_mse += (uint64_t)(sb_count * lambda * i);
+
         /* Count header signalling cost. */
         tot_mse += (uint64_t)(nb_strengths * lambda * CDEF_STRENGTH_BITS);
+#endif
+
         if (tot_mse < best_tot_mse) {
             best_tot_mse = tot_mse;
             nb_strength_bits = i;
@@ -1677,8 +1717,14 @@ void eb_av1_cdef_search(
     int32_t i;
     int32_t nb_strengths;
     int32_t nb_strength_bits;
+#if !UPDATE_CDEF
     int32_t quantizer;
+#endif
+#if UPDATE_CDEF
+    uint64_t lambda;
+#else
     double lambda;
+#endif
     const int32_t num_planes = 3;// av1_num_planes(cm);
     const int32_t total_strengths = fast ? REDUCED_TOTAL_STRENGTHS : TOTAL_STRENGTHS;
     DECLARE_ALIGNED(32, uint16_t, inbuf[CDEF_INBUF_SIZE]);
@@ -1691,11 +1737,27 @@ void eb_av1_cdef_search(
     int32_t mid_gi = pPcs->cdf_ref_frame_strenght;
     int32_t start_gi = pPcs->use_ref_frame_cdef_strength && pPcs->cdef_filter_mode == 1 ? (AOMMAX(0, mid_gi - gi_step)) : 0;
     int32_t end_gi = pPcs->use_ref_frame_cdef_strength ? AOMMIN(total_strengths, mid_gi + gi_step) : pPcs->cdef_filter_mode == 1 ? 8 : total_strengths;
-
+#if UPDATE_CDEF
+    uint16_t qp_index = (uint8_t)picture_control_set_ptr->parent_pcs_ptr->frm_hdr.quantization_params.base_q_idx;
+    uint32_t fast_lambda;
+    uint32_t full_lambda;
+    uint32_t fast_chroma_lambda;
+    uint32_t full_chroma_lambda;
+    (*av1_lambda_assignment_function_table[picture_control_set_ptr->parent_pcs_ptr->pred_structure])(
+        &fast_lambda,
+        &full_lambda,
+        &fast_chroma_lambda,
+        &full_chroma_lambda,
+        (uint8_t)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
+        qp_index,
+        picture_control_set_ptr->hbd_mode_decision);
+    // Adjust lambda based on empirical data
+    lambda = (full_lambda * 120) / 100;
+#else
     quantizer =
-        //CHKN av1_ac_quant_Q3(cm->quant_param.base_q_idx, 0, cm->bit_depth) >> (cm->bit_depth - 8);
-        eb_av1_ac_quant_Q3(frm_hdr->quantization_params.base_q_idx, 0, (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth) >> (sequence_control_set_ptr->static_config.encoder_bit_depth - 8);
+        eb_av1_ac_quant_Q3(pPcs->frm_hdr.quantization_params.base_q_idx, 0, (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth) >> (sequence_control_set_ptr->static_config.encoder_bit_depth - 8);
     lambda = .12 * quantizer * quantizer / 256.;
+#endif
 
     //eb_av1_setup_dst_planes(xd->plane, cm->seq_params.sb_size, frame, 0, 0, 0,    num_planes);
 
@@ -1866,10 +1928,18 @@ void eb_av1_cdef_search(
             tot_mse = joint_strength_search_dual(best_lev0, best_lev1, nb_strengths, mse, sb_count, fast, start_gi, end_gi);
         else
             tot_mse = joint_strength_search(best_lev0, nb_strengths, mse[0], sb_count, fast, start_gi, end_gi);
+#if UPDATE_CDEF
+        const int total_bits = sb_count * i + nb_strengths * CDEF_STRENGTH_BITS *
+            (num_planes > 1 ? 2 : 1);
+        const int rate_cost = av1_cost_literal(total_bits);
+        const uint64_t dist = tot_mse * 16;
+        tot_mse = RDCOST(lambda, rate_cost, dist);
+#else
         /* Count superblock signalling cost. */
         tot_mse += (uint64_t)(sb_count * lambda * i);
         /* Count header signalling cost. */
         tot_mse += (uint64_t)(nb_strengths * lambda * CDEF_STRENGTH_BITS);
+#endif
         if (tot_mse < best_tot_mse) {
             best_tot_mse = tot_mse;
             nb_strength_bits = i;
@@ -2015,8 +2085,14 @@ void av1_cdef_search16bit(
     int32_t i;
     int32_t nb_strengths;
     int32_t nb_strength_bits;
+#if !UPDATE_CDEF
     int32_t quantizer;
+#endif
+#if UPDATE_CDEF
+    uint64_t lambda;
+#else
     double lambda;
+#endif
     const int32_t num_planes = 3;// av1_num_planes(cm);
     const int32_t total_strengths = fast ? REDUCED_TOTAL_STRENGTHS : TOTAL_STRENGTHS;
     DECLARE_ALIGNED(32, uint16_t, inbuf[CDEF_INBUF_SIZE]);
@@ -2030,10 +2106,27 @@ void av1_cdef_search16bit(
     int32_t start_gi = pPcs->use_ref_frame_cdef_strength && pPcs->cdef_filter_mode == 1 ? (AOMMAX(0, mid_gi - gi_step)) : 0;
     int32_t end_gi = pPcs->use_ref_frame_cdef_strength ? AOMMIN(total_strengths, mid_gi + gi_step) : pPcs->cdef_filter_mode == 1 ? 8 : total_strengths;
 
+#if UPDATE_CDEF
+    uint16_t qp_index = (uint8_t)picture_control_set_ptr->parent_pcs_ptr->frm_hdr.quantization_params.base_q_idx;
+    uint32_t fast_lambda;
+    uint32_t full_lambda;
+    uint32_t fast_chroma_lambda;
+    uint32_t full_chroma_lambda;
+    (*av1_lambda_assignment_function_table[picture_control_set_ptr->parent_pcs_ptr->pred_structure])(
+        &fast_lambda,
+        &full_lambda,
+        &fast_chroma_lambda,
+        &full_chroma_lambda,
+        (uint8_t)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
+        qp_index,
+        picture_control_set_ptr->hbd_mode_decision);
+    // Adjust lambda based on empirical data
+    lambda = (full_lambda * 120) / 100;
+#else
     quantizer =
-        //CHKN av1_ac_quant_Q3(cm->quant_param.base_q_idx, 0, cm->bit_depth) >> (cm->bit_depth - 8);
-        eb_av1_ac_quant_Q3(frm_hdr->quantization_params.base_q_idx, 0, (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth) >> (sequence_control_set_ptr->static_config.encoder_bit_depth - 8);
+        eb_av1_ac_quant_Q3(pPcs->frm_hdr.quantization_params.base_q_idx, 0, (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth) >> (sequence_control_set_ptr->static_config.encoder_bit_depth - 8);
     lambda = .12 * quantizer * quantizer / 256.;
+#endif
 
     //eb_av1_setup_dst_planes(xd->plane, cm->seq_params.sb_size, frame, 0, 0, 0,    num_planes);
 
@@ -2204,10 +2297,18 @@ void av1_cdef_search16bit(
             tot_mse = joint_strength_search_dual(best_lev0, best_lev1, nb_strengths, mse, sb_count, fast, start_gi, end_gi);
         else
             tot_mse = joint_strength_search(best_lev0, nb_strengths, mse[0], sb_count, fast, start_gi, end_gi);
+#if UPDATE_CDEF
+        const int total_bits = sb_count * i + nb_strengths * CDEF_STRENGTH_BITS *
+            (num_planes > 1 ? 2 : 1);
+        const int rate_cost = av1_cost_literal(total_bits);
+        const uint64_t dist = tot_mse * 16;
+        tot_mse = RDCOST(lambda, rate_cost, dist);
+#else
         /* Count superblock signalling cost. */
         tot_mse += (uint64_t)(sb_count * lambda * i);
         /* Count header signalling cost. */
         tot_mse += (uint64_t)(nb_strengths * lambda * CDEF_STRENGTH_BITS);
+#endif
         if (tot_mse < best_tot_mse) {
             best_tot_mse = tot_mse;
             nb_strength_bits = i;

--- a/Source/Lib/Common/Codec/EbCdefProcess.c
+++ b/Source/Lib/Common/Codec/EbCdefProcess.c
@@ -39,7 +39,9 @@ int32_t eb_sb_compute_cdef_list(PictureControlSet   *picture_control_set_ptr, co
     cdef_list *dlist, BlockSize bs);
 void finish_cdef_search(
     EncDecContext                *context_ptr,
+#if !UPDATE_CDEF
     SequenceControlSet           *sequence_control_set_ptr,
+#endif
     PictureControlSet            *picture_control_set_ptr
     ,int32_t                         selected_strength_cnt[64]
    );
@@ -472,7 +474,9 @@ void* cdef_kernel(void *input_ptr)
         if (sequence_control_set_ptr->seq_header.enable_cdef && picture_control_set_ptr->parent_pcs_ptr->cdef_filter_mode) {
                 finish_cdef_search(
                     0,
+#if !UPDATE_CDEF
                     sequence_control_set_ptr,
+#endif
                     picture_control_set_ptr,
                     selected_strength_cnt);
 

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -33,6 +33,9 @@
 extern "C" {
 #endif
 
+#define CDEF_MR_MODE     1 // Use full CDEF for MR mode
+#define UPDATE_CDEF      0 // Update bit cost estimation for CDEF
+
 #define II_COMP_FLAG 1
 #define PRED_CHANGE                  1 // Change the MRP in 4L Pictures 3, 5 , 7 and 9 use 1 as the reference
 #define PRED_CHANGE_5L               1 // Change the MRP in 5L Pictures 3, 5 , 7 and 9 use 1 as the reference, 11, 13, 15 and 17 use 9 as the reference

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -986,7 +986,13 @@ EbErrorType signal_derivation_multi_processes_oq(
     // 4                                            16 step refinement
     // 5                                            64 step refinement
     if (sequence_control_set_ptr->seq_header.enable_cdef && frm_hdr->allow_intrabc == 0) {
+#if CDEF_MR_MODE
+        if (MR_MODE) 
+            picture_control_set_ptr->cdef_filter_mode = 5;
+        else if (sc_content_detected)
+#else
         if (sc_content_detected)
+#endif
             if (picture_control_set_ptr->enc_mode <= ENC_M1)
                 picture_control_set_ptr->cdef_filter_mode = 4;
             else


### PR DESCRIPTION
## Description

Improved CDEF decision using more accurate cost calculation.

Closes #688 

## Author

@NaderMahdi 

## Type of Change

Enhancement

## Tests and Performance

Similar speeds for M0 with 360p clip.  
No memory deviations using M0. 
BD rate of -0.04% when compared to the base, using M0.
BD rate difference of -0.03% compared to aom-fd530f8.