### PR TITLE
Annex-B support in Decoder and Intrinsic Fixes

### DIFF
--- a/Source/API/EbSvtAv1Dec.h
+++ b/Source/API/EbSvtAv1Dec.h
@@ -204,7 +204,7 @@ typedef struct EbSvtAv1DecConfiguration
         EbComponentType     *svt_dec_component,
         const uint8_t       *data,
         const size_t         data_size,
-        int                  is_annexb);
+        uint32_t             is_annexb);
 
     /*!\brief STEP 5-alt-2: Decodes a temporal unit (TU). Decoding a TU
      * may result in several output pictures generated if output_all_layers

--- a/Source/API/EbSvtAv1Dec.h
+++ b/Source/API/EbSvtAv1Dec.h
@@ -203,7 +203,8 @@ typedef struct EbSvtAv1DecConfiguration
     EB_API EbErrorType eb_svt_decode_frame(
         EbComponentType     *svt_dec_component,
         const uint8_t       *data,
-        const size_t         data_size);
+        const size_t         data_size,
+        int                  is_annexb);
 
     /*!\brief STEP 5-alt-2: Decodes a temporal unit (TU). Decoding a TU
      * may result in several output pictures generated if output_all_layers

--- a/Source/App/DecApp/EbDecAppMain.c
+++ b/Source/App/DecApp/EbDecAppMain.c
@@ -151,7 +151,7 @@ int32_t main(int32_t argc, char* argv[])
     cli.fps_summary = 0;
 
     DecInputContext input = { NULL, NULL };
-    ObuDecInputContext obu_ctx = { NULL, 0, 0, 0 };
+    ObuDecInputContext obu_ctx = { NULL, 0, 0, 0, 0 };
     input.cli_ctx = &cli;
     input.obu_ctx = &obu_ctx;
 
@@ -230,7 +230,8 @@ int32_t main(int32_t argc, char* argv[])
 
                     dec_timer_start(&timer);
 
-                    return_error |= eb_svt_decode_frame(p_handle, buf, bytes_in_buffer);
+                    return_error |= eb_svt_decode_frame(p_handle, buf,
+                        bytes_in_buffer, obu_ctx.is_annexb);
 
                     dec_timer_mark(&timer);
                     dx_time += dec_timer_elapsed(&timer);

--- a/Source/App/DecApp/EbDecParamParser.c
+++ b/Source/App/DecApp/EbDecParamParser.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 #include "EbDecParamParser.h"
 
@@ -103,14 +104,6 @@ EbErrorType read_command_line(int32_t argc, char *const argv[],
                 else {
                     cli->inFile = fin;
                     cli->inFilename = config_strings[token_index];
-                    if (file_is_ivf(cli))
-                        cli->inFileType = FILE_TYPE_IVF;
-                    else if (file_is_obu(cli, obu_ctx))
-                        cli->inFileType = FILE_TYPE_OBU;
-                    else {
-                        printf("Unsupported input file format. \n");
-                        return EB_ErrorBadParameter;
-                    }
                 }
             }
             else if (EB_STRCMP(cmd_copy[token_index], OUTPUT_FILE_TOKEN) == 0) {
@@ -133,6 +126,8 @@ EbErrorType read_command_line(int32_t argc, char *const argv[],
                 cli->fps_summary = 1;
             else if (EB_STRCMP(cmd_copy[token_index], FILM_GRAIN_TOKEN) == 0)
                 cli->skip_film_grain = 1;
+            else if (EB_STRCMP(cmd_copy[token_index], ANNEX_B_TOKEN) == 0)
+                obu_ctx->is_annexb = 1;
             else if (EB_STRCMP(cmd_copy[token_index], HELP_TOKEN) == 0)
                 showHelp();
             else {
@@ -180,5 +175,15 @@ EbErrorType read_command_line(int32_t argc, char *const argv[],
 
     configs->skip_film_grain = cli->skip_film_grain;
 
+    if (file_is_ivf(cli)) {
+        cli->inFileType = FILE_TYPE_IVF;
+        assert(0 == obu_ctx->is_annexb);
+    }
+    else if (file_is_obu(cli, obu_ctx))
+        cli->inFileType = FILE_TYPE_OBU;
+    else {
+        printf("Unsupported input file format. \n");
+        return EB_ErrorBadParameter;
+    }
     return EB_ErrorNone;
 }

--- a/Source/App/DecApp/EbDecParamParser.h
+++ b/Source/App/DecApp/EbDecParamParser.h
@@ -41,6 +41,7 @@
 #define FPS_FRM_TOKEN                   "-fps-frm"
 #define FPS_SUMMARY_TOKEN               "-fps-summary"
 #define FILM_GRAIN_TOKEN                "-skip-film-grain"
+#define ANNEX_B_TOKEN                   "-annex-b"
 #define MAX_NUM_TOKENS 200
 
 #define EB_STRCMP(target,token) \

--- a/Source/App/DecApp/EbFileUtils.c
+++ b/Source/App/DecApp/EbFileUtils.c
@@ -423,6 +423,13 @@ int file_is_obu(CLInput *cli, ObuDecInputContext *obu_ctx) {
         }
         obu_ctx->bytes_buffered += payload_bytes;
     }
+
+    /* This is because to avoid to many conditions while reading
+    frame by frame information in TU's */
+    if (is_annexb) {
+        rewind(f);
+        obu_ctx->bytes_buffered = 0;
+    }
     return 1;
 }
 
@@ -526,16 +533,19 @@ int obudec_read_temporal_unit(DecInputContext *input,
         return 0;
     }
 
-    size_t tu_size;
+    size_t tu_size = 0, fr_size = 0;
     size_t obu_size = 0;
     size_t length_of_temporal_unit_size = 0;
-    uint8_t tuheader[OBU_MAX_LENGTH_FIELD_SIZE] = { 0 };
+    size_t length_of_frame_unit_size = 0;
+    uint8_t frheader[OBU_MAX_LENGTH_FIELD_SIZE] = { 0 };
 
     if (obu_ctx->is_annexb) {
         uint64_t size = 0;
 
-        if (obu_ctx->bytes_buffered == 0) {
-            if (obudec_read_leb128(f, &tuheader[0], &length_of_temporal_unit_size,
+        assert(obu_ctx->bytes_buffered == 0);
+
+        if (!obu_ctx->rem_tu_size) {
+            if (obudec_read_leb128(f, &frheader[0], &length_of_temporal_unit_size,
                 &size) != 0) {
                 fprintf(stderr, "obudec: Failure reading temporal unit header\n");
                 return 0;
@@ -543,14 +553,8 @@ int obudec_read_temporal_unit(DecInputContext *input,
             if (size == 0 && feof(f)) {
                 return 0;
             }
-        }
-        else {
-            // temporal unit size was already stored in buffer
-            if (uleb_decode(obu_ctx->buffer, obu_ctx->bytes_buffered, &size,
-                &length_of_temporal_unit_size) != 0) {
-                fprintf(stderr, "obudec: Failure reading temporal unit header\n");
-                return 0;
-            }
+            /*Stores only tu size ie excluding tu header*/
+            obu_ctx->rem_tu_size = size;
         }
 
         if (size > UINT32_MAX || size + length_of_temporal_unit_size > UINT32_MAX) {
@@ -558,8 +562,17 @@ int obudec_read_temporal_unit(DecInputContext *input,
             return 0;
         }
 
-        size += length_of_temporal_unit_size;
-        tu_size = (size_t)size;
+        if (obudec_read_leb128(f, &frheader[0], &length_of_frame_unit_size,
+            &size) != 0) {
+            fprintf(stderr, "obudec: Failure reading frame header\n");
+            return 0;
+    }
+        if (size == 0 && feof(f)) {
+            return 0;
+        }
+
+        fr_size = (size_t)size;
+        tu_size = fr_size;
     }
     else {
         while (1) {
@@ -604,24 +617,11 @@ int obudec_read_temporal_unit(DecInputContext *input,
     }
     else {
         if (!feof(f)) {
-            size_t data_size;
-            size_t offset;
-            if (!obu_ctx->bytes_buffered) {
-                data_size = tu_size - length_of_temporal_unit_size;
-                memcpy(*buffer, &tuheader[0], length_of_temporal_unit_size);
-                offset = length_of_temporal_unit_size;
-            }
-            else {
-                memcpy(*buffer, obu_ctx->buffer, obu_ctx->bytes_buffered);
-                offset = obu_ctx->bytes_buffered;
-                data_size = tu_size - obu_ctx->bytes_buffered;
-                obu_ctx->bytes_buffered = 0;
-            }
-
-            if (fread(*buffer + offset, 1, data_size, f) != data_size) {
+            if (fread(*buffer, 1, fr_size, f) != fr_size) {
                 fprintf(stderr, "obudec: Failed to read full temporal unit\n");
                 return 0;
             }
+            obu_ctx->rem_tu_size -= (fr_size + length_of_frame_unit_size);
         }
     }
     return 1;

--- a/Source/App/DecApp/EbFileUtils.c
+++ b/Source/App/DecApp/EbFileUtils.c
@@ -146,7 +146,7 @@ static int valid_obu_type(int obu_type) {
 
 // Parses OBU header and stores values in 'header'.
 static int read_obu_header(ReadBitBuffer *rb,
-    int is_annexb, ObuHeader *header)
+    uint32_t is_annexb, ObuHeader *header)
 {
     if (!rb || !header) return -1;
 
@@ -194,7 +194,7 @@ static int read_obu_header(ReadBitBuffer *rb,
 
 int svt_read_obu_header(uint8_t *buffer, size_t buffer_length,
     size_t *consumed, ObuHeader *header,
-    int is_annexb)
+    uint32_t is_annexb)
 {
     if (buffer_length < 1 || !consumed || !header) return -1;
 
@@ -211,7 +211,7 @@ int svt_read_obu_header(uint8_t *buffer, size_t buffer_length,
 // success, and non-zero on failure. When end of file is reached, the return
 // value is 0 and the 'bytes_read' value is set to 0.
 static int obudec_read_obu_header(FILE *f, size_t buffer_capacity,
-    int is_annexb, uint8_t *obu_data,
+    uint32_t is_annexb, uint8_t *obu_data,
     ObuHeader *obu_header, size_t *bytes_read)
 {
     if (!f || buffer_capacity < (OBU_HEADER_SIZE + OBU_EXTENSION_SIZE) ||
@@ -245,7 +245,7 @@ static int obudec_read_obu_header(FILE *f, size_t buffer_capacity,
 }
 
 static int obudec_read_obu_header_and_size(FILE *f, size_t buffer_capacity,
-    int is_annexb, uint8_t *buffer,
+    uint32_t is_annexb, uint8_t *buffer,
     size_t *bytes_read,
     size_t *payload_length,
     ObuHeader *obu_header)
@@ -334,7 +334,7 @@ int file_is_obu(CLInput *cli, ObuDecInputContext *obu_ctx) {
     if (!obu_ctx || !cli) return 0;
 
     uint8_t detect_buf[OBU_DETECTION_SIZE] = { 0 };
-    const int is_annexb = obu_ctx->is_annexb;
+    const uint32_t is_annexb = obu_ctx->is_annexb;
     FILE *f = cli->inFile;
     size_t payload_length = 0;
     ObuHeader obu_header;
@@ -463,7 +463,7 @@ static int obudec_grow_buffer(size_t growth_amount, uint8_t **obu_buffer,
 static int obudec_read_one_obu(FILE *f, uint8_t **obu_buffer,
     size_t obu_bytes_buffered,
     size_t *obu_buffer_capacity, size_t *obu_length,
-    ObuHeader *obu_header, int is_annexb)
+    ObuHeader *obu_header, uint32_t is_annexb)
 {
     if (!f || !(*obu_buffer) || !obu_buffer_capacity || !obu_length ||
         !obu_header) {
@@ -566,7 +566,7 @@ int obudec_read_temporal_unit(DecInputContext *input,
             &size) != 0) {
             fprintf(stderr, "obudec: Failure reading frame header\n");
             return 0;
-    }
+        }
         if (size == 0 && feof(f)) {
             return 0;
         }

--- a/Source/App/DecApp/EbFileUtils.h
+++ b/Source/App/DecApp/EbFileUtils.h
@@ -76,6 +76,7 @@ typedef struct ObuDecInputContext {
     size_t buffer_capacity;
     size_t bytes_buffered;
     int is_annexb;
+    uint64_t rem_tu_size;
 }ObuDecInputContext;
 
 typedef struct DecInputContext {

--- a/Source/App/DecApp/EbFileUtils.h
+++ b/Source/App/DecApp/EbFileUtils.h
@@ -75,7 +75,7 @@ typedef struct ObuDecInputContext {
     uint8_t *buffer;
     size_t buffer_capacity;
     size_t bytes_buffered;
-    int is_annexb;
+    uint32_t is_annexb;
     uint64_t rem_tu_size;
 }ObuDecInputContext;
 

--- a/Source/Lib/Common/ASM_AVX2/EbHighbdIntraPrediction_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbHighbdIntraPrediction_AVX2.c
@@ -189,7 +189,7 @@ static INLINE void dc_common_predictor_16xh_kernel(uint16_t *dst,
     const ptrdiff_t stride, const int32_t h, const __m256i dc)
 {
     for (int32_t i = 0; i < h; i++) {
-        _mm256_store_si256((__m256i *)dst, dc);
+        _mm256_storeu_si256((__m256i *)dst, dc);
         dst += stride;
     }
 }
@@ -198,8 +198,8 @@ static INLINE void dc_common_predictor_32xh_kernel(uint16_t *dst,
     const ptrdiff_t stride, const int32_t h, const __m256i dc)
 {
     for (int32_t i = 0; i < h; i++) {
-        _mm256_store_si256((__m256i *)(dst + 0x00), dc);
-        _mm256_store_si256((__m256i *)(dst + 0x10), dc);
+        _mm256_storeu_si256((__m256i *)(dst + 0x00), dc);
+        _mm256_storeu_si256((__m256i *)(dst + 0x10), dc);
         dst += stride;
     }
 }
@@ -208,10 +208,10 @@ static INLINE void dc_common_predictor_64xh_kernel(uint16_t *dst,
     const ptrdiff_t stride, const int32_t h, const __m256i dc)
 {
     for (int32_t i = 0; i < h; i++) {
-        _mm256_store_si256((__m256i *)(dst + 0x00), dc);
-        _mm256_store_si256((__m256i *)(dst + 0x10), dc);
-        _mm256_store_si256((__m256i *)(dst + 0x20), dc);
-        _mm256_store_si256((__m256i *)(dst + 0x30), dc);
+        _mm256_storeu_si256((__m256i *)(dst + 0x00), dc);
+        _mm256_storeu_si256((__m256i *)(dst + 0x10), dc);
+        _mm256_storeu_si256((__m256i *)(dst + 0x20), dc);
+        _mm256_storeu_si256((__m256i *)(dst + 0x30), dc);
         dst += stride;
     }
 }
@@ -835,7 +835,7 @@ static INLINE void h_pred_16(uint16_t **const dst, const ptrdiff_t stride,
     // Broadcast the 16-bit left pixel to 256-bit register.
     const __m256i row = _mm256_broadcastw_epi16(left);
 
-    _mm256_store_si256((__m256i *)(*dst + 0x00), row);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x00), row);
     *dst += stride;
 }
 
@@ -901,8 +901,8 @@ static INLINE void h_pred_32(uint16_t **const dst, const ptrdiff_t stride,
     // Broadcast the 16-bit left pixel to 256-bit register.
     const __m256i row = _mm256_broadcastw_epi16(left);
 
-    _mm256_store_si256((__m256i *)(*dst + 0x00), row);
-    _mm256_store_si256((__m256i *)(*dst + 0x10), row);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x00), row);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x10), row);
     *dst += stride;
 }
 
@@ -959,10 +959,10 @@ static INLINE void h_pred_64(uint16_t **const dst, const ptrdiff_t stride,
     // Broadcast the 16-bit left pixel to 256-bit register.
     const __m256i row = _mm256_broadcastw_epi16(left);
 
-    _mm256_store_si256((__m256i *)(*dst + 0x00), row);
-    _mm256_store_si256((__m256i *)(*dst + 0x10), row);
-    _mm256_store_si256((__m256i *)(*dst + 0x20), row);
-    _mm256_store_si256((__m256i *)(*dst + 0x30), row);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x00), row);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x10), row);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x20), row);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x30), row);
     *dst += stride;
 }
 
@@ -1031,7 +1031,7 @@ void eb_aom_highbd_h_predictor_64x64_avx2(uint16_t *dst, ptrdiff_t stride,
 static INLINE void v_pred_16(uint16_t **const dst, const ptrdiff_t stride,
     const __m256i above0)
 {
-    _mm256_store_si256((__m256i *)(*dst + 0x00), above0);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x00), above0);
     *dst += stride;
 }
 
@@ -1144,8 +1144,8 @@ void eb_aom_highbd_v_predictor_16x64_avx2(uint16_t *dst, ptrdiff_t stride,
 static INLINE void v_pred_32(uint16_t **const dst, const ptrdiff_t stride,
     const __m256i above0, const __m256i above1)
 {
-    _mm256_store_si256((__m256i *)(*dst + 0x00), above0);
-    _mm256_store_si256((__m256i *)(*dst + 0x10), above1);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x00), above0);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x10), above1);
     *dst += stride;
 }
 
@@ -1238,10 +1238,10 @@ static INLINE void v_pred_64(uint16_t **const dst, const ptrdiff_t stride,
     const __m256i above0, const __m256i above1, const __m256i above2,
     const __m256i above3)
 {
-    _mm256_store_si256((__m256i *)(*dst + 0x00), above0);
-    _mm256_store_si256((__m256i *)(*dst + 0x10), above1);
-    _mm256_store_si256((__m256i *)(*dst + 0x20), above2);
-    _mm256_store_si256((__m256i *)(*dst + 0x30), above3);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x00), above0);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x10), above1);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x20), above2);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x30), above3);
     *dst += stride;
 }
 
@@ -1665,7 +1665,7 @@ static INLINE void smooth_pred_16(const __m256i *const weights_w,
     const __m256i lr, uint16_t **const dst, const ptrdiff_t stride)
 {
     const __m256i d = smooth_pred_kernel(weights_w, weights_h, rep, ab, lr);
-    _mm256_store_si256((__m256i *)*dst, d);
+    _mm256_storeu_si256((__m256i *)*dst, d);
     *dst += stride;
 }
 
@@ -1808,11 +1808,11 @@ static INLINE void smooth_pred_32(const __m256i *const weights_w,
 
     //  0  1  2  3  4  5  6  7   8  9 10 11 12 13 14 15
     d = smooth_pred_kernel(weights_w + 0, weights_h, rep, ab + 0, lr);
-    _mm256_store_si256((__m256i *)(*dst + 0x00), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x00), d);
 
     // 16 17 18 19 20 21 22 23  24 25 26 27 28 29 30 31
     d = smooth_pred_kernel(weights_w + 2, weights_h, rep, ab + 2, lr);
-    _mm256_store_si256((__m256i *)(*dst + 0x10), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x10), d);
     *dst += stride;
 }
 
@@ -1952,19 +1952,19 @@ static INLINE void smooth_pred_64(const __m256i *const weights_w,
 
     //  0  1  2  3  4  5  6  7   8  9 10 11 12 13 14 15
     d = smooth_pred_kernel(weights_w + 0, weights_h, rep, ab + 0, lr);
-    _mm256_store_si256((__m256i *)(*dst + 0x00), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x00), d);
 
     // 16 17 18 19 20 21 22 23  24 25 26 27 28 29 30 31
     d = smooth_pred_kernel(weights_w + 2, weights_h, rep, ab + 2, lr);
-    _mm256_store_si256((__m256i *)(*dst + 0x10), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x10), d);
 
     // 32 33 34 35 36 37 38 39  40 41 42 43 44 45 46 47
     d = smooth_pred_kernel(weights_w + 4, weights_h, rep, ab + 4, lr);
-    _mm256_store_si256((__m256i *)(*dst + 0x20), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x20), d);
 
     // 48 49 50 51 52 53 54 55  56 57 58 59 60 61 62 63
     d = smooth_pred_kernel(weights_w + 6, weights_h, rep, ab + 6, lr);
-    _mm256_store_si256((__m256i *)(*dst + 0x30), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x30), d);
     *dst += stride;
 }
 
@@ -2175,7 +2175,7 @@ static INLINE void smooth_h_pred_16(const __m256i *const weights,
     const __m256i t = _mm256_shuffle_epi8(*lr, rep); // 0 0 0 0  0 0 0 0
     //  0  1  2  3  4  5  6  7   8  9 10 11 12 13 14 15
     const __m256i d = smooth_h_pred_kernel(weights, t);
-    _mm256_store_si256((__m256i *)*dst, d);
+    _mm256_storeu_si256((__m256i *)*dst, d);
     *dst += stride;
     *lr = _mm256_srli_si256(*lr, 4); // 1 2 3 x  1 2 3 x
 }
@@ -2279,11 +2279,11 @@ static INLINE void smooth_h_pred_32(const __m256i *const weights,
 
     //  0  1  2  3  4  5  6  7   8  9 10 11 12 13 14 15
     d = smooth_h_pred_kernel(weights + 0, t);
-    _mm256_store_si256((__m256i *)(*dst + 0x00), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x00), d);
 
     // 16 17 18 19 20 21 22 23  24 25 26 27 28 29 30 31
     d = smooth_h_pred_kernel(weights + 2, t);
-    _mm256_store_si256((__m256i *)(*dst + 0x10), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x10), d);
     *dst += stride;
     *lr = _mm256_srli_si256(*lr, 4); // 1 2 3 x  1 2 3 x
 }
@@ -2362,19 +2362,19 @@ static INLINE void smooth_h_pred_64(const __m256i *const weights,
 
     //  0  1  2  3  4  5  6  7   8  9 10 11 12 13 14 15
     d = smooth_h_pred_kernel(weights + 0, t);
-    _mm256_store_si256((__m256i *)(*dst + 0x00), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x00), d);
 
     // 16 17 18 19 20 21 22 23  24 25 26 27 28 29 30 31
     d = smooth_h_pred_kernel(weights + 2, t);
-    _mm256_store_si256((__m256i *)(*dst + 0x10), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x10), d);
 
     // 32 33 34 35 36 37 38 39  40 41 42 43 44 45 46 47
     d = smooth_h_pred_kernel(weights + 4, t);
-    _mm256_store_si256((__m256i *)(*dst + 0x20), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x20), d);
 
     // 48 49 50 51 52 53 54 55  56 57 58 59 60 61 62 63
     d = smooth_h_pred_kernel(weights + 6, t);
-    _mm256_store_si256((__m256i *)(*dst + 0x30), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x30), d);
     *dst += stride;
     *lr = _mm256_srli_si256(*lr, 4); // 1 2 3 x  1 2 3 x
 }
@@ -2585,7 +2585,7 @@ static INLINE void smooth_v_pred_16(const __m256i weights, const __m256i rep,
     const __m256i *const ab, uint16_t **const dst, const ptrdiff_t stride)
 {
     const __m256i d = smooth_v_pred_kernel(weights, rep, ab);
-    _mm256_store_si256((__m256i *)*dst, d);
+    _mm256_storeu_si256((__m256i *)*dst, d);
     *dst += stride;
 }
 
@@ -2699,11 +2699,11 @@ static INLINE void smooth_v_pred_32(const __m256i weights, const __m256i rep,
 
     //  0  1  2  3  4  5  6  7   8  9 10 11 12 13 14 15
     d = smooth_v_pred_kernel(weights, rep, ab + 0);
-    _mm256_store_si256((__m256i *)(*dst + 0x00), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x00), d);
 
     // 16 17 18 19 20 21 22 23  24 25 26 27 28 29 30 31
     d = smooth_v_pred_kernel(weights, rep, ab + 2);
-    _mm256_store_si256((__m256i *)(*dst + 0x10), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x10), d);
     *dst += stride;
 }
 
@@ -2807,19 +2807,19 @@ static INLINE void smooth_v_pred_64(const __m256i weights, const __m256i rep,
 
     //  0  1  2  3  4  5  6  7   8  9 10 11 12 13 14 15
     d = smooth_v_pred_kernel(weights, rep, ab + 0);
-    _mm256_store_si256((__m256i *)(*dst + 0x00), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x00), d);
 
     // 16 17 18 19 20 21 22 23  24 25 26 27 28 29 30 31
     d = smooth_v_pred_kernel(weights, rep, ab + 2);
-    _mm256_store_si256((__m256i *)(*dst + 0x10), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x10), d);
 
     // 32 33 34 35 36 37 38 39  40 41 42 43 44 45 46 47
     d = smooth_v_pred_kernel(weights, rep, ab + 4);
-    _mm256_store_si256((__m256i *)(*dst + 0x20), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x20), d);
 
     // 48 49 50 51 52 53 54 55  56 57 58 59 60 61 62 63
     d = smooth_v_pred_kernel(weights, rep, ab + 6);
-    _mm256_store_si256((__m256i *)(*dst + 0x30), d);
+    _mm256_storeu_si256((__m256i *)(*dst + 0x30), d);
     *dst += stride;
 }
 

--- a/Source/Lib/Common/ASM_AVX2/highbd_jnt_convolve_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/highbd_jnt_convolve_avx2.c
@@ -97,13 +97,13 @@ void eb_av1_highbd_jnt_convolve_2d_copy_avx2(
                         _mm256_packus_epi32(round_result_lo, round_result_hi);
                     const __m256i res_clip = _mm256_min_epi16(res_16b, clip_pixel_to_bd);
 
-                    _mm256_store_si256((__m256i *)(&dst0[i * dst_stride0 + j]), res_clip);
+                    _mm256_storeu_si256((__m256i *)(&dst0[i * dst_stride0 + j]), res_clip);
                 }
                 else {
                     const __m256i res_unsigned_16b =
                         _mm256_adds_epu16(res, offset_const_16b);
 
-                    _mm256_store_si256((__m256i *)(&dst[i * dst_stride + j]),
+                    _mm256_storeu_si256((__m256i *)(&dst[i * dst_stride + j]),
                         res_unsigned_16b);
                 }
             }

--- a/Source/Lib/Decoder/Codec/EbDecHandle.c
+++ b/Source/Lib/Decoder/Codec/EbDecHandle.c
@@ -60,7 +60,7 @@ void dec_init_intra_predictors_internal(void);
 extern void av1_init_wedge_masks(void);
 
 EbErrorType decode_multiple_obu(EbDecHandle *dec_handle_ptr,
-                                uint8_t **data, size_t data_size);
+                                uint8_t **data, size_t data_size, int is_annexb);
 
 void SwitchToRealTime(){
 #ifndef _WIN32
@@ -520,7 +520,8 @@ __attribute__((visibility("default")))
 EB_API EbErrorType eb_svt_decode_frame(
     EbComponentType     *svt_dec_component,
     const uint8_t       *data,
-    const size_t         data_size)
+    const size_t         data_size,
+    int                  is_annexb)
 {
     EbErrorType return_error = EB_ErrorNone;
     if (svt_dec_component == NULL)
@@ -538,11 +539,9 @@ EB_API EbErrorType eb_svt_decode_frame(
         //printf("\n SVT-AV1 Dec : Decoding Pic #%d", dec_handle_ptr->dec_cnt);
 
         uint64_t frame_size = 0;
-        /*if (ctx->is_annexb) {
-        }
-        else*/
         frame_size = data_end - data_start;
-        return_error = decode_multiple_obu(dec_handle_ptr, &data_start, frame_size);
+        return_error = decode_multiple_obu(dec_handle_ptr, &data_start,
+            frame_size, is_annexb);
 
         if (return_error != EB_ErrorNone)
             assert(0);

--- a/Source/Lib/Decoder/Codec/EbDecHandle.c
+++ b/Source/Lib/Decoder/Codec/EbDecHandle.c
@@ -60,7 +60,7 @@ void dec_init_intra_predictors_internal(void);
 extern void av1_init_wedge_masks(void);
 
 EbErrorType decode_multiple_obu(EbDecHandle *dec_handle_ptr,
-                                uint8_t **data, size_t data_size, int is_annexb);
+                                uint8_t **data, size_t data_size, uint32_t is_annexb);
 
 void SwitchToRealTime(){
 #ifndef _WIN32
@@ -521,7 +521,7 @@ EB_API EbErrorType eb_svt_decode_frame(
     EbComponentType     *svt_dec_component,
     const uint8_t       *data,
     const size_t         data_size,
-    int                  is_annexb)
+    uint32_t             is_annexb)
 {
     EbErrorType return_error = EB_ErrorNone;
     if (svt_dec_component == NULL)

--- a/Source/Lib/Decoder/Codec/EbDecParseObu.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseObu.c
@@ -476,8 +476,6 @@ EbErrorType read_obu_header(bitstrm_t *bs, ObuHeader   *header)
     PRINT("obu_extension_flag", header->obu_extension_flag);
     header->obu_has_size_field = dec_get_bits(bs, 1);
     PRINT("obu_has_size_field", header->obu_has_size_field);
-    if (!header->obu_has_size_field)
-        return EB_Corrupt_Frame;
 
     if (dec_get_bits(bs, 1) != 0) {
         // obu_reserved_1bit must be set to 0
@@ -519,7 +517,7 @@ EbErrorType read_obu_size(bitstrm_t *bs, size_t bytes_available,
 }
 
 /** Reads OBU header and size */
-EbErrorType open_bistream_unit(bitstrm_t *bs, ObuHeader *header, size_t size,
+EbErrorType read_obu_header_size(bitstrm_t *bs, ObuHeader *header, size_t size,
     size_t *const length_size)
 {
     EbErrorType status;
@@ -528,9 +526,11 @@ EbErrorType open_bistream_unit(bitstrm_t *bs, ObuHeader *header, size_t size,
     if (status != EB_ErrorNone)
         return status;
 
+    if (header->obu_has_size_field) {
     status = read_obu_size(bs, size, &header->payload_size, length_size);
     if (status != EB_ErrorNone)
         return status;
+    }
 
     return EB_ErrorNone;
 }
@@ -2607,7 +2607,8 @@ EbErrorType decode_obu(EbDecHandle *dec_handle_ptr, unsigned char *data, unsigne
 }
 
 // Decode all OBUs in a Frame
-EbErrorType decode_multiple_obu(EbDecHandle *dec_handle_ptr, uint8_t **data, size_t data_size)
+EbErrorType decode_multiple_obu(EbDecHandle *dec_handle_ptr, uint8_t **data,
+    size_t data_size, int is_annexb)
 {
     bitstrm_t bs;
     EbErrorType status = EB_ErrorNone;
@@ -2639,8 +2640,23 @@ EbErrorType decode_multiple_obu(EbDecHandle *dec_handle_ptr, uint8_t **data, siz
 
         dec_bits_init(&bs, *data, data_size);
 
-        status = open_bistream_unit(&bs, &obu_header, data_size, &length_size);
+        if (is_annexb) {
+            // read the size of OBU
+            status = read_obu_size(&bs, data_size, &obu_header.payload_size,
+                &length_size);
+            if (status != EB_ErrorNone)
+                return status;
+
+            *data += length_size;
+            data_size -= length_size;
+            length_size = 0;
+        }
+
+        status = read_obu_header_size(&bs, &obu_header, data_size, &length_size);
         if (status != EB_ErrorNone) return status;
+
+        if (is_annexb)
+            obu_header.payload_size -= obu_header.size;
 
         payload_size = obu_header.payload_size;
 
@@ -2758,7 +2774,7 @@ EB_API EbErrorType eb_get_sequence_info(
         ObuHeader ou;
         memset(&ou, 0, sizeof(ou));
         size_t length_size = 0;
-        status = open_bistream_unit(&bs, &ou, frame_sz, &length_size);
+        status = read_obu_header_size(&bs, &ou, frame_sz, &length_size);
         if (status != EB_ErrorNone)
             return status;
 

--- a/Source/Lib/Decoder/Codec/EbDecParseObu.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseObu.c
@@ -527,9 +527,9 @@ EbErrorType read_obu_header_size(bitstrm_t *bs, ObuHeader *header, size_t size,
         return status;
 
     if (header->obu_has_size_field) {
-    status = read_obu_size(bs, size, &header->payload_size, length_size);
-    if (status != EB_ErrorNone)
-        return status;
+        status = read_obu_size(bs, size, &header->payload_size, length_size);
+        if (status != EB_ErrorNone)
+            return status;
     }
 
     return EB_ErrorNone;
@@ -2608,7 +2608,7 @@ EbErrorType decode_obu(EbDecHandle *dec_handle_ptr, unsigned char *data, unsigne
 
 // Decode all OBUs in a Frame
 EbErrorType decode_multiple_obu(EbDecHandle *dec_handle_ptr, uint8_t **data,
-    size_t data_size, int is_annexb)
+    size_t data_size, uint32_t is_annexb)
 {
     bitstrm_t bs;
     EbErrorType status = EB_ErrorNone;

--- a/Source/Lib/Decoder/Codec/EbObuParse.h
+++ b/Source/Lib/Decoder/Codec/EbObuParse.h
@@ -195,7 +195,8 @@ void parse_super_block(EbDecHandle *dec_handle, uint32_t blk_row,
 void svt_setup_motion_field(EbDecHandle *dec_handle);
 
 EbErrorType decode_obu(EbDecHandle *dec_handle_ptr, uint8_t *data, uint32_t data_size);
-EbErrorType decode_multiple_obu(EbDecHandle *dec_handle_ptr, uint8_t **data, size_t data_size);
+EbErrorType decode_multiple_obu(EbDecHandle *dec_handle_ptr, uint8_t **data,
+    size_t data_size, int is_annexb);
 
 static INLINE int allow_intrabc(const EbDecHandle *dec_handle) {
     return  (dec_handle->frame_header.frame_type == KEY_FRAME

--- a/Source/Lib/Decoder/Codec/EbObuParse.h
+++ b/Source/Lib/Decoder/Codec/EbObuParse.h
@@ -196,7 +196,7 @@ void svt_setup_motion_field(EbDecHandle *dec_handle);
 
 EbErrorType decode_obu(EbDecHandle *dec_handle_ptr, uint8_t *data, uint32_t data_size);
 EbErrorType decode_multiple_obu(EbDecHandle *dec_handle_ptr, uint8_t **data,
-    size_t data_size, int is_annexb);
+    size_t data_size, uint32_t is_annexb);
 
 static INLINE int allow_intrabc(const EbDecHandle *dec_handle) {
     return  (dec_handle->frame_header.frame_type == KEY_FRAME


### PR DESCRIPTION
Added support for Annex-B streams in Decoder.
Changed few of the aligned stores to unaligned stores based on the buffer alignment requirement.