### PR TITLE
Fix temporal filtering for non-key Intra frames

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -82,6 +82,7 @@ extern "C" {
 #define TWO_PASS_USE_2NDP_ME_IN_1STP      1 // Add a config parameter to the first pass to use the ME settings of the second pass
 
 #define REMOVE_MD_STAGE_1                 1 // Simplified MD Staging; removed md_stage_1
+#define NON_KF_INTRA_TF_FIX               1 // Fix temporal filtering for non-key Intra frames
 
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC                         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -3603,7 +3603,11 @@ void* picture_decision_kernel(void *input_ptr)
                             picture_control_set_ptr = cur_picture_control_set_ptr;
 
                             if( sequence_control_set_ptr->enable_altrefs == EB_TRUE &&
+#if NON_KF_INTRA_TF_FIX
+                                ((picture_control_set_ptr->slice_type == I_SLICE && picture_control_set_ptr->sc_content_detected == 0) ||
+#else  
                                 ( (picture_control_set_ptr->idr_flag && picture_control_set_ptr->sc_content_detected == 0) ||
+#endif
                                   (picture_control_set_ptr->slice_type != I_SLICE && picture_control_set_ptr->temporal_layer_index == 0)
 #if TWO_PASS
                                     || (sequence_control_set_ptr->use_input_stat_file && picture_control_set_ptr->temporal_layer_index == 1 && picture_control_set_ptr->sc_content_detected == 0)


### PR DESCRIPTION
Description:
Fix a bug related to temporal filtering of non-key Intra frames. Temporal Filtering now enable for all Intra frame

Authors
@anaghdin

Type of change
Bug Fix

Tests and performance
Expected Average Y-PSNR BD-rate gain in the range of -3% on the jctvc list with Intra refresh enabled, using 4 QP values: {20, 32, 43 and 55}.

