### PR TITLE
[SIMD] Add combined_averaging_ssd_avx512() and eb_av1_txb_init_levels_avx512()

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/EbCombinedAveragingSAD_Inline_AVX2.h
+++ b/Source/Lib/Common/ASM_AVX2/EbCombinedAveragingSAD_Inline_AVX2.h
@@ -1,0 +1,58 @@
+/*
+* Copyright(c) 2019 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#ifndef EbCombinedAveragingSAD_Inline_AVX2_h
+#define EbCombinedAveragingSAD_Inline_AVX2_h
+
+#include "immintrin.h"
+#include "EbDefinitions.h"
+#include "EbMemory_AVX2.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    static INLINE void ssd8x2_avx2(const uint8_t *const src,
+        const ptrdiff_t src_stride,
+        const uint8_t *const ref1,
+        const ptrdiff_t ref1_stride,
+        const uint8_t *const ref2,
+        const ptrdiff_t ref2_stride, __m256i *const sum) {
+        const __m256i zero = _mm256_setzero_si256();
+        const __m256i s = load_u8_8x2_avx2(src, src_stride);
+        const __m256i r1 = load_u8_8x2_avx2(ref1, ref1_stride);
+        const __m256i r2 = load_u8_8x2_avx2(ref2, ref2_stride);
+        const __m256i avg = _mm256_avg_epu8(r1, r2);
+        const __m256i s_256 = _mm256_unpacklo_epi8(s, zero);
+        const __m256i avg_256 = _mm256_unpacklo_epi8(avg, zero);
+        const __m256i dif = _mm256_sub_epi16(s_256, avg_256);
+        const __m256i sqr = _mm256_madd_epi16(dif, dif);
+        *sum = _mm256_add_epi32(*sum, sqr);
+    }
+
+    static INLINE void ssd32_avx2(const uint8_t *const src,
+        const uint8_t *const ref1,
+        const uint8_t *const ref2, __m256i *const sum) {
+        const __m256i zero = _mm256_setzero_si256();
+        const __m256i s = _mm256_loadu_si256((__m256i *)src);
+        const __m256i r1 = _mm256_loadu_si256((__m256i *)ref1);
+        const __m256i r2 = _mm256_loadu_si256((__m256i *)ref2);
+        const __m256i avg = _mm256_avg_epu8(r1, r2);
+        const __m256i s0 = _mm256_unpacklo_epi8(s, zero);
+        const __m256i s1 = _mm256_unpackhi_epi8(s, zero);
+        const __m256i avg0 = _mm256_unpacklo_epi8(avg, zero);
+        const __m256i avg1 = _mm256_unpackhi_epi8(avg, zero);
+        const __m256i dif0 = _mm256_sub_epi16(s0, avg0);
+        const __m256i dif1 = _mm256_sub_epi16(s1, avg1);
+        const __m256i sqr0 = _mm256_madd_epi16(dif0, dif0);
+        const __m256i sqr1 = _mm256_madd_epi16(dif1, dif1);
+        *sum = _mm256_add_epi32(*sum, sqr0);
+        *sum = _mm256_add_epi32(*sum, sqr1);
+    }
+
+#ifdef __cplusplus
+}
+#endif
+#endif // EbCombinedAveragingSAD_Inline_AVX2_h

--- a/Source/Lib/Common/ASM_AVX2/EbCombinedAveragingSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbCombinedAveragingSAD_Intrinsic_AVX2.c
@@ -3,12 +3,11 @@
 * SPDX - License - Identifier: BSD - 2 - Clause - Patent
 */
 
-#include "EbCombinedAveragingSAD_Intrinsic_AVX2.h"
 #include "immintrin.h"
+#include "EbCombinedAveragingSAD_Inline_AVX2.h"
+#include "EbCombinedAveragingSAD_Intrinsic_AVX2.h"
 #include "EbMemory_AVX2.h"
-
-#define _mm256_set_m128i(/* __m128i */ hi, /* __m128i */ lo) \
-    _mm256_insertf128_si256(_mm256_castsi128_si256(lo), (hi), 0x1)
+#include "EbMemory_SSE4_1.h"
 
 uint32_t combined_averaging8x_msad_avx2_intrin(
     uint8_t  *src,
@@ -22,10 +21,10 @@ uint32_t combined_averaging8x_msad_avx2_intrin(
 {
     __m256i sum = _mm256_setzero_si256();
     __m128i sad;
-    uint32_t y;
+    uint32_t y = height;
     (void)width;
 
-    for (y = 0; y < height; y += 4) {
+    do {
         const __m256i s = load_u8_8x4_avx2(src, src_stride);
         const __m256i r1 = load_u8_8x4_avx2(ref1, ref1_stride);
         const __m256i r2 = load_u8_8x4_avx2(ref2, ref2_stride);
@@ -35,7 +34,8 @@ uint32_t combined_averaging8x_msad_avx2_intrin(
         src += src_stride << 2;
         ref1 += ref1_stride << 2;
         ref2 += ref2_stride << 2;
-    }
+        y -= 4;
+    } while (y);
 
     sad = _mm_add_epi32(_mm256_castsi256_si128(sum),
         _mm256_extracti128_si256(sum, 1));
@@ -68,16 +68,17 @@ uint32_t combined_averaging16x_msad_avx2_intrin(
 {
     __m256i sum = _mm256_setzero_si256();
     __m128i sad;
-    uint32_t y;
+    uint32_t y = height;
     (void)width;
 
-    for (y = 0; y < height; y += 2) {
+    do {
         sum = CombinedAveragingSad16x2_AVX2(src, src_stride, ref1, ref1_stride,
             ref2, ref2_stride, sum);
         src += src_stride << 1;
         ref1 += ref1_stride << 1;
         ref2 += ref2_stride << 1;
-    }
+        y -= 2;
+    } while (y);
 
     sad = _mm_add_epi32(_mm256_castsi256_si128(sum),
         _mm256_extracti128_si256(sum, 1));
@@ -109,10 +110,10 @@ uint32_t combined_averaging24x_msad_avx2_intrin(
 {
     __m256i sum = _mm256_setzero_si256();
     __m128i sad;
-    uint32_t y;
+    uint32_t y = height;
     (void)width;
 
-    for (y = 0; y < height; y += 2) {
+    do {
         sum = CombinedAveragingSad24_AVX2(src + 0 * src_stride,
             ref1 + 0 * ref1_stride, ref2 + 0 * ref2_stride, sum);
         sum = CombinedAveragingSad24_AVX2(src + 1 * src_stride,
@@ -120,7 +121,8 @@ uint32_t combined_averaging24x_msad_avx2_intrin(
         src += src_stride << 1;
         ref1 += ref1_stride << 1;
         ref2 += ref2_stride << 1;
-    }
+        y -= 2;
+    } while (y);
 
     sad = _mm_add_epi32(_mm256_castsi256_si128(sum),
         _mm_slli_si128(_mm256_extracti128_si256(sum, 1), 8));
@@ -152,10 +154,10 @@ uint32_t combined_averaging32x_msad_avx2_intrin(
 {
     __m256i sum = _mm256_setzero_si256();
     __m128i sad;
-    uint32_t y;
+    uint32_t y = height;
     (void)width;
 
-    for (y = 0; y < height; y += 2) {
+    do {
         sum = CombinedAveragingSad32_AVX2(src + 0 * src_stride,
             ref1 + 0 * ref1_stride, ref2 + 0 * ref2_stride, sum);
         sum = CombinedAveragingSad32_AVX2(src + 1 * src_stride,
@@ -163,7 +165,8 @@ uint32_t combined_averaging32x_msad_avx2_intrin(
         src += src_stride << 1;
         ref1 += ref1_stride << 1;
         ref2 += ref2_stride << 1;
-    }
+        y -= 2;
+    } while (y);
 
     sad = _mm_add_epi32(_mm256_castsi256_si128(sum),
         _mm256_extracti128_si256(sum, 1));
@@ -184,10 +187,10 @@ uint32_t combined_averaging48x_msad_avx2_intrin(
 {
     __m256i sum = _mm256_setzero_si256();
     __m128i sad;
-    uint32_t y;
+    uint32_t y = height;
     (void)width;
 
-    for (y = 0; y < height; y += 2) {
+    do {
         sum = CombinedAveragingSad32_AVX2(src + 0 * src_stride,
             ref1 + 0 * ref1_stride, ref2 + 0 * ref2_stride, sum);
         sum = CombinedAveragingSad32_AVX2(src + 1 * src_stride,
@@ -198,7 +201,8 @@ uint32_t combined_averaging48x_msad_avx2_intrin(
         src += src_stride << 1;
         ref1 += ref1_stride << 1;
         ref2 += ref2_stride << 1;
-    }
+        y -= 2;
+    } while (y);
 
     sad = _mm_add_epi32(_mm256_castsi256_si128(sum),
         _mm256_extracti128_si256(sum, 1));
@@ -219,10 +223,10 @@ uint32_t combined_averaging64x_msad_avx2_intrin(
 {
     __m256i sum = _mm256_setzero_si256();
     __m128i sad;
-    uint32_t y;
+    uint32_t y = height;
     (void)width;
 
-    for (y = 0; y < height; y++) {
+    do {
         sum = CombinedAveragingSad32_AVX2(src + 0x00,
             ref1 + 0x00, ref2 + 0x00, sum);
         sum = CombinedAveragingSad32_AVX2(src + 0x20,
@@ -230,7 +234,7 @@ uint32_t combined_averaging64x_msad_avx2_intrin(
         src += src_stride;
         ref1 += ref1_stride;
         ref2 += ref2_stride;
-    }
+    } while (--y);
 
     sad = _mm_add_epi32(_mm256_castsi256_si128(sum),
         _mm256_extracti128_si256(sum, 1));
@@ -349,7 +353,7 @@ void  compute_interm_var_four8x8_avx2_intrin(
     ymm_blockMeanSquaredlow = _mm256_permutevar8x32_epi32(ymm_blockMeanSquaredlow, ymm_permute8/*8*/);
     ymm_blockMeanSquaredHi = _mm256_permutevar8x32_epi32(ymm_blockMeanSquaredHi, ymm_permute8);
 
-    ymm_blockMeanSquaredlo = _mm256_extracti128_si256(ymm_blockMeanSquaredlow, 0); //lower 128
+    ymm_blockMeanSquaredlo = _mm256_castsi256_si128(ymm_blockMeanSquaredlow); //lower 128
     ymm_blockMeanSquaredhi = _mm256_extracti128_si256(ymm_blockMeanSquaredHi, 0); //lower 128
 
     ymm_result = _mm256_unpacklo_epi32(_mm256_castsi128_si256(ymm_blockMeanSquaredlo), _mm256_castsi128_si256(ymm_blockMeanSquaredhi));
@@ -368,48 +372,118 @@ void  compute_interm_var_four8x8_avx2_intrin(
     _mm256_storeu_si256((__m256i *)(mean_of_squared8x8_blocks), ymm_result);
 }
 
-uint32_t combined_averaging_ssd_avx2(
-    uint8_t   *src,
-    ptrdiff_t  src_stride,
-    uint8_t   *ref1,
-    ptrdiff_t  ref1_stride,
-    uint8_t   *ref2,
-    ptrdiff_t  ref2_stride,
-    uint32_t   height,
-    uint32_t   width)
-{
-    __m256i sum = _mm256_setzero_si256();
-    __m256i s, r1, r2, avg, ssd;
-    __m128i sum1_128, sum2_128;
-    uint32_t row, col;
+uint32_t combined_averaging_ssd_avx2(uint8_t *src, ptrdiff_t src_stride,
+    uint8_t *ref1, ptrdiff_t ref1_stride,
+    uint8_t *ref2, ptrdiff_t ref2_stride,
+    uint32_t height, uint32_t width) {
+    uint32_t y = height;
+    __m128i sum_128;
 
-    for (row = 0; row < height; row++)
-    {
-        for (col = 0; col < width; col += 4)
-        {
-            s = _mm256_setzero_si256();
-            r1 = _mm256_setzero_si256();
-            r2 = _mm256_setzero_si256();
-            s = _mm256_insert_epi32(s, *(int32_t *)(src + col), 0);
-            r1 = _mm256_insert_epi32(r1, *(int32_t *)(ref1 + col), 0);
-            r2 = _mm256_insert_epi32(r2, *(int32_t *)(ref2 + col), 0);
+    if (width & 4) {
+        const __m128i zero = _mm_setzero_si128();
 
-            avg = _mm256_avg_epu8(r1, r2);
-            ssd = _mm256_cvtepu8_epi64(_mm256_castsi256_si128(avg));
-            s = _mm256_cvtepu8_epi64(_mm256_castsi256_si128(s));
-            ssd = _mm256_sub_epi64(s, ssd);
-            ssd = _mm256_mul_epi32(ssd, ssd);
+        sum_128 = _mm_setzero_si128();
 
-            sum = _mm256_add_epi64(sum, ssd);
-        }
-        src += src_stride;
-        ref1 += ref1_stride;
-        ref2 += ref2_stride;
+        do {
+            uint32_t x = 0;
+            do {
+                const __m128i s = load_u8_4x2_sse4_1(src + x, src_stride);
+                const __m128i r1 = load_u8_4x2_sse4_1(ref1 + x, ref1_stride);
+                const __m128i r2 = load_u8_4x2_sse4_1(ref2 + x, ref2_stride);
+                const __m128i avg = _mm_avg_epu8(r1, r2);
+                const __m128i s16 = _mm_unpacklo_epi8(s, zero);
+                const __m128i avg16 = _mm_unpacklo_epi8(avg, zero);
+                const __m128i dif = _mm_sub_epi16(s16, avg16);
+                const __m128i sqr = _mm_madd_epi16(dif, dif);
+                sum_128 = _mm_add_epi32(sum_128, sqr);
+                x += 4;
+            } while (x < width);
+
+            src += 2 * src_stride;
+            ref1 += 2 * ref1_stride;
+            ref2 += 2 * ref2_stride;
+            y -= 2;
+        } while (y);
     }
-    sum1_128 = _mm256_extracti128_si256(sum, 0);
-    sum2_128 = _mm256_extracti128_si256(sum, 1);
-    sum1_128 = _mm_add_epi64(sum1_128, sum2_128);
-    sum2_128 = _mm_shuffle_epi32(sum1_128, 0xc6);
-    sum1_128 = _mm_add_epi64(sum1_128, sum2_128);
-    return _mm_cvtsi128_si32(sum1_128);
+    else {
+        __m256i sum = _mm256_setzero_si256();
+
+        if (width == 8) {
+            do {
+                ssd8x2_avx2(src,
+                    src_stride,
+                    ref1,
+                    ref1_stride,
+                    ref2,
+                    ref2_stride,
+                    &sum);
+                src += 2 * src_stride;
+                ref1 += 2 * ref1_stride;
+                ref2 += 2 * ref2_stride;
+                y -= 2;
+            } while (y);
+        }
+        else if (width == 16) {
+            do {
+                const __m128i s = _mm_loadu_si128((__m128i *)src);
+                const __m128i r1 = _mm_loadu_si128((__m128i *)ref1);
+                const __m128i r2 = _mm_loadu_si128((__m128i *)ref2);
+                const __m128i avg = _mm_avg_epu8(r1, r2);
+                const __m256i s_256 = _mm256_cvtepu8_epi16(s);
+                const __m256i avg_256 = _mm256_cvtepu8_epi16(avg);
+                const __m256i dif = _mm256_sub_epi16(s_256, avg_256);
+                const __m256i sqr = _mm256_madd_epi16(dif, dif);
+                sum = _mm256_add_epi32(sum, sqr);
+
+                src += src_stride;
+                ref1 += ref1_stride;
+                ref2 += ref2_stride;
+            } while (--y);
+        }
+        else if (width == 32) {
+            do {
+                ssd32_avx2(src, ref1, ref2, &sum);
+                src += src_stride;
+                ref1 += ref1_stride;
+                ref2 += ref2_stride;
+            } while (--y);
+        }
+        else if (width == 64) {
+            do {
+                ssd32_avx2(src + 0 * 32, ref1 + 0 * 32, ref2 + 0 * 32, &sum);
+                ssd32_avx2(src + 1 * 32, ref1 + 1 * 32, ref2 + 1 * 32, &sum);
+                src += src_stride;
+                ref1 += ref1_stride;
+                ref2 += ref2_stride;
+            } while (--y);
+        }
+        else {
+            do {
+                uint32_t x = 0;
+                do {
+                    ssd8x2_avx2(src + x,
+                        src_stride,
+                        ref1 + x,
+                        ref1_stride,
+                        ref2 + x,
+                        ref2_stride,
+                        &sum);
+                    x += 8;
+                } while (x < width);
+
+                src += 2 * src_stride;
+                ref1 += 2 * ref1_stride;
+                ref2 += 2 * ref2_stride;
+                y -= 2;
+            } while (y);
+        }
+
+        const __m128i sum0_128 = _mm256_castsi256_si128(sum);
+        const __m128i sum1_128 = _mm256_extracti128_si256(sum, 1);
+        sum_128 = _mm_add_epi32(sum0_128, sum1_128);
+    }
+
+    sum_128 = _mm_add_epi32(sum_128, _mm_srli_si128(sum_128, 8));
+    sum_128 = _mm_add_epi32(sum_128, _mm_srli_si128(sum_128, 4));
+    return _mm_cvtsi128_si32(sum_128);
 }

--- a/Source/Lib/Common/ASM_AVX2/EbCombinedAveragingSAD_Intrinsic_AVX2.h
+++ b/Source/Lib/Common/ASM_AVX2/EbCombinedAveragingSAD_Intrinsic_AVX2.h
@@ -82,16 +82,6 @@ extern "C" {
         uint64_t *mean_of8x8_blocks,      // mean of four  8x8
         uint64_t *mean_of_squared8x8_blocks);
 
-    uint32_t combined_averaging_ssd_avx2(
-        uint8_t   *src,
-        ptrdiff_t  src_stride,
-        uint8_t   *ref1,
-        ptrdiff_t  ref1_stride,
-        uint8_t   *ref2,
-        ptrdiff_t  ref2_stride,
-        uint32_t   height,
-        uint32_t   width);
-
 #ifdef __cplusplus
 }
 #endif

--- a/Source/Lib/Common/ASM_AVX2/EbMemory_AVX2.h
+++ b/Source/Lib/Common/ASM_AVX2/EbMemory_AVX2.h
@@ -33,6 +33,13 @@ static INLINE __m256i load_u8_4x4_avx2(const uint8_t *const src,
     return _mm256_setr_m128i(src01, src23);
 }
 
+static INLINE __m256i load_u8_8x2_avx2(const uint8_t *const src,
+    const ptrdiff_t stride) {
+    const __m128i s0 = _mm_loadl_epi64((__m128i *)src);
+    const __m128i s1 = _mm_loadl_epi64((__m128i *)(src + stride));
+    return _mm256_setr_m128i(s0, s1);
+}
+
 static INLINE __m256i load_u8_8x4_avx2(const uint8_t *const src,
     const uint32_t stride)
 {

--- a/Source/Lib/Common/ASM_AVX512/EbCombinedAveragingSAD_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/EbCombinedAveragingSAD_AVX512.c
@@ -1,0 +1,181 @@
+/*
+* Copyright(c) 2019 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#include "immintrin.h"
+#include "EbCombinedAveragingSAD_Inline_AVX2.h"
+#include "EbCombinedAveragingSAD_Intrinsic_AVX2.h"
+#include "EbMemory_AVX2.h"
+#include "EbMemory_SSE4_1.h"
+
+#ifndef NON_AVX512_SUPPORT
+
+static INLINE void ssd32_avx512(const uint8_t *const src,
+    const uint8_t *const ref1,
+    const uint8_t *const ref2, __m512i *const sum) {
+    const __m256i s = _mm256_loadu_si256((__m256i *)src);
+    const __m256i r1 = _mm256_loadu_si256((__m256i *)ref1);
+    const __m256i r2 = _mm256_loadu_si256((__m256i *)ref2);
+    const __m256i avg = _mm256_avg_epu8(r1, r2);
+    const __m512i s0 = _mm512_cvtepu8_epi16(s);
+    const __m512i avg0 = _mm512_cvtepu8_epi16(avg);
+    const __m512i dif0 = _mm512_sub_epi16(s0, avg0);
+    const __m512i sqr0 = _mm512_madd_epi16(dif0, dif0);
+    *sum = _mm512_add_epi32(*sum, sqr0);
+}
+
+static INLINE void ssd64_avx512(const uint8_t *const src,
+    const uint8_t *const ref1,
+    const uint8_t *const ref2, __m512i *const sum) {
+    const __m512i zero = _mm512_setzero_si512();
+    const __m512i s = _mm512_loadu_si512((__m512i *)src);
+    const __m512i r1 = _mm512_loadu_si512((__m512i *)ref1);
+    const __m512i r2 = _mm512_loadu_si512((__m512i *)ref2);
+    const __m512i avg = _mm512_avg_epu8(r1, r2);
+    const __m512i s0 = _mm512_unpacklo_epi8(s, zero);
+    const __m512i s1 = _mm512_unpackhi_epi8(s, zero);
+    const __m512i avg0 = _mm512_unpacklo_epi8(avg, zero);
+    const __m512i avg1 = _mm512_unpackhi_epi8(avg, zero);
+    const __m512i dif0 = _mm512_sub_epi16(s0, avg0);
+    const __m512i dif1 = _mm512_sub_epi16(s1, avg1);
+    const __m512i sqr0 = _mm512_madd_epi16(dif0, dif0);
+    const __m512i sqr1 = _mm512_madd_epi16(dif1, dif1);
+    *sum = _mm512_add_epi32(*sum, sqr0);
+    *sum = _mm512_add_epi32(*sum, sqr1);
+}
+
+uint32_t combined_averaging_ssd_avx512(uint8_t *src, ptrdiff_t src_stride,
+    uint8_t *ref1, ptrdiff_t ref1_stride,
+    uint8_t *ref2, ptrdiff_t ref2_stride,
+    uint32_t height, uint32_t width) {
+    uint32_t y = height;
+    __m128i sum_128;
+
+    if (width & 4) {
+        const __m128i zero = _mm_setzero_si128();
+
+        sum_128 = _mm_setzero_si128();
+
+        do {
+            uint32_t x = 0;
+            do {
+                const __m128i s = load_u8_4x2_sse4_1(src + x, src_stride);
+                const __m128i r1 = load_u8_4x2_sse4_1(ref1 + x, ref1_stride);
+                const __m128i r2 = load_u8_4x2_sse4_1(ref2 + x, ref2_stride);
+                const __m128i avg = _mm_avg_epu8(r1, r2);
+                const __m128i s16 = _mm_unpacklo_epi8(s, zero);
+                const __m128i avg16 = _mm_unpacklo_epi8(avg, zero);
+                const __m128i dif = _mm_sub_epi16(s16, avg16);
+                const __m128i sqr = _mm_madd_epi16(dif, dif);
+                sum_128 = _mm_add_epi32(sum_128, sqr);
+                x += 4;
+            } while (x < width);
+
+            src += 2 * src_stride;
+            ref1 += 2 * ref1_stride;
+            ref2 += 2 * ref2_stride;
+            y -= 2;
+        } while (y);
+    }
+    else {
+        __m256i sum;
+
+        if (width == 8) {
+            sum = _mm256_setzero_si256();
+
+            do {
+                ssd8x2_avx2(src,
+                    src_stride,
+                    ref1,
+                    ref1_stride,
+                    ref2,
+                    ref2_stride,
+                    &sum);
+                src += 2 * src_stride;
+                ref1 += 2 * ref1_stride;
+                ref2 += 2 * ref2_stride;
+                y -= 2;
+            } while (y);
+        }
+        else if (width == 16) {
+            sum = _mm256_setzero_si256();
+
+            do {
+                const __m128i s = _mm_loadu_si128((__m128i *)src);
+                const __m128i r1 = _mm_loadu_si128((__m128i *)ref1);
+                const __m128i r2 = _mm_loadu_si128((__m128i *)ref2);
+                const __m128i avg = _mm_avg_epu8(r1, r2);
+                const __m256i s_256 = _mm256_cvtepu8_epi16(s);
+                const __m256i avg_256 = _mm256_cvtepu8_epi16(avg);
+                const __m256i dif = _mm256_sub_epi16(s_256, avg_256);
+                const __m256i sqr = _mm256_madd_epi16(dif, dif);
+                sum = _mm256_add_epi32(sum, sqr);
+
+                src += src_stride;
+                ref1 += ref1_stride;
+                ref2 += ref2_stride;
+            } while (--y);
+        }
+        else if (width == 32) {
+            __m512i sum_512 = _mm512_setzero_si512();
+
+            do {
+                ssd32_avx512(src, ref1, ref2, &sum_512);
+                src += src_stride;
+                ref1 += ref1_stride;
+                ref2 += ref2_stride;
+            } while (--y);
+
+            const __m256i sum0_256 = _mm512_castsi512_si256(sum_512);
+            const __m256i sum1_256 = _mm512_extracti64x4_epi64(sum_512, 1);
+            sum = _mm256_add_epi32(sum0_256, sum1_256);
+        }
+        else if (width == 64) {
+            __m512i sum_512 = _mm512_setzero_si512();
+
+            do {
+                ssd64_avx512(src, ref1, ref2, &sum_512);
+                src += src_stride;
+                ref1 += ref1_stride;
+                ref2 += ref2_stride;
+            } while (--y);
+
+            const __m256i sum0_256 = _mm512_castsi512_si256(sum_512);
+            const __m256i sum1_256 = _mm512_extracti64x4_epi64(sum_512, 1);
+            sum = _mm256_add_epi32(sum0_256, sum1_256);
+        }
+        else {
+            sum = _mm256_setzero_si256();
+
+            do {
+                uint32_t x = 0;
+                do {
+                    ssd8x2_avx2(src + x,
+                        src_stride,
+                        ref1 + x,
+                        ref1_stride,
+                        ref2 + x,
+                        ref2_stride,
+                        &sum);
+                    x += 8;
+                } while (x < width);
+
+                src += 2 * src_stride;
+                ref1 += 2 * ref1_stride;
+                ref2 += 2 * ref2_stride;
+                y -= 2;
+            } while (y);
+        }
+
+        const __m128i sum0_128 = _mm256_castsi256_si128(sum);
+        const __m128i sum1_128 = _mm256_extracti128_si256(sum, 1);
+        sum_128 = _mm_add_epi32(sum0_128, sum1_128);
+    }
+
+    sum_128 = _mm_add_epi32(sum_128, _mm_srli_si128(sum_128, 8));
+    sum_128 = _mm_add_epi32(sum_128, _mm_srli_si128(sum_128, 4));
+    return _mm_cvtsi128_si32(sum_128);
+}
+
+#endif // !NON_AVX512_SUPPORT

--- a/Source/Lib/Common/ASM_AVX512/encodetxb_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/encodetxb_avx512.c
@@ -1,0 +1,147 @@
+/*
+* Copyright(c) 2019 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#include <immintrin.h> /* AVX2 */
+
+#include "EbDefinitions.h"
+#include "synonyms.h"
+#include "synonyms_avx2.h"
+
+static INLINE __m256i txb_init_levels_32_avx512(const TranLow *const coeff) {
+    const __m512i idx =
+        _mm512_setr_epi32(0, 4, 8, 12, 1, 5, 9, 13, 0, 0, 0, 0, 0, 0, 0, 0);
+    const __m512i c0 = _mm512_loadu_si512((__m512i *)(coeff + 0 * 16));
+    const __m512i c1 = _mm512_loadu_si512((__m512i *)(coeff + 1 * 16));
+    const __m512i c01 = _mm512_packs_epi32(c0, c1);
+    const __m512i abs01 = _mm512_abs_epi16(c01);
+    const __m512i abs_8 = _mm512_packs_epi16(abs01, abs01);
+    const __m512i res = _mm512_permutexvar_epi32(idx, abs_8);
+    return _mm512_castsi512_si256(res);
+}
+
+static INLINE __m512i txb_init_levels_64_avx512(const TranLow *const coeff) {
+    const __m512i idx =
+        _mm512_setr_epi32(0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15);
+    const __m512i c0 = _mm512_loadu_si512((__m512i *)(coeff + 0 * 16));
+    const __m512i c1 = _mm512_loadu_si512((__m512i *)(coeff + 1 * 16));
+    const __m512i c2 = _mm512_loadu_si512((__m512i *)(coeff + 2 * 16));
+    const __m512i c3 = _mm512_loadu_si512((__m512i *)(coeff + 3 * 16));
+    const __m512i c01 = _mm512_packs_epi32(c0, c1);
+    const __m512i c23 = _mm512_packs_epi32(c2, c3);
+    const __m512i abs01 = _mm512_abs_epi16(c01);
+    const __m512i abs23 = _mm512_abs_epi16(c23);
+    const __m512i abs_8 = _mm512_packs_epi16(abs01, abs23);
+    return _mm512_permutexvar_epi32(idx, abs_8);
+}
+
+void eb_av1_txb_init_levels_avx512(const TranLow *const coeff,
+    const int32_t width, const int32_t height,
+    uint8_t *const levels) {
+    const TranLow *cf = coeff;
+    const __m128i x_zeros = _mm_setzero_si128();
+    uint8_t *ls = levels;
+    int32_t i = height;
+
+    if (width == 4) {
+        const __m256i y_zeros = _mm256_setzero_si256();
+
+        xx_storeu_128(ls - 16, x_zeros);
+
+        do {
+            const __m256i c0 = yy_loadu_256(cf);
+            const __m256i c1 = yy_loadu_256(cf + 8);
+            const __m256i c01 = _mm256_packs_epi32(c0, c1);
+            const __m256i abs01 = _mm256_abs_epi16(c01);
+            const __m256i abs_8 = _mm256_packs_epi16(abs01, y_zeros);
+            const __m256i res_ = _mm256_shuffle_epi32(abs_8, 0xd8);
+            const __m256i res = _mm256_permute4x64_epi64(res_, 0xd8);
+            yy_storeu_256(ls, res);
+            cf += 4 * 4;
+            ls += 4 * 8;
+            i -= 4;
+        } while (i);
+
+        yy_storeu_256(ls, y_zeros);
+    }
+    else if (width == 8) {
+        const __m256i y_zeros = _mm256_setzero_si256();
+
+        yy_storeu_256(ls - 24, y_zeros);
+
+        do {
+            const __m256i res = txb_init_levels_32_avx512(cf);
+            const __m128i res0 = _mm256_castsi256_si128(res);
+            const __m128i res1 = _mm256_extracti128_si256(res, 1);
+            xx_storel_64(ls + 0 * 12 + 0, res0);
+            *(int32_t *)(ls + 0 * 12 + 8) = 0;
+            _mm_storeh_epi64((__m128i *)(ls + 1 * 12 + 0), res0);
+            *(int32_t *)(ls + 1 * 12 + 8) = 0;
+            xx_storel_64(ls + 2 * 12 + 0, res1);
+            *(int32_t *)(ls + 2 * 12 + 8) = 0;
+            _mm_storeh_epi64((__m128i *)(ls + 3 * 12 + 0), res1);
+            *(int32_t *)(ls + 3 * 12 + 8) = 0;
+            cf += 4 * 8;
+            ls += 4 * 12;
+            i -= 4;
+        } while (i);
+
+        yy_storeu_256(ls + 0 * 32, y_zeros);
+        xx_storeu_128(ls + 1 * 32, x_zeros);
+    }
+    else if (width == 16) {
+        const __m256i y_zeros = _mm256_setzero_si256();
+        const __m512i z_zeros = _mm512_setzero_si512();
+
+        yy_storeu_256(ls - 40, y_zeros);
+        xx_storel_64(ls - 8, x_zeros);
+
+        do {
+            const __m512i res = txb_init_levels_64_avx512(cf);
+            const __m256i r0 = _mm512_castsi512_si256(res);
+            const __m256i r1 = _mm512_extracti64x4_epi64(res, 1);
+            const __m128i res0 = _mm256_castsi256_si128(r0);
+            const __m128i res1 = _mm256_extracti128_si256(r0, 1);
+            const __m128i res2 = _mm256_castsi256_si128(r1);
+            const __m128i res3 = _mm256_extracti128_si256(r1, 1);
+            xx_storeu_128(ls + 0 * 20, res0);
+            *(int32_t *)(ls + 0 * 20 + 16) = 0;
+            xx_storeu_128(ls + 1 * 20, res1);
+            *(int32_t *)(ls + 1 * 20 + 16) = 0;
+            xx_storeu_128(ls + 2 * 20, res2);
+            *(int32_t *)(ls + 2 * 20 + 16) = 0;
+            xx_storeu_128(ls + 3 * 20, res3);
+            *(int32_t *)(ls + 3 * 20 + 16) = 0;
+            cf += 4 * 16;
+            ls += 4 * 20;
+            i -= 4;
+        } while (i);
+
+        _mm512_storeu_si512((__m512i *)(ls + 0 * 64), z_zeros);
+        xx_storeu_128(ls + 1 * 64, x_zeros);
+    }
+    else {
+        const __m512i z_zeros = _mm512_setzero_si512();
+
+        _mm512_storeu_si512((__m512i *)(ls - 72), z_zeros);
+        xx_storel_64(ls - 8, x_zeros);
+
+        do {
+            const __m512i res = txb_init_levels_64_avx512(cf);
+            const __m256i res0 = _mm512_castsi512_si256(res);
+            const __m256i res1 = _mm512_extracti64x4_epi64(res, 1);
+            yy_storeu_256(ls, res0);
+            *(int32_t *)(ls + 32) = 0;
+            yy_storeu_256(ls + 36, res1);
+            *(int32_t *)(ls + 36 + 32) = 0;
+            cf += 2 * 32;
+            ls += 2 * 36;
+            i -= 2;
+        } while (i);
+
+        _mm512_storeu_si512((__m512i *)(ls + 0 * 64), z_zeros);
+        _mm512_storeu_si512((__m512i *)(ls + 1 * 64), z_zeros);
+        xx_storeu_128(ls + 2 * 64, x_zeros);
+    }
+}

--- a/Source/Lib/Common/ASM_SSE2/synonyms.h
+++ b/Source/Lib/Common/ASM_SSE2/synonyms.h
@@ -51,18 +51,18 @@ static INLINE void _mm_storeh_epi64(__m128i *const p, const __m128i x) {
 }
 
 static INLINE __m128i load8bit_8x2_sse2(const void *const src,
-    const uint32_t strideInByte) {
+    const ptrdiff_t strideInByte) {
     const __m128i s = _mm_loadl_epi64((__m128i *)src);
     return _mm_loadh_epi64((__m128i *)((uint8_t *)src + strideInByte), s);
 }
 
 static INLINE __m128i load_u8_8x2_sse2(const uint8_t *const src,
-    const uint32_t stride) {
+    const ptrdiff_t stride) {
     return load8bit_8x2_sse2(src, sizeof(*src) * stride);
 }
 
 static INLINE __m128i load_u16_4x2_sse2(const uint16_t *const src,
-    const uint32_t stride) {
+    const ptrdiff_t stride) {
     return load8bit_8x2_sse2(src, sizeof(*src) * stride);
 }
 

--- a/Source/Lib/Common/ASM_SSE4_1/EbMemory_SSE4_1.h
+++ b/Source/Lib/Common/ASM_SSE4_1/EbMemory_SSE4_1.h
@@ -10,20 +10,20 @@
 #include "smmintrin.h"
 
 static INLINE __m128i load8bit_4x2_sse4_1(const void *const src,
-    const uint32_t strideInByte)
+    const ptrdiff_t strideInByte)
 {
     const __m128i s = _mm_cvtsi32_si128(*(int32_t*)((uint8_t *)src));
     return _mm_insert_epi32(s, *(int32_t *)((uint8_t *)src + strideInByte), 1);
 }
 
 static INLINE __m128i load_u8_4x2_sse4_1(const uint8_t *const src,
-    const uint32_t stride)
+    const ptrdiff_t stride)
 {
     return load8bit_4x2_sse4_1(src, sizeof(*src) * stride);
 }
 
 static INLINE __m128i load_u16_2x2_sse4_1(const uint16_t *const src,
-    const uint32_t stride)
+    const ptrdiff_t stride)
 {
     return load8bit_4x2_sse4_1(src, sizeof(*src) * stride);
 }

--- a/Source/Lib/Common/Codec/EbComputeSAD.h
+++ b/Source/Lib/Common/Codec/EbComputeSAD.h
@@ -169,16 +169,6 @@ extern "C" {
         },
     };
 
-    uint32_t combined_averaging_ssd_c(
-        uint8_t   *src,
-        ptrdiff_t  src_stride,
-        uint8_t   *ref1,
-        ptrdiff_t  ref1_stride,
-        uint8_t   *ref2,
-        ptrdiff_t  ref2_stride,
-        uint32_t   height,
-        uint32_t   width);
-
 uint32_t sad_16b_kernel(
     uint16_t  *src,                           // input parameter, source samples Ptr
     uint32_t  src_stride,                     // input parameter, source stride

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.c
@@ -501,8 +501,6 @@ void setup_rtcd_internal(EbAsm asm_type)
     aom_highbd_blend_a64_vmask = aom_highbd_blend_a64_vmask_c;
     if (flags & HAS_SSE4_1) aom_highbd_blend_a64_vmask = aom_highbd_blend_a64_vmask_sse4_1;
 
-    eb_av1_txb_init_levels = eb_av1_txb_init_levels_c;
-    if (flags & HAS_AVX2) eb_av1_txb_init_levels = eb_av1_txb_init_levels_avx2;
     eb_aom_paeth_predictor_16x16 = eb_aom_paeth_predictor_16x16_c;
     if (flags & HAS_SSSE3) eb_aom_paeth_predictor_16x16 = eb_aom_paeth_predictor_16x16_ssse3;
     if (flags & HAS_AVX2) eb_aom_paeth_predictor_16x16 = eb_aom_paeth_predictor_16x16_avx2;
@@ -1018,14 +1016,17 @@ void setup_rtcd_internal(EbAsm asm_type)
     if (flags & HAS_AVX2) eb_aom_sad8x4x4d = eb_aom_sad8x4x4d_avx2;
 
 #ifndef NON_AVX512_SUPPORT
-    eb_aom_sad64x128 = eb_aom_sad64x128_avx512;
-    eb_aom_sad64x16 = eb_aom_sad64x16_avx512;
-    eb_aom_sad64x32 = eb_aom_sad64x32_avx512;
-    eb_aom_sad64x64 = eb_aom_sad64x64_avx512;
-    eb_aom_sad128x128 = eb_aom_sad128x128_avx512;
-    eb_aom_sad128x128x4d = eb_aom_sad128x128x4d_avx512;
-    eb_aom_sad128x64 = eb_aom_sad128x64_avx512;
-    eb_aom_sad128x64x4d = eb_aom_sad128x64x4d_avx512;
+    if (CanUseIntelAVX512()) {
+        eb_aom_sad64x128 = eb_aom_sad64x128_avx512;
+        eb_aom_sad64x16 = eb_aom_sad64x16_avx512;
+        eb_aom_sad64x32 = eb_aom_sad64x32_avx512;
+        eb_aom_sad64x64 = eb_aom_sad64x64_avx512;
+        eb_aom_sad128x128 = eb_aom_sad128x128_avx512;
+        eb_aom_sad128x128x4d = eb_aom_sad128x128x4d_avx512;
+        eb_aom_sad128x64 = eb_aom_sad128x64_avx512;
+        eb_aom_sad128x64x4d = eb_aom_sad128x64x4d_avx512;
+        eb_av1_txb_init_levels = eb_av1_txb_init_levels_avx512;
+    }
 #else
     eb_aom_sad64x128 = eb_aom_sad64x128_c;
     if (flags & HAS_AVX2) eb_aom_sad64x128 = eb_aom_sad64x128_avx2;
@@ -1043,6 +1044,8 @@ void setup_rtcd_internal(EbAsm asm_type)
     if (flags & HAS_AVX2) eb_aom_sad128x64 = eb_aom_sad128x64_avx2;
     eb_aom_sad128x64x4d = eb_aom_sad128x64x4d_c;
     if (flags & HAS_AVX2) eb_aom_sad128x64x4d = eb_aom_sad128x64x4d_avx2;
+    eb_av1_txb_init_levels = eb_av1_txb_init_levels_c;
+    if (flags & HAS_AVX2) eb_av1_txb_init_levels = eb_av1_txb_init_levels_avx2;
 #endif // !NON_AVX512_SUPPORT
 #if OBMC_FLAG
     eb_aom_highbd_blend_a64_vmask = eb_aom_highbd_blend_a64_vmask_c;
@@ -1756,9 +1759,10 @@ void setup_rtcd_internal(EbAsm asm_type)
     SET_SSE41(svt_av1_apply_filtering_highbd,
               svt_av1_apply_filtering_highbd_c,
               svt_av1_highbd_apply_temporal_filter_sse4_1);
-    SET_AVX2(combined_averaging_ssd,
-             combined_averaging_ssd_c,
-             combined_averaging_ssd_avx2);
+    SET_AVX2_AVX512(combined_averaging_ssd,
+                    combined_averaging_ssd_c,
+                    combined_averaging_ssd_avx2,
+                    combined_averaging_ssd_avx512);
     SET_AVX2(ext_sad_calculation_8x8_16x16,
              ext_sad_calculation_8x8_16x16_c,
              ext_sad_calculation_8x8_16x16_avx2_intrin);

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -78,6 +78,10 @@ extern "C" {
     void eb_apply_selfguided_restoration_avx2(const uint8_t *dat, int32_t width, int32_t height, int32_t stride, int32_t eps, const int32_t *xqd, uint8_t *dst, int32_t dst_stride, int32_t *tmpbuf, int32_t bit_depth, int32_t highbd);
     RTCD_EXTERN void(*eb_apply_selfguided_restoration)(const uint8_t *dat, int32_t width, int32_t height, int32_t stride, int32_t eps, const int32_t *xqd, uint8_t *dst, int32_t dst_stride, int32_t *tmpbuf, int32_t bit_depth, int32_t highbd);
 
+    uint32_t combined_averaging_ssd_c(uint8_t *src, ptrdiff_t src_stride, uint8_t *ref1, ptrdiff_t ref1_stride, uint8_t *ref2, ptrdiff_t ref2_stride, uint32_t height, uint32_t width);
+    uint32_t combined_averaging_ssd_avx2(uint8_t *src, ptrdiff_t src_stride, uint8_t *ref1, ptrdiff_t ref1_stride, uint8_t *ref2, ptrdiff_t ref2_stride, uint32_t height, uint32_t width);
+    uint32_t combined_averaging_ssd_avx512(uint8_t *src, ptrdiff_t src_stride, uint8_t *ref1, ptrdiff_t ref1_stride, uint8_t *ref2, ptrdiff_t ref2_stride, uint32_t height, uint32_t width);
+
     void eb_av1_wiener_convolve_add_src_c(const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst, ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4, const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h, const ConvolveParams *conv_params);
     void eb_av1_wiener_convolve_add_src_avx2(const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst, ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4, const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h, const ConvolveParams *conv_params);
     RTCD_EXTERN void(*eb_av1_wiener_convolve_add_src)(const uint8_t *src, ptrdiff_t src_stride, uint8_t *dst, ptrdiff_t dst_stride, const int16_t *filter_x, int32_t x_step_q4, const int16_t *filter_y, int32_t y_step_q4, int32_t w, int32_t h, const ConvolveParams *conv_params);
@@ -2827,6 +2831,7 @@ extern "C" {
 
     void eb_av1_txb_init_levels_c(const TranLow *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
     void eb_av1_txb_init_levels_avx2(const TranLow *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
+    void eb_av1_txb_init_levels_avx512(const TranLow *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
     RTCD_EXTERN void(*eb_av1_txb_init_levels)(const TranLow *const coeff, const int32_t width, const int32_t height, uint8_t *const levels);
 
     void av1_get_gradient_hist_c(const uint8_t *src, int src_stride, int rows, int cols, uint64_t *hist);

--- a/test/SadTest.cc
+++ b/test/SadTest.cc
@@ -42,7 +42,7 @@
 #include "EbMeSadCalculation_SSE2.h"
 #include "EbMotionEstimation.h"
 #include "EbMotionEstimationContext.h"
-#include "EbUnitTestUtility.h"
+#include "EbTime.h"
 #include "random.h"
 #include "util.h"
 
@@ -1653,6 +1653,18 @@ INSTANTIATE_TEST_CASE_P(
  * Test cases:
  *
  */
+
+typedef uint32_t (*combined_averaging_ssd_func)(
+    uint8_t *src, ptrdiff_t src_stride, uint8_t *ref1, ptrdiff_t ref1_stride,
+    uint8_t *ref2, ptrdiff_t ref2_stride, uint32_t height, uint32_t width);
+
+static const combined_averaging_ssd_func combined_averaging_ssd_func_table[] = {
+    combined_averaging_ssd_avx2,
+#ifndef NON_AVX512_SUPPORT
+    combined_averaging_ssd_avx512
+#endif
+};
+
 class SSDAvgTest : public ::testing::WithParamInterface<TestSadParam>,
                    public SADTestBase {
   public:
@@ -1663,35 +1675,110 @@ class SSDAvgTest : public ::testing::WithParamInterface<TestSadParam>,
 
   protected:
     void check_ssd_loop() {
-        uint32_t sum1_ssd, sum2_ssd;
+        prepare_data();
+
+        const uint32_t sum0_ssd = combined_averaging_ssd_c(src_aligned_,
+                                                           src_stride_,
+                                                           ref1_aligned_,
+                                                           ref1_stride_,
+                                                           ref2_aligned_,
+                                                           ref2_stride_,
+                                                           height_,
+                                                           width_);
+
+        for (int i = 0; i < sizeof(combined_averaging_ssd_func_table) /
+                                sizeof(*combined_averaging_ssd_func_table);
+             i++) {
+            const uint32_t sum1_ssd =
+                combined_averaging_ssd_func_table[i](src_aligned_,
+                                                     src_stride_,
+                                                     ref1_aligned_,
+                                                     ref1_stride_,
+                                                     ref2_aligned_,
+                                                     ref2_stride_,
+                                                     height_,
+                                                     width_);
+
+            EXPECT_EQ(sum0_ssd, sum1_ssd)
+                << "compare sum combined averaging ssd error"
+                << " block dim: [" << width_ << " x " << height_ << "] ";
+        }
+    }
+
+    void check_ssd_speed() {
+        uint32_t sum0_ssd;
+        double time_c, time_o;
+        uint64_t start_time_seconds, start_time_useconds;
+        uint64_t middle_time_seconds, middle_time_useconds;
+        uint64_t finish_time_seconds, finish_time_useconds;
+
+        const uint64_t num_loop = 1000000000 / (width_ * height_);
 
         prepare_data();
 
-        sum1_ssd = combined_averaging_ssd_avx2(src_aligned_,
-                                               src_stride_,
-                                               ref1_aligned_,
-                                               ref1_stride_,
-                                               ref2_aligned_,
-                                               ref2_stride_,
-                                               height_,
-                                               width_);
+        EbStartTime(&start_time_seconds, &start_time_useconds);
 
-        sum2_ssd = combined_averaging_ssd_c(src_aligned_,
-                                            src_stride_,
-                                            ref1_aligned_,
-                                            ref1_stride_,
-                                            ref2_aligned_,
-                                            ref2_stride_,
-                                            height_,
-                                            width_);
-        EXPECT_EQ(sum1_ssd, sum2_ssd)
-            << "compare sum combined averaging ssd error"
-            << " block dim: [" << width_ << " x " << height_ << "] ";
+        for (uint64_t i = 0; i < num_loop; i++) {
+            sum0_ssd = combined_averaging_ssd_c(src_aligned_,
+                                                src_stride_,
+                                                ref1_aligned_,
+                                                ref1_stride_,
+                                                ref2_aligned_,
+                                                ref2_stride_,
+                                                height_,
+                                                width_);
+        }
+
+        EbStartTime(&middle_time_seconds, &middle_time_useconds);
+        EbComputeOverallElapsedTimeMs(start_time_seconds,
+                                      start_time_useconds,
+                                      middle_time_seconds,
+                                      middle_time_useconds,
+                                      &time_c);
+
+        for (int i = 0; i < sizeof(combined_averaging_ssd_func_table) /
+                                sizeof(*combined_averaging_ssd_func_table);
+             i++) {
+            uint32_t sum1_ssd;
+
+            EbStartTime(&middle_time_seconds, &middle_time_useconds);
+
+            for (uint64_t j = 0; j < num_loop; j++) {
+                sum1_ssd = combined_averaging_ssd_func_table[i](src_aligned_,
+                                                                src_stride_,
+                                                                ref1_aligned_,
+                                                                ref1_stride_,
+                                                                ref2_aligned_,
+                                                                ref2_stride_,
+                                                                height_,
+                                                                width_);
+            }
+
+            EbStartTime(&finish_time_seconds, &finish_time_useconds);
+            EbComputeOverallElapsedTimeMs(middle_time_seconds,
+                                          middle_time_useconds,
+                                          finish_time_seconds,
+                                          finish_time_useconds,
+                                          &time_o);
+
+            EXPECT_EQ(sum0_ssd, sum1_ssd)
+                << "compare sum combined averaging ssd error"
+                << " block dim: [" << width_ << " x " << height_ << "] ";
+
+            printf("combined_averaging_ssd(%3dx%3d): %6.2f\n",
+                   width_,
+                   height_,
+                   time_c / time_o);
+        }
     }
 };
 
 TEST_P(SSDAvgTest, SSDTest) {
     check_ssd_loop();
+}
+
+TEST_P(SSDAvgTest, DISABLED_SSDSpeedTest) {
+    check_ssd_speed();
 }
 
 INSTANTIATE_TEST_CASE_P(


### PR DESCRIPTION
Add combined_averaging_ssd_avx512()

Speed comparing with original avx2:
 8x8 :  3.61x
16x16:  7.67x
32x32: 14.34x
64x64: 18.31x

Update eb_av1_txb_init_levels_avx2()

Speed comparison:
 4x 4: 2.12x
 4x 8: 2.01x
 4x16: 1.62x
 8x 4: 1.82x
 8x 8: 1.53x
 8x16: 1.47x
 8x32: 1.43x
16x 4: 1.38x
16x 8: 1.49x
16x16: 1.47x
16x32: 1.36x
32x 8: 1.52x
32x16: 1.15x
32x32: 1.24x

Add eb_av1_txb_init_levels_avx512()

About 10% to 30% faster for 16x and 32x.