### PR TITLE
Bug fixes

### DIFF
--- a/Source/Lib/Common/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Common/Codec/EbEntropyCoding.c
@@ -5692,7 +5692,7 @@ static EbErrorType av1_code_tx_size(
     return return_error;
 }
 
-static INLINE void set_mi_row_col(
+void set_mi_row_col(
     PictureControlSet       *picture_control_set_ptr,
     MacroBlockD             *xd,
     TileInfo *              tile,
@@ -5709,10 +5709,6 @@ static INLINE void set_mi_row_col(
     xd->mb_to_right_edge = ((mi_cols - bw - mi_col) * MI_SIZE) * 8;
 
     xd->mi_stride = mi_stride;
-
-    // NM: To be updated when tile is supported.
-    tile->mi_row_start = 0;
-    tile->mi_col_start = 0;
 
     // Are edges available for intra prediction?
     xd->up_available = (mi_row > tile->mi_row_start);
@@ -6089,6 +6085,10 @@ assert(bsize < BlockSizeS_ALL);
     cu_ptr->av1xd->mi = picture_control_set_ptr->parent_pcs_ptr->av1_cm->pcs_ptr->mi_grid_base + offset;
     ModeInfo *mi_ptr = *cu_ptr->av1xd->mi;
 
+    cu_ptr->av1xd->tile.mi_col_start = tb_ptr->tile_info.mi_col_start;
+    cu_ptr->av1xd->tile.mi_col_end = tb_ptr->tile_info.mi_col_end;
+    cu_ptr->av1xd->tile.mi_row_start = tb_ptr->tile_info.mi_row_start;
+    cu_ptr->av1xd->tile.mi_row_end = tb_ptr->tile_info.mi_row_end;
     cu_ptr->av1xd->up_available = (mi_row > tb_ptr->tile_info.mi_row_start);
     cu_ptr->av1xd->left_available = (mi_col > tb_ptr->tile_info.mi_col_start);
     if (cu_ptr->av1xd->up_available)

--- a/Source/Lib/Common/Codec/EbFullLoop.c
+++ b/Source/Lib/Common/Codec/EbFullLoop.c
@@ -2978,7 +2978,8 @@ void  d1_non_square_block_decision(
     {
         tot_cost += context_ptr->md_local_cu_unit[first_blk_idx + blk_it].cost;
         if (context_ptr->blk_geom->sqi_mds != first_blk_idx + blk_it)
-            merge_block_cnt += merge_1D_inter_block(context_ptr, context_ptr->blk_geom->sqi_mds, first_blk_idx + blk_it);
+            if (context_ptr->md_local_cu_unit[context_ptr->blk_geom->sqi_mds].avail_blk_flag)
+                merge_block_cnt += merge_1D_inter_block(context_ptr, context_ptr->blk_geom->sqi_mds, first_blk_idx + blk_it);
     }
     if (context_ptr->blk_geom->bsize > BLOCK_4X4) {
         uint64_t split_cost = 0;
@@ -3069,53 +3070,57 @@ void   compute_depth_costs(
     else
         *above_depth_cost = MAX_MODE_COST;
     if (context_ptr->blk_geom->bsize > BLOCK_4X4) {
-        if (context_ptr->md_cu_arr_nsq[curr_depth_blk0_mds].mdc_split_flag == 0)
-            av1_split_flag_rate(
-                sequence_control_set_ptr,
-                context_ptr,
-                &context_ptr->md_cu_arr_nsq[curr_depth_blk0_mds],
-                0,
-                PARTITION_NONE,
-                &curr_non_split_rate_blk0,
-                context_ptr->full_lambda,
-                context_ptr->md_rate_estimation_ptr,
-                sequence_control_set_ptr->max_sb_depth);
+        if (context_ptr->md_local_cu_unit[curr_depth_blk0_mds].tested_cu_flag)
+            if (context_ptr->md_cu_arr_nsq[curr_depth_blk0_mds].mdc_split_flag == 0)
+                av1_split_flag_rate(
+                    sequence_control_set_ptr,
+                    context_ptr,
+                    &context_ptr->md_cu_arr_nsq[curr_depth_blk0_mds],
+                    0,
+                    PARTITION_NONE,
+                    &curr_non_split_rate_blk0,
+                    context_ptr->full_lambda,
+                    context_ptr->md_rate_estimation_ptr,
+                    sequence_control_set_ptr->max_sb_depth);
 
-        if (context_ptr->md_cu_arr_nsq[curr_depth_blk1_mds].mdc_split_flag == 0)
-            av1_split_flag_rate(
-                sequence_control_set_ptr,
-                context_ptr,
-                &context_ptr->md_cu_arr_nsq[curr_depth_blk1_mds],
-                0,
-                PARTITION_NONE,
-                &curr_non_split_rate_blk1,
-                context_ptr->full_lambda,
-                context_ptr->md_rate_estimation_ptr,
-                sequence_control_set_ptr->max_sb_depth);
+        if (context_ptr->md_local_cu_unit[curr_depth_blk1_mds].tested_cu_flag)
+            if (context_ptr->md_cu_arr_nsq[curr_depth_blk1_mds].mdc_split_flag == 0)
+                av1_split_flag_rate(
+                    sequence_control_set_ptr,
+                    context_ptr,
+                    &context_ptr->md_cu_arr_nsq[curr_depth_blk1_mds],
+                    0,
+                    PARTITION_NONE,
+                    &curr_non_split_rate_blk1,
+                    context_ptr->full_lambda,
+                    context_ptr->md_rate_estimation_ptr,
+                    sequence_control_set_ptr->max_sb_depth);
 
-        if (context_ptr->md_cu_arr_nsq[curr_depth_blk2_mds].mdc_split_flag == 0)
-            av1_split_flag_rate(
-                sequence_control_set_ptr,
-                context_ptr,
-                &context_ptr->md_cu_arr_nsq[curr_depth_blk2_mds],
-                0,
-                PARTITION_NONE,
-                &curr_non_split_rate_blk2,
-                context_ptr->full_lambda,
-                context_ptr->md_rate_estimation_ptr,
-                sequence_control_set_ptr->max_sb_depth);
+        if (context_ptr->md_local_cu_unit[curr_depth_blk2_mds].tested_cu_flag)
+            if (context_ptr->md_cu_arr_nsq[curr_depth_blk2_mds].mdc_split_flag == 0)
+                av1_split_flag_rate(
+                    sequence_control_set_ptr,
+                    context_ptr,
+                    &context_ptr->md_cu_arr_nsq[curr_depth_blk2_mds],
+                    0,
+                    PARTITION_NONE,
+                    &curr_non_split_rate_blk2,
+                    context_ptr->full_lambda,
+                    context_ptr->md_rate_estimation_ptr,
+                    sequence_control_set_ptr->max_sb_depth);
 
-        if (context_ptr->md_cu_arr_nsq[curr_depth_blk3_mds].mdc_split_flag == 0)
-            av1_split_flag_rate(
-                sequence_control_set_ptr,
-                context_ptr,
-                &context_ptr->md_cu_arr_nsq[curr_depth_blk3_mds],
-                0,
-                PARTITION_NONE,
-                &curr_non_split_rate_blk3,
-                context_ptr->full_lambda,
-                context_ptr->md_rate_estimation_ptr,
-                sequence_control_set_ptr->max_sb_depth);
+        if (context_ptr->md_local_cu_unit[curr_depth_blk3_mds].tested_cu_flag)
+            if (context_ptr->md_cu_arr_nsq[curr_depth_blk3_mds].mdc_split_flag == 0)
+                av1_split_flag_rate(
+                    sequence_control_set_ptr,
+                    context_ptr,
+                    &context_ptr->md_cu_arr_nsq[curr_depth_blk3_mds],
+                    0,
+                    PARTITION_NONE,
+                    &curr_non_split_rate_blk3,
+                    context_ptr->full_lambda,
+                    context_ptr->md_rate_estimation_ptr,
+                    sequence_control_set_ptr->max_sb_depth);
     }
     //curr_non_split_rate_344 = splitflag_mdc_344 || 4x4 ? 0 : compute;
 
@@ -3207,17 +3212,18 @@ void   compute_depth_costs_md_skip(
         uint32_t curr_depth_cur_blk_mds = context_ptr->blk_geom->sqi_mds - i * step;
         uint64_t       curr_non_split_rate_blk = 0;
         if (context_ptr->blk_geom->bsize > BLOCK_4X4) {
-            if (context_ptr->md_cu_arr_nsq[curr_depth_cur_blk_mds].mdc_split_flag == 0)
-                av1_split_flag_rate(
-                    sequence_control_set_ptr,
-                    context_ptr,
-                    &context_ptr->md_cu_arr_nsq[curr_depth_cur_blk_mds],
-                    0,
-                    PARTITION_NONE,
-                    &curr_non_split_rate_blk,
-                    context_ptr->full_lambda,
-                    context_ptr->md_rate_estimation_ptr,
-                    sequence_control_set_ptr->max_sb_depth);
+            if (context_ptr->md_local_cu_unit[curr_depth_cur_blk_mds].tested_cu_flag)
+                if (context_ptr->md_cu_arr_nsq[curr_depth_cur_blk_mds].mdc_split_flag == 0)
+                    av1_split_flag_rate(
+                        sequence_control_set_ptr,
+                        context_ptr,
+                        &context_ptr->md_cu_arr_nsq[curr_depth_cur_blk_mds],
+                        0,
+                        PARTITION_NONE,
+                        &curr_non_split_rate_blk,
+                        context_ptr->full_lambda,
+                        context_ptr->md_rate_estimation_ptr,
+                        sequence_control_set_ptr->max_sb_depth);
         }
         *curr_depth_cost +=
             context_ptr->md_local_cu_unit[curr_depth_cur_blk_mds].cost + curr_non_split_rate_blk;


### PR DESCRIPTION
+ Fix R2R CFL  : store luma data for 4xN and Nx4 blocks regardless of the candidate type and chrome mode 
+ Add a check on parent CU availability before checking the merge algorithm
+ Fix TILE ATB 
+ Fix R2R for split rate
Fixes #473 