### PR TITLE
Add missing eb_aom_highbd_8_mse16x16 for C version with tests

### DIFF
--- a/Source/Lib/Common/C_DEFAULT/variance.c
+++ b/Source/Lib/Common/C_DEFAULT/variance.c
@@ -402,3 +402,20 @@ OBMC_VAR(16, 64)
 OBMC_SUBPIX_VAR(16, 64)
 OBMC_VAR(64, 16)
 OBMC_SUBPIX_VAR(64, 16)
+
+void eb_aom_highbd_8_mse16x16_c(const uint8_t* src_ptr, int32_t  source_stride,
+	const uint8_t* ref_ptr, int32_t  recon_stride, uint32_t* sse) {
+	const uint16_t* a = CONVERT_TO_SHORTPTR(src_ptr);
+	const uint16_t* b = CONVERT_TO_SHORTPTR(ref_ptr);
+	uint64_t tsse = 0;
+
+	for (int i = 0; i < 16; ++i) {
+		for (int j = 0; j < 16; ++j) {
+			const int diff = a[j] - b[j];
+			tsse += (uint32_t)(diff * diff);
+		}
+		a += source_stride;
+		b += recon_stride;
+	}
+	*sse = (uint32_t)tsse;
+}

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -646,8 +646,8 @@ extern "C" {
     void eb_av1_quantize_fp_64x64_avx2(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
     RTCD_EXTERN void(*eb_av1_quantize_fp_64x64)(const TranLow *coeff_ptr, intptr_t n_coeffs, const int16_t *zbin_ptr, const int16_t *round_ptr, const int16_t *quant_ptr, const int16_t *quant_shift_ptr, TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr, const int16_t *dequant_ptr, uint16_t *eob_ptr, const int16_t *scan, const int16_t *iscan);
 
-    //uint32_t eb_aom_highbd_8_mse16x16_c(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
-    void      eb_aom_highbd_8_mse16x16_sse2(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
+    void eb_aom_highbd_8_mse16x16_c(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
+    void eb_aom_highbd_8_mse16x16_sse2(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
     RTCD_EXTERN void(*eb_aom_highbd_8_mse16x16)(const uint8_t *src_ptr, int32_t  source_stride, const uint8_t *ref_ptr, int32_t  recon_stride, uint32_t *sse);
 
     void eb_av1_upsample_intra_edge_c(uint8_t *p, int32_t sz);
@@ -3205,7 +3205,7 @@ extern "C" {
         highbd_variance64 = highbd_variance64_c;
         if (flags & HAS_AVX2) highbd_variance64 = highbd_variance64_avx2;
 
-        //aom_highbd_8_mse16x16 = eb_aom_highbd_8_mse16x16_c;
+        eb_aom_highbd_8_mse16x16 = eb_aom_highbd_8_mse16x16_c;
         if (flags & HAS_SSE2) eb_aom_highbd_8_mse16x16 = eb_aom_highbd_8_mse16x16_sse2;
 
         eb_av1_upsample_intra_edge = eb_av1_upsample_intra_edge_c;

--- a/test/VarianceTest.cc
+++ b/test/VarianceTest.cc
@@ -37,29 +37,17 @@ using svt_av1_test_tool::SVTRandom;  // to generate the random
 namespace {
 #define MAX_BLOCK_SIZE (128 * 128)
 
-// MSE test
-static uint32_t mse_ref(const uint8_t *src, const uint8_t *ref, int width,
-                        int height, int src_stride, int ref_stride,
-                        uint32_t *sse_ptr) {
-    int64_t se = 0;
-    uint64_t sse = 0;
-    for (int y = 0; y < height; y++) {
-        for (int x = 0; x < width; x++) {
-            int diff;
-            diff = src[y * src_stride + x] - ref[y * ref_stride + x];
-            se += diff;
-            sse += diff * diff;
-        }
-    }
-    *sse_ptr = static_cast<uint32_t>(sse);
-    return static_cast<uint32_t>(sse - ((se * se) / (width * height)));
-}
-
 using MSE_NXM_FUNC = uint32_t (*)(const uint8_t *src_ptr, int32_t src_stride,
                                   const uint8_t *ref_ptr, int32_t ref_stride,
                                   uint32_t *sse);
 
-typedef std::tuple<uint32_t, uint32_t, MSE_NXM_FUNC> TestMseParam;
+using MSE_HIGHBD_NXM_FUNC = void (*)(const uint8_t *src_ptr, int32_t src_stride,
+                                  const uint8_t *ref_ptr, int32_t ref_stride,
+                                  uint32_t *sse);
+
+typedef std::tuple<uint32_t, uint32_t, MSE_NXM_FUNC, MSE_NXM_FUNC> TestMseParam;
+typedef std::tuple<uint32_t, uint32_t, MSE_HIGHBD_NXM_FUNC, MSE_HIGHBD_NXM_FUNC>
+    TestMseParamHighbd;
 /**
  * @brief Unit test for mse functions, target functions include:
  *  - aom_mse16x16_{c,avx2}
@@ -83,7 +71,8 @@ class MseTest : public ::testing::TestWithParam<TestMseParam> {
     MseTest()
         : width_(TEST_GET_PARAM(0)),
           height_(TEST_GET_PARAM(1)),
-          mse_tst_(TEST_GET_PARAM(2)) {
+          mse_tst_(TEST_GET_PARAM(2)),
+          mse_ref_(TEST_GET_PARAM(3)) {
         src_data_ =
             reinterpret_cast<uint8_t *>(eb_aom_memalign(32, MAX_BLOCK_SIZE));
         ref_data_ =
@@ -107,14 +96,8 @@ class MseTest : public ::testing::TestWithParam<TestMseParam> {
             }
 
             uint32_t sse_tst, sse_ref;
-            mse_tst_(src_data_, width_, ref_data_, width_, &sse_tst);
-            mse_ref(src_data_,
-                    ref_data_,
-                    width_,
-                    height_,
-                    width_,
-                    width_,
-                    &sse_ref);
+            mse_tst_(src_data_, width_, ref_data_, height_, &sse_tst);
+            mse_ref_(src_data_, width_, ref_data_, height_, &sse_ref);
             ASSERT_EQ(sse_tst, sse_ref) << "SSE Error at index: " << i;
         }
     }
@@ -134,6 +117,7 @@ class MseTest : public ::testing::TestWithParam<TestMseParam> {
     uint32_t width_;
     uint32_t height_;
     MSE_NXM_FUNC mse_tst_;
+    MSE_NXM_FUNC mse_ref_;
 };
 
 TEST_P(MseTest, MatchTest) {
@@ -146,7 +130,89 @@ TEST_P(MseTest, MaxTest) {
 
 INSTANTIATE_TEST_CASE_P(Variance, MseTest,
                         ::testing::Values(TestMseParam(16, 16,
-                                                       &eb_aom_mse16x16_avx2)));
+                                                       &eb_aom_mse16x16_avx2,
+                                                       &eb_aom_mse16x16_c)));
+
+class MseTestHighbd : public ::testing::TestWithParam<TestMseParamHighbd> {
+  public:
+    MseTestHighbd()
+        : width_(TEST_GET_PARAM(0)),
+          height_(TEST_GET_PARAM(1)),
+          mse_tst_(TEST_GET_PARAM(2)),
+          mse_ref_(TEST_GET_PARAM(3)) {
+          src_data_ =
+            reinterpret_cast<uint16_t *>(eb_aom_memalign(32, MAX_BLOCK_SIZE * 2));
+          ref_data_ =
+            reinterpret_cast<uint16_t *>(eb_aom_memalign(32, MAX_BLOCK_SIZE * 2));
+    }
+
+    ~MseTestHighbd() {
+        eb_aom_free(src_data_);
+        src_data_ = nullptr;
+        eb_aom_free(ref_data_);
+        ref_data_ = nullptr;
+    }
+
+    void run_match_test() {
+        const int32_t mask = (1 << 8) - 1;
+        SVTRandom rnd(0, mask);
+        for (int i = 0; i < 10; ++i) {
+            for (int j = 0; j < MAX_BLOCK_SIZE; ++j) {
+                src_data_[j] = rnd.random();
+                ref_data_[j] = rnd.random();
+            }
+
+            uint32_t sse_tst, sse_ref;
+
+            mse_ref_(CONVERT_TO_BYTEPTR(src_data_), width_,
+                     CONVERT_TO_BYTEPTR(ref_data_), height_,
+                     &sse_ref);
+            mse_tst_(CONVERT_TO_BYTEPTR(src_data_), width_,
+                     CONVERT_TO_BYTEPTR(ref_data_), height_,
+                     &sse_tst);
+            ASSERT_EQ(sse_tst, sse_ref) << "SSE Error at index: " << i;
+        }
+    }
+
+    void run_max_test() {
+        for (int j = 0; j < MAX_BLOCK_SIZE; ++j) {
+            src_data_[j] = 255;
+            ref_data_[j] = 0;
+        }
+        uint32_t sse_tst, sse_ref;
+
+        mse_ref_(CONVERT_TO_BYTEPTR(src_data_), width_,
+                 CONVERT_TO_BYTEPTR(ref_data_), height_,
+                 &sse_ref);
+        mse_tst_(CONVERT_TO_BYTEPTR(src_data_), width_,
+                 CONVERT_TO_BYTEPTR(ref_data_), height_,
+                 &sse_tst);
+
+        ASSERT_EQ(sse_tst, sse_ref) << "Error at MSE maximum test ";
+    }
+
+  private:
+    uint16_t *src_data_;
+    uint16_t *ref_data_;
+    uint32_t width_;
+    uint32_t height_;
+    MSE_HIGHBD_NXM_FUNC mse_tst_;
+    MSE_HIGHBD_NXM_FUNC mse_ref_;
+};
+
+TEST_P(MseTestHighbd, MatchTest) {
+    run_match_test();
+};
+
+TEST_P(MseTestHighbd, MaxTest) {
+    run_max_test();
+};
+
+INSTANTIATE_TEST_CASE_P(Variance, MseTestHighbd,
+                        ::testing::Values(TestMseParamHighbd(16, 16,
+                                                             &eb_aom_highbd_8_mse16x16_sse2,
+                                                             &eb_aom_highbd_8_mse16x16_c)));
+
 
 // sum of squares test
 static uint32_t mb_ss_ref(const int16_t *src) {


### PR DESCRIPTION
Fix MseTest to test eb_aom_mse16x16_avx2 with eb_aom_mse16x16_c instead of local implementation