### PR TITLE
lower 'ahd' threshold and restrict 'ahd' summing to one region

### DIFF
--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -3645,22 +3645,24 @@ void* picture_decision_kernel(void *input_ptr)
                                     int pic_itr, ahd;
                                     uint32_t regionInPictureWidthIndex;
                                     uint32_t regionInPictureHeightIndex;
-                                    int32_t center_histogram[HISTOGRAM_NUMBER_OF_BINS] = { 0 };
-                                    int32_t altref_histogram[HISTOGRAM_NUMBER_OF_BINS] = { 0 };
+                                    int32_t center_histogram = 0;
+                                    int32_t altref_histogram = 0;
 
                                     int ahd_th = (((sequence_control_set_ptr->seq_header.max_frame_width * sequence_control_set_ptr->seq_header.max_frame_height) * AHD_TH_WEIGHT) / 100);
 
                                     // Accumulative histogram absolute differences between the central and future frame
                                     for (pic_itr = (index_center + actual_future_pics); pic_itr > index_center; pic_itr--) {
                                         ahd = 0;
+                                        center_histogram = 0;
+                                        altref_histogram = 0;
                                         for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
                                             for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
                                                 for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
-                                                    center_histogram[bin] += picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
-                                                    altref_histogram[bin] += picture_control_set_ptr->temp_filt_pcs_list[pic_itr]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
+                                                    center_histogram += picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
+                                                    altref_histogram += picture_control_set_ptr->temp_filt_pcs_list[pic_itr]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
                                                 }
                                             }
-                                            ahd += ABS(center_histogram[bin] - altref_histogram[bin]);
+                                            ahd += ABS(center_histogram - altref_histogram);
                                         }
 
                                         if (ahd < ahd_th)
@@ -3761,22 +3763,24 @@ void* picture_decision_kernel(void *input_ptr)
                                 int ahd_th = (((sequence_control_set_ptr->seq_header.max_frame_width * sequence_control_set_ptr->seq_header.max_frame_height) * AHD_TH_WEIGHT) / 100);
 
                                 // Accumulative histogram absolute differences between the central and past frame
-                                int32_t center_histogram[HISTOGRAM_NUMBER_OF_BINS] = { 0 };
-                                int32_t altref_histogram[HISTOGRAM_NUMBER_OF_BINS] = { 0 };
+                                int32_t center_histogram = 0;
+                                int32_t altref_histogram = 0;
 #if FIX_ALTREF
                                 for (pic_itr = index_center - actual_past_pics; pic_itr < index_center; pic_itr++) {
 #else
                                 for (pic_itr = index_center - actual_past_pics; pic_itr < index_center - 1; pic_itr++) {
 #endif
                                     ahd = 0;
+                                    center_histogram = 0;
+                                    altref_histogram = 0;
                                     for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
                                         for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
                                             for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
-                                                center_histogram[bin] = picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
-                                                altref_histogram[bin] = picture_control_set_ptr->temp_filt_pcs_list[pic_itr]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
+                                                center_histogram += picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
+                                                altref_histogram += picture_control_set_ptr->temp_filt_pcs_list[pic_itr]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
                                             }
                                         }
-                                        ahd += ABS(center_histogram[bin] - altref_histogram[bin]);
+                                        ahd += ABS(center_histogram - altref_histogram);
                                     }
 
                                     if (ahd < ahd_th)
@@ -3785,18 +3789,18 @@ void* picture_decision_kernel(void *input_ptr)
                                 picture_control_set_ptr->past_altref_nframes = actual_past_pics = index_center - pic_itr;
 
                                 // Accumulative histogram absolute differences between the central and past frame
-                                memset(center_histogram, 0, HISTOGRAM_NUMBER_OF_BINS * sizeof(int32_t));
-                                memset(altref_histogram, 0, HISTOGRAM_NUMBER_OF_BINS * sizeof(int32_t));
                                 for (pic_itr = (index_center + actual_future_pics); pic_itr > index_center; pic_itr--) {
                                     ahd = 0;
+                                    center_histogram = 0;
+                                    altref_histogram = 0;
                                     for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
                                         for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
                                             for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
-                                                center_histogram[bin] = picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
-                                                altref_histogram[bin] = picture_control_set_ptr->temp_filt_pcs_list[pic_itr]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
+                                                center_histogram += picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
+                                                altref_histogram += picture_control_set_ptr->temp_filt_pcs_list[pic_itr]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
                                             }
                                         }
-                                        ahd += ABS(center_histogram[bin] - altref_histogram[bin]);
+                                        ahd += ABS(center_histogram - altref_histogram);
                                     }
 
                                     if (ahd < ahd_th)

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -26,8 +26,6 @@
 /************************************************
  * Defines
  ************************************************/
-#define DYNAMIC_WINDOW_TH   50
-
 #define  LAY0_OFF  0
 #define  LAY1_OFF  3
 #define  LAY2_OFF  5
@@ -3647,18 +3645,22 @@ void* picture_decision_kernel(void *input_ptr)
                                     int pic_itr, ahd;
                                     uint32_t regionInPictureWidthIndex;
                                     uint32_t regionInPictureHeightIndex;
+                                    int32_t center_histogram[HISTOGRAM_NUMBER_OF_BINS] = { 0 };
+                                    int32_t altref_histogram[HISTOGRAM_NUMBER_OF_BINS] = { 0 };
 
-                                    int ahd_th = (((sequence_control_set_ptr->seq_header.max_frame_width * sequence_control_set_ptr->seq_header.max_frame_height) * DYNAMIC_WINDOW_TH) / 100);
+                                    int ahd_th = (((sequence_control_set_ptr->seq_header.max_frame_width * sequence_control_set_ptr->seq_header.max_frame_height) * AHD_TH_WEIGHT) / 100);
 
                                     // Accumulative histogram absolute differences between the central and future frame
                                     for (pic_itr = (index_center + actual_future_pics); pic_itr > index_center; pic_itr--) {
                                         ahd = 0;
-                                        for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
-                                            for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
-                                                for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
-                                                    ahd += ABS((int32_t)picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin] - (int32_t)picture_control_set_ptr->temp_filt_pcs_list[pic_itr]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin]);
+                                        for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
+                                            for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
+                                                for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
+                                                    center_histogram[bin] += picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
+                                                    altref_histogram[bin] += picture_control_set_ptr->temp_filt_pcs_list[pic_itr]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
                                                 }
                                             }
+                                            ahd += ABS(center_histogram[bin] - altref_histogram[bin]);
                                         }
 
                                         if (ahd < ahd_th)
@@ -3759,18 +3761,22 @@ void* picture_decision_kernel(void *input_ptr)
                                 int ahd_th = (((sequence_control_set_ptr->seq_header.max_frame_width * sequence_control_set_ptr->seq_header.max_frame_height) * AHD_TH_WEIGHT) / 100);
 
                                 // Accumulative histogram absolute differences between the central and past frame
+                                int32_t center_histogram[HISTOGRAM_NUMBER_OF_BINS] = { 0 };
+                                int32_t altref_histogram[HISTOGRAM_NUMBER_OF_BINS] = { 0 };
 #if FIX_ALTREF
                                 for (pic_itr = index_center - actual_past_pics; pic_itr < index_center; pic_itr++) {
 #else
                                 for (pic_itr = index_center - actual_past_pics; pic_itr < index_center - 1; pic_itr++) {
 #endif
                                     ahd = 0;
-                                    for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
-                                        for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
-                                            for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
-                                                ahd += ABS((int32_t)picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin] - (int32_t)picture_control_set_ptr->temp_filt_pcs_list[pic_itr]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin]);
+                                    for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
+                                        for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
+                                            for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
+                                                center_histogram[bin] = picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
+                                                altref_histogram[bin] = picture_control_set_ptr->temp_filt_pcs_list[pic_itr]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
                                             }
                                         }
+                                        ahd += ABS(center_histogram[bin] - altref_histogram[bin]);
                                     }
 
                                     if (ahd < ahd_th)
@@ -3778,16 +3784,19 @@ void* picture_decision_kernel(void *input_ptr)
                                 }
                                 picture_control_set_ptr->past_altref_nframes = actual_past_pics = index_center - pic_itr;
 
-
                                 // Accumulative histogram absolute differences between the central and past frame
+                                memset(center_histogram, 0, HISTOGRAM_NUMBER_OF_BINS * sizeof(int32_t));
+                                memset(altref_histogram, 0, HISTOGRAM_NUMBER_OF_BINS * sizeof(int32_t));
                                 for (pic_itr = (index_center + actual_future_pics); pic_itr > index_center; pic_itr--) {
                                     ahd = 0;
-                                    for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
-                                        for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
-                                            for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
-                                                ahd += ABS((int32_t)picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin] - (int32_t)picture_control_set_ptr->temp_filt_pcs_list[pic_itr]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin]);
+                                    for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
+                                        for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
+                                            for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
+                                                center_histogram[bin] = picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
+                                                altref_histogram[bin] = picture_control_set_ptr->temp_filt_pcs_list[pic_itr]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
                                             }
                                         }
+                                        ahd += ABS(center_histogram[bin] - altref_histogram[bin]);
                                     }
 
                                     if (ahd < ahd_th)

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -3653,9 +3653,9 @@ void* picture_decision_kernel(void *input_ptr)
                                     // Accumulative histogram absolute differences between the central and future frame
                                     for (pic_itr = (index_center + actual_future_pics); pic_itr > index_center; pic_itr--) {
                                         ahd = 0;
-                                        center_histogram = 0;
-                                        altref_histogram = 0;
                                         for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
+                                            center_histogram = 0;
+                                            altref_histogram = 0;
                                             for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
                                                 for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
                                                     center_histogram += picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
@@ -3771,9 +3771,9 @@ void* picture_decision_kernel(void *input_ptr)
                                 for (pic_itr = index_center - actual_past_pics; pic_itr < index_center - 1; pic_itr++) {
 #endif
                                     ahd = 0;
-                                    center_histogram = 0;
-                                    altref_histogram = 0;
                                     for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
+                                        center_histogram = 0;
+                                        altref_histogram = 0;
                                         for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
                                             for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
                                                 center_histogram += picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
@@ -3791,9 +3791,9 @@ void* picture_decision_kernel(void *input_ptr)
                                 // Accumulative histogram absolute differences between the central and past frame
                                 for (pic_itr = (index_center + actual_future_pics); pic_itr > index_center; pic_itr--) {
                                     ahd = 0;
-                                    center_histogram = 0;
-                                    altref_histogram = 0;
                                     for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
+                                        center_histogram = 0;
+                                        altref_histogram = 0;
                                         for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
                                             for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
                                                 center_histogram += picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -2846,7 +2846,7 @@ void initialize_overlay_frame(PictureParentControlSet     *picture_control_set_p
  * absolute difference between the two frames from a histogram of luma values
 ***************************************************************************************************/
 
-__inline uint32_t compute_luma_sad_between_center_and_target_frame(
+static __inline uint32_t compute_luma_sad_between_center_and_target_frame(
     int target_frame_index,
     PictureParentControlSet *picture_control_set_ptr,
     SequenceControlSet *sequence_control_set_ptr) {

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -2842,9 +2842,8 @@ void initialize_overlay_frame(PictureParentControlSet     *picture_control_set_p
  }
 
 /***************************************************************************************************
- * Helper function. Compare nearby consecutive frames with respect to a center 
- * frame. Return the summation of absolute difference between luma value frequency
- * for one target luma value.
+ * Helper function. Compare two frames: a center frame and a target frame. Return the summation of  
+ * absolute difference between frequency in luma values.
 ***************************************************************************************************/
 
 uint32_t inline compute_luma_frequency_sad_between_center_and_target_frame(

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -2846,7 +2846,7 @@ void initialize_overlay_frame(PictureParentControlSet     *picture_control_set_p
  * absolute difference between the two frames from a histogram of luma values
 ***************************************************************************************************/
 
-uint32_t inline compute_luma_sad_between_center_and_target_frame(
+__inline uint32_t compute_luma_sad_between_center_and_target_frame(
     uint32_t target_frame_index,
     PictureParentControlSet *picture_control_set_ptr,
     SequenceControlSet *sequence_control_set_ptr) {

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -2847,18 +2847,19 @@ void initialize_overlay_frame(PictureParentControlSet     *picture_control_set_p
 ***************************************************************************************************/
 
 static __inline uint32_t compute_luma_sad_between_center_and_target_frame(
+    int center_index,
     int target_frame_index,
     PictureParentControlSet *picture_control_set_ptr,
     SequenceControlSet *sequence_control_set_ptr) {
 
     int32_t center_sum = 0, altref_sum = 0;
-    uint32_t index_center = 0, ahd = 0;
+    uint32_t ahd = 0;
 
     for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
         center_sum = 0, altref_sum = 0;
         for (uint32_t regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
             for (uint32_t regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
-                center_sum += picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
+                center_sum += picture_control_set_ptr->temp_filt_pcs_list[center_index]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
                 altref_sum += picture_control_set_ptr->temp_filt_pcs_list[target_frame_index]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
             }
         }
@@ -3675,7 +3676,7 @@ void* picture_decision_kernel(void *input_ptr)
 
                                     // Accumulative histogram absolute differences between the central and future frame
                                     for (pic_itr = (index_center + actual_future_pics); pic_itr > index_center; pic_itr--) {
-                                        ahd = compute_luma_sad_between_center_and_target_frame(pic_itr, picture_control_set_ptr, sequence_control_set_ptr);
+                                        ahd = compute_luma_sad_between_center_and_target_frame(index_center, pic_itr, picture_control_set_ptr, sequence_control_set_ptr);
                                         if (ahd < ahd_th)
                                             break;
                                     }
@@ -3777,7 +3778,7 @@ void* picture_decision_kernel(void *input_ptr)
 #else
                                 for (pic_itr = index_center - actual_past_pics; pic_itr < index_center - 1; pic_itr++) {
 #endif
-                                    ahd = compute_luma_sad_between_center_and_target_frame(pic_itr, picture_control_set_ptr, sequence_control_set_ptr);
+                                    ahd = compute_luma_sad_between_center_and_target_frame(index_center, pic_itr, picture_control_set_ptr, sequence_control_set_ptr);
 
                                     if (ahd < ahd_th)
                                         break;
@@ -3786,7 +3787,7 @@ void* picture_decision_kernel(void *input_ptr)
 
                                 // Accumulative histogram absolute differences between the central and past frame
                                 for (pic_itr = (index_center + actual_future_pics); pic_itr > index_center; pic_itr--) {
-                                    ahd = compute_luma_sad_between_center_and_target_frame(pic_itr, picture_control_set_ptr, sequence_control_set_ptr);
+                                    ahd = compute_luma_sad_between_center_and_target_frame(index_center, pic_itr, picture_control_set_ptr, sequence_control_set_ptr);
                                     if (ahd < ahd_th)
                                         break;
                                 }

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -2847,12 +2847,12 @@ void initialize_overlay_frame(PictureParentControlSet     *picture_control_set_p
 ***************************************************************************************************/
 
 __inline uint32_t compute_luma_sad_between_center_and_target_frame(
-    uint32_t target_frame_index,
+    int target_frame_index,
     PictureParentControlSet *picture_control_set_ptr,
     SequenceControlSet *sequence_control_set_ptr) {
 
-    int32_t center_sum = 0, altref_sum = 0, ahd = 0;
-    uint32_t index_center = 0;
+    int32_t center_sum = 0, altref_sum = 0;
+    uint32_t index_center = 0, ahd = 0;
 
     for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
         center_sum = 0, altref_sum = 0;

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -2840,6 +2840,35 @@ void initialize_overlay_frame(PictureParentControlSet     *picture_control_set_p
 
     perform_simple_picture_analysis_for_overlay(picture_control_set_ptr);
  }
+
+/***************************************************************************************************
+ * Helper function. Compare nearby consecutive frames with respect to a center 
+ * frame. Return the summation of absolute difference between luma value frequency
+ * for one target luma value.
+***************************************************************************************************/
+
+uint32_t inline compute_luma_frequency_sad_between_center_and_target_frame(
+    uint32_t ahd_threshold,
+    uint32_t target_frame_index,
+    PictureParentControlSet *picture_control_set_ptr,
+    SequenceControlSet *sequence_control_set_ptr) {
+
+    int32_t center_sum = 0, altref_sum = 0, ahd = 0;
+    uint32_t index_center = 0, regionInPictureWidthIndex = 0, regionInPictureHeightIndex = 0;
+
+    for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
+        center_sum = 0, altref_sum = 0;
+        for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
+            for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
+                center_sum += picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
+                altref_sum += picture_control_set_ptr->temp_filt_pcs_list[target_frame_index]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
+            }
+        }
+        ahd += ABS(center_sum - altref_sum);
+    }
+    return ahd;
+}
+
 /***************************************************************************************************
  * Picture Decision Kernel
  *
@@ -3643,28 +3672,12 @@ void* picture_decision_kernel(void *input_ptr)
                                     int index_center = 0;
                                     uint32_t actual_future_pics = picture_control_set_ptr->future_altref_nframes;
                                     int pic_itr, ahd;
-                                    uint32_t regionInPictureWidthIndex;
-                                    uint32_t regionInPictureHeightIndex;
-                                    int32_t center_histogram = 0;
-                                    int32_t altref_histogram = 0;
 
                                     int ahd_th = (((sequence_control_set_ptr->seq_header.max_frame_width * sequence_control_set_ptr->seq_header.max_frame_height) * AHD_TH_WEIGHT) / 100);
 
                                     // Accumulative histogram absolute differences between the central and future frame
                                     for (pic_itr = (index_center + actual_future_pics); pic_itr > index_center; pic_itr--) {
-                                        ahd = 0;
-                                        for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
-                                            center_histogram = 0;
-                                            altref_histogram = 0;
-                                            for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
-                                                for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
-                                                    center_histogram += picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
-                                                    altref_histogram += picture_control_set_ptr->temp_filt_pcs_list[pic_itr]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
-                                                }
-                                            }
-                                            ahd += ABS(center_histogram - altref_histogram);
-                                        }
-
+                                        ahd = compute_luma_frequency_sad_between_center_and_target_frame(ahd_th, pic_itr, picture_control_set_ptr, sequence_control_set_ptr); 
                                         if (ahd < ahd_th)
                                             break;
                                     }
@@ -3757,31 +3770,16 @@ void* picture_decision_kernel(void *input_ptr)
                                 int index_center = (uint8_t)(picture_control_set_ptr->sequence_control_set_ptr->static_config.altref_nframes / 2);
                                 int pic_itr;
                                 int ahd;
-                                uint32_t regionInPictureWidthIndex;
-                                uint32_t regionInPictureHeightIndex;
 
                                 int ahd_th = (((sequence_control_set_ptr->seq_header.max_frame_width * sequence_control_set_ptr->seq_header.max_frame_height) * AHD_TH_WEIGHT) / 100);
 
                                 // Accumulative histogram absolute differences between the central and past frame
-                                int32_t center_histogram = 0;
-                                int32_t altref_histogram = 0;
 #if FIX_ALTREF
                                 for (pic_itr = index_center - actual_past_pics; pic_itr < index_center; pic_itr++) {
 #else
                                 for (pic_itr = index_center - actual_past_pics; pic_itr < index_center - 1; pic_itr++) {
 #endif
-                                    ahd = 0;
-                                    for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
-                                        center_histogram = 0;
-                                        altref_histogram = 0;
-                                        for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
-                                            for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
-                                                center_histogram += picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
-                                                altref_histogram += picture_control_set_ptr->temp_filt_pcs_list[pic_itr]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
-                                            }
-                                        }
-                                        ahd += ABS(center_histogram - altref_histogram);
-                                    }
+                                    ahd = compute_luma_frequency_sad_between_center_and_target_frame(ahd_th, pic_itr, picture_control_set_ptr, sequence_control_set_ptr);
 
                                     if (ahd < ahd_th)
                                         break;
@@ -3790,19 +3788,7 @@ void* picture_decision_kernel(void *input_ptr)
 
                                 // Accumulative histogram absolute differences between the central and past frame
                                 for (pic_itr = (index_center + actual_future_pics); pic_itr > index_center; pic_itr--) {
-                                    ahd = 0;
-                                    for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
-                                        center_histogram = 0;
-                                        altref_histogram = 0;
-                                        for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
-                                            for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
-                                                center_histogram += picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
-                                                altref_histogram += picture_control_set_ptr->temp_filt_pcs_list[pic_itr]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
-                                            }
-                                        }
-                                        ahd += ABS(center_histogram - altref_histogram);
-                                    }
-
+                                    ahd = compute_luma_frequency_sad_between_center_and_target_frame(ahd_th, pic_itr, picture_control_set_ptr, sequence_control_set_ptr);
                                     if (ahd < ahd_th)
                                         break;
                                 }

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -2842,23 +2842,22 @@ void initialize_overlay_frame(PictureParentControlSet     *picture_control_set_p
  }
 
 /***************************************************************************************************
- * Helper function. Compare two frames: a center frame and a target frame. Return the summation of  
- * absolute difference between frequency in luma values.
+ * Helper function. Compare two frames: center frame and target frame. Return the summation of  
+ * absolute difference between the two frames from a histogram of luma values
 ***************************************************************************************************/
 
-uint32_t inline compute_luma_frequency_sad_between_center_and_target_frame(
-    uint32_t ahd_threshold,
+uint32_t inline compute_luma_sad_between_center_and_target_frame(
     uint32_t target_frame_index,
     PictureParentControlSet *picture_control_set_ptr,
     SequenceControlSet *sequence_control_set_ptr) {
 
     int32_t center_sum = 0, altref_sum = 0, ahd = 0;
-    uint32_t index_center = 0, regionInPictureWidthIndex = 0, regionInPictureHeightIndex = 0;
+    uint32_t index_center = 0;
 
     for (int bin = 0; bin < HISTOGRAM_NUMBER_OF_BINS; ++bin) {
         center_sum = 0, altref_sum = 0;
-        for (regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
-            for (regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
+        for (uint32_t regionInPictureWidthIndex = 0; regionInPictureWidthIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_width; regionInPictureWidthIndex++) {
+            for (uint32_t regionInPictureHeightIndex = 0; regionInPictureHeightIndex < sequence_control_set_ptr->picture_analysis_number_of_regions_per_height; regionInPictureHeightIndex++) {
                 center_sum += picture_control_set_ptr->temp_filt_pcs_list[index_center]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
                 altref_sum += picture_control_set_ptr->temp_filt_pcs_list[target_frame_index]->picture_histogram[regionInPictureWidthIndex][regionInPictureHeightIndex][0][bin];
             }
@@ -3676,7 +3675,7 @@ void* picture_decision_kernel(void *input_ptr)
 
                                     // Accumulative histogram absolute differences between the central and future frame
                                     for (pic_itr = (index_center + actual_future_pics); pic_itr > index_center; pic_itr--) {
-                                        ahd = compute_luma_frequency_sad_between_center_and_target_frame(ahd_th, pic_itr, picture_control_set_ptr, sequence_control_set_ptr); 
+                                        ahd = compute_luma_sad_between_center_and_target_frame(pic_itr, picture_control_set_ptr, sequence_control_set_ptr);
                                         if (ahd < ahd_th)
                                             break;
                                     }
@@ -3778,7 +3777,7 @@ void* picture_decision_kernel(void *input_ptr)
 #else
                                 for (pic_itr = index_center - actual_past_pics; pic_itr < index_center - 1; pic_itr++) {
 #endif
-                                    ahd = compute_luma_frequency_sad_between_center_and_target_frame(ahd_th, pic_itr, picture_control_set_ptr, sequence_control_set_ptr);
+                                    ahd = compute_luma_sad_between_center_and_target_frame(pic_itr, picture_control_set_ptr, sequence_control_set_ptr);
 
                                     if (ahd < ahd_th)
                                         break;
@@ -3787,7 +3786,7 @@ void* picture_decision_kernel(void *input_ptr)
 
                                 // Accumulative histogram absolute differences between the central and past frame
                                 for (pic_itr = (index_center + actual_future_pics); pic_itr > index_center; pic_itr--) {
-                                    ahd = compute_luma_frequency_sad_between_center_and_target_frame(ahd_th, pic_itr, picture_control_set_ptr, sequence_control_set_ptr);
+                                    ahd = compute_luma_sad_between_center_and_target_frame(pic_itr, picture_control_set_ptr, sequence_control_set_ptr);
                                     if (ahd < ahd_th)
                                         break;
                                 }

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.h
@@ -93,4 +93,10 @@ void GatheringPictureStatistics(
 void DownSampleChroma(EbPictureBufferDesc* input_picture_ptr,
                       EbPictureBufferDesc* outputPicturePtr);
 
+uint32_t inline compute_luma_frequency_sad_between_center_and_target_frame(
+    uint32_t ahd_threshold,
+    uint32_t target_frame_index,
+    PictureParentControlSet *picture_control_set_ptr,
+    SequenceControlSet *sequence_control_set_ptr);
+
 #endif // EbPictureDecision_h

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.h
@@ -93,10 +93,4 @@ void GatheringPictureStatistics(
 void DownSampleChroma(EbPictureBufferDesc* input_picture_ptr,
                       EbPictureBufferDesc* outputPicturePtr);
 
-uint32_t inline compute_luma_frequency_sad_between_center_and_target_frame(
-    uint32_t ahd_threshold,
-    uint32_t target_frame_index,
-    PictureParentControlSet *picture_control_set_ptr,
-    SequenceControlSet *sequence_control_set_ptr);
-
 #endif // EbPictureDecision_h

--- a/Source/Lib/Common/Codec/EbTemporalFiltering.h
+++ b/Source/Lib/Common/Codec/EbTemporalFiltering.h
@@ -60,7 +60,7 @@
 #define THRES_DIFF_HIGH 12000
 
 #define OD_DIVU_DMAX (1024)
-#define AHD_TH_WEIGHT 50
+#define AHD_TH_WEIGHT 20
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This change improves bdrate for 240P clips without introducing a negative impact on clips greater than 240P. 

- Adjusted weighing for luma SAD threshold.
- Instead of taking the absolute difference across multiple divided regions, modified algorithm to effectively take the absolute difference across one region. This will affect how many frames are considered for temporal filtering. Summation of 'ahd' will lower overall.