### PR TITLE
Fix assertion fail 

### DIFF
--- a/Source/Lib/Common/Codec/EbPictureBufferDesc.c
+++ b/Source/Lib/Common/Codec/EbPictureBufferDesc.c
@@ -66,6 +66,7 @@ EbErrorType eb_picture_buffer_desc_ctor(
     pictureBufferDescPtr->stride_cb = pictureBufferDescPtr->stride_cr = pictureBufferDescPtr->stride_y >> subsampling_x;
     pictureBufferDescPtr->origin_x = pictureBufferDescInitDataPtr->left_padding;
     pictureBufferDescPtr->origin_y = pictureBufferDescInitDataPtr->top_padding;
+    pictureBufferDescPtr->origin_bot_y = pictureBufferDescInitDataPtr->bot_padding;
 
     pictureBufferDescPtr->luma_size = (pictureBufferDescInitDataPtr->max_width + pictureBufferDescInitDataPtr->left_padding + pictureBufferDescInitDataPtr->right_padding) *
         (pictureBufferDescInitDataPtr->max_height + pictureBufferDescInitDataPtr->top_padding + pictureBufferDescInitDataPtr->bot_padding);
@@ -144,6 +145,7 @@ EbErrorType eb_recon_picture_buffer_desc_ctor(
     pictureBufferDescPtr->stride_cb = pictureBufferDescPtr->stride_cr = pictureBufferDescPtr->stride_y >> subsampling_x;
     pictureBufferDescPtr->origin_x = pictureBufferDescInitDataPtr->left_padding;
     pictureBufferDescPtr->origin_y = pictureBufferDescInitDataPtr->top_padding;
+    pictureBufferDescPtr->origin_bot_y = pictureBufferDescInitDataPtr->bot_padding;
 
     pictureBufferDescPtr->luma_size = (pictureBufferDescInitDataPtr->max_width + pictureBufferDescInitDataPtr->left_padding + pictureBufferDescInitDataPtr->right_padding) *
         (pictureBufferDescInitDataPtr->max_height + pictureBufferDescInitDataPtr->top_padding + pictureBufferDescInitDataPtr->bot_padding);

--- a/Source/Lib/Common/Codec/EbPictureBufferDesc.h
+++ b/Source/Lib/Common/Codec/EbPictureBufferDesc.h
@@ -48,6 +48,7 @@ extern "C" {
         // Picture Parameters
         uint16_t          origin_x;         // Horizontal padding distance
         uint16_t          origin_y;         // Vertical padding distance
+        uint16_t          origin_bot_y;     // Vertical bottom padding distance
         uint16_t          width;            // Luma picture width which excludes the padding
         uint16_t          height;           // Luma picture height which excludes the padding
         uint16_t          max_width;        // input Luma picture width

--- a/Source/Lib/Common/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Common/Codec/EbTemporalFiltering.c
@@ -2184,9 +2184,9 @@ static EbErrorType save_src_pic_buffers(PictureParentControlSet *picture_control
     // copy buffers
     // Y
     uint32_t height_y = (uint32_t)(picture_control_set_ptr_central->enhanced_picture_ptr->height +
-                                  picture_control_set_ptr_central->enhanced_picture_ptr->origin_y * 2);
+                                  picture_control_set_ptr_central->enhanced_picture_ptr->origin_y + picture_control_set_ptr_central->enhanced_picture_ptr->origin_bot_y);
     uint32_t height_uv = (uint32_t)((picture_control_set_ptr_central->enhanced_picture_ptr->height +
-                                   picture_control_set_ptr_central->enhanced_picture_ptr->origin_y * 2) >> ss_y);
+                                   picture_control_set_ptr_central->enhanced_picture_ptr->origin_y + picture_control_set_ptr_central->enhanced_picture_ptr->origin_bot_y) >> ss_y);
 
     assert(height_y * picture_control_set_ptr_central->enhanced_picture_ptr->stride_y == picture_control_set_ptr_central->enhanced_picture_ptr->luma_size);
     assert(height_uv * picture_control_set_ptr_central->enhanced_picture_ptr->stride_cb == picture_control_set_ptr_central->enhanced_picture_ptr->chroma_size);

--- a/Source/Lib/Decoder/Codec/EbDecMemInit.c
+++ b/Source/Lib/Decoder/Codec/EbDecMemInit.c
@@ -65,6 +65,7 @@ EbErrorType dec_eb_recon_picture_buffer_desc_ctor(
             = picture_buffer_desc_ptr->stride_y;
     picture_buffer_desc_ptr->origin_x = pictureBufferDescInitDataPtr->left_padding;
     picture_buffer_desc_ptr->origin_y = pictureBufferDescInitDataPtr->top_padding;
+    picture_buffer_desc_ptr->origin_bot_y = pictureBufferDescInitDataPtr->bot_padding;
 
     picture_buffer_desc_ptr->luma_size = (pictureBufferDescInitDataPtr->max_width +
         pictureBufferDescInitDataPtr->left_padding + pictureBufferDescInitDataPtr->right_padding) *


### PR DESCRIPTION
Fix #695 
add origin_bot_y in picture buffer descriptor to hold the bottom padding value (different than the top padding when SB size is 128)