### PR TITLE
Fix mismatch between C and SSE4, AVX2 for sad_loop_kernel_sparse

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -202,7 +202,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     ss3 = ss5 = _mm256_setzero_si256();
@@ -255,7 +255,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     s3 = _mm_setzero_si128();
@@ -316,7 +316,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
@@ -374,7 +374,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     s3 = s4 = _mm_setzero_si128();
@@ -435,7 +435,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
@@ -507,7 +507,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
@@ -602,7 +602,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
@@ -705,7 +705,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
@@ -803,7 +803,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
@@ -907,7 +907,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
@@ -1004,7 +1004,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
@@ -1118,7 +1118,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
@@ -1246,7 +1246,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     s3 = s4 = s5 = s6 = _mm_setzero_si128();
@@ -1389,7 +1389,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     s3 = s4 = s5 = s6 = _mm_setzero_si128();
@@ -1531,7 +1531,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
@@ -1656,7 +1656,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     ss3 = ss4 = ss5 = ss6 = ss7 = ss8 = ss9 = ss10 = _mm256_setzero_si256();

--- a/Source/Lib/Common/ASM_SSE4_1/EbComputeSAD_Intrinsic_SSE4_1.c
+++ b/Source/Lib/Common/ASM_SSE4_1/EbComputeSAD_Intrinsic_SSE4_1.c
@@ -1789,7 +1789,7 @@ void sad_loop_kernel_sparse_sse4_1_intrin(
                 }
             }
 
-            if (leftover) {
+            if (leftover && j < search_area_width ) {
                 pSrc = src;
                 pRef = ref + j;
                 s3 = _mm_setzero_si128();
@@ -1845,7 +1845,7 @@ void sad_loop_kernel_sparse_sse4_1_intrin(
                 }
             }
 
-            if (leftover) {
+            if (leftover && j < search_area_width ) {
                 pSrc = src;
                 pRef = ref + j;
                 s3 = s4 = _mm_setzero_si128();
@@ -1904,7 +1904,7 @@ void sad_loop_kernel_sparse_sse4_1_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     s3 = s4 = s5 = s6 = _mm_setzero_si128();
@@ -1974,7 +1974,7 @@ void sad_loop_kernel_sparse_sse4_1_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     s3 = s4 = s5 = s6 = _mm_setzero_si128();
@@ -2067,7 +2067,7 @@ void sad_loop_kernel_sparse_sse4_1_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     s3 = s4 = s5 = s6 = _mm_setzero_si128();
@@ -2171,7 +2171,7 @@ void sad_loop_kernel_sparse_sse4_1_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     s3 = s4 = s5 = s6 = _mm_setzero_si128();
@@ -2272,7 +2272,7 @@ void sad_loop_kernel_sparse_sse4_1_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     s3 = s4 = s5 = s6 = _mm_setzero_si128();
@@ -2392,7 +2392,7 @@ void sad_loop_kernel_sparse_sse4_1_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     s3 = s4 = s5 = s6 = _mm_setzero_si128();
@@ -2544,7 +2544,7 @@ void sad_loop_kernel_sparse_sse4_1_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     s3 = s4 = s5 = s6 = _mm_setzero_si128();
@@ -2743,7 +2743,7 @@ void sad_loop_kernel_sparse_sse4_1_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     s3 = s4 = s5 = s6 = _mm_setzero_si128();
@@ -2920,7 +2920,7 @@ void sad_loop_kernel_sparse_sse4_1_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     s9 = s10 = _mm_setzero_si128();
@@ -3114,7 +3114,7 @@ void sad_loop_kernel_sparse_sse4_1_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     s3 = s4 = s5 = s6 = _mm_setzero_si128();
@@ -3312,7 +3312,7 @@ void sad_loop_kernel_sparse_sse4_1_intrin(
                     }
                 }
 
-                if (leftover) {
+                if (leftover && j < search_area_width ) {
                     pSrc = src;
                     pRef = ref + j;
                     s9 = s10 = _mm_setzero_si128();


### PR DESCRIPTION
Fix UT Mismatch issue in SAD loop unit test #771
