### PR TITLE
Two pass tuning

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -83,6 +83,7 @@ extern "C" {
 
 #define REMOVE_MD_STAGE_1                 1 // Simplified MD Staging; removed md_stage_1
 
+#define TWO_PASS_IMPROVEMENT              1 // Tune 2 pass for better Luma by adjusting the reference area and the actions
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC                         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch
 
@@ -3310,6 +3311,9 @@ typedef struct stat_struct_t
 {
     uint32_t                        referenced_area[MAX_NUMBER_OF_TREEBLOCKS_PER_PICTURE];
 } stat_struct_t;
+#if TWO_PASS_IMPROVEMENT
+#define TWO_PASS_IR_THRSHLD 40
+#endif
 #endif
 #define SC_MAX_LEVEL 2 // 2 sets of HME/ME settings are used depending on the scene content mode
 

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -3312,7 +3312,9 @@ typedef struct stat_struct_t
     uint32_t                        referenced_area[MAX_NUMBER_OF_TREEBLOCKS_PER_PICTURE];
 } stat_struct_t;
 #if TWO_PASS_IMPROVEMENT
-#define TWO_PASS_IR_THRSHLD 40
+#define TWO_PASS_IR_THRSHLD 40  // Intra refresh threshold used to reduce the reference area.
+                                // If the periodic Intra refresh is less than the threshold,
+                                // the referenced area is normalized
 #endif
 #endif
 #define SC_MAX_LEVEL 2 // 2 sets of HME/ME settings are used depending on the scene content mode

--- a/Source/Lib/Common/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Common/Codec/EbRateControlProcess.c
@@ -3686,8 +3686,9 @@ static int adaptive_qindex_calc_two_pass(
     int                        qindex) {
 
     SequenceControlSet        *sequence_control_set_ptr = picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr;
+#if !TWO_PASS_IMPROVEMENT
     const Av1Common  *const cm = picture_control_set_ptr->parent_pcs_ptr->av1_cm;
-
+#endif
     const int cq_level = qindex;
     int active_best_quality = 0;
     int active_worst_quality = qindex;

--- a/Source/Lib/Common/Codec/EbRateDistortionCost.c
+++ b/Source/Lib/Common/Codec/EbRateDistortionCost.c
@@ -1907,6 +1907,15 @@ uint64_t av1_inter_fast_cost(
                 rate += rate * FIRST_PASS_COST_PENALTY / 100;
                 totalDistortion += totalDistortion * FIRST_PASS_COST_PENALTY / 100;
             }
+#if TWO_PASS_IMPROVEMENT
+            EbReferenceObject  *refObjL1 = (EbReferenceObject*)picture_control_set_ptr->ref_pic_ptr_array[REF_LIST_1][0]->object_ptr;
+            if (picture_control_set_ptr->slice_type == B_SLICE &&
+                (candidate_ptr->is_compound || ref_type[0] == BWDREF_FRAME) &&
+                (refObjL1->slice_type == I_SLICE && refObjL1->ref_poc > picture_control_set_ptr->picture_number)) {
+                rate += rate * 2;
+                totalDistortion += totalDistortion * 2;
+            }
+#endif
         }
 #endif
         if (candidate_ptr->merge_flag) {
@@ -1932,6 +1941,15 @@ uint64_t av1_inter_fast_cost(
                 rate += rate * FIRST_PASS_COST_PENALTY / 100;
                 totalDistortion += totalDistortion * FIRST_PASS_COST_PENALTY / 100;
             }
+#if TWO_PASS_IMPROVEMENT
+            EbReferenceObject  *refObjL1 = (EbReferenceObject*)picture_control_set_ptr->ref_pic_ptr_array[REF_LIST_1][0]->object_ptr;
+            if (picture_control_set_ptr->slice_type == B_SLICE &&
+                (candidate_ptr->is_compound || ref_type[0] == BWDREF_FRAME) &&
+                (refObjL1->slice_type == I_SLICE && refObjL1->ref_poc > picture_control_set_ptr->picture_number)) {
+                rate += rate * 2;
+                totalDistortion += totalDistortion * 2;
+            }
+#endif
         }
 #endif
         // Assign fast cost
@@ -2193,6 +2211,15 @@ EbErrorType Av1FullCost(
             rate += rate * FIRST_PASS_COST_PENALTY / 100;
             totalDistortion += totalDistortion * FIRST_PASS_COST_PENALTY / 100;
         }
+#if TWO_PASS_IMPROVEMENT
+        EbReferenceObject  *refObjL1 = (EbReferenceObject*)picture_control_set_ptr->ref_pic_ptr_array[REF_LIST_1][0]->object_ptr;
+        if (picture_control_set_ptr->slice_type == B_SLICE &&
+            (candidate_buffer_ptr->candidate_ptr->is_compound || ref_type[0] == BWDREF_FRAME) &&
+            (refObjL1->slice_type == I_SLICE && refObjL1->ref_poc > picture_control_set_ptr->picture_number)) {
+            rate += rate * 2;
+            totalDistortion += totalDistortion * 2;
+        }
+#endif
     }
 #endif
     // Assign full cost
@@ -2358,6 +2385,15 @@ EbErrorType  Av1MergeSkipFullCost(
             skip_cost += skip_cost * FIRST_PASS_COST_PENALTY / 100;
             merge_cost += merge_cost * FIRST_PASS_COST_PENALTY / 100;
         }
+#if TWO_PASS_IMPROVEMENT
+        EbReferenceObject  *refObjL1 = (EbReferenceObject*)picture_control_set_ptr->ref_pic_ptr_array[REF_LIST_1][0]->object_ptr;
+        if (picture_control_set_ptr->slice_type == B_SLICE &&
+            (candidate_buffer_ptr->candidate_ptr->is_compound || ref_type[0] == BWDREF_FRAME)
+            && refObjL1->slice_type == I_SLICE && refObjL1->ref_poc > picture_control_set_ptr->picture_number) {
+            skip_cost += skip_cost * 2;
+            merge_cost += merge_cost * 2;
+        }
+#endif
     }
 #endif
     // Assigne full cost

--- a/Source/Lib/Common/Codec/EbRateDistortionCost.c
+++ b/Source/Lib/Common/Codec/EbRateDistortionCost.c
@@ -1561,8 +1561,8 @@ uint64_t mdc_av1_inter_fast_cost(
 #endif
 #if TWO_PASS_IMPROVEMENT
 /* two_pass_cost_update
- * This function add some biases for distortion and rate. 
- * The function is used in the first pass only and for the porpuse of data collection */
+ * This function adds some biases for distortion and rate. 
+ * The function is used in the first pass only and for the purpose of data collection */
 void two_pass_cost_update(
     PictureControlSet     *picture_control_set_ptr,
     ModeDecisionCandidate *candidate_ptr,

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -563,6 +563,11 @@ static void read_stat_from_file(
         referenced_area_has_non_zero += picture_control_set_ptr->stat_struct.referenced_area[sb_addr];
     }
     referenced_area_avg /= sequence_control_set_ptr->sb_total_count;
+#if TWO_PASS_IMPROVEMENT
+    // adjust the reference area based on the intra refresh
+    if (sequence_control_set_ptr->intra_period_length && sequence_control_set_ptr->intra_period_length < TWO_PASS_IR_THRSHLD)
+        referenced_area_avg = referenced_area_avg * (sequence_control_set_ptr->intra_period_length + 1) / TWO_PASS_IR_THRSHLD;
+#endif
     picture_control_set_ptr->referenced_area_avg = referenced_area_avg;
     picture_control_set_ptr->referenced_area_has_non_zero = referenced_area_has_non_zero ? 1 : 0;
 


### PR DESCRIPTION
Description:
Tune the two pass encoding for better Luma by adjusting the reference area, the maximum values and the actions

Authors
@anaghdin

Type of change
Feature Improvement

Tests and performance
Expected Average Y-PSNR BD-rate gain in the range of -0.2% on the objective fast 1 test set, using 5 QP values: {20, 32, 43, 55 and 63}.

No Speed impact.