### PR TITLE
Fix run-to-run in hbd-md 1

### DIFF
--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -378,7 +378,7 @@ config_entry_t config_entry[] = {
     { SINGLE_INPUT, LOCAL_WARPED_ENABLE_TOKEN, "LocalWarpedMotion", SetEnableLocalWarpedMotionFlag },
     // OBMC
     { SINGLE_INPUT, OBMC_TOKEN, "Obmc", SetEnableObmcFlag },
-	// Filter Intra
+    // Filter Intra
     { SINGLE_INPUT, FILTER_INTRA_TOKEN, "FilterIntra", SetEnableFilterIntraFlag },
     // ME Tools
     { SINGLE_INPUT, USE_DEFAULT_ME_HME_TOKEN, "UseDefaultMeHme", SetCfgUseDefaultMeHme },

--- a/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
+++ b/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
@@ -975,12 +975,12 @@ void setup_ref_mv_list(
             for (int32_t idx = 0; idx < 2; ++idx) {
                 int32_t comp_idx = 0;
                 for (int32_t list_idx = 0;
-    	             list_idx < ref_id_count[idx] && comp_idx < MAX_MV_REF_CANDIDATES;
-	             ++list_idx, ++comp_idx)
+                     list_idx < ref_id_count[idx] && comp_idx < MAX_MV_REF_CANDIDATES;
+                 ++list_idx, ++comp_idx)
                   comp_list[comp_idx][idx] = ref_id[idx][list_idx];
                 for (int32_t list_idx = 0;
-    	            list_idx < ref_diff_count[idx] && comp_idx < MAX_MV_REF_CANDIDATES;
-	            ++list_idx, ++comp_idx)
+                    list_idx < ref_diff_count[idx] && comp_idx < MAX_MV_REF_CANDIDATES;
+                ++list_idx, ++comp_idx)
                   comp_list[comp_idx][idx] = ref_diff[idx][list_idx];
                 for (; comp_idx < MAX_MV_REF_CANDIDATES; ++comp_idx)
                   comp_list[comp_idx][idx] = gm_mv_candidates[idx];

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -47,7 +47,7 @@ extern "C" {
 #define OBMC_FLAG            1 // OBMC motion mode flag
 #define OBMC_CONVOLVE        1 // to track convolve kernels changes
 
-#define INJECT_NEW_NEAR_NEAR_NEW   1   // Inject NEW_NEAR / NEAR_NEW inter prediction 
+#define INJECT_NEW_NEAR_NEAR_NEW   1   // Inject NEW_NEAR / NEAR_NEW inter prediction
 #define FILTER_INTRA_FLAG    1 // Filter intra prediction
 
 

--- a/Source/Lib/Common/Codec/EbInterPrediction.h
+++ b/Source/Lib/Common/Codec/EbInterPrediction.h
@@ -61,41 +61,117 @@ extern "C" {
         const ScaleFactors *sf, int32_t w, int32_t h, ConvolveParams *conv_params,
         InterpFilters interp_filters, int32_t is_intrabc, int32_t bd);
 
-    EbErrorType av1_inter_prediction(
-        PictureControlSet                    *picture_control_set_ptr,
-        uint32_t                                interp_filters,
-        CodingUnit                           *cu_ptr,
-        uint8_t                                 ref_frame_type,
-        MvUnit                               *mv_unit,
-        uint8_t                                  use_intrabc,
+typedef EbErrorType(*EB_AV1_INTER_PREDICTION_FUNC_PTR)(
+    PictureControlSet              *picture_control_set_ptr,
+    uint32_t                        interp_filters,
+    CodingUnit                     *cu_ptr,
+    uint8_t                         ref_frame_type,
+    MvUnit                         *mv_unit,
+    uint8_t                         use_intrabc,
 #if OBMC_FLAG
-        MotionMode                              motion_mode,
-        uint8_t                                 use_precomputed_obmc,
-        struct ModeDecisionContext              *md_context,
+    MotionMode                      motion_mode,
+    uint8_t                         use_precomputed_obmc,
+    struct ModeDecisionContext     *md_context,
 #endif
-        uint8_t                                compound_idx,
-    InterInterCompoundData                     *interinter_comp,
+    uint8_t                         compound_idx,
+    InterInterCompoundData         *interinter_comp,
 #if II_COMP_FLAG
-        TileInfo                                * tile,
-        NeighborArrayUnit                       *luma_recon_neighbor_array,
-        NeighborArrayUnit                       *cb_recon_neighbor_array ,
-        NeighborArrayUnit                       *cr_recon_neighbor_array ,
-        uint8_t                                 is_interintra_used ,
-        INTERINTRA_MODE                         interintra_mode,
-        uint8_t                                 use_wedge_interintra,
-        int32_t                                 interintra_wedge_index,
+    TileInfo                       * tile,
+    NeighborArrayUnit              *luma_recon_neighbor_array,
+    NeighborArrayUnit              *cb_recon_neighbor_array ,
+    NeighborArrayUnit              *cr_recon_neighbor_array ,
+    uint8_t                         is_interintra_used ,
+    INTERINTRA_MODE                 interintra_mode,
+    uint8_t                         use_wedge_interintra,
+    int32_t                         interintra_wedge_index,
 #endif
-        uint16_t                                pu_origin_x,
-        uint16_t                                pu_origin_y,
-        uint8_t                                 bwidth,
-        uint8_t                                 bheight,
-        EbPictureBufferDesc                  *ref_pic_list0,
-        EbPictureBufferDesc                  *ref_pic_list1,
-        EbPictureBufferDesc                  *prediction_ptr,
-        uint16_t                                dst_origin_x,
-        uint16_t                                dst_origin_y,
-        EbBool                                  perform_chroma,
-        EbAsm                                   asm_type);
+    uint16_t                        pu_origin_x,
+    uint16_t                        pu_origin_y,
+    uint8_t                         bwidth,
+    uint8_t                         bheight,
+    EbPictureBufferDesc             *ref_pic_list0,
+    EbPictureBufferDesc             *ref_pic_list1,
+    EbPictureBufferDesc             *prediction_ptr,
+    uint16_t                        dst_origin_x,
+    uint16_t                        dst_origin_y,
+    EbBool                          perform_chroma,
+    uint8_t                         bit_depth);
+
+
+
+    EbErrorType av1_inter_prediction(
+    PictureControlSet              *picture_control_set_ptr,
+    uint32_t                        interp_filters,
+    CodingUnit                     *cu_ptr,
+    uint8_t                         ref_frame_type,
+    MvUnit                         *mv_unit,
+    uint8_t                         use_intrabc,
+#if OBMC_FLAG
+    MotionMode                      motion_mode,
+    uint8_t                         use_precomputed_obmc,
+    struct ModeDecisionContext     *md_context,
+#endif
+    uint8_t                         compound_idx,
+    InterInterCompoundData         *interinter_comp,
+#if II_COMP_FLAG
+    TileInfo                       * tile,
+    NeighborArrayUnit              *luma_recon_neighbor_array,
+    NeighborArrayUnit              *cb_recon_neighbor_array ,
+    NeighborArrayUnit              *cr_recon_neighbor_array ,
+    uint8_t                         is_interintra_used ,
+    INTERINTRA_MODE                 interintra_mode,
+    uint8_t                         use_wedge_interintra,
+    int32_t                         interintra_wedge_index,
+#endif
+    uint16_t                        pu_origin_x,
+    uint16_t                        pu_origin_y,
+    uint8_t                         bwidth,
+    uint8_t                         bheight,
+    EbPictureBufferDesc             *ref_pic_list0,
+    EbPictureBufferDesc             *ref_pic_list1,
+    EbPictureBufferDesc             *prediction_ptr,
+    uint16_t                        dst_origin_x,
+    uint16_t                        dst_origin_y,
+    EbBool                          perform_chroma,
+    uint8_t                         bit_depth);
+
+
+EbErrorType av1_inter_prediction_hbd(
+    PictureControlSet              *picture_control_set_ptr,
+    uint32_t                        interp_filters,
+    CodingUnit                     *cu_ptr,
+    uint8_t                         ref_frame_type,
+    MvUnit                         *mv_unit,
+    uint8_t                         use_intrabc,
+#if OBMC_FLAG
+    MotionMode                      motion_mode,
+    uint8_t                         use_precomputed_obmc,
+    struct ModeDecisionContext     *md_context,
+#endif
+    uint8_t                         compound_idx,
+    InterInterCompoundData         *interinter_comp,
+#if II_COMP_FLAG
+    TileInfo                       * tile,
+    NeighborArrayUnit              *luma_recon_neighbor_array,
+    NeighborArrayUnit              *cb_recon_neighbor_array ,
+    NeighborArrayUnit              *cr_recon_neighbor_array ,
+    uint8_t                         is_interintra_used ,
+    INTERINTRA_MODE                 interintra_mode,
+    uint8_t                         use_wedge_interintra,
+    int32_t                         interintra_wedge_index,
+#endif
+    uint16_t                        pu_origin_x,
+    uint16_t                        pu_origin_y,
+    uint8_t                         bwidth,
+    uint8_t                         bheight,
+    EbPictureBufferDesc             *ref_pic_list0,
+    EbPictureBufferDesc             *ref_pic_list1,
+    EbPictureBufferDesc             *prediction_ptr,
+    uint16_t                        dst_origin_x,
+    uint16_t                        dst_origin_y,
+    EbBool                          perform_chroma,
+    uint8_t                         bit_depth);
+
     void search_compound_diff_wedge(
         PictureControlSet                    *picture_control_set_ptr,
         struct ModeDecisionContext                  *context_ptr,
@@ -178,40 +254,6 @@ extern "C" {
         ModeDecisionCandidateBuffer          *candidate_buffer_ptr,
         EbAsm                                   asm_type);
 
-    EbErrorType av1_inter_prediction_hbd(
-        PictureControlSet                    *picture_control_set_ptr,
-        uint8_t                                 ref_frame_type,
-        CodingUnit                           *cu_ptr,
-        MvUnit                               *mv_unit,
-        uint8_t                                  use_intrabc,
-#if OBMC_FLAG
-        MotionMode                              motion_mode,
-#endif
-#if INTER_INTER_HBD
-        uint8_t                         compound_idx,
-        InterInterCompoundData          *interinter_comp,
-#endif
-#if INTER_INTRA_HBD
-    TileInfo                        * tile,
-    NeighborArrayUnit               *luma_recon_neighbor_array,
-    NeighborArrayUnit               *cb_recon_neighbor_array ,
-    NeighborArrayUnit               *cr_recon_neighbor_array ,
-    uint8_t                         is_interintra_used ,
-    INTERINTRA_MODE                 interintra_mode,
-    uint8_t                         use_wedge_interintra,
-    int32_t                         interintra_wedge_index,
-#endif
-        uint16_t                                pu_origin_x,
-        uint16_t                                pu_origin_y,
-        uint8_t                                 bwidth,
-        uint8_t                                 bheight,
-        EbPictureBufferDesc                  *ref_pic_list0,
-        EbPictureBufferDesc                  *ref_pic_list1,
-        EbPictureBufferDesc                  *prediction_ptr,
-        uint16_t                                dst_origin_x,
-        uint16_t                                dst_origin_y,
-        uint8_t                                 bit_depth,
-        EbAsm                                   asm_type);
 
     EbErrorType choose_mvp_idx_v2(
         ModeDecisionCandidate               *candidate_ptr,

--- a/Source/Lib/Common/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Common/Codec/EbTemporalFiltering.c
@@ -41,6 +41,12 @@
 #undef _MM_HINT_T2
 #define _MM_HINT_T2  1
 
+static EB_AV1_INTER_PREDICTION_FUNC_PTR   av1_inter_prediction_function_table[2] =
+{
+    av1_inter_prediction,
+    av1_inter_prediction_hbd
+};
+
 static unsigned int index_mult[14] = {
         0, 0, 0, 0, 49152, 39322, 32768, 28087, 24576, 21846, 19661, 17874, 0, 15124
 };
@@ -1488,78 +1494,41 @@ static void tf_inter_prediction(PictureParentControlSet *picture_control_set_ptr
                         mv_unit.mv->x = mv_x + i;
                         mv_unit.mv->y = mv_y + j;
 
-                        if(!is_highbd){
-                            av1_inter_prediction(
-                                    NULL,  //picture_control_set_ptr,
-                                    (uint32_t)interp_filters,
-                                    &cu_ptr,
-                                    0,//ref_frame_type,
-                                    &mv_unit,
-                                    0,//use_intrabc,
+                        av1_inter_prediction_function_table[is_highbd](
+                            NULL,  //picture_control_set_ptr,
+                            (uint32_t)interp_filters,
+                            &cu_ptr,
+                            0,//ref_frame_type,
+                            &mv_unit,
+                            0,//use_intrabc,
 #if OBMC_FLAG
-                                    SIMPLE_TRANSLATION,
-                                    0,
-                                    0,
+                            SIMPLE_TRANSLATION,
+                            0,
+                            0,
 #endif
-                                    1,//compound_idx not used
-                                    NULL,// interinter_comp not used
+                            1,//compound_idx not used
+                            NULL,// interinter_comp not used
 #if II_COMP_FLAG
-                                    NULL,
-                                    NULL,
-                                    NULL,
-                                    NULL,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
+                            NULL,
+                            NULL,
+                            NULL,
+                            NULL,
+                            0,
+                            0,
+                            0,
+                            0,
 #endif
-                                    pu_origin_x,
-                                    pu_origin_y,
-                                    bsize,
-                                    bsize,
-                                    pic_ptr_ref,
-                                    NULL,//ref_pic_list1,
-                                    &prediction_ptr,
-                                    local_origin_x,
-                                    local_origin_y,
-                                    1,//perform_chroma,
-                                    asm_type);
-                        }else{
-                            cu_ptr.interp_filters = interp_filters;
-                            av1_inter_prediction_hbd(NULL, //picture_control_set_ptr,
-                                                     0, //ref_frame_type,
-                                                     &cu_ptr,
-                                                     &mv_unit,
-                                                     0, //use_intrabc,
-#if OBMC_FLAG
-                                                     SIMPLE_TRANSLATION,
-#endif
-#if INTER_INTER_HBD
-                                                     1,//compound_idx not used
-                                                     NULL,// interinter_comp not used
-#endif
-#if INTER_INTRA_HBD
-                                                     NULL,
-                                                     NULL,
-                                                     NULL,
-                                                     NULL,
-                                                     0,
-                                                     0,
-                                                     0,
-                                                     0,
-#endif
-                                                     pu_origin_x,
-                                                     pu_origin_y,
-                                                     bsize,
-                                                     bsize,
-                                                     &reference_ptr,
-                                                     NULL, //ref_pic_list1,
-                                                     &prediction_ptr,
-                                                     local_origin_x,
-                                                     local_origin_y,
-                                                     (uint8_t)encoder_bit_depth, //bit depth
-                                                     asm_type);
-                        }
+                            pu_origin_x,
+                            pu_origin_y,
+                            bsize,
+                            bsize,
+                            !is_highbd ? pic_ptr_ref : &reference_ptr,
+                            NULL,//ref_pic_list1,
+                            &prediction_ptr,
+                            local_origin_x,
+                            local_origin_y,
+                            1,//perform_chroma,
+                            (uint8_t)encoder_bit_depth);
 
                         uint64_t distortion;
                         if(!is_highbd){
@@ -1591,78 +1560,42 @@ static void tf_inter_prediction(PictureParentControlSet *picture_control_set_ptr
                 mv_unit.mv->x = best_mv_x;
                 mv_unit.mv->y = best_mv_y;
 
-                if(!is_highbd){
-                    av1_inter_prediction(
-                            NULL,  //picture_control_set_ptr,
-                            (uint32_t)interp_filters,
-                            &cu_ptr,
-                            0,//ref_frame_type,
-                            &mv_unit,
-                            0,//use_intrabc,
+                av1_inter_prediction_function_table[is_highbd](
+                    NULL,  //picture_control_set_ptr,
+                    (uint32_t)interp_filters,
+                    &cu_ptr,
+                    0,//ref_frame_type,
+                    &mv_unit,
+                    0,//use_intrabc,
 #if OBMC_FLAG
-                            SIMPLE_TRANSLATION,
-                            0,
-                            0,
+                    SIMPLE_TRANSLATION,
+                    0,
+                    0,
 #endif
-                            1,//compound_idx not used
-                            NULL,// interinter_comp not used
+                    1,//compound_idx not used
+                    NULL,// interinter_comp not used
 #if II_COMP_FLAG
-                            NULL,
-                            NULL,
-                            NULL,
-                            NULL,
-                            0,
-                            0,
-                            0,
-                            0,
+                    NULL,
+                    NULL,
+                    NULL,
+                    NULL,
+                    0,
+                    0,
+                    0,
+                    0,
 #endif
-                            pu_origin_x,
-                            pu_origin_y,
-                            bsize,
-                            bsize,
-                            pic_ptr_ref,
-                            NULL,//ref_pic_list1,
-                            &prediction_ptr,
-                            local_origin_x,
-                            local_origin_y,
-                            1,//perform_chroma,
-                            asm_type);
-                }else{
-                    cu_ptr.interp_filters = interp_filters;
-                    av1_inter_prediction_hbd(NULL, //picture_control_set_ptr,
-                                             0, //ref_frame_type,
-                                             &cu_ptr,
-                                             &mv_unit,
-                                             0, //use_intrabc,
-#if OBMC_FLAG
-                                             SIMPLE_TRANSLATION,
-#endif
-#if INTER_INTER_HBD
-                                             1,//compound_idx not used
-                                             NULL,// interinter_comp not used
-#endif
-#if INTER_INTRA_HBD
-                                             NULL,
-                                             NULL,
-                                             NULL,
-                                             NULL,
-                                             0,
-                                             0,
-                                             0,
-                                             0,
-#endif
-                                             pu_origin_x,
-                                             pu_origin_y,
-                                             bsize,
-                                             bsize,
-                                             &reference_ptr,
-                                             NULL, //ref_pic_list1,
-                                             &prediction_ptr,
-                                             local_origin_x,
-                                             local_origin_y,
-                                             (uint8_t)encoder_bit_depth, //bit depth
-                                             asm_type);
-                }
+                    pu_origin_x,
+                    pu_origin_y,
+                    bsize,
+                    bsize,
+                    !is_highbd ? pic_ptr_ref : &reference_ptr,
+                    NULL,//ref_pic_list1,
+                    &prediction_ptr,
+                    local_origin_x,
+                    local_origin_y,
+                    1,//perform_chroma,
+                    (uint8_t)encoder_bit_depth);
+
             }
         }
     }

--- a/Source/Lib/Decoder/Codec/EbDecParseObu.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseObu.c
@@ -2056,7 +2056,7 @@ void read_uncompressed_header(bitstrm_t *bs, EbDecHandle *dec_handle_ptr,
 
     read_film_grain_params(dec_handle_ptr, bs, &frame_info->film_grain_params);
 
-    dec_handle_ptr->cur_pic_buf[0]->film_grain_params = 
+    dec_handle_ptr->cur_pic_buf[0]->film_grain_params =
                             dec_handle_ptr->frame_header.film_grain_params;
 
     dec_handle_ptr->show_existing_frame = frame_info->show_existing_frame;

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -2085,7 +2085,7 @@ void CopyApiFromApp(
 
     // Filter intra prediction
     sequence_control_set_ptr->static_config.enable_filter_intra = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->enable_filter_intra;
-	
+
     // ME Tools
     sequence_control_set_ptr->static_config.use_default_me_hme = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->use_default_me_hme;
     sequence_control_set_ptr->static_config.enable_hme_flag = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->enable_hme_flag;


### PR DESCRIPTION
### **Description**
1. Fix when hbd-md 1:
- run to run in release
- crash in debug  
2. created a function table :  av1_inter_prediction_function_table for 8 and 10 bit
3. Code clean up 
Fixes #728 

### **Author**
@okhlif 

### **Type of change**
Bug fix

### **Tests and performance**
BDR : ~0.9% gain on 360p objective-fast1 clips ( changed to 10bit)