### PR TITLE
Two Pass Encoding

### DIFF
--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -114,6 +114,9 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **QpFile** | -qp-file | any string | Null | Path to qp file |
 | **StatReport** | -stat-report | [0 - 1] | 0 | When set to 1, calculate and display PSNR values |
 | **StatFile** | -stat-file | any string | Null | Path to statistics file if specified and StatReport is set to 1, per picture statistics are outputted in the file|
+| **EncoderMode2p** | -enc-mode-2p | [0 - 8] | 8 | Encoder Preset [0,1,2,3,4,5,6,7,8] 0 = highest quality, 8 = highest speed. Passed to encoder's first pass to use the ME settings of the second pass to achieve better bdRate|
+| **InputStatFile** | -input-stat-file | any string | Null | Input stat file for second pass|
+| **OutputStatFile** | -output-stat-file | any string | Null | Output stat file for first pass|
 | **EncoderMode** | -enc-mode | [0 - 8] | 8 | Encoder Preset [0,1,2,3,4,5,6,7,8] 0 = highest quality, 8 = highest speed |
 | **EncoderBitDepth** | -bit-depth | [8 , 10] | 8 | specifies the bit depth of the input video |
 | **CompressedTenBitFormat** | -compressed-ten-bit-format | [0 - 1] | 0 | Offline packing of the 2bits: requires two bits packed input (0: OFF, 1: ON) |

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -12,8 +12,13 @@ extern "C" {
 
 #include "stdint.h"
 #include "EbSvtAv1.h"
-
+#if 1 //TWO_PASS
+#include <stdlib.h>
+#include <stdio.h>
+#endif
 #define TILES    1
+#define TWO_PASS_USE_2NDP_ME_IN_1STP                1
+#define TWO_PASS                                    1
 #define ALT_REF_OVERLAY_APP                         1
     //***HME***
 #define EB_HME_SEARCH_AREA_COLUMN_MAX_COUNT         2
@@ -39,7 +44,13 @@ typedef struct EbSvtAv1EncConfiguration
      *
      * Default is defined as MAX_ENC_PRESET. */
     uint8_t                  enc_mode;
-
+#if TWO_PASS_USE_2NDP_ME_IN_1STP
+    /* For two pass encoding, the enc_mod of the second pass is passed in the first pass.
+    * First pass has the option to run with second pass ME settings.
+    *
+    * Default is defined as MAX_ENC_PRESET. */
+    uint8_t                  snd_pass_enc_mode;
+#endif
     // GOP Structure
 
     /* The intra period defines the interval of frames after which you insert an
@@ -180,7 +191,12 @@ typedef struct EbSvtAv1EncConfiguration
     *
     * Default is 0.*/
     EbBool                   use_qp_file;
-
+#if 1 //TWO_PASS
+    /* Input stats file */
+    FILE                    *input_stat_file;
+    /* output stats file */
+    FILE                    *output_stat_file;
+#endif
     /* Enable picture QP scaling between hierarchical levels
     *
     * Default is null.*/

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -174,7 +174,12 @@ typedef struct EbConfig
     FILE                    *buffer_file;
 
     FILE                    *qp_file;
-
+#if TWO_PASS
+    FILE                    *input_stat_file;
+    FILE                    *output_stat_file;
+    EbBool                  use_input_stat_file;
+    EbBool                  use_output_stat_file;
+#endif
     EbBool                  y4m_input;
     unsigned char           y4m_buf[9];
 
@@ -214,6 +219,9 @@ typedef struct EbConfig
      *****************************************/
     uint32_t                 base_layer_switch_mode;
     uint8_t                  enc_mode;
+#if TWO_PASS_USE_2NDP_ME_IN_1STP
+    uint8_t                  snd_pass_enc_mode;
+#endif
     int32_t                  intra_period;
     uint32_t                 intra_refresh_type;
     uint32_t                 hierarchical_levels;

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -160,6 +160,9 @@ EbErrorType CopyConfigurationParameters(
     callback_data->eb_enc_parameters.intra_refresh_type = config->intra_refresh_type;
     callback_data->eb_enc_parameters.base_layer_switch_mode = config->base_layer_switch_mode;
     callback_data->eb_enc_parameters.enc_mode = (EbBool)config->enc_mode;
+#if TWO_PASS_USE_2NDP_ME_IN_1STP
+    callback_data->eb_enc_parameters.snd_pass_enc_mode = (EbBool)config->snd_pass_enc_mode;
+#endif
     callback_data->eb_enc_parameters.frame_rate = config->frame_rate;
     callback_data->eb_enc_parameters.frame_rate_denominator = config->frame_rate_denominator;
     callback_data->eb_enc_parameters.frame_rate_numerator = config->frame_rate_numerator;
@@ -180,6 +183,10 @@ EbErrorType CopyConfigurationParameters(
     callback_data->eb_enc_parameters.enable_adaptive_quantization = (EbBool)config->enable_adaptive_quantization;
     callback_data->eb_enc_parameters.qp = config->qp;
     callback_data->eb_enc_parameters.use_qp_file = (EbBool)config->use_qp_file;
+#if TWO_PASS
+    callback_data->eb_enc_parameters.input_stat_file = config->input_stat_file;
+    callback_data->eb_enc_parameters.output_stat_file = config->output_stat_file;
+#endif
     callback_data->eb_enc_parameters.stat_report = (EbBool)config->stat_report;
     callback_data->eb_enc_parameters.disable_dlf_flag = (EbBool)config->disable_dlf_flag;
     callback_data->eb_enc_parameters.enable_warped_motion = (EbBool)config->enable_warped_motion;

--- a/Source/Lib/Common/Codec/EbCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbCodingLoop.c
@@ -3644,6 +3644,103 @@ EB_EXTERN void av1_encode_pass(
                             context_ptr->blk_geom->bheight_uv,
                             context_ptr->blk_geom->has_uv ? PICTURE_BUFFER_DESC_FULL_MASK : PICTURE_BUFFER_DESC_LUMA_MASK,
                             is16bit);
+#if TWO_PASS
+                    // Collect the referenced area per 64x64
+                    if (sequence_control_set_ptr->use_output_stat_file) {
+                        if (cu_ptr->prediction_unit_array->ref_frame_index_l0 >= 0) {
+                            eb_block_on_mutex(refObj0->referenced_area_mutex);
+                            {
+                                if (context_ptr->mv_unit.pred_direction == UNI_PRED_LIST_0 || context_ptr->mv_unit.pred_direction == BI_PRED) {
+                                    //List0-Y
+                                    uint16_t origin_x = MAX(0, (int16_t)context_ptr->cu_origin_x + (context_ptr->mv_unit.mv[REF_LIST_0].x >> 3));
+                                    uint16_t origin_y = MAX(0, (int16_t)context_ptr->cu_origin_y + (context_ptr->mv_unit.mv[REF_LIST_0].y >> 3));
+                                    uint16_t sb_origin_x = origin_x / context_ptr->sb_sz * context_ptr->sb_sz;
+                                    uint16_t sb_origin_y = origin_y / context_ptr->sb_sz * context_ptr->sb_sz;
+                                    uint32_t pic_width_in_sb = (sequence_control_set_ptr->seq_header.max_frame_width + sequence_control_set_ptr->sb_sz - 1) / sequence_control_set_ptr->sb_sz;
+                                    uint16_t sb_index = sb_origin_x / context_ptr->sb_sz + pic_width_in_sb * (sb_origin_y / context_ptr->sb_sz);
+                                    uint16_t width, height, weight;
+                                    weight = 1 << (4 - picture_control_set_ptr->parent_pcs_ptr->temporal_layer_index);
+
+                                    width = MIN(sb_origin_x + context_ptr->sb_sz, origin_x + blk_geom->bwidth) - origin_x;
+                                    height = MIN(sb_origin_y + context_ptr->sb_sz, origin_y + blk_geom->bheight) - origin_y;
+                                    refObj0->stat_struct.referenced_area[sb_index] += width * height*weight;
+
+                                    if (origin_x + blk_geom->bwidth > sb_origin_x + context_ptr->sb_sz) {
+                                        sb_origin_x = (origin_x / context_ptr->sb_sz + 1)* context_ptr->sb_sz;
+                                        sb_origin_y = origin_y / context_ptr->sb_sz * context_ptr->sb_sz;
+                                        sb_index = sb_origin_x / context_ptr->sb_sz + pic_width_in_sb * (sb_origin_y / context_ptr->sb_sz);
+                                        width = origin_x + blk_geom->bwidth - MAX(sb_origin_x, origin_x);
+                                        height = MIN(sb_origin_y + context_ptr->sb_sz, origin_y + blk_geom->bheight) - origin_y;
+                                        refObj0->stat_struct.referenced_area[sb_index] += width * height*weight;
+                                    }
+                                    if (origin_y + blk_geom->bheight > sb_origin_y + context_ptr->sb_sz) {
+                                        sb_origin_x = (origin_x / context_ptr->sb_sz)* context_ptr->sb_sz;
+                                        sb_origin_y = (origin_y / context_ptr->sb_sz + 1) * context_ptr->sb_sz;
+                                        sb_index = sb_origin_x / context_ptr->sb_sz + pic_width_in_sb * (sb_origin_y / context_ptr->sb_sz);
+                                        width = MIN(sb_origin_x + context_ptr->sb_sz, origin_x + blk_geom->bwidth) - origin_x;
+                                        height = origin_y + blk_geom->bheight - MAX(sb_origin_y, origin_y);
+                                        refObj0->stat_struct.referenced_area[sb_index] += width * height*weight;
+                                    }
+                                    if (origin_x + blk_geom->bwidth > sb_origin_x + context_ptr->sb_sz &&
+                                        origin_y + blk_geom->bheight > sb_origin_y + context_ptr->sb_sz) {
+                                        sb_origin_x = (origin_x / context_ptr->sb_sz + 1)* context_ptr->sb_sz;
+                                        sb_origin_y = (origin_y / context_ptr->sb_sz + 1) * context_ptr->sb_sz;
+                                        sb_index = sb_origin_x / context_ptr->sb_sz + pic_width_in_sb * (sb_origin_y / context_ptr->sb_sz);
+                                        width = origin_x + blk_geom->bwidth - MAX(sb_origin_x, origin_x);
+                                        height = origin_y + blk_geom->bheight - MAX(sb_origin_y, origin_y);
+                                        refObj0->stat_struct.referenced_area[sb_index] += width * height*weight;
+                                    }
+                                }
+                            }
+                            eb_release_mutex(refObj0->referenced_area_mutex);
+                        }
+
+                        if (cu_ptr->prediction_unit_array->ref_frame_index_l1 >= 0) {
+                            eb_block_on_mutex(refObj1->referenced_area_mutex);
+                            if (context_ptr->mv_unit.pred_direction == UNI_PRED_LIST_1 || context_ptr->mv_unit.pred_direction == BI_PRED) {
+                                //List1-Y
+                                uint16_t origin_x = MAX(0, (int16_t)context_ptr->cu_origin_x + (context_ptr->mv_unit.mv[REF_LIST_1].x >> 3));
+                                uint16_t origin_y = MAX(0, (int16_t)context_ptr->cu_origin_y + (context_ptr->mv_unit.mv[REF_LIST_1].y >> 3));
+                                uint16_t sb_origin_x = origin_x / context_ptr->sb_sz * context_ptr->sb_sz;
+                                uint16_t sb_origin_y = origin_y / context_ptr->sb_sz * context_ptr->sb_sz;
+                                uint32_t pic_width_in_sb = (sequence_control_set_ptr->seq_header.max_frame_width + sequence_control_set_ptr->sb_sz - 1) / sequence_control_set_ptr->sb_sz;
+                                uint16_t sb_index = sb_origin_x / context_ptr->sb_sz + pic_width_in_sb * (sb_origin_y / context_ptr->sb_sz);
+                                uint16_t width, height, weight;
+                                weight = 1 << (4 - picture_control_set_ptr->parent_pcs_ptr->temporal_layer_index);
+
+                                width = MIN(sb_origin_x + context_ptr->sb_sz, origin_x + blk_geom->bwidth) - origin_x;
+                                height = MIN(sb_origin_y + context_ptr->sb_sz, origin_y + blk_geom->bheight) - origin_y;
+                                refObj1->stat_struct.referenced_area[sb_index] += width * height*weight;
+                                if (origin_x + blk_geom->bwidth > sb_origin_x + context_ptr->sb_sz) {
+                                    sb_origin_x = (origin_x / context_ptr->sb_sz + 1)* context_ptr->sb_sz;
+                                    sb_origin_y = origin_y / context_ptr->sb_sz * context_ptr->sb_sz;
+                                    sb_index = sb_origin_x / context_ptr->sb_sz + pic_width_in_sb * (sb_origin_y / context_ptr->sb_sz);
+                                    width = origin_x + blk_geom->bwidth - MAX(sb_origin_x, origin_x);
+                                    height = MIN(sb_origin_y + context_ptr->sb_sz, origin_y + blk_geom->bheight) - origin_y;
+                                    refObj1->stat_struct.referenced_area[sb_index] += width * height*weight;
+                                }
+                                if (origin_y + blk_geom->bheight > sb_origin_y + context_ptr->sb_sz) {
+                                    sb_origin_x = (origin_x / context_ptr->sb_sz)* context_ptr->sb_sz;
+                                    sb_origin_y = (origin_y / context_ptr->sb_sz + 1) * context_ptr->sb_sz;
+                                    sb_index = sb_origin_x / context_ptr->sb_sz + pic_width_in_sb * (sb_origin_y / context_ptr->sb_sz);
+                                    width = MIN(sb_origin_x + context_ptr->sb_sz, origin_x + blk_geom->bwidth) - origin_x;
+                                    height = origin_y + blk_geom->bheight - MAX(sb_origin_y, origin_y);
+                                    refObj1->stat_struct.referenced_area[sb_index] += width * height*weight;
+                                }
+                                if (origin_x + blk_geom->bwidth > sb_origin_x + context_ptr->sb_sz &&
+                                    origin_y + blk_geom->bheight > sb_origin_y + context_ptr->sb_sz) {
+                                    sb_origin_x = (origin_x / context_ptr->sb_sz + 1)* context_ptr->sb_sz;
+                                    sb_origin_y = (origin_y / context_ptr->sb_sz + 1) * context_ptr->sb_sz;
+                                    sb_index = sb_origin_x / context_ptr->sb_sz + pic_width_in_sb * (sb_origin_y / context_ptr->sb_sz);
+                                    width = origin_x + blk_geom->bwidth - MAX(sb_origin_x, origin_x);
+                                    height = origin_y + blk_geom->bheight - MAX(sb_origin_y, origin_y);
+                                    refObj1->stat_struct.referenced_area[sb_index] += width * height*weight;
+                                }
+                            }
+                            eb_release_mutex(refObj1->referenced_area_mutex);
+                        }
+                    }
+#endif
                 }
                 else {
                     CHECK_REPORT_ERROR_NC(

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -68,6 +68,12 @@ extern "C" {
 #define ENHANCE_ATB                       1
 
 #define RDOQ_CHROMA                       1
+
+
+#define TWO_PASS                          1 // Two pass encoding. For now, the encoder is called two times and data transfered using file.
+                                            // Actions in the second pass: Frame and SB QP assignment and temporal filtering strenght change
+#define TWO_PASS_USE_2NDP_ME_IN_1STP      1 // Add a config parameter to the first pass to use the ME settings of the second pass
+
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC                         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch
 
@@ -3256,6 +3262,12 @@ static const uint32_t MD_SCAN_TO_OIS_32x32_SCAN[CU_MAX_COUNT] =
     /*84 */3,
 };
 
+#if TWO_PASS
+typedef struct stat_struct_t
+{
+    uint32_t                        referenced_area[MAX_NUMBER_OF_TREEBLOCKS_PER_PICTURE];
+} stat_struct_t;
+#endif
 #define SC_MAX_LEVEL 2 // 2 sets of HME/ME settings are used depending on the scene content mode
 
 /******************************************************************************

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1126,6 +1126,9 @@ void PadRefAndSetFlags(
 
     // set up the Slice Type
     referenceObject->slice_type = picture_control_set_ptr->parent_pcs_ptr->slice_type;
+#if TWO_PASS
+    referenceObject->referenced_area_avg = picture_control_set_ptr->parent_pcs_ptr->referenced_area_avg;
+#endif
 }
 
 void CopyStatisticsToRefObject(

--- a/Source/Lib/Common/Codec/EbEncodeContext.c
+++ b/Source/Lib/Common/Codec/EbEncodeContext.c
@@ -19,6 +19,9 @@ static void encode_context_dctor(EbPtr p)
     EB_DESTROY_MUTEX(obj->rate_table_update_mutex);
     EB_DESTROY_MUTEX(obj->sc_buffer_mutex);
     EB_DESTROY_MUTEX(obj->shared_reference_mutex);
+#if TWO_PASS
+    EB_DESTROY_MUTEX(obj->stat_file_mutex);
+#endif
 
     EB_DELETE(obj->prediction_structure_group_ptr);
     EB_DELETE_PTR_ARRAY(obj->picture_decision_reorder_queue, PICTURE_DECISION_REORDER_QUEUE_MAX_DEPTH);
@@ -133,5 +136,8 @@ EbErrorType encode_context_ctor(
     encode_context_ptr->max_coded_poc_selected_ref_qp = 32;
 
     EB_CREATE_MUTEX(encode_context_ptr->shared_reference_mutex);
+#if TWO_PASS
+    EB_CREATE_MUTEX(encode_context_ptr->stat_file_mutex);
+#endif
     return EB_ErrorNone;
 }

--- a/Source/Lib/Common/Codec/EbEncodeContext.h
+++ b/Source/Lib/Common/Codec/EbEncodeContext.h
@@ -148,6 +148,9 @@ typedef struct EncodeContext
     EbHandle                                          shared_reference_mutex;
 
     uint64_t                                          picture_number_alt; // The picture number overlay includes all the overlay frames
+#if TWO_PASS
+    EbHandle                                          stat_file_mutex;
+#endif
 } EncodeContext;
 
 typedef struct EncodeContextInitData {

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -13704,6 +13704,9 @@ extern "C" {
 
         uint8_t                               ref_pic_qp_array[MAX_NUM_OF_REF_PIC_LIST][REF_LIST_MAX_DEPTH];
         EB_SLICE                              ref_slice_type_array[MAX_NUM_OF_REF_PIC_LIST][REF_LIST_MAX_DEPTH];
+#if TWO_PASS
+        uint64_t                            ref_pic_referenced_area_avg_array[MAX_NUM_OF_REF_PIC_LIST][REF_LIST_MAX_DEPTH];
+#endif
         // GOP
         uint64_t                              picture_number;
         uint8_t                               temporal_layer_index;
@@ -14103,6 +14106,9 @@ extern "C" {
 
         // MD
         EbEncMode                             enc_mode;
+#if TWO_PASS_USE_2NDP_ME_IN_1STP
+        EbEncMode                             snd_pass_enc_mode;
+#endif
         EB_SB_DEPTH_MODE                     *sb_depth_mode_array;
         EbSbComplexityStatus                 *complex_sb_array;
         EbCu8x8Mode                           cu8x8_mode;
@@ -14250,6 +14256,12 @@ extern "C" {
 #endif
 #if OBMC_FLAG
         uint8_t                              pic_obmc_mode;
+#endif
+#if TWO_PASS
+        stat_struct_t*                       stat_struct_first_pass_ptr; // pointer to stat_struct in the first pass
+        struct stat_struct_t                 stat_struct; // stat_struct used in the second pass
+        uint64_t                             referenced_area_avg; // average referenced area per frame
+        uint8_t                              referenced_area_has_non_zero;
 #endif
     } PictureParentControlSet;
 

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -777,7 +777,19 @@ EbErrorType signal_derivation_multi_processes_oq(
 
     uint8_t sc_content_detected = picture_control_set_ptr->sc_content_detected;
 
+#if TWO_PASS_USE_2NDP_ME_IN_1STP
+    uint8_t enc_mode_hme = sequence_control_set_ptr->use_output_stat_file ? picture_control_set_ptr->snd_pass_enc_mode : picture_control_set_ptr->enc_mode;
+    picture_control_set_ptr->enable_hme_flag = enable_hme_flag[picture_control_set_ptr->sc_content_detected][sequence_control_set_ptr->input_resolution][enc_mode_hme];
 
+    picture_control_set_ptr->enable_hme_level0_flag = enable_hme_level0_flag[picture_control_set_ptr->sc_content_detected][sequence_control_set_ptr->input_resolution][enc_mode_hme];
+    picture_control_set_ptr->enable_hme_level1_flag = enable_hme_level1_flag[picture_control_set_ptr->sc_content_detected][sequence_control_set_ptr->input_resolution][enc_mode_hme];
+    picture_control_set_ptr->enable_hme_level2_flag = enable_hme_level2_flag[picture_control_set_ptr->sc_content_detected][sequence_control_set_ptr->input_resolution][enc_mode_hme];
+
+    picture_control_set_ptr->tf_enable_hme_flag = tf_enable_hme_flag[picture_control_set_ptr->sc_content_detected][sequence_control_set_ptr->input_resolution][enc_mode_hme];
+    picture_control_set_ptr->tf_enable_hme_level0_flag = tf_enable_hme_level0_flag[picture_control_set_ptr->sc_content_detected][sequence_control_set_ptr->input_resolution][enc_mode_hme];
+    picture_control_set_ptr->tf_enable_hme_level1_flag = tf_enable_hme_level1_flag[picture_control_set_ptr->sc_content_detected][sequence_control_set_ptr->input_resolution][enc_mode_hme];
+    picture_control_set_ptr->tf_enable_hme_level2_flag = tf_enable_hme_level2_flag[picture_control_set_ptr->sc_content_detected][sequence_control_set_ptr->input_resolution][enc_mode_hme];
+#else
     picture_control_set_ptr->enable_hme_flag = enable_hme_flag[picture_control_set_ptr->sc_content_detected][sequence_control_set_ptr->input_resolution][picture_control_set_ptr->enc_mode];
 
     picture_control_set_ptr->enable_hme_level0_flag = enable_hme_level0_flag[picture_control_set_ptr->sc_content_detected][sequence_control_set_ptr->input_resolution][picture_control_set_ptr->enc_mode];
@@ -788,6 +800,7 @@ EbErrorType signal_derivation_multi_processes_oq(
     picture_control_set_ptr->tf_enable_hme_level0_flag = tf_enable_hme_level0_flag[picture_control_set_ptr->sc_content_detected][sequence_control_set_ptr->input_resolution][picture_control_set_ptr->enc_mode];
     picture_control_set_ptr->tf_enable_hme_level1_flag = tf_enable_hme_level1_flag[picture_control_set_ptr->sc_content_detected][sequence_control_set_ptr->input_resolution][picture_control_set_ptr->enc_mode];
     picture_control_set_ptr->tf_enable_hme_level2_flag = tf_enable_hme_level2_flag[picture_control_set_ptr->sc_content_detected][sequence_control_set_ptr->input_resolution][picture_control_set_ptr->enc_mode];
+#endif
 
         if (sc_content_detected)
             if (picture_control_set_ptr->enc_mode <= ENC_M1)
@@ -3498,7 +3511,11 @@ void* picture_decision_kernel(void *input_ptr)
 
                             if( sequence_control_set_ptr->enable_altrefs == EB_TRUE &&
                                 ( (picture_control_set_ptr->idr_flag && picture_control_set_ptr->sc_content_detected == 0) ||
-                                  (picture_control_set_ptr->slice_type != I_SLICE && picture_control_set_ptr->temporal_layer_index == 0) ) ) {
+                                  (picture_control_set_ptr->slice_type != I_SLICE && picture_control_set_ptr->temporal_layer_index == 0)
+#if TWO_PASS
+                                    || (sequence_control_set_ptr->use_input_stat_file && picture_control_set_ptr->temporal_layer_index == 1 && picture_control_set_ptr->sc_content_detected == 0)
+#endif
+                                    ) ) {
                                 int altref_nframes = picture_control_set_ptr->sequence_control_set_ptr->static_config.altref_nframes;
                                 if (picture_control_set_ptr->idr_flag) {
 
@@ -3703,7 +3720,14 @@ void* picture_decision_kernel(void *input_ptr)
                                     picture_control_set_ptr->tf_segments_total_count = (uint16_t)(picture_control_set_ptr->tf_segments_column_count  * picture_control_set_ptr->tf_segments_row_count);
 
                                     picture_control_set_ptr->temp_filt_seg_acc = 0;
+#if  TWO_PASS
+                                    if (picture_control_set_ptr->temporal_layer_index == 0)
+                                        picture_control_set_ptr->altref_strength = sequence_control_set_ptr->static_config.altref_strength;
+                                    else
+                                        picture_control_set_ptr->altref_strength = 2;
+#else
                                     picture_control_set_ptr->altref_strength = sequence_control_set_ptr->static_config.altref_strength;
+#endif
 
                                     for (seg_idx = 0; seg_idx < picture_control_set_ptr->tf_segments_total_count; ++seg_idx) {
                                         eb_get_empty_object(

--- a/Source/Lib/Common/Codec/EbReferenceObject.c
+++ b/Source/Lib/Common/Codec/EbReferenceObject.c
@@ -127,6 +127,9 @@ static void eb_reference_object_dctor(EbPtr p)
     EB_DELETE(obj->reference_picture16bit);
     EB_DELETE(obj->reference_picture);
     EB_FREE_ALIGNED_ARRAY(obj->mvs);
+#if TWO_PASS
+    EB_DESTROY_MUTEX(obj->referenced_area_mutex);
+#endif
 }
 
 
@@ -188,7 +191,9 @@ EbErrorType eb_reference_object_ctor(
         EB_CALLOC_ALIGNED_ARRAY(referenceObject->mvs, mem_size);
     }
     memset(&referenceObject->film_grain_params, 0, sizeof(referenceObject->film_grain_params));
-
+#if TWO_PASS
+    EB_CREATE_MUTEX(referenceObject->referenced_area_mutex);
+#endif
     return EB_ErrorNone;
 }
 

--- a/Source/Lib/Common/Codec/EbReferenceObject.h
+++ b/Source/Lib/Common/Codec/EbReferenceObject.h
@@ -40,6 +40,11 @@ typedef struct EbReferenceObject
     FrameType                       frame_type;
     uint32_t                        order_hint;
     uint32_t                        ref_order_hint[7];
+#if TWO_PASS
+    stat_struct_t                   stat_struct;
+    EbHandle                        referenced_area_mutex;
+    uint64_t                        referenced_area_avg;
+#endif
 } EbReferenceObject;
 
 typedef struct EbReferenceObjectDescInitData {

--- a/Source/Lib/Common/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Common/Codec/EbSequenceControlSet.c
@@ -295,6 +295,10 @@ EbErrorType copy_sequence_control_set(
     dst->tf_segment_row_count = src->tf_segment_row_count;
     dst->over_boundary_block_mode = src->over_boundary_block_mode;
     dst->mfmv_enabled = src->mfmv_enabled;
+#if TWO_PASS
+    dst->use_input_stat_file = src->use_input_stat_file;
+    dst->use_output_stat_file = src->use_output_stat_file;
+#endif
     return EB_ErrorNone;
 }
 

--- a/Source/Lib/Common/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Common/Codec/EbSequenceControlSet.h
@@ -216,6 +216,11 @@ extern "C" {
         uint8_t                                 over_boundary_block_mode;
         SeqHeader                               seq_header;
         uint8_t                                 compound_mode;
+
+#if TWO_PASS
+        EbBool                                  use_input_stat_file;
+        EbBool                                  use_output_stat_file;
+#endif
     } SequenceControlSet;
 
     typedef struct EbSequenceControlSetInitData

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -1388,6 +1388,11 @@ void* initial_rate_control_kernel(void *input_ptr)
                                 ((PictureParentControlSet*)(queueEntryPtr->parent_pcs_wrapper_ptr->object_ptr))->reference_picture_wrapper_ptr,
                                 1);
                         }
+#if TWO_PASS
+                        picture_control_set_ptr->stat_struct_first_pass_ptr = picture_control_set_ptr->is_used_as_reference_flag ? &((EbReferenceObject*)picture_control_set_ptr->reference_picture_wrapper_ptr->object_ptr)->stat_struct : &picture_control_set_ptr->stat_struct;
+                        if (sequence_control_set_ptr->use_output_stat_file)
+                            memset(picture_control_set_ptr->stat_struct_first_pass_ptr, 0, sizeof(stat_struct_t));
+#endif
                         //OPTION 1:  get the output stream buffer in ressource coordination
                         eb_get_empty_object(
                             sequence_control_set_ptr->encode_context_ptr->stream_output_fifo_ptr,

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -54,7 +54,12 @@ static void ConfigurePictureEdges(
 
     return;
 }
-
+#if TWO_PASS
+void write_stat_to_file(
+    SequenceControlSet    *sequence_control_set_ptr,
+    stat_struct_t          stat_struct,
+    uint64_t               ref_poc);
+#endif
 /************************************************
  * Picture Manager Context Constructor
  ************************************************/
@@ -739,7 +744,10 @@ void* picture_manager_kernel(void *input_ptr)
 
                         EB_MEMSET(ChildPictureControlSetPtr->ref_slice_type_array[REF_LIST_0], 0, REF_LIST_MAX_DEPTH * sizeof(EB_SLICE));
                         EB_MEMSET(ChildPictureControlSetPtr->ref_slice_type_array[REF_LIST_1], 0, REF_LIST_MAX_DEPTH * sizeof(EB_SLICE));
-
+#if TWO_PASS
+                        EB_MEMSET(ChildPictureControlSetPtr->ref_pic_referenced_area_avg_array[REF_LIST_0], 0, REF_LIST_MAX_DEPTH * sizeof(uint64_t));
+                        EB_MEMSET(ChildPictureControlSetPtr->ref_pic_referenced_area_avg_array[REF_LIST_1], 0, REF_LIST_MAX_DEPTH * sizeof(uint64_t));
+#endif
                         int8_t max_temporal_index = -1, ref_index = 0;
                         // Configure List0
                         if ((entryPictureControlSetPtr->slice_type == P_SLICE) || (entryPictureControlSetPtr->slice_type == B_SLICE)) {
@@ -771,6 +779,9 @@ void* picture_manager_kernel(void *input_ptr)
                                     ChildPictureControlSetPtr->ref_pic_ptr_array[REF_LIST_0][refIdx] = referenceEntryPtr->reference_object_ptr;
                                     ChildPictureControlSetPtr->ref_pic_qp_array[REF_LIST_0][refIdx] = (uint8_t)((EbReferenceObject*)referenceEntryPtr->reference_object_ptr->object_ptr)->qp;
                                     ChildPictureControlSetPtr->ref_slice_type_array[REF_LIST_0][refIdx] = ((EbReferenceObject*)referenceEntryPtr->reference_object_ptr->object_ptr)->slice_type;
+#if TWO_PASS
+                                    ChildPictureControlSetPtr->ref_pic_referenced_area_avg_array[REF_LIST_0][refIdx] = ((EbReferenceObject*)referenceEntryPtr->reference_object_ptr->object_ptr)->referenced_area_avg;
+#endif
                                     // Increment the Reference's liveCount by the number of tiles in the input picture
                                     eb_object_inc_live_count(
                                         referenceEntryPtr->reference_object_ptr,
@@ -820,7 +831,9 @@ void* picture_manager_kernel(void *input_ptr)
 
                                     ChildPictureControlSetPtr->ref_pic_qp_array[REF_LIST_1][refIdx] = (uint8_t)((EbReferenceObject*)referenceEntryPtr->reference_object_ptr->object_ptr)->qp;
                                     ChildPictureControlSetPtr->ref_slice_type_array[REF_LIST_1][refIdx] = ((EbReferenceObject*)referenceEntryPtr->reference_object_ptr->object_ptr)->slice_type;
-
+#if TWO_PASS
+                                    ChildPictureControlSetPtr->ref_pic_referenced_area_avg_array[REF_LIST_1][refIdx] = ((EbReferenceObject*)referenceEntryPtr->reference_object_ptr->object_ptr)->referenced_area_avg;
+#endif
                                     // Increment the Reference's liveCount by the number of tiles in the input picture
                                     eb_object_inc_live_count(
                                         referenceEntryPtr->reference_object_ptr,
@@ -905,6 +918,14 @@ void* picture_manager_kernel(void *input_ptr)
                     (referenceEntryPtr->reference_object_ptr))
                 {
                     // Release the nominal live_count value
+#if TWO_PASS
+                    if (sequence_control_set_ptr->use_output_stat_file &&
+                        referenceEntryPtr->reference_object_ptr->live_count == 1)
+                        write_stat_to_file(
+                            sequence_control_set_ptr,
+                            ((EbReferenceObject*)referenceEntryPtr->reference_object_ptr->object_ptr)->stat_struct,
+                            ((EbReferenceObject*)referenceEntryPtr->reference_object_ptr->object_ptr)->ref_poc);
+#endif
                     eb_release_object(referenceEntryPtr->reference_object_ptr);
                     referenceEntryPtr->reference_object_ptr = (EbObjectWrapper*)EB_NULL;
                     referenceEntryPtr->reference_available = EB_FALSE;

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -550,10 +550,10 @@ static void read_stat_from_file(
         printf("Error in fseek  returnVal %i\n", (int)fseek_return_value);
     }
     size_t fread_return_value = fread(&picture_control_set_ptr->stat_struct,
-        sizeof(stat_struct_t),
         (size_t)1,
+        sizeof(stat_struct_t),
         sequence_control_set_ptr->static_config.input_stat_file);
-    if (fread_return_value != 0) {
+    if (fread_return_value != sizeof(stat_struct_t)) {
         printf("Error in freed  returnVal %i\n", (int)fread_return_value);
     }
 
@@ -865,7 +865,7 @@ void* resource_coordination_kernel(void *input_ptr)
                 picture_control_set_ptr->picture_number = context_ptr->picture_number_array[instance_index];
             ResetPcsAv1(picture_control_set_ptr);
 #if TWO_PASS
-            if (sequence_control_set_ptr->use_input_stat_file)
+            if (sequence_control_set_ptr->use_input_stat_file && !end_of_sequence_flag)
                 read_stat_from_file(
                     picture_control_set_ptr,
                     sequence_control_set_ptr);


### PR DESCRIPTION
## Description:
Two pass encoding. For now, the encoder is called two times and data transferred using file.
First pass collect the referenced area per SB and the second pass uses it to: 
- Frame QP assignment 
- SB QP assignment 
- Temporal filtering strength adjustment

A config parameter (-enc-mode-2p) is passed to the first pass to use the ME settings of the second pass (to achieve better bdRate)

## Sample CLI:
### First pass:
SvtAv1EncApp.exe -enc-mode 5  -w 1920  -h 1080  -i -q 20  -fps-num 60000 -fps-denom 1001 -b out.bin   -n 60  -intra-period 119  **-output-stat-file out.stat**   -bit-depth 8 
### Second pass:
SvtAv1EncApp.exe -enc-mode 0  -w 1920  -h 1080  -i aspen_1080p_60f.yuv  -q 20  -fps-num 60000 -fps-denom 1001 -b out-m0.bin   -n 60  -intra-period 119   **-input-stat-file in.stat**   -bit-depth 8


## Authors
@anaghdin

## Type of change
New Feature

## Tests and performance
Expected Average Y-PSNR BD-rate gain in the range of -2.4% on the objective fast 1 test set, using 4 QP values: {20, 32, 43 and 55}.

No Speed impact.