### PR TITLE
Adaptive Open Loop Partitioning

### DIFF
--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -184,6 +184,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **TileCol** | -tile-columns | [0-6] | 0 | log2 of tile columns |
 | **UnrestrictedMotionVector** | -umv | [0-1] | 1 | Enables or disables unrestriced motion vectors, 0 = OFF(motion vectors are constrained within tile boundary), 1 = ON. For MCTS support, set -umv 0 |
 | **PaletteMode** | -palette | [0 - 6] | -1 | Enable Palette mode (-1: Auto Mode(ON at level6 when SC is detected), 0: OFF 1: ON Level 1, ...6: ON Level6 ) |
+| **OlpdRefinement** | -olpd-refinement | [0 - 1] | -1 | Enable open loop partitioning decision refinement (-1: Auto Mode(ON for M0, no SC, OFF otherwise), 0: OFF 1: ON for M0, error otherwise ) |
 | **SquareWeight** | -sqw | 0 for off and any whole number percentage | 100 | Weighting applied to square/h/v shape costs when deciding if a and b shapes could be skipped. Set to 100 for neutral weighting, lesser than 100 for faster encode and BD-Rate loss, and greater than 100 for slower encode and BD-Rate gain|
 | **MDStage1PruneClassThreshold** | -mds1p-class-th | 0 for off and any whole number percentage | 100 | Deviation threshold (expressed as a percentage) of an inter-class class pruning mechanism before MD Stage 1 |
 | **MDStage1PruneCandThreshold** | -mds1p-cand-th | 0 for off and any whole number percentage | 75 | Deviation threshold (expressed as a percentage) of an intra-class candidate pruning mechanism before MD Stage 1 |

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -284,6 +284,11 @@ typedef struct EbSvtAv1EncConfiguration
     * Default is -1. */
     int32_t                   enable_palette;
 
+    /* Open Loop Partitioning Decision refinement
+    *
+    * Default is -1. */
+    int32_t                   olpd_refinement;
+
     /* Enable the use of Constrained Intra, which yields sending two picture
      * parameter sets in the elementary streams .
      *

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -97,6 +97,7 @@
 // --- end: ALTREF_FILTERING_SUPPORT
 #define HBD_MD_ENABLE_TOKEN             "-hbd-md"
 #define PALETTE_TOKEN                   "-palette"
+#define OLPD_REFINEMENT_TOKEN           "-olpd-refinement"
 #define CONSTRAINED_INTRA_ENABLE_TOKEN  "-constrd-intra"
 #define HDR_INPUT_TOKEN                 "-hdr"
 #define RATE_CONTROL_ENABLE_TOKEN       "-rc"
@@ -286,6 +287,7 @@ static void SetEnableOverlays                   (const char *value, EbConfig *cf
 // --- end: ALTREF_FILTERING_SUPPORT
 static void SetEnableHBDModeDecision            (const char *value, EbConfig *cfg) {cfg->enable_hbd_mode_decision = (uint8_t)strtoul(value, NULL, 0);};
 static void SetEnablePalette                    (const char *value, EbConfig *cfg) { cfg->enable_palette = (int32_t)strtoul(value, NULL, 0); };
+static void SetEnableOlpdRefinement              (const char *value, EbConfig *cfg) { cfg->olpd_refinement = (int32_t)strtoul(value, NULL, 0); };
 static void SetEnableConstrainedIntra           (const char *value, EbConfig *cfg) {cfg->constrained_intra                                             = (EbBool)strtoul(value, NULL, 0);};
 static void SetHighDynamicRangeInput            (const char *value, EbConfig *cfg) {cfg->high_dynamic_range_input            = strtol(value,  NULL, 0);};
 static void SetProfile                          (const char *value, EbConfig *cfg) {cfg->profile                          = strtol(value,  NULL, 0);};
@@ -437,6 +439,7 @@ config_entry_t config_entry[] = {
     { SINGLE_INPUT, SCREEN_CONTENT_TOKEN, "ScreenContentMode", SetScreenContentMode},
     { SINGLE_INPUT, HBD_MD_ENABLE_TOKEN, "HighBitDepthModeDecision", SetEnableHBDModeDecision },
     { SINGLE_INPUT, PALETTE_TOKEN, "PaletteMode", SetEnablePalette },
+    { SINGLE_INPUT, OLPD_REFINEMENT_TOKEN, "OlpdRefinement", SetEnableOlpdRefinement },
     { SINGLE_INPUT, CONSTRAINED_INTRA_ENABLE_TOKEN, "ConstrainedIntra", SetEnableConstrainedIntra},
     // Thread Management
     { SINGLE_INPUT, THREAD_MGMNT, "logicalProcessors", SetLogicalProcessors },
@@ -539,6 +542,7 @@ void eb_config_ctor(EbConfig *config_ptr)
     config_ptr->screen_content_mode                  = 2;
     config_ptr->enable_hbd_mode_decision             = 1;
     config_ptr->enable_palette                       = -1;
+    config_ptr->olpd_refinement                      = -1;
     config_ptr->injector_frame_rate                    = 60 << 16;
 
     // ASM Type

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -304,6 +304,7 @@ typedef struct EbConfig
     int32_t                  enable_palette;
     int32_t                  tile_columns;
     int32_t                  tile_rows;
+    int32_t                  olpd_refinement;   // Open Loop Partitioning Decision Refinement
 
     /****************************************
      * Rate Control

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -207,6 +207,7 @@ EbErrorType CopyConfigurationParameters(
     callback_data->eb_enc_parameters.screen_content_mode = (EbBool)config->screen_content_mode;
     callback_data->eb_enc_parameters.enable_hbd_mode_decision = (EbBool)config->enable_hbd_mode_decision;
     callback_data->eb_enc_parameters.enable_palette = config->enable_palette;
+    callback_data->eb_enc_parameters.olpd_refinement = config->olpd_refinement;
     callback_data->eb_enc_parameters.constrained_intra = (EbBool)config->constrained_intra;
     callback_data->eb_enc_parameters.channel_id = config->channel_id;
     callback_data->eb_enc_parameters.active_channel_count = config->active_channel_count;

--- a/Source/Lib/Common/Codec/EbCodingUnit.h
+++ b/Source/Lib/Common/Codec/EbCodingUnit.h
@@ -584,6 +584,10 @@ extern "C" {
 
         // Quantized Coefficients
         EbPictureBufferDesc          *quantized_coeff;
+#if MDC_ADAPTIVE_LEVEL
+        uint8_t                       depth_ranking[NUMBER_OF_DEPTH];
+        uint64_t                      depth_cost[NUMBER_OF_DEPTH];
+#endif
         TileInfo tile_info;
     } LargestCodingUnit;
 

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -191,6 +191,7 @@ enum {
 #define ADD_MDC_FULL_COST                               1
 #define NSQ_TAB_SIZE                                    8
 #define MAX_MDC_LEVEL                                   8
+#define MDC_ADAPTIVE_LEVEL                              1
 #else
 #define NSQ_TAB_SIZE                                    6
 #endif

--- a/Source/Lib/Common/Codec/EbModeDecisionConfiguration.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfiguration.h
@@ -72,6 +72,13 @@ typedef EbErrorType(*EB_MDC_FUNC)(
 #define D1sqonly    0x02
 #define Comp_no_4xn 0xA0
 #endif
+#if MDC_ADAPTIVE_LEVEL
+#define Predm2p1 0xA1
+#define Predm2p2 0xA2
+#define Predm3p2 0xA3
+#define Predm3p3 0xA4
+#define Predm3p1 0xA5
+#endif
 
 EB_ALIGN(16) static const uint8_t ndp_level_0[4] = {Pred + Predp1 + Predp2, Pred + Predp1, Pred + Predp1, Pred + Predm1};
 EB_ALIGN(16) static const uint8_t ndp_level_1[4] = {Pred + Predp1         , Pred + Predp1, Pred + Predp1, Pred + Predm1 };

--- a/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
@@ -275,7 +275,7 @@ static const int16_t ac_qlookup_12_Q3[QINDEX_RANGE] = {
 };
 
 #if PREDICT_NSQ_SHAPE
-EbErrorType nsq_prediction_shape(
+EbErrorType open_loop_partitioning_sb(
     SequenceControlSet                *sequence_control_set_ptr,
     PictureControlSet                 *picture_control_set_ptr,
     ModeDecisionConfigurationContext  *context_ptr,
@@ -1068,6 +1068,36 @@ void sb_forward_sq_blocks_to_md(
 
 #if PREDICT_NSQ_SHAPE
 #if ADD_MDC_REFINEMENT_LOOP
+#if MDC_ADAPTIVE_LEVEL
+void  set_parent_to_be_considered(
+    MdcLcuData *resultsPtr,
+    uint32_t    blk_index,
+    int32_t     sb_size,
+    int8_t      depth_step) {
+    uint32_t  parent_depth_idx_mds, block_1d_idx;
+    const BlockGeom * blk_geom = get_blk_geom_mds(blk_index);
+    if (blk_geom->sq_size < ((sb_size == BLOCK_128X128) ? 128 : 64)) {
+        //Set parent to be considered
+        parent_depth_idx_mds = (blk_geom->sqi_mds - (blk_geom->quadi - 3) * ns_depth_offset[sb_size == BLOCK_128X128][blk_geom->depth]) - parent_depth_offset[sb_size == BLOCK_128X128][blk_geom->depth];
+        const BlockGeom * parent_blk_geom = get_blk_geom_mds(parent_depth_idx_mds);
+        uint32_t parent_tot_d1_blocks =
+            parent_blk_geom->sq_size == 128 ? 17 :
+            parent_blk_geom->sq_size > 8 ? 25 :
+            parent_blk_geom->sq_size == 8 ? 5 : 1;
+        for (block_1d_idx = 0; block_1d_idx < parent_tot_d1_blocks; block_1d_idx++) {
+            resultsPtr->leaf_data_array[parent_depth_idx_mds + block_1d_idx].consider_block = 1;
+        }
+
+        if (depth_step < -1)
+            set_parent_to_be_considered(
+                resultsPtr,
+                parent_depth_idx_mds,
+                sb_size,
+                depth_step + 1);
+    }
+}
+#endif
+
 void set_child_to_be_considered(
     MdcLcuData *resultsPtr,
     uint32_t    blk_index,
@@ -1158,6 +1188,168 @@ void set_child_to_be_considered(
     }
 }
 
+#if MDC_ADAPTIVE_LEVEL
+#define MDC_COST_WEIGHT 50000
+
+uint64_t  mdc_tab[9][2][3] = {
+    {{150,80,40},{150,80,40}},
+    {{150,80,40},{150,80,40}},
+    {{100,20,0},{150,50,0}},
+    {{100,20,0},{150,50,0}},
+    {{100,20,0},{150,50,0}},
+    {{100,20,0},{150,50,0}},
+    {{100,20,0},{150,50,0}},
+    {{100,20,0},{150,50,0}},
+    {{100,20,0},{150,50,0}}
+};
+
+// Update MDC refinement
+uint8_t update_mdc_level(
+    PictureControlSet  *picture_control_set_ptr,
+    LargestCodingUnit  *sb_ptr,
+    uint32_t sb_size,
+    const BlockGeom * blk_geom,
+    uint8_t mdc_depth_level) {
+    uint8_t depth_offset = sb_size == BLOCK_128X128 ? 0 : 1;
+    int8_t depth = blk_geom->depth + depth_offset;
+    uint8_t adjusted_depth_level = mdc_depth_level;
+    uint8_t depth_refinement_mode = mdc_depth_level;
+    uint8_t encode_mode = picture_control_set_ptr->parent_pcs_ptr->enc_mode;
+    int8_t start_depth = sb_size == BLOCK_128X128 ? 0 : 1;
+    int8_t end_depth = 5;
+    int8_t depthp1 = depth + 1 <= end_depth ? depth + 1 : depth;
+    int8_t depthp2 = depth + 2 <= end_depth ? depth + 2 : depth + 1 <= end_depth ? depth + 1 : depth;
+    int8_t depthp3 = depth + 3 <= end_depth ? depth + 3 : depth + 2 <= end_depth ? depth + 2 : depth + 1 <= end_depth ? depth + 1 : depth;
+    uint8_t depthm1 = depth - 1 >= start_depth ? depth - 1 : depth;
+    uint8_t depthm2 = depth - 2 >= start_depth ? depth - 2 : depth - 1 >= start_depth ? depth - 1 : depth;
+    uint8_t depthm3 = depth - 3 >= start_depth ? depth - 3 : depth - 2 >= start_depth ? depth - 2 : depth - 1 >= start_depth ? depth - 1 : depth;
+    adjusted_depth_level = 13;
+
+    uint64_t max_distance = 0xFFFFFFFFFFFFFFFF;
+    uint64_t mth01 = mdc_tab[encode_mode][0][0];
+    uint64_t mth02 = mdc_tab[encode_mode][0][1];
+    uint64_t mth03 = mdc_tab[encode_mode][0][2];
+    uint64_t pth01 = mdc_tab[encode_mode][1][0];
+    uint64_t pth02 = mdc_tab[encode_mode][1][1];
+    uint64_t pth03 = mdc_tab[encode_mode][1][2];
+    uint64_t dist_001 = sb_ptr->depth_cost[depth] != 0 ? (ABS((int64_t)sb_ptr->depth_cost[depth] - (int64_t)sb_ptr->depth_cost[depthp1]) * 100) / sb_ptr->depth_cost[depth] : max_distance;
+    uint64_t dist_100 = sb_ptr->depth_cost[depth] != 0 ? (ABS((int64_t)sb_ptr->depth_cost[depth] - (int64_t)sb_ptr->depth_cost[depthm1]) * 100) / sb_ptr->depth_cost[depth] : max_distance;
+    uint64_t dist_002 = sb_ptr->depth_cost[depth] != 0 ? (ABS((int64_t)sb_ptr->depth_cost[depth] - (int64_t)sb_ptr->depth_cost[depthp2]) * 100) / sb_ptr->depth_cost[depth] : max_distance;
+    uint64_t dist_200 = sb_ptr->depth_cost[depth] != 0 ? (ABS((int64_t)sb_ptr->depth_cost[depth] - (int64_t)sb_ptr->depth_cost[depthm2]) * 100) / sb_ptr->depth_cost[depth] : max_distance;
+    uint64_t dist_003 = sb_ptr->depth_cost[depth] != 0 ? (ABS((int64_t)sb_ptr->depth_cost[depth] - (int64_t)sb_ptr->depth_cost[depthp3]) * 100) / sb_ptr->depth_cost[depth] : max_distance;
+    uint64_t dist_300 = sb_ptr->depth_cost[depth] != 0 ? (ABS((int64_t)sb_ptr->depth_cost[depth] - (int64_t)sb_ptr->depth_cost[depthm3]) * 100) / sb_ptr->depth_cost[depth] : max_distance;
+
+    int8_t s_depth = -3;
+    int8_t e_depth = 3;
+    if (dist_300 < mth03)
+        s_depth = -3;
+    else if (dist_200 < mth02)
+        s_depth = -2;
+    else if (dist_100 < mth01)
+        s_depth = -1;
+    else
+        s_depth = 0;
+
+    if (dist_003 < pth03)
+        e_depth = 3;
+    else if (dist_002 < pth02)
+        e_depth = 2;
+    else if (dist_001 < pth01)
+        e_depth = 1;
+    else
+        e_depth = 0;
+
+    if (s_depth == 0 && e_depth == 0)
+        adjusted_depth_level = 0; // Pred only
+    else if (s_depth == -1 && e_depth == 0)
+        adjusted_depth_level = 8; // Pred -1
+    else if (s_depth == -2 && e_depth == 0)
+        adjusted_depth_level = 9; // Pred -2
+    else if (s_depth == -3 && e_depth == 0)
+        adjusted_depth_level = 14; // Pred -3
+    else if (s_depth == -3 && e_depth == 1)
+        adjusted_depth_level = 15; // Pred -3 + 1
+    else if (s_depth == -2 && e_depth == 1)
+        adjusted_depth_level = 10; // Pred -2 + 1
+    else if (s_depth == -1 && e_depth == 1)
+        adjusted_depth_level = 4; // Pred -1 + 1
+    else if (s_depth == 0 && e_depth == 1)
+        adjusted_depth_level = 1; // Pred + 1
+    else if (s_depth == -3 && e_depth == 2)
+        adjusted_depth_level = 12; // Pred -3 + 2
+    else if (s_depth == -2 && e_depth == 2)
+        adjusted_depth_level = 11; // Pred -2 + 2
+    else if (s_depth == -1 && e_depth == 2)
+        adjusted_depth_level = 5; // Pred -1 + 2
+    else if (s_depth == 0 && e_depth == 2)
+        adjusted_depth_level = 2; // Pred + 2
+    else if (s_depth == -3 && e_depth == 3)
+        adjusted_depth_level = 13; // Pred -3 + 3
+    else if (s_depth == -2 && e_depth == 3)
+        adjusted_depth_level = 7; // Pred -2 + 3
+    else if (s_depth == -1 && e_depth == 3)
+        adjusted_depth_level = 6; // Pred -1 + 3
+    else if (s_depth == 0 && e_depth == 3)
+        adjusted_depth_level = 3; // Pred + 3
+    else
+        printf("Error: unvalid s_depth && e_depth");
+
+    switch (adjusted_depth_level) {
+    case 0:
+        depth_refinement_mode = Pred;
+        break;
+    case 1:
+        depth_refinement_mode = Predp1;
+        break;
+    case 2:
+        depth_refinement_mode = Predp2;
+        break;
+    case 3:
+        depth_refinement_mode = Predp3;
+        break;
+    case 4:
+        depth_refinement_mode = Predm1p1;
+        break;
+    case 5:
+        depth_refinement_mode = Predm1p2;
+        break;
+    case 6:
+        depth_refinement_mode = Predm1p3;
+        break;
+    case 7:
+        depth_refinement_mode = Predm2p3;
+        break;
+    case 8:
+        depth_refinement_mode = Predm1;
+        break;
+    case 9:
+        depth_refinement_mode = Predm2;
+        break;
+    case 10:
+        depth_refinement_mode = Predm2p1;
+        break;
+    case 11:
+        depth_refinement_mode = Predm2p2;
+        break;
+    case 12:
+        depth_refinement_mode = Predm3p2;
+        break;
+    case 13:
+        depth_refinement_mode = Predm3p3;
+        break;
+    case 14:
+        depth_refinement_mode = Predm3;
+        break;
+    case 15:
+        depth_refinement_mode = Predm3p1;
+        break;
+    default:
+        printf("Not supported refined mdc_depth_level");
+        break;
+    }
+    return depth_refinement_mode;
+}
+#endif
 void init_considered_block(
     SequenceControlSet *sequence_control_set_ptr,
     PictureControlSet  *picture_control_set_ptr,
@@ -1166,12 +1358,21 @@ void init_considered_block(
     MdcLcuData *resultsPtr = &picture_control_set_ptr->mdc_sb_array[sb_index];
     resultsPtr->leaf_count = 0;
     uint32_t  blk_index = 0;
-    uint32_t  parent_depth_idx_mds, sparent_depth_idx_mds, child_block_idx_1, child_block_idx_2, child_block_idx_3, child_block_idx_4;
+
+#if MDC_ADAPTIVE_LEVEL
+    LargestCodingUnit  *sb_ptr = picture_control_set_ptr->sb_ptr_array[sb_index];
+#else
+    uint32_t  parent_depth_idx_mds, sparent_depth_idx_mds, ssparent_depth_idx_mds, child_block_idx_1, child_block_idx_2, child_block_idx_3, child_block_idx_4;
+#endif
     SbParams *sb_params = &sequence_control_set_ptr->sb_params_array[sb_index];
     uint8_t  is_complete_sb = sb_params->is_complete_sb;
     uint32_t tot_d1_blocks, block_1d_idx;
     EbBool split_flag;
+#if MDC_ADAPTIVE_LEVEL
+    uint32_t depth_refinement_mode = Predm1p3;
+#else
     uint32_t depth_refinement_mode = AllD;
+
     switch (picture_control_set_ptr->parent_pcs_ptr->mdc_depth_level) {
     case 0:
         depth_refinement_mode = is_complete_sb ? Pred : AllD;
@@ -1204,6 +1405,7 @@ void init_considered_block(
         printf("not supported mdc_depth_level");
         break;
     }
+#endif
     while (blk_index < sequence_control_set_ptr->max_block_cnt) {
         const BlockGeom * blk_geom = get_blk_geom_mds(blk_index);
         tot_d1_blocks =
@@ -1218,7 +1420,22 @@ void init_considered_block(
             split_flag = context_ptr->local_cu_array[blk_index].early_split_flag;
         if (sequence_control_set_ptr->sb_geom[sb_index].block_is_inside_md_scan[blk_index] && is_blk_allowed) {
             if (blk_geom->shape == PART_N) {
+#if MDC_ADAPTIVE_LEVEL
+                // Update MDC refinement
+                uint8_t adjusted_refinement_mode = depth_refinement_mode;
+                if (picture_control_set_ptr->parent_pcs_ptr->enable_adaptive_ol_partitioning)
+                    if (is_complete_sb && (context_ptr->local_cu_array[blk_index].early_split_flag == EB_FALSE))
+                        adjusted_refinement_mode = update_mdc_level(
+                            picture_control_set_ptr,
+                            sb_ptr,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            blk_geom,
+                            depth_refinement_mode);
+
+                switch (adjusted_refinement_mode) {
+#else
                 switch (depth_refinement_mode) {
+#endif
                 case Pred:
                     // Set predicted block to be considered
                     if (context_ptr->local_cu_array[blk_index].early_split_flag == EB_FALSE) {
@@ -1274,6 +1491,13 @@ void init_considered_block(
                             resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
                             resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
                         }
+#if MDC_ADAPTIVE_LEVEL
+                        set_parent_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            -1);
+#else
                         if (blk_geom->sq_size < (sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128 ? 128 : 64) && blk_geom->sq_size > 4) {
                             //Set parent to be considered
                             parent_depth_idx_mds = (blk_geom->sqi_mds - (blk_geom->quadi - 3) * ns_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth]) - parent_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth];
@@ -1286,6 +1510,7 @@ void init_considered_block(
                                 resultsPtr->leaf_data_array[parent_depth_idx_mds + block_1d_idx].consider_block = 1;
                             }
                         }
+#endif
                         for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
                             resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
                             resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
@@ -1303,6 +1528,13 @@ void init_considered_block(
                             resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
                             resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
                         }
+#if MDC_ADAPTIVE_LEVEL
+                        set_parent_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            -1);
+#else
                         if (blk_geom->sq_size < (sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128 ? 128 : 64) && blk_geom->sq_size > 4) {
                             //Set parent to be considered
                             parent_depth_idx_mds = (blk_geom->sqi_mds - (blk_geom->quadi - 3) * ns_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth]) - parent_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth];
@@ -1315,6 +1547,7 @@ void init_considered_block(
                                 resultsPtr->leaf_data_array[parent_depth_idx_mds + block_1d_idx].consider_block = 1;
                             }
                         }
+#endif
                         for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
                             resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
                             resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
@@ -1332,6 +1565,13 @@ void init_considered_block(
                             resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
                             resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
                         }
+#if MDC_ADAPTIVE_LEVEL
+                        set_parent_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            -2);
+#else
                         if (blk_geom->sq_size < (sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128 ? 128 : 64) && blk_geom->sq_size > 4) {
                             //Set parent to be considered
                             parent_depth_idx_mds = (blk_geom->sqi_mds - (blk_geom->quadi - 3) * ns_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth]) - parent_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth];
@@ -1354,6 +1594,7 @@ void init_considered_block(
                                     resultsPtr->leaf_data_array[sparent_depth_idx_mds + block_1d_idx].consider_block = 1;
                             }
                         }
+#endif
                         for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
                             resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
                             resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
@@ -1372,6 +1613,17 @@ void init_considered_block(
                             resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
                             resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
                         }
+#if MDC_ADAPTIVE_LEVEL
+                        set_parent_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            -1);
+                        for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
+                        }
+#else
                         if (blk_geom->sq_size < (sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128 ? 128 : 64) && blk_geom->sq_size > 4) {
                             //Set parent to be considered
                             parent_depth_idx_mds = (blk_geom->sqi_mds - (blk_geom->quadi - 3) * ns_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth]) - parent_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth];
@@ -1384,6 +1636,50 @@ void init_considered_block(
                                 resultsPtr->leaf_data_array[parent_depth_idx_mds + block_1d_idx].consider_block = 1;
                             }
                         }
+#endif
+                    }
+                    break;
+                case Predm2:
+                    if (context_ptr->local_cu_array[blk_index].early_split_flag == EB_FALSE) {
+                        for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
+                        }
+#if MDC_ADAPTIVE_LEVEL
+                        set_parent_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            -2);
+
+#else
+                        if (blk_geom->sq_size < (sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128 ? 128 : 64) && blk_geom->sq_size > 4) {
+                            //Set parent to be considered
+                            parent_depth_idx_mds = (blk_geom->sqi_mds - (blk_geom->quadi - 3) * ns_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth]) - parent_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth];
+                            const BlockGeom * parent_blk_geom = get_blk_geom_mds(parent_depth_idx_mds);
+                            uint32_t parent_tot_d1_blocks =
+                                parent_blk_geom->sq_size == 128 ? 17 :
+                                parent_blk_geom->sq_size > 8 ? 25 :
+                                parent_blk_geom->sq_size == 8 ? 5 : 1;
+                            for (block_1d_idx = 0; block_1d_idx < parent_tot_d1_blocks; block_1d_idx++) {
+                                resultsPtr->leaf_data_array[parent_depth_idx_mds + block_1d_idx].consider_block = 1;
+                            }
+                            if (parent_blk_geom->sq_size < (sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128 ? 128 : 64) && parent_blk_geom->sq_size > 4) {
+                                //Set parent to be considered
+                                sparent_depth_idx_mds = (parent_blk_geom->sqi_mds - (parent_blk_geom->quadi - 3) * ns_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][parent_blk_geom->depth]) - parent_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][parent_blk_geom->depth];
+                                uint32_t sparent_tot_d1_blocks =
+                                    parent_blk_geom->sq_size == 128 ? 17 :
+                                    parent_blk_geom->sq_size > 8 ? 25 :
+                                    parent_blk_geom->sq_size == 8 ? 5 : 1;
+                                for (block_1d_idx = 0; block_1d_idx < sparent_tot_d1_blocks; block_1d_idx++)
+                                    resultsPtr->leaf_data_array[sparent_depth_idx_mds + block_1d_idx].consider_block = 1;
+                            }
+                        }
+#endif
+                        for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
+                        }
                     }
                     break;
                 case Predm1p1:
@@ -1393,6 +1689,22 @@ void init_considered_block(
                             resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
                             resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
                         }
+#if MDC_ADAPTIVE_LEVEL
+                        set_parent_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            -1);
+                        for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
+                        }
+                        set_child_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            1);
+#else
                         if (blk_geom->sq_size < (sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128 ? 128 : 64) && blk_geom->sq_size > 4) {
                             //Set parent to be considered
                             parent_depth_idx_mds = (blk_geom->sqi_mds - (blk_geom->quadi - 3) * ns_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth]) - parent_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth];
@@ -1459,8 +1771,143 @@ void init_considered_block(
                                 resultsPtr->leaf_data_array[child_block_idx_4 + block_1d_idx].refined_split_flag = EB_FALSE;
                             }
                         }
+#endif
                     }
                     break;
+#if MDC_ADAPTIVE_LEVEL
+                case Predm2p1:
+                    if (context_ptr->local_cu_array[blk_index].early_split_flag == EB_FALSE) {
+                        for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
+                        }
+                        set_parent_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            -2);
+                        for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
+                        }
+                        set_child_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            1);
+                    }
+                    break;
+                case Predm2p2:
+                    if (context_ptr->local_cu_array[blk_index].early_split_flag == EB_FALSE) {
+                        for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
+                        }
+                        set_parent_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            -2);
+                        for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
+                        }
+                        set_child_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            2);
+                    }
+                    break;
+                case Predm3p2:
+                    if (context_ptr->local_cu_array[blk_index].early_split_flag == EB_FALSE) {
+                        for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
+                        }
+                        set_parent_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            -3);
+                        for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
+                        }
+                        set_child_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            2);
+                    }
+                    break;
+                case Predm3p3:
+                    if (context_ptr->local_cu_array[blk_index].early_split_flag == EB_FALSE) {
+                        for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
+                        }
+                        set_parent_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            -3);
+                        for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
+                        }
+                        set_child_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            3);
+                    }
+                    break;
+                case Predm3p1:
+                    if (context_ptr->local_cu_array[blk_index].early_split_flag == EB_FALSE) {
+                        for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
+                        }
+                        set_parent_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            -3);
+                        for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
+                        }
+                        set_child_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            1);
+                    }
+                    break;
+                case Predm3:
+                    if (context_ptr->local_cu_array[blk_index].early_split_flag == EB_FALSE) {
+                        for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
+                        }
+                        set_parent_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            -3);
+                        for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].consider_block = 1;
+                            resultsPtr->leaf_data_array[blk_index + block_1d_idx].refined_split_flag = EB_FALSE;
+                        }
+                        set_child_to_be_considered(
+                            resultsPtr,
+                            blk_index,
+                            sequence_control_set_ptr->seq_header.sb_size,
+                            1);
+                    }
+                    break;
+#endif
                 case AllD:
                     // Set all block to be considered
                     for (block_1d_idx = 0; block_1d_idx < tot_d1_blocks; block_1d_idx++) {
@@ -1561,14 +2008,21 @@ void open_loop_partitioning_pass(
         // SB Loop : Partitionnig Decision
         sb_ptr = picture_control_set_ptr->sb_ptr_array[sb_index];
         sb_ptr->qp = (uint8_t)picture_control_set_ptr->parent_pcs_ptr->picture_qp;
-        nsq_prediction_shape(
-            sequence_control_set_ptr,
-            picture_control_set_ptr,
-            context_ptr,
-            resultsPtr,
-            sb_ptr->origin_x,
-            sb_ptr->origin_y,
-            sb_index);
+#if MDC_ADAPTIVE_LEVEL
+        uint32_t is_complete_sb = sequence_control_set_ptr->sb_geom[sb_index].is_complete_sb;
+        if (sequence_control_set_ptr->over_boundary_block_mode == 1 || is_complete_sb) {
+#endif
+            open_loop_partitioning_sb(
+                sequence_control_set_ptr,
+                picture_control_set_ptr,
+                context_ptr,
+                resultsPtr,
+                sb_ptr->origin_x,
+                sb_ptr->origin_y,
+                sb_index);
+#if MDC_ADAPTIVE_LEVEL
+        }
+#endif
     }
     picture_control_set_ptr->parent_pcs_ptr->average_qp = (uint8_t)picture_control_set_ptr->parent_pcs_ptr->picture_qp;
 }
@@ -2679,32 +3133,47 @@ void* mode_decision_configuration_kernel(void *input_ptr)
         }
 #if ADD_MDC_REFINEMENT_LOOP
         if (picture_control_set_ptr->parent_pcs_ptr->slice_type != I_SLICE) {
+#if MDC_ADAPTIVE_LEVEL
+            if (picture_control_set_ptr->parent_pcs_ptr->enable_adaptive_ol_partitioning) {
+#else
             if (picture_control_set_ptr->parent_pcs_ptr->mdc_depth_level < MAX_MDC_LEVEL) {
+#endif
                 // SB Constants
                 uint8_t sb_sz = (uint8_t)sequence_control_set_ptr->sb_size_pix;
                 uint8_t lcu_size_log_2 = (uint8_t)Log2f(sb_sz);
                 uint32_t picture_height_in_sb = (sequence_control_set_ptr->seq_header.max_frame_height + sb_sz - 1) >> lcu_size_log_2;
                 uint32_t picture_width_in_sb = (sequence_control_set_ptr->seq_header.max_frame_width + sb_sz - 1) >> lcu_size_log_2;
+
                 for (uint32_t y_lcu_index = 0; y_lcu_index < picture_height_in_sb; ++y_lcu_index) {
                     for (uint32_t x_lcu_index = 0; x_lcu_index < picture_width_in_sb; ++x_lcu_index) {
                         uint32_t sb_index = (uint16_t)(y_lcu_index * picture_width_in_sb + x_lcu_index);
                         LargestCodingUnit  *sb_ptr = picture_control_set_ptr->sb_ptr_array[sb_index];
+#if MDC_ADAPTIVE_LEVEL
+                        uint32_t is_complete_sb = sequence_control_set_ptr->sb_geom[sb_index].is_complete_sb;
+#endif
                         sb_ptr->origin_x = x_lcu_index << lcu_size_log_2;
                         sb_ptr->origin_y = y_lcu_index << lcu_size_log_2;
+#if MDC_ADAPTIVE_LEVEL
+                        if (sequence_control_set_ptr->over_boundary_block_mode == 1 || is_complete_sb) {
+#endif
                         open_loop_partitioning_pass(
                             sequence_control_set_ptr,
                             picture_control_set_ptr,
                             context_ptr,
                             sb_index);
-                        init_considered_block(
-                            sequence_control_set_ptr,
-                            picture_control_set_ptr,
-                            context_ptr,
-                            sb_index);
-                        forward_considered_blocks(
-                            sequence_control_set_ptr,
-                            picture_control_set_ptr,
-                            sb_index);
+
+                            init_considered_block(
+                                sequence_control_set_ptr,
+                                picture_control_set_ptr,
+                                context_ptr,
+                                sb_index);
+                            forward_considered_blocks(
+                                sequence_control_set_ptr,
+                                picture_control_set_ptr,
+                                sb_index);
+#if MDC_ADAPTIVE_LEVEL
+                        }
+#endif
                     }
                 }
             }

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -14303,8 +14303,11 @@ extern "C" {
         uint64_t                             referenced_area_avg; // average referenced area per frame
         uint8_t                              referenced_area_has_non_zero;
 #endif
-#if PREDICT_NSQ_SHAPE
+#if PREDICT_NSQ_SHAPE && !MDC_ADAPTIVE_LEVEL
         uint8_t                                mdc_depth_level;
+#endif
+#if MDC_ADAPTIVE_LEVEL
+        uint8_t                                enable_adaptive_ol_partitioning;
 #endif
     } PictureParentControlSet;
 

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -3161,10 +3161,17 @@ void predictive_me_search(
                             ref_idx,
                             best_search_mvx,
                             best_search_mvy,
+#if MDC_ADAPTIVE_LEVEL
+                            -(EIGHT_PEL_REF_WINDOW >> 1),
+                            +(EIGHT_PEL_REF_WINDOW >> 1),
+                            -(EIGHT_PEL_REF_WINDOW >> 1),
+                            +(EIGHT_PEL_REF_WINDOW >> 1),
+#else
                             -(QUARTER_PEL_REF_WINDOW >> 1),
                             +(QUARTER_PEL_REF_WINDOW >> 1),
                             -(QUARTER_PEL_REF_WINDOW >> 1),
                             +(QUARTER_PEL_REF_WINDOW >> 1),
+#endif
                             1,
                             &best_search_mvx,
                             &best_search_mvy,
@@ -6465,7 +6472,11 @@ EbBool allowed_ns_cu(
 
 #if COMBINE_MDC_NSQ_TABLE
     if (is_nsq_table_used) {
+#if MDC_ADAPTIVE_LEVEL
+        if (!mdc_depth_level) {
+#else
         if (mdc_depth_level == MAX_MDC_LEVEL) {
+#endif
             if (context_ptr->blk_geom->shape != PART_N) {
                 ret = 0;
                 for (int i = 0; i < nsq_max_shapes_md; i++) {
@@ -7040,8 +7051,11 @@ void  adjust_nsq_rank(
         else
             context_ptr->nsq_table[5] = neighbor_part != PART_N && neighbor_part != PART_S ? neighbor_part : me_part_0;
     }
-
+#if MDC_ADAPTIVE_LEVEL
+    if (picture_control_set_ptr->parent_pcs_ptr->enable_adaptive_ol_partitioning) {
+#else
     if (picture_control_set_ptr->parent_pcs_ptr->mdc_depth_level < MAX_MDC_LEVEL) {
+#endif
         context_ptr->nsq_table[2] = context_ptr->nsq_table[0] != ol_part1 && context_ptr->nsq_table[1] != ol_part1 ? ol_part1
             : context_ptr->nsq_table[0] != ol_part2 && context_ptr->nsq_table[1] != ol_part2 ? ol_part2
             : ol_part3 != PART_N ? ol_part3 : context_ptr->nsq_table[2];
@@ -7654,7 +7668,11 @@ void md_encode_block(
 #if ADJUST_NSQ_RANK_BASED_ON_NEIGH
     if (is_nsq_table_used) {
         if (context_ptr->blk_geom->shape == PART_N) {
+#if MDC_ADAPTIVE_LEVEL
+            if (picture_control_set_ptr->parent_pcs_ptr->enable_adaptive_ol_partitioning) {
+#else
             if (picture_control_set_ptr->parent_pcs_ptr->mdc_depth_level < MAX_MDC_LEVEL) {
+#endif
                 adjust_nsq_rank(
                     picture_control_set_ptr,
                     context_ptr,
@@ -7696,7 +7714,11 @@ void md_encode_block(
 
     if (allowed_ns_cu(
 #if COMBINE_MDC_NSQ_TABLE
+#if MDC_ADAPTIVE_LEVEL
+        picture_control_set_ptr->parent_pcs_ptr->enable_adaptive_ol_partitioning,
+#else
         picture_control_set_ptr->parent_pcs_ptr->mdc_depth_level,
+#endif
 #endif
         is_nsq_table_used, picture_control_set_ptr->parent_pcs_ptr->nsq_max_shapes_md, context_ptr, is_complete_sb))
     {

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -2147,6 +2147,7 @@ void CopyApiFromApp(
     sequence_control_set_ptr->static_config.enable_hbd_mode_decision = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->encoder_bit_depth > 8 ? ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->enable_hbd_mode_decision : 0;
     sequence_control_set_ptr->static_config.constrained_intra = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->constrained_intra;
     sequence_control_set_ptr->static_config.enable_palette = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->enable_palette;
+    sequence_control_set_ptr->static_config.olpd_refinement = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->olpd_refinement;
     // Adaptive Loop Filter
     sequence_control_set_ptr->static_config.tile_rows = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->tile_rows;
     sequence_control_set_ptr->static_config.tile_columns = ((EbSvtAv1EncConfiguration*)pComponentParameterStructure)->tile_columns;
@@ -2589,6 +2590,15 @@ static EbErrorType VerifySettings(
         SVT_LOG( "Error instance %u: Invalid Palette Mode [0 .. 6], your input: %i\n", channelNumber + 1, config->enable_palette);
         return_error = EB_ErrorBadParameter;
     }
+    // mdc refinement
+    if (config->olpd_refinement < (int32_t)(-1) || config->olpd_refinement > 1) {
+        SVT_LOG("Error instance %u: Invalid OLPD Refinement Mode [0 .. 1], your input: %i\n", channelNumber + 1, config->olpd_refinement);
+        return_error = EB_ErrorBadParameter;
+    }
+    else if (config->olpd_refinement == 1 && config->enc_mode >= ENC_M1) {
+        SVT_LOG("Error instance %u: Invalid OLPD Refinement mode for M%d [0], your input: %i\n", channelNumber + 1, config->enc_mode, config->olpd_refinement);
+        return_error = EB_ErrorBadParameter;
+    }
 
     return return_error;
 }
@@ -2669,6 +2679,7 @@ EbErrorType eb_svt_enc_init_parameter(
     config_ptr->enable_hbd_mode_decision = 1;
     config_ptr->constrained_intra = EB_FALSE;
     config_ptr->enable_palette = -1;
+    config_ptr->olpd_refinement = -1;
     // Bitstream options
     //config_ptr->codeVpsSpsPps = 0;
     //config_ptr->codeEosNal = 0;


### PR DESCRIPTION
## Description

Adaptive open loop partitioning consists of assigning a specific refinement mode for each block instead of using the same refinement mode for all the blocks within the picture. The refinement mode is selected based on the cost difference between the predicted block depth and the above and below depths. Assuming a maximum of 3 above refinement depths (Pred-3) and 3 below refinement depths (Pred+3) can be considered to provide the same quality as all depths, the algorithm can select one of the 16 [0..15] refinement combinations illustrated in the following table.


Combination | Start depth (s_depth) | End depth (e_depth) | Refinement mode
-- | -- | -- | --
0 | -3 | 3 | Pred -3/+3
1 | -2 | 3 | Pred -2/+3
2 | -1 | 3 | Pred -1/+3
3 | 0 | 3 | Pred +3
4 | -3 | 2 | Pred -3/+2
5 | -2 | 2 | Pred -2/+2
6 | -1 | 2 | Pred -1/+2
7 | 0 | 2 | Pred +2
8 | -3 | 1 | Pred -3/+1
9 | -2 | 1 | Pred -2/+1
10 | -1 | 1 | Pred -1/+1
11 | 0 | 1 | Pred +1
12 | -3 | 0 | Pred -3
13 | -2 | 0 | Pred -2
14 | -1 | 0 | Pred -1
15 | 0 | 0 | Pred

Closes #789 

## Type of Change

New feature

## Author

@NaderMahdi

## Tests and performance

- BD rate difference (compared to master commit d647dc) of -0.02% relative to AOM, averaged over all resolutions
- Speed gain of 13.1% averaged over all resolutions
- Slope of -0.0012 
- No bitstream differences for M{1-8}
- No memory deviations
- No effect on 10-bit encoding