### PR TITLE
A/B shape skip based on SQ/H/V shape costs

### DIFF
--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -163,7 +163,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **TileRow** | -tile-rows | [0-6] | 0 | log2 of tile rows |
 | **TileCol** | -tile-columns | [0-6] | 0 | log2 of tile columns |
 | **UnrestrictedMotionVector** | -umv | [0-1] | 1 | Enables or disables unrestriced motion vectors, 0 = OFF(motion vectors are constrained within tile boundary), 1 = ON. For MCTS support, set -umv 0 |
-
+| **SquareWeight** | -sqw | 0 for off and any whole number percentage | 100 | Weighting applied to square/h/v shape costs when deciding if a and b shapes could be skipped. Set to 100 for neutral weighting, lesser than 100 for faster encode and BD-Rate loss, and greater than 100 for slower encode and BD-Rate gain|
 ## Appendix A Encoder Parameters
 
 ### 1. Thread management parameters

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -455,6 +455,8 @@ typedef struct EbSvtAv1EncConfiguration
     uint8_t                  altref_strength;
     uint8_t                  altref_nframes;
     EbBool                   enable_overlays;
+
+    uint32_t                     sq_weight;
 } EbSvtAv1EncConfiguration;
 
     /* STEP 1: Call the library to construct a Component Handle.

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -107,6 +107,8 @@
 #define TILE_ROW_TOKEN                   "-tile-rows"
 #define TILE_COL_TOKEN                   "-tile-columns"
 
+#define SQ_WEIGHT_TOKEN                 "-sqw"
+
 #define SCENE_CHANGE_DETECTION_TOKEN    "-scd"
 #define INJECTOR_TOKEN                  "-inj"  // no Eval
 #define INJECTOR_FRAMERATE_TOKEN        "-inj-frm-rt" // no Eval
@@ -303,6 +305,11 @@ static void SetLogicalProcessors                (const char *value, EbConfig *cf
 static void SetTargetSocket                     (const char *value, EbConfig *cfg)  {cfg->target_socket              = (int32_t)strtol(value, NULL, 0);};
 static void SetUnrestrictedMotionVector         (const char *value, EbConfig *cfg)  {cfg->unrestricted_motion_vector = (EbBool)strtol(value, NULL, 0);};
 
+static void SetSquareWeight                     (const char *value, EbConfig *cfg)  {cfg->sq_weight                  = (uint64_t)strtoul(value, NULL, 0);
+        if (cfg->sq_weight == 0)
+            cfg->sq_weight = (uint32_t)~0;
+}
+
 enum cfg_type{
     SINGLE_INPUT,   // Configuration parameters that have only 1 value input
     ARRAY_INPUT     // Configuration parameters that have multiple values as input
@@ -433,6 +440,8 @@ config_entry_t config_entry[] = {
     { SINGLE_INPUT, ALTREF_NFRAMES, "AltRefNframes", SetAltRefNFrames },
     { SINGLE_INPUT, ENABLE_OVERLAYS, "EnableOverlays", SetEnableOverlays },
     // --- end: ALTREF_FILTERING_SUPPORT
+
+    { SINGLE_INPUT, SQ_WEIGHT_TOKEN, "SquareWeight", SetSquareWeight },
 
     // Termination
     {SINGLE_INPUT,NULL,  NULL,                                NULL}
@@ -596,6 +605,8 @@ void eb_config_ctor(EbConfig *config_ptr)
     config_ptr->altref_nframes                       = 7;
     config_ptr->enable_overlays                      = EB_FALSE;
     // --- end: ALTREF_FILTERING_SUPPORT
+
+    config_ptr->sq_weight                            = 100;
 
     return;
 }

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -366,6 +366,10 @@ typedef struct EbConfig
     uint8_t                 altref_nframes;
     EbBool                  enable_overlays;
     // --- end: ALTREF_FILTERING_SUPPORT
+
+    // square cost weighting for deciding if a/b shapes could be skipped
+    uint32_t                 sq_weight;
+
 } EbConfig;
 
 extern void eb_config_ctor(EbConfig *config_ptr);

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -242,6 +242,8 @@ EbErrorType CopyConfigurationParameters(
         callback_data->eb_enc_parameters.hme_level2_search_area_in_height_array[hmeRegionIndex] = config->hme_level2_search_area_in_height_array[hmeRegionIndex];
     }
 
+    callback_data->eb_enc_parameters.sq_weight = config->sq_weight;
+
     return return_error;
 }
 

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -33,6 +33,8 @@
 extern "C" {
 #endif
 
+#define LESS_RECTANGULAR_CHECK_LEVEL 1
+
 #define FIX_ALTREF                   1 // Address ALTREF mismatch between rtime-m0-test and master: fixed actual_future_pics derivation, shut padding of the central frame, fixed end past frame index prior to window shrinking
 #define FIX_NEAREST_NEW              1 // Address NEAREST_NEW mismatch between rtime-m0-test and master: fixed injection and fixed settings
 #define FIX_ESTIMATE_INTRA           1 // Address ESTIMATE_INTRA mismatch between rtime-m0-test and master: fixed settings

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -33,7 +33,7 @@
 extern "C" {
 #endif
 
-#define LESS_RECTANGULAR_CHECK_LEVEL 1
+#define LESS_RECTANGULAR_CHECK_LEVEL 1 // Shortcut to skip a/b shapes depending on SQ/H/V shape costs
 
 #define FIX_ALTREF                   1 // Address ALTREF mismatch between rtime-m0-test and master: fixed actual_future_pics derivation, shut padding of the central frame, fixed end past frame index prior to window shrinking
 #define FIX_NEAREST_NEW              1 // Address NEAREST_NEW mismatch between rtime-m0-test and master: fixed injection and fixed settings

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1535,6 +1535,22 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         context_ptr->dist_base_md_stage_0_count_th = 75;
 #endif
 
+
+#if LESS_RECTANGULAR_CHECK_LEVEL
+
+    // Weighting (expressed as a percentage) applied to 
+    // square shape costs for determining if a and b 
+    // shapes should be skipped. Namely:
+    // skip HA and HB if h_cost > (weighted sq_cost)
+    // skip VA and VB if v_cost > (weighted sq_cost)
+    
+    if (MR_MODE)
+        context_ptr->sq_to_h_v_weight_to_skip_a_b = (uint32_t)~0;
+    else
+        context_ptr->sq_to_h_v_weight_to_skip_a_b = 100;
+#endif
+
+
     return return_error;
 }
 

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1538,16 +1538,17 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 
 #if LESS_RECTANGULAR_CHECK_LEVEL
 
-    // Weighting (expressed as a percentage) applied to 
-    // square shape costs for determining if a and b 
+    // Weighting (expressed as a percentage) applied to
+    // square shape costs for determining if a and b
     // shapes should be skipped. Namely:
     // skip HA and HB if h_cost > (weighted sq_cost)
     // skip VA and VB if v_cost > (weighted sq_cost)
-    
+
     if (MR_MODE)
-        context_ptr->sq_to_h_v_weight_to_skip_a_b = (uint32_t)~0;
+        context_ptr->sq_weight = (uint32_t)~0;
     else
-        context_ptr->sq_to_h_v_weight_to_skip_a_b = 100;
+        context_ptr->sq_weight = sequence_control_set_ptr->static_config.sq_weight;
+
 #endif
 
 

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -335,6 +335,10 @@ extern "C" {
     PART best_nsq_sahpe7;
     PART best_nsq_sahpe8;
 #endif
+
+#if LESS_RECTANGULAR_CHECK_LEVEL
+    uint32_t sq_to_h_v_weight_to_skip_a_b;
+#endif
     } ModeDecisionContext;
 
     typedef void(*EbAv1LambdaAssignFunc)(

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -337,7 +337,8 @@ extern "C" {
 #endif
 
 #if LESS_RECTANGULAR_CHECK_LEVEL
-    uint32_t sq_to_h_v_weight_to_skip_a_b;
+    // square cost weighting for deciding if a/b shapes could be skipped
+    uint32_t sq_weight;
 #endif
     } ModeDecisionContext;
 

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -904,7 +904,7 @@ EbErrorType signal_derivation_multi_processes_oq(
             if (picture_control_set_ptr->is_used_as_reference_flag)
                 picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_LEVEL5;
             else
-				picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_LEVEL3;
+                picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_LEVEL3;
         else
             picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_OFF;
 

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -7538,7 +7538,7 @@ void md_encode_block(
         picture_control_set_ptr->parent_pcs_ptr->pic_depth_mode <= PIC_ALL_C_DEPTH_MODE &&
         picture_control_set_ptr->parent_pcs_ptr->nsq_search_level >= NSQ_SEARCH_LEVEL1 &&
         picture_control_set_ptr->parent_pcs_ptr->nsq_search_level < NSQ_SEARCH_FULL) ? EB_TRUE : EB_FALSE;
-		
+
     is_nsq_table_used = picture_control_set_ptr->parent_pcs_ptr->sc_content_detected || picture_control_set_ptr->enc_mode == ENC_M0 ? EB_FALSE : is_nsq_table_used;
 #if ADJUST_NSQ_RANK_BASED_ON_NEIGH
     if (is_nsq_table_used) {
@@ -7568,7 +7568,7 @@ void md_encode_block(
         picture_control_set_ptr->parent_pcs_ptr->nsq_search_level >= NSQ_SEARCH_LEVEL1 &&
         picture_control_set_ptr->parent_pcs_ptr->nsq_search_level < NSQ_SEARCH_FULL) ? EB_TRUE : EB_FALSE;
 
-	is_nsq_table_used = picture_control_set_ptr->enc_mode == ENC_M0 ?  EB_FALSE : is_nsq_table_used;
+    is_nsq_table_used = picture_control_set_ptr->enc_mode == ENC_M0 ?  EB_FALSE : is_nsq_table_used;
     if (is_nsq_table_used) {
         if (context_ptr->blk_geom->shape == PART_N) {
             order_nsq_table(
@@ -8146,7 +8146,7 @@ void update_skip_next_nsq_for_a_b_shapes(
         break;
     case 4:
         *v_cost += context_ptr->md_local_cu_unit[context_ptr->cu_ptr->mds_idx].cost;
-        *skip_next_nsq = (*h_cost > ((*sq_cost * context_ptr->sq_to_h_v_weight_to_skip_a_b) / 100)) ? 1 : *skip_next_nsq;
+        *skip_next_nsq = (*h_cost > ((*sq_cost * context_ptr->sq_weight) / 100)) ? 1 : *skip_next_nsq;
         break;
 
     // HA
@@ -8157,7 +8157,7 @@ void update_skip_next_nsq_for_a_b_shapes(
     // HB
     case 8:
     case 9:
-        *skip_next_nsq = (*h_cost > ((*sq_cost * context_ptr->sq_to_h_v_weight_to_skip_a_b) / 100)) ? 1 : *skip_next_nsq;
+        *skip_next_nsq = (*h_cost > ((*sq_cost * context_ptr->sq_weight) / 100)) ? 1 : *skip_next_nsq;
         break;
     case 10:
 
@@ -8169,7 +8169,7 @@ void update_skip_next_nsq_for_a_b_shapes(
     // VB
     case 14:
     case 15:
-        *skip_next_nsq = (*v_cost > ((*sq_cost * context_ptr->sq_to_h_v_weight_to_skip_a_b) / 100)) ? 1 : *skip_next_nsq;
+        *skip_next_nsq = (*v_cost > ((*sq_cost * context_ptr->sq_weight) / 100)) ? 1 : *skip_next_nsq;
         break;
     }
 }
@@ -8544,7 +8544,7 @@ EB_EXTERN EbErrorType mode_decision_sb(
         }
 
 #if LESS_RECTANGULAR_CHECK_LEVEL
-        if (context_ptr->sq_to_h_v_weight_to_skip_a_b != (uint32_t)~0 && blk_geom->bsize > BLOCK_8X8)
+        if (context_ptr->sq_weight != (uint32_t)~0 && blk_geom->bsize > BLOCK_8X8)
             update_skip_next_nsq_for_a_b_shapes(context_ptr, &sq_cost, &h_cost, &v_cost, &skip_next_nsq);
 #endif
 

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -2206,6 +2206,8 @@ void CopyApiFromApp(
     sequence_control_set_ptr->static_config.altref_nframes = pComponentParameterStructure->altref_nframes;
     sequence_control_set_ptr->static_config.enable_overlays = pComponentParameterStructure->enable_overlays;
 
+    sequence_control_set_ptr->static_config.sq_weight = pComponentParameterStructure->sq_weight;
+
     return;
 }
 
@@ -2674,6 +2676,8 @@ EbErrorType eb_svt_enc_init_parameter(
     config_ptr->altref_nframes = 7;
     config_ptr->altref_strength = 5;
     config_ptr->enable_overlays = EB_FALSE;
+
+    config_ptr->sq_weight = 100;
 
     return return_error;
 }


### PR DESCRIPTION
## Description
Determine if the evaluation of a and b shapes could be skipped based on cost of square, h and v shapes. Namely:
 - skip HA and HB if h_cost > (weighted sq_cost)
 - skip VA and VB if v_cost > (weighted sq_cost)

Weighting to sq cost can be controlled with the `-sqw` flag, which is expressed as a percentage and set to `100` (neutral) by default.
 - To turn off this feature, set `-sqw 0`
 - To use *aggressive* weighting, set `-sqw` to a value lesser than 100
     - faster but more BD-Rate loss
 - To use *conservative* weighting, set `-sqw` to a value greater than 100
     - slower but less BD-Rate loss


## Author

@hguermaz 
@JackZhouVCD 

## Type of change

Enhancement

## Tests and performance
All data generated from full-list objective-1-fast dataset in the context of enc-mode 0. Speed data is generated using AWS ec2 48 vCPU instances

| | Deviation|
|-|-|
| **Speed** | 13.58% |
| **BD-Rate** | 0.106% |