### PR TITLE
Fix and enable global motion compensation for high bit depth streams

### DIFF
--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1255,8 +1255,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 #if GLOBAL_WARPED_MOTION
     if (sequence_control_set_ptr->static_config.enable_global_motion == EB_TRUE)
     {
-        if (picture_control_set_ptr->enc_mode == ENC_M0
-            && sequence_control_set_ptr->encoder_bit_depth == EB_8BIT)
+        if (picture_control_set_ptr->enc_mode == ENC_M0)
             context_ptr->global_mv_injection = 1;
         else
             context_ptr->global_mv_injection = 0;

--- a/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
@@ -245,8 +245,7 @@ EbErrorType signal_derivation_me_kernel_oq(
 
     if (sequence_control_set_ptr->static_config.enable_global_motion == EB_TRUE)
     {
-        if (enc_mode == ENC_M0
-            && sequence_control_set_ptr->encoder_bit_depth == EB_8BIT)
+        if (enc_mode == ENC_M0)
             context_ptr->me_context_ptr->compute_global_motion = EB_TRUE;
         else
             context_ptr->me_context_ptr->compute_global_motion = EB_FALSE;


### PR DESCRIPTION
The first commit fixes the global motion estimation for high bit depth frames by removing a wrong 8 bit conversion.
The second commit enables the global motion compensation for high bit depth streams.
