### PR TITLE
Remove duplicated implementation of warp_plane for high bit depth

### DIFF
--- a/Source/Lib/Common/Codec/EbInterPrediction.c
+++ b/Source/Lib/Common/Codec/EbInterPrediction.c
@@ -6418,41 +6418,23 @@ static void plane_warped_motion_prediction(
     if (!is_compound) {
         ConvolveParams conv_params = get_conv_params_no_round(0, 0, 0, NULL, 128, is_compound, bit_depth);
 
-        if (!is16bit)
-            eb_av1_warp_plane(
-                wm_params_l0,
-                (int) is16bit,
-                bit_depth,
-                src_ptr_l0,
-                (int) buf_width,
-                (int) buf_height,
-                src_stride,
-                dst_ptr,
-                pu_origin_x,
-                pu_origin_y,
-                bwidth,
-                bheight,
-                dst_stride,
-                ss_x,
-                ss_y,
-                &conv_params);
-        else
-            av1_warp_plane_hbd(
-                wm_params_l0,
-                bit_depth,
-                (uint16_t *)src_ptr_l0,
-                (int) buf_width,
-                (int) buf_height,
-                src_stride,
-                (uint16_t *)dst_ptr,
-                pu_origin_x,
-                pu_origin_y,
-                bwidth,
-                bheight,
-                dst_stride,
-                ss_x,
-                ss_y,
-                &conv_params);
+        eb_av1_warp_plane(
+            wm_params_l0,
+            (int) is16bit,
+            bit_depth,
+            src_ptr_l0,
+            (int) buf_width,
+            (int) buf_height,
+            src_stride,
+            dst_ptr,
+            pu_origin_x,
+            pu_origin_y,
+            bwidth,
+            bheight,
+            dst_stride,
+            ss_x,
+            ss_y,
+            &conv_params);
     } else {
         DECLARE_ALIGNED(32, uint16_t, tmp_dstY[128 * 128]);//move this to context if stack does not hold.
 
@@ -6469,41 +6451,23 @@ static void plane_warped_motion_prediction(
         conv_params.use_jnt_comp_avg = conv_params.use_dist_wtd_comp_avg;
 
         conv_params.do_average = 0;
-        if (!is16bit)
-            eb_av1_warp_plane(
-                wm_params_l0,
-                (int) is16bit,
-                bit_depth,
-                src_ptr_l0,
-                (int) buf_width,
-                (int) buf_height,
-                src_stride,
-                dst_ptr,
-                pu_origin_x,
-                pu_origin_y,
-                bwidth,
-                bheight,
-                dst_stride,
-                ss_x,
-                ss_y,
-                &conv_params);
-        else
-            av1_warp_plane_hbd(
-                wm_params_l0,
-                bit_depth,
-                (uint16_t *)src_ptr_l0,
-                (int) buf_width,
-                (int) buf_height,
-                src_stride,
-                (uint16_t *)dst_ptr,
-                pu_origin_x,
-                pu_origin_y,
-                bwidth,
-                bheight,
-                dst_stride,
-                ss_x,
-                ss_y,
-                &conv_params);
+        eb_av1_warp_plane(
+            wm_params_l0,
+            (int) is16bit,
+            bit_depth,
+            src_ptr_l0,
+            (int) buf_width,
+            (int) buf_height,
+            src_stride,
+            dst_ptr,
+            pu_origin_x,
+            pu_origin_y,
+            bwidth,
+            bheight,
+            dst_stride,
+            ss_x,
+            ss_y,
+            &conv_params);
 
         if (is_masked_compound_type(interinter_comp->type)) {
             av1_make_masked_warp_inter_predictor(
@@ -6526,41 +6490,23 @@ static void plane_warped_motion_prediction(
             );
         } else {
             conv_params.do_average = 1;
-            if (!is16bit)
-                eb_av1_warp_plane(
-                    wm_params_l1,
-                    (int) is16bit,
-                    bit_depth,
-                    src_ptr_l1,
-                    (int) buf_width,
-                    (int) buf_height,
-                    src_stride,
-                    dst_ptr,
-                    pu_origin_x,
-                    pu_origin_y,
-                    bwidth,
-                    bheight,
-                    dst_stride,
-                    ss_x,
-                    ss_y,
-                    &conv_params);
-            else
-                av1_warp_plane_hbd(
-                    wm_params_l1,
-                    bit_depth,
-                    (uint16_t *)src_ptr_l1,
-                    (int) buf_width,
-                    (int) buf_height,
-                    src_stride,
-                    (uint16_t *)dst_ptr,
-                    pu_origin_x,
-                    pu_origin_y,
-                    bwidth,
-                    bheight,
-                    dst_stride,
-                    ss_x,
-                    ss_y,
-                    &conv_params);
+            eb_av1_warp_plane(
+                wm_params_l1,
+                (int) is16bit,
+                bit_depth,
+                src_ptr_l1,
+                (int) buf_width,
+                (int) buf_height,
+                src_stride,
+                dst_ptr,
+                pu_origin_x,
+                pu_origin_y,
+                bwidth,
+                bheight,
+                dst_stride,
+                ss_x,
+                ss_y,
+                &conv_params);
         }
     }
 }

--- a/Source/Lib/Common/Codec/EbWarpedMotion.c
+++ b/Source/Lib/Common/Codec/EbWarpedMotion.c
@@ -520,8 +520,8 @@ static void highbd_warp_plane(EbWarpedMotionParams *wm, const uint8_t *const ref
   const int16_t gamma = wm->gamma;
   const int16_t delta = wm->delta;
 
-  const uint16_t *const ref = CONVERT_TO_SHORTPTR(ref8);
-  uint16_t *pred = CONVERT_TO_SHORTPTR(pred8);
+  const uint16_t *const ref = (uint16_t *)ref8;
+  uint16_t *pred = (uint16_t *)pred8;
   eb_av1_highbd_warp_affine_c(mat, ref, width, height, stride, pred, p_col, p_row,
                          p_width, p_height, p_stride, subsampling_x,
                          subsampling_y, bd, conv_params, alpha, beta, gamma,
@@ -884,56 +884,6 @@ void eb_av1_warp_plane(EbWarpedMotionParams *wm, int use_hbd, int bd,
   else
     warp_plane(wm, ref, width, height, stride, pred, p_col, p_row, p_width,
                p_height, p_stride, subsampling_x, subsampling_y, conv_params);
-}
-
-void av1_warp_plane_hbd(
-    EbWarpedMotionParams *wm,
-    int bd,
-    const uint16_t *ref,
-    int width,
-    int height,
-    int stride,
-    uint16_t *pred,
-    int p_col,
-    int p_row,
-    int p_width,
-    int p_height,
-    int p_stride,
-    int subsampling_x,
-    int subsampling_y,
-    ConvolveParams *conv_params)
-{
-  if(wm->wmtype == ROTZOOM) {
-      wm->wmmat[5] = wm->wmmat[2];
-      wm->wmmat[4] = -wm->wmmat[3];
-  }
-
-  const int32_t *const mat = wm->wmmat;
-  const int16_t alpha = wm->alpha;
-  const int16_t beta = wm->beta;
-  const int16_t gamma = wm->gamma;
-  const int16_t delta = wm->delta;
-
-  eb_av1_highbd_warp_affine_c(
-      mat,
-      ref,
-      width,
-      height,
-      stride,
-      pred,
-      p_col,
-      p_row,
-      p_width,
-      p_height,
-      p_stride,
-      subsampling_x,
-      subsampling_y,
-      bd,
-      conv_params,
-      alpha,
-      beta,
-      gamma,
-      delta);
 }
 
 #define LS_MV_MAX 256  // max mv in 1/8-pel

--- a/Source/Lib/Common/Codec/EbWarpedMotion.h
+++ b/Source/Lib/Common/Codec/EbWarpedMotion.h
@@ -144,23 +144,6 @@ void eb_av1_warp_plane(
     int             subsampling_y,
     ConvolveParams *conv_params);
 
-void av1_warp_plane_hbd(
-    EbWarpedMotionParams *wm,
-    int             bd,
-    const uint16_t *ref,
-    int             width,
-    int             height,
-    int             stride,
-    uint16_t       *pred,
-    int             p_col,
-    int             p_row,
-    int             p_width,
-    int             p_height,
-    int             p_stride,
-    int             subsampling_x,
-    int             subsampling_y,
-    ConvolveParams *conv_params);
-
 EbBool eb_find_projection(
     int        np,
     int       *pts1,

--- a/Source/Lib/Decoder/Codec/EbDecInterPrediction.c
+++ b/Source/Lib/Decoder/Codec/EbDecInterPrediction.c
@@ -167,21 +167,13 @@ void svt_make_inter_predictor(PartitionInfo_t *part_info, int32_t ref,
 
         wm_params = (mi->motion_mode == WARPED_CAUSAL) ? wm_local : wm_global;
 
-        if (highbd)
-            eb_av1_warp_plane((EbWarpedMotionParams *)wm_params,
-                highbd, bit_depth, CONVERT_TO_BYTEPTR(src),
-                ref_buf->ps_pic_buf->width >> ss_x,
-                ref_buf->ps_pic_buf->height >> ss_y,
-                src_stride, CONVERT_TO_BYTEPTR(dst_mod),
-                pre_x, pre_y, bw, bh, dst_stride,
-                ss_x, ss_y, conv_params);
-        else
-            eb_av1_warp_plane((EbWarpedMotionParams *)wm_params,
-                highbd, bit_depth,
-                src, ref_buf->ps_pic_buf->width >> ss_x,
-                ref_buf->ps_pic_buf->height >> ss_y,
-                src_stride, dst_mod, pre_x, pre_y, bw, bh, dst_stride,
-                ss_x, ss_y, conv_params);
+        eb_av1_warp_plane((EbWarpedMotionParams *)wm_params,
+            highbd, bit_depth, src,
+            ref_buf->ps_pic_buf->width >> ss_x,
+            ref_buf->ps_pic_buf->height >> ss_y,
+            src_stride, dst_mod,
+            pre_x, pre_y, bw, bh, dst_stride,
+            ss_x, ss_y, conv_params);
     }
     else if (highbd) {
         uint16_t *src16 = (uint16_t *)src_mod;


### PR DESCRIPTION
This removes code and should have no impact on the bit stream for low and high bit depth.