### PR TITLE
Add optimization level "-asm" to limit cpu features at runtime

### DIFF
--- a/Config/Sample.cfg
+++ b/Config/Sample.cfg
@@ -77,7 +77,7 @@ HmeLevel2SearchAreaInWidth      : 1  1          # Array containing search area w
 HmeLevel2SearchAreaInHeight     : 1  1          # Array containing search area height values for HME level 2 - [1 - SourceHeight]
 
 ====================== Platform Specific Flags ===============================
-AsmType                         : 1             # Assembly instruction set (0: Lowest optimization available, 1: Highest optimization available)
+Asm                             : max           # Assembly instruction set limit [0 - 11, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512, max]
 LogicalProcessors               : 0             # The number of logical processor which encoder threads run on [0-N] (N is maximum number of logical processor)
 TargetSocket                    : -1            # For dual socket systems, this can specify which socket the encoder runs on (-1=Both Sockets, 0=Socket 0, 1=Socket 1)
 #====================== Rate Control ===============================

--- a/Source/API/EbSvtAv1.h
+++ b/Source/API/EbSvtAv1.h
@@ -271,6 +271,29 @@ typedef struct EbTimingInfo {
 
 } EbTimingInfo;
 
+/**
+CPU FLAGS
+*/
+typedef uint64_t CPU_FLAGS;
+#define CPU_FLAGS_MMX        (1 << 0)
+#define CPU_FLAGS_SSE        (1 << 1)
+#define CPU_FLAGS_SSE2       (1 << 2)
+#define CPU_FLAGS_SSE3       (1 << 3)
+#define CPU_FLAGS_SSSE3      (1 << 4)
+#define CPU_FLAGS_SSE4_1     (1 << 5)
+#define CPU_FLAGS_SSE4_2     (1 << 6)
+#define CPU_FLAGS_AVX        (1 << 7)
+#define CPU_FLAGS_AVX2       (1 << 8)
+#define CPU_FLAGS_AVX512F    (1 << 9)
+#define CPU_FLAGS_AVX512CD   (1 << 10)
+#define CPU_FLAGS_AVX512DQ   (1 << 11)
+#define CPU_FLAGS_AVX512ER   (1 << 12)
+#define CPU_FLAGS_AVX512PF   (1 << 13)
+#define CPU_FLAGS_AVX512BW   (1 << 14)
+#define CPU_FLAGS_AVX512VL   (1 << 15)
+#define CPU_FLAGS_ALL        (( CPU_FLAGS_AVX512VL << 1 ) - 1)
+#define CPU_FLAGS_INVALID    (1ULL << (sizeof(CPU_FLAGS) * 8ULL - 1ULL))
+
 
 #ifdef __cplusplus
 }

--- a/Source/API/EbSvtAv1Dec.h
+++ b/Source/API/EbSvtAv1Dec.h
@@ -103,13 +103,6 @@ typedef struct EbSvtAv1DecConfiguration
 
     EbColorFormat           max_color_format;
 
-    /* Assembly instruction set used by encoder.
-    *
-    * 0 = non-AVX2, C only.
-    * 1 = up to AVX512, auto-select highest assembly instruction set supported.
-    *
-    * Default is 1. */
-    uint32_t                 asm_type;
     // Application Specific parameters
 
     /* Number of threads used by decoder.

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -373,13 +373,10 @@ typedef struct EbSvtAv1EncConfiguration
      * Default is 0. */
     uint32_t                 level;
 
-    /* Assembly instruction set used by encoder.
-    *
-    * 0 = non-AVX2, C only.
-    * 1 = up to AVX512, auto-select highest assembly instruction set supported.
-    *
-    * Default is 1. */
-    uint32_t                 asm_type;
+    /* CPU FLAGS to limit assembly instruction set used by encoder.
+    * Default is CPU_FLAGS_ALL. */
+    CPU_FLAGS            use_cpu_flags;
+
     // Application Specific parameters
 
     /* ID assigned to each channel when multiple instances are running within the

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -313,7 +313,36 @@ static void SetInjectorFrameRate                (const char *value, EbConfig *cf
         cfg->injector_frame_rate = cfg->injector_frame_rate << 16;
 }
 static void SetLatencyMode                      (const char *value, EbConfig *cfg)  {cfg->latency_mode               = (uint8_t)strtol(value, NULL, 0);};
-static void SetAsmType                          (const char *value, EbConfig *cfg)  {cfg->asm_type                   = (uint32_t)strtoul(value, NULL, 0);};
+static void SetAsmType                          (const char *value, EbConfig *cfg)  {
+    const struct {
+        char *name;
+        CPU_FLAGS flags;
+    } param_maps[] ={
+        {"c",       0},                             {"0",  0},
+        {"mmx",     (CPU_FLAGS_MMX << 1) - 1},      {"1",  (CPU_FLAGS_MMX << 1) - 1},
+        {"sse",     (CPU_FLAGS_SSE << 1) - 1},      {"2",  (CPU_FLAGS_SSE << 1) - 1},
+        {"sse2",    (CPU_FLAGS_SSE2 << 1) - 1},     {"3",  (CPU_FLAGS_SSE2 << 1) - 1},
+        {"sse3",    (CPU_FLAGS_SSE3 << 1) - 1},     {"4",  (CPU_FLAGS_SSE3 << 1) - 1},
+        {"ssse3",   (CPU_FLAGS_SSSE3 << 1) - 1},    {"5",  (CPU_FLAGS_SSSE3 << 1) - 1},
+        {"sse4_1",  (CPU_FLAGS_SSE4_1 << 1) - 1},   {"6",  (CPU_FLAGS_SSE4_1 << 1) - 1},
+        {"sse4_2",  (CPU_FLAGS_SSE4_2 << 1) - 1},   {"7",  (CPU_FLAGS_SSE4_2 << 1) - 1},
+        {"avx",     (CPU_FLAGS_AVX << 1) - 1},      {"8",  (CPU_FLAGS_AVX << 1) - 1},
+        {"avx2",    (CPU_FLAGS_AVX2 << 1) - 1},     {"9",  (CPU_FLAGS_AVX2 << 1) - 1},
+        {"avx512",  (CPU_FLAGS_AVX512VL << 1) - 1}, {"10", (CPU_FLAGS_AVX512VL << 1) - 1},
+        {"max",     CPU_FLAGS_ALL},                 {"11", CPU_FLAGS_ALL},
+    };
+    const uint32_t para_map_size = sizeof(param_maps) / sizeof(param_maps[0]);
+    uint32_t i;
+
+    for (i = 0; i < para_map_size; ++i) {
+        if (EB_STRCMP(value, param_maps[i].name) == 0) {
+            cfg->cpu_flags_limit = param_maps[i].flags;
+            return;
+        }
+    }
+
+    cfg->cpu_flags_limit = CPU_FLAGS_INVALID;
+};
 static void SetLogicalProcessors                (const char *value, EbConfig *cfg)  {cfg->logical_processors         = (uint32_t)strtoul(value, NULL, 0);};
 static void SetTargetSocket                     (const char *value, EbConfig *cfg)  {cfg->target_socket              = (int32_t)strtol(value, NULL, 0);};
 static void SetUnrestrictedMotionVector         (const char *value, EbConfig *cfg)  {cfg->unrestricted_motion_vector = (EbBool)strtol(value, NULL, 0);};
@@ -468,7 +497,7 @@ config_entry_t config_entry[] = {
     { SINGLE_INPUT, LATENCY_MODE, "LatencyMode", SetLatencyMode },
     { SINGLE_INPUT, FILM_GRAIN_TOKEN, "FilmGrain", SetCfgFilmGrain },
     // Asm Type
-    { SINGLE_INPUT, ASM_TYPE_TOKEN, "AsmType", SetAsmType },
+    { SINGLE_INPUT, ASM_TYPE_TOKEN, "Asm", SetAsmType },
     // HME
     { ARRAY_INPUT,HME_LEVEL0_WIDTH, "HmeLevel0SearchAreaInWidth", SetHmeLevel0SearchAreaInWidthArray },
     { ARRAY_INPUT,HME_LEVEL0_HEIGHT, "HmeLevel0SearchAreaInHeight", SetHmeLevel0SearchAreaInHeightArray },
@@ -556,7 +585,7 @@ void eb_config_ctor(EbConfig *config_ptr)
     config_ptr->injector_frame_rate                    = 60 << 16;
 
     // ASM Type
-    config_ptr->asm_type                              = 1;
+    config_ptr->cpu_flags_limit                         = CPU_FLAGS_ALL;
 
     config_ptr->target_socket                         = -1;
 

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -346,9 +346,9 @@ typedef struct EbConfig
     EbBool                   eos_flag;
 
     /****************************************
-    * Optimization Type
+    * CPU FLAGS available
     ****************************************/
-    uint32_t                  asm_type;
+    CPU_FLAGS                cpu_flags_limit;
 
     /****************************************
      * Computational Performance Data

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -222,7 +222,7 @@ EbErrorType CopyConfigurationParameters(
     callback_data->eb_enc_parameters.level = config->level;
     callback_data->eb_enc_parameters.injector_frame_rate = config->injector_frame_rate;
     callback_data->eb_enc_parameters.speed_control_flag = config->speed_control_flag;
-    callback_data->eb_enc_parameters.asm_type = config->asm_type;
+    callback_data->eb_enc_parameters.use_cpu_flags = config->cpu_flags_limit;
     callback_data->eb_enc_parameters.logical_processors = config->logical_processors;
     callback_data->eb_enc_parameters.target_socket = config->target_socket;
     callback_data->eb_enc_parameters.unrestricted_motion_vector = config->unrestricted_motion_vector;

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -2389,15 +2389,6 @@ static const uint8_t QP_OFFSET_WEIGHT[3][4] = { // [Slice Type][QP Offset Weight
     { 9, 8, 7, 6 },
     { 10, 9, 8, 7 }
 };
-/** Assembly Types
-*/
-typedef enum EbAsm
-{
-    ASM_NON_AVX2,
-    ASM_AVX2,
-    ASM_TYPE_TOTAL,
-    ASM_TYPE_INVALID = ~0
-} EbAsm;
 
 #if PAL_SUP
 #define  MAX_PAL_CAND   14

--- a/Source/Lib/Common/Codec/EbEncodeContext.h
+++ b/Source/Lib/Common/Codec/EbEncodeContext.h
@@ -143,7 +143,6 @@ typedef struct EncodeContext
 
     // Dynamic GOP
     uint32_t                                          previous_mini_gop_hierarchical_levels;
-    EbAsm                                             asm_type;
     EbObjectWrapper                                  *previous_picture_control_set_wrapper_ptr;
     EbHandle                                          shared_reference_mutex;
 

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -39,21 +39,6 @@
 #define UNLIKELY(v) (v)
 #endif
 
-
-/*
- * DSP
- */
-
-#define HAS_MMX 0x01
-#define HAS_SSE 0x02
-#define HAS_SSE2 0x04
-#define HAS_SSE3 0x08
-#define HAS_SSSE3 0x10
-#define HAS_SSE4_1 0x20
-#define HAS_AVX 0x40
-#define HAS_AVX2 0x80
-#define HAS_SSE4_2 0x100
-
  /**************************************
  * Instruction Set Support
  **************************************/
@@ -68,9 +53,9 @@ extern "C" {
 #endif
 
     // Helper Functions
-    int32_t Check4thGenIntelCoreFeatures();
-    int32_t CanUseIntelAVX512();
-    void setup_rtcd_internal(EbAsm asm_type);
+    CPU_FLAGS get_cpu_flags();
+    CPU_FLAGS get_cpu_flags_to_use();
+    void setup_rtcd_internal(CPU_FLAGS flags);
 
     //to not include convolve.h, just forward declare what's needed.
     struct ConvolveParams;

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -109,24 +109,34 @@ typedef struct logicalProcessorGroup {
 #define INITIAL_PROCESSOR_GROUP 16
 processorGroup                  *lp_group = NULL;
 #endif
-static int32_t CanUseIntelCore4thGenFeatures()
-{
-    static int32_t the_4th_gen_features_available = -1;
-    /* test is performed once */
-    if (the_4th_gen_features_available < 0)
-        the_4th_gen_features_available = Check4thGenIntelCoreFeatures();
-    return the_4th_gen_features_available;
-}
-EbAsm GetCpuAsmType()
-{
-    EbAsm asm_type = ASM_NON_AVX2;
 
-    if (CanUseIntelCore4thGenFeatures() == 1)
-        asm_type = ASM_AVX2;
-    else
-        // Need to change to support lower CPU Technologies
-        asm_type = ASM_NON_AVX2;
-    return asm_type;
+static const char *get_asm_level_name_str(CPU_FLAGS cpu_flags) {
+
+    const struct {
+        char *name;
+        CPU_FLAGS flags;
+    } param_maps[] = {
+        {"c",       0},
+        {"mmx",     CPU_FLAGS_MMX},
+        {"sse",     CPU_FLAGS_SSE},
+        {"sse2",    CPU_FLAGS_SSE2},
+        {"sse3",    CPU_FLAGS_SSE3},
+        {"ssse3",   CPU_FLAGS_SSSE3},
+        {"sse4_1",  CPU_FLAGS_SSE4_1},
+        {"sse4_2",  CPU_FLAGS_SSE4_2},
+        {"avx",     CPU_FLAGS_AVX},
+        {"avx2",    CPU_FLAGS_AVX2},
+        {"avx512",  CPU_FLAGS_AVX512F}
+    };
+    const uint32_t para_map_size = sizeof(param_maps) / sizeof(param_maps[0]);
+    int32_t i;
+
+    for (i = para_map_size -1; i >= 0; --i) {
+        if (param_maps[i].flags & cpu_flags) {
+            return param_maps[i].name;
+        }
+    }
+    return "c";
 }
 
 //Get Number of logical processors
@@ -509,6 +519,15 @@ EbErrorType load_default_buffer_configuration_settings(
     sequence_control_set_ptr->total_process_init_count += 6; // single processes count
     printf("Number of logical cores available: %u\nNumber of PPCS %u\n", core_count, sequence_control_set_ptr->picture_control_set_pool_init_count);
 
+    /******************************************************************
+    * Platform detection, limit cpu flags to hardware available CPU
+    ******************************************************************/
+    const CPU_FLAGS cpu_flags = get_cpu_flags();
+    const CPU_FLAGS cpu_flags_to_use = get_cpu_flags_to_use();
+    sequence_control_set_ptr->static_config.use_cpu_flags &= cpu_flags_to_use;
+    printf("[asm level on system : up to %s]\n", get_asm_level_name_str(cpu_flags));
+    printf("[asm level selected : up to %s]\n", get_asm_level_name_str(sequence_control_set_ptr->static_config.use_cpu_flags));
+
     return return_error;
 }
  // Rate Control
@@ -830,14 +849,7 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
     EbColorFormat color_format = enc_handle_ptr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->static_config.encoder_color_format;
     SequenceControlSet* control_set_ptr;
 
-    /************************************
-    * Plateform detection
-    ************************************/
-    if (enc_handle_ptr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->static_config.asm_type == 1)
-        enc_handle_ptr->sequence_control_set_instance_array[0]->encode_context_ptr->asm_type = GetCpuAsmType();
-    else
-        enc_handle_ptr->sequence_control_set_instance_array[0]->encode_context_ptr->asm_type = enc_handle_ptr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->static_config.asm_type;
-    setup_rtcd_internal(enc_handle_ptr->sequence_control_set_instance_array[0]->encode_context_ptr->asm_type);
+    setup_rtcd_internal(enc_handle_ptr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->static_config.use_cpu_flags);
     asmSetConvolveAsmTable();
 
     init_intra_dc_predictors_c_internal();
@@ -2211,7 +2223,7 @@ void CopyApiFromApp(
     sequence_control_set_ptr->static_config.speed_control_flag = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->speed_control_flag;
 
     // Buffers - Hardcoded(Cleanup)
-    sequence_control_set_ptr->static_config.asm_type = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->asm_type;
+    sequence_control_set_ptr->static_config.use_cpu_flags = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->use_cpu_flags;
 
     sequence_control_set_ptr->static_config.channel_id = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->channel_id;
     sequence_control_set_ptr->static_config.active_channel_count = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->active_channel_count;
@@ -2569,9 +2581,9 @@ static EbErrorType VerifySettings(
         return_error = EB_ErrorBadParameter;
     }
 
-    if (((int32_t)(config->asm_type) < -1) || ((int32_t)(config->asm_type) != 1)) {
-       // SVT_LOG("Error Instance %u: Invalid asm type value [0: C Only, 1: Auto] .\n", channelNumber + 1);
-        SVT_LOG("Error Instance %u: Asm 0 is not supported in this build .\n", channelNumber + 1);
+    if (config->use_cpu_flags & CPU_FLAGS_INVALID) {
+        SVT_LOG("Error Instance %u: param '-asm' have invalid value.\n"
+            "Value should be [0 - 11, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512, max]\n", channelNumber + 1);
         return_error = EB_ErrorBadParameter;
     }
 
@@ -2718,8 +2730,8 @@ EbErrorType eb_svt_enc_init_parameter(
     config_ptr->speed_control_flag = 0;
     config_ptr->film_grain_denoise_strength = 0;
 
-    // ASM Type
-    config_ptr->asm_type = 1;
+    // CPU Flags
+    config_ptr->use_cpu_flags = CPU_FLAGS_ALL;
 
     // Channel info
     config_ptr->logical_processors = 0;

--- a/gstreamer-plugin/gstsvtav1enc.c
+++ b/gstreamer-plugin/gstsvtav1enc.c
@@ -676,7 +676,7 @@ set_default_svt_configuration (EbSvtAv1EncConfiguration * svt_config)
   svt_config->super_block_size = 128;
   svt_config->partition_depth = 4;
   svt_config->enable_qp_scaling_flag = 0;
-  svt_config->asm_type = 1;
+  svt_config->use_cpu_flags = CPU_FLAGS_ALL;
 }
 
 GstFlowReturn

--- a/test/InvTxfm2dAsmTest.cc
+++ b/test/InvTxfm2dAsmTest.cc
@@ -214,10 +214,10 @@ class InvTxfm2dAsmTest : public ::testing::TestWithParam<InvTxfm2dParam> {
         aom_clear_system_state();
     }
 
-    void run_sqr_txfm_match_test(const TxSize tx_size, int asm_type) {
+    void run_sqr_txfm_match_test(const TxSize tx_size, int is_asm_kernel) {
         const int width = tx_size_wide[tx_size];
         const int height = tx_size_high[tx_size];
-        InvSqrTxfmFuncPair pair = (asm_type == 0)
+        InvSqrTxfmFuncPair pair = (is_asm_kernel == 0)
                                       ? inv_txfm_c_avx2_func_pairs[tx_size]
                                       : inv_txfm_c_sse4_1_func_pairs[tx_size];
         if (pair.ref_func == nullptr || pair.test_func == nullptr)
@@ -252,7 +252,8 @@ class InvTxfm2dAsmTest : public ::testing::TestWithParam<InvTxfm2dParam> {
                                  output_test_,
                                  height * stride_ * sizeof(output_test_[0])))
                     << "loop: " << k << " tx_type: " << tx_type
-                    << " tx_size: " << tx_size << " asm_type: " << asm_type;
+                    << " tx_size: " << tx_size
+                    << " is_asm_kernel: " << is_asm_kernel;
             }
         }
     }
@@ -644,11 +645,10 @@ class InvTxfm2dAsmTest : public ::testing::TestWithParam<InvTxfm2dParam> {
 };
 
 TEST_P(InvTxfm2dAsmTest, sqr_txfm_match_test) {
-    for (int asm_type = 0; asm_type < 2; ++asm_type) {
-        for (int i = TX_4X4; i <= TX_64X64; i++) {
-            const TxSize tx_size = static_cast<TxSize>(i);
-            run_sqr_txfm_match_test(tx_size, asm_type);
-        }
+    for (int i = TX_4X4; i <= TX_64X64; i++) {
+        const TxSize tx_size = static_cast<TxSize>(i);
+        run_sqr_txfm_match_test(tx_size, 0);
+        run_sqr_txfm_match_test(tx_size, 1);
     }
 }
 

--- a/test/PsnrTest.cc
+++ b/test/PsnrTest.cc
@@ -50,7 +50,7 @@ extern "C" int32_t eb_aom_realloc_frame_buffer(
     aom_get_frame_buffer_cb_fn_t cb, void* cb_priv);
 
 /** setup_test_env is implemented in test/TestEnv.c */
-extern "C" void setup_test_env(EbAsm asm_type);
+extern "C" void setup_test_env();
 
 using SseCalcFunc = int64_t (*)(const Yv12BufferConfig*,
                                 const Yv12BufferConfig*);
@@ -88,7 +88,7 @@ class PsnrCalcTest : public ::testing::TestWithParam<ParamType> {
         memset(&tst_ref_, 0, sizeof(tst_ref_));
         memset(&lbd_src_, 0, sizeof(lbd_src_));
         memset(&lbd_ref_, 0, sizeof(lbd_ref_));
-        setup_test_env(ASM_AVX2);
+        setup_test_env();
     }
     virtual ~PsnrCalcTest() {
         eb_aom_free_frame_buffer(&tst_src_);

--- a/test/RestorationPickTest.cc
+++ b/test/RestorationPickTest.cc
@@ -591,25 +591,25 @@ TEST(EbRestorationPick_avx2, DISABLED_speed_highbd) {
 #ifndef NON_AVX512_SUPPORT
 
 TEST(EbRestorationPick_avx512, match) {
-    if (CanUseIntelAVX512()) {
+    if (get_cpu_flags_to_use() & CPU_FLAGS_AVX512F) {
         match_test(eb_av1_compute_stats_avx512);
     }
 }
 
 TEST(EbRestorationPick_avx512, match_highbd) {
-    if (CanUseIntelAVX512()) {
+    if (get_cpu_flags_to_use() & CPU_FLAGS_AVX512F) {
         highbd_match_test(eb_av1_compute_stats_highbd_avx512);
     }
 }
 
 TEST(EbRestorationPick_avx512, DISABLED_speed) {
-    if (CanUseIntelAVX512()) {
+    if (get_cpu_flags_to_use() & CPU_FLAGS_AVX512F) {
         speed_test(eb_av1_compute_stats_avx512);
     }
 }
 
 TEST(EbRestorationPick_avx512, DISABLED_speed_highbd) {
-    if (CanUseIntelAVX512()) {
+    if (get_cpu_flags_to_use() & CPU_FLAGS_AVX512F) {
         highbd_speed_test(eb_av1_compute_stats_highbd_avx512);
     }
 }

--- a/test/TestEnv.c
+++ b/test/TestEnv.c
@@ -16,6 +16,8 @@
 
 /** setup_test_env is a util for unit test setup environment without create a
  * encoder */
-void setup_test_env(EbAsm asm_type) {
-    setup_rtcd_internal(asm_type);
+void setup_test_env() {
+    CPU_FLAGS cpu_flags = get_cpu_flags_to_use();
+
+    setup_rtcd_internal(cpu_flags);
 }

--- a/test/api_test/SvtAv1EncParamsTest.cc
+++ b/test/api_test/SvtAv1EncParamsTest.cc
@@ -374,9 +374,9 @@ PARAM_TEST(EncParamTierTest);
 DEFINE_PARAM_TEST_CLASS(EncParamLevelTest, level);
 PARAM_TEST(EncParamLevelTest);
 
-/** Test case for asm_type*/
-DEFINE_PARAM_TEST_CLASS(EncParamAsmTypeTest, asm_type);
-PARAM_TEST(EncParamAsmTypeTest);
+/** Test case for use_cpu_flags*/
+DEFINE_PARAM_TEST_CLASS(EncParamOplLevelTest, use_cpu_flags);
+PARAM_TEST(EncParamOplLevelTest);
 
 /** Test case for channel_id*/
 DEFINE_PARAM_TEST_CLASS(EncParamChIdTest, channel_id);

--- a/test/api_test/params.h
+++ b/test/api_test/params.h
@@ -829,15 +829,29 @@ static const vector<uint32_t> invalid_level = {
  * 1 = up to AVX512, auto-select highest assembly instruction set supported.
  *
  * Default is 1. */
-static const vector<uint32_t> default_asm_type = {
-    1,
+static const vector<CPU_FLAGS> default_use_cpu_flags = {
+    CPU_FLAGS_ALL,
 };
-static const vector<uint32_t> valid_asm_type = {
-    0,
-    1,
+static const vector<CPU_FLAGS> valid_use_cpu_flags = {
+    CPU_FLAGS_MMX,
+    CPU_FLAGS_SSE,
+    CPU_FLAGS_SSE2,
+    CPU_FLAGS_SSE3,
+    CPU_FLAGS_SSSE3,
+    CPU_FLAGS_SSE4_1,
+    CPU_FLAGS_SSE4_2,
+    CPU_FLAGS_AVX,
+    CPU_FLAGS_AVX2,
+    CPU_FLAGS_AVX512F,
+    CPU_FLAGS_AVX512CD,
+    CPU_FLAGS_AVX512DQ,
+    CPU_FLAGS_AVX512ER,
+    CPU_FLAGS_AVX512PF,
+    CPU_FLAGS_AVX512BW,
+    CPU_FLAGS_AVX512VL,
 };
-static const vector<uint32_t> invalid_asm_type = {
-    2,
+static const vector<CPU_FLAGS> invalid_use_cpu_flags = {
+    CPU_FLAGS_INVALID
 };
 
 // Application Specific parameters


### PR DESCRIPTION
Final remove asm_type.

CPU optimization levels divided into flags (type CPU_FLAGS) , for example AVX512 extensions (AVX512F, AVX512CD, AVX512ER) can exists independently.

To enable optimization limit level use param: -asm [0 - 11, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512, max]

Added print CPU Flags list in Encoder, with information about limitations.
Sample param '-asm ssse3' on CPU with AVX2:
"CPU Flags[ignored]: mmx sse sse2 sss3 ssse3 [sse4_1] [sse4_2] [avx] [avx2]"

Closes #165 