### PR TITLE
hbd clean up

### DIFF
--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -270,10 +270,14 @@ typedef struct EbSvtAv1EncConfiguration
     uint32_t                 search_area_height;
 
     // MD Parameters
-    /* Enable the use of HBD (10-bit) at the mode decision step
-    *
-    * Default is 0. */
-    EbBool                   enable_hbd_mode_decision;
+    /* Enable the use of HBD (10-bit) for 10 bit content at the mode decision step
+     *
+     * 0 = 8bit mode decision
+     * 1 = 10bit mode decision
+     * 2 = Auto: 8bit & 10bit mode decision
+     *
+    * Default is 1. */
+    uint8_t                   enable_hbd_mode_decision;
 
     /* Palette Mode
     *

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -281,7 +281,7 @@ static void SetAltRefStrength                   (const char *value, EbConfig *cf
 static void SetAltRefNFrames                    (const char *value, EbConfig *cfg) {cfg->altref_nframes = (uint8_t)strtoul(value, NULL, 0);};
 static void SetEnableOverlays                   (const char *value, EbConfig *cfg) { cfg->enable_overlays = (EbBool)strtoul(value, NULL, 0); };
 // --- end: ALTREF_FILTERING_SUPPORT
-static void SetEnableHBDModeDecision            (const char *value, EbConfig *cfg) {cfg->enable_hbd_mode_decision = (EbBool)strtoul(value, NULL, 0);};
+static void SetEnableHBDModeDecision            (const char *value, EbConfig *cfg) {cfg->enable_hbd_mode_decision = (uint8_t)strtoul(value, NULL, 0);};
 static void SetEnablePalette                    (const char *value, EbConfig *cfg) { cfg->enable_palette = (int32_t)strtoul(value, NULL, 0); };
 static void SetEnableConstrainedIntra           (const char *value, EbConfig *cfg) {cfg->constrained_intra                                             = (EbBool)strtoul(value, NULL, 0);};
 static void SetHighDynamicRangeInput            (const char *value, EbConfig *cfg) {cfg->high_dynamic_range_input            = strtol(value,  NULL, 0);};
@@ -547,7 +547,7 @@ void eb_config_ctor(EbConfig *config_ptr)
     config_ptr->hme_level2_search_area_in_height_array[0]  = 1;
     config_ptr->hme_level2_search_area_in_height_array[1]  = 1;
     config_ptr->screen_content_mode                  = 2;
-    config_ptr->enable_hbd_mode_decision             = EB_TRUE;
+    config_ptr->enable_hbd_mode_decision             = 1;
     config_ptr->enable_palette                       = -1;
     config_ptr->constrained_intra                    = 0;
     config_ptr->film_grain_denoise_strength          = 0;
@@ -966,8 +966,8 @@ static EbErrorType VerifySettings(EbConfig *config, uint32_t channelNumber)
     }
 
     // HBD mode decision
-    if (config->enable_hbd_mode_decision != 0 && config->enable_hbd_mode_decision != 1) {
-        fprintf(config->error_log_file, "Error instance %u: Invalid HBD mode decision flag [0 - 1], your input: %d\n", channelNumber + 1, config->target_socket);
+    if (config->enable_hbd_mode_decision != 0 && config->enable_hbd_mode_decision != 1 && config->enable_hbd_mode_decision != 2) {
+        fprintf(config->error_log_file, "Error instance %u: Invalid HBD mode decision flag [0 - 2], your input: %d\n", channelNumber + 1, config->target_socket);
         return_error = EB_ErrorBadParameter;
     }
 

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -300,7 +300,7 @@ typedef struct EbConfig
      * MD Parameters
      ****************************************/
     EbBool                  constrained_intra;
-    EbBool                  enable_hbd_mode_decision;
+    int8_t                  enable_hbd_mode_decision;
     int32_t                  enable_palette;
     int32_t                  tile_columns;
     int32_t                  tile_rows;

--- a/Source/Lib/Common/Codec/EbCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbCodingLoop.c
@@ -2281,7 +2281,7 @@ EB_EXTERN void av1_encode_pass(
                 sb_height >> 1);
         }
 
-        if (picture_control_set_ptr->hbd_mode_decision == 0)
+        if (context_ptr->md_context->hbd_mode_decision == 0)
             Store16bitInputSrc(context_ptr->input_sample16bit_buffer, picture_control_set_ptr, sb_origin_x, sb_origin_y, sb_width, sb_height);
     }
 

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -32,6 +32,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+#define HBD_CLEAN_UP                 1
+
+#define IFS_8BIT_MD                  1
+
 
 /* Note: shutting the macro PAL_SUP will not give SS as pcs->palette_mode = 0
    rate estimation is changed for I frame + enabled sc for P (rate estimation
@@ -2171,7 +2175,17 @@ typedef enum EbBitDepthEnum
     EB_16BIT = 16,
     EB_32BIT = 32
 } EbBitDepthEnum;
+#if HBD_CLEAN_UP
+/** The MD_BIT_DEPTH_MODE type is used to describe the bitdepth of MD path.
+*/
 
+typedef enum MD_BIT_DEPTH_MODE
+{
+    EB_8_BIT_MD     = 0,    // 8bit mode decision
+    EB_10_BIT_MD    = 1,    // 10bit mode decision
+    EB_DUAL_BIT_MD  = 2     // Auto: 8bit & 10bit mode decision
+} MD_BIT_DEPTH_MODE;
+#endif
 /** The EB_GOP type is used to describe the hierarchical coding structure of
 Groups of Pictures (GOP) units.
 */

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -101,7 +101,7 @@ EbErrorType enc_dec_context_ctor(
 #endif
     EbBool                  is16bit,
     EbColorFormat           color_format,
-    EbBool                  enable_hbd_mode_decision,
+    uint8_t                 enable_hbd_mode_decision,
     uint32_t                max_input_luma_width,
     uint32_t                max_input_luma_height)
 {
@@ -278,7 +278,7 @@ static void ResetEncDec(
         &context_ptr->full_chroma_lambda,
         (uint8_t)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
         context_ptr->qp_index,
-        picture_control_set_ptr->hbd_mode_decision);
+        context_ptr->md_context->hbd_mode_decision);
     // Reset MD rate Estimation table to initial values by copying from md_rate_estimation_array
     if (context_ptr->is_md_rate_estimation_ptr_owner) {
         EB_FREE(context_ptr->md_rate_estimation_ptr);
@@ -317,7 +317,7 @@ static void EncDecConfigureLcu(
         &context_ptr->full_chroma_lambda,
         (uint8_t)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
         context_ptr->qp_index,
-        picture_control_set_ptr->hbd_mode_decision);
+        context_ptr->md_context->hbd_mode_decision);
 
     return;
 }

--- a/Source/Lib/Common/Codec/EbEncDecProcess.h
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.h
@@ -138,7 +138,7 @@ extern "C" {
 #endif
         EbBool                   is16bit,
         EbColorFormat            color_format,
-        EbBool                   enable_hbd_mode_decision,
+        uint8_t                  enable_hbd_mode_decision,
         uint32_t                 max_input_luma_width,
         uint32_t                 max_input_luma_height);
 

--- a/Source/Lib/Common/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Common/Codec/EbEntropyCoding.c
@@ -6705,7 +6705,7 @@ assert(bsize < BlockSizeS_ALL);
 
 #if PAL_SUP
     if (svt_av1_allow_palette(picture_control_set_ptr->parent_pcs_ptr->palette_mode, blk_geom->bsize)) {
-        assert(cu_ptr->palette_info.color_idx_map != NULL && "free palette:Null");     
+        assert(cu_ptr->palette_info.color_idx_map != NULL && "free palette:Null");
         free(cu_ptr->palette_info.color_idx_map);
         cu_ptr->palette_info.color_idx_map = NULL;
     }

--- a/Source/Lib/Common/Codec/EbFullLoop.c
+++ b/Source/Lib/Common/Codec/EbFullLoop.c
@@ -1392,6 +1392,7 @@ int32_t av1_quantize_inv_quantize(
 #else
     EbBool perform_rdoq = ((md_context->md_staging_skip_rdoq == EB_FALSE || is_encode_pass) && md_context->trellis_quant_coeff_optimization && component_type == COMPONENT_LUMA && !is_intra_bc);
 #endif
+
     perform_rdoq = perform_rdoq && !picture_control_set_ptr->hbd_mode_decision && !bit_increment;
 
     // Hsan: set to FALSE until adding x86 quantize_fp
@@ -1543,7 +1544,7 @@ void product_full_loop(
             context_ptr->blk_geom->txsize[tx_depth][txb_itr],
             &context_ptr->three_quad_energy,
             context_ptr->transform_inner_array_ptr,
-            picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
+            context_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
             candidate_buffer->candidate_ptr->transform_type[txb_itr],
             PLANE_TYPE_Y,
             DEFAULT_SHAPE);
@@ -1565,7 +1566,7 @@ void product_full_loop(
             &candidate_buffer->candidate_ptr->eob[0][txb_itr],
             &(y_count_non_zero_coeffs[txb_itr]),
             COMPONENT_LUMA,
-            picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
+            context_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
             candidate_buffer->candidate_ptr->transform_type[txb_itr],
             candidate_buffer,
             context_ptr->luma_txb_skip_context,
@@ -1588,7 +1589,7 @@ void product_full_loop(
                     candidate_buffer->recon_ptr->stride_y,
                     (int32_t*) candidate_buffer->recon_coeff_ptr->buffer_y,
                     txb_1d_offset,
-                    picture_control_set_ptr->hbd_mode_decision,
+                    context_ptr->hbd_mode_decision,
                     context_ptr->blk_geom->txsize[tx_depth][txb_itr],
                     candidate_buffer->candidate_ptr->transform_type[txb_itr],
                     PLANE_TYPE_Y,
@@ -1606,10 +1607,10 @@ void product_full_loop(
                     0,
                     0,
                     PICTURE_BUFFER_DESC_Y_FLAG,
-                    picture_control_set_ptr->hbd_mode_decision);
+                    context_ptr->hbd_mode_decision);
             }
 
-            EbSpatialFullDistType spatial_full_dist_type_fun = picture_control_set_ptr->hbd_mode_decision ?
+            EbSpatialFullDistType spatial_full_dist_type_fun = context_ptr->hbd_mode_decision ?
                 full_distortion_kernel16_bits :
                 spatial_full_distortion_kernel;
 
@@ -1853,7 +1854,7 @@ void product_full_loop_tx_search(
                 context_ptr->blk_geom->txsize[tx_depth][txb_itr],
                 &context_ptr->three_quad_energy,
                 context_ptr->transform_inner_array_ptr,
-                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
+                context_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 tx_type,
                 PLANE_TYPE_Y,
                 context_ptr->pf_md_mode);
@@ -1876,7 +1877,7 @@ void product_full_loop_tx_search(
                 &candidate_buffer->candidate_ptr->eob[0][txb_itr],
                 &yCountNonZeroCoeffsTemp,
                 COMPONENT_LUMA,
-                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
+                context_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 tx_type,
                 candidate_buffer,
                 context_ptr->luma_txb_skip_context,
@@ -1901,7 +1902,7 @@ void product_full_loop_tx_search(
                         candidate_buffer->recon_ptr->stride_y,
                         (int32_t*) candidate_buffer->recon_coeff_ptr->buffer_y,
                         tu_origin_index,
-                        picture_control_set_ptr->hbd_mode_decision,
+                        context_ptr->hbd_mode_decision,
                         context_ptr->blk_geom->txsize[tx_depth][txb_itr],
                         tx_type,
                         PLANE_TYPE_Y,
@@ -1919,13 +1920,13 @@ void product_full_loop_tx_search(
                         0,
                         0,
                         PICTURE_BUFFER_DESC_Y_FLAG,
-                        picture_control_set_ptr->hbd_mode_decision);
+                        context_ptr->hbd_mode_decision);
 
-                EbPictureBufferDesc *input_picture_ptr = picture_control_set_ptr->hbd_mode_decision ?
+                EbPictureBufferDesc *input_picture_ptr = context_ptr->hbd_mode_decision ?
                     picture_control_set_ptr->input_frame16bit : picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
                 uint32_t input_tu_origin_index = (context_ptr->sb_origin_x + txb_origin_x + input_picture_ptr->origin_x) + ((context_ptr->sb_origin_y + txb_origin_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_y);
 
-                EbSpatialFullDistType spatial_full_dist_type_fun = picture_control_set_ptr->hbd_mode_decision ?
+                EbSpatialFullDistType spatial_full_dist_type_fun = context_ptr->hbd_mode_decision ?
                     full_distortion_kernel16_bits : spatial_full_distortion_kernel;
 
                 tuFullDistortion[0][DIST_CALC_PREDICTION] = spatial_full_dist_type_fun(
@@ -2556,7 +2557,7 @@ void full_loop_r(
                 context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr],
                 &context_ptr->three_quad_energy,
                 context_ptr->transform_inner_array_ptr,
-                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
+                context_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 candidate_buffer->candidate_ptr->transform_type_uv,
                 PLANE_TYPE_UV,
                 DEFAULT_SHAPE);
@@ -2578,7 +2579,7 @@ void full_loop_r(
                 &candidate_buffer->candidate_ptr->eob[1][txb_itr],
                 &(cb_count_non_zero_coeffs[txb_itr]),
                 COMPONENT_CHROMA_CB,
-                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
+                context_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 candidate_buffer->candidate_ptr->transform_type_uv,
                 candidate_buffer,
 #if RDOQ_CHROMA
@@ -2606,7 +2607,7 @@ void full_loop_r(
                         candidate_buffer->recon_ptr->stride_cb,
                         (int32_t*) candidate_buffer->recon_coeff_ptr->buffer_cb,
                         txb_1d_offset,
-                        picture_control_set_ptr->hbd_mode_decision,
+                        context_ptr->hbd_mode_decision,
                         context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr],
                         candidate_buffer->candidate_ptr->transform_type_uv,
                         PLANE_TYPE_UV,
@@ -2624,7 +2625,7 @@ void full_loop_r(
                         context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
                         context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr],
                         PICTURE_BUFFER_DESC_Cb_FLAG,
-                        picture_control_set_ptr->hbd_mode_decision);
+                        context_ptr->hbd_mode_decision);
             }
         }
 
@@ -2644,7 +2645,7 @@ void full_loop_r(
                 context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr],
                 &context_ptr->three_quad_energy,
                 context_ptr->transform_inner_array_ptr,
-                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
+                context_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 candidate_buffer->candidate_ptr->transform_type_uv,
                 PLANE_TYPE_UV,
                 DEFAULT_SHAPE);
@@ -2666,7 +2667,7 @@ void full_loop_r(
                 &candidate_buffer->candidate_ptr->eob[2][txb_itr],
                 &(cr_count_non_zero_coeffs[txb_itr]),
                 COMPONENT_CHROMA_CR,
-                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
+                context_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
                 candidate_buffer->candidate_ptr->transform_type_uv,
                 candidate_buffer,
 #if RDOQ_CHROMA
@@ -2694,7 +2695,7 @@ void full_loop_r(
                         candidate_buffer->recon_ptr->stride_cr,
                         (int32_t*) candidate_buffer->recon_coeff_ptr->buffer_cr,
                         txb_1d_offset,
-                        picture_control_set_ptr->hbd_mode_decision,
+                        context_ptr->hbd_mode_decision,
                         context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr],
                         candidate_buffer->candidate_ptr->transform_type_uv,
                         PLANE_TYPE_UV,
@@ -2712,7 +2713,7 @@ void full_loop_r(
                         context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
                         context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr],
                         PICTURE_BUFFER_DESC_Cr_FLAG,
-                        picture_control_set_ptr->hbd_mode_decision);
+                        context_ptr->hbd_mode_decision);
             }
         }
 
@@ -2786,7 +2787,7 @@ void cu_full_distortion_fast_tu_mode_r(
                 uint32_t input_chroma_tu_origin_index = (((context_ptr->sb_origin_y + ((txb_origin_y >> 3) << 3)) >> 1) + (input_picture_ptr->origin_y >> 1)) * input_picture_ptr->stride_cb + (((context_ptr->sb_origin_x + ((txb_origin_x >> 3) << 3)) >> 1) + (input_picture_ptr->origin_x >> 1));
                 uint32_t tu_uv_origin_index = (((txb_origin_x >> 3) << 3) + (((txb_origin_y >> 3) << 3) * candidate_buffer->residual_quant_coeff_ptr->stride_cb)) >> 1;
 
-                EbSpatialFullDistType spatial_full_dist_type_fun = picture_control_set_ptr->hbd_mode_decision ?
+                EbSpatialFullDistType spatial_full_dist_type_fun = context_ptr->hbd_mode_decision ?
                     full_distortion_kernel16_bits : spatial_full_distortion_kernel;
 
                 tuFullDistortion[1][DIST_CALC_PREDICTION] = spatial_full_dist_type_fun(

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -316,7 +316,7 @@ void inter_intra_search(
     pred_desc.buffer_y = tmp_buf;
 
     //we call the regular inter prediction path here(no compound)
-    av1_inter_prediction_function_table[context_ptr->hbd_mode_decision](
+    av1_inter_prediction_function_table[context_ptr->hbd_mode_decision > EB_8_BIT_MD](
         picture_control_set_ptr,
         0,//ASSUMPTION: fixed interpolation filter.
         context_ptr->cu_ptr,
@@ -6067,7 +6067,7 @@ uint32_t product_full_mode_decision(
 
 #if PAL_SUP
         if (cu_ptr->prediction_mode_flag == INTRA_MODE)
-        { 
+        {
             memcpy(&cu_ptr->palette_info.pmi, &candidate_ptr->palette_info.pmi, sizeof(PaletteModeInfo));
             if(svt_av1_allow_palette(context_ptr->sb_ptr->picture_control_set_ptr->parent_pcs_ptr->palette_mode, context_ptr->blk_geom->bsize))
                memcpy(cu_ptr->palette_info.color_idx_map, candidate_ptr->palette_info.color_idx_map, MAX_PALETTE_SQUARE);

--- a/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
@@ -2129,6 +2129,7 @@ EbErrorType signal_derivation_mode_decision_config_kernel_oq(
         picture_control_set_ptr->pic_filter_intra_mode = picture_control_set_ptr->parent_pcs_ptr->sc_content_detected == 0 && picture_control_set_ptr->temporal_layer_index == 0 ? 1 : 0;
     else
         picture_control_set_ptr->pic_filter_intra_mode = 0;
+
 #endif
     return return_error;
 }

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.c
@@ -45,9 +45,17 @@ static void mode_decision_context_dctor(EbPtr p)
 #endif
 
     EB_DELETE(obj->trans_quant_buffers_ptr);
+#if !HBD_CLEAN_UP // cfl_temp_luma_recon16bit
     if (obj->hbd_mode_decision)
+#else
+    if (obj->hbd_mode_decision > EB_8_BIT_MD)
+#endif
         EB_FREE_ALIGNED_ARRAY(obj->cfl_temp_luma_recon16bit);
+#if !HBD_CLEAN_UP
     else
+#else
+    if (obj->hbd_mode_decision != EB_10_BIT_MD)
+#endif
         EB_FREE_ALIGNED_ARRAY(obj->cfl_temp_luma_recon);
     EB_FREE(obj->transform_inner_array_ptr);
     if (obj->is_md_rate_estimation_ptr_owner)
@@ -60,10 +68,20 @@ static void mode_decision_context_dctor(EbPtr p)
     EB_FREE_ARRAY(obj->full_cost_merge_ptr);
     if (obj->md_cu_arr_nsq) {
         EB_FREE_ARRAY(obj->md_cu_arr_nsq[0].av1xd);
+#if !HBD_CLEAN_UP // neigh_left_recon_16bit neigh_top_recon_16bit
         if (obj->hbd_mode_decision) {
+#else
+        if (obj->hbd_mode_decision > EB_8_BIT_MD) {
+#endif
             EB_FREE_ARRAY(obj->md_cu_arr_nsq[0].neigh_left_recon_16bit[0]);
             EB_FREE_ARRAY(obj->md_cu_arr_nsq[0].neigh_top_recon_16bit[0]);
-        } else {
+        }
+#if HBD_CLEAN_UP
+        if (obj->hbd_mode_decision != EB_10_BIT_MD) {
+#else
+        else {
+
+#endif
             EB_FREE_ARRAY(obj->md_cu_arr_nsq[0].neigh_left_recon[0]);
             EB_FREE_ARRAY(obj->md_cu_arr_nsq[0].neigh_top_recon[0]);
         }
@@ -82,7 +100,7 @@ EbErrorType mode_decision_context_ctor(
     EbColorFormat         color_format,
     EbFifo                *mode_decision_configuration_input_fifo_ptr,
     EbFifo                *mode_decision_output_fifo_ptr,
-    EbBool                 enable_hbd_mode_decision
+    uint8_t                enable_hbd_mode_decision
 #if PAL_SUP
     ,uint8_t                 cfg_palette
 #endif
@@ -104,12 +122,21 @@ EbErrorType mode_decision_context_ctor(
     EB_MALLOC(context_ptr->transform_inner_array_ptr, 3120); //refer to EbInvTransform_SSE2.as. case 32x32
 
     // Cfl scratch memory
+#if !HBD_CLEAN_UP // cfl_temp_luma_recon16bit
     if (context_ptr->hbd_mode_decision) {
+#else
+    if (context_ptr->hbd_mode_decision > EB_8_BIT_MD)
+#endif
         EB_MALLOC_ALIGNED(context_ptr->cfl_temp_luma_recon16bit, sizeof(uint16_t) * 128 * 128);
+#if !HBD_CLEAN_UP
     } else {
+#else
+    if (context_ptr->hbd_mode_decision != EB_10_BIT_MD)
+#endif
         EB_MALLOC_ALIGNED(context_ptr->cfl_temp_luma_recon, sizeof(uint8_t) * 128 * 128);
+#if !HBD_CLEAN_UP
     }
-
+#endif
     // MD rate Estimation tables
     EB_MALLOC_ARRAY(context_ptr->md_rate_estimation_ptr, 1);
     context_ptr->is_md_rate_estimation_ptr_owner = EB_TRUE;
@@ -180,10 +207,19 @@ EbErrorType mode_decision_context_ctor(
     context_ptr->md_cu_arr_nsq[0].neigh_top_recon_16bit[0] = NULL;
     EB_MALLOC_ARRAY(context_ptr->md_cu_arr_nsq[0].av1xd, BLOCK_MAX_COUNT_SB_128);
     uint16_t sz = sizeof(uint16_t);
+#if !HBD_CLEAN_UP // neigh_left_recon_16bit neigh_top_recon_16bit
     if (context_ptr->hbd_mode_decision) {
+#else
+    if (context_ptr->hbd_mode_decision > EB_8_BIT_MD){
+#endif
         EB_MALLOC_ARRAY(context_ptr->md_cu_arr_nsq[0].neigh_left_recon_16bit[0], BLOCK_MAX_COUNT_SB_128 * 128 * 3 * sz);
         EB_MALLOC_ARRAY(context_ptr->md_cu_arr_nsq[0].neigh_top_recon_16bit[0], BLOCK_MAX_COUNT_SB_128 * 128 * 3 * sz);
-    } else {
+    }
+#if HBD_CLEAN_UP
+    if (context_ptr->hbd_mode_decision != EB_10_BIT_MD){
+#else
+    else {
+#endif
         EB_MALLOC_ARRAY(context_ptr->md_cu_arr_nsq[0].neigh_left_recon[0], BLOCK_MAX_COUNT_SB_128 * 128 * 3);
         EB_MALLOC_ARRAY(context_ptr->md_cu_arr_nsq[0].neigh_top_recon[0], BLOCK_MAX_COUNT_SB_128 * 128 * 3);
     }
@@ -194,18 +230,24 @@ EbErrorType mode_decision_context_ctor(
         const BlockGeom * blk_geom = get_blk_geom_mds(codedLeafIndex);
         UNUSED(blk_geom);
         context_ptr->md_cu_arr_nsq[codedLeafIndex].av1xd = context_ptr->md_cu_arr_nsq[0].av1xd + codedLeafIndex;
+#if !HBD_CLEAN_UP
         if (context_ptr->hbd_mode_decision) {
+#endif
              for (int i = 0; i < 3; i++) {
                 size_t offset = (codedLeafIndex * 128 * 3 + i * 128) * sz;
                 context_ptr->md_cu_arr_nsq[codedLeafIndex].neigh_left_recon_16bit[i] = context_ptr->md_cu_arr_nsq[0].neigh_left_recon_16bit[0] + offset;
                 context_ptr->md_cu_arr_nsq[codedLeafIndex].neigh_top_recon_16bit[i] = context_ptr->md_cu_arr_nsq[0].neigh_top_recon_16bit[0] + offset;
             }
+#if !HBD_CLEAN_UP
         } else {
+#endif
              for (int i = 0; i < 3; i++) {
                 size_t offset = codedLeafIndex * 128 * 3 + i * 128;
                 context_ptr->md_cu_arr_nsq[codedLeafIndex].neigh_left_recon[i] = context_ptr->md_cu_arr_nsq[0].neigh_left_recon[0] + offset;
                 context_ptr->md_cu_arr_nsq[codedLeafIndex].neigh_top_recon[i] = context_ptr->md_cu_arr_nsq[0].neigh_top_recon[0] + offset;
+#if !HBD_CLEAN_UP
             }
+#endif
         }
 #if PAL_SUP
         if (cfg_palette)
@@ -275,17 +317,28 @@ void reset_mode_decision_neighbor_arrays(PictureControlSet *picture_control_set_
         neighbor_array_unit_reset(picture_control_set_ptr->md_leaf_depth_neighbor_array[depth]);
         neighbor_array_unit_reset(picture_control_set_ptr->mdleaf_partition_neighbor_array[depth]);
 
+#if !HBD_CLEAN_UP // md_luma_recon_neighbor_array md_tx_depth_1_luma_recon_neighbor_array
         if (!picture_control_set_ptr->hbd_mode_decision) {
+#else
+        if (picture_control_set_ptr->hbd_mode_decision != EB_10_BIT_MD) {
+#endif
             neighbor_array_unit_reset(picture_control_set_ptr->md_luma_recon_neighbor_array[depth]);
             neighbor_array_unit_reset(picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[depth]);
             neighbor_array_unit_reset(picture_control_set_ptr->md_cb_recon_neighbor_array[depth]);
             neighbor_array_unit_reset(picture_control_set_ptr->md_cr_recon_neighbor_array[depth]);
-        } else {
+        }
+#if HBD_CLEAN_UP
+        if (picture_control_set_ptr->hbd_mode_decision > EB_8_BIT_MD) {
+#else
+         else {
+#endif
+
             neighbor_array_unit_reset(picture_control_set_ptr->md_luma_recon_neighbor_array16bit[depth]);
             neighbor_array_unit_reset(picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[depth]);
             neighbor_array_unit_reset(picture_control_set_ptr->md_cb_recon_neighbor_array16bit[depth]);
             neighbor_array_unit_reset(picture_control_set_ptr->md_cr_recon_neighbor_array16bit[depth]);
         }
+
         neighbor_array_unit_reset(picture_control_set_ptr->md_skip_coeff_neighbor_array[depth]);
         neighbor_array_unit_reset(picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[depth]);
         neighbor_array_unit_reset(picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[depth]);
@@ -461,7 +514,7 @@ void reset_mode_decision(
         &context_ptr->full_chroma_lambda,
         (uint8_t)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
         context_ptr->qp_index,
-        picture_control_set_ptr->hbd_mode_decision);
+        context_ptr->hbd_mode_decision);
     // Reset MD rate Estimation table to initial values by copying from md_rate_estimation_array
     if (context_ptr->is_md_rate_estimation_ptr_owner) {
         context_ptr->is_md_rate_estimation_ptr_owner = EB_FALSE;
@@ -566,7 +619,7 @@ void mode_decision_configure_lcu(
         &context_ptr->full_chroma_lambda,
         (uint8_t)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
         context_ptr->qp_index,
-        picture_control_set_ptr->hbd_mode_decision);
+        context_ptr->hbd_mode_decision);
 
     return;
 }

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -178,7 +178,7 @@ extern "C" {
         uint16_t                        pu_height;
         EbPfMode                        pf_md_mode;
         EbBool                          cu_use_ref_src_flag;
-        EbBool                          hbd_mode_decision;
+        uint8_t                         hbd_mode_decision;
         uint16_t                        qp_index;
         uint64_t                        three_quad_energy;
 #if ENHANCE_ATB
@@ -378,7 +378,7 @@ extern "C" {
         EbColorFormat              color_format,
         EbFifo                    *mode_decision_configuration_input_fifo_ptr,
         EbFifo                    *mode_decision_output_fifo_ptr,
-        EbBool                     enable_hbd_mode_decision
+        uint8_t                    enable_hbd_mode_decision
 #if PAL_SUP
         ,uint8_t                 cfg_palette
 #endif

--- a/Source/Lib/Common/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.c
@@ -168,17 +168,28 @@ void picture_control_set_dctor(EbPtr p)
         EB_DELETE(obj->md_mode_type_neighbor_array[depth]);
         EB_DELETE(obj->md_leaf_depth_neighbor_array[depth]);
         EB_DELETE(obj->mdleaf_partition_neighbor_array[depth]);
+
+#if !HBD_CLEAN_UP // md_luma_recon_neighbor_array16bit md_tx_depth_1_luma_recon_neighbor_array16bit
         if (obj->hbd_mode_decision) {
+#else
+        if (obj->hbd_mode_decision > EB_8_BIT_MD){
+#endif
             EB_DELETE(obj->md_luma_recon_neighbor_array16bit[depth]);
             EB_DELETE(obj->md_tx_depth_1_luma_recon_neighbor_array16bit[depth]);
             EB_DELETE(obj->md_cb_recon_neighbor_array16bit[depth]);
             EB_DELETE(obj->md_cr_recon_neighbor_array16bit[depth]);
-        } else {
+        }
+#if HBD_CLEAN_UP
+        if (obj->hbd_mode_decision != EB_10_BIT_MD){
+#else
+         else {
+#endif
             EB_DELETE(obj->md_luma_recon_neighbor_array[depth]);
             EB_DELETE(obj->md_tx_depth_1_luma_recon_neighbor_array[depth]);
             EB_DELETE(obj->md_cb_recon_neighbor_array[depth]);
             EB_DELETE(obj->md_cr_recon_neighbor_array[depth]);
         }
+
         EB_DELETE(obj->md_skip_coeff_neighbor_array[depth]);
         EB_DELETE(obj->md_luma_dc_sign_level_coeff_neighbor_array[depth]);
         EB_DELETE(obj->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[depth]);
@@ -605,9 +616,13 @@ EbErrorType picture_control_set_ctor(
         return_error = create_neighbor_array_units(data, DIM(data));
         if (return_error == EB_ErrorInsufficientResources)
             return EB_ErrorInsufficientResources;
-
+#if HBD_CLEAN_UP //md_luma_recon_neighbor_array
+        if (initDataPtr->hbd_mode_decision != EB_10_BIT_MD) {
+#else
         if (!initDataPtr->hbd_mode_decision) {
+#endif
             InitData data[] = {
+
                 {
                     &object_ptr->md_luma_recon_neighbor_array[depth],
                     MAX_PICTURE_WIDTH_SIZE,
@@ -644,11 +659,18 @@ EbErrorType picture_control_set_ctor(
                     SAMPLE_NEIGHBOR_ARRAY_GRANULARITY,
                     NEIGHBOR_ARRAY_UNIT_FULL_MASK,
                 }
+
             };
             return_error = create_neighbor_array_units(data, DIM(data));
             if (return_error == EB_ErrorInsufficientResources)
                 return EB_ErrorInsufficientResources;
-        } else {
+        }
+#if HBD_CLEAN_UP
+
+        if (initDataPtr->hbd_mode_decision > EB_8_BIT_MD) {
+#else
+         else {
+#endif
             InitData data[] = {
                 {
                     &object_ptr->md_luma_recon_neighbor_array16bit[depth],

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -13796,7 +13796,8 @@ extern "C" {
         NeighborArrayUnit                  *md_tx_depth_1_luma_recon_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
         NeighborArrayUnit                  *md_cb_recon_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
         NeighborArrayUnit                  *md_cr_recon_neighbor_array[NEIGHBOR_ARRAY_TOTAL_COUNT];
-        EbBool                             hbd_mode_decision;
+
+        uint8_t                             hbd_mode_decision;
         NeighborArrayUnit                  *md_luma_recon_neighbor_array16bit[NEIGHBOR_ARRAY_TOTAL_COUNT];
         NeighborArrayUnit                  *md_tx_depth_1_luma_recon_neighbor_array16bit[NEIGHBOR_ARRAY_TOTAL_COUNT];
         NeighborArrayUnit                  *md_cb_recon_neighbor_array16bit[NEIGHBOR_ARRAY_TOTAL_COUNT];
@@ -14331,7 +14332,7 @@ extern "C" {
         uint16_t                           enc_dec_segment_row;
         EbEncMode                          enc_mode;
         uint8_t                            speed_control;
-        EbBool                             hbd_mode_decision;
+        uint8_t                            hbd_mode_decision;
         uint16_t                           film_grain_noise_level;
         EbBool                             ext_block_flag;
         EbBool                             in_loop_me_flag;

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -854,6 +854,7 @@ EbErrorType signal_derivation_multi_processes_oq(
     // 5                                     pred - 1 + 2
     // 6                                     pred - 1 + 3
     // 7                                     All
+
     if (MR_MODE || sc_content_detected || sequence_control_set_ptr->static_config.enable_hbd_mode_decision)
         picture_control_set_ptr->mdc_depth_level = MAX_MDC_LEVEL;
     else if (picture_control_set_ptr->enc_mode == ENC_M0)
@@ -1295,7 +1296,6 @@ EbErrorType signal_derivation_multi_processes_oq(
         // 0                                     OFF
         // 1                                     ON
             picture_control_set_ptr->enable_inter_intra = picture_control_set_ptr->slice_type != I_SLICE ? sequence_control_set_ptr->seq_header.enable_interintra_compound : 0;
-
 #endif
         // Set compound mode      Settings
         // 0                 OFF: No compond mode search : AVG only
@@ -1306,7 +1306,6 @@ EbErrorType signal_derivation_multi_processes_oq(
             picture_control_set_ptr->enc_mode <= ENC_M1 ? 2 : 1;
         else
             picture_control_set_ptr->compound_mode = 0;
-
 
         // set compound_types_to_try
         if (picture_control_set_ptr->compound_mode)
@@ -3638,7 +3637,7 @@ void* picture_decision_kernel(void *input_ptr)
                             if( sequence_control_set_ptr->enable_altrefs == EB_TRUE &&
 #if NON_KF_INTRA_TF_FIX
                                 ((picture_control_set_ptr->slice_type == I_SLICE && picture_control_set_ptr->sc_content_detected == 0) ||
-#else  
+#else
                                 ( (picture_control_set_ptr->idr_flag && picture_control_set_ptr->sc_content_detected == 0) ||
 #endif
                                   (picture_control_set_ptr->slice_type != I_SLICE && picture_control_set_ptr->temporal_layer_index == 0)

--- a/Source/Lib/Common/Codec/EbPictureOperators.h
+++ b/Source/Lib/Common/Codec/EbPictureOperators.h
@@ -264,7 +264,7 @@ extern "C" {
         uint32_t                   chroma_area_width,
         uint32_t                   chroma_area_height,
         uint32_t                   component_mask,
-        EbBool                     hbd);
+        uint8_t                    hbd);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -1197,18 +1197,18 @@ void AV1PerformInverseTransformReconLuma(
                     candidate_buffer->prediction_ptr->buffer_y,
                     tu_origin_index,
                     candidate_buffer->prediction_ptr->stride_y,
-                    picture_control_set_ptr->hbd_mode_decision ? (uint8_t *)context_ptr->cfl_temp_luma_recon16bit : context_ptr->cfl_temp_luma_recon,
+                    context_ptr->hbd_mode_decision ? (uint8_t *)context_ptr->cfl_temp_luma_recon16bit : context_ptr->cfl_temp_luma_recon,
                     recLumaOffset,
                     candidate_buffer->recon_ptr->stride_y,
                     (int32_t*) candidate_buffer->recon_coeff_ptr->buffer_y,
                     txb_1d_offset,
-                    picture_control_set_ptr->hbd_mode_decision,
+                    context_ptr->hbd_mode_decision,
                     context_ptr->blk_geom->txsize[tx_depth][txb_itr],
                     candidate_buffer->candidate_ptr->transform_type[txb_itr],
                     PLANE_TYPE_Y,
                     (uint32_t)candidate_buffer->candidate_ptr->eob[0][txb_itr]);
             else {
-                if (picture_control_set_ptr->hbd_mode_decision) {
+                if (context_ptr->hbd_mode_decision) {
                     pic_copy_kernel_16bit(
                         ((uint16_t *) candidate_buffer->prediction_ptr->buffer_y) + tu_origin_index,
                         candidate_buffer->prediction_ptr->stride_y,
@@ -1278,7 +1278,7 @@ void AV1PerformInverseTransformRecon(
                     candidate_buffer->recon_ptr->stride_y,
                     (int32_t*) candidate_buffer->recon_coeff_ptr->buffer_y,
                     txb_1d_offset,
-                    picture_control_set_ptr->hbd_mode_decision,
+                    context_ptr->hbd_mode_decision,
                     context_ptr->blk_geom->txsize[tx_depth][txb_itr],
                     candidate_buffer->candidate_ptr->transform_type[txb_itr],
                     PLANE_TYPE_Y,
@@ -1296,7 +1296,7 @@ void AV1PerformInverseTransformRecon(
                     0,//chromaTuSize,
                     0,//chromaTuSize,
                     PICTURE_BUFFER_DESC_Y_FLAG,
-                    picture_control_set_ptr->hbd_mode_decision);
+                    context_ptr->hbd_mode_decision);
 
             //CHROMA
             uint8_t tx_depth = candidate_buffer->candidate_ptr->tx_depth;
@@ -1318,7 +1318,7 @@ void AV1PerformInverseTransformRecon(
                         candidate_buffer->recon_ptr->stride_cb,
                         (int32_t*) candidate_buffer->recon_coeff_ptr->buffer_cb,
                         txb_1d_offset_uv,
-                        picture_control_set_ptr->hbd_mode_decision,
+                        context_ptr->hbd_mode_decision,
                         context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr],
                         candidate_buffer->candidate_ptr->transform_type_uv,
                         PLANE_TYPE_UV,
@@ -1336,7 +1336,7 @@ void AV1PerformInverseTransformRecon(
                         chroma_tu_width,
                         chroma_tu_height,
                         PICTURE_BUFFER_DESC_Cb_FLAG,
-                        picture_control_set_ptr->hbd_mode_decision);
+                        context_ptr->hbd_mode_decision);
 
 
             if (context_ptr->blk_geom->has_uv && txb_ptr->v_has_coeff)
@@ -1349,7 +1349,7 @@ void AV1PerformInverseTransformRecon(
                         candidate_buffer->recon_ptr->stride_cr,
                         (int32_t*) candidate_buffer->recon_coeff_ptr->buffer_cr,
                         txb_1d_offset_uv,
-                        picture_control_set_ptr->hbd_mode_decision,
+                        context_ptr->hbd_mode_decision,
                         context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr],
                         candidate_buffer->candidate_ptr->transform_type_uv,
                         PLANE_TYPE_UV,
@@ -1367,7 +1367,7 @@ void AV1PerformInverseTransformRecon(
                         chroma_tu_width,
                         chroma_tu_height,
                         PICTURE_BUFFER_DESC_Cr_FLAG,
-                        picture_control_set_ptr->hbd_mode_decision);
+                        context_ptr->hbd_mode_decision);
 
                 if (context_ptr->blk_geom->has_uv)
                     txb_1d_offset_uv += context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr] * context_ptr->blk_geom->tx_height_uv[tx_depth][txb_itr];
@@ -2762,7 +2762,7 @@ void predictive_me_sub_pel_search(
 
             // Distortion
             if (use_ssd) {
-                EbSpatialFullDistType spatial_full_dist_type_fun = picture_control_set_ptr->hbd_mode_decision ?
+                EbSpatialFullDistType spatial_full_dist_type_fun = context_ptr->hbd_mode_decision ?
                     full_distortion_kernel16_bits : spatial_full_distortion_kernel;
 
                 distortion = (uint32_t) spatial_full_dist_type_fun(
@@ -3944,7 +3944,7 @@ EbErrorType av1_intra_luma_prediction(
     TxSize  tx_size = md_context_ptr->blk_geom->txsize[md_context_ptr->tx_depth][md_context_ptr->txb_itr];
 
     PredictionMode mode;
-    if (!picture_control_set_ptr->hbd_mode_decision) {
+    if (!md_context_ptr->hbd_mode_decision) {
         uint8_t topNeighArray[64 * 2 + 1];
         uint8_t leftNeighArray[64 * 2 + 1];
 
@@ -4270,7 +4270,7 @@ void tx_type_search(
             context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
             &context_ptr->three_quad_energy,
             context_ptr->transform_inner_array_ptr,
-            picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
+            context_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
             tx_type,
             PLANE_TYPE_Y,
             DEFAULT_SHAPE);
@@ -4290,7 +4290,7 @@ void tx_type_search(
             &candidate_buffer->candidate_ptr->eob[0][context_ptr->txb_itr],
             &y_count_non_zero_coeffs,
             COMPONENT_LUMA,
-            picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
+            context_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
             tx_type,
             candidate_buffer,
             context_ptr->luma_txb_skip_context,
@@ -4317,7 +4317,7 @@ void tx_type_search(
                 candidate_buffer->recon_ptr->stride_y,
                 (int32_t*)candidate_buffer->recon_coeff_ptr->buffer_y,
                 context_ptr->txb_1d_offset,
-                picture_control_set_ptr->hbd_mode_decision,
+                context_ptr->hbd_mode_decision,
                 context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
                 tx_type,
                 PLANE_TYPE_Y,
@@ -4335,7 +4335,7 @@ void tx_type_search(
                 0,
                 0,
                 PICTURE_BUFFER_DESC_Y_FLAG,
-                picture_control_set_ptr->hbd_mode_decision);
+                context_ptr->hbd_mode_decision);
 
         EbSpatialFullDistType spatial_full_dist_type_fun = context_ptr->hbd_mode_decision ?
             full_distortion_kernel16_bits : spatial_full_distortion_kernel;
@@ -5787,7 +5787,7 @@ void full_loop_core(
                     (int16_t*)candidate_buffer->residual_ptr->buffer_y,
                     cuOriginIndex,
                     candidate_buffer->residual_ptr->stride_y,
-                    picture_control_set_ptr->hbd_mode_decision,
+                    context_ptr->hbd_mode_decision,
                     context_ptr->blk_geom->bwidth,
                     context_ptr->blk_geom->bheight);
 
@@ -5820,7 +5820,7 @@ void full_loop_core(
                 (int16_t*)candidate_buffer->residual_ptr->buffer_y,
                 cuOriginIndex,
                 candidate_buffer->residual_ptr->stride_y,
-                picture_control_set_ptr->hbd_mode_decision,
+                context_ptr->hbd_mode_decision,
                 context_ptr->blk_geom->bwidth,
                 context_ptr->blk_geom->bheight);
 
@@ -5897,7 +5897,7 @@ void full_loop_core(
                     (int16_t*)candidate_buffer->residual_ptr->buffer_cb,
                     cuChromaOriginIndex,
                     candidate_buffer->residual_ptr->stride_cb,
-                    picture_control_set_ptr->hbd_mode_decision,
+                    context_ptr->hbd_mode_decision,
                     context_ptr->blk_geom->bwidth_uv,
                     context_ptr->blk_geom->bheight_uv);
 
@@ -5912,7 +5912,7 @@ void full_loop_core(
                     (int16_t*)candidate_buffer->residual_ptr->buffer_cr,
                     cuChromaOriginIndex,
                     candidate_buffer->residual_ptr->stride_cr,
-                    picture_control_set_ptr->hbd_mode_decision,
+                    context_ptr->hbd_mode_decision,
                     context_ptr->blk_geom->bwidth_uv,
                     context_ptr->blk_geom->bheight_uv);
             }
@@ -6184,13 +6184,13 @@ void move_cu_data(
     CodingUnit *src_cu,
     CodingUnit *dst_cu)
 {
-#if PAL_SUP  
+#if PAL_SUP
         memcpy(&dst_cu->palette_info.pmi, &src_cu->palette_info.pmi, sizeof(PaletteModeInfo));
         if (svt_av1_allow_palette(pcs->parent_pcs_ptr->palette_mode, context_ptr->blk_geom->bsize)){
-            dst_cu->palette_info.color_idx_map = (uint8_t *)malloc(MAX_PALETTE_SQUARE);          
+            dst_cu->palette_info.color_idx_map = (uint8_t *)malloc(MAX_PALETTE_SQUARE);
             assert(dst_cu->palette_info.color_idx_map != NULL && "palette:Not-Enough-Memory");
             if(dst_cu->palette_info.color_idx_map != NULL)
-                 memcpy(dst_cu->palette_info.color_idx_map, src_cu->palette_info.color_idx_map, MAX_PALETTE_SQUARE);   
+                 memcpy(dst_cu->palette_info.color_idx_map, src_cu->palette_info.color_idx_map, MAX_PALETTE_SQUARE);
             else
                 printf("ERROR palette:Not-Enough-Memory\n");
         }
@@ -6315,16 +6315,16 @@ void move_cu_data_redund(
 #endif
     CodingUnit *src_cu,
     CodingUnit *dst_cu){
-
+#if PAL_SUP
     dst_cu->segment_id = src_cu->segment_id;
     dst_cu->seg_id_predicted = src_cu->seg_id_predicted;
     dst_cu->ref_qp = src_cu->ref_qp;
     dst_cu->org_delta_qp = src_cu->org_delta_qp;
-#if PAL_SUP 
+
     memcpy(&dst_cu->palette_info.pmi, &src_cu->palette_info.pmi, sizeof(PaletteModeInfo));
     if (svt_av1_allow_palette(pcs->parent_pcs_ptr->palette_mode, context_ptr->blk_geom->bsize))
         memcpy(dst_cu->palette_info.color_idx_map, src_cu->palette_info.color_idx_map, MAX_PALETTE_SQUARE);
-  
+
 #endif
 #if OBMC_FLAG
     dst_cu->interp_filters = src_cu->interp_filters;
@@ -7395,7 +7395,7 @@ void search_best_independent_uv_mode(
                 (int16_t*)candidate_buffer->residual_ptr->buffer_cb,
                 cuChromaOriginIndex,
                 candidate_buffer->residual_ptr->stride_cb,
-                picture_control_set_ptr->hbd_mode_decision,
+                context_ptr->hbd_mode_decision,
                 context_ptr->blk_geom->bwidth_uv,
                 context_ptr->blk_geom->bheight_uv);
 
@@ -7410,7 +7410,7 @@ void search_best_independent_uv_mode(
                 (int16_t*)candidate_buffer->residual_ptr->buffer_cr,
                 cuChromaOriginIndex,
                 candidate_buffer->residual_ptr->stride_cr,
-                picture_control_set_ptr->hbd_mode_decision,
+                context_ptr->hbd_mode_decision,
                 context_ptr->blk_geom->bwidth_uv,
                 context_ptr->blk_geom->bheight_uv);
 
@@ -8047,7 +8047,7 @@ void md_encode_block(
             // Store the luma data for 4x* and *x4 blocks to be used for CFL
             EbPictureBufferDesc  *recon_ptr = candidate_buffer->recon_ptr;
             uint32_t rec_luma_offset = context_ptr->blk_geom->origin_x + context_ptr->blk_geom->origin_y * recon_ptr->stride_y;
-            if (picture_control_set_ptr->hbd_mode_decision) {
+            if (context_ptr->hbd_mode_decision) {
                for (uint32_t j = 0; j < context_ptr->blk_geom->bheight; ++j)
                     memcpy(context_ptr->cfl_temp_luma_recon16bit + rec_luma_offset + j* recon_ptr->stride_y, ((uint16_t *)recon_ptr->buffer_y) + (rec_luma_offset + j * recon_ptr->stride_y), sizeof(uint16_t) * context_ptr->blk_geom->bwidth);
             } else {
@@ -8448,7 +8448,7 @@ EB_EXTERN EbErrorType mode_decision_sb(
             CodingUnit *src_cu = &context_ptr->md_cu_arr_nsq[redundant_blk_mds];
             CodingUnit *dst_cu = cu_ptr;
 #if PAL_SUP
-         
+
             move_cu_data_redund(picture_control_set_ptr, context_ptr,src_cu, dst_cu);
 #else
             move_cu_data_redund(src_cu, dst_cu);

--- a/Source/Lib/Common/Codec/EbRateDistortionCost.c
+++ b/Source/Lib/Common/Codec/EbRateDistortionCost.c
@@ -1624,7 +1624,7 @@ uint64_t mdc_av1_inter_fast_cost(
 #endif
 #if TWO_PASS_IMPROVEMENT
 /* two_pass_cost_update
- * This function adds some biases for distortion and rate. 
+ * This function adds some biases for distortion and rate.
  * The function is used in the first pass only and for the purpose of data collection */
 void two_pass_cost_update(
     PictureControlSet     *picture_control_set_ptr,
@@ -2316,7 +2316,7 @@ EbErrorType Av1FullCost(
             candidate_buffer_ptr->candidate_ptr,
             &rate,
             &totalDistortion);
-#else        
+#else
         MvReferenceFrame ref_type[2];
         av1_set_ref_frame(ref_type, candidate_buffer_ptr->candidate_ptr->ref_frame_type);
         if ((candidate_buffer_ptr->candidate_ptr->is_compound && (ref_type[0] != LAST_FRAME || ref_type[1] != BWDREF_FRAME)) ||

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -2664,7 +2664,7 @@ EbErrorType eb_svt_enc_init_parameter(
     config_ptr->hme_level2_search_area_in_width_array[1] = 1;
     config_ptr->hme_level2_search_area_in_height_array[0] = 1;
     config_ptr->hme_level2_search_area_in_height_array[1] = 1;
-    config_ptr->enable_hbd_mode_decision = EB_TRUE;
+    config_ptr->enable_hbd_mode_decision = 1;
     config_ptr->constrained_intra = EB_FALSE;
     config_ptr->enable_palette = -1;
     // Bitstream options


### PR DESCRIPTION
### Description
Hbd clean up to support three mode for 10bit samples
   - EB_8_BIT_MD    = 8bit mode decision
   - EB_10_BIT_MD   = 10bit mode decision **(default)**
   - EB_DUAL_BIT_MD = Auto: 8bit & 10bit mode decision

Add 8bit IFS path in 10bit MD
### Author
@okhlif 
### Type of change
Cleanup
Enhancement
### Tests and performance
EB_10_BIT_MD  & EB_8_BIT_MD unchanged
Add IFS 8 bit under EB_DUAL_BIT_MD
~ 2.8% speed gain for 10bit 360p
~ BDR over 7 clips 360p-10bit -0.11% (PSNR) -0.04% (SSIM)
~ Memory increase ~1%