### PR TITLE
Inter-Intra class pruning before MD Stage 1 and 2

### DIFF
--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -185,10 +185,10 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **UnrestrictedMotionVector** | -umv | [0-1] | 1 | Enables or disables unrestriced motion vectors, 0 = OFF(motion vectors are constrained within tile boundary), 1 = ON. For MCTS support, set -umv 0 |
 | **PaletteMode** | -palette | [0 - 6] | -1 | Enable Palette mode (-1: Auto Mode(ON at level6 when SC is detected), 0: OFF 1: ON Level 1, ...6: ON Level6 ) |
 | **SquareWeight** | -sqw | 0 for off and any whole number percentage | 100 | Weighting applied to square/h/v shape costs when deciding if a and b shapes could be skipped. Set to 100 for neutral weighting, lesser than 100 for faster encode and BD-Rate loss, and greater than 100 for slower encode and BD-Rate gain|
-| **MDStage1PruneCThreshold** | -mds1p-c-th | 0 for off and any whole number percentage | 100 | Deviation threshold (expressed as a percentage) of an inter-class class pruning mechanism before MD Stage 1 |
-| **MDStage1PruneSThreshold** | -mds1p-s-th | 0 for off and any whole number percentage | 75 | Deviation threshold (expressed as a percentage) of an intra-class candidate pruning mechanism before MD Stage 1 |
-| **MDStage2PruneCThreshold** | -mds2p-c-th | 0 for off and any whole number percentage | 25 | Deviation threshold (expressed as a percentage) of an inter-class class pruning mechanism before MD Stage 2 |
-| **MDStage2PruneSThreshold** | -mds2p-s-th | 0 for off and any whole number percentage | 15 | Deviation threshold (expressed as a percentage) of an intra-class candidate pruning mechanism before MD Stage 2 |
+| **MDStage1PruneClassThreshold** | -mds1p-class-th | 0 for off and any whole number percentage | 100 | Deviation threshold (expressed as a percentage) of an inter-class class pruning mechanism before MD Stage 1 |
+| **MDStage1PruneCandThreshold** | -mds1p-cand-th | 0 for off and any whole number percentage | 75 | Deviation threshold (expressed as a percentage) of an intra-class candidate pruning mechanism before MD Stage 1 |
+| **MDStage2PruneClassThreshold** | -mds2p-class-th | 0 for off and any whole number percentage | 25 | Deviation threshold (expressed as a percentage) of an inter-class class pruning mechanism before MD Stage 2 |
+| **MDStage2PruneCandThreshold** | -mds2p-cand-th | 0 for off and any whole number percentage | 15 | Deviation threshold (expressed as a percentage) of an intra-class candidate pruning mechanism before MD Stage 2 |
 ## Appendix A Encoder Parameters
 
 ### 1. Thread management parameters

--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -185,6 +185,10 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **UnrestrictedMotionVector** | -umv | [0-1] | 1 | Enables or disables unrestriced motion vectors, 0 = OFF(motion vectors are constrained within tile boundary), 1 = ON. For MCTS support, set -umv 0 |
 | **PaletteMode** | -palette | [0 - 6] | -1 | Enable Palette mode (-1: Auto Mode(ON at level6 when SC is detected), 0: OFF 1: ON Level 1, ...6: ON Level6 ) |
 | **SquareWeight** | -sqw | 0 for off and any whole number percentage | 100 | Weighting applied to square/h/v shape costs when deciding if a and b shapes could be skipped. Set to 100 for neutral weighting, lesser than 100 for faster encode and BD-Rate loss, and greater than 100 for slower encode and BD-Rate gain|
+| **MDStage1PruneCThreshold** | -mds1p-c-th | 0 for off and any whole number percentage | 100 | Deviation threshold (expressed as a percentage) of an inter-class class pruning mechanism before MD Stage 1 |
+| **MDStage1PruneSThreshold** | -mds1p-s-th | 0 for off and any whole number percentage | 75 | Deviation threshold (expressed as a percentage) of an intra-class candidate pruning mechanism before MD Stage 1 |
+| **MDStage2PruneCThreshold** | -mds2p-c-th | 0 for off and any whole number percentage | 25 | Deviation threshold (expressed as a percentage) of an inter-class class pruning mechanism before MD Stage 2 |
+| **MDStage2PruneSThreshold** | -mds2p-s-th | 0 for off and any whole number percentage | 15 | Deviation threshold (expressed as a percentage) of an intra-class candidate pruning mechanism before MD Stage 2 |
 ## Appendix A Encoder Parameters
 
 ### 1. Thread management parameters

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -467,6 +467,12 @@ typedef struct EbSvtAv1EncConfiguration
     EbBool                   enable_overlays;
 
     uint32_t                     sq_weight;
+
+    uint64_t                 md_stage_1_count_th_c;
+    uint64_t                 md_stage_1_count_th_s;
+    uint64_t                 md_stage_2_count_th_c;
+    uint64_t                 md_stage_2_count_th_s;
+
 } EbSvtAv1EncConfiguration;
 
     /* STEP 1: Call the library to construct a Component Handle.

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -468,10 +468,10 @@ typedef struct EbSvtAv1EncConfiguration
 
     uint32_t                     sq_weight;
 
-    uint64_t                 md_stage_1_count_th_c;
-    uint64_t                 md_stage_1_count_th_s;
-    uint64_t                 md_stage_2_count_th_c;
-    uint64_t                 md_stage_2_count_th_s;
+    uint64_t                 md_stage_1_class_prune_th;
+    uint64_t                 md_stage_1_cand_prune_th;
+    uint64_t                 md_stage_2_class_prune_th;
+    uint64_t                 md_stage_2_cand_prune_th;
 
 } EbSvtAv1EncConfiguration;
 

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -134,6 +134,11 @@
 #define BUFFER_FILE_MAX_ARG_COUNT   320
 #define BUFFER_FILE_MAX_VAR_LEN     128
 
+#define MDS1_PRUNE_C_TH             "-mds1p-c-th"
+#define MDS1_PRUNE_S_TH             "-mds1p-s-th"
+#define MDS2_PRUNE_C_TH             "-mds2p-c-th"
+#define MDS2_PRUNE_S_TH             "-mds2p-s-th"
+
 /**********************************
  * Set Cfg Functions
  **********************************/
@@ -314,6 +319,27 @@ static void SetSquareWeight                     (const char *value, EbConfig *cf
             cfg->sq_weight = (uint32_t)~0;
 }
 
+static void SetMDS1_PRUNE_C_TH(const char *value, EbConfig *cfg) {
+    cfg->md_stage_1_count_th_c = (uint64_t)strtoul(value, NULL, 0);
+    if (cfg->md_stage_1_count_th_c == 0)
+        cfg->md_stage_1_count_th_c = (uint64_t)~0;
+}
+static void SetMDS1_PRUNE_S_TH(const char *value, EbConfig *cfg) {
+    cfg->md_stage_1_count_th_s = (uint64_t)strtoul(value, NULL, 0);
+    if (cfg->md_stage_1_count_th_s == 0)
+        cfg->md_stage_1_count_th_s = (uint64_t)~0;
+}
+static void SetMDS2_PRUNE_C_TH(const char *value, EbConfig *cfg) {
+    cfg->md_stage_2_count_th_c = (uint64_t)strtoul(value, NULL, 0);
+    if (cfg->md_stage_2_count_th_c == 0)
+        cfg->md_stage_2_count_th_c = (uint64_t)~0;
+}
+static void SetMDS2_PRUNE_S_TH(const char *value, EbConfig *cfg) {
+    cfg->md_stage_2_count_th_s = (uint64_t)strtoul(value, NULL, 0);
+    if (cfg->md_stage_2_count_th_s == 0)
+        cfg->md_stage_2_count_th_s = (uint64_t)~0;
+}
+
 enum cfg_type{
     SINGLE_INPUT,   // Configuration parameters that have only 1 value input
     ARRAY_INPUT     // Configuration parameters that have multiple values as input
@@ -449,6 +475,14 @@ config_entry_t config_entry[] = {
     // --- end: ALTREF_FILTERING_SUPPORT
 
     { SINGLE_INPUT, SQ_WEIGHT_TOKEN, "SquareWeight", SetSquareWeight },
+
+    { SINGLE_INPUT, MDS1_PRUNE_C_TH, "MDStage1PruneCThreshold", SetMDS1_PRUNE_C_TH },
+    { SINGLE_INPUT, MDS1_PRUNE_S_TH, "MDStage1PruneSThreshold", SetMDS1_PRUNE_S_TH },
+    { SINGLE_INPUT, MDS2_PRUNE_C_TH, "MDStage2PruneCThreshold", SetMDS2_PRUNE_C_TH },
+    { SINGLE_INPUT, MDS2_PRUNE_S_TH, "MDStage2PruneSThreshold", SetMDS2_PRUNE_S_TH },
+
+
+
 
     // Termination
     {SINGLE_INPUT,NULL,  NULL,                                NULL}
@@ -616,6 +650,11 @@ void eb_config_ctor(EbConfig *config_ptr)
     // --- end: ALTREF_FILTERING_SUPPORT
 
     config_ptr->sq_weight                            = 100;
+
+    config_ptr->md_stage_1_count_th_s                = 75;
+    config_ptr->md_stage_1_count_th_c                = 100;
+    config_ptr->md_stage_2_count_th_s                = 15;
+    config_ptr->md_stage_2_count_th_c                = 25;
 
     return;
 }

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -134,10 +134,10 @@
 #define BUFFER_FILE_MAX_ARG_COUNT   320
 #define BUFFER_FILE_MAX_VAR_LEN     128
 
-#define MDS1_PRUNE_C_TH             "-mds1p-c-th"
-#define MDS1_PRUNE_S_TH             "-mds1p-s-th"
-#define MDS2_PRUNE_C_TH             "-mds2p-c-th"
-#define MDS2_PRUNE_S_TH             "-mds2p-s-th"
+#define MDS1_PRUNE_C_TH             "-mds1p-class-th"
+#define MDS1_PRUNE_S_TH             "-mds1p-cand-th"
+#define MDS2_PRUNE_C_TH             "-mds2p-class-th"
+#define MDS2_PRUNE_S_TH             "-mds2p-cand-th"
 
 /**********************************
  * Set Cfg Functions
@@ -320,24 +320,24 @@ static void SetSquareWeight                     (const char *value, EbConfig *cf
 }
 
 static void SetMDS1_PRUNE_C_TH(const char *value, EbConfig *cfg) {
-    cfg->md_stage_1_count_th_c = (uint64_t)strtoul(value, NULL, 0);
-    if (cfg->md_stage_1_count_th_c == 0)
-        cfg->md_stage_1_count_th_c = (uint64_t)~0;
+    cfg->md_stage_1_class_prune_th = (uint64_t)strtoul(value, NULL, 0);
+    if (cfg->md_stage_1_class_prune_th == 0)
+        cfg->md_stage_1_class_prune_th = (uint64_t)~0;
 }
 static void SetMDS1_PRUNE_S_TH(const char *value, EbConfig *cfg) {
-    cfg->md_stage_1_count_th_s = (uint64_t)strtoul(value, NULL, 0);
-    if (cfg->md_stage_1_count_th_s == 0)
-        cfg->md_stage_1_count_th_s = (uint64_t)~0;
+    cfg->md_stage_1_cand_prune_th = (uint64_t)strtoul(value, NULL, 0);
+    if (cfg->md_stage_1_cand_prune_th == 0)
+        cfg->md_stage_1_cand_prune_th = (uint64_t)~0;
 }
 static void SetMDS2_PRUNE_C_TH(const char *value, EbConfig *cfg) {
-    cfg->md_stage_2_count_th_c = (uint64_t)strtoul(value, NULL, 0);
-    if (cfg->md_stage_2_count_th_c == 0)
-        cfg->md_stage_2_count_th_c = (uint64_t)~0;
+    cfg->md_stage_2_class_prune_th = (uint64_t)strtoul(value, NULL, 0);
+    if (cfg->md_stage_2_class_prune_th == 0)
+        cfg->md_stage_2_class_prune_th = (uint64_t)~0;
 }
 static void SetMDS2_PRUNE_S_TH(const char *value, EbConfig *cfg) {
-    cfg->md_stage_2_count_th_s = (uint64_t)strtoul(value, NULL, 0);
-    if (cfg->md_stage_2_count_th_s == 0)
-        cfg->md_stage_2_count_th_s = (uint64_t)~0;
+    cfg->md_stage_2_cand_prune_th = (uint64_t)strtoul(value, NULL, 0);
+    if (cfg->md_stage_2_cand_prune_th == 0)
+        cfg->md_stage_2_cand_prune_th = (uint64_t)~0;
 }
 
 enum cfg_type{
@@ -476,13 +476,10 @@ config_entry_t config_entry[] = {
 
     { SINGLE_INPUT, SQ_WEIGHT_TOKEN, "SquareWeight", SetSquareWeight },
 
-    { SINGLE_INPUT, MDS1_PRUNE_C_TH, "MDStage1PruneCThreshold", SetMDS1_PRUNE_C_TH },
-    { SINGLE_INPUT, MDS1_PRUNE_S_TH, "MDStage1PruneSThreshold", SetMDS1_PRUNE_S_TH },
-    { SINGLE_INPUT, MDS2_PRUNE_C_TH, "MDStage2PruneCThreshold", SetMDS2_PRUNE_C_TH },
-    { SINGLE_INPUT, MDS2_PRUNE_S_TH, "MDStage2PruneSThreshold", SetMDS2_PRUNE_S_TH },
-
-
-
+    { SINGLE_INPUT, MDS1_PRUNE_C_TH, "MDStage1PruneClassThreshold", SetMDS1_PRUNE_C_TH },
+    { SINGLE_INPUT, MDS1_PRUNE_S_TH, "MDStage1PruneCandThreshold", SetMDS1_PRUNE_S_TH },
+    { SINGLE_INPUT, MDS2_PRUNE_C_TH, "MDStage2PruneClassThreshold", SetMDS2_PRUNE_C_TH },
+    { SINGLE_INPUT, MDS2_PRUNE_S_TH, "MDStage2PruneCandThreshold", SetMDS2_PRUNE_S_TH },
 
     // Termination
     {SINGLE_INPUT,NULL,  NULL,                                NULL}
@@ -651,10 +648,10 @@ void eb_config_ctor(EbConfig *config_ptr)
 
     config_ptr->sq_weight                            = 100;
 
-    config_ptr->md_stage_1_count_th_s                = 75;
-    config_ptr->md_stage_1_count_th_c                = 100;
-    config_ptr->md_stage_2_count_th_s                = 15;
-    config_ptr->md_stage_2_count_th_c                = 25;
+    config_ptr->md_stage_1_cand_prune_th                = 75;
+    config_ptr->md_stage_1_class_prune_th                = 100;
+    config_ptr->md_stage_2_cand_prune_th                = 15;
+    config_ptr->md_stage_2_class_prune_th                = 25;
 
     return;
 }

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -375,6 +375,12 @@ typedef struct EbConfig
     // square cost weighting for deciding if a/b shapes could be skipped
     uint32_t                 sq_weight;
 
+    // inter/intra class pruning costs before MD stage 1/2
+    uint64_t                 md_stage_1_count_th_c;
+    uint64_t                 md_stage_1_count_th_s;
+    uint64_t                 md_stage_2_count_th_c;
+    uint64_t                 md_stage_2_count_th_s;
+
 } EbConfig;
 
 extern void eb_config_ctor(EbConfig *config_ptr);

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -376,10 +376,10 @@ typedef struct EbConfig
     uint32_t                 sq_weight;
 
     // inter/intra class pruning costs before MD stage 1/2
-    uint64_t                 md_stage_1_count_th_c;
-    uint64_t                 md_stage_1_count_th_s;
-    uint64_t                 md_stage_2_count_th_c;
-    uint64_t                 md_stage_2_count_th_s;
+    uint64_t                 md_stage_1_class_prune_th;
+    uint64_t                 md_stage_1_cand_prune_th;
+    uint64_t                 md_stage_2_class_prune_th;
+    uint64_t                 md_stage_2_cand_prune_th;
 
 } EbConfig;
 

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -246,6 +246,11 @@ EbErrorType CopyConfigurationParameters(
 
     callback_data->eb_enc_parameters.sq_weight = config->sq_weight;
 
+    callback_data->eb_enc_parameters.md_stage_1_count_th_s = config->md_stage_1_count_th_s;
+    callback_data->eb_enc_parameters.md_stage_1_count_th_c = config->md_stage_1_count_th_c;
+    callback_data->eb_enc_parameters.md_stage_2_count_th_s = config->md_stage_2_count_th_s;
+    callback_data->eb_enc_parameters.md_stage_2_count_th_c = config->md_stage_2_count_th_c;
+
     return return_error;
 }
 

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -246,10 +246,10 @@ EbErrorType CopyConfigurationParameters(
 
     callback_data->eb_enc_parameters.sq_weight = config->sq_weight;
 
-    callback_data->eb_enc_parameters.md_stage_1_count_th_s = config->md_stage_1_count_th_s;
-    callback_data->eb_enc_parameters.md_stage_1_count_th_c = config->md_stage_1_count_th_c;
-    callback_data->eb_enc_parameters.md_stage_2_count_th_s = config->md_stage_2_count_th_s;
-    callback_data->eb_enc_parameters.md_stage_2_count_th_c = config->md_stage_2_count_th_c;
+    callback_data->eb_enc_parameters.md_stage_1_cand_prune_th = config->md_stage_1_cand_prune_th;
+    callback_data->eb_enc_parameters.md_stage_1_class_prune_th = config->md_stage_1_class_prune_th;
+    callback_data->eb_enc_parameters.md_stage_2_cand_prune_th = config->md_stage_2_cand_prune_th;
+    callback_data->eb_enc_parameters.md_stage_2_class_prune_th = config->md_stage_2_class_prune_th;
 
     return return_error;
 }

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -44,11 +44,7 @@ extern "C" {
 
 #define LESS_RECTANGULAR_CHECK_LEVEL 1 // Shortcut to skip a/b shapes depending on SQ/H/V shape costs
 
-#define STAGE_1_COUNT_PRUNING_TH_S   1
-#define TUNED_TH_S                   1
-#define STAGE_1_COUNT_PRUNING_TH_C   1
-#define STAGE_2_COUNT_PRUNING_TH_S   1
-#define STAGE_2_COUNT_PRUNING_TH_C   1
+#define INTER_INTRA_CLASS_PRUNING    1
 
 #define FIX_ALTREF                   1 // Address ALTREF mismatch between rtime-m0-test and master: fixed actual_future_pics derivation, shut padding of the central frame, fixed end past frame index prior to window shrinking
 #define FIX_NEAREST_NEW              1 // Address NEAREST_NEW mismatch between rtime-m0-test and master: fixed injection and fixed settings

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -44,6 +44,12 @@ extern "C" {
 
 #define LESS_RECTANGULAR_CHECK_LEVEL 1 // Shortcut to skip a/b shapes depending on SQ/H/V shape costs
 
+#define STAGE_1_COUNT_PRUNING_TH_S   1
+#define TUNED_TH_S                   1
+#define STAGE_1_COUNT_PRUNING_TH_C   1
+#define STAGE_2_COUNT_PRUNING_TH_S   1
+#define STAGE_2_COUNT_PRUNING_TH_C   1
+
 #define FIX_ALTREF                   1 // Address ALTREF mismatch between rtime-m0-test and master: fixed actual_future_pics derivation, shut padding of the central frame, fixed end past frame index prior to window shrinking
 #define FIX_NEAREST_NEW              1 // Address NEAREST_NEW mismatch between rtime-m0-test and master: fixed injection and fixed settings
 #define FIX_ESTIMATE_INTRA           1 // Address ESTIMATE_INTRA mismatch between rtime-m0-test and master: fixed settings

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1561,11 +1561,11 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     // TH_S (for single candidate removal per class)
     // Remove candidate if deviation to the best is higher than TH_S
     if (MR_MODE || picture_control_set_ptr->enc_mode == ENC_M0 || sequence_control_set_ptr->input_resolution == INPUT_SIZE_576p_RANGE_OR_LOWER)
-        context_ptr->md_stage_1_count_th_s = (uint64_t)~0;
+        context_ptr->md_stage_1_cand_prune_th = (uint64_t)~0;
     else if (picture_control_set_ptr->enc_mode <= ENC_M4)
-        context_ptr->md_stage_1_count_th_s = sequence_control_set_ptr->static_config.md_stage_1_count_th_s;
+        context_ptr->md_stage_1_cand_prune_th = sequence_control_set_ptr->static_config.md_stage_1_cand_prune_th;
     else
-        context_ptr->md_stage_1_count_th_s = (uint64_t)~0;
+        context_ptr->md_stage_1_cand_prune_th = (uint64_t)~0;
 #else
     if (MR_MODE)
         context_ptr->dist_base_md_stage_0_count_th = (uint64_t)~0;
@@ -1579,33 +1579,33 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     // TH_C (for class removal)
     // Remove class if deviation to the best higher than TH_C
     if (MR_MODE || picture_control_set_ptr->enc_mode == ENC_M0 || sequence_control_set_ptr->input_resolution == INPUT_SIZE_576p_RANGE_OR_LOWER)
-        context_ptr->md_stage_1_count_th_c = (uint64_t)~0;
+        context_ptr->md_stage_1_class_prune_th = (uint64_t)~0;
     else if (picture_control_set_ptr->enc_mode <= ENC_M4)
-        context_ptr->md_stage_1_count_th_c = sequence_control_set_ptr->static_config.md_stage_1_count_th_c;
+        context_ptr->md_stage_1_class_prune_th = sequence_control_set_ptr->static_config.md_stage_1_class_prune_th;
     else
-        context_ptr->md_stage_1_count_th_c = (uint64_t)~0;
+        context_ptr->md_stage_1_class_prune_th = (uint64_t)~0;
 
     // TH_S (for single candidate removal per class)
     // Remove candidate if deviation to the best is higher than TH_S
     if (MR_MODE || picture_control_set_ptr->parent_pcs_ptr->sc_content_detected)
-        context_ptr->md_stage_2_count_th_s = (uint64_t)~0;
+        context_ptr->md_stage_2_cand_prune_th = (uint64_t)~0;
     else if (picture_control_set_ptr->enc_mode <= ENC_M0)
-        context_ptr->md_stage_2_count_th_s = sequence_control_set_ptr->static_config.md_stage_2_count_th_s;
+        context_ptr->md_stage_2_cand_prune_th = sequence_control_set_ptr->static_config.md_stage_2_cand_prune_th;
     else if (picture_control_set_ptr->enc_mode <= ENC_M2)
-        context_ptr->md_stage_2_count_th_s = sequence_control_set_ptr->input_resolution <= INPUT_SIZE_1080i_RANGE ? 15 : 12;
+        context_ptr->md_stage_2_cand_prune_th = sequence_control_set_ptr->input_resolution <= INPUT_SIZE_1080i_RANGE ? 15 : 12;
     else if (picture_control_set_ptr->enc_mode <= ENC_M4)
-        context_ptr->md_stage_2_count_th_s = sequence_control_set_ptr->input_resolution <= INPUT_SIZE_1080i_RANGE ? 5 : 3;
+        context_ptr->md_stage_2_cand_prune_th = sequence_control_set_ptr->input_resolution <= INPUT_SIZE_1080i_RANGE ? 5 : 3;
     else
-        context_ptr->md_stage_2_count_th_s = (uint64_t)~0;
+        context_ptr->md_stage_2_cand_prune_th = (uint64_t)~0;
     
     // TH_C (for class removal)
     // Remove class if deviation to the best is higher than TH_C
     if (MR_MODE || picture_control_set_ptr->parent_pcs_ptr->sc_content_detected)
-        context_ptr->md_stage_2_count_th_c = (uint64_t)~0;
+        context_ptr->md_stage_2_class_prune_th = (uint64_t)~0;
     else if (picture_control_set_ptr->enc_mode <= ENC_M4)
-        context_ptr->md_stage_2_count_th_c = sequence_control_set_ptr->static_config.md_stage_2_count_th_c;
+        context_ptr->md_stage_2_class_prune_th = sequence_control_set_ptr->static_config.md_stage_2_class_prune_th;
     else // to be tested for m5-m8
-        context_ptr->md_stage_2_count_th_c = (uint64_t)~0;
+        context_ptr->md_stage_2_class_prune_th = (uint64_t)~0;
 
 #endif
 

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1561,7 +1561,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     if (MR_MODE || picture_control_set_ptr->enc_mode == ENC_M0 || sequence_control_set_ptr->input_resolution == INPUT_SIZE_576p_RANGE_OR_LOWER)
         context_ptr->md_stage_1_count_th_s = (uint64_t)~0;
     else if (picture_control_set_ptr->enc_mode <= ENC_M4)
-        context_ptr->md_stage_1_count_th_s = 75;
+        context_ptr->md_stage_1_count_th_s = sequence_control_set_ptr->static_config.md_stage_1_count_th_s;
     else
         context_ptr->md_stage_1_count_th_s = (uint64_t)~0;
 #else
@@ -1578,7 +1578,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     if (MR_MODE || picture_control_set_ptr->enc_mode == ENC_M0 || sequence_control_set_ptr->input_resolution == INPUT_SIZE_576p_RANGE_OR_LOWER)
         context_ptr->md_stage_1_count_th_c = (uint64_t)~0;
     else if (picture_control_set_ptr->enc_mode <= ENC_M4)
-        context_ptr->md_stage_1_count_th_c = 100;
+        context_ptr->md_stage_1_count_th_c = sequence_control_set_ptr->static_config.md_stage_1_count_th_c;
     else
         context_ptr->md_stage_1_count_th_c = (uint64_t)~0;
 #endif
@@ -1589,7 +1589,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     if (MR_MODE || picture_control_set_ptr->parent_pcs_ptr->sc_content_detected)
         context_ptr->md_stage_2_count_th_s = (uint64_t)~0;
     else if (picture_control_set_ptr->enc_mode <= ENC_M0)
-        context_ptr->md_stage_2_count_th_s = 15;
+        context_ptr->md_stage_2_count_th_s = sequence_control_set_ptr->static_config.md_stage_2_count_th_s;
     else if (picture_control_set_ptr->enc_mode <= ENC_M2)
         context_ptr->md_stage_2_count_th_s = sequence_control_set_ptr->input_resolution <= INPUT_SIZE_1080i_RANGE ? 15 : 12;
     else if (picture_control_set_ptr->enc_mode <= ENC_M4)
@@ -1604,7 +1604,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     if (MR_MODE || picture_control_set_ptr->parent_pcs_ptr->sc_content_detected)
         context_ptr->md_stage_2_count_th_c = (uint64_t)~0;
     else if (picture_control_set_ptr->enc_mode <= ENC_M4)
-        context_ptr->md_stage_2_count_th_c = 25;
+        context_ptr->md_stage_2_count_th_c = sequence_control_set_ptr->static_config.md_stage_2_count_th_c;
     else // to be tested for m5-m8
         context_ptr->md_stage_2_count_th_c = (uint64_t)~0;
 

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1556,13 +1556,59 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     else
         context_ptr->md_exit_th = (picture_control_set_ptr->parent_pcs_ptr->sc_content_detected) ? 10 : 18;
 
-    // Derive distortion-based md_stage_0_count proning
+    // Derive distortion-based md_stage_0_count pruning
+#if STAGE_1_COUNT_PRUNING_TH_S
+    if (MR_MODE || picture_control_set_ptr->enc_mode == ENC_M0 || sequence_control_set_ptr->input_resolution == INPUT_SIZE_576p_RANGE_OR_LOWER)
+        context_ptr->md_stage_1_count_th_s = (uint64_t)~0;
+    else if (picture_control_set_ptr->enc_mode <= ENC_M4)
+        context_ptr->md_stage_1_count_th_s = 75;
+    else
+        context_ptr->md_stage_1_count_th_s = (uint64_t)~0;
+#else
     if (MR_MODE)
         context_ptr->dist_base_md_stage_0_count_th = (uint64_t)~0;
     else
         context_ptr->dist_base_md_stage_0_count_th = 75;
 #endif
+#endif
 
+#if STAGE_1_COUNT_PRUNING_TH_C
+    // TH_C(for class removal)
+    // Remove class if deviation to the best higher than TH_C
+    if (MR_MODE || picture_control_set_ptr->enc_mode == ENC_M0 || sequence_control_set_ptr->input_resolution == INPUT_SIZE_576p_RANGE_OR_LOWER)
+        context_ptr->md_stage_1_count_th_c = (uint64_t)~0;
+    else if (picture_control_set_ptr->enc_mode <= ENC_M4)
+        context_ptr->md_stage_1_count_th_c = 100;
+    else
+        context_ptr->md_stage_1_count_th_c = (uint64_t)~0;
+#endif
+
+#if STAGE_2_COUNT_PRUNING_TH_S
+    // TH_S(for candidate removal per class)
+    // Remove candidate if deviation to the best higher than TH_S
+    if (MR_MODE || picture_control_set_ptr->parent_pcs_ptr->sc_content_detected)
+        context_ptr->md_stage_2_count_th_s = (uint64_t)~0;
+    else if (picture_control_set_ptr->enc_mode <= ENC_M0)
+        context_ptr->md_stage_2_count_th_s = 15;
+    else if (picture_control_set_ptr->enc_mode <= ENC_M2)
+        context_ptr->md_stage_2_count_th_s = sequence_control_set_ptr->input_resolution <= INPUT_SIZE_1080i_RANGE ? 15 : 12;
+    else if (picture_control_set_ptr->enc_mode <= ENC_M4)
+        context_ptr->md_stage_2_count_th_s = sequence_control_set_ptr->input_resolution <= INPUT_SIZE_1080i_RANGE ? 5 : 3;
+    else
+        context_ptr->md_stage_2_count_th_s = (uint64_t)~0; // until tested
+#endif
+
+#if STAGE_2_COUNT_PRUNING_TH_C
+    // TH_C(for class removal)
+    // Remove class if deviation to the best higher than TH_C
+    if (MR_MODE || picture_control_set_ptr->parent_pcs_ptr->sc_content_detected)
+        context_ptr->md_stage_2_count_th_c = (uint64_t)~0;
+    else if (picture_control_set_ptr->enc_mode <= ENC_M4)
+        context_ptr->md_stage_2_count_th_c = 25;
+    else // to be tested for m5-m8
+        context_ptr->md_stage_2_count_th_c = (uint64_t)~0;
+
+#endif
 
 #if LESS_RECTANGULAR_CHECK_LEVEL
 

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1556,8 +1556,10 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     else
         context_ptr->md_exit_th = (picture_control_set_ptr->parent_pcs_ptr->sc_content_detected) ? 10 : 18;
 
-    // Derive distortion-based md_stage_0_count pruning
-#if STAGE_1_COUNT_PRUNING_TH_S
+#if INTER_INTRA_CLASS_PRUNING
+
+    // TH_S (for single candidate removal per class)
+    // Remove candidate if deviation to the best is higher than TH_S
     if (MR_MODE || picture_control_set_ptr->enc_mode == ENC_M0 || sequence_control_set_ptr->input_resolution == INPUT_SIZE_576p_RANGE_OR_LOWER)
         context_ptr->md_stage_1_count_th_s = (uint64_t)~0;
     else if (picture_control_set_ptr->enc_mode <= ENC_M4)
@@ -1572,8 +1574,9 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 #endif
 #endif
 
-#if STAGE_1_COUNT_PRUNING_TH_C
-    // TH_C(for class removal)
+#if INTER_INTRA_CLASS_PRUNING
+
+    // TH_C (for class removal)
     // Remove class if deviation to the best higher than TH_C
     if (MR_MODE || picture_control_set_ptr->enc_mode == ENC_M0 || sequence_control_set_ptr->input_resolution == INPUT_SIZE_576p_RANGE_OR_LOWER)
         context_ptr->md_stage_1_count_th_c = (uint64_t)~0;
@@ -1581,11 +1584,9 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         context_ptr->md_stage_1_count_th_c = sequence_control_set_ptr->static_config.md_stage_1_count_th_c;
     else
         context_ptr->md_stage_1_count_th_c = (uint64_t)~0;
-#endif
 
-#if STAGE_2_COUNT_PRUNING_TH_S
-    // TH_S(for candidate removal per class)
-    // Remove candidate if deviation to the best higher than TH_S
+    // TH_S (for single candidate removal per class)
+    // Remove candidate if deviation to the best is higher than TH_S
     if (MR_MODE || picture_control_set_ptr->parent_pcs_ptr->sc_content_detected)
         context_ptr->md_stage_2_count_th_s = (uint64_t)~0;
     else if (picture_control_set_ptr->enc_mode <= ENC_M0)
@@ -1595,12 +1596,10 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     else if (picture_control_set_ptr->enc_mode <= ENC_M4)
         context_ptr->md_stage_2_count_th_s = sequence_control_set_ptr->input_resolution <= INPUT_SIZE_1080i_RANGE ? 5 : 3;
     else
-        context_ptr->md_stage_2_count_th_s = (uint64_t)~0; // until tested
-#endif
-
-#if STAGE_2_COUNT_PRUNING_TH_C
-    // TH_C(for class removal)
-    // Remove class if deviation to the best higher than TH_C
+        context_ptr->md_stage_2_count_th_s = (uint64_t)~0;
+    
+    // TH_C (for class removal)
+    // Remove class if deviation to the best is higher than TH_C
     if (MR_MODE || picture_control_set_ptr->parent_pcs_ptr->sc_content_detected)
         context_ptr->md_stage_2_count_th_c = (uint64_t)~0;
     else if (picture_control_set_ptr->enc_mode <= ENC_M4)

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -321,19 +321,15 @@ extern "C" {
     unsigned int                        source_variance; // input block variance
     unsigned int                        inter_inter_wedge_variance_th;
     uint64_t                            md_exit_th;
-#if STAGE_1_COUNT_PRUNING_TH_S
+#if INTER_INTRA_CLASS_PRUNING
     uint64_t                            md_stage_1_count_th_s; // THs (for candidate removal per class) 
+    uint64_t                            md_stage_1_count_th_c; // THc (for class removal)
 #else
     uint64_t                            dist_base_md_stage_0_count_th;
 #endif
-#if STAGE_1_COUNT_PRUNING_TH_C
-    uint64_t                            md_stage_1_count_th_c; // THc (for class removal)
 #endif
-#endif
-#if STAGE_2_COUNT_PRUNING_TH_S
+#if INTER_INTRA_CLASS_PRUNING
     uint64_t                            md_stage_2_count_th_s; // THs (for candidate removal per class) 
-#endif
-#if STAGE_2_COUNT_PRUNING_TH_C
     uint64_t                            md_stage_2_count_th_c; // THc (for class removal)
 #endif
 #if OBMC_FLAG

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -321,7 +321,20 @@ extern "C" {
     unsigned int                        source_variance; // input block variance
     unsigned int                        inter_inter_wedge_variance_th;
     uint64_t                            md_exit_th;
+#if STAGE_1_COUNT_PRUNING_TH_S
+    uint64_t                            md_stage_1_count_th_s; // THs (for candidate removal per class) 
+#else
     uint64_t                            dist_base_md_stage_0_count_th;
+#endif
+#if STAGE_1_COUNT_PRUNING_TH_C
+    uint64_t                            md_stage_1_count_th_c; // THc (for class removal)
+#endif
+#endif
+#if STAGE_2_COUNT_PRUNING_TH_S
+    uint64_t                            md_stage_2_count_th_s; // THs (for candidate removal per class) 
+#endif
+#if STAGE_2_COUNT_PRUNING_TH_C
+    uint64_t                            md_stage_2_count_th_c; // THc (for class removal)
 #endif
 #if OBMC_FLAG
     DECLARE_ALIGNED(16, uint8_t, obmc_buff_0[2 * MAX_MB_PLANE * MAX_SB_SQUARE]);

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -322,15 +322,15 @@ extern "C" {
     unsigned int                        inter_inter_wedge_variance_th;
     uint64_t                            md_exit_th;
 #if INTER_INTRA_CLASS_PRUNING
-    uint64_t                            md_stage_1_count_th_s; // THs (for candidate removal per class) 
-    uint64_t                            md_stage_1_count_th_c; // THc (for class removal)
+    uint64_t                            md_stage_1_cand_prune_th;
+    uint64_t                            md_stage_1_class_prune_th;
 #else
     uint64_t                            dist_base_md_stage_0_count_th;
 #endif
 #endif
 #if INTER_INTRA_CLASS_PRUNING
-    uint64_t                            md_stage_2_count_th_s; // THs (for candidate removal per class) 
-    uint64_t                            md_stage_2_count_th_c; // THc (for class removal)
+    uint64_t                            md_stage_2_cand_prune_th;
+    uint64_t                            md_stage_2_class_prune_th;
 #endif
 #if OBMC_FLAG
     DECLARE_ALIGNED(16, uint8_t, obmc_buff_0[2 * MAX_MB_PLANE * MAX_SB_SQUARE]);

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -7546,7 +7546,7 @@ void inter_class_decision_count_1(
 )
 {
     ModeDecisionCandidateBuffer **buffer_ptr_array = context_ptr->candidate_buffer_ptr_array;
-    // Distortion-based NIC proning not applied to INTRA clases: CLASS_0 and CLASS
+    // Distortion-based NIC pruning not applied to INTRA clases: CLASS_0 and CLASS
     for (CAND_CLASS cand_class_it = CAND_CLASS_1; cand_class_it <= CAND_CLASS_3; cand_class_it++) {
         if (context_ptr->md_stage_0_count[cand_class_it] > 0 && context_ptr->md_stage_1_count[cand_class_it] > 0) {
             uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
@@ -7564,6 +7564,58 @@ void inter_class_decision_count_1(
 extern aom_variance_fn_ptr_t mefn_ptr[BlockSizeS_ALL];
 unsigned int eb_av1_get_sby_perpixel_variance(const aom_variance_fn_ptr_t *fn_ptr, const uint8_t *src, int stride, BlockSize bs);
 #endif
+
+#if INTER_INTRA_CLASS_PRUNING
+
+void interintra_class_pruning_1(ModeDecisionContext *context_ptr, uint64_t best_md_stage_cost) {
+    
+    for (CAND_CLASS cand_class_it = CAND_CLASS_0; cand_class_it < CAND_CLASS_TOTAL; cand_class_it++) {
+        if (context_ptr->md_stage_0_count[cand_class_it] > 0 && context_ptr->md_stage_1_count[cand_class_it] > 0) {
+            uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
+            uint64_t class_best_cost = *(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr);
+
+            // inter class pruning
+            if ((((class_best_cost - best_md_stage_cost) * 100) / best_md_stage_cost) > context_ptr->md_stage_1_count_th_c){
+                context_ptr->md_stage_1_count[cand_class_it] = 0;
+                continue;
+            }
+            // intra class pruning
+            uint32_t cand_count = 1;
+            while (cand_count < context_ptr->md_stage_1_count[cand_class_it] && ((((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[cand_count]]->fast_cost_ptr) - class_best_cost) * 100) / class_best_cost) < context_ptr->md_stage_1_count_th_s)) {
+                cand_count++;
+            }
+            context_ptr->md_stage_1_count[cand_class_it] = cand_count;
+        }
+        context_ptr->md_stage_1_total_count += context_ptr->md_stage_1_count[cand_class_it];
+    }
+}
+
+void interintra_class_pruning_2(ModeDecisionContext *context_ptr, uint64_t best_md_stage_cost) {
+    
+    for (CAND_CLASS cand_class_it = CAND_CLASS_0; cand_class_it < CAND_CLASS_TOTAL; cand_class_it++) {
+        if (context_ptr->md_stage_1_count[cand_class_it] > 0 && context_ptr->md_stage_2_count[cand_class_it] > 0 && context_ptr->bypass_md_stage_1[cand_class_it] == EB_FALSE) {
+            uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
+            uint64_t class_best_cost = *(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->full_cost_ptr);
+
+            // inter class pruning
+            if ((((class_best_cost - best_md_stage_cost) * 100) / best_md_stage_cost) > context_ptr->md_stage_2_count_th_c) {
+                context_ptr->md_stage_2_count[cand_class_it] = 0;
+                continue;
+            }
+
+            // intra class pruning
+            uint32_t cand_count = 1;
+            while (cand_count < context_ptr->md_stage_2_count[cand_class_it] && ((((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[cand_count]]->full_cost_ptr) - class_best_cost) * 100) / class_best_cost) < context_ptr->md_stage_2_count_th_s)) {
+                cand_count++;
+            }
+            context_ptr->md_stage_2_count[cand_class_it] = cand_count;
+        }
+        context_ptr->md_stage_2_total_count += context_ptr->md_stage_2_count[cand_class_it];
+    }
+}
+
+#endif
+
 void md_encode_block(
     SequenceControlSet             *sequence_control_set_ptr,
     PictureControlSet              *picture_control_set_ptr,
@@ -7779,8 +7831,8 @@ void md_encode_block(
 
         context_ptr->md_stage = MD_STAGE_0;
 #endif
-#if STAGE_1_COUNT_PRUNING_TH_C
-        uint64_t best_md_stage_0_cost = (uint64_t)~0;
+#if INTER_INTRA_CLASS_PRUNING
+        uint64_t best_md_stage_cost = (uint64_t)~0;
 #endif
         for (cand_class_it = CAND_CLASS_0; cand_class_it < CAND_CLASS_TOTAL; cand_class_it++) {
 
@@ -7824,14 +7876,12 @@ void md_encode_block(
                     buffer_count_for_curr_class, //how many cand buffers to sort. one of the buffers can have max cost.
                     context_ptr->cand_buff_indices[cand_class_it]);
 
-#if STAGE_1_COUNT_PRUNING_TH_C
+#if INTER_INTRA_CLASS_PRUNING
                 uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
-                best_md_stage_0_cost = MIN((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr)), best_md_stage_0_cost);
-#endif
-
-#if !STAGE_1_COUNT_PRUNING_TH_S
+                best_md_stage_cost = MIN((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr)), best_md_stage_cost);
+#else
 #if REMOVE_MD_STAGE_1
-                // Distortion-based NIC proning to CLASS_1, CLASS_2, CLASS_3
+                // Distortion-based NIC pruning to CLASS_1, CLASS_2, CLASS_3
                 if (cand_class_it == CAND_CLASS_1 || cand_class_it == CAND_CLASS_2 || cand_class_it == CAND_CLASS_3) {
                     uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
                     assert(context_ptr->md_stage_0_count[CAND_CLASS_0] > 0);
@@ -7851,49 +7901,15 @@ void md_encode_block(
 
             }
 
-#if !STAGE_1_COUNT_PRUNING_TH_S
+#if !INTER_INTRA_CLASS_PRUNING
 #if REMOVE_MD_STAGE_1
             context_ptr->md_stage_1_total_count += context_ptr->md_stage_1_count[cand_class_it];
 #endif
 #endif
         }
 
-#if STAGE_1_COUNT_PRUNING_TH_S
-        for (cand_class_it = CAND_CLASS_0; cand_class_it < CAND_CLASS_TOTAL; cand_class_it++) {
-
-            //number of next level candidates could not exceed number of curr level candidates
-            context_ptr->md_stage_1_count[cand_class_it] = MIN(context_ptr->md_stage_0_count[cand_class_it], context_ptr->md_stage_1_count[cand_class_it]);
-
-            if (context_ptr->md_stage_0_count[cand_class_it] > 0 && context_ptr->md_stage_1_count[cand_class_it] > 0) {
-                // Distortion-based NIC proning to CLASS_1, CLASS_2, CLASS_3
-#if !TUNED_TH_S
-                if (cand_class_it == CAND_CLASS_1 || cand_class_it == CAND_CLASS_2 || cand_class_it == CAND_CLASS_3)
-#endif
-                {
-                    uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
-#if STAGE_1_COUNT_PRUNING_TH_C
-                    if ((((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr) - best_md_stage_0_cost) * 100) / best_md_stage_0_cost) > context_ptr->md_stage_1_count_th_c) {
-                        context_ptr->md_stage_1_count[cand_class_it] = 0;
-                        context_ptr->md_stage_2_count[cand_class_it] = 0;
-                    }
-                    if (context_ptr->md_stage_1_count[cand_class_it])
-#endif
-
-#if !TUNED_TH_S
-                        if (context_ptr->md_stage_0_count[CAND_CLASS_0] > 0 && *(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr) <
-                            *(context_ptr->candidate_buffer_ptr_array[context_ptr->cand_buff_indices[CAND_CLASS_0][0]]->fast_cost_ptr))
-#endif
-                        {
-                            uint32_t fast1_cand_count = 1;
-                            while (fast1_cand_count < context_ptr->md_stage_1_count[cand_class_it] && ((((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[fast1_cand_count]]->fast_cost_ptr) - *(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr)) * 100) / (*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr))) < context_ptr->md_stage_1_count_th_s)) {
-                                fast1_cand_count++;
-                            }
-                            context_ptr->md_stage_1_count[cand_class_it] = fast1_cand_count;
-                        }
-                }
-            }
-            context_ptr->md_stage_1_total_count += context_ptr->md_stage_1_count[cand_class_it];
-        }
+#if INTER_INTRA_CLASS_PRUNING
+        interintra_class_pruning_1(context_ptr,best_md_stage_cost);
 #endif
 
 #if !REMOVE_MD_STAGE_1
@@ -7951,14 +7967,14 @@ void md_encode_block(
 
 
         // 1st Full-Loop
-#if STAGE_2_COUNT_PRUNING_TH_C
-        uint64_t best_md_stage_1_cost = (uint64_t)~0;
+#if INTER_INTRA_CLASS_PRUNING
+        best_md_stage_cost = (uint64_t)~0;
 #endif
 #if REMOVE_MD_STAGE_1
         for (cand_class_it = CAND_CLASS_0; cand_class_it < CAND_CLASS_TOTAL; cand_class_it++) {
             //number of next level candidates could not exceed number of curr level candidates
             context_ptr->md_stage_2_count[cand_class_it] = MIN(context_ptr->md_stage_1_count[cand_class_it], context_ptr->md_stage_2_count[cand_class_it]);
-#if !STAGE_2_COUNT_PRUNING_TH_S && !STAGE_2_COUNT_PRUNING_TH_C
+#if !INTER_INTRA_CLASS_PRUNING
             context_ptr->md_stage_2_total_count += context_ptr->md_stage_2_count[cand_class_it];
 #endif
             if (context_ptr->bypass_md_stage_1[cand_class_it] == EB_FALSE && context_ptr->md_stage_1_count[cand_class_it] > 0 && context_ptr->md_stage_2_count[cand_class_it] > 0) {
@@ -8005,36 +8021,14 @@ void md_encode_block(
                         context_ptr->cand_buff_indices[cand_class_it]);
 #endif
 
-#if STAGE_2_COUNT_PRUNING_TH_C
+#if INTER_INTRA_CLASS_PRUNING
                 uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
-                best_md_stage_1_cost = MIN((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->full_cost_ptr)), best_md_stage_1_cost);
+                best_md_stage_cost = MIN((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->full_cost_ptr)), best_md_stage_cost);
 #endif
             }
         }
-
-#if STAGE_2_COUNT_PRUNING_TH_S || STAGE_2_COUNT_PRUNING_TH_C
-        for (cand_class_it = CAND_CLASS_0; cand_class_it < CAND_CLASS_TOTAL; cand_class_it++) {
-
-            if (context_ptr->bypass_md_stage_1[cand_class_it] == EB_FALSE && context_ptr->md_stage_1_count[cand_class_it] > 0 && context_ptr->md_stage_2_count[cand_class_it] > 0) {
-                uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
-#if STAGE_2_COUNT_PRUNING_TH_C
-                if ((((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->full_cost_ptr) - best_md_stage_1_cost) * 100) / best_md_stage_1_cost) > context_ptr->md_stage_2_count_th_c) {
-                    context_ptr->md_stage_2_count[cand_class_it] = 0;
-                }
-#endif
-#if STAGE_2_COUNT_PRUNING_TH_S
-                // Remove outliers from the list; prone if cost-to-best deviation bigger than  context_ptr->cost_dev_based_md_stage_2_count_pruning
-                if (context_ptr->md_stage_2_count[cand_class_it]) {
-                    uint32_t md_stage_2_count = 1;
-                    while (md_stage_2_count < context_ptr->md_stage_2_count[cand_class_it] && ((((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[md_stage_2_count]]->full_cost_ptr) - *(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->full_cost_ptr)) * 100) / (*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->full_cost_ptr))) < context_ptr->md_stage_2_count_th_s)) {
-                        md_stage_2_count++;
-                    }
-                    context_ptr->md_stage_2_count[cand_class_it] = md_stage_2_count;
-                }
-#endif
-            }
-            context_ptr->md_stage_2_total_count += context_ptr->md_stage_2_count[cand_class_it];
-        }
+#if INTER_INTRA_CLASS_PRUNING
+        interintra_class_pruning_2(context_ptr, best_md_stage_cost);
 #endif
 
 #if REMOVE_MD_STAGE_1

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -7575,13 +7575,13 @@ void interintra_class_pruning_1(ModeDecisionContext *context_ptr, uint64_t best_
             uint64_t class_best_cost = *(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr);
 
             // inter class pruning
-            if ((((class_best_cost - best_md_stage_cost) * 100) / best_md_stage_cost) > context_ptr->md_stage_1_count_th_c){
+            if ((((class_best_cost - best_md_stage_cost) * 100) / best_md_stage_cost) > context_ptr->md_stage_1_class_prune_th){
                 context_ptr->md_stage_1_count[cand_class_it] = 0;
                 continue;
             }
             // intra class pruning
             uint32_t cand_count = 1;
-            while (cand_count < context_ptr->md_stage_1_count[cand_class_it] && ((((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[cand_count]]->fast_cost_ptr) - class_best_cost) * 100) / class_best_cost) < context_ptr->md_stage_1_count_th_s)) {
+            while (cand_count < context_ptr->md_stage_1_count[cand_class_it] && ((((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[cand_count]]->fast_cost_ptr) - class_best_cost) * 100) / class_best_cost) < context_ptr->md_stage_1_cand_prune_th)) {
                 cand_count++;
             }
             context_ptr->md_stage_1_count[cand_class_it] = cand_count;
@@ -7598,14 +7598,14 @@ void interintra_class_pruning_2(ModeDecisionContext *context_ptr, uint64_t best_
             uint64_t class_best_cost = *(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->full_cost_ptr);
 
             // inter class pruning
-            if ((((class_best_cost - best_md_stage_cost) * 100) / best_md_stage_cost) > context_ptr->md_stage_2_count_th_c) {
+            if ((((class_best_cost - best_md_stage_cost) * 100) / best_md_stage_cost) > context_ptr->md_stage_2_class_prune_th) {
                 context_ptr->md_stage_2_count[cand_class_it] = 0;
                 continue;
             }
 
             // intra class pruning
             uint32_t cand_count = 1;
-            while (cand_count < context_ptr->md_stage_2_count[cand_class_it] && ((((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[cand_count]]->full_cost_ptr) - class_best_cost) * 100) / class_best_cost) < context_ptr->md_stage_2_count_th_s)) {
+            while (cand_count < context_ptr->md_stage_2_count[cand_class_it] && ((((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[cand_count]]->full_cost_ptr) - class_best_cost) * 100) / class_best_cost) < context_ptr->md_stage_2_cand_prune_th)) {
                 cand_count++;
             }
             context_ptr->md_stage_2_count[cand_class_it] = cand_count;

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -7779,6 +7779,9 @@ void md_encode_block(
 
         context_ptr->md_stage = MD_STAGE_0;
 #endif
+#if STAGE_1_COUNT_PRUNING_TH_C
+        uint64_t best_md_stage_0_cost = (uint64_t)~0;
+#endif
         for (cand_class_it = CAND_CLASS_0; cand_class_it < CAND_CLASS_TOTAL; cand_class_it++) {
 
             //number of next level candidates could not exceed number of curr level candidates
@@ -7820,6 +7823,13 @@ void md_encode_block(
                     buffer_start_idx,
                     buffer_count_for_curr_class, //how many cand buffers to sort. one of the buffers can have max cost.
                     context_ptr->cand_buff_indices[cand_class_it]);
+
+#if STAGE_1_COUNT_PRUNING_TH_C
+                uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
+                best_md_stage_0_cost = MIN((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr)), best_md_stage_0_cost);
+#endif
+
+#if !STAGE_1_COUNT_PRUNING_TH_S
 #if REMOVE_MD_STAGE_1
                 // Distortion-based NIC proning to CLASS_1, CLASS_2, CLASS_3
                 if (cand_class_it == CAND_CLASS_1 || cand_class_it == CAND_CLASS_2 || cand_class_it == CAND_CLASS_3) {
@@ -7835,13 +7845,57 @@ void md_encode_block(
                     }
                 }
 #endif
+#endif
+
                 buffer_start_idx += buffer_count_for_curr_class;//for next iteration.
 
             }
+
+#if !STAGE_1_COUNT_PRUNING_TH_S
 #if REMOVE_MD_STAGE_1
             context_ptr->md_stage_1_total_count += context_ptr->md_stage_1_count[cand_class_it];
 #endif
+#endif
         }
+
+#if STAGE_1_COUNT_PRUNING_TH_S
+        for (cand_class_it = CAND_CLASS_0; cand_class_it < CAND_CLASS_TOTAL; cand_class_it++) {
+
+            //number of next level candidates could not exceed number of curr level candidates
+            context_ptr->md_stage_1_count[cand_class_it] = MIN(context_ptr->md_stage_0_count[cand_class_it], context_ptr->md_stage_1_count[cand_class_it]);
+
+            if (context_ptr->md_stage_0_count[cand_class_it] > 0 && context_ptr->md_stage_1_count[cand_class_it] > 0) {
+                // Distortion-based NIC proning to CLASS_1, CLASS_2, CLASS_3
+#if !TUNED_TH_S
+                if (cand_class_it == CAND_CLASS_1 || cand_class_it == CAND_CLASS_2 || cand_class_it == CAND_CLASS_3)
+#endif
+                {
+                    uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
+#if STAGE_1_COUNT_PRUNING_TH_C
+                    if ((((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr) - best_md_stage_0_cost) * 100) / best_md_stage_0_cost) > context_ptr->md_stage_1_count_th_c) {
+                        context_ptr->md_stage_1_count[cand_class_it] = 0;
+                        context_ptr->md_stage_2_count[cand_class_it] = 0;
+                    }
+                    if (context_ptr->md_stage_1_count[cand_class_it])
+#endif
+
+#if !TUNED_TH_S
+                        if (context_ptr->md_stage_0_count[CAND_CLASS_0] > 0 && *(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr) <
+                            *(context_ptr->candidate_buffer_ptr_array[context_ptr->cand_buff_indices[CAND_CLASS_0][0]]->fast_cost_ptr))
+#endif
+                        {
+                            uint32_t fast1_cand_count = 1;
+                            while (fast1_cand_count < context_ptr->md_stage_1_count[cand_class_it] && ((((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[fast1_cand_count]]->fast_cost_ptr) - *(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr)) * 100) / (*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr))) < context_ptr->md_stage_1_count_th_s)) {
+                                fast1_cand_count++;
+                            }
+                            context_ptr->md_stage_1_count[cand_class_it] = fast1_cand_count;
+                        }
+                }
+            }
+            context_ptr->md_stage_1_total_count += context_ptr->md_stage_1_count[cand_class_it];
+        }
+#endif
+
 #if !REMOVE_MD_STAGE_1
 #if SPEED_OPT
         //after completing stage0, we might shorten cand count for some classes.
@@ -7897,12 +7951,16 @@ void md_encode_block(
 
 
         // 1st Full-Loop
+#if STAGE_2_COUNT_PRUNING_TH_C
+        uint64_t best_md_stage_1_cost = (uint64_t)~0;
+#endif
 #if REMOVE_MD_STAGE_1
         for (cand_class_it = CAND_CLASS_0; cand_class_it < CAND_CLASS_TOTAL; cand_class_it++) {
             //number of next level candidates could not exceed number of curr level candidates
             context_ptr->md_stage_2_count[cand_class_it] = MIN(context_ptr->md_stage_1_count[cand_class_it], context_ptr->md_stage_2_count[cand_class_it]);
+#if !STAGE_2_COUNT_PRUNING_TH_S && !STAGE_2_COUNT_PRUNING_TH_C
             context_ptr->md_stage_2_total_count += context_ptr->md_stage_2_count[cand_class_it];
-
+#endif
             if (context_ptr->bypass_md_stage_1[cand_class_it] == EB_FALSE && context_ptr->md_stage_1_count[cand_class_it] > 0 && context_ptr->md_stage_2_count[cand_class_it] > 0) {
 #else
         context_ptr->md_stage = MD_STAGE_2;
@@ -7946,9 +8004,38 @@ void md_encode_block(
                         context_ptr->md_stage_2_count[cand_class_it],
                         context_ptr->cand_buff_indices[cand_class_it]);
 #endif
+
+#if STAGE_2_COUNT_PRUNING_TH_C
+                uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
+                best_md_stage_1_cost = MIN((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->full_cost_ptr)), best_md_stage_1_cost);
+#endif
             }
         }
 
+#if STAGE_2_COUNT_PRUNING_TH_S || STAGE_2_COUNT_PRUNING_TH_C
+        for (cand_class_it = CAND_CLASS_0; cand_class_it < CAND_CLASS_TOTAL; cand_class_it++) {
+
+            if (context_ptr->bypass_md_stage_1[cand_class_it] == EB_FALSE && context_ptr->md_stage_1_count[cand_class_it] > 0 && context_ptr->md_stage_2_count[cand_class_it] > 0) {
+                uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
+#if STAGE_2_COUNT_PRUNING_TH_C
+                if ((((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->full_cost_ptr) - best_md_stage_1_cost) * 100) / best_md_stage_1_cost) > context_ptr->md_stage_2_count_th_c) {
+                    context_ptr->md_stage_2_count[cand_class_it] = 0;
+                }
+#endif
+#if STAGE_2_COUNT_PRUNING_TH_S
+                // Remove outliers from the list; prone if cost-to-best deviation bigger than  context_ptr->cost_dev_based_md_stage_2_count_pruning
+                if (context_ptr->md_stage_2_count[cand_class_it]) {
+                    uint32_t md_stage_2_count = 1;
+                    while (md_stage_2_count < context_ptr->md_stage_2_count[cand_class_it] && ((((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[md_stage_2_count]]->full_cost_ptr) - *(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->full_cost_ptr)) * 100) / (*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->full_cost_ptr))) < context_ptr->md_stage_2_count_th_s)) {
+                        md_stage_2_count++;
+                    }
+                    context_ptr->md_stage_2_count[cand_class_it] = md_stage_2_count;
+                }
+#endif
+            }
+            context_ptr->md_stage_2_total_count += context_ptr->md_stage_2_count[cand_class_it];
+        }
+#endif
 
 #if REMOVE_MD_STAGE_1
         assert(context_ptr->md_stage_2_total_count <= MAX_NFL);

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -2234,6 +2234,11 @@ void CopyApiFromApp(
 
     sequence_control_set_ptr->static_config.sq_weight = pComponentParameterStructure->sq_weight;
 
+    sequence_control_set_ptr->static_config.md_stage_1_count_th_s = pComponentParameterStructure->md_stage_1_count_th_s;
+    sequence_control_set_ptr->static_config.md_stage_1_count_th_c = pComponentParameterStructure->md_stage_1_count_th_c;
+    sequence_control_set_ptr->static_config.md_stage_2_count_th_s = pComponentParameterStructure->md_stage_2_count_th_s;
+    sequence_control_set_ptr->static_config.md_stage_2_count_th_c = pComponentParameterStructure->md_stage_2_count_th_c;
+
     return;
 }
 
@@ -2710,6 +2715,11 @@ EbErrorType eb_svt_enc_init_parameter(
     config_ptr->enable_overlays = EB_FALSE;
 
     config_ptr->sq_weight = 100;
+
+    config_ptr->md_stage_1_count_th_s = 75;
+    config_ptr->md_stage_1_count_th_c = 100;
+    config_ptr->md_stage_2_count_th_s = 15;
+    config_ptr->md_stage_2_count_th_c = 25;
 
     return return_error;
 }

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -2234,10 +2234,10 @@ void CopyApiFromApp(
 
     sequence_control_set_ptr->static_config.sq_weight = pComponentParameterStructure->sq_weight;
 
-    sequence_control_set_ptr->static_config.md_stage_1_count_th_s = pComponentParameterStructure->md_stage_1_count_th_s;
-    sequence_control_set_ptr->static_config.md_stage_1_count_th_c = pComponentParameterStructure->md_stage_1_count_th_c;
-    sequence_control_set_ptr->static_config.md_stage_2_count_th_s = pComponentParameterStructure->md_stage_2_count_th_s;
-    sequence_control_set_ptr->static_config.md_stage_2_count_th_c = pComponentParameterStructure->md_stage_2_count_th_c;
+    sequence_control_set_ptr->static_config.md_stage_1_cand_prune_th = pComponentParameterStructure->md_stage_1_cand_prune_th;
+    sequence_control_set_ptr->static_config.md_stage_1_class_prune_th = pComponentParameterStructure->md_stage_1_class_prune_th;
+    sequence_control_set_ptr->static_config.md_stage_2_cand_prune_th = pComponentParameterStructure->md_stage_2_cand_prune_th;
+    sequence_control_set_ptr->static_config.md_stage_2_class_prune_th = pComponentParameterStructure->md_stage_2_class_prune_th;
 
     return;
 }
@@ -2716,10 +2716,10 @@ EbErrorType eb_svt_enc_init_parameter(
 
     config_ptr->sq_weight = 100;
 
-    config_ptr->md_stage_1_count_th_s = 75;
-    config_ptr->md_stage_1_count_th_c = 100;
-    config_ptr->md_stage_2_count_th_s = 15;
-    config_ptr->md_stage_2_count_th_c = 25;
+    config_ptr->md_stage_1_cand_prune_th = 75;
+    config_ptr->md_stage_1_class_prune_th = 100;
+    config_ptr->md_stage_2_cand_prune_th = 15;
+    config_ptr->md_stage_2_class_prune_th = 25;
 
     return return_error;
 }


### PR DESCRIPTION
## Description

This PR adds a mechanism before MD Stage 1 and 2 to prune at the candidate level (intra-class) and class level (inter-class) in terms of cost following a heuristic that is as follows:

Intra-class:
- Prune all candidates that are a threshold percentage away from the best candidate

Inter-class:
- Prune all classes that are a threshold percentage away from the best class (in terms of its best candidate)

The default percentages are as seen in the following table:

| |*inter*-class|*intra*-class|
|-|-|-|
| Before MD stage **1** | 100 | 75 |
| Before MD stage **2** | 25 | 15 |

API signals are included in this PR for the ease of tweaking the thresholds:

| |*inter*-class pruning|*intra*-class pruning|
|-|-|-|
| Before MD stage **1** | `-mds1p-class-th` | `-mds1p-cand-th` |
| Before MD stage **2** | `-mds2p-class-th` | `-mds2p-cand-th` |

A value of 0 passed to an API switch turns off the respective mechanism.

## Author

@hguermaz 
@JackZhouVCD 

## Type of change

Enhancement

## Performance impact
All data generated from full-list objective-1-fast dataset in the context of enc-mode 0. Speed data is generated using AWS ec2 48 vCPU instances

| | M0 | M1 |
|-|-|-|
| **BD-Rate** | 0.106% | 0.207%|
| **Speed** |  13.41% | 29.11% |