### PR TITLE
Add NSQ shape prediction

### DIFF
--- a/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
+++ b/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
@@ -24,18 +24,6 @@
 #include "EbCommonUtils.h"
 
 #define UNUSED_FUNC
-static PartitionType from_shape_to_part[] = {
-    PARTITION_NONE,
-    PARTITION_HORZ,
-    PARTITION_VERT,
-    PARTITION_HORZ_A,
-    PARTITION_HORZ_B,
-    PARTITION_VERT_A,
-    PARTITION_VERT_B,
-    PARTITION_HORZ_4,
-    PARTITION_VERT_4,
-    PARTITION_SPLIT
-};
 
 /** ScaleMV
         is used to scale the motion vector in AMVP process.
@@ -67,7 +55,18 @@ static inline void scale_mv(
     return;
 }
 */
-
+static PartitionType from_shape_to_part[] = {
+    PARTITION_NONE,
+    PARTITION_HORZ,
+    PARTITION_VERT,
+    PARTITION_HORZ_A,
+    PARTITION_HORZ_B,
+    PARTITION_VERT_A,
+    PARTITION_VERT_B,
+    PARTITION_HORZ_4,
+    PARTITION_VERT_4,
+    PARTITION_SPLIT
+};
 EbErrorType clip_mv(
     uint32_t                   cu_origin_x,
     uint32_t                   cu_origin_y,

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -85,7 +85,6 @@ extern "C" {
 #define NO_ENCDEC                         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch
 
 #define ADP_STATS_PER_LAYER                             0
-#define NSQ_TAB_SIZE                                    6
 #define AOM_INTERP_EXTEND                               4
 #define OPTIMISED_EX_SUBPEL                             1
 
@@ -155,6 +154,23 @@ enum {
 #define ALTREF_MAX_STRENGTH 6
 
 #define PAD_VALUE                                (128+32)
+
+/* Use open-loop data to predict the NSQ partitions. */
+#define PREDICT_NSQ_SHAPE                               1
+#if PREDICT_NSQ_SHAPE
+#define NUMBER_OF_DEPTH                                 6
+#define NUMBER_OF_SHAPES                                10
+#define ADD_SAD_FOR_128X128                             1
+#define ADJUST_NSQ_RANK_BASED_ON_NEIGH                  1
+#define COMBINE_MDC_NSQ_TABLE                           1
+#define ADD_SUPPORT_TO_SKIP_PART_N                      1
+#define ADD_MDC_REFINEMENT_LOOP                         1
+#define ADD_MDC_FULL_COST                               1
+#define NSQ_TAB_SIZE                                    8
+#define MAX_MDC_LEVEL                                   8
+#else
+#define NSQ_TAB_SIZE                                    6
+#endif
 
 //  Delta QP support
 #define ADD_DELTA_QP_SUPPORT                      1  // Add delta QP support
@@ -591,6 +607,9 @@ typedef enum NsqSearchLevel
     NSQ_SEARCH_LEVEL4,
     NSQ_SEARCH_LEVEL5,
     NSQ_SEARCH_LEVEL6,
+#if PREDICT_NSQ_SHAPE
+    NSQ_SEARCH_LEVEL7,
+#endif
     NSQ_SEARCH_FULL
 } NsqSearchLevel;
 

--- a/Source/Lib/Common/Codec/EbFullLoop.c
+++ b/Source/Lib/Common/Codec/EbFullLoop.c
@@ -29,18 +29,17 @@
 #define LIKELY(v) (v)
 #define UNLIKELY(v) (v)
 #endif
-static PartitionType from_shape_to_part[] =
-{
-PARTITION_NONE,
-PARTITION_HORZ,
-PARTITION_VERT,
-PARTITION_HORZ_A,
-PARTITION_HORZ_B,
-PARTITION_VERT_A,
-PARTITION_VERT_B,
-PARTITION_HORZ_4,
-PARTITION_VERT_4,
-PARTITION_SPLIT
+static PartitionType from_shape_to_part[] = {
+    PARTITION_NONE,
+    PARTITION_HORZ,
+    PARTITION_VERT,
+    PARTITION_HORZ_A,
+    PARTITION_HORZ_B,
+    PARTITION_VERT_A,
+    PARTITION_VERT_B,
+    PARTITION_HORZ_4,
+    PARTITION_VERT_4,
+    PARTITION_SPLIT
 };
 void quantize_b_helper_c_II(const TranLow *coeff_ptr, intptr_t n_coeffs,
     int32_t skip_block, const int16_t *zbin_ptr,
@@ -2994,6 +2993,9 @@ EbBool merge_1D_inter_block(
 }
 void  d1_non_square_block_decision(
     ModeDecisionContext               *context_ptr
+#if ADD_SUPPORT_TO_SKIP_PART_N
+    , uint32_t                         d1_block_itr
+#endif
 )
 {
     //compute total cost for the whole block partition
@@ -3024,7 +3026,11 @@ void  d1_non_square_block_decision(
         tot_cost += split_cost;
     }
     if (merge_block_cnt == context_ptr->blk_geom->totns) merge_block_flag = EB_TRUE;
+#if ADD_SUPPORT_TO_SKIP_PART_N
+    if (d1_block_itr == 0 || (tot_cost < context_ptr->md_local_cu_unit[context_ptr->blk_geom->sqi_mds].cost && merge_block_flag == EB_FALSE))
+#else
     if (context_ptr->blk_geom->shape == PART_N || (tot_cost < context_ptr->md_local_cu_unit[context_ptr->blk_geom->sqi_mds].cost && merge_block_flag == EB_FALSE))
+#endif
     {
         //store best partition cost in parent square
         context_ptr->md_local_cu_unit[context_ptr->blk_geom->sqi_mds].cost = tot_cost;

--- a/Source/Lib/Common/Codec/EbFullLoop.h
+++ b/Source/Lib/Common/Codec/EbFullLoop.h
@@ -65,6 +65,21 @@ extern "C" {
         uint64_t                     *y_coeff_bits,
         uint64_t                     *y_full_distortion);
 
+#if ADD_MDC_FULL_COST
+    extern void av1_quantize_b_facade_II(
+        const TranLow           *coeff_ptr,
+        int32_t                 stride,
+        int32_t                 width,
+        int32_t                 height,
+        intptr_t                n_coeffs,
+        const MacroblockPlane   *p,
+        TranLow                 *qcoeff_ptr,
+        TranLow                 *dqcoeff_ptr,
+        uint16_t                *eob_ptr,
+        const ScanOrder         *sc,
+        const QuantParam        *qparam);
+#endif
+
     void product_full_loop_tx_search(
         ModeDecisionCandidateBuffer  *candidate_buffer,
         ModeDecisionContext          *context_ptr,
@@ -106,6 +121,9 @@ extern "C" {
         uint64_t            *curr_depth_cost);
     void  d1_non_square_block_decision(
         ModeDecisionContext               *context_ptr
+#if ADD_SUPPORT_TO_SKIP_PART_N
+        , uint32_t                         d1_block_itr
+#endif
     );
 
     static const uint8_t clip_max3[256] = {

--- a/Source/Lib/Common/Codec/EbIntraPrediction.c
+++ b/Source/Lib/Common/Codec/EbIntraPrediction.c
@@ -39,24 +39,20 @@ int32_t is_inter_block(const BlockModeInfo *mbmi);
   assert(weights_scale - weights_w[bw - 1] < weights_scale);          \
   assert(weights_scale - weights_h[bh - 1] < weights_scale);          \
   assert(pred_scale < 31)  // ensures no overflow when calculating predictor.
-
-static PartitionType from_shape_to_part[] =
-{
-PARTITION_NONE,
-PARTITION_HORZ,
-PARTITION_VERT,
-PARTITION_HORZ_A,
-PARTITION_HORZ_B,
-PARTITION_VERT_A,
-PARTITION_VERT_B,
-PARTITION_HORZ_4,
-PARTITION_VERT_4,
-PARTITION_SPLIT
-};
-
 #define MIDRANGE_VALUE_8BIT    128
 #define MIDRANGE_VALUE_10BIT   512
-
+static PartitionType from_shape_to_part[] = {
+    PARTITION_NONE,
+    PARTITION_HORZ,
+    PARTITION_VERT,
+    PARTITION_HORZ_A,
+    PARTITION_HORZ_B,
+    PARTITION_VERT_A,
+    PARTITION_VERT_B,
+    PARTITION_HORZ_4,
+    PARTITION_VERT_4,
+    PARTITION_SPLIT
+};
 int is_smooth(const BlockModeInfo *block_mi, int plane) {
     if (plane == 0) {
         const PredictionMode mode = block_mi->mode;

--- a/Source/Lib/Common/Codec/EbModeDecisionConfiguration.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfiguration.c
@@ -8,6 +8,10 @@
 #include "EbUtility.h"
 #include "EbModeDecisionProcess.h"
 #include "EbDefinitions.h"
+#if ADD_MDC_FULL_COST
+#include "aom_dsp_rtcd.h"
+#include "EbAdaptiveMotionVectorPrediction.h"
+#endif
 /********************************************
  * Constants
  ********************************************/
@@ -50,7 +54,20 @@ int pa_to_ep_block_index[85] = {
     1040 ,
     1065 ,    1074 ,    1083 ,    1092
 };
-
+#if ADD_MDC_FULL_COST
+static PartitionType from_shape_to_part[] = {
+    PARTITION_NONE,
+    PARTITION_HORZ,
+    PARTITION_VERT,
+    PARTITION_HORZ_A,
+    PARTITION_HORZ_B,
+    PARTITION_VERT_A,
+    PARTITION_VERT_B,
+    PARTITION_HORZ_4,
+    PARTITION_VERT_4,
+    PARTITION_SPLIT
+};
+#endif
 #define ADD_CU_STOP_SPLIT             0   // Take into account & Stop Splitting
 #define ADD_CU_CONTINUE_SPLIT         1   // Take into account & Continue Splitting
 #define DO_NOT_ADD_CU_CONTINUE_SPLIT  2   // Do not take into account & Continue Splitting
@@ -90,6 +107,14 @@ const uint8_t incrementalCount[85] = {
     0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 4, 0, 0, 0, 4
 };
+
+#if PREDICT_NSQ_SHAPE
+extern uint32_t get_me_info_index(
+    uint32_t         max_me_block,
+    const BlockGeom *blk_geom,
+    uint32_t         geom_offset_x,
+    uint32_t         geom_offset_y);
+#endif
 
 /*******************************************
 mdcSetDepth : set depth to be tested
@@ -573,6 +598,990 @@ void MdcInterDepthDecision(
     context_ptr->group_of8x8_blocks_count = group_of8x8_blocks_count;
     context_ptr->group_of16x16_blocks_count = group_of16x16_blocks_count;
 }
+
+#if PREDICT_NSQ_SHAPE
+/// compute the cost of curr depth, and the depth above
+void   mdc_compute_depth_costs(
+    ModeDecisionConfigurationContext    *context_ptr,
+    uint32_t                             curr_depth_mds,
+    uint32_t                             above_depth_mds,
+    uint32_t                             step,
+    uint64_t                            *above_depth_cost,
+    uint64_t                            *curr_depth_cost)
+{
+    uint64_t       above_non_split_rate = 0;
+    uint64_t       above_split_rate = 0;
+
+    // Rate of not spliting the current depth (Depth != 4) in case the children were omitted by MDC
+    uint64_t       curr_non_split_rate_blk0 = 0;
+    uint64_t       curr_non_split_rate_blk1 = 0;
+    uint64_t       curr_non_split_rate_blk2 = 0;
+    uint64_t       curr_non_split_rate_blk3 = 0;
+
+    // Compute above depth  cost
+    *above_depth_cost = context_ptr->local_cu_array[above_depth_mds].early_cost + above_non_split_rate;
+
+    // Compute current depth  cost
+    *curr_depth_cost =
+        context_ptr->local_cu_array[curr_depth_mds].early_cost + curr_non_split_rate_blk3 +
+        context_ptr->local_cu_array[curr_depth_mds - 1 * step].early_cost + curr_non_split_rate_blk2 +
+        context_ptr->local_cu_array[curr_depth_mds - 2 * step].early_cost + curr_non_split_rate_blk1 +
+        context_ptr->local_cu_array[curr_depth_mds - 3 * step].early_cost + curr_non_split_rate_blk0 +
+        above_split_rate;
+}
+uint32_t mdc_d2_inter_depth_block_decision(
+    PictureControlSet                         *picture_control_set_ptr,
+    ModeDecisionConfigurationContext          *context_ptr,
+    EbMdcLeafData                             *results_ptr,
+    uint32_t                                   blk_mds,
+    uint32_t                                   sb_index) {
+
+
+    uint32_t                last_cu_index;
+    uint64_t                parent_depth_cost = 0, current_depth_cost = 0;
+    SequenceControlSet     *sequence_control_set_ptr = (SequenceControlSet*)picture_control_set_ptr->sequence_control_set_wrapper_ptr->object_ptr;
+    EbBool                  last_depth_flag;
+    const BlockGeom        *blk_geom;
+
+    last_depth_flag = context_ptr->local_cu_array[blk_mds].early_split_flag == EB_FALSE ? EB_TRUE : EB_FALSE;
+
+    last_cu_index = blk_mds;
+    blk_geom = get_blk_geom_mds(blk_mds);
+    uint32_t    parent_depth_idx_mds = blk_mds;
+    uint32_t    current_depth_idx_mds = blk_mds;
+
+    if (last_depth_flag) {
+        while (blk_geom->is_last_quadrant) {
+            //get parent idx
+            parent_depth_idx_mds = current_depth_idx_mds - parent_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth];
+            if (picture_control_set_ptr->slice_type == I_SLICE && parent_depth_idx_mds == 0 && sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128)
+                parent_depth_cost = MAX_MODE_COST;
+            else
+                mdc_compute_depth_costs(context_ptr, current_depth_idx_mds, parent_depth_idx_mds, ns_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth], &parent_depth_cost, &current_depth_cost);
+            if (!sequence_control_set_ptr->sb_geom[sb_index].block_is_allowed[parent_depth_idx_mds])
+                parent_depth_cost = MAX_MODE_COST;
+            if (parent_depth_cost <= current_depth_cost) {
+                context_ptr->local_cu_array[parent_depth_idx_mds].early_split_flag = EB_FALSE;
+                context_ptr->local_cu_array[parent_depth_idx_mds].early_cost = parent_depth_cost;
+                results_ptr[parent_depth_idx_mds].early_split_flag = context_ptr->local_cu_array[parent_depth_idx_mds].early_split_flag;
+                last_cu_index = parent_depth_idx_mds;
+            }
+            else 
+                context_ptr->local_cu_array[parent_depth_idx_mds].early_cost = current_depth_cost;
+
+            //setup next parent inter depth
+            blk_geom = get_blk_geom_mds(parent_depth_idx_mds);
+            current_depth_idx_mds = parent_depth_idx_mds;
+        }
+    }
+
+    return last_cu_index;
+}
+
+uint64_t  mdc_d1_non_square_block_decision(ModeDecisionConfigurationContext *context_ptr){
+    //compute total cost for the whole block partition
+    uint64_t tot_cost = 0;
+    uint32_t first_blk_idx = context_ptr->mds_idx - (context_ptr->blk_geom->totns - 1);//index of first block in this partition
+    uint32_t blk_it;
+
+    for (blk_it = 0; blk_it < context_ptr->blk_geom->totns; blk_it++)
+        tot_cost += context_ptr->local_cu_array[first_blk_idx + blk_it].early_cost;
+
+    if (context_ptr->blk_geom->shape == PART_N || tot_cost < context_ptr->local_cu_array[context_ptr->blk_geom->sqi_mds].early_cost)
+    {
+        //store best partition cost in parent square
+        context_ptr->local_cu_array[context_ptr->blk_geom->sqi_mds].early_cost = tot_cost;
+#if ADD_MDC_FULL_COST
+        context_ptr->local_cu_array[context_ptr->blk_geom->sqi_mds].part = from_shape_to_part[context_ptr->blk_geom->shape];
+#endif
+        context_ptr->local_cu_array[context_ptr->blk_geom->sqi_mds].best_d1_blk = first_blk_idx;
+    }
+    return tot_cost;
+}
+
+uint8_t find_shape_index(PART shape, PART nsq_shape_table[10]) {
+    uint8_t i;
+    for (i = 0; i < 10; i++)
+        if (shape == nsq_shape_table[i]) return i;
+
+    return 0;
+}
+uint8_t find_depth_index(uint8_t shape, uint8_t depth_table[NUMBER_OF_DEPTH]) {
+    uint8_t i;
+    for (i = 0; i < NUMBER_OF_DEPTH; i++)
+        if (shape == depth_table[i]) return i;
+
+    return 0;
+}
+
+uint8_t get_depth(
+    uint8_t sq_size) {
+    uint8_t depth = sq_size == 128 ? 0 :
+        sq_size == 64 ? 1 :
+        sq_size == 32 ? 2 :
+        sq_size == 16 ? 3 :
+        sq_size == 8 ? 4 : 5;
+
+    return depth;
+}
+#if ADD_MDC_FULL_COST
+static INLINE void set_dc_sign(int32_t *cul_level, int32_t dc_val) {
+    if (dc_val < 0)
+        *cul_level |= 1 << COEFF_CONTEXT_BITS;
+    else if (dc_val > 0)
+        *cul_level += 2 << COEFF_CONTEXT_BITS;
+}
+
+extern void av1_quantize_b_facade_II(
+    const TranLow               *coeff_ptr,
+    int32_t                     stride,
+    int32_t                     width,
+    int32_t                     height,
+    intptr_t                    n_coeffs,
+    const MacroblockPlane       *p,
+    TranLow                     *qcoeff_ptr,
+    TranLow                     *dqcoeff_ptr,
+    uint16_t                    *eob_ptr,
+    const ScanOrder             *sc,
+    const QuantParam            *qparam);
+
+int32_t mdc_av1_quantize_inv_quantize(
+    PictureControlSet           *picture_control_set_ptr,
+    int32_t                     *coeff,
+    const uint32_t               coeff_stride,
+    int32_t                     *quant_coeff,
+    int32_t                     *recon_coeff,
+    uint32_t                     qp,
+    uint32_t                     width,
+    uint32_t                     height,
+    TxSize                       txsize,
+    uint16_t                    *eob,
+    uint32_t                    *count_non_zero_coeffs,
+    uint32_t                     component_type,
+    TxType                       tx_type)
+{
+    MacroblockPlane candidate_plane;
+    const QmVal *qMatrix = picture_control_set_ptr->parent_pcs_ptr->gqmatrix[NUM_QM_LEVELS - 1][0][txsize];
+    const QmVal *iqMatrix = picture_control_set_ptr->parent_pcs_ptr->giqmatrix[NUM_QM_LEVELS - 1][0][txsize];
+    uint32_t qIndex = picture_control_set_ptr->parent_pcs_ptr->delta_q_present_flag ? quantizer_to_qindex[qp] : picture_control_set_ptr->parent_pcs_ptr->base_qindex;
+    if (component_type == COMPONENT_LUMA) {
+        candidate_plane.quant_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.y_quant[qIndex];
+        candidate_plane.quant_fp_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.y_quant_fp[qIndex];
+        candidate_plane.round_fp_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.y_round_fp[qIndex];
+        candidate_plane.quant_shift_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.y_quant_shift[qIndex];
+        candidate_plane.zbin_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.y_zbin[qIndex];
+        candidate_plane.round_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.y_round[qIndex];
+        candidate_plane.dequant_QTX = picture_control_set_ptr->parent_pcs_ptr->deqMd.y_dequant_QTX[qIndex];
+    }
+    if (component_type == COMPONENT_CHROMA_CB) {
+        candidate_plane.quant_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.u_quant[qIndex];
+        candidate_plane.quant_fp_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.u_quant_fp[qIndex];
+        candidate_plane.round_fp_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.u_round_fp[qIndex];
+        candidate_plane.quant_shift_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.u_quant_shift[qIndex];
+        candidate_plane.zbin_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.u_zbin[qIndex];
+        candidate_plane.round_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.u_round[qIndex];
+        candidate_plane.dequant_QTX = picture_control_set_ptr->parent_pcs_ptr->deqMd.u_dequant_QTX[qIndex];
+    }
+    if (component_type == COMPONENT_CHROMA_CR) {
+        candidate_plane.quant_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.v_quant[qIndex];
+        candidate_plane.quant_fp_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.v_quant_fp[qIndex];
+        candidate_plane.round_fp_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.v_round_fp[qIndex];
+        candidate_plane.quant_shift_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.v_quant_shift[qIndex];
+        candidate_plane.zbin_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.v_zbin[qIndex];
+        candidate_plane.round_QTX = picture_control_set_ptr->parent_pcs_ptr->quantsMd.v_round[qIndex];
+        candidate_plane.dequant_QTX = picture_control_set_ptr->parent_pcs_ptr->deqMd.v_dequant_QTX[qIndex];
+    }
+    const ScanOrder *const scan_order = &av1_scan_orders[txsize][tx_type];
+
+    const int32_t n_coeffs = av1_get_max_eob(txsize);
+
+    QuantParam qparam;
+
+    qparam.log_scale = av1_get_tx_scale(txsize);
+    qparam.tx_size = txsize;
+    qparam.qmatrix = qMatrix;
+    qparam.iqmatrix = iqMatrix;
+
+    av1_quantize_b_facade_II(
+        (TranLow*)coeff,
+        coeff_stride,
+        width,
+        height,
+        n_coeffs,
+        &candidate_plane,
+        quant_coeff,
+        (TranLow*)recon_coeff,
+        eob,
+        scan_order,
+        &qparam);
+
+    *count_non_zero_coeffs = *eob;
+    // Derive cul_level
+    int32_t cul_level = 0;
+    const int16_t *const scan = scan_order->scan;
+    for (int32_t c = 0; c < *eob; ++c) {
+        const int16_t pos = scan[c];
+        const int32_t v = quant_coeff[pos];
+        int32_t level = ABS(v);
+        cul_level += level;
+    }
+    cul_level = AOMMIN(COEFF_CONTEXT_MASK, cul_level);
+    // DC value
+    set_dc_sign(&cul_level, quant_coeff[0]);
+    return cul_level;
+}
+
+EbErrorType mdc_av1_tu_estimate_coeff_bits(
+    uint8_t                                  allow_update_cdf,
+    FRAME_CONTEXT                           *ec_ctx,
+    PictureControlSet                       *picture_control_set_ptr,
+    struct ModeDecisionCandidateBuffer      *candidate_buffer_ptr,
+    uint32_t                                 tu_origin_index,
+    EbPictureBufferDesc                     *coeff_buffer_sb,
+    uint32_t                                 y_eob,
+    uint64_t                                *y_tu_coeff_bits,
+    TxSize                                   txsize,
+    TxType                                   tx_type,
+    COMPONENT_TYPE                           component_type)
+{
+    EbErrorType return_error = EB_ErrorNone;
+    int32_t *coeff_buffer;
+    int16_t  luma_txb_skip_context = 0;
+    int16_t  luma_dc_sign_context = 0;
+    EbBool reducedTransformSetFlag = picture_control_set_ptr->parent_pcs_ptr->reduced_tx_set_used ? EB_TRUE : EB_FALSE;
+    //Estimate the rate of the transform type and coefficient for Luma
+    if (component_type == COMPONENT_LUMA || component_type == COMPONENT_ALL) {
+        if (y_eob) {
+            coeff_buffer = (int32_t*)&coeff_buffer_sb->buffer_y[tu_origin_index * sizeof(int32_t)];
+            *y_tu_coeff_bits = eb_av1_cost_coeffs_txb(
+                allow_update_cdf,
+                ec_ctx,
+                candidate_buffer_ptr,
+                coeff_buffer,
+                (uint16_t)y_eob,
+                PLANE_TYPE_Y,
+                txsize,
+                tx_type,
+                luma_txb_skip_context,
+                luma_dc_sign_context,
+                reducedTransformSetFlag);
+        }
+        else {
+            *y_tu_coeff_bits = av1_cost_skip_txb(
+                allow_update_cdf,
+                ec_ctx,
+                candidate_buffer_ptr,
+                txsize,
+                PLANE_TYPE_Y,
+                luma_txb_skip_context);
+        }
+    }
+    return return_error;
+}
+void mdc_full_loop(
+    ModeDecisionCandidateBuffer       *candidate_buffer,
+    ModeDecisionConfigurationContext  *context_ptr,
+    PictureControlSet                 *picture_control_set_ptr,
+    uint32_t                           qp,
+    uint32_t                          *y_count_non_zero_coeffs,
+    uint64_t                          *y_coeff_bits,
+    uint64_t                          *y_full_distortion)
+{
+    uint32_t                          tu_origin_index;
+    uint64_t                          y_full_cost;
+    SequenceControlSet                *sequence_control_set_ptr = (SequenceControlSet*)picture_control_set_ptr->sequence_control_set_wrapper_ptr->object_ptr;
+    EbAsm                             asm_type = sequence_control_set_ptr->encode_context_ptr->asm_type;
+    uint64_t                          y_tu_coeff_bits;
+    uint64_t                          tu_full_distortion[3][DIST_CALC_TOTAL];
+    context_ptr->three_quad_energy = 0;
+    uint32_t  txb_1d_offset = 0;
+    uint32_t txb_itr = 0;
+    assert(asm_type >= 0 && asm_type < ASM_TYPE_TOTAL);
+    uint8_t  tx_depth = candidate_buffer->candidate_ptr->tx_depth;
+    uint16_t txb_count = context_ptr->blk_geom->txb_count[tx_depth];
+    for (txb_itr = 0; txb_itr < txb_count; txb_itr++) {
+        uint16_t tx_org_x = context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr];
+        uint16_t tx_org_y = context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr];
+        int32_t cropped_tx_width = MIN(context_ptr->blk_geom->tx_width[tx_depth][txb_itr], sequence_control_set_ptr->seq_header.max_frame_width - (context_ptr->sb_origin_x + tx_org_x));
+        int32_t cropped_tx_height = MIN(context_ptr->blk_geom->tx_height[tx_depth][txb_itr], sequence_control_set_ptr->seq_header.max_frame_height - (context_ptr->sb_origin_y + tx_org_y));
+        tu_origin_index = tx_org_x + (tx_org_y * candidate_buffer->residual_ptr->stride_y);
+        y_tu_coeff_bits = 0;
+
+        // Y: T Q iQ
+        av1_estimate_transform(
+            &(((int16_t*)candidate_buffer->residual_ptr->buffer_y)[tu_origin_index]),
+            candidate_buffer->residual_ptr->stride_y,
+            &(((int32_t*)context_ptr->trans_quant_buffers_ptr->tu_trans_coeff2_nx2_n_ptr->buffer_y)[txb_1d_offset]),
+            NOT_USED_VALUE,
+            context_ptr->blk_geom->txsize[tx_depth][txb_itr],
+            &context_ptr->three_quad_energy,
+            context_ptr->transform_inner_array_ptr,
+            0,
+            candidate_buffer->candidate_ptr->transform_type[txb_itr],
+            asm_type,
+            PLANE_TYPE_Y,
+            DEFAULT_SHAPE);
+
+        candidate_buffer->candidate_ptr->quantized_dc[0][txb_itr] = mdc_av1_quantize_inv_quantize(
+            picture_control_set_ptr,
+            &(((int32_t*)context_ptr->trans_quant_buffers_ptr->tu_trans_coeff2_nx2_n_ptr->buffer_y)[txb_1d_offset]),
+            NOT_USED_VALUE,
+            &(((int32_t*)candidate_buffer->residual_quant_coeff_ptr->buffer_y)[txb_1d_offset]),
+            &(((int32_t*)candidate_buffer->recon_coeff_ptr->buffer_y)[txb_1d_offset]),
+            qp,
+            context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
+            context_ptr->blk_geom->tx_height[tx_depth][txb_itr],
+            context_ptr->blk_geom->txsize[tx_depth][txb_itr],
+            &candidate_buffer->candidate_ptr->eob[0][txb_itr],
+            &(y_count_non_zero_coeffs[txb_itr]),
+            COMPONENT_LUMA,
+            candidate_buffer->candidate_ptr->transform_type[txb_itr]);
+
+        if (context_ptr->spatial_sse_full_loop) {
+            EbPictureBufferDesc          *input_picture_ptr = picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
+            uint32_t input_tu_origin_index = (context_ptr->sb_origin_x + tx_org_x + input_picture_ptr->origin_x) + ((context_ptr->sb_origin_y + tx_org_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_y);
+            uint32_t y_has_coeff = y_count_non_zero_coeffs[txb_itr] > 0;
+
+            if (y_has_coeff) {
+                (void)context_ptr;
+                uint8_t     *pred_buffer = &(candidate_buffer->prediction_ptr->buffer_y[tu_origin_index]);
+                uint8_t     *rec_buffer = &(candidate_buffer->recon_ptr->buffer_y[tu_origin_index]);
+                uint32_t j;
+                for (j = 0; j < context_ptr->blk_geom->tx_height[tx_depth][txb_itr]; j++)
+                    memcpy(rec_buffer + j * candidate_buffer->recon_ptr->stride_y, pred_buffer + j * candidate_buffer->prediction_ptr->stride_y, context_ptr->blk_geom->tx_width[tx_depth][txb_itr]);
+
+                av1_inv_transform_recon8bit(
+                    &(((int32_t*)candidate_buffer->recon_coeff_ptr->buffer_y)[txb_1d_offset]),
+                    rec_buffer, candidate_buffer->recon_ptr->stride_y,
+                    rec_buffer, candidate_buffer->recon_ptr->stride_y,
+                    context_ptr->blk_geom->txsize[tx_depth][txb_itr],
+                    candidate_buffer->candidate_ptr->transform_type[txb_itr],
+                    PLANE_TYPE_Y,
+                    (uint16_t)candidate_buffer->candidate_ptr->eob[0][txb_itr],
+                    0 /*lossless*/);
+            }
+            else {
+                picture_copy(
+                    candidate_buffer->prediction_ptr,
+                    tu_origin_index,
+                    0,
+                    candidate_buffer->recon_ptr,
+                    tu_origin_index,
+                    0,
+                    context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
+                    context_ptr->blk_geom->tx_height[tx_depth][txb_itr],
+                    0,
+                    0,
+                    PICTURE_BUFFER_DESC_Y_FLAG,
+                    0,
+                    asm_type);
+
+            }
+
+            tu_full_distortion[0][DIST_CALC_PREDICTION] = spatial_full_distortion(
+                input_picture_ptr->buffer_y,
+                input_tu_origin_index,
+                input_picture_ptr->stride_y,
+                candidate_buffer->prediction_ptr->buffer_y,
+                tu_origin_index,
+                candidate_buffer->prediction_ptr->stride_y,
+                cropped_tx_width,
+                cropped_tx_height,
+                Log2f(context_ptr->blk_geom->tx_width[tx_depth][txb_itr]) - 2);
+
+            tu_full_distortion[0][DIST_CALC_RESIDUAL] = spatial_full_distortion(
+                input_picture_ptr->buffer_y,
+                input_tu_origin_index,
+                input_picture_ptr->stride_y,
+                &(((uint8_t*)candidate_buffer->recon_ptr->buffer_y)[tu_origin_index]),
+                0,
+                candidate_buffer->recon_ptr->stride_y,
+                cropped_tx_width,
+                cropped_tx_height,
+                Log2f(context_ptr->blk_geom->tx_width[tx_depth][txb_itr]) - 2);
+
+            tu_full_distortion[0][DIST_CALC_PREDICTION] <<= 4;
+            tu_full_distortion[0][DIST_CALC_RESIDUAL] <<= 4;
+        }
+        else {
+            // LUMA DISTORTION
+            picture_full_distortion32_bits(
+                context_ptr->trans_quant_buffers_ptr->tu_trans_coeff2_nx2_n_ptr,
+                txb_1d_offset,
+                0,
+                candidate_buffer->recon_coeff_ptr,
+                txb_1d_offset,
+                0,
+                context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
+                context_ptr->blk_geom->tx_height[tx_depth][txb_itr],
+                NOT_USED_VALUE,
+                NOT_USED_VALUE,
+                tu_full_distortion[0],
+                NOT_USED_VALUE,
+                NOT_USED_VALUE,
+                y_count_non_zero_coeffs[txb_itr],
+                0,
+                0,
+                COMPONENT_LUMA,
+                asm_type);
+
+            tu_full_distortion[0][DIST_CALC_RESIDUAL] += context_ptr->three_quad_energy;
+            tu_full_distortion[0][DIST_CALC_PREDICTION] += context_ptr->three_quad_energy;
+            //assert(context_ptr->three_quad_energy == 0 && context_ptr->cu_stats->size < 64);
+            TxSize tx_size = context_ptr->blk_geom->txsize[tx_depth][txb_itr];
+            int32_t shift = (MAX_TX_SCALE - av1_get_tx_scale(tx_size)) * 2;
+            tu_full_distortion[0][DIST_CALC_RESIDUAL] = RIGHT_SIGNED_SHIFT(tu_full_distortion[0][DIST_CALC_RESIDUAL], shift);
+            tu_full_distortion[0][DIST_CALC_PREDICTION] = RIGHT_SIGNED_SHIFT(tu_full_distortion[0][DIST_CALC_PREDICTION], shift);
+        }
+        //LUMA-ONLY
+        mdc_av1_tu_estimate_coeff_bits(
+            0,//allow_update_cdf,
+            NULL,//FRAME_CONTEXT *ec_ctx,
+            picture_control_set_ptr,
+            candidate_buffer,
+            txb_1d_offset,
+            candidate_buffer->residual_quant_coeff_ptr,
+            y_count_non_zero_coeffs[txb_itr],
+            &y_tu_coeff_bits,
+            context_ptr->blk_geom->txsize[tx_depth][txb_itr],
+            candidate_buffer->candidate_ptr->transform_type[txb_itr],
+            COMPONENT_LUMA);
+
+        av1_tu_calc_cost_luma(
+            0,
+            candidate_buffer->candidate_ptr,
+            txb_itr,
+            context_ptr->blk_geom->txsize[tx_depth][0],
+            y_count_non_zero_coeffs[txb_itr],
+            tu_full_distortion[0],      //gets updated inside based on cbf decision
+            &y_tu_coeff_bits,            //gets updated inside based on cbf decision
+            &y_full_cost,
+            context_ptr->full_lambda);
+
+        (*y_coeff_bits) += y_tu_coeff_bits;
+        y_full_distortion[DIST_CALC_RESIDUAL] += tu_full_distortion[0][DIST_CALC_RESIDUAL];
+        y_full_distortion[DIST_CALC_PREDICTION] += tu_full_distortion[0][DIST_CALC_PREDICTION];
+        txb_1d_offset += context_ptr->blk_geom->tx_width[tx_depth][txb_itr] * context_ptr->blk_geom->tx_height[tx_depth][txb_itr];
+    }
+}
+
+void av1_set_ref_frame(MvReferenceFrame *rf, int8_t ref_frame_type);
+
+EbErrorType mdc_inter_pu_prediction_av1(
+    ModeDecisionConfigurationContext     *context_ptr,
+    PictureControlSet                    *picture_control_set_ptr,
+    ModeDecisionCandidateBuffer          *candidate_buffer_ptr,
+    EbAsm                                 asm_type)
+{
+    EbErrorType           return_error = EB_ErrorNone;
+    EbPictureBufferDesc  *ref_pic_list0;
+    EbPictureBufferDesc  *ref_pic_list1 = NULL;
+
+    Mv mv_0;
+    Mv mv_1;
+    mv_0.x = candidate_buffer_ptr->candidate_ptr->motion_vector_xl0;
+    mv_0.y = candidate_buffer_ptr->candidate_ptr->motion_vector_yl0;
+    mv_1.x = candidate_buffer_ptr->candidate_ptr->motion_vector_xl1;
+    mv_1.y = candidate_buffer_ptr->candidate_ptr->motion_vector_yl1;
+    MvUnit mv_unit;
+    mv_unit.pred_direction = candidate_buffer_ptr->candidate_ptr->prediction_direction[0];
+    mv_unit.mv[0] = mv_0;
+    mv_unit.mv[1] = mv_1;
+    int8_t ref_idx_l0 = candidate_buffer_ptr->candidate_ptr->ref_frame_index_l0;
+    int8_t ref_idx_l1 = candidate_buffer_ptr->candidate_ptr->ref_frame_index_l1;
+    // MRP_MD_UNI_DIR_BIPRED
+    MvReferenceFrame rf[2];
+    av1_set_ref_frame(rf, candidate_buffer_ptr->candidate_ptr->ref_frame_type);
+    uint8_t list_idx0, list_idx1;
+    list_idx0 = get_list_idx(rf[0]);
+    if (rf[1] == NONE_FRAME)
+        list_idx1 = get_list_idx(rf[0]);
+    else
+        list_idx1 = get_list_idx(rf[1]);
+    assert(list_idx0 < MAX_NUM_OF_REF_PIC_LIST);
+    assert(list_idx1 < MAX_NUM_OF_REF_PIC_LIST);
+    if (ref_idx_l0 >= 0)
+        ref_pic_list0 = ((EbReferenceObject*)picture_control_set_ptr->ref_pic_ptr_array[list_idx0][ref_idx_l0]->object_ptr)->reference_picture;
+    else
+        ref_pic_list0 = (EbPictureBufferDesc*)EB_NULL;
+    if (ref_idx_l1 >= 0)
+        ref_pic_list1 = ((EbReferenceObject*)picture_control_set_ptr->ref_pic_ptr_array[list_idx1][ref_idx_l1]->object_ptr)->reference_picture;
+    else
+        ref_pic_list1 = (EbPictureBufferDesc*)EB_NULL;
+
+    candidate_buffer_ptr->candidate_ptr->interp_filters = 0;
+
+    av1_inter_prediction(
+        picture_control_set_ptr,
+        candidate_buffer_ptr->candidate_ptr->interp_filters,
+        context_ptr->mdc_cu_ptr,
+        candidate_buffer_ptr->candidate_ptr->ref_frame_type,
+        &mv_unit,
+        candidate_buffer_ptr->candidate_ptr->use_intrabc,
+#if OBMC_FLAG
+        SIMPLE_TRANSLATION,
+        0,
+        0,
+#endif
+        candidate_buffer_ptr->candidate_ptr->compound_idx,
+        &candidate_buffer_ptr->candidate_ptr->interinter_comp,
+#if II_COMP_FLAG
+        NULL,
+        NULL,//ep_luma_recon_neighbor_array,
+        NULL,//ep_cb_recon_neighbor_array ,
+        NULL,//ep_cr_recon_neighbor_array ,
+        0,//cu_ptr->is_interintra_used,
+        0,//cu_ptr->interintra_mode,
+        0,//cu_ptr->use_wedge_interintra,
+        0,//cu_ptr->interintra_wedge_index,
+#endif
+        context_ptr->cu_origin_x,
+        context_ptr->cu_origin_y,
+        context_ptr->blk_geom->bwidth,
+        context_ptr->blk_geom->bheight,
+        ref_pic_list0,
+        ref_pic_list1,
+        candidate_buffer_ptr->prediction_ptr,
+        context_ptr->blk_geom->origin_x,
+        context_ptr->blk_geom->origin_y,
+        0,
+        asm_type); // No chroma
+
+    return return_error;
+}
+
+int8_t av1_ref_frame_type(const MvReferenceFrame *const rf);
+
+uint64_t mdc_av1_full_cost(
+    ModeDecisionConfigurationContext     *context_ptr,
+    uint64_t                             *y_distortion,
+    uint64_t                             *y_coeff_bits,
+    uint64_t                              lambda) {
+
+    //EbErrorType return_error = EB_ErrorNone;
+    // Luma and chroma rate
+    uint64_t lumaRate = 0;
+    uint64_t coeffRate = 0;
+
+    // Luma and chroma SSE
+    uint64_t luma_sse;
+    uint64_t totalDistortion;
+    uint64_t rate;
+
+    lumaRate += context_ptr->candidate_buffer->candidate_ptr->fast_luma_rate;
+
+    // Coeff rate
+    coeffRate = (*y_coeff_bits);
+    luma_sse = y_distortion[0];
+    totalDistortion = luma_sse;
+    rate = lumaRate + coeffRate;
+    // Assign full cost
+    uint64_t full_cost = RDCOST(lambda, rate, totalDistortion);
+
+    return full_cost;
+}
+#endif
+EB_EXTERN EbErrorType nsq_prediction_shape(
+    SequenceControlSet                *sequence_control_set_ptr,
+    PictureControlSet                 *picture_control_set_ptr,
+    ModeDecisionConfigurationContext  *context_ptr,
+    MdcLcuData                        *mdc_result_tb_ptr,
+    uint32_t                           sb_originx,
+    uint32_t                           sb_originy,
+    uint32_t                           sb_index) {
+
+    EbErrorType                 return_error = EB_ErrorNone;
+    uint32_t                    cuIdx;
+    uint32_t                    leaf_idx;
+    uint32_t                    start_idx, end_idx;
+    uint32_t                    leaf_count = mdc_result_tb_ptr->leaf_count;
+    EbMdcLeafData               *leaf_data_array = mdc_result_tb_ptr->leaf_data_array;
+    MdcpLocalCodingUnit         *local_cu_array = context_ptr->local_cu_array;
+    MdcpLocalCodingUnit         *cu_ptr;
+    //CU Loop
+    cuIdx = 0;  //index over mdc array
+    start_idx = 0;
+    uint64_t nsq_cost[NUMBER_OF_SHAPES] = { MAX_CU_COST, MAX_CU_COST,MAX_CU_COST,MAX_CU_COST,MAX_CU_COST,
+        MAX_CU_COST, MAX_CU_COST,MAX_CU_COST,MAX_CU_COST,MAX_CU_COST };
+    PART nsq_shape_table[NUMBER_OF_SHAPES] = { PART_N, PART_H, PART_V, PART_HA, PART_HB,
+        PART_VA, PART_VB, PART_H4, PART_V4, PART_S };
+    uint32_t blk_idx_mds = 0;
+    uint32_t  d1_blocks_accumlated = 0;
+#if ADD_SAD_FOR_128X128
+    uint64_t me_128x128 = 0;
+#endif
+#if ADD_MDC_FULL_COST
+    context_ptr->coeff_est_entropy_coder_ptr = picture_control_set_ptr->coeff_est_entropy_coder_ptr;
+#endif
+    uint64_t tot_me_sb;
+    do {
+        EbMdcLeafData * leaf_data_ptr = &mdc_result_tb_ptr->leaf_data_array[cuIdx];
+        blk_idx_mds = leaf_data_array[cuIdx].mds_idx;
+        context_ptr->mds_idx = blk_idx_mds;
+        const BlockGeom * blk_geom = context_ptr->blk_geom = get_blk_geom_mds(blk_idx_mds);
+        uint32_t cu_origin_x = sb_originx + blk_geom->origin_x;
+        uint32_t cu_origin_y = sb_originy + blk_geom->origin_y;
+        if (!(cu_origin_x < sequence_control_set_ptr->seq_header.max_frame_width && cu_origin_y < sequence_control_set_ptr->seq_header.max_frame_height))
+        {
+            cuIdx++;
+            continue;
+        }
+        cu_ptr = &local_cu_array[cuIdx];
+#if ADD_MDC_FULL_COST
+        context_ptr->round_origin_x = ((context_ptr->cu_origin_x >> 3) << 3);
+        context_ptr->round_origin_y = ((context_ptr->cu_origin_y >> 3) << 3);
+        EbPictureBufferDesc  *input_picture_ptr = picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
+        context_ptr->cu_size_log2 = blk_geom->bwidth_log2;
+        context_ptr->cu_origin_x = sb_originx + blk_geom->origin_x;
+        context_ptr->cu_origin_y = sb_originy + blk_geom->origin_y;
+        context_ptr->sb_origin_x = sb_originx;
+        context_ptr->sb_origin_y = sb_originy;
+        uint64_t      y_full_distortion[DIST_CALC_TOTAL] = { 0 };
+        uint32_t      count_non_zero_coeffs[MAX_NUM_OF_TU_PER_CU] = { 0 };
+        uint64_t      y_coeff_bits = 0;
+        const uint32_t       input_origin_index = (context_ptr->cu_origin_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_y + (context_ptr->cu_origin_x + input_picture_ptr->origin_x);
+        const uint32_t       cu_origin_index = blk_geom->origin_x + blk_geom->origin_y * SB_STRIDE_Y;
+        context_ptr->candidate_buffer->candidate_ptr = &context_ptr->fast_candidate_array[0];
+        EbAsm asm_type = sequence_control_set_ptr->encode_context_ptr->asm_type;
+        cu_ptr->best_d1_blk = blk_idx_mds;
+#endif
+        if (picture_control_set_ptr->slice_type != I_SLICE) {
+            uint32_t geom_offset_x = 0;
+            uint32_t geom_offset_y = 0;
+            uint32_t me_sb_addr;
+            if (sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128) {
+                uint32_t me_sb_size = sequence_control_set_ptr->sb_sz;
+                uint32_t me_pic_width_in_sb = (sequence_control_set_ptr->seq_header.max_frame_width + sequence_control_set_ptr->sb_sz - 1) / me_sb_size;
+                uint32_t me_pic_height_in_sb = (sequence_control_set_ptr->seq_header.max_frame_height + sequence_control_set_ptr->sb_sz - 1) / me_sb_size;
+                tot_me_sb = me_pic_width_in_sb * me_pic_height_in_sb;
+                uint32_t me_sb_x = (cu_origin_x / me_sb_size);
+                uint32_t me_sb_y = (cu_origin_y / me_sb_size);
+                me_sb_addr = me_sb_x + me_sb_y * me_pic_width_in_sb;
+                geom_offset_x = (me_sb_x & 0x1) * me_sb_size;
+                geom_offset_y = (me_sb_y & 0x1) * me_sb_size;
+#if ADD_SAD_FOR_128X128
+                uint64_t sb_6x6_index;
+                uint64_t sb_6x6_dist_0 = 0;
+                uint64_t sb_6x6_dist_1 = 0;
+                uint64_t sb_6x6_dist_2 = 0;
+                uint64_t sb_6x6_dist_3 = 0;
+                if (blk_geom->sq_size == 128) {
+                    sb_6x6_index = me_sb_addr;
+                    SbParams *sb_params = &sequence_control_set_ptr->sb_params_array[sb_6x6_index];
+                    if (sb_params->is_complete_sb) {
+                        MeLcuResults *me_results_64x64 = picture_control_set_ptr->parent_pcs_ptr->me_results[sb_6x6_index];
+                        const MeCandidate *me_block_results_64x64 = me_results_64x64->me_candidate[0];
+                        sb_6x6_dist_0 = me_block_results_64x64[0].distortion;
+                    }
+                    if (blk_geom->bsize == BLOCK_128X128 || blk_geom->bsize == BLOCK_128X64) {
+                        sb_6x6_index = MIN(tot_me_sb - 1, me_sb_addr + 1);
+                        SbParams *sb_params = &sequence_control_set_ptr->sb_params_array[sb_6x6_index];
+                        if (sb_params->is_complete_sb) {
+                            MeLcuResults *me_results_64x64 = picture_control_set_ptr->parent_pcs_ptr->me_results[sb_6x6_index];
+                            const MeCandidate *me_block_results_64x64 = me_results_64x64->me_candidate[0];
+                            sb_6x6_dist_1 = me_block_results_64x64[0].distortion;
+                        }
+                    }
+                    if (blk_geom->bsize == BLOCK_128X128 || blk_geom->bsize == BLOCK_64X128) {
+                        sb_6x6_index = MIN(tot_me_sb - 1, me_sb_addr + me_pic_width_in_sb);
+
+                        SbParams *sb_params = &sequence_control_set_ptr->sb_params_array[sb_6x6_index];
+                        if (sb_params->is_complete_sb) {
+                            MeLcuResults *me_results_64x64 = picture_control_set_ptr->parent_pcs_ptr->me_results[sb_6x6_index];
+                            const MeCandidate *me_block_results_64x64 = me_results_64x64->me_candidate[0];
+                            sb_6x6_dist_2 = me_block_results_64x64[0].distortion;
+                        }
+                    }
+                    if (blk_geom->bsize == BLOCK_128X128) {
+                        sb_6x6_index = MIN(tot_me_sb - 1, me_sb_addr + me_pic_width_in_sb + 1);
+                        SbParams *sb_params = &sequence_control_set_ptr->sb_params_array[sb_6x6_index];
+                        if (sb_params->is_complete_sb) {
+                            MeLcuResults *me_results_64x64 = picture_control_set_ptr->parent_pcs_ptr->me_results[sb_6x6_index];
+                            const MeCandidate *me_block_results_64x64 = me_results_64x64->me_candidate[0];
+                            sb_6x6_dist_3 = me_block_results_64x64[0].distortion;
+                        }
+                    }
+                    if (blk_geom->bsize == BLOCK_128X128)
+                        me_128x128 = sb_6x6_dist_0 + sb_6x6_dist_1 + sb_6x6_dist_2 + sb_6x6_dist_3;
+                    if (blk_geom->bsize == BLOCK_128X64) {
+                        me_128x128 = sb_6x6_dist_0 + sb_6x6_dist_1 + sb_6x6_dist_2 + sb_6x6_dist_3;
+                        if (blk_geom->bsize == BLOCK_64X128) {
+                            me_128x128 = sb_6x6_dist_0 + sb_6x6_dist_1 + sb_6x6_dist_2 + sb_6x6_dist_3;
+                        }
+                    }
+                }
+#endif
+            }
+            else
+                me_sb_addr = sb_index;
+            uint32_t max_number_of_pus_per_sb;
+            max_number_of_pus_per_sb = picture_control_set_ptr->parent_pcs_ptr->max_number_of_pus_per_sb;
+            uint32_t me_block_offset =
+                (blk_geom->bwidth == 4 || blk_geom->bheight == 4 || blk_geom->bwidth == 128 || blk_geom->bheight == 128) ?
+                0 :
+                get_me_info_index(max_number_of_pus_per_sb, context_ptr->blk_geom, geom_offset_x, geom_offset_y);
+            MeLcuResults *me_results = picture_control_set_ptr->parent_pcs_ptr->me_results[me_sb_addr];
+            EbBool allow_bipred = (context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4) ? EB_FALSE : EB_TRUE;
+            EbBool is_compound_enabled = (picture_control_set_ptr->parent_pcs_ptr->reference_mode == SINGLE_REFERENCE) ? 0 : 1;
+            const MeCandidate *me_block_results = me_results->me_candidate[me_block_offset];
+            uint8_t total_me_cnt = me_results->total_me_candidate_index[me_block_offset];
+            uint8_t me_index = 0;
+            for (uint8_t me_candidate_index = 0; me_candidate_index < total_me_cnt; me_candidate_index++) {
+                const MeCandidate *me_block_results_ptr = &me_block_results[me_candidate_index];
+                if (is_compound_enabled) {
+                    if (allow_bipred) {
+                        if (me_block_results_ptr->direction == 2) {
+                            me_index = me_candidate_index;
+                            break;
+                        }
+                    }
+                    else {
+                        if (me_block_results_ptr->direction == 0) {
+                            me_index = me_candidate_index;
+                            break;
+                        }
+                    }
+                }
+                else {
+                    if (me_block_results_ptr->direction == 0) {
+                        me_index = me_candidate_index;
+                        break;
+                    }
+                }
+            }
+            // Initialize the mdc candidate (only av1 rate estimation inputs)
+            context_ptr->mdc_candidate_ptr->md_rate_estimation_ptr = context_ptr->md_rate_estimation_ptr;
+            context_ptr->mdc_candidate_ptr->type = INTER_MODE;
+            context_ptr->mdc_candidate_ptr->merge_flag = EB_FALSE;
+            context_ptr->mdc_candidate_ptr->prediction_direction[0] = (picture_control_set_ptr->parent_pcs_ptr->temporal_layer_index == 0) ?
+                UNI_PRED_LIST_0 :
+                me_block_results[me_index].direction;
+            context_ptr->mdc_candidate_ptr->inter_mode = NEARESTMV;
+            context_ptr->mdc_candidate_ptr->pred_mode = NEARESTMV;
+            context_ptr->mdc_candidate_ptr->motion_mode = SIMPLE_TRANSLATION;
+            context_ptr->mdc_candidate_ptr->is_new_mv = 1;
+            context_ptr->mdc_candidate_ptr->is_zero_mv = 0;
+            context_ptr->mdc_candidate_ptr->drl_index = 0;
+            context_ptr->mdc_candidate_ptr->motion_vector_xl0 = me_results->me_mv_array[me_block_offset][0].x_mv << 1;
+            context_ptr->mdc_candidate_ptr->motion_vector_yl0 = me_results->me_mv_array[me_block_offset][0].y_mv << 1;
+            context_ptr->mdc_candidate_ptr->motion_vector_xl1 = me_results->me_mv_array[me_block_offset][((sequence_control_set_ptr->mrp_mode == 0) ? 4 : 2)].x_mv << 1;
+            context_ptr->mdc_candidate_ptr->motion_vector_yl1 = me_results->me_mv_array[me_block_offset][((sequence_control_set_ptr->mrp_mode == 0) ? 4 : 2)].y_mv << 1;
+            context_ptr->mdc_candidate_ptr->ref_mv_index = 0;
+            context_ptr->mdc_candidate_ptr->pred_mv_weight = 0;
+            if (context_ptr->mdc_candidate_ptr->prediction_direction[0] == BI_PRED) {
+                context_ptr->mdc_candidate_ptr->ref_frame_type = LAST_BWD_FRAME;
+                context_ptr->mdc_candidate_ptr->is_compound = 1;
+            }
+            else if (context_ptr->mdc_candidate_ptr->prediction_direction[0] == UNI_PRED_LIST_0) {
+                context_ptr->mdc_candidate_ptr->ref_frame_type = LAST_FRAME;
+                context_ptr->mdc_candidate_ptr->is_compound = 0;
+            }
+            else {
+                context_ptr->mdc_candidate_ptr->ref_frame_type = BWDREF_FRAME;
+                context_ptr->mdc_candidate_ptr->is_compound = 0;
+            }
+            context_ptr->mdc_candidate_ptr->motion_vector_pred_x[REF_LIST_0] = 0;
+            context_ptr->mdc_candidate_ptr->motion_vector_pred_y[REF_LIST_0] = 0;
+            // Initialize the ref mv
+            memset(context_ptr->mdc_ref_mv_stack, 0, sizeof(CandidateMv));
+            context_ptr->mdc_cu_ptr->is_inter_ctx = 0;
+            context_ptr->mdc_cu_ptr->skip_flag_context = 0;
+            context_ptr->mdc_cu_ptr->inter_mode_ctx[context_ptr->mdc_candidate_ptr->ref_frame_type] = 0;
+            context_ptr->mdc_cu_ptr->reference_mode_context = 0;
+            context_ptr->mdc_cu_ptr->compoud_reference_type_context = 0;
+            av1_zero(context_ptr->mdc_cu_ptr->av1xd->neighbors_ref_counts);
+#if ADD_MDC_FULL_COST
+            const uint8_t list0_ref_index = me_block_results[me_index].ref_idx_l0;
+            const uint8_t list1_ref_index = me_block_results[me_index].ref_idx_l1;
+            context_ptr->candidate_buffer->candidate_ptr->use_intrabc = 0;
+            context_ptr->candidate_buffer->candidate_ptr->motion_mode = SIMPLE_TRANSLATION;
+            context_ptr->candidate_buffer->candidate_ptr->md_rate_estimation_ptr = context_ptr->md_rate_estimation_ptr;
+            context_ptr->candidate_buffer->candidate_ptr->type = INTER_MODE;
+            context_ptr->candidate_buffer->candidate_ptr->merge_flag = EB_FALSE;
+            context_ptr->candidate_buffer->candidate_ptr->prediction_direction[0] = me_block_results[me_index].direction;
+            context_ptr->candidate_buffer->candidate_ptr->motion_mode = SIMPLE_TRANSLATION;
+            context_ptr->candidate_buffer->candidate_ptr->is_new_mv = 1;
+            context_ptr->candidate_buffer->candidate_ptr->is_zero_mv = 0;
+            context_ptr->candidate_buffer->candidate_ptr->drl_index = 0;
+            int16_t to_inject_mv_x_l0 = me_results->me_mv_array[me_block_offset][list0_ref_index].x_mv << 1;
+            int16_t to_inject_mv_y_l0 = me_results->me_mv_array[me_block_offset][list0_ref_index].y_mv << 1;
+            int16_t to_inject_mv_x_l1 = me_results->me_mv_array[me_block_offset][((sequence_control_set_ptr->mrp_mode == 0) ? (me_block_results[me_index].ref1_list << 2) : (me_block_results[me_index].ref1_list << 1)) + list1_ref_index].x_mv << 1;
+            int16_t to_inject_mv_y_l1 = me_results->me_mv_array[me_block_offset][((sequence_control_set_ptr->mrp_mode == 0) ? (me_block_results[me_index].ref1_list << 2) : (me_block_results[me_index].ref1_list << 1)) + list1_ref_index].y_mv << 1;
+            context_ptr->candidate_buffer->candidate_ptr->motion_vector_xl0 = to_inject_mv_x_l0;
+            context_ptr->candidate_buffer->candidate_ptr->motion_vector_yl0 = to_inject_mv_y_l0;
+            context_ptr->candidate_buffer->candidate_ptr->motion_vector_xl1 = to_inject_mv_x_l1;
+            context_ptr->candidate_buffer->candidate_ptr->motion_vector_yl1 = to_inject_mv_y_l1;
+            context_ptr->candidate_buffer->candidate_ptr->ref_mv_index = 0;
+            context_ptr->candidate_buffer->candidate_ptr->pred_mv_weight = 0;
+            if (context_ptr->candidate_buffer->candidate_ptr->prediction_direction[0] == 0) {
+                context_ptr->candidate_buffer->candidate_ptr->inter_mode = NEARESTMV;
+                context_ptr->candidate_buffer->candidate_ptr->pred_mode = NEARESTMV;
+                context_ptr->candidate_buffer->candidate_ptr->ref_frame_type = svt_get_ref_frame_type(REF_LIST_0, list0_ref_index);
+                context_ptr->candidate_buffer->candidate_ptr->ref_frame_index_l0 = list0_ref_index;
+                context_ptr->candidate_buffer->candidate_ptr->ref_frame_index_l1 = -1;
+                context_ptr->candidate_buffer->candidate_ptr->is_compound = 0;
+            }
+            else if (context_ptr->candidate_buffer->candidate_ptr->prediction_direction[0] == 1) {
+                context_ptr->candidate_buffer->candidate_ptr->inter_mode = NEARESTMV;
+                context_ptr->candidate_buffer->candidate_ptr->pred_mode = NEARESTMV;
+                context_ptr->candidate_buffer->candidate_ptr->ref_frame_type = svt_get_ref_frame_type(REF_LIST_1, list1_ref_index);
+                context_ptr->candidate_buffer->candidate_ptr->ref_frame_index_l0 = -1;
+                context_ptr->candidate_buffer->candidate_ptr->ref_frame_index_l1 = list1_ref_index;
+                context_ptr->candidate_buffer->candidate_ptr->is_compound = 0;
+            }
+            else if (context_ptr->candidate_buffer->candidate_ptr->prediction_direction[0] == 2) {
+                MvReferenceFrame rf[2];
+                rf[0] = svt_get_ref_frame_type(me_block_results[me_index].ref0_list, list0_ref_index);
+                rf[1] = svt_get_ref_frame_type(me_block_results[me_index].ref1_list, list1_ref_index);
+                context_ptr->candidate_buffer->candidate_ptr->ref_frame_type = av1_ref_frame_type(rf);
+                context_ptr->candidate_buffer->candidate_ptr->ref_frame_index_l0 = list0_ref_index;
+                context_ptr->candidate_buffer->candidate_ptr->ref_frame_index_l1 = list1_ref_index;
+                context_ptr->candidate_buffer->candidate_ptr->inter_mode = NEW_NEWMV;
+                context_ptr->candidate_buffer->candidate_ptr->pred_mode = NEW_NEWMV;
+                context_ptr->candidate_buffer->candidate_ptr->is_compound = 1;
+            }
+            else {
+                SVT_LOG("mdc invalid pred_direction");
+            }
+            context_ptr->candidate_buffer->candidate_ptr->motion_vector_pred_x[REF_LIST_0] = 0;
+            context_ptr->candidate_buffer->candidate_ptr->motion_vector_pred_y[REF_LIST_0] = 0;
+            context_ptr->candidate_buffer->candidate_ptr->motion_vector_pred_x[REF_LIST_1] = 0;
+            context_ptr->candidate_buffer->candidate_ptr->motion_vector_pred_y[REF_LIST_1] = 0;
+            context_ptr->candidate_buffer->candidate_ptr->interp_filters = 0;
+            context_ptr->candidate_buffer->candidate_ptr->compound_idx = 0;
+            context_ptr->candidate_buffer->candidate_ptr->interinter_comp.type = COMPOUND_AVERAGE;
+            context_ptr->mdc_cu_ptr->is_inter_ctx = 0;
+            context_ptr->mdc_cu_ptr->skip_flag_context = 0;
+            context_ptr->mdc_cu_ptr->inter_mode_ctx[context_ptr->candidate_buffer->candidate_ptr->ref_frame_type] = 0;
+            context_ptr->mdc_cu_ptr->reference_mode_context = 0;
+            context_ptr->mdc_cu_ptr->compoud_reference_type_context = 0;
+            av1_zero(context_ptr->mdc_cu_ptr->av1xd->neighbors_ref_counts);
+            uint16_t txb_count = context_ptr->blk_geom->txb_count[0];
+            for (uint16_t txb_itr = 0; txb_itr < txb_count; txb_itr++) 
+                context_ptr->candidate_buffer->candidate_ptr->transform_type[txb_itr] = DCT_DCT;
+            
+            mdc_inter_pu_prediction_av1(
+                context_ptr,
+                picture_control_set_ptr,
+                context_ptr->candidate_buffer,
+                asm_type);
+
+            //Y Residual
+            ResidualKernel(
+                &(input_picture_ptr->buffer_y[input_origin_index]),
+                input_picture_ptr->stride_y,
+                &(context_ptr->candidate_buffer->prediction_ptr->buffer_y[cu_origin_index]),
+                context_ptr->candidate_buffer->prediction_ptr->stride_y/* 64*/,
+                &(((int16_t*)context_ptr->candidate_buffer->residual_ptr->buffer_y)[cu_origin_index]),
+                context_ptr->candidate_buffer->residual_ptr->stride_y,
+                context_ptr->blk_geom->bwidth,
+                context_ptr->blk_geom->bheight);
+
+            context_ptr->candidate_buffer->candidate_ptr->tx_depth = 0;
+            context_ptr->spatial_sse_full_loop = 0;
+
+            mdc_full_loop(
+                context_ptr->candidate_buffer,
+                context_ptr,
+                picture_control_set_ptr,
+                context_ptr->qp,
+                count_non_zero_coeffs,
+                &y_coeff_bits,
+                y_full_distortion);
+            for (uint8_t txb_itr = 0; txb_itr < txb_count; txb_itr++)
+                context_ptr->mdc_cu_ptr->quantized_dc[0][txb_itr] = context_ptr->candidate_buffer->candidate_ptr->quantized_dc[0][txb_itr];
+
+#endif
+            // Fast Cost Calc
+#if! ADD_MDC_FULL_COST
+            cu_ptr->early_cost = av1_inter_fast_cost(
+                context_ptr->mdc_cu_ptr,
+                context_ptr->mdc_candidate_ptr,
+                context_ptr->qp,
+
+                me_block_results[me_index].distortion,
+
+                (uint64_t)0,
+                context_ptr->lambda,
+                0,
+                picture_control_set_ptr,
+                context_ptr->mdc_ref_mv_stack,
+                blk_geom,
+                (sb_originy + blk_geom->origin_y) >> MI_SIZE_LOG2,
+                (sb_originx + blk_geom->origin_x) >> MI_SIZE_LOG2,
+                0,
+                DC_PRED,        // Hsan: neighbor not generated @ open loop partitioning
+                DC_PRED);       // Hsan: neighbor not generated @ open loop partitioning
+#endif
+#if ADD_MDC_FULL_COST
+            mdc_av1_inter_fast_cost(
+                context_ptr->mdc_cu_ptr,
+                context_ptr->candidate_buffer->candidate_ptr,
+                blk_geom->sq_size == 128 ? me_128x128 : me_block_results[me_index].distortion,
+                context_ptr->lambda,
+                0,
+                picture_control_set_ptr,
+                context_ptr->mdc_ref_mv_stack,
+                blk_geom);
+
+            cu_ptr->early_cost = mdc_av1_full_cost(
+                context_ptr,
+                y_full_distortion,
+                &y_coeff_bits,
+                context_ptr->full_lambda);
+#endif
+        }
+        if (blk_geom->nsi + 1 == blk_geom->totns)
+            nsq_cost[context_ptr->blk_geom->shape] = mdc_d1_non_square_block_decision(context_ptr);
+        d1_blocks_accumlated = blk_geom->shape == PART_N ? 1 : d1_blocks_accumlated + 1;
+        if (d1_blocks_accumlated == leaf_data_ptr->tot_d1_blocks) {
+            end_idx = cuIdx + 1;
+            //Sorting
+            uint32_t i, j, index;
+            for (i = 0; i < NUMBER_OF_SHAPES - 1; ++i) {
+                for (j = i + 1; j < NUMBER_OF_SHAPES; ++j) {
+                    if (nsq_cost[nsq_shape_table[j]] < nsq_cost[nsq_shape_table[i]]) {
+                        index = nsq_shape_table[i];
+                        nsq_shape_table[i] = nsq_shape_table[j];
+                        nsq_shape_table[j] = index;
+                    }
+                }
+            }
+            // Assign ranking # to each block
+            for (leaf_idx = start_idx; leaf_idx < end_idx; leaf_idx++) {
+                EbMdcLeafData * current_depth_leaf_data = &mdc_result_tb_ptr->leaf_data_array[leaf_idx];
+#if COMBINE_MDC_NSQ_TABLE
+                current_depth_leaf_data->ol_best_nsq_shape1 = nsq_shape_table[0];
+                current_depth_leaf_data->ol_best_nsq_shape2 = nsq_shape_table[1];
+                current_depth_leaf_data->ol_best_nsq_shape3 = nsq_shape_table[2];
+                current_depth_leaf_data->ol_best_nsq_shape4 = nsq_shape_table[3];
+                current_depth_leaf_data->ol_best_nsq_shape5 = nsq_shape_table[4];
+                current_depth_leaf_data->ol_best_nsq_shape6 = nsq_shape_table[5];
+                current_depth_leaf_data->ol_best_nsq_shape7 = nsq_shape_table[6];
+                current_depth_leaf_data->ol_best_nsq_shape8 = nsq_shape_table[7];
+#endif
+            }
+            //Reset nsq table
+            //memset(nsq_cost, MAX_CU_COST,NUMBER_OF_SHAPES*sizeof(uint64_t));
+            for (int cost_idx = 0; cost_idx < NUMBER_OF_SHAPES; cost_idx++)
+                nsq_cost[cost_idx] = MAX_CU_COST;
+            for (int sh = 0; sh < NUMBER_OF_SHAPES; sh++)
+                nsq_shape_table[sh] = (PART)sh;
+            start_idx = end_idx;
+            uint32_t  last_cu_index = mdc_d2_inter_depth_block_decision(
+                picture_control_set_ptr,
+                context_ptr,
+                leaf_data_ptr,
+                blk_geom->sqi_mds,//input is parent square,
+                sb_index);
+            if (last_cu_index)
+                last_cu_index = 0;
+        }
+        cuIdx++;
+    } while (cuIdx < leaf_count);// End of CU loop
+    return return_error;
+}
+#endif
 
 void PredictionPartitionLoop(
     SequenceControlSet                   *sequence_control_set_ptr,

--- a/Source/Lib/Common/Codec/EbModeDecisionConfiguration.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfiguration.h
@@ -63,6 +63,15 @@ typedef EbErrorType(*EB_MDC_FUNC)(
 #define ALL16       0x33
 #define ALL8        0x71
 #define AllD        0x80
+#if ADD_MDC_REFINEMENT_LOOP
+#define Predm1p1    0x90
+#define Predm1p2    0xA0
+#define Predm1p3    0xB0
+#define Predm2p3    0xC0
+#define D1all       0x01
+#define D1sqonly    0x02
+#define Comp_no_4xn 0xA0
+#endif
 
 EB_ALIGN(16) static const uint8_t ndp_level_0[4] = {Pred + Predp1 + Predp2, Pred + Predp1, Pred + Predp1, Pred + Predm1};
 EB_ALIGN(16) static const uint8_t ndp_level_1[4] = {Pred + Predp1         , Pred + Predp1, Pred + Predp1, Pred + Predm1 };

--- a/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.h
@@ -12,6 +12,9 @@
 #include "EbRateControlProcess.h"
 #include "EbSequenceControlSet.h"
 #include "EbModeDecision.h"
+#if ADD_MDC_FULL_COST
+#include "EbTransQuantBuffers.h"
+#endif
 #include "EbObject.h"
 #ifdef __cplusplus
 extern "C" {
@@ -31,6 +34,10 @@ extern "C" {
         uint32_t split_context;
         EbBool   selected_cu;
         EbBool   stop_split;
+#if PREDICT_NSQ_SHAPE
+        PartitionType part;
+        uint32_t best_d1_blk;
+#endif
     } MdcpLocalCodingUnit;
 
     typedef struct ModeDecisionConfigurationContext
@@ -44,7 +51,11 @@ extern "C" {
 
         uint8_t                              qp;
         uint64_t                             lambda;
+#if PREDICT_NSQ_SHAPE
+        MdcpLocalCodingUnit                   local_cu_array[BLOCK_MAX_COUNT_SB_128];
+#else
         MdcpLocalCodingUnit                  local_cu_array[CU_MAX_COUNT];
+#endif
 
         // Inter depth decision
         uint8_t                              group_of8x8_blocks_count;
@@ -81,6 +92,31 @@ extern "C" {
 
         // Multi - Mode signal(s)
         uint8_t                             adp_level;
+#if PREDICT_NSQ_SHAPE
+        uint32_t                            mds_idx;
+#endif
+#if ADD_MDC_FULL_COST
+        MdcpLocalCodingUnit                  *cu_ptr;
+        ModeDecisionCandidateBuffer          *candidate_buffer;
+        uint16_t                             sb_origin_y;
+        uint16_t                             sb_origin_x;
+        uint16_t                             cu_origin_y;
+        uint16_t                             cu_origin_x;
+        uint16_t                             round_origin_x;
+        uint16_t                             round_origin_y;
+        uint8_t                              cu_size_log2;
+        uint64_t                             three_quad_energy;
+        // Transform and Quantization Buffers
+        EbTransQuantBuffers                  *trans_quant_buffers_ptr;
+        // Trasform Scratch Memory
+        int16_t                              *transform_inner_array_ptr;
+        uint8_t                               spatial_sse_full_loop;
+        EntropyCoder                         *coeff_est_entropy_coder_ptr;
+        uint64_t                             full_lambda;
+        ModeDecisionCandidate                **fast_candidate_ptr_array;
+        ModeDecisionCandidate                *fast_candidate_array;
+        ModeDecisionCandidateBuffer          **candidate_buffer_ptr_array;
+#endif
     } ModeDecisionConfigurationContext;
 
     /**************************************

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -312,7 +312,16 @@ extern "C" {
     uint8_t                            *above_txfm_context;
     uint8_t                            *left_txfm_context;
 #endif
-
+#if COMBINE_MDC_NSQ_TABLE
+    PART best_nsq_sahpe1;
+    PART best_nsq_sahpe2;
+    PART best_nsq_sahpe3;
+    PART best_nsq_sahpe4;
+    PART best_nsq_sahpe5;
+    PART best_nsq_sahpe6;
+    PART best_nsq_sahpe7;
+    PART best_nsq_sahpe8;
+#endif
     } ModeDecisionContext;
 
     typedef void(*EbAv1LambdaAssignFunc)(

--- a/Source/Lib/Common/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimation.c
@@ -15178,12 +15178,8 @@ EbErrorType motion_estimate_lcu(
                             enableHalfPel16x16,
                             enableHalfPel8x8,
                             enableQuarterPel,
-#if TEST5_DISABLE_NSQ_ME
-                            EB_FALSE);
-#else
                             picture_control_set_ptr->pic_depth_mode <=
                                 PIC_ALL_C_DEPTH_MODE);
-#endif
                     }
                 }
                 if (is_nsq_table_used && ref_pic_index == 0) {

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -13619,6 +13619,24 @@ extern "C" {
         uint32_t          tot_d1_blocks; //how many d1 bloks every parent square would have
         uint8_t           leaf_index;
         EbBool            split_flag;
+#if PREDICT_NSQ_SHAPE
+        //uint8_t           open_loop_ranking;
+        uint8_t           early_split_flag;
+#if COMBINE_MDC_NSQ_TABLE
+        uint8_t           ol_best_nsq_shape1;
+        uint8_t           ol_best_nsq_shape2;
+        uint8_t           ol_best_nsq_shape3;
+        uint8_t           ol_best_nsq_shape4;
+        uint8_t           ol_best_nsq_shape5;
+        uint8_t           ol_best_nsq_shape6;
+        uint8_t           ol_best_nsq_shape7;
+        uint8_t           ol_best_nsq_shape8;
+#endif
+#endif
+#if ADD_MDC_REFINEMENT_LOOP
+        uint8_t           consider_block;
+        uint8_t           refined_split_flag;
+#endif
     } EbMdcLeafData;
 
     typedef struct MdcLcuData
@@ -14141,6 +14159,9 @@ extern "C" {
 #if CONFIG_ENTROPY_STATS
         int32_t                               coef_cdf_category;
 #endif
+#if PREDICT_NSQ_SHAPE
+        uint16_t                              base_qindex;
+#endif
         int32_t                               separate_uv_delta_q;
 
         // Global quant matrix tables
@@ -14163,6 +14184,11 @@ extern "C" {
         uint64_t                              frame_offset;
         uint32_t                              large_scale_tile;
         int32_t                               nb_cdef_strengths;
+#if PREDICT_NSQ_SHAPE
+        ReferenceMode                         reference_mode;
+        int32_t                               delta_q_present_flag;
+        int32_t                               reduced_tx_set_used;
+#endif
 
 #if ADD_DELTA_QP_SUPPORT
         // Resolution of delta quant
@@ -14265,6 +14291,9 @@ extern "C" {
         struct stat_struct_t                 stat_struct; // stat_struct used in the second pass
         uint64_t                             referenced_area_avg; // average referenced area per frame
         uint8_t                              referenced_area_has_non_zero;
+#endif
+#if PREDICT_NSQ_SHAPE
+        uint8_t                                mdc_depth_level;
 #endif
     } PictureParentControlSet;
 

--- a/Source/Lib/Common/Codec/EbPictureOperators.c
+++ b/Source/Lib/Common/Codec/EbPictureOperators.c
@@ -69,7 +69,6 @@ void pic_copy_kernel_8bit(
     for (uint32_t j = 0; j < area_height; j++)
         memcpy(dst + j * dst_stride, src + j * src_stride, area_width);
 }
-
 void pic_copy_kernel_16bit(
     uint16_t                  *src,
     uint32_t                   src_stride,

--- a/Source/Lib/Common/Codec/EbPictureOperators.h
+++ b/Source/Lib/Common/Codec/EbPictureOperators.h
@@ -30,6 +30,22 @@ extern "C" {
         uint32_t  height,
         EbAsm     asm_type);
 
+#if PREDICT_NSQ_SHAPE
+    extern EbErrorType picture_copy8_bit(
+        EbPictureBufferDesc  *src,
+        uint32_t                src_luma_origin_index,
+        uint32_t                src_chroma_origin_index,
+        EbPictureBufferDesc  *dst,
+        uint32_t                dst_luma_origin_index,
+        uint32_t                dst_chroma_origin_index,
+        uint32_t                area_width,
+        uint32_t                area_height,
+        uint32_t                chroma_area_width,
+        uint32_t                chroma_area_height,
+        uint32_t                component_mask,
+        EbAsm                   asm_type);
+#endif
+
     extern EbErrorType picture_full_distortion32_bits(
         EbPictureBufferDesc  *coeff,
         uint32_t                coeff_luma_origin_index,

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -6167,17 +6167,44 @@ void check_redundant_block(const BlockGeom * blk_geom, ModeDecisionContext *cont
         }
     }
 }
+
 /*******************************************
 * ModeDecision LCU
 *   performs CL (LCU)
 *******************************************/
 EbBool allowed_ns_cu(
+#if COMBINE_MDC_NSQ_TABLE
+    uint8_t                            mdc_depth_level,
+#endif
     EbBool                             is_nsq_table_used,
     uint8_t                            nsq_max_shapes_md,
     ModeDecisionContext              *context_ptr,
     uint8_t                            is_complete_sb){
     EbBool  ret = 1;
     UNUSED(is_complete_sb);
+
+#if COMBINE_MDC_NSQ_TABLE
+    if (is_nsq_table_used) {
+        if (mdc_depth_level == MAX_MDC_LEVEL) {
+            if (context_ptr->blk_geom->shape != PART_N) {
+                ret = 0;
+                for (int i = 0; i < nsq_max_shapes_md; i++) {
+                    if (context_ptr->blk_geom->shape == context_ptr->nsq_table[i])
+                        ret = 1;
+                }
+            }
+        }
+        else {
+            if (context_ptr->blk_geom->shape != PART_N) {
+                ret = 0;
+                for (int i = 0; i < nsq_max_shapes_md; i++) {
+                    if (context_ptr->blk_geom->shape == context_ptr->nsq_table[i])
+                        ret = 1;
+                }
+            }
+        }
+    }
+#else
     if (is_nsq_table_used) {
         if (context_ptr->blk_geom->shape != PART_N) {
             ret = 0;
@@ -6187,6 +6214,7 @@ EbBool allowed_ns_cu(
             }
         }
     }
+#endif
     return ret;
 }
 
@@ -6564,6 +6592,243 @@ PART get_partition_shape(
         printf("error: unsupported above_size && left_size\n");
     return part;
 };
+
+#if ADJUST_NSQ_RANK_BASED_ON_NEIGH
+/****************************************************
+* Adjust the nsq_rank in order to keep the most
+* probable Shape to be selected in the lowest index
+****************************************************/
+void  adjust_nsq_rank(
+    PictureControlSet            *picture_control_set_ptr,
+    ModeDecisionContext          *context_ptr,
+    const SequenceControlSet     *sequence_control_set_ptr,
+    LargestCodingUnit            *sb_ptr,
+    NeighborArrayUnit            *leaf_partition_neighbor_array) {
+    const uint32_t                lcu_addr = sb_ptr->index;
+    uint8_t ol_part1 = context_ptr->best_nsq_sahpe1;
+    uint8_t ol_part2 = context_ptr->best_nsq_sahpe2;
+    uint8_t ol_part3 = context_ptr->best_nsq_sahpe3;
+    uint8_t ol_part4 = context_ptr->best_nsq_sahpe4;
+    uint8_t ol_part5 = context_ptr->best_nsq_sahpe5;
+    uint8_t ol_part6 = context_ptr->best_nsq_sahpe6;
+    uint8_t ol_part7 = context_ptr->best_nsq_sahpe7;
+    uint8_t ol_part8 = context_ptr->best_nsq_sahpe8;
+    EbBool is_compound_enabled = (picture_control_set_ptr->parent_pcs_ptr->reference_mode == SINGLE_REFERENCE) ? 0 : 1;
+    uint32_t me_sb_addr;
+    uint32_t me_2Nx2N_table_offset;
+    uint32_t max_number_of_pus_per_sb;
+    uint32_t geom_offset_x = 0;
+    uint32_t geom_offset_y = 0;
+    uint8_t cnt[PART_S + 1] = { 0 };
+    if (sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128) {
+        uint32_t me_sb_size = sequence_control_set_ptr->sb_sz;
+        uint32_t me_pic_width_in_sb = (sequence_control_set_ptr->seq_header.max_frame_width + sequence_control_set_ptr->sb_sz - 1) / me_sb_size;
+        uint32_t me_sb_x = (context_ptr->cu_origin_x / me_sb_size);
+        uint32_t me_sb_y = (context_ptr->cu_origin_y / me_sb_size);
+        me_sb_addr = me_sb_x + me_sb_y * me_pic_width_in_sb;
+        geom_offset_x = (me_sb_x & 0x1) * me_sb_size;
+        geom_offset_y = (me_sb_y & 0x1) * me_sb_size;
+    }
+    else
+        me_sb_addr = lcu_addr;
+    max_number_of_pus_per_sb = picture_control_set_ptr->parent_pcs_ptr->max_number_of_pus_per_sb;
+    me_2Nx2N_table_offset = (context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4 || context_ptr->blk_geom->bwidth == 128 || context_ptr->blk_geom->bheight == 128) ? 0 :
+
+        get_me_info_index(
+            max_number_of_pus_per_sb,
+            context_ptr->blk_geom,
+            geom_offset_x,
+            geom_offset_y);
+
+    const MeLcuResults *me_results = picture_control_set_ptr->parent_pcs_ptr->me_results[me_sb_addr];
+    uint8_t nsq0 = me_results->me_nsq_0[me_2Nx2N_table_offset];
+    uint8_t nsq1 = me_results->me_nsq_1[me_2Nx2N_table_offset];
+
+    uint8_t me_part_0 = nsq0 == 0 ? PART_N : nsq0 == 1 ? PART_H : nsq0 == 2 ? PART_V : nsq0 == 3 ? PART_H4 : nsq0 == 4 ? PART_V4 : nsq0 == 5 ? PART_S : 0;
+    uint8_t me_part_1 = nsq1 == 0 ? PART_N : nsq1 == 1 ? PART_H : nsq1 == 2 ? PART_V : nsq1 == 3 ? PART_H4 : nsq1 == 4 ? PART_V4 : nsq1 == 5 ? PART_S : 0;
+
+    // Generate Partition context
+    uint32_t partition_left_neighbor_index = get_neighbor_array_unit_left_index(
+        leaf_partition_neighbor_array,
+        context_ptr->cu_origin_y);
+    uint32_t partition_above_neighbor_index = get_neighbor_array_unit_top_index(
+        leaf_partition_neighbor_array,
+        context_ptr->cu_origin_x);
+    const PartitionContextType above_ctx = (((PartitionContext*)leaf_partition_neighbor_array->top_array)[partition_above_neighbor_index].above == (int8_t)INVALID_NEIGHBOR_DATA) ?
+        0 : ((PartitionContext*)leaf_partition_neighbor_array->top_array)[partition_above_neighbor_index].above;
+    const PartitionContextType left_ctx = (((PartitionContext*)leaf_partition_neighbor_array->left_array)[partition_left_neighbor_index].left == (int8_t)INVALID_NEIGHBOR_DATA) ?
+        0 : ((PartitionContext*)leaf_partition_neighbor_array->left_array)[partition_left_neighbor_index].left;
+
+    PART neighbor_part = get_partition_shape(
+        above_ctx,
+        left_ctx,
+        context_ptr->blk_geom->bwidth,
+        context_ptr->blk_geom->bheight);
+
+    //init table
+    context_ptr->nsq_table[0] = PART_H;
+    context_ptr->nsq_table[1] = PART_V;
+    context_ptr->nsq_table[2] = PART_HA;
+    context_ptr->nsq_table[3] = PART_HB;
+    context_ptr->nsq_table[4] = PART_VA;
+    context_ptr->nsq_table[5] = PART_VB;
+    context_ptr->nsq_table[6] = PART_H4;
+    context_ptr->nsq_table[7] = PART_V4;
+
+    if (is_compound_enabled == 0) me_part_1 = me_part_0;
+
+    // Insert predicted Shapes based on ME information
+    if (me_part_0 != me_part_1) {
+        context_ptr->nsq_table[0] = me_part_0;
+        context_ptr->nsq_table[1] = me_part_1;
+
+        if (me_part_0 == PART_H) {
+            context_ptr->nsq_table[2] = PART_HA;
+            context_ptr->nsq_table[3] = PART_HB;
+            context_ptr->nsq_table[4] = me_part_1 != PART_H4 ? PART_H4 : PART_V;
+        }
+        else if (me_part_0 == PART_V) {
+            context_ptr->nsq_table[2] = PART_VA;
+            context_ptr->nsq_table[3] = PART_VB;
+            context_ptr->nsq_table[4] = me_part_1 != PART_V4 ? PART_V4 : PART_H;
+        }
+        else if (me_part_0 == PART_H4) {
+            context_ptr->nsq_table[2] = PART_HA;
+            context_ptr->nsq_table[3] = PART_HB;
+            context_ptr->nsq_table[4] = me_part_1 != PART_H ? PART_H : PART_V;
+        }
+        else if (me_part_0 == PART_V4) {
+            context_ptr->nsq_table[2] = PART_VA;
+            context_ptr->nsq_table[3] = PART_VB;
+            context_ptr->nsq_table[4] = me_part_1 != PART_V ? PART_V : PART_H;
+        }
+        else if (me_part_0 == PART_S) {
+            context_ptr->nsq_table[2] = PART_VA;
+            context_ptr->nsq_table[3] = PART_HB;
+            context_ptr->nsq_table[4] = me_part_1 != PART_V ? PART_V : PART_H;
+        }
+    }
+    else {
+        context_ptr->nsq_table[0] = me_part_0;
+        if (me_part_0 == PART_H) {
+            context_ptr->nsq_table[1] = PART_HA;
+            context_ptr->nsq_table[2] = PART_HB;
+            context_ptr->nsq_table[3] = PART_H4;
+            context_ptr->nsq_table[4] = PART_V;
+        }
+        else if (me_part_0 == PART_V) {
+            context_ptr->nsq_table[1] = PART_VA;
+            context_ptr->nsq_table[2] = PART_VB;
+            context_ptr->nsq_table[3] = PART_V4;
+            context_ptr->nsq_table[4] = PART_H;
+        }
+        else if (me_part_0 == PART_H4) {
+            context_ptr->nsq_table[1] = PART_H;
+            context_ptr->nsq_table[2] = PART_HA;
+            context_ptr->nsq_table[3] = PART_HB;
+            context_ptr->nsq_table[4] = PART_V;
+        }
+        else if (me_part_0 == PART_V4) {
+            context_ptr->nsq_table[1] = PART_V;
+            context_ptr->nsq_table[2] = PART_VA;
+            context_ptr->nsq_table[3] = PART_VB;
+            context_ptr->nsq_table[4] = PART_H;
+        }
+        else if (me_part_0 == PART_S) {
+            context_ptr->nsq_table[1] = PART_HA;
+            context_ptr->nsq_table[2] = PART_VA;
+            context_ptr->nsq_table[3] = PART_HB;
+            context_ptr->nsq_table[4] = PART_VB;
+        }
+    }
+    // Insert predicted Shapes based on neighbor information
+    if (neighbor_part == PART_S && me_part_0 == PART_S && me_part_1 == PART_S) {
+        context_ptr->nsq_table[0] = PART_HA;
+        context_ptr->nsq_table[1] = PART_VA;
+        context_ptr->nsq_table[2] = PART_HB;
+        context_ptr->nsq_table[3] = PART_VB;
+        context_ptr->nsq_table[4] = PART_H4;
+        context_ptr->nsq_table[5] = PART_V4;
+    }
+    else {
+        if (neighbor_part != PART_N && neighbor_part != PART_S && neighbor_part != me_part_0 && neighbor_part != me_part_1) {
+            context_ptr->nsq_table[5] = context_ptr->nsq_table[4];
+            context_ptr->nsq_table[4] = context_ptr->nsq_table[3];
+            context_ptr->nsq_table[3] = context_ptr->nsq_table[2];
+            context_ptr->nsq_table[2] = context_ptr->nsq_table[1];
+            context_ptr->nsq_table[1] = context_ptr->nsq_table[0];
+            context_ptr->nsq_table[0] = neighbor_part;
+        }
+        else
+            context_ptr->nsq_table[5] = neighbor_part != PART_N && neighbor_part != PART_S ? neighbor_part : me_part_0;
+    }
+
+    if (picture_control_set_ptr->parent_pcs_ptr->mdc_depth_level < MAX_MDC_LEVEL) {
+        context_ptr->nsq_table[2] = context_ptr->nsq_table[0] != ol_part1 && context_ptr->nsq_table[1] != ol_part1 ? ol_part1
+            : context_ptr->nsq_table[0] != ol_part2 && context_ptr->nsq_table[1] != ol_part2 ? ol_part2
+            : ol_part3 != PART_N ? ol_part3 : context_ptr->nsq_table[2];
+        context_ptr->nsq_table[3] = context_ptr->nsq_table[0] != ol_part1 && context_ptr->nsq_table[1] != ol_part1 && context_ptr->nsq_table[2] != ol_part1 ? ol_part1
+            : context_ptr->nsq_table[0] != ol_part2 && context_ptr->nsq_table[1] != ol_part2 && context_ptr->nsq_table[2] != ol_part2 ? ol_part2
+            : context_ptr->nsq_table[0] != ol_part3 && context_ptr->nsq_table[1] != ol_part3 && context_ptr->nsq_table[2] != ol_part3 ? ol_part3
+            : ol_part4 != PART_N ? ol_part4 : context_ptr->nsq_table[3];
+        context_ptr->nsq_table[4] = context_ptr->nsq_table[0] != ol_part1 && context_ptr->nsq_table[1] != ol_part1 && context_ptr->nsq_table[2] != ol_part1 && context_ptr->nsq_table[3] != ol_part1 ? ol_part1
+            : context_ptr->nsq_table[0] != ol_part2 && context_ptr->nsq_table[1] != ol_part2 && context_ptr->nsq_table[2] != ol_part2 && context_ptr->nsq_table[3] != ol_part2 ? ol_part2
+            : context_ptr->nsq_table[0] != ol_part3 && context_ptr->nsq_table[1] != ol_part3 && context_ptr->nsq_table[2] != ol_part3 && context_ptr->nsq_table[3] != ol_part3 ? ol_part3
+            : context_ptr->nsq_table[0] != ol_part4 && context_ptr->nsq_table[1] != ol_part4 && context_ptr->nsq_table[2] != ol_part4 && context_ptr->nsq_table[3] != ol_part4 ? ol_part4
+            : ol_part5 != PART_N ? ol_part5 : context_ptr->nsq_table[4];
+        context_ptr->nsq_table[5] = context_ptr->nsq_table[0] != ol_part1 && context_ptr->nsq_table[1] != ol_part1 && context_ptr->nsq_table[2] != ol_part1 && context_ptr->nsq_table[3] != ol_part1 && context_ptr->nsq_table[4] != ol_part1 ? ol_part1
+            : context_ptr->nsq_table[0] != ol_part2 && context_ptr->nsq_table[1] != ol_part2 && context_ptr->nsq_table[2] != ol_part2 && context_ptr->nsq_table[3] != ol_part2 && context_ptr->nsq_table[4] != ol_part2 ? ol_part2
+            : context_ptr->nsq_table[0] != ol_part3 && context_ptr->nsq_table[1] != ol_part3 && context_ptr->nsq_table[2] != ol_part3 && context_ptr->nsq_table[3] != ol_part3 && context_ptr->nsq_table[4] != ol_part3 ? ol_part3
+            : context_ptr->nsq_table[0] != ol_part4 && context_ptr->nsq_table[1] != ol_part4 && context_ptr->nsq_table[2] != ol_part4 && context_ptr->nsq_table[3] != ol_part4 && context_ptr->nsq_table[4] != ol_part4 ? ol_part4
+            : context_ptr->nsq_table[0] != ol_part5 && context_ptr->nsq_table[1] != ol_part5 && context_ptr->nsq_table[2] != ol_part5 && context_ptr->nsq_table[3] != ol_part5 && context_ptr->nsq_table[4] != ol_part5 ? ol_part5
+            : ol_part6 != PART_N ? ol_part6 : context_ptr->nsq_table[5];
+        context_ptr->nsq_table[6] = context_ptr->nsq_table[0] != ol_part1 && context_ptr->nsq_table[1] != ol_part1 && context_ptr->nsq_table[2] != ol_part1 && context_ptr->nsq_table[3] != ol_part1 && context_ptr->nsq_table[4] != ol_part1 && context_ptr->nsq_table[5] != ol_part1 ? ol_part1
+            : context_ptr->nsq_table[0] != ol_part2 && context_ptr->nsq_table[1] != ol_part2 && context_ptr->nsq_table[2] != ol_part2 && context_ptr->nsq_table[3] != ol_part2 && context_ptr->nsq_table[4] != ol_part2 && context_ptr->nsq_table[5] != ol_part2 ? ol_part2
+            : context_ptr->nsq_table[0] != ol_part3 && context_ptr->nsq_table[1] != ol_part3 && context_ptr->nsq_table[2] != ol_part3 && context_ptr->nsq_table[3] != ol_part3 && context_ptr->nsq_table[4] != ol_part3 && context_ptr->nsq_table[5] != ol_part3 ? ol_part3
+            : context_ptr->nsq_table[0] != ol_part4 && context_ptr->nsq_table[1] != ol_part4 && context_ptr->nsq_table[2] != ol_part4 && context_ptr->nsq_table[3] != ol_part4 && context_ptr->nsq_table[4] != ol_part4 && context_ptr->nsq_table[5] != ol_part4 ? ol_part4
+            : context_ptr->nsq_table[0] != ol_part5 && context_ptr->nsq_table[1] != ol_part5 && context_ptr->nsq_table[2] != ol_part5 && context_ptr->nsq_table[3] != ol_part5 && context_ptr->nsq_table[4] != ol_part5 && context_ptr->nsq_table[5] != ol_part5 ? ol_part5
+            : context_ptr->nsq_table[0] != ol_part6 && context_ptr->nsq_table[1] != ol_part6 && context_ptr->nsq_table[2] != ol_part6 && context_ptr->nsq_table[3] != ol_part6 && context_ptr->nsq_table[4] != ol_part6 && context_ptr->nsq_table[5] != ol_part6 ? ol_part6
+            : ol_part7;
+
+        // Replace PART_N by best MDC.
+        for (uint8_t idx = 0; idx < NSQ_TAB_SIZE; idx++) {
+            if (context_ptr->nsq_table[idx] == PART_N) {
+                context_ptr->nsq_table[idx] = ol_part1 != PART_N ? ol_part1 :
+                    ol_part2 != PART_N ? ol_part2 :
+                    ol_part3 != PART_N ? ol_part3 :
+                    ol_part4 != PART_N ? ol_part4 :
+                    ol_part5 != PART_N ? ol_part5 :
+                    ol_part6 != PART_N ? ol_part6 :
+                    ol_part7 != PART_N ? ol_part7 : ol_part8;
+                break;
+            }
+        }
+    }
+    // Remove duplicate candidates
+    for (int pidx = 0; pidx < NSQ_TAB_SIZE; pidx++)
+        cnt[context_ptr->nsq_table[pidx]]++;
+    cnt[context_ptr->nsq_table[0]] = 1;
+    for (int iter = 0; iter < NSQ_TAB_SIZE - 1; iter++) {
+        for (int idx = 1 + iter; idx < NSQ_TAB_SIZE; idx++) {
+            if (context_ptr->nsq_table[iter] != context_ptr->nsq_table[idx])
+                continue;
+            else {
+                for (int i = idx; i < NSQ_TAB_SIZE; i++) {
+                    if (idx < NSQ_TAB_SIZE - 1)
+                        context_ptr->nsq_table[idx] = context_ptr->nsq_table[idx + 1];
+                    else if (idx == NSQ_TAB_SIZE - 1) {
+                        for (int pidx = 1; pidx < PART_S; pidx++) {
+                            if (cnt[pidx] == 0)
+                                context_ptr->nsq_table[idx] = (PART)pidx;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+#endif
+
 /****************************************************
 * Reorder the nsq_table in order to keep the most
 * probable Shape to be selected in the lowest index
@@ -7049,11 +7314,43 @@ void md_encode_block(
     candidate_buffer_ptr_array = &(candidate_buffer_ptr_array_base[0]);
     for (uint8_t ref_idx = 0; ref_idx < MAX_REF_TYPE_CAND; ref_idx++)
         context_ptr->ref_best_cost_sq_table[ref_idx] = MAX_CU_COST;
+
+#if PREDICT_NSQ_SHAPE
     EbBool is_nsq_table_used = (picture_control_set_ptr->slice_type == !I_SLICE &&
         picture_control_set_ptr->parent_pcs_ptr->pic_depth_mode <= PIC_ALL_C_DEPTH_MODE &&
         picture_control_set_ptr->parent_pcs_ptr->nsq_search_level >= NSQ_SEARCH_LEVEL1 &&
         picture_control_set_ptr->parent_pcs_ptr->nsq_search_level < NSQ_SEARCH_FULL) ? EB_TRUE : EB_FALSE;
-    is_nsq_table_used = picture_control_set_ptr->enc_mode == ENC_M0 ?  EB_FALSE : is_nsq_table_used;
+		
+    is_nsq_table_used = picture_control_set_ptr->parent_pcs_ptr->sc_content_detected || picture_control_set_ptr->enc_mode == ENC_M0 ? EB_FALSE : is_nsq_table_used;
+#if ADJUST_NSQ_RANK_BASED_ON_NEIGH
+    if (is_nsq_table_used) {
+        if (context_ptr->blk_geom->shape == PART_N) {
+            if (picture_control_set_ptr->parent_pcs_ptr->mdc_depth_level < MAX_MDC_LEVEL) {
+                adjust_nsq_rank(
+                    picture_control_set_ptr,
+                    context_ptr,
+                    sequence_control_set_ptr,
+                    context_ptr->sb_ptr,
+                    context_ptr->leaf_partition_neighbor_array);
+            }
+            else {
+                order_nsq_table(
+                    picture_control_set_ptr,
+                    context_ptr,
+                    sequence_control_set_ptr,
+                    context_ptr->sb_ptr,
+                    context_ptr->leaf_partition_neighbor_array);
+            }
+        }
+    }
+#endif
+#else
+    EbBool is_nsq_table_used = (picture_control_set_ptr->slice_type == !I_SLICE &&
+        picture_control_set_ptr->parent_pcs_ptr->pic_depth_mode <= PIC_ALL_C_DEPTH_MODE &&
+        picture_control_set_ptr->parent_pcs_ptr->nsq_search_level >= NSQ_SEARCH_LEVEL1 &&
+        picture_control_set_ptr->parent_pcs_ptr->nsq_search_level < NSQ_SEARCH_FULL) ? EB_TRUE : EB_FALSE;
+
+	is_nsq_table_used = picture_control_set_ptr->enc_mode == ENC_M0 ?  EB_FALSE : is_nsq_table_used;
     if (is_nsq_table_used) {
         if (context_ptr->blk_geom->shape == PART_N) {
             order_nsq_table(
@@ -7064,11 +7361,15 @@ void md_encode_block(
                 context_ptr->leaf_partition_neighbor_array);
         }
     }
+#endif
 
     uint8_t                            is_complete_sb = sequence_control_set_ptr->sb_geom[lcuAddr].is_complete_sb;
 
     if (allowed_ns_cu(
-        is_nsq_table_used, picture_control_set_ptr->parent_pcs_ptr->nsq_max_shapes_md,context_ptr,is_complete_sb ))
+#if COMBINE_MDC_NSQ_TABLE
+        picture_control_set_ptr->parent_pcs_ptr->mdc_depth_level,
+#endif
+        is_nsq_table_used, picture_control_set_ptr->parent_pcs_ptr->nsq_max_shapes_md, context_ptr, is_complete_sb))
     {
 
 #if SPEED_OPT
@@ -7593,6 +7894,10 @@ EB_EXTERN EbErrorType mode_decision_sb(
     context_ptr->inter_pred_dir_neighbor_array = picture_control_set_ptr->md_inter_pred_dir_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
     context_ptr->ref_frame_type_neighbor_array = picture_control_set_ptr->md_ref_frame_type_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
     context_ptr->interpolation_type_neighbor_array = picture_control_set_ptr->md_interpolation_type_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
+#if ADD_SUPPORT_TO_SKIP_PART_N
+    uint32_t  d1_block_itr = 0;
+    uint32_t  d1_first_block = 1;
+#endif
 
     EbPictureBufferDesc *input_picture_ptr = picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
     if (context_ptr->hbd_mode_decision) {
@@ -7680,21 +7985,44 @@ EB_EXTERN EbErrorType mode_decision_sb(
 #endif
         cu_ptr->mds_idx = blk_idx_mds;
         context_ptr->md_cu_arr_nsq[blk_idx_mds].mdc_split_flag = (uint16_t)leafDataPtr->split_flag;
-
+#if ADD_SUPPORT_TO_SKIP_PART_N
+        context_ptr->md_cu_arr_nsq[blk_geom->sqi_mds].split_flag = (uint16_t)leafDataPtr->split_flag;
+#endif
         cu_ptr->split_flag = (uint16_t)leafDataPtr->split_flag; //mdc indicates smallest or non valid CUs with split flag=
         cu_ptr->qp = context_ptr->qp;
         cu_ptr->best_d1_blk = blk_idx_mds;
-
+#if COMBINE_MDC_NSQ_TABLE
+        context_ptr->best_nsq_sahpe1 = leafDataPtr->ol_best_nsq_shape1;
+        context_ptr->best_nsq_sahpe2 = leafDataPtr->ol_best_nsq_shape2;
+        context_ptr->best_nsq_sahpe3 = leafDataPtr->ol_best_nsq_shape3;
+        context_ptr->best_nsq_sahpe4 = leafDataPtr->ol_best_nsq_shape4;
+        context_ptr->best_nsq_sahpe5 = leafDataPtr->ol_best_nsq_shape5;
+        context_ptr->best_nsq_sahpe6 = leafDataPtr->ol_best_nsq_shape6;
+        context_ptr->best_nsq_sahpe7 = leafDataPtr->ol_best_nsq_shape7;
+        context_ptr->best_nsq_sahpe8 = leafDataPtr->ol_best_nsq_shape8;
+#endif
             if (leafDataPtr->tot_d1_blocks != 1)
             {
+#if ADD_SUPPORT_TO_SKIP_PART_N
+                // We need to get the index of the sq_block for each NSQ branch
+                if (d1_first_block) {
+#else
                 if (blk_geom->shape == PART_N)
+#endif
                     copy_neighbour_arrays(      //save a clean neigh in [1], encode uses [0], reload the clean in [0] after done last ns block in a partition
                         picture_control_set_ptr,
                         context_ptr,
                         0, 1,
+#if ADD_SUPPORT_TO_SKIP_PART_N
+                        blk_geom->sqi_mds,
+#else
                         blk_idx_mds,
+#endif
                         sb_origin_x,
                         sb_origin_y);
+#if ADD_SUPPORT_TO_SKIP_PART_N
+                }
+#endif
             }
 
             int32_t mi_row = context_ptr->cu_origin_y >> MI_SIZE_LOG2;
@@ -7746,12 +8074,21 @@ EB_EXTERN EbErrorType mode_decision_sb(
             }
 
             memcpy(&context_ptr->md_ep_pipe_sb[cu_ptr->mds_idx], &context_ptr->md_ep_pipe_sb[redundant_blk_mds], sizeof(MdEncPassCuData));
+#if ADD_SUPPORT_TO_SKIP_PART_N
+            if (d1_block_itr == 0) {
+                uint8_t sq_index = LOG2F(context_ptr->blk_geom->sq_size) - 2;
+                context_ptr->parent_sq_type[sq_index] = src_cu->prediction_mode_flag;
+                context_ptr->parent_sq_has_coeff[sq_index] = src_cu->block_has_coeff;
+                context_ptr->parent_sq_pred_mode[sq_index] = src_cu->pred_mode;
+            }
+#else
             if (context_ptr->blk_geom->shape == PART_N) {
                 uint8_t sq_index = LOG2F(context_ptr->blk_geom->sq_size) - 2;
                 context_ptr->parent_sq_type[sq_index] = src_cu->prediction_mode_flag;
                 context_ptr->parent_sq_has_coeff[sq_index] = src_cu->block_has_coeff;
                 context_ptr->parent_sq_pred_mode[sq_index] = src_cu->pred_mode;
             }
+#endif
         }
         else
 #if FIX_SKIP_REDUNDANT_BLOCK
@@ -7759,7 +8096,11 @@ EB_EXTERN EbErrorType mode_decision_sb(
 #endif
             // Initialize tx_depth
             cu_ptr->tx_depth = 0;
+#if ADD_SUPPORT_TO_SKIP_PART_N
+            if (blk_geom->quadi > 0 && d1_block_itr == 0) {
+#else
             if (blk_geom->quadi > 0 && blk_geom->shape == PART_N) {
+#endif
 
                 uint32_t blk_mds = context_ptr->blk_geom->sqi_mds;
                 uint64_t parent_depth_cost = 0, current_depth_cost = 0;
@@ -7830,9 +8171,20 @@ EB_EXTERN EbErrorType mode_decision_sb(
         }
 #endif
         skip_next_nsq = 0;
+#if ADD_SUPPORT_TO_SKIP_PART_N
+        if (blk_geom->nsi + 1 == blk_geom->totns) {
+            d1_non_square_block_decision(context_ptr, d1_block_itr);
+            d1_block_itr++;
+        }
+#else
         if (blk_geom->nsi + 1 == blk_geom->totns)
             d1_non_square_block_decision(context_ptr);
+#endif
+#if ADD_SUPPORT_TO_SKIP_PART_N
+        else if (d1_block_itr) {
+#else
         else {
+#endif
             uint64_t tot_cost = 0;
             uint32_t first_blk_idx = context_ptr->cu_ptr->mds_idx - (blk_geom->nsi);//index of first block in this partition
             for (int blk_it = 0; blk_it < blk_geom->nsi + 1; blk_it++)
@@ -7844,6 +8196,7 @@ EB_EXTERN EbErrorType mode_decision_sb(
 #endif
                 skip_next_nsq = 1;
         }
+
         if (blk_geom->shape != PART_N) {
             if (blk_geom->nsi + 1 < blk_geom->totns)
                 md_update_all_neighbour_arrays(
@@ -7862,7 +8215,11 @@ EB_EXTERN EbErrorType mode_decision_sb(
                     sb_origin_y);
         }
 
+#if ADD_SUPPORT_TO_SKIP_PART_N
+        d1_blocks_accumlated = d1_first_block == 1 ? 1 : d1_blocks_accumlated + 1;
+#else
         d1_blocks_accumlated = blk_geom->shape == PART_N ? 1 : d1_blocks_accumlated + 1;
+#endif
 
         if (d1_blocks_accumlated == leafDataPtr->tot_d1_blocks)
         {
@@ -7876,6 +8233,10 @@ EB_EXTERN EbErrorType mode_decision_sb(
                 context_ptr->full_lambda,
                 context_ptr->md_rate_estimation_ptr,
                 picture_control_set_ptr);
+#if ADD_SUPPORT_TO_SKIP_PART_N
+            d1_block_itr = 0;
+            d1_first_block = 1;
+#endif
             context_ptr->coeff_based_skip_atb = picture_control_set_ptr->parent_pcs_ptr->coeff_based_skip_atb && context_ptr->md_cu_arr_nsq[lastCuIndex_mds].block_has_coeff == 0 ? 1 : 0;
             if (context_ptr->md_cu_arr_nsq[lastCuIndex_mds].split_flag == EB_FALSE)
             {
@@ -7887,6 +8248,11 @@ EB_EXTERN EbErrorType mode_decision_sb(
                     sb_origin_y);
             }
         }
+#if ADD_SUPPORT_TO_SKIP_PART_N
+        else if (d1_first_block)
+            d1_first_block = 0;
+#endif
+
         if (skip_sub_blocks && leaf_data_array[cuIdx].split_flag) {
             cuIdx++;
             while (cuIdx < leaf_count) {
@@ -11471,3 +11837,67 @@ EB_EXTERN EbErrorType in_loop_motion_estimation_sblock(
 
     return return_error;
 }
+
+#if PREDICT_NSQ_SHAPE
+uint64_t spatial_full_distortion_helper(
+    uint8_t  *input,
+    uint32_t input_offset,
+    uint32_t  input_stride,
+    uint8_t  *recon,
+    uint32_t recon_offset,
+    uint32_t  recon_stride,
+    uint32_t  area_width,
+    uint32_t  area_height,
+    uint8_t  choice) {
+
+    uint64_t sfd = 0;
+
+    switch (choice) {
+    case 0:
+        sfd = spatial_full_distortion_kernel4x_n_sse2_intrin(input, input_offset, input_stride, recon, recon_offset, recon_stride, area_width, area_height);break;
+    case 1:
+        sfd = spatial_full_distortion_kernel8x_n_sse2_intrin(input, input_offset, input_stride, recon, recon_offset, recon_stride, area_width, area_height);break;
+    case 2:
+        sfd = spatial_full_distortion_kernel16x_n_sse2_intrin(input, input_offset, input_stride, recon, recon_offset, recon_stride, area_width, area_height);break;
+    case 3:
+        sfd = spatial_full_distortion_kernel32x_n_sse2_intrin(input, input_offset, input_stride, recon, recon_offset, recon_stride, area_width, area_height);break;
+    case 4:
+        sfd = spatial_full_distortion_kernel64x_n_sse2_intrin(input, input_offset, input_stride, recon, recon_offset, recon_stride, area_width, area_height);break;
+    case 5:
+        sfd = spatial_full_distortion_kernel128x_n_sse2_intrin(input, input_offset, input_stride, recon, recon_offset, recon_stride, area_width, area_height);break;
+    }
+
+    return sfd;
+}
+
+uint64_t spatial_full_distortion_avx2_helper(
+    uint8_t  *input,
+    uint32_t input_offset,
+    uint32_t  input_stride,
+    uint8_t  *recon,
+    uint32_t recon_offset,
+    uint32_t  recon_stride,
+    uint32_t  area_width,
+    uint32_t  area_height,
+    uint8_t  choice) {
+
+    uint64_t sfd = 0;
+
+    switch (choice) {
+    case 0:
+        sfd = spatial_full_distortion_kernel4x_n_avx2_intrin(input, input_offset, input_stride, recon, recon_offset, recon_stride, area_width, area_height);break;
+    case 1:
+        sfd = spatial_full_distortion_kernel8x_n_avx2_intrin(input, input_offset, input_stride, recon, recon_offset, recon_stride, area_width, area_height);break;
+    case 2:
+        sfd = spatial_full_distortion_kernel16x_n_avx2_intrin(input, input_offset, input_stride, recon, recon_offset, recon_stride, area_width, area_height);break;
+    case 3:
+        sfd = spatial_full_distortion_kernel32x_n_avx2_intrin(input, input_offset, input_stride, recon, recon_offset, recon_stride, area_width, area_height);break;
+    case 4:
+        sfd = spatial_full_distortion_kernel64x_n_avx2_intrin(input, input_offset, input_stride, recon, recon_offset, recon_stride, area_width, area_height);break;
+    case 5:
+        sfd = spatial_full_distortion_kernel128x_n_avx2_intrin(input, input_offset, input_stride, recon, recon_offset, recon_stride, area_width, area_height);break;
+    }
+
+    return sfd;
+}
+#endif

--- a/Source/Lib/Common/Codec/EbRateDistortionCost.c
+++ b/Source/Lib/Common/Codec/EbRateDistortionCost.c
@@ -321,7 +321,11 @@ static int32_t get_eob_cost(int32_t eob, const LvMapEobCost *txb_eob_costs,
     return eob_cost;
 }
 
+#if ADD_MDC_FULL_COST
+int32_t av1_cost_skip_txb(
+#else
 static INLINE int32_t av1_cost_skip_txb(
+#endif
     uint8_t        allow_update_cdf,
     FRAME_CONTEXT *ec_ctx,
     struct ModeDecisionCandidateBuffer    *candidate_buffer_ptr,
@@ -704,32 +708,7 @@ uint64_t av1_intra_fast_cost(
         }
     }
 #endif
-    // NM- Harcoded assuming luma mode is equal to chroma mode
-    //if (!cm->seq_params.monochrome &&
-    //    is_chroma_reference(mi_row, mi_col, bsize, xd->plane[1].subsampling_x,
-    //    xd->plane[1].subsampling_y)) {
-    //    mbmi->uv_mode =
-    //        read_intra_mode_uv(ec_ctx, r, is_cfl_allowed(xd), mbmi->mode);
-    //    if (mbmi->uv_mode == UV_CFL_PRED) {
-    //        mbmi->cfl_alpha_idx =
-    //            read_cfl_alphas(xd->tile_ctx, r, &mbmi->cfl_alpha_signs);
-    //        xd->cfl.store_y = 1;
-    //    }
-    //    else {
-    //        xd->cfl.store_y = 0;
-    //    }
-    //    mbmi->angle_delta[PLANE_TYPE_UV] =
-    //        use_angle_delta && av1_is_directional_mode(get_uv_mode(mbmi->uv_mode))
-    //        ? read_angle_delta(r,
-    //        ec_ctx->angle_delta_cdf[mbmi->uv_mode - V_PRED])
-    //        : 0;
-    //}
-    //else {
-    //    // Avoid decoding angle_info if there is is no chroma prediction
-    //    mbmi->uv_mode = UV_DC_PRED;
-    //    xd->cfl.is_chroma_reference = 0;
-    //    xd->cfl.store_y = 1;
-    //}
+
     if (blk_geom->has_uv) {
         if (!isMonochromeFlag && is_chroma_reference(miRow, miCol, blk_geom->bsize, subSamplingX, subSamplingY)) {
             // Estimate luma nominal intra mode bits
@@ -1298,6 +1277,289 @@ int svt_is_interintra_allowed(
     PredictionMode mode,
     MvReferenceFrame ref_frame[2]);
 #endif
+
+#if ADD_MDC_FULL_COST
+uint64_t mdc_av1_inter_fast_cost(
+    CodingUnit                  *cu_ptr,
+    ModeDecisionCandidate       *candidate_ptr,
+    uint64_t                    luma_distortion,
+    uint64_t                    lambda,
+    EbBool                      use_ssd,
+    PictureControlSet           *picture_control_set_ptr,
+    CandidateMv                 *ref_mv_stack,
+    const BlockGeom             *blk_geom)
+
+{
+    // Luma rate
+    uint32_t           luma_rate = 0;
+    uint32_t           chroma_rate = 0;
+    uint64_t           mv_rate = 0;
+    uint64_t           skip_mode_rate;
+    // Luma and chroma distortion
+    uint64_t           luma_sad;
+    uint64_t           total_distortion;
+
+    uint32_t           rate;
+
+    int16_t           pred_ref_x;
+    int16_t           pred_ref_y;
+    int16_t           mv_ref_x;
+    int16_t           mv_ref_y;
+
+    EbReflist       ref_list_idx;
+
+    candidate_ptr->fast_luma_rate = 0;
+
+    PredictionMode inter_mode = (PredictionMode)candidate_ptr->pred_mode;
+
+    uint64_t inter_mode_bits_num = 0;
+
+    uint8_t skip_mode_ctx = 0;// cu_ptr->skip_flag_context;
+    MvReferenceFrame rf[2];
+    av1_set_ref_frame(rf, candidate_ptr->ref_frame_type);
+    const int8_t ref_frame = av1_ref_frame_type(rf);
+    cu_ptr->inter_mode_ctx[ref_frame] = 0;
+    uint32_t mode_ctx = Av1ModeContextAnalyzer(cu_ptr->inter_mode_ctx, rf);
+    skip_mode_rate = candidate_ptr->md_rate_estimation_ptr->skip_mode_fac_bits[skip_mode_ctx][0];
+    uint64_t reference_picture_bits_num = 0;
+
+    //Reference Type and Mode Bit estimation
+
+    reference_picture_bits_num = EstimateRefFramesNumBits(
+        picture_control_set_ptr,
+        candidate_ptr,
+        cu_ptr,
+        blk_geom->bwidth,
+        blk_geom->bheight,
+        candidate_ptr->ref_frame_type,
+        0,
+        candidate_ptr->is_compound);
+
+    if (candidate_ptr->is_compound)
+        inter_mode_bits_num += candidate_ptr->md_rate_estimation_ptr->inter_compound_mode_fac_bits[mode_ctx][INTER_COMPOUND_OFFSET(inter_mode)];
+    else {
+        //uint32_t newmv_ctx = mode_ctx & NEWMV_CTX_MASK;
+        //inter_mode_bits_num = candidate_buffer_ptr->candidate_ptr->md_rate_estimation_ptr->new_mv_mode_fac_bits[mode_ctx][0];
+
+        int16_t newmv_ctx = mode_ctx & NEWMV_CTX_MASK;
+        //aom_write_symbol(ec_writer, mode != NEWMV, frameContext->newmv_cdf[newmv_ctx], 2);
+        inter_mode_bits_num += candidate_ptr->md_rate_estimation_ptr->new_mv_mode_fac_bits[newmv_ctx][inter_mode != NEWMV];
+        if (inter_mode != NEWMV) {
+            const int16_t zeromvCtx = (mode_ctx >> GLOBALMV_OFFSET) & GLOBALMV_CTX_MASK;
+            //aom_write_symbol(ec_writer, mode != GLOBALMV, frameContext->zeromv_cdf[zeromvCtx], 2);
+            inter_mode_bits_num += candidate_ptr->md_rate_estimation_ptr->zero_mv_mode_fac_bits[zeromvCtx][inter_mode != GLOBALMV];
+            if (inter_mode != GLOBALMV) {
+                int16_t refmvCtx = (mode_ctx >> REFMV_OFFSET) & REFMV_CTX_MASK;
+                /*aom_write_symbol(ec_writer, mode != NEARESTMV, frameContext->refmv_cdf[refmv_ctx], 2);*/
+                inter_mode_bits_num += candidate_ptr->md_rate_estimation_ptr->ref_mv_mode_fac_bits[refmvCtx][inter_mode != NEARESTMV];
+            }
+        }
+    }
+    if (inter_mode == NEWMV || inter_mode == NEW_NEWMV || have_nearmv_in_inter_mode(inter_mode)) {
+        //drLIdex cost estimation
+        const int32_t new_mv = inter_mode == NEWMV || inter_mode == NEW_NEWMV;
+        if (new_mv) {
+            int32_t idx;
+            for (idx = 0; idx < 2; ++idx) {
+                if (cu_ptr->av1xd->ref_mv_count[candidate_ptr->ref_frame_type] > idx + 1) {
+                    uint8_t drl1Ctx =
+                        av1_drl_ctx(ref_mv_stack, idx);
+                    inter_mode_bits_num += candidate_ptr->md_rate_estimation_ptr->drl_mode_fac_bits[drl1Ctx][candidate_ptr->drl_index != idx];
+                    if (candidate_ptr->drl_index == idx) break;
+                }
+            }
+        }
+
+        if (have_nearmv_in_inter_mode(inter_mode)) {
+            int32_t idx;
+            // TODO(jingning): Temporary solution to compensate the NEARESTMV offset.
+            for (idx = 1; idx < 3; ++idx) {
+                if (cu_ptr->av1xd->ref_mv_count[candidate_ptr->ref_frame_type] > idx + 1) {
+                    uint8_t drl_ctx =
+                        av1_drl_ctx(ref_mv_stack, idx);
+                    inter_mode_bits_num += candidate_ptr->md_rate_estimation_ptr->drl_mode_fac_bits[drl_ctx][candidate_ptr->drl_index != (idx - 1)];
+
+                    if (candidate_ptr->drl_index == (idx - 1)) break;
+                }
+            }
+        }
+    }
+
+    if (have_newmv_in_inter_mode(inter_mode)) {
+        if (candidate_ptr->is_compound) {
+            mv_rate = 0;
+
+            if (inter_mode == NEW_NEWMV) {
+                for (ref_list_idx = 0; ref_list_idx < 2; ++ref_list_idx) {
+                    pred_ref_x = candidate_ptr->motion_vector_pred_x[ref_list_idx];
+                    pred_ref_y = candidate_ptr->motion_vector_pred_y[ref_list_idx];
+                    mv_ref_x = ref_list_idx == REF_LIST_1 ? candidate_ptr->motion_vector_xl1 : candidate_ptr->motion_vector_xl0;
+                    mv_ref_y = ref_list_idx == REF_LIST_1 ? candidate_ptr->motion_vector_yl1 : candidate_ptr->motion_vector_yl0;
+
+                    MV mv;
+                    mv.row = mv_ref_y;
+                    mv.col = mv_ref_x;
+
+                    MV ref_mv;
+                    ref_mv.row = pred_ref_y;
+                    ref_mv.col = pred_ref_x;
+
+                    mv_rate += eb_av1_mv_bit_cost(
+                        &mv,
+                        &ref_mv,
+                        candidate_ptr->md_rate_estimation_ptr->nmv_vec_cost,
+                        candidate_ptr->md_rate_estimation_ptr->nmvcoststack,
+                        MV_COST_WEIGHT);
+                }
+            }
+            else if (inter_mode == NEAREST_NEWMV || inter_mode == NEAR_NEWMV) {
+                pred_ref_x = candidate_ptr->motion_vector_pred_x[REF_LIST_1];
+                pred_ref_y = candidate_ptr->motion_vector_pred_y[REF_LIST_1];
+                mv_ref_x = candidate_ptr->motion_vector_xl1;
+                mv_ref_y = candidate_ptr->motion_vector_yl1;
+
+                MV mv;
+                mv.row = mv_ref_y;
+                mv.col = mv_ref_x;
+
+                MV ref_mv;
+                ref_mv.row = pred_ref_y;
+                ref_mv.col = pred_ref_x;
+
+                mv_rate += eb_av1_mv_bit_cost(
+                    &mv,
+                    &ref_mv,
+                    candidate_ptr->md_rate_estimation_ptr->nmv_vec_cost,
+                    candidate_ptr->md_rate_estimation_ptr->nmvcoststack,
+                    MV_COST_WEIGHT);
+            }
+            else {
+                assert(inter_mode == NEW_NEARESTMV || inter_mode == NEW_NEARMV);
+
+                pred_ref_x = candidate_ptr->motion_vector_pred_x[REF_LIST_0];
+                pred_ref_y = candidate_ptr->motion_vector_pred_y[REF_LIST_0];
+                mv_ref_x = candidate_ptr->motion_vector_xl0;
+                mv_ref_y = candidate_ptr->motion_vector_yl0;
+
+                MV mv;
+                mv.row = mv_ref_y;
+                mv.col = mv_ref_x;
+
+                MV ref_mv;
+                ref_mv.row = pred_ref_y;
+                ref_mv.col = pred_ref_x;
+
+                mv_rate += eb_av1_mv_bit_cost(
+                    &mv,
+                    &ref_mv,
+                    candidate_ptr->md_rate_estimation_ptr->nmv_vec_cost,
+                    candidate_ptr->md_rate_estimation_ptr->nmvcoststack,
+                    MV_COST_WEIGHT);
+            }
+        }
+        else {
+            ref_list_idx = candidate_ptr->prediction_direction[0] == 0 ? 0 : 1;
+
+            pred_ref_x = candidate_ptr->motion_vector_pred_x[ref_list_idx];
+            pred_ref_y = candidate_ptr->motion_vector_pred_y[ref_list_idx];
+
+            mv_ref_x = ref_list_idx == 0 ? candidate_ptr->motion_vector_xl0 : candidate_ptr->motion_vector_xl1;
+            mv_ref_y = ref_list_idx == 0 ? candidate_ptr->motion_vector_yl0 : candidate_ptr->motion_vector_yl1;
+
+            MV mv;
+            mv.row = mv_ref_y;
+            mv.col = mv_ref_x;
+
+            MV ref_mv;
+            ref_mv.row = pred_ref_y;
+            ref_mv.col = pred_ref_x;
+
+            mv_rate = eb_av1_mv_bit_cost(
+                &mv,
+                &ref_mv,
+                candidate_ptr->md_rate_estimation_ptr->nmv_vec_cost,
+                candidate_ptr->md_rate_estimation_ptr->nmvcoststack,
+                MV_COST_WEIGHT);
+        }
+    }
+    EbBool is_inter = inter_mode >= SINGLE_INTER_MODE_START && inter_mode < SINGLE_INTER_MODE_END;
+    if (is_inter
+        //&& picture_control_set_ptr->parent_pcs_ptr->switchable_motion_mode
+        && rf[1] != INTRA_FRAME)
+    {
+        MotionMode motion_mode_rd = candidate_ptr->motion_mode;
+        BlockSize bsize = blk_geom->bsize;
+        cu_ptr->prediction_unit_array[0].num_proj_ref = candidate_ptr->num_proj_ref;
+        MotionMode last_motion_mode_allowed = motion_mode_allowed(
+            picture_control_set_ptr,
+            cu_ptr,
+            bsize,
+            rf[0],
+            rf[1],
+            inter_mode);
+
+        switch (last_motion_mode_allowed) {
+        case SIMPLE_TRANSLATION: break;
+        case OBMC_CAUSAL:
+            assert(motion_mode_rd == SIMPLE_TRANSLATION); // TODO: remove when OBMC added
+            inter_mode_bits_num += candidate_ptr->md_rate_estimation_ptr->motion_mode_fac_bits1[bsize][motion_mode_rd];
+            break;
+        default:
+            inter_mode_bits_num += candidate_ptr->md_rate_estimation_ptr->motion_mode_fac_bits[bsize][motion_mode_rd];
+        }
+    }
+
+    uint32_t is_inter_rate = candidate_ptr->md_rate_estimation_ptr->intra_inter_fac_bits[cu_ptr->is_inter_ctx][1];
+    luma_rate = (uint32_t)(reference_picture_bits_num + skip_mode_rate + inter_mode_bits_num + mv_rate + is_inter_rate);
+    // Keep the Fast Luma and Chroma rate for future use
+    candidate_ptr->fast_luma_rate = luma_rate;
+    candidate_ptr->fast_chroma_rate = chroma_rate;
+
+    if (use_ssd) {
+        int32_t current_q_index = MAX(0, MIN(QINDEX_RANGE - 1, picture_control_set_ptr->parent_pcs_ptr->base_qindex));
+        Dequants *const dequants = &picture_control_set_ptr->parent_pcs_ptr->deq;
+
+        int16_t quantizer = dequants->y_dequant_Q3[current_q_index][1];
+        rate = 0;
+        model_rd_from_sse(
+            blk_geom->bsize,
+            quantizer,
+            luma_distortion,
+            &rate,
+            &luma_sad);
+        luma_rate += rate;
+        total_distortion = luma_sad;
+        rate = luma_rate;
+
+        if (candidate_ptr->merge_flag) {
+            uint64_t skip_mode_rate = candidate_ptr->md_rate_estimation_ptr->skip_mode_fac_bits[skip_mode_ctx][1];
+            if (skip_mode_rate < rate) {
+                candidate_ptr->fast_luma_rate = skip_mode_rate;
+                return(RDCOST(lambda, skip_mode_rate, total_distortion));
+            }
+        }
+        candidate_ptr->fast_luma_rate = rate;
+        return(RDCOST(lambda, rate, total_distortion));
+    }
+    else {
+        luma_sad = (LUMA_WEIGHT * luma_distortion) << AV1_COST_PRECISION;
+        total_distortion = luma_sad;
+        rate = luma_rate;
+
+        // Assign fast cost
+        if (candidate_ptr->merge_flag) {
+            uint64_t skip_mode_rate = candidate_ptr->md_rate_estimation_ptr->skip_mode_fac_bits[skip_mode_ctx][1];
+            if (skip_mode_rate < rate) {
+                candidate_ptr->fast_luma_rate = skip_mode_rate;
+                return(RDCOST(lambda, skip_mode_rate, total_distortion));
+            }
+        }
+        candidate_ptr->fast_luma_rate = rate;
+        return(RDCOST(lambda, rate, total_distortion));
+    }
+}
+#endif
+
 uint64_t av1_inter_fast_cost(
     CodingUnit            *cu_ptr,
     ModeDecisionCandidate *candidate_ptr,
@@ -1681,6 +1943,7 @@ uint64_t av1_inter_fast_cost(
         return(RDCOST(lambda, rate, totalDistortion));
     }
 }
+
 
 EbErrorType av1_tu_estimate_coeff_bits(
     struct ModeDecisionContext         *md_context,

--- a/Source/Lib/Common/Codec/EbRateDistortionCost.h
+++ b/Source/Lib/Common/Codec/EbRateDistortionCost.h
@@ -192,6 +192,18 @@ extern "C" {
         uint32_t                 left_neighbor_mode,
         uint32_t                 top_neighbor_mode);
 
+#if ADD_MDC_FULL_COST
+    uint64_t mdc_av1_inter_fast_cost(
+        CodingUnit             *cu_ptr,
+        ModeDecisionCandidate  *candidate_ptr,
+        uint64_t                 luma_distortion,
+        uint64_t                 lambda,
+        EbBool                   use_ssd,
+        PictureControlSet       *picture_control_set_ptr,
+        CandidateMv             *ref_mv_stack,
+        const BlockGeom         *blk_geom);
+#endif
+
     extern EbErrorType av1_intra_full_cost(
         PictureControlSet                    *picture_control_set_ptr,
         ModeDecisionContext                  *context_ptr,
@@ -219,6 +231,16 @@ extern "C" {
         uint64_t                                 *cb_coeff_bits,
         uint64_t                                 *cr_coeff_bits,
         BlockSize                                bsize);
+
+#if ADD_MDC_FULL_COST
+    int32_t av1_cost_skip_txb(
+        uint8_t                                 allow_update_cdf,
+        FRAME_CONTEXT                           *ec_ctx,
+        struct ModeDecisionCandidateBuffer    *candidate_buffer_ptr,
+        TxSize                                  transform_size,
+        PlaneType                               plane_type,
+        int16_t                                   txb_skip_ctx);
+#endif
 
 #if ENHANCE_ATB
     extern uint64_t get_tx_size_bits(

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -257,6 +257,12 @@ extern "C" {
     uint64_t spatial_full_distortion_kernel_avx2(uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon, uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
     uint64_t spatial_full_distortion_kernel_avx512(uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon, uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
 
+#if PREDICT_NSQ_SHAPE
+    uint64_t spatial_full_distortion_helper(uint8_t  *input, uint32_t input_offset, uint32_t  input_stride, uint8_t  *recon, uint32_t recon_offset, uint32_t  recon_stride, uint32_t  area_width, uint32_t  area_height, uint8_t  choice);
+    uint64_t spatial_full_distortion_avx2_helper(uint8_t  *input, uint32_t input_offset, uint32_t  input_stride, uint8_t  *recon, uint32_t recon_offset, uint32_t  recon_stride, uint32_t  area_width, uint32_t  area_height, uint8_t  choice);
+    RTCD_EXTERN uint64_t(*spatial_full_distortion)(uint8_t  *input, uint32_t input_offset, uint32_t  input_stride, uint8_t  *recon, uint32_t recon_offset, uint32_t  recon_stride, uint32_t  area_width, uint32_t  area_height, uint8_t  choice);
+#endif
+
     typedef uint64_t(*EbSpatialFullDistType)(
         uint8_t   *input,
         uint32_t   input_offset,
@@ -3030,6 +3036,11 @@ extern "C" {
         if (flags & HAS_AVX2) eb_compute_cdef_dist = compute_cdef_dist_avx2;
         eb_compute_cdef_dist_8bit = compute_cdef_dist_8bit_c;
         if (flags & HAS_AVX2) eb_compute_cdef_dist_8bit = compute_cdef_dist_8bit_avx2;
+
+#if PREDICT_NSQ_SHAPE
+        spatial_full_distortion = spatial_full_distortion_helper;
+        if (flags & HAS_AVX2) spatial_full_distortion = spatial_full_distortion_avx2_helper;
+#endif
 
         eb_copy_rect8_8bit_to_16bit = eb_copy_rect8_8bit_to_16bit_c;
         if (flags & HAS_AVX2) eb_copy_rect8_8bit_to_16bit = eb_copy_rect8_8bit_to_16bit_avx2;


### PR DESCRIPTION
## Description

This is a first pass of partitioning decision which ranks all possible partitions based on the open loop EME data. A reduced set of partitions is forwarded to the closed loop partitioning decision pass.

Closes #721  

## Author

@NaderMahdi 

## Type of Change

New feature

## Tests and Performance

- BD rate difference of -0.05% compared to libaom_fd530f8 in M0 with the fullset of clips.
- No BD rate difference for 360p or screen content clips
- A speed gain of 6% was obtained measured over all clips.
- ~1% memory allocation increase