### PR TITLE
More aggressive MD Exit TH for M0 non-SC

### DIFF
--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1500,7 +1500,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     if (MR_MODE)
         context_ptr->md_exit_th = 0;
     else
-        context_ptr->md_exit_th = 10;
+        context_ptr->md_exit_th = (picture_control_set_ptr->parent_pcs_ptr->sc_content_detected) ? 10 : 18;
 
     // Derive distortion-based md_stage_0_count proning
     if (MR_MODE)


### PR DESCRIPTION
## Description
More aggressive MD Exit TH for M0 non-SC.

## Author

@hguermaz 

## Type of change

Tuning

## Tests and performance
* BD-Rate to aom cpu0-2pass on the full list: ~0.006% BD-Rate loss.
* Speed on AWS on Full-list: ~2.36% faster.
* Memory footprint on a 4-core machine: ~0%.