### PR TITLE
add svt log system

### DIFF
--- a/Source/App/DecApp/EbDecAppMain.c
+++ b/Source/App/DecApp/EbDecAppMain.c
@@ -46,7 +46,7 @@ int init_pic_buffer(EbSvtIOFormat *pic_buffer, CLInput *cli,
         pic_buffer->y_stride = cli->width;
         break;
     default:
-        printf("Unsupported colour format. \n");
+        fprintf(stderr, "Unsupported colour format. \n");
         return 0;
     }
     pic_buffer->width = cli->width;
@@ -74,7 +74,7 @@ int read_input_frame(DecInputContext *input, uint8_t **buffer, size_t *bytes_rea
             buffer_size);
         break;
     default:
-        printf("Unsupported bitstream type. \n");
+        fprintf(stderr, "Unsupported bitstream type. \n");
         return 0;
     }
 }
@@ -125,7 +125,7 @@ void write_frame(EbBufferHeaderType *recon_buffer, CLInput *cli) {
 }
 
 static void show_progress(int in_frame, uint64_t dx_time) {
-    printf("\n%d frames decoded in %" PRId64 " us (%.2f fps)\r",
+    fprintf(stderr, "\n%d frames decoded in %" PRId64 " us (%.2f fps)\r",
         in_frame, dx_time,
         (double)in_frame * 1000000.0 / (double)dx_time);
 }
@@ -170,8 +170,8 @@ int32_t main(int32_t argc, char* argv[])
     size_t bytes_in_buffer = 0, buffer_size = 0;
 
     // Print Decoder Info
-    printf("-------------------------------------\n");
-    printf("SVT-AV1 Decoder\n");
+    fprintf(stderr, "-------------------------------------\n");
+    fprintf(stderr, "SVT-AV1 Decoder\n");
 
     // Initialize config
     if (!config_ptr)
@@ -210,7 +210,7 @@ int32_t main(int32_t argc, char* argv[])
         ((EbSvtIOFormat *)recon_buffer->p_buffer)->cb = (uint8_t*)malloc(size >> 2);
         ((EbSvtIOFormat *)recon_buffer->p_buffer)->cr = (uint8_t*)malloc(size >> 2);
         if (!init_pic_buffer((EbSvtIOFormat*)recon_buffer->p_buffer, &cli, config_ptr)) {
-            printf("Decoding \n");
+            fprintf(stderr, "Decoding \n");
             EbAV1StreamInfo *stream_info = (EbAV1StreamInfo*)malloc(sizeof(EbAV1StreamInfo));
             EbAV1FrameInfo *frame_info = (EbAV1FrameInfo*)malloc(sizeof(EbAV1FrameInfo));
 
@@ -252,7 +252,7 @@ int32_t main(int32_t argc, char* argv[])
             }
             if (fps_summary || fps_frm) {
                 show_progress(in_frame, dx_time);
-                printf("\n");
+                fprintf(stderr, "\n");
             }
 
             if (enable_md5) {
@@ -273,7 +273,7 @@ int32_t main(int32_t argc, char* argv[])
         free(buf);
     }
     else
-        printf("Error in configuration. \n");
+        fprintf(stderr, "Error in configuration. \n");
     return_error |= eb_dec_deinit_handle(p_handle);
 
 fail:

--- a/Source/App/DecApp/EbDecParamParser.c
+++ b/Source/App/DecApp/EbDecParamParser.c
@@ -32,7 +32,7 @@ static void set_num_thread(const char *value, EbSvtAv1DecConfiguration *cfg) { c
 static void set_num_pframes(const char *value, EbSvtAv1DecConfiguration *cfg) {
     cfg->num_p_frames = strtoul(value, NULL, 0);
     if (cfg->num_p_frames != 1) {
-        printf("Warning : Multi frame parallelism not supported. Setting parallel frames to 1. \n");
+        fprintf(stderr, "Warning : Multi frame parallelism not supported. Setting parallel frames to 1. \n");
         cfg->num_p_frames = 1;
     }
 };
@@ -98,7 +98,7 @@ EbErrorType read_command_line(int32_t argc, char *const argv[],
                 config_strings[cmd_token_cnt] = argv[++token_index];
         }
         else {
-            printf(" Invalid CLI: %s \n", argv[token_index]);
+            fprintf(stderr, " Invalid CLI: %s \n", argv[token_index]);
             return EB_ErrorBadParameter;
         }
     }
@@ -111,7 +111,7 @@ EbErrorType read_command_line(int32_t argc, char *const argv[],
                 FILE * fin = NULL;
                 FOPEN(fin, config_strings[token_index], "rb");
                 if (!fin) {
-                    printf("Invalid input file \n");
+                    fprintf(stderr, "Invalid input file \n");
                     return EB_ErrorBadParameter;
                 }
                 else {
@@ -123,7 +123,7 @@ EbErrorType read_command_line(int32_t argc, char *const argv[],
                 FILE * fout = NULL;
                 FOPEN(fout, config_strings[token_index], "wb");
                 if (!fout) {
-                    printf("Invalid output file \n");
+                    fprintf(stderr, "Invalid output file \n");
                     return EB_ErrorBadParameter;
                 }
                 else {
@@ -151,7 +151,7 @@ EbErrorType read_command_line(int32_t argc, char *const argv[],
                     if (EB_STRCMP(cmd_copy[token_index], config_entry[temp_ind].token) == 0) {
                         if (config_strings[token_index] == NULL) {
                             if (config_entry[temp_ind].valueRequired == 1) {
-                                printf("Invalid CLI option: %s \n", cmd_copy[token_index]);
+                                fprintf(stderr, "Invalid CLI option: %s \n", cmd_copy[token_index]);
                                 return EB_ErrorBadParameter;
                             }
                             else
@@ -163,7 +163,7 @@ EbErrorType read_command_line(int32_t argc, char *const argv[],
                     temp_ind++;
                 }
                 if (!cli_read) {
-                    printf("Invalid CLI option: %s \n", cmd_copy[token_index]);
+                    fprintf(stderr, "Invalid CLI option: %s \n", cmd_copy[token_index]);
                     return EB_ErrorBadParameter;
                 }
             }
@@ -174,7 +174,7 @@ EbErrorType read_command_line(int32_t argc, char *const argv[],
     }
 
     if (!cli->inFile) {
-        printf("Input file not specified. \n");
+        fprintf(stderr, "Input file not specified. \n");
         showHelp();
         return EB_ErrorBadParameter;
     }
@@ -195,7 +195,7 @@ EbErrorType read_command_line(int32_t argc, char *const argv[],
     else if (file_is_obu(cli, obu_ctx))
         cli->inFileType = FILE_TYPE_OBU;
     else {
-        printf("Unsupported input file format. \n");
+        fprintf(stderr, "Unsupported input file format. \n");
         return EB_ErrorBadParameter;
     }
     return EB_ErrorNone;

--- a/Source/App/DecApp/EbFileUtils.c
+++ b/Source/App/DecApp/EbFileUtils.c
@@ -668,13 +668,13 @@ int read_ivf_frame(FILE *infile, uint8_t **buffer, size_t *bytes_read,
 
     if (fread(raw_header, IVF_FRAME_HDR_SZ, 1, infile) != 1) {
         if (!feof(infile))
-            printf("Failed to read frame size. \n");
+            fprintf(stderr, "Failed to read frame size. \n");
     }
     else {
         frame_size = mem_get_le32(raw_header);
 
         if (frame_size > 256 * 1024 * 1024) {
-            printf("Read invalid frame size (%u) \n", (unsigned int)frame_size);
+            fprintf(stderr, "Read invalid frame size (%u) \n", (unsigned int)frame_size);
             frame_size = 0;
         }
 
@@ -686,7 +686,7 @@ int read_ivf_frame(FILE *infile, uint8_t **buffer, size_t *bytes_read,
                 *buffer_size = 2 * frame_size;
             }
             else {
-                printf("Failed to allocate compressed data buffer. \n");
+                fprintf(stderr, "Failed to allocate compressed data buffer. \n");
                 frame_size = 0;
             }
         }
@@ -699,7 +699,7 @@ int read_ivf_frame(FILE *infile, uint8_t **buffer, size_t *bytes_read,
 
     if (!feof(infile)) {
         if (fread(*buffer, 1, frame_size, infile) != frame_size) {
-            printf("Failed to read full frame. \n");
+            fprintf(stderr, "Failed to read full frame. \n");
             return 0;
         }
         *bytes_read = frame_size;

--- a/Source/App/DecApp/EbMD5Utility.c
+++ b/Source/App/DecApp/EbMD5Utility.c
@@ -242,8 +242,8 @@ void md5_transform(unsigned int buf[4],
 void print_md5(unsigned char digest[16]) {
     int i;
 
-    printf("\n");
-    for (i = 0; i < 16; ++i) printf("%02x", digest[i]);
+    fprintf(stderr, "\n");
+    for (i = 0; i < 16; ++i) fprintf(stderr, "%02x", digest[i]);
 }
 
 void write_md5(EbBufferHeaderType *recon_buffer, MD5Context *md5) {

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -929,11 +929,11 @@ static int32_t ReadConfigFile(
             if (resultSize == configFileSize) {
                 ParseConfigFile(config, configFileBuffer, configFileSize);
             } else {
-                printf("Error channel %u: File Read Failed\n",instance_idx+1);
+                fprintf(stderr, "Error channel %u: File Read Failed\n",instance_idx+1);
                 return_error = -1;
             }
         } else {
-            printf("Error channel %u: Memory Allocation Failed\n",instance_idx+1);
+            fprintf(stderr, "Error channel %u: Memory Allocation Failed\n",instance_idx+1);
             return_error = -1;
         }
 
@@ -941,7 +941,7 @@ static int32_t ReadConfigFile(
         fclose(config->config_file);
         config->config_file = (FILE*) NULL;
     } else {
-        printf("Error channel %u: Couldn't open Config File: %s\n", instance_idx+1,configPath);
+        fprintf(stderr, "Error channel %u: Couldn't open Config File: %s\n", instance_idx+1,configPath);
         return_error = -1;
     }
 
@@ -1057,10 +1057,10 @@ uint32_t get_help(
     if (FindToken(argc, argv, HELP_TOKEN, config_string) == 0) {
         int32_t token_index = -1;
 
-        printf("\n%-25s\t%-25s\t%s\n\n" ,"TOKEN", "DESCRIPTION", "INPUT TYPE");
-        printf("%-25s\t%-25s\t%s\n" ,"-nch", "NumberOfChannels", "Single input");
+        fprintf(stderr, "\n%-25s\t%-25s\t%s\n\n" ,"TOKEN", "DESCRIPTION", "INPUT TYPE");
+        fprintf(stderr, "%-25s\t%-25s\t%s\n" ,"-nch", "NumberOfChannels", "Single input");
         while (config_entry[++token_index].token != NULL)
-            printf("%-25s\t%-25s\t%s\n", config_entry[token_index].token, config_entry[token_index].name, config_entry[token_index].type ? "Array input": "Single input");
+            fprintf(stderr, "%-25s\t%-25s\t%s\n", config_entry[token_index].token, config_entry[token_index].name, config_entry[token_index].type ? "Array input": "Single input");
         return 1;
     }
     else
@@ -1080,7 +1080,7 @@ uint32_t get_number_of_channels(
         // Set the input file
         channelNumber = strtol(config_string,  NULL, 0);
         if ((channelNumber > (uint32_t) MAX_CHANNEL_NUMBER) || channelNumber == 0){
-            printf("Error: The number of channels has to be within the range [1,%u]\n",(uint32_t) MAX_CHANNEL_NUMBER);
+            fprintf(stderr, "Error: The number of channels has to be within the range [1,%u]\n",(uint32_t) MAX_CHANNEL_NUMBER);
             return 0;
         }else{
             return channelNumber;
@@ -1192,7 +1192,7 @@ EbErrorType read_command_line(
     }
     else {
         if (FindToken(argc, argv, CONFIG_FILE_TOKEN, config_string) == 0) {
-            printf("Error: Config File Token Not Found\n");
+            fprintf(stderr, "Error: Config File Token Not Found\n");
             return EB_ErrorBadParameter;
         }
         else
@@ -1230,7 +1230,7 @@ EbErrorType read_command_line(
         if ((configs[index])->y4m_input == EB_TRUE){
             ret_y4m = read_y4m_header(configs[index]);
             if(ret_y4m == EB_ErrorBadParameter){
-                printf("Error found when reading the y4m file parameters.\n");
+                fprintf(stderr, "Error found when reading the y4m file parameters.\n");
                 return EB_ErrorBadParameter;
             }
         }
@@ -1401,10 +1401,10 @@ EbErrorType read_command_line(
     // Print message for unprocessed tokens
     if (cmd_token_cnt > 0) {
         int32_t cmd_copy_index;
-        printf("Unprocessed tokens: ");
+        fprintf(stderr, "Unprocessed tokens: ");
         for (cmd_copy_index = 0; cmd_copy_index < cmd_token_cnt; ++cmd_copy_index)
-            printf(" %s ", cmd_copy[cmd_copy_index]);
-        printf("\n\n");
+            fprintf(stderr, " %s ", cmd_copy[cmd_copy_index]);
+        fprintf(stderr, "\n\n");
         return_error = EB_ErrorBadParameter;
     }
 

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -93,7 +93,7 @@ extern    uint32_t                   app_malloc_count;
     pointer = (type)malloc(n_elements); \
     if (pointer == (type)EB_NULL){ \
         return_type = EB_ErrorInsufficientResources; \
-        printf("Malloc has failed due to insuffucient resources"); \
+        fprintf(stderr, "Malloc has failed due to insuffucient resources"); \
         return; \
             } \
                 else { \
@@ -108,14 +108,14 @@ extern    uint32_t                   app_malloc_count;
         } \
     if (*(app_memory_map_index) >= MAX_APP_NUM_PTR) { \
         return_type = EB_ErrorInsufficientResources; \
-        printf("Malloc has failed due to insuffucient resources"); \
+        fprintf(stderr, "Malloc has failed due to insuffucient resources"); \
         return; \
                 } \
     app_malloc_count++;
 
 #define EB_APP_MEMORY() \
-    printf("Total Number of Mallocs in App: %d\n", app_malloc_count); \
-    printf("Total App Memory: %.2lf KB\n\n",*total_app_memory/(double)1024);
+    fprintf(stderr, "Total Number of Mallocs in App: %d\n", app_malloc_count); \
+    fprintf(stderr, "Total App Memory: %.2lf KB\n\n",*total_app_memory/(double)1024);
 
 #define MAX_CHANNEL_NUMBER      6
 #define MAX_NUM_TOKENS          200

--- a/Source/App/EncApp/EbAppInputy4m.c
+++ b/Source/App/EncApp/EbAppInputy4m.c
@@ -44,7 +44,7 @@ int32_t read_y4m_header(EbConfig *cfg){
 
     /* print header */
     if(PRINT_HEADER) {
-        printf("y4m header:");
+        fprintf(stderr, "y4m header:");
         fputs(buffer, stdout);
     }
 
@@ -61,13 +61,13 @@ int32_t read_y4m_header(EbConfig *cfg){
         case 'W': /* width, required. */
             width = (uint32_t)strtol(tokstart, &tokend, 10);
             if(PRINT_HEADER)
-                printf("width = %d\n", width);
+                fprintf(stderr, "width = %d\n", width);
             tokstart = tokend;
             break;
         case 'H': /* height, required. */
             height = (uint32_t)strtol(tokstart, &tokend, 10);
             if(PRINT_HEADER)
-                printf("height = %d\n", height);
+                fprintf(stderr, "height = %d\n", height);
             tokstart = tokend;
             break;
         case 'I': /* scan type, not required, default: 'p' */
@@ -87,7 +87,7 @@ int32_t read_y4m_header(EbConfig *cfg){
                 return EB_ErrorBadParameter;
             }
             if(PRINT_HEADER)
-                printf("scan_type = %c\n", scan_type);
+                fprintf(stderr, "scan_type = %c\n", scan_type);
             break;
         case 'C': /* color space, not required: default "420" */
             tokstart = copyUntilCharacterOrNewLine(tokstart, format_str, 0x20);
@@ -180,7 +180,7 @@ int32_t read_y4m_header(EbConfig *cfg){
                 return EB_ErrorBadParameter;
             }
             if(PRINT_HEADER)
-                printf("chroma = %s, bitdepth = %d\n", chroma, bitdepth);
+                fprintf(stderr, "chroma = %s, bitdepth = %d\n", chroma, bitdepth);
             break;
         case 'F': /* frame rate, required */
             tokstart = copyUntilCharacterOrNewLine(tokstart, format_str, ':');
@@ -189,8 +189,8 @@ int32_t read_y4m_header(EbConfig *cfg){
             tokstart = copyUntilCharacterOrNewLine(tokstart, format_str, 0x20);
             fr_d = (uint32_t) strtol(format_str, (char **)NULL, 10);
             if(PRINT_HEADER) {
-                printf("framerate_n = %d\n", fr_n);
-                printf("framerate_d = %d\n", fr_d);
+                fprintf(stderr, "framerate_n = %d\n", fr_n);
+                fprintf(stderr, "framerate_d = %d\n", fr_d);
             }
             break;
         case 'A': /* aspect ratio, not required */
@@ -200,8 +200,8 @@ int32_t read_y4m_header(EbConfig *cfg){
             tokstart = copyUntilCharacterOrNewLine(tokstart, format_str, 0x20);
             aspect_d = (uint32_t) strtol(format_str, (char **)NULL, 10);
             if(PRINT_HEADER) {
-                printf("aspect_n = %d\n", aspect_n);
-                printf("aspect_d = %d\n", aspect_d);
+                fprintf(stderr, "aspect_n = %d\n", aspect_n);
+                fprintf(stderr, "aspect_d = %d\n", aspect_d);
             }
             break;
         default:

--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -104,8 +104,8 @@ int32_t main(int32_t argc, char* argv[])
     uint32_t                instanceCount=0;
     EbAppContext         *appCallbacks[MAX_CHANNEL_NUMBER];   // Instances App callback data
     signal(SIGINT, EventHandler);
-    printf("-------------------------------------------\n");
-    printf("SVT-AV1 Encoder\n");
+    fprintf(stderr, "-------------------------------------------\n");
+    fprintf(stderr, "SVT-AV1 Encoder\n");
     if (!get_help(argc, argv)) {
         // Get num_channels
         num_channels = get_number_of_channels(argc, argv);
@@ -189,7 +189,7 @@ int32_t main(int32_t argc, char* argv[])
                     EB_APP_MEMORY();
 #endif
                 }
-                printf("Encoding          ");
+                fprintf(stderr, "Encoding          ");
                 fflush(stdout);
 
                 while (exitCondition == APP_ExitConditionNone) {
@@ -264,10 +264,10 @@ int32_t main(int32_t argc, char* argv[])
                                 }
                             }
 
-                            printf("\nSUMMARY --------------------------------- Channel %u  --------------------------------\n", instanceCount + 1);
+                            fprintf(stderr, "\nSUMMARY --------------------------------- Channel %u  --------------------------------\n", instanceCount + 1);
                             {
-                                printf("Total Frames\t\tFrame Rate\t\tByte Count\t\tBitrate\n");
-                                printf("%12d\t\t%4.2f fps\t\t%10.0f\t\t%5.2f kbps\n",
+                                fprintf(stderr, "Total Frames\t\tFrame Rate\t\tByte Count\t\tBitrate\n");
+                                fprintf(stderr, "%12d\t\t%4.2f fps\t\t%10.0f\t\t%5.2f kbps\n",
                                     (int32_t)frame_count,
                                     (double)frame_rate,
                                     (double)configs[instanceCount]->performance_context.byte_count,
@@ -275,9 +275,9 @@ int32_t main(int32_t argc, char* argv[])
                             }
 
                             if (configs[instanceCount]->stat_report) {
-                                printf("\n\t\t\t\tAverage PSNR (using per-frame PSNR)\t\t\t|\t\tOverall PSNR (using per-frame MSE)\n");
-                                printf("Average QP\t\tY-PSNR\t\t\tU-PSNR\t\t\tV-PSNR\t\t|\tY-PSNR\t\t\tU-PSNR\t\t\tV-PSNR\t\n");
-                                printf("%11.2f\t\t%4.2f dB\t\t%4.2f dB\t\t%4.2f dB\t|\t%4.2f dB\t\t%4.2f dB\t\t%4.2f dB\n",
+                                fprintf(stderr, "\n\t\t\t\tAverage PSNR (using per-frame PSNR)\t\t\t|\t\tOverall PSNR (using per-frame MSE)\n");
+                                fprintf(stderr, "Average QP\t\tY-PSNR\t\t\tU-PSNR\t\t\tV-PSNR\t\t|\tY-PSNR\t\t\tU-PSNR\t\t\tV-PSNR\t\n");
+                                fprintf(stderr, "%11.2f\t\t%4.2f dB\t\t%4.2f dB\t\t%4.2f dB\t|\t%4.2f dB\t\t%4.2f dB\t\t%4.2f dB\n",
                                     (float)configs[instanceCount]->performance_context.sum_qp / frame_count,
                                     (float)configs[instanceCount]->performance_context.sum_luma_psnr / frame_count,
                                     (float)configs[instanceCount]->performance_context.sum_cb_psnr / frame_count,
@@ -291,13 +291,13 @@ int32_t main(int32_t argc, char* argv[])
                         }
                     }
                 }
-                printf("\n");
+                fprintf(stderr, "\n");
                 fflush(stdout);
             }
             for (instanceCount = 0; instanceCount < num_channels; ++instanceCount) {
                 if (exitConditions[instanceCount] == APP_ExitConditionFinished && return_errors[instanceCount] == EB_ErrorNone) {
                     if (configs[instanceCount]->stop_encoder == EB_FALSE) {
-                            printf("\nChannel %u\nAverage Speed:\t\t%.3f fps\nTotal Encoding Time:\t%.0f ms\nTotal Execution Time:\t%.0f ms\nAverage Latency:\t%.0f ms\nMax Latency:\t\t%u ms\n",
+                            fprintf(stderr, "\nChannel %u\nAverage Speed:\t\t%.3f fps\nTotal Encoding Time:\t%.0f ms\nTotal Execution Time:\t%.0f ms\nAverage Latency:\t%.0f ms\nMax Latency:\t\t%u ms\n",
                                 (uint32_t)(instanceCount + 1),
                                 configs[instanceCount]->performance_context.average_speed,
                                 configs[instanceCount]->performance_context.total_encode_time * 1000,
@@ -306,12 +306,12 @@ int32_t main(int32_t argc, char* argv[])
                                 (uint32_t)(configs[instanceCount]->performance_context.max_latency));
                     }
                     else
-                        printf("\nChannel %u Encoding Interrupted\n", (uint32_t)(instanceCount + 1));
+                        fprintf(stderr, "\nChannel %u Encoding Interrupted\n", (uint32_t)(instanceCount + 1));
                 }
                 else if (return_errors[instanceCount] == EB_ErrorInsufficientResources)
-                    printf("Could not allocate enough memory for channel %u\n", instanceCount + 1);
+                    fprintf(stderr, "Could not allocate enough memory for channel %u\n", instanceCount + 1);
                 else
-                    printf("Error encoding at channel %u! Check error log file for more details ... \n", instanceCount + 1);
+                    fprintf(stderr, "Error encoding at channel %u! Check error log file for more details ... \n", instanceCount + 1);
             }
             // DeInit Encoder
             for (instanceCount = num_channels; instanceCount > 0; --instanceCount) {
@@ -320,8 +320,8 @@ int32_t main(int32_t argc, char* argv[])
             }
         }
         else {
-            printf("Error in configuration, could not begin encoding! ... \n");
-            printf("Run %s -help for a list of options\n", argv[0]);
+            fprintf(stderr, "Error in configuration, could not begin encoding! ... \n");
+            fprintf(stderr, "Run %s -help for a list of options\n", argv[0]);
         }
         // Destruct the App memory variables
         for (instanceCount = 0; instanceCount < num_channels; ++instanceCount) {
@@ -332,7 +332,7 @@ int32_t main(int32_t argc, char* argv[])
                 free(appCallbacks[instanceCount]);
         }
 
-        printf("Encoder finished\n");
+        fprintf(stderr, "Encoder finished\n");
     }
 
     return (return_error == 0) ? 0 : 1;

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -881,7 +881,7 @@ void SendQpOnTheFly(
             tmpQp = GetNextQpFromQpFile(config);
 
             if (tmpQp == (int32_t)EB_ErrorInsufficientResources) {
-                printf("Malloc has failed due to insuffucient resources");
+                fprintf(stderr, "Malloc has failed due to insuffucient resources");
                 return;
             }
 
@@ -896,7 +896,7 @@ void SendQpOnTheFly(
 
         if (tmpQp == -1) {
             config->use_qp_file = EB_FALSE;
-            printf("\nWarning: QP File did not contain any valid QPs");
+            fprintf(stderr, "\nWarning: QP File did not contain any valid QPs");
         }
 
         qpPtr = CLIP3(0, 51, tmpQp);
@@ -1169,7 +1169,7 @@ AppExitConditionType ProcessOutputStreamBuffer(
         stream_status = eb_svt_get_packet(componentHandle, &headerPtr, pic_send_done);
 
         if (stream_status == EB_ErrorMax) {
-            printf("\n");
+            fprintf(stderr, "\n");
             LogErrorOutput(
                 config->error_log_file,
                 headerPtr->flags);
@@ -1278,7 +1278,7 @@ AppExitConditionType ProcessOutputStreamBuffer(
 #else
             //++frame_count;
             if (!(headerPtr->flags & EB_BUFFERFLAG_IS_ALT_REF))
-                printf("\b\b\b\b\b\b\b\b\b%9d", ++frame_count);
+                fprintf(stderr, "\b\b\b\b\b\b\b\b\b%9d", ++frame_count);
 #endif
 
             //++frame_count;
@@ -1291,8 +1291,8 @@ AppExitConditionType ProcessOutputStreamBuffer(
 
             if (!(frame_count % SPEED_MEASUREMENT_INTERVAL)) {
                 {
-                    printf("\n");
-                    printf("Average System Encoding Speed:        %.2f\n", (double)(frame_count) / config->performance_context.total_encode_time);
+                    fprintf(stderr, "\n");
+                    fprintf(stderr, "Average System Encoding Speed:        %.2f\n", (double)(frame_count) / config->performance_context.total_encode_time);
                 }
             }
         }
@@ -1312,7 +1312,7 @@ AppExitConditionType ProcessOutputReconBuffer(
     recon_status = eb_svt_get_recon(componentHandle, headerPtr);
 
     if (recon_status == EB_ErrorMax) {
-        printf("\n");
+        fprintf(stderr, "\n");
         LogErrorOutput(
             config->error_log_file,
             headerPtr->flags);
@@ -1326,7 +1326,7 @@ AppExitConditionType ProcessOutputReconBuffer(
             fseekReturnVal = fseeko(config->recon_file, headerPtr->n_filled_len, SEEK_CUR);
 
             if (fseekReturnVal != 0) {
-                printf("Error in fseeko  returnVal %i\n", fseekReturnVal);
+                fprintf(stderr, "Error in fseeko  returnVal %i\n", fseekReturnVal);
                 return APP_ExitConditionError;
             }
             frameNum = frameNum - 1;

--- a/Source/Lib/Common/Codec/EbBitstreamUnit.c
+++ b/Source/Lib/Common/Codec/EbBitstreamUnit.c
@@ -355,9 +355,9 @@ uint8_t *eb_od_ec_enc_done(OdEcEnc *enc, uint32_t *nbytes) {
         uint32_t tell;
         /* Don't count the 1 bit we lose to raw bits as overhead. */
         tell = eb_od_ec_enc_tell(enc) - 1;
-        fprintf(stderr, "overhead: %f%%\n",
+        SVT_ERROR("overhead: %f%%\n",
             100 * (tell - enc->entropy) / enc->entropy);
-        fprintf(stderr, "efficiency: %f bits/symbol\n",
+        SVT_ERROR("efficiency: %f bits/symbol\n",
             (double)tell / enc->nb_symbols);
     }
 #endif

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -2442,7 +2442,7 @@ API.  This is a 32 bit pointer and is aligned on a 32 bit word boundary.
     do { \
         if (!pointer) return return_type; \
         if (*(app_memory_map_index) >= MAX_APP_NUM_PTR) { \
-            printf("Malloc has failed due to insuffucient resources"); \
+            SVT_LOG("Malloc has failed due to insuffucient resources"); \
             release(pointer); \
             return return_type; \
         } \
@@ -2495,15 +2495,15 @@ API.  This is a 32 bit pointer and is aligned on a 32 bit word boundary.
 
 
 #define EB_MEMORY() \
-printf("Total Number of Mallocs in Library: %d\n", lib_malloc_count); \
-printf("Total Number of Threads in Library: %d\n", lib_thread_count); \
-printf("Total Number of Semaphore in Library: %d\n", lib_semaphore_count); \
-printf("Total Number of Mutex in Library: %d\n", lib_mutex_count); \
-printf("Total Library Memory: %.2lf KB\n\n",*total_lib_memory/(double)1024);
+SVT_LOG("Total Number of Mallocs in Library: %d\n", lib_malloc_count); \
+SVT_LOG("Total Number of Threads in Library: %d\n", lib_thread_count); \
+SVT_LOG("Total Number of Semaphore in Library: %d\n", lib_semaphore_count); \
+SVT_LOG("Total Number of Mutex in Library: %d\n", lib_mutex_count); \
+SVT_LOG("Total Library Memory: %.2lf KB\n\n",*total_lib_memory/(double)1024);
 
 #define EB_APP_MEMORY() \
-printf("Total Number of Mallocs in App: %d\n", app_malloc_count); \
-printf("Total App Memory: %.2lf KB\n\n",*total_app_memory/(double)1024);
+SVT_LOG("Total Number of Mallocs in App: %d\n", app_malloc_count); \
+SVT_LOG("Total App Memory: %.2lf KB\n\n",*total_app_memory/(double)1024);
 
 #define RSIZE_MAX_MEM      ( 256UL << 20 )     /* 256MB */
 
@@ -2538,19 +2538,6 @@ memset(dst, val, count)
             EbPtr handle,
             uint32_t errorCode);
     } EbCallback;
-
-    // DEBUG MACROS
-#define LIB_PRINTF_ENABLE                1
-
-#if LIB_PRINTF_ENABLE
-#define SVT_LOG printf
-#else
-#ifdef _MSC_VER
-#define SVT_LOG(s, ...) printf("")
-#else
-#define SVT_LOG(s, ...) printf("",##__VA_ARGS__)
-#endif
-#endif
 
 // Common Macros
 #define UNUSED(x) (void)(x)

--- a/Source/Lib/Common/Codec/EbLog.c
+++ b/Source/Lib/Common/Codec/EbLog.c
@@ -1,0 +1,74 @@
+/*
+* Copyright(c) 2019 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+#include "EbLog.h"
+//for getenv and fopen on windows
+#define _CRT_SECURE_NO_WARNINGS
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+
+static SvtLogLevel g_log_level;
+static FILE* g_log_file;
+
+static void svt_log_set_level(SvtLogLevel level)
+{
+    g_log_level = level;
+}
+
+static void svt_log_set_log_file(const char* file)
+{
+    if (file)
+        g_log_file = fopen(file, "w+");
+}
+
+void svt_log_init()
+{
+    const char* log = getenv("SVT_LOG");
+    SvtLogLevel level = SVT_LOG_INFO;
+    if (log)
+        level = (SvtLogLevel)atoi(log);
+    svt_log_set_level(level);
+
+    if (!g_log_file) {
+        const char* file = getenv("SVT_LOG_FILE");
+        svt_log_set_log_file(file);
+    }
+}
+
+static const char* log_level_str(SvtLogLevel level)
+{
+    switch (level) {
+        case SVT_LOG_FATAL:
+            return "fatal";
+        case SVT_LOG_ERROR:
+            return "error";
+        case SVT_LOG_WARN:
+            return "warn";
+        case SVT_LOG_INFO:
+            return "info";
+        case SVT_LOG_DEBUG:
+            return "debug";
+        default:
+            return "unknown";
+    }
+}
+
+void svt_log(SvtLogLevel level, const char* tag, const char* format, ...)
+{
+    if (level > g_log_level)
+        return;
+
+    if (!g_log_file)
+        g_log_file = stderr;
+
+    if (tag)
+        fprintf(g_log_file, "%s[%s]: ", tag, log_level_str(level));
+
+    va_list args;
+    va_start (args, format);
+    vfprintf (g_log_file, format, args);
+    va_end (args);
+}

--- a/Source/Lib/Common/Codec/EbLog.h
+++ b/Source/Lib/Common/Codec/EbLog.h
@@ -1,0 +1,48 @@
+/*
+* Copyright(c) 2019 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+#ifndef EbLog_h
+#define EbLog_h
+
+#ifndef LOG_TAG
+#define LOG_TAG "Svt"
+#endif
+
+typedef enum {
+    SVT_LOG_ALL     = -1,
+    SVT_LOG_FATAL   = 0,
+    SVT_LOG_ERROR   = 1,
+    SVT_LOG_WARN    = 2,
+    SVT_LOG_INFO    = 3,
+    SVT_LOG_DEBUG   = 4,
+} SvtLogLevel;
+
+//define this to turn off all library log
+//#define SVT_LOG_QUIET
+#ifndef SVT_LOG_QUIET
+
+//SVT_LOG will not output the prefix. you can contorl the output style.
+#define SVT_LOG(format, ...) svt_log(SVT_LOG_ALL, NULL, format, ##__VA_ARGS__)
+
+#define SVT_DEBUG(format, ...) svt_log(SVT_LOG_DEBUG, LOG_TAG, format, ##__VA_ARGS__)
+#define SVT_INFO(format, ...) svt_log(SVT_LOG_INFO, LOG_TAG, format, ##__VA_ARGS__)
+#define SVT_WARN(format, ...) svt_log(SVT_LOG_WARN, LOG_TAG, format, ##__VA_ARGS__)
+#define SVT_ERROR(format, ...) svt_log(SVT_LOG_ERROR, LOG_TAG, format, ##__VA_ARGS__)
+#define SVT_FATAL(format, ...) svt_log(SVT_LOG_FATAL, LOG_TAG, format, ##__VA_ARGS__)
+
+#else
+
+#define SVT_LOG(format, ...) do { } while (0)
+#define SVT_DEBUG(format, ...) do { } while (0)
+#define SVT_INFO(format, ...) do { } while (0)
+#define SVT_WARN(format, ...) do { } while (0)
+#define SVT_ERROR(format, ...) do { } while (0)
+#define SVT_FATAL(format, ...) do { } while (0)
+
+#endif //SVT_LOG_QUIET
+
+void svt_log_init();
+void svt_log(SvtLogLevel level, const char* tag, const char* format, ...);
+
+#endif //EbLog_h

--- a/Source/Lib/Common/Codec/EbMalloc.c
+++ b/Source/Lib/Common/Codec/EbMalloc.c
@@ -9,6 +9,8 @@
 
 #include "EbMalloc.h"
 #include "EbThreads.h"
+#define LOG_TAG "SvtMalloc"
+#include "EbLog.h"
 
 #ifdef DEBUG_MEMORY_USAGE
 
@@ -176,8 +178,8 @@ void eb_add_mem_entry(void* ptr,  EbPtrType type, size_t count, const char* file
     if (for_each_mem_entry(hash(ptr), add_mem_entry, &item))
         return;
     if (g_add_mem_entry_warning) {
-        fprintf(stderr, "SVT: can't add memory entry.\r\n");
-        fprintf(stderr, "SVT: You have memory leak or you need increase MEM_ENTRY_SIZE\r\n");
+        SVT_ERROR("can't add memory entry.\r\n");
+        SVT_ERROR("You have memory leak or you need increase MEM_ENTRY_SIZE\r\n");
         g_add_mem_entry_warning = EB_FALSE;
     }
 }
@@ -208,7 +210,7 @@ void eb_remove_mem_entry(void* ptr, EbPtrType type)
     if (for_each_mem_entry(hash(ptr), remove_mem_entry, &item))
         return;
     if (g_remove_mem_entry_warning) {
-        fprintf(stderr, "SVT: something wrong. you freed a unallocated memory %p, type = %s\r\n", ptr, mem_type_name(type));
+        SVT_ERROR("something wrong. you freed a unallocated memory %p, type = %s\r\n", ptr, mem_type_name(type));
         g_remove_mem_entry_warning = EB_FALSE;
     }
 }
@@ -296,7 +298,7 @@ static void print_top_10_locations() {
     eb_block_on_mutex(m);
     g_profile_entry = (MemoryEntry*)calloc(MEM_ENTRY_SIZE, sizeof(MemoryEntry));
     if (!g_profile_entry) {
-        fprintf(stderr, "not enough memory for memory profile");
+        SVT_ERROR("not enough memory for memory profile");
         eb_release_mutex(m);
         return;
     }
@@ -304,13 +306,13 @@ static void print_top_10_locations() {
     for_each_hash_entry(g_mem_entry, 0, collect_mem, &type);
     qsort(g_profile_entry, MEM_ENTRY_SIZE, sizeof(MemoryEntry), compare_count);
 
-    printf("top 10 %s locations:\r\n", mem_type_name(type));
+    SVT_INFO("top 10 %s locations:\r\n", mem_type_name(type));
     for (int i = 0; i < 10; i++) {
         double usage;
         char scale;
         MemoryEntry* e = g_profile_entry + i;
         get_memory_usage_and_scale(e->count, &usage, &scale);
-        printf("(%.2lf %cB): %s:%d\r\n", usage, scale, e->file, e->line);
+        SVT_INFO("(%.2lf %cB): %s:%d\r\n", usage, scale, e->file, e->line);
     }
     free(g_profile_entry);
     eb_release_mutex(m);
@@ -331,21 +333,21 @@ void eb_print_memory_usage()
     memset(&sum, 0, sizeof(MemSummary));
 
     for_each_mem_entry(0, count_mem_entry, &sum);
-    printf("SVT Memory Usage:\r\n");
+    SVT_INFO("SVT Memory Usage:\r\n");
     get_memory_usage_and_scale(sum.amount[EB_N_PTR] + sum.amount[EB_C_PTR] + sum.amount[EB_A_PTR], &usage, &scale);
-    printf("    total allocated memory:       %.2lf %cB\r\n", usage, scale);
+    SVT_INFO("    total allocated memory:       %.2lf %cB\r\n", usage, scale);
     get_memory_usage_and_scale(sum.amount[EB_N_PTR], &usage, &scale);
-    printf("        malloced memory:          %.2lf %cB\r\n", usage, scale);
+    SVT_INFO("        malloced memory:          %.2lf %cB\r\n", usage, scale);
     get_memory_usage_and_scale(sum.amount[EB_C_PTR], &usage, &scale);
-    printf("        callocated memory:        %.2lf %cB\r\n", usage, scale);
+    SVT_INFO("        callocated memory:        %.2lf %cB\r\n", usage, scale);
     get_memory_usage_and_scale(sum.amount[EB_A_PTR], &usage, &scale);
-    printf("        allocated aligned memory: %.2lf %cB\r\n", usage, scale);
+    SVT_INFO("        allocated aligned memory: %.2lf %cB\r\n", usage, scale);
 
-    printf("    mutex count: %d\r\n", (int)sum.amount[EB_MUTEX]);
-    printf("    semaphore count: %d\r\n", (int)sum.amount[EB_SEMAPHORE]);
-    printf("    thread count: %d\r\n", (int)sum.amount[EB_THREAD]);
+    SVT_INFO("    mutex count: %d\r\n", (int)sum.amount[EB_MUTEX]);
+    SVT_INFO("    semaphore count: %d\r\n", (int)sum.amount[EB_SEMAPHORE]);
+    SVT_INFO("    thread count: %d\r\n", (int)sum.amount[EB_THREAD]);
     fulless = (double)sum.occupied / MEM_ENTRY_SIZE;
-    printf("    hash table fulless: %f, hash bucket is %s\r\n", fulless, fulless < .3 ? "healthy":"too full" );
+    SVT_INFO("    hash table fulless: %f, hash bucket is %s\r\n", fulless, fulless < .3 ? "healthy":"too full" );
 #ifdef PROFILE_MEMORY_USAGE
     print_top_10_locations();
 #endif
@@ -369,7 +371,7 @@ static EbBool print_leak(MemoryEntry* e, void* param)
     if (e->ptr) {
         EbBool* leaked = (EbBool*)param;
         *leaked = EB_TRUE;
-        fprintf(stderr, "SVt: %s leaked at %s:L%d\r\n", mem_type_name(e->type), e->file, e->line);
+        SVT_ERROR("%s leaked at %s:L%d\r\n", mem_type_name(e->type), e->file, e->line);
     }
     //loop through all items
     return EB_FALSE;
@@ -386,7 +388,7 @@ void eb_decrease_component_count()
         EbBool leaked = EB_FALSE;
         for_each_hash_entry(g_mem_entry, 0, print_leak, &leaked);
         if (!leaked) {
-            printf("SVT: you have no memory leak\r\n");
+            SVT_INFO("you have no memory leak\r\n");
         }
     }
     eb_release_mutex(m);

--- a/Source/Lib/Common/Codec/EbMalloc.h
+++ b/Source/Lib/Common/Codec/EbMalloc.h
@@ -35,7 +35,7 @@ void eb_remove_mem_entry(void* ptr, EbPtrType type);
 #define EB_NO_THROW_ADD_MEM(p, size, type) \
     do { \
         if (!p) { \
-            fprintf(stderr,"allocate memory failed, at %s, L%d\n", __FILE__, __LINE__); \
+            fprintf(stderr, "allocate memory failed, at %s, L%d\n", __FILE__, __LINE__); \
         } else { \
             EB_ADD_MEM_ENTRY(p, type, size); \
         } \

--- a/Source/Lib/Common/Codec/EbThreads.c
+++ b/Source/Lib/Common/Codec/EbThreads.c
@@ -15,6 +15,7 @@
  ****************************************/
 #include <stdlib.h>
 #include "EbThreads.h"
+#include "EbLog.h"
  /****************************************
   * Win32 Includes
   ****************************************/
@@ -35,7 +36,7 @@ void printfTime(const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    printf("  [%i ms]\t", ((int32_t)clock()));
+    SVT_LOG("  [%i ms]\t", ((int32_t)clock()));
     vprintf(fmt, args);
     va_end(args);
 }
@@ -198,7 +199,7 @@ EbHandle eb_create_semaphore(uint32_t initial_count, uint32_t max_count)
     sprintf(name, "/sem_%05d_%03d", getpid(), semaphore_id());
     sem_t *s = sem_open(name, O_CREAT | O_EXCL, 0644, initial_count);
     if (s == SEM_FAILED) {
-        fprintf(stderr, "errno: %d\n", errno);
+        SVT_ERROR("errno: %d\n", errno);
         return NULL;
     }
     sem_unlink(name);

--- a/Source/Lib/Common/Codec/EbUtility.c
+++ b/Source/Lib/Common/Codec/EbUtility.c
@@ -15,7 +15,7 @@
 #endif
 
 #include "EbUtility.h"
-
+#include "EbLog.h"
 /********************************************************************************************
 * faster memcopy for <= 64B blocks, great w/ inlining and size known at compile time (or w/ PGO)
 * THIS NEEDS TO STAY IN A HEADER FOR BEST PERFORMANCE
@@ -213,7 +213,7 @@ const CodedUnitStats* get_coded_unit_stats(const uint32_t cuIdx)
 {
     //ASSERT(cuIdx < CU_MAX_COUNT && "get_coded_unit_stats: Out-of-range CU Idx\n");
     if (cuIdx == 255)
-        printf("Invalid CuIndex\n");
+        SVT_LOG("Invalid CuIndex\n");
 
     return &coded_unit_stats_array[cuIdx];
 }
@@ -397,7 +397,7 @@ uint32_t search_matching_from_dps(
     }
 
     if (matched == 0xFFFF)
-        printf(" \n\n PROBLEM\n\n ");
+        SVT_LOG(" \n\n PROBLEM\n\n ");
 
     return matched;
 }
@@ -427,7 +427,7 @@ uint32_t search_matching_from_mds(
     }
 
     if (matched == 0xFFFF)
-        printf(" \n\n PROBLEM\n\n ");
+        SVT_LOG(" \n\n PROBLEM\n\n ");
 
     return matched;
 }
@@ -554,7 +554,7 @@ void md_scan_all_blks(uint32_t *idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] = blk_geom_mds[*idx_mds].origin_y;
                 }
                 /*if (blk_geom_mds[*idx_mds].bsize == BLOCK_16X8)
-                    printf("");*/
+                    SVT_LOG("");*/
                 blk_geom_mds[*idx_mds].tx_boff_x[tx_depth][txb_itr] = blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] - blk_geom_mds[*idx_mds].origin_x;
                 blk_geom_mds[*idx_mds].tx_boff_y[tx_depth][txb_itr] = blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] - blk_geom_mds[*idx_mds].origin_y;
                 blk_geom_mds[*idx_mds].tx_width[tx_depth][txb_itr] = tx_size_wide[blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr]];
@@ -700,7 +700,7 @@ void md_scan_all_blks(uint32_t *idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
 
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] = blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] = blk_geom_mds[*idx_mds].origin_y + tby;
-                    //printf("");
+                    //SVT_LOG("");
                 }
                 else if (blk_geom_mds[*idx_mds].bsize == BLOCK_8X16)
                 {
@@ -939,7 +939,7 @@ void finish_depth_scan_all_blks()
         if (do_print)
         {
             fprintf(fp, "\n\n\n");
-            printf("\n\n\n");
+            SVT_LOG("\n\n\n");
         }
 
         for (sq_it_y = 0; sq_it_y < tot_num_sq; sq_it_y++)
@@ -949,7 +949,7 @@ void finish_depth_scan_all_blks()
                 for (uint32_t i = 0; i < sq_size / min_size; i++)
                 {
                     fprintf(fp, "\n ");
-                    printf("\n ");
+                    SVT_LOG("\n ");
                 }
             }
 
@@ -974,12 +974,12 @@ void finish_depth_scan_all_blks()
                         if (do_print && part_it == 0)
                         {
                             fprintf(fp, "%i", blk_geom_dps[depth_scan_idx].blkidx_mds);
-                            printf("%i", blk_geom_dps[depth_scan_idx].blkidx_mds);
+                            SVT_LOG("%i", blk_geom_dps[depth_scan_idx].blkidx_mds);
 
                             for (uint32_t i = 0; i < sq_size / min_size; i++)
                             {
                                 fprintf(fp, ",");
-                                printf(",");
+                                SVT_LOG(",");
                             }
                         }
                         depth_scan_idx++;
@@ -1073,7 +1073,7 @@ void build_blk_geom(int32_t use_128x128)
     //(0)compute total number of blocks using the information provided
     max_num_active_blocks = count_total_num_of_active_blks();
     if (max_num_active_blocks != max_block_count)
-        printf(" \n\n Error %i blocks\n\n ", max_num_active_blocks);
+        SVT_LOG(" \n\n Error %i blocks\n\n ", max_num_active_blocks);
 
     //(1) Construct depth scan blk_geom_dps
     depth_scan_all_blks();

--- a/Source/Lib/Common/Codec/grainSynthesis.c
+++ b/Source/Lib/Common/Codec/grainSynthesis.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include "grainSynthesis.h"
+#include "EbLog.h"
 
   // Samples with Gaussian distribution in the range of [-2048, 2047] (12 bits)
   // with zero mean and standard deviation of about 512.
@@ -561,7 +562,7 @@ static void generate_chroma_grain_blocks(
                     wsum_cr = wsum_cr + params->ar_coeffs_cr[pos] * av_luma;
                 }
                 else {
-                    printf(
+                    SVT_LOG(
                         "Grain synthesis: prediction between two chroma components is "
                         "not supported!");
                     exit(1);

--- a/Source/Lib/Decoder/Codec/EbDecBitstreamUnit.h
+++ b/Source/Lib/Decoder/Codec/EbDecBitstreamUnit.h
@@ -168,7 +168,7 @@ static INLINE int aom_daala_read(DaalaReader_t *r, int prob) {
   const int frame_idx = bitstream_queue_get_frame_read();
   bitstream_queue_pop(&ref_bit, ref_cdf, &ref_nsymbs);
   if (ref_nsymbs != 2) {
-      fprintf(stderr,
+      SVT_ERROR(
           "\n *** [bit] nsymbs error, frame_idx_r %d nsymbs %d ref_nsymbs "
           "%d queue_r %d\n",
           frame_idx, 2, ref_nsymbs, queue_r);
@@ -176,15 +176,15 @@ static INLINE int aom_daala_read(DaalaReader_t *r, int prob) {
       }
   if ((ref_nsymbs != 2) || (ref_cdf[0] != (AomCdfProb)p) ||
       (ref_cdf[1] != 32767)) {
-      fprintf(stderr,
+      SVT_ERROR(
           "\n *** [bit] cdf error, frame_idx_r %d cdf {%d, %d} ref_cdf {%d",
           frame_idx, p, 32767, ref_cdf[0]);
-      for (i = 1; i < ref_nsymbs; ++i) fprintf(stderr, ", %d", ref_cdf[i]);
-      fprintf(stderr, "} queue_r %d\n", queue_r);
+      for (i = 1; i < ref_nsymbs; ++i) SVT_ERROR(", %d", ref_cdf[i]);
+      SVT_ERROR("} queue_r %d\n", queue_r);
       assert(0);
       }
   if (bit != ref_bit) {
-      fprintf(stderr,
+      SVT_ERROR(
           "\n *** [bit] symb error, frame_idx_r %d symb %d ref_symb %d "
           "queue_r %d\n",
           frame_idx, bit, ref_bit, queue_r);
@@ -202,8 +202,8 @@ static INLINE int aom_daala_read(DaalaReader_t *r, int prob) {
   }
 #else
   if (enable_dump) {
-      printf("\n *** p %d \t", p);
-      printf("symb : %d \t", bit);
+      SVT_LOG("\n *** p %d \t", p);
+      SVT_LOG("symb : %d \t", bit);
       fflush(stdout);
   }
 #endif
@@ -226,7 +226,7 @@ static INLINE int daala_read_symbol(DaalaReader_t *r, const AomCdfProb *cdf,
   const int frame_idx = bitstream_queue_get_frame_read();
   bitstream_queue_pop(&ref_symb, ref_cdf, &ref_nsymbs);
   if (nsymbs != ref_nsymbs) {
-      fprintf(stderr,
+      SVT_ERROR(
           "\n *** nsymbs error, frame_idx_r %d nsymbs %d ref_nsymbs %d "
           "queue_r %d\n",
           frame_idx, nsymbs, ref_nsymbs, queue_r);
@@ -238,12 +238,12 @@ static INLINE int daala_read_symbol(DaalaReader_t *r, const AomCdfProb *cdf,
           if (cdf[i] != ref_cdf[i]) cdf_error = 1;
       }
   if (cdf_error) {
-      fprintf(stderr, "\n *** cdf error, frame_idx_r %d cdf {%d", frame_idx,
+      SVT_ERROR("\n *** cdf error, frame_idx_r %d cdf {%d", frame_idx,
           cdf[0]);
-      for (i = 1; i < nsymbs; ++i) fprintf(stderr, ", %d", cdf[i]);
-      fprintf(stderr, "} ref_cdf {%d", ref_cdf[0]);
-      for (i = 1; i < ref_nsymbs; ++i) fprintf(stderr, ", %d", ref_cdf[i]);
-      fprintf(stderr, "} queue_r %d\n", queue_r);
+      for (i = 1; i < nsymbs; ++i) SVT_ERROR(", %d", cdf[i]);
+      SVT_ERROR("} ref_cdf {%d", ref_cdf[0]);
+      for (i = 1; i < ref_nsymbs; ++i) SVT_ERROR(", %d", ref_cdf[i]);
+      SVT_ERROR("} queue_r %d\n", queue_r);
       assert(0);
       }
   if (symb != ref_symb) {
@@ -266,9 +266,9 @@ static INLINE int daala_read_symbol(DaalaReader_t *r, const AomCdfProb *cdf,
   }
 #else
   if (enable_dump) {
-      printf("\n *** nsymbs %d \t", nsymbs);
-      for (int i = 0; i < nsymbs; ++i) printf("cdf[%d] : %d \t", i, cdf[i]);
-      printf("symb : %d \t", symb);
+      SVT_LOG("\n *** nsymbs %d \t", nsymbs);
+      for (int i = 0; i < nsymbs; ++i) SVT_LOG("cdf[%d] : %d \t", i, cdf[i]);
+      SVT_LOG("symb : %d \t", symb);
       fflush(stdout);
   }
 #endif

--- a/Source/Lib/Decoder/Codec/EbDecHandle.c
+++ b/Source/Lib/Decoder/Codec/EbDecHandle.c
@@ -20,6 +20,7 @@
 #include "EbDecPicMgr.h"
 #include "grainSynthesis.h"
 
+
 #ifndef _WIN32
 #include <pthread.h>
 #include <errno.h>
@@ -32,6 +33,8 @@
 #endif
 
 #include "../../Encoder/Codec/aom_dsp_rtcd.h"
+
+#include "EbLog.h"
 
 /**************************************
 * Globals
@@ -172,7 +175,7 @@ int svt_dec_out_buf(
                 chroma_size = size * ht * wd;
                 break;
             default:
-                printf("Unsupported colour format. \n");
+                SVT_LOG("Unsupported colour format. \n");
                 return 0;
             }
 
@@ -180,7 +183,7 @@ int svt_dec_out_buf(
             out_img->width = wd;
             out_img->height = ht;
             if (out_img->bit_depth != (EbBitDepth)recon_picture_buf->bit_depth) {
-                printf("Warning : Output bit depth conversion not supported."
+                SVT_LOG("Warning : Output bit depth conversion not supported."
                     " Output depth set to %d. ", recon_picture_buf->bit_depth);
                 out_img->bit_depth = (EbBitDepth)recon_picture_buf->bit_depth;
             }
@@ -380,20 +383,20 @@ static EbErrorType init_svt_av1_decoder_handle(
     EbErrorType       return_error = EB_ErrorNone;
     EbComponentType  *svt_dec_component = (EbComponentType*)hComponent;
 
-    printf("SVT [version]:\tSVT-AV1 Decoder Lib v%d.%d.%d\n",
+    SVT_LOG("SVT [version]:\tSVT-AV1 Decoder Lib v%d.%d.%d\n",
         SVT_VERSION_MAJOR, SVT_VERSION_MINOR, SVT_VERSION_PATCHLEVEL);
 #if ( defined( _MSC_VER ) && (_MSC_VER < 1910) )
-    printf("SVT [build]  : Visual Studio 2013");
+    SVT_LOG("SVT [build]  : Visual Studio 2013");
 #elif ( defined( _MSC_VER ) && (_MSC_VER >= 1910) )
-    printf("SVT [build]  :\tVisual Studio 2017");
+    SVT_LOG("SVT [build]  :\tVisual Studio 2017");
 #elif defined(__GNUC__)
-    printf("SVT [build]  :\tGCC %d.%d.%d\t", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
+    SVT_LOG("SVT [build]  :\tGCC %d.%d.%d\t", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
 #else
-    printf("SVT [build]  :\tunknown compiler");
+    SVT_LOG("SVT [build]  :\tunknown compiler");
 #endif
-    printf(" %u bit\n", (unsigned) sizeof(void*) * 8);
-    printf("LIB Build date: %s %s\n", __DATE__, __TIME__);
-    printf("-------------------------------------------\n");
+    SVT_LOG(" %u bit\n", (unsigned) sizeof(void*) * 8);
+    SVT_LOG("LIB Build date: %s %s\n", __DATE__, __TIME__);
+    SVT_LOG("-------------------------------------------\n");
 
     SwitchToRealTime();
 
@@ -420,6 +423,8 @@ EB_API EbErrorType eb_dec_init_handle(
 
     if (p_handle == NULL)
         return EB_ErrorBadParameter;
+
+    svt_log_init();
 
     *p_handle = (EbComponentType*) malloc(sizeof(EbComponentType));
 
@@ -533,7 +538,7 @@ EB_API EbErrorType eb_svt_decode_frame(
     {
         /*TODO : Remove or move. For Test purpose only */
         dec_handle_ptr->dec_cnt++;
-        //printf("\n SVT-AV1 Dec : Decoding Pic #%d", dec_handle_ptr->dec_cnt);
+        //SVT_LOG("\n SVT-AV1 Dec : Decoding Pic #%d", dec_handle_ptr->dec_cnt);
 
         uint64_t frame_size = 0;
         frame_size = data_end - data_start;
@@ -553,7 +558,7 @@ EB_API EbErrorType eb_svt_decode_frame(
             ++data;
         }
 
-        /*printf("\nDecoding Pic #%d  frm_w : %d    frm_h : %d
+        /*SVT_LOG("\nDecoding Pic #%d  frm_w : %d    frm_h : %d
             frm_typ : %d", dec_handle_ptr->dec_cnt,
             dec_handle_ptr->frame_header.frame_size.frame_width,
             dec_handle_ptr->frame_header.frame_size.frame_height,

--- a/Source/Lib/Decoder/Codec/EbDecObmc.c
+++ b/Source/Lib/Decoder/Codec/EbDecObmc.c
@@ -26,6 +26,7 @@
 #include "EbDecUtils.h"
 #include "EbDecInterPrediction.h"
 #include "../../Encoder/Codec/aom_dsp_rtcd.h"
+#include "EbLog.h"
 
 //This function is present in encoder also, but encoder structures & decoder structures are different.
 static INLINE int dec_is_neighbor_overlappable(const BlockModeInfo *mbmi){
@@ -198,7 +199,7 @@ static INLINE void dec_build_prediction_by_above_pred(DecModCtxt *dec_mod_ctx,
         backup_pi->block_ref_sf[ref] = get_ref_scale_factors(dec_handle, frame);
 
         if ((!av1_is_valid_scale(backup_pi->block_ref_sf[ref]))) {
-            printf("\n Reference frame has invalid dimensions \n");
+            SVT_LOG("\n Reference frame has invalid dimensions \n");
             assert(0);
         }
     }
@@ -343,7 +344,7 @@ static INLINE void dec_build_prediction_by_left_pred(DecModCtxt *dec_mod_ctx,
         backup_pi->block_ref_sf[ref] = get_ref_scale_factors(dec_handle, frame);
 
         if ((!av1_is_valid_scale(backup_pi->block_ref_sf[ref]))) {
-            printf("\n Reference frame has invalid dimensions \n");
+            SVT_LOG("\n Reference frame has invalid dimensions \n");
             assert(0);
         }
     }

--- a/Source/Lib/Decoder/Codec/EbDecParseBlock.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseBlock.c
@@ -35,6 +35,8 @@
 #include "../../Encoder/Codec/EbEntropyCoding.h"
 #include "../../Encoder/Codec/EbFullLoop.h"
 
+#include "EbLog.h"
+
 #if ENABLE_ENTROPY_TRACE
 FILE* temp_fp;
 int enable_dump;
@@ -1860,7 +1862,7 @@ static INLINE int read_golomb(SvtReader *r) {
         i = svt_read_bit(r, ACCT_STR);
         ++length;
         if (length > 20) {
-            printf("Invalid length in read_golomb");
+            SVT_LOG("Invalid length in read_golomb");
             break;
         }
     }

--- a/Source/Lib/Decoder/Codec/EbDecParseInterBlock.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseInterBlock.c
@@ -2078,7 +2078,7 @@ void inter_block_mode_info(EbDecHandle *dec_handle, ParseCtxt *parse_ctxt,
     read_ref_frames(parse_ctxt, pi);
    /* if ((pi->mi->ref_frame[0] >= BWDREF_FRAME && pi->mi->ref_frame[0] <= ALTREF_FRAME) ||
         (pi->mi->ref_frame[1] >= BWDREF_FRAME && pi->mi->ref_frame[1] <= ALTREF_FRAME)) {
-        printf("ALTREF found - frame : %d\n", dec_handle->dec_cnt);
+        SVT_LOG("ALTREF found - frame : %d\n", dec_handle->dec_cnt);
         exit(0);
     }*/
     const int is_compound = has_second_ref(mbmi);
@@ -2090,11 +2090,11 @@ void inter_block_mode_info(EbDecHandle *dec_handle, ParseCtxt *parse_ctxt,
 
 #if EXTRA_DUMP
     if (enable_dump) {
-        printf("\n mi_row: %d mi_col: %d\n", pi->mi_row, pi->mi_col);
+        SVT_LOG("\n mi_row: %d mi_col: %d\n", pi->mi_row, pi->mi_col);
         /*for (int i = 0; i < MODE_CTX_REF_FRAMES; i++)
             for (int j = 0; j < MAX_REF_MV_STACK_SIZE; j++)
-                printf("ref_mv_stack[%d][%d]=%d\t", i, j, pi->ref_mv_stack[i][j].this_mv.as_int);
-        printf("\n");*/
+                SVT_LOG("ref_mv_stack[%d][%d]=%d\t", i, j, pi->ref_mv_stack[i][j].this_mv.as_int);
+        SVT_LOG("\n");*/
         fflush(stdout);
     }
 #endif
@@ -2197,7 +2197,7 @@ void inter_block_mode_info(EbDecHandle *dec_handle, ParseCtxt *parse_ctxt,
 
 #if EXTRA_DUMP
     if (enable_dump) {
-        printf("\n mode %d MV %d %d \n", mbmi->mode, mbmi->mv[0].as_mv.row, mbmi->mv[0].as_mv.col);
+        SVT_LOG("\n mode %d MV %d %d \n", mbmi->mode, mbmi->mv[0].as_mv.row, mbmi->mv[0].as_mv.col);
         fflush(stdout);
     }
 #endif

--- a/Source/Lib/Decoder/Codec/EbDecParseObu.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseObu.c
@@ -38,7 +38,7 @@
 #include "EbDecLF.h"
 
 #include "EbDecCdef.h"
-
+#include "EbLog.h"
 
 void dec_av1_loop_filter_frame_mt(
     EbDecHandle *dec_handle_ptr,
@@ -1778,7 +1778,7 @@ static void check_mt_support(EbDecHandle *dec_handle_ptr){
         master_frame_buf.cur_frame_bufs[0].dec_mt_frame_data;
 
     if(dec_handle_ptr->seq_header.color_config.bit_depth != EB_EIGHT_BIT) {
-        printf("Warning : Multi thread supported only for 8 bit depth."
+        SVT_LOG("Warning : Multi thread supported only for 8 bit depth."
             "Falling back to single thread. \n");
        dec_handle_ptr->dec_config.threads = 1;
        return;
@@ -1802,7 +1802,7 @@ static void check_mt_support(EbDecHandle *dec_handle_ptr){
         dec_mt_frame_data->prev_frame_info.prev_max_frame_height !=
         dec_handle_ptr->frame_header.frame_size.frame_height)
     {
-        printf("Warning : Multi thread not supported for change in frame resoulution."
+        SVT_LOG("Warning : Multi thread not supported for change in frame resoulution."
             "Falling back to single thread. \n");
         dec_handle_ptr->dec_config.threads = 1;
         return;
@@ -1810,7 +1810,7 @@ static void check_mt_support(EbDecHandle *dec_handle_ptr){
 
     if (dec_mt_frame_data->prev_frame_info.prev_sb_size !=
         dec_handle_ptr->seq_header.sb_size) {
-        printf("Warning : Multi thread not supported for change in SB size."
+        SVT_LOG("Warning : Multi thread not supported for change in SB size."
             "Falling back to single thread. \n");
         dec_handle_ptr->dec_config.threads = 1;
         return;
@@ -1819,7 +1819,7 @@ static void check_mt_support(EbDecHandle *dec_handle_ptr){
     if (dec_mt_frame_data->prev_frame_info.prev_tiles_info.tile_cols != tiles_info.tile_cols ||
         dec_mt_frame_data->prev_frame_info.prev_tiles_info.tile_rows != tiles_info.tile_rows)
     {
-        printf("Warning : Multi thread not supported for change in number of tiles."
+        SVT_LOG("Warning : Multi thread not supported for change in number of tiles."
             "Falling back to single thread. \n");
         dec_handle_ptr->dec_config.threads = 1;
         return;
@@ -1829,7 +1829,7 @@ static void check_mt_support(EbDecHandle *dec_handle_ptr){
         if (dec_mt_frame_data->prev_frame_info.prev_tiles_info.tile_col_start_mi[i] !=
             tiles_info.tile_col_start_mi[i])
         {
-            printf("Warning : Multi thread not supported for change in tile sizes."
+            SVT_LOG("Warning : Multi thread not supported for change in tile sizes."
                 "Falling back to single thread. \n");
             dec_handle_ptr->dec_config.threads = 1;
             return;
@@ -1840,7 +1840,7 @@ static void check_mt_support(EbDecHandle *dec_handle_ptr){
         if (dec_mt_frame_data->prev_frame_info.prev_tiles_info.tile_row_start_mi[i] !=
             tiles_info.tile_row_start_mi[i])
         {
-            printf("Warning : Multi thread not supported for change in tile sizes."
+            SVT_LOG("Warning : Multi thread not supported for change in tile sizes."
                 "Falling back to single thread. \n");
             dec_handle_ptr->dec_config.threads = 1;
             return;
@@ -2168,7 +2168,7 @@ void read_uncompressed_header(bitstrm_t *bs, EbDecHandle *dec_handle_ptr,
                 frame_info->frame_size.frame_height);
 
             if ((!av1_is_valid_scale(ref_scale_factors))) {
-                printf("\n Reference frame has invalid dimensions \n");
+                SVT_LOG("\n Reference frame has invalid dimensions \n");
                 assert(0);
             }
         }

--- a/Source/Lib/Decoder/Codec/EbDecProcess.c
+++ b/Source/Lib/Decoder/Codec/EbDecProcess.c
@@ -27,6 +27,7 @@
 #include "EbTime.h"
 
 #include "EbDecInverseQuantize.h"
+#include "EbLog.h"
 
 #include <stdlib.h>
 
@@ -428,7 +429,7 @@ void recon_tile_job_post(DecMTFrameData  *dec_mt_frame_data, uint32_t    node_in
     DecMTNode *recon_context_ptr =
         (DecMTNode*)recon_results_wrapper_ptr->object_ptr;
     recon_context_ptr->node_index = node_index;
-    //printf("\nPost dec job in queue Thread id : %d Tile id : %d \n",
+    //SVT_LOG("\nPost dec job in queue Thread id : %d Tile id : %d \n",
     //    th_cnt, recon_context_ptr->node_index);
     // Post Recon Tile Job
     eb_post_full_object(recon_results_wrapper_ptr);
@@ -466,7 +467,7 @@ void parse_frame_tiles(EbDecHandle     *dec_handle_ptr, int th_cnt) {
             if (EB_ErrorNone !=
                 parse_tile_job(dec_handle_ptr, context_ptr->node_index))
             {
-                printf("\nParse Issue for Tile %d", context_ptr->node_index);
+                SVT_LOG("\nParse Issue for Tile %d", context_ptr->node_index);
                 break;
             }
 
@@ -531,7 +532,7 @@ void decode_frame_tiles(EbDecHandle *dec_handle_ptr, DecThreadCtxt *thread_ctxt)
             if (EB_ErrorNone !=
                 decode_tile_job(dec_handle_ptr, context_ptr->node_index, dec_mod_ctxt))
             {
-                printf("\nDecode Issue for Tile %d", context_ptr->node_index);
+                SVT_LOG("\nDecode Issue for Tile %d", context_ptr->node_index);
                 break;
             }
             eb_release_object(recon_results_wrapper_ptr);
@@ -593,7 +594,7 @@ void decode_frame_tiles(EbDecHandle *dec_handle_ptr, DecThreadCtxt *thread_ctxt)
                 if (EB_ErrorNone !=
                     decode_tile_job(dec_handle_ptr, next_tile_idx, dec_mod_ctxt))
                 {
-                    printf("\nDecode Issue for Tile %d", next_tile_idx);
+                    SVT_LOG("\nDecode Issue for Tile %d", next_tile_idx);
                     break;
                 }
 
@@ -1037,11 +1038,11 @@ void dec_av1_loop_restoration_filter_frame_mt(EbDecHandle *dec_handle
         if (NULL != lr_results_wrapper_ptr) {
             context_ptr = (DecMTNode*)lr_results_wrapper_ptr->object_ptr;
 
-            printf("\nLR Row id : %d", context_ptr->node_index);
+            SVT_LOG("\nLR Row id : %d", context_ptr->node_index);
 
             //Sleep(1);
 
-            printf("\nLR Row id : %d done \n", context_ptr->node_index);
+            SVT_LOG("\nLR Row id : %d done \n", context_ptr->node_index);
 
             /* Update LR done map */
             dec_mt_frame_data->lr_row_map[context_ptr->node_index] = 1;
@@ -1103,11 +1104,11 @@ void dec_pad_frame_mt(EbDecHandle *dec_handle
         if (NULL != pad_results_wrapper_ptr) {
             context_ptr = (DecMTNode*)pad_results_wrapper_ptr->object_ptr;
 
-            printf("\nPad Row id : %d", context_ptr->node_index);
+            SVT_LOG("\nPad Row id : %d", context_ptr->node_index);
 
             //Sleep(1);
 
-            printf("\nPad Row id : %d done \n", context_ptr->node_index);
+            SVT_LOG("\nPad Row id : %d done \n", context_ptr->node_index);
 
             // Release Parse Results
             eb_release_object(pad_results_wrapper_ptr);

--- a/Source/Lib/Decoder/Codec/EbObuParse.h
+++ b/Source/Lib/Decoder/Codec/EbObuParse.h
@@ -16,10 +16,10 @@
 #define HEADER_DUMP 0
 
 #if HEADER_DUMP
-#define PRINT_NL printf("\n");
-#define PRINT(name, val) printf("\n%s :\t%X", name, val);
-#define PRINT_NAME(name) printf("\n%s :\t", name);
-#define PRINT_FRAME(name, val) printf("\n%s :\t%X", name, val);
+#define PRINT_NL SVT_LOG("\n");
+#define PRINT(name, val) SVT_LOG("\n%s :\t%X", name, val);
+#define PRINT_NAME(name) SVT_LOG("\n%s :\t", name);
+#define PRINT_FRAME(name, val) SVT_LOG("\n%s :\t%X", name, val);
 #else
 #define PRINT_NL
 #define PRINT(name, val)

--- a/Source/Lib/Encoder/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
@@ -11,6 +11,7 @@
 #include "EbPictureOperators_SSE2.h"
 #include "EbMemory_AVX2.h"
 #include "synonyms.h"
+#include "EbLog.h"
 
 #define _mm256_set_m128i(/* __m128i */ hi, /* __m128i */ lo) \
     _mm256_insertf128_si256(_mm256_castsi128_si256(lo), (hi), 0x1)
@@ -1151,7 +1152,7 @@ int32_t  sum_residual8bit_avx2_intrin(
         return sumBlock;
     }
     else {
-        printf("\n add the rest \n");
+        SVT_LOG("\n add the rest \n");
         return 0;
     }
 }
@@ -1285,7 +1286,7 @@ void memset16bit_block_avx2_intrin(
     }
 
     else
-        printf("\n add the rest \n");
+        SVT_LOG("\n add the rest \n");
 }
 
 void unpack_avg_safe_sub_avx2_intrin(

--- a/Source/Lib/Encoder/ASM_AVX2/synonyms_avx2.h
+++ b/Source/Lib/Encoder/ASM_AVX2/synonyms_avx2.h
@@ -27,7 +27,7 @@
 static INLINE __m256i yy_load_256(const void *const a) {
 #ifdef EB_TEST_SIMD_ALIGN
     if ((intptr_t)a % 32)
-        printf("\n yy_load_256() NOT 32-byte aligned!!!\n");
+        SVT_LOG("\n yy_load_256() NOT 32-byte aligned!!!\n");
 #endif
     return _mm256_load_si256((const __m256i *)a);
 }
@@ -39,7 +39,7 @@ static INLINE __m256i yy_loadu_256(const void *const a) {
 static INLINE void yy_store_256(void *const a, const __m256i v) {
 #ifdef EB_TEST_SIMD_ALIGN
     if ((intptr_t)a % 32)
-        printf("\n yy_store_256() NOT 32-byte aligned!!!\n");
+        SVT_LOG("\n yy_store_256() NOT 32-byte aligned!!!\n");
 #endif
     _mm256_store_si256((__m256i *)a, v);
 }

--- a/Source/Lib/Encoder/ASM_AVX512/synonyms_avx512.h
+++ b/Source/Lib/Encoder/ASM_AVX512/synonyms_avx512.h
@@ -26,7 +26,7 @@
 static INLINE __m512i zz_load_512(const void *const a) {
 #ifdef EB_TEST_SIMD_ALIGN
     if ((intptr_t)a % 64)
-        printf("\n zz_load_512() NOT 64-byte aligned!!!\n");
+        SVT_LOG("\n zz_load_512() NOT 64-byte aligned!!!\n");
 #endif
     return _mm512_load_si512((const __m512i *)a);
 }
@@ -38,7 +38,7 @@ static INLINE __m512i zz_loadu_512(const void *const a) {
 static INLINE void zz_store_512(void *const a, const __m512i v) {
 #ifdef EB_TEST_SIMD_ALIGN
     if ((intptr_t)a % 64)
-        printf("\n zz_store_512() NOT 64-byte aligned!!!\n");
+        SVT_LOG("\n zz_store_512() NOT 64-byte aligned!!!\n");
 #endif
     _mm512_store_si512((__m512i *)a, v);
 }

--- a/Source/Lib/Encoder/Codec/EbCdef.c
+++ b/Source/Lib/Encoder/Codec/EbCdef.c
@@ -17,6 +17,7 @@
 #include "EbCdef.h"
 #include "stdint.h"
 #include "aom_dsp_rtcd.h"
+#include "EbLog.h"
 
 extern int16_t eb_av1_ac_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth);
 
@@ -535,7 +536,7 @@ void eb_av1_cdef_frame(
             if (pCs->mi_grid_base[MI_SIZE_64X64 * fbr * cm->mi_stride + MI_SIZE_64X64 * fbc] == NULL ||
                 pCs->mi_grid_base[MI_SIZE_64X64 * fbr * cm->mi_stride + MI_SIZE_64X64 * fbc]->mbmi.cdef_strength == -1) {
                 cdef_left = 0;
-                printf("\n\n\nCDEF ERROR: Skipping Current FB\n\n\n");
+                SVT_LOG("\n\n\nCDEF ERROR: Skipping Current FB\n\n\n");
                 continue;
             }
 
@@ -835,7 +836,7 @@ void av1_cdef_frame16bit(
             if (pCs->mi_grid_base[MI_SIZE_64X64 * fbr * cm->mi_stride + MI_SIZE_64X64 * fbc] == NULL ||
                 pCs->mi_grid_base[MI_SIZE_64X64 * fbr * cm->mi_stride + MI_SIZE_64X64 * fbc]->mbmi.cdef_strength == -1) {
                 cdef_left = 0;
-                printf("\n\n\nCDEF ERROR: Skipping Current FB\n\n\n");
+                SVT_LOG("\n\n\nCDEF ERROR: Skipping Current FB\n\n\n");
                 continue;
             }
 

--- a/Source/Lib/Encoder/Codec/EbCdefProcess.c
+++ b/Source/Lib/Encoder/Codec/EbCdefProcess.c
@@ -262,7 +262,7 @@ void cdef_seg_search(
                 }
 
                 //if (pPcs->picture_number == 15)
-                //    printf(" bs:%i count:%i  mse:%I64i\n", bs, cdef_count,picture_control_set_ptr->mse_seg[0][fbr*nhfb + fbc][4]);
+                //    SVT_LOG(" bs:%i count:%i  mse:%I64i\n", bs, cdef_count,picture_control_set_ptr->mse_seg[0][fbr*nhfb + fbc][4]);
             }
         }
     }
@@ -491,7 +491,7 @@ void* cdef_kernel(void *input_ptr)
         picture_control_set_ptr->tot_seg_searched_cdef++;
         if (picture_control_set_ptr->tot_seg_searched_cdef == picture_control_set_ptr->cdef_segments_total_count)
         {
-           // printf("    CDEF all seg here  %i\n", picture_control_set_ptr->picture_number);
+           // SVT_LOG("    CDEF all seg here  %i\n", picture_control_set_ptr->picture_number);
         if (sequence_control_set_ptr->seq_header.enable_cdef && picture_control_set_ptr->parent_pcs_ptr->cdef_filter_mode) {
                 finish_cdef_search(
                     0,

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -2311,7 +2311,7 @@ EB_EXTERN void av1_encode_pass(
                 cu_ptr->block_has_coeff = 0;
 
                 // if(picture_control_set_ptr->picture_number==4 && context_ptr->cu_origin_x==0 && context_ptr->cu_origin_y==0)
-                //     printf("CHEDD");
+                //     SVT_LOG("CHEDD");
                 uint32_t  coded_area_org = context_ptr->coded_area_sb;
                 uint32_t  coded_area_org_uv = context_ptr->coded_area_sb_uv;
 

--- a/Source/Lib/Encoder/Codec/EbDeblockingFilter.c
+++ b/Source/Lib/Encoder/Codec/EbDeblockingFilter.c
@@ -25,6 +25,7 @@
 #include "EbSequenceControlSet.h"
 #include "EbReferenceObject.h"
 #include "EbCommonUtils.h"
+#include "EbLog.h"
 
 #define   convertToChromaQp(iQpY)  ( ((iQpY) < 0) ? (iQpY) : (((iQpY) > 57) ? ((iQpY)-6) : (int32_t)(map_chroma_qp((uint32_t)iQpY))) )
 
@@ -544,7 +545,7 @@ uint8_t get_filter_level(
     PredictionMode mode; // Added to address 4x4 problem
     mode = (pred_mode == INTRA_MODE_4x4) ? DC_PRED : pred_mode;
     if (frm_hdr->delta_lf_params.delta_lf_present) {
-        printf("ERROR[AN]: delta_lf_present not supported yet\n");
+        SVT_LOG("ERROR[AN]: delta_lf_present not supported yet\n");
         int32_t delta_lf = -1;
         if (frm_hdr->delta_lf_params.delta_lf_multi) {
             const int32_t delta_lf_idx = delta_lf_id_lut[plane][dir_idx];

--- a/Source/Lib/Encoder/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Encoder/Codec/EbEntropyCoding.c
@@ -27,6 +27,7 @@
 #include "EbSegmentation.h"
 #include "EbCommonUtils.h"
 #include "EbAdaptiveMotionVectorPrediction.h"
+#include "EbLog.h"
 
 #include "aom_dsp_rtcd.h"
 
@@ -2051,7 +2052,7 @@ void eb_av1_encode_mv(
     NmvContext *mvctx,
     int32_t usehp) {
     if (is_mv_valid(mv) == 0)
-        printf("Corrupted MV\n");
+        SVT_LOG("Corrupted MV\n");
 
     int32_t diff[2] = { mv->row - ref->row, mv->col - ref->col };
     const MvJointType j = av1_get_mv_joint_diff(diff);
@@ -2146,7 +2147,7 @@ int32_t eb_av1_get_pred_context_switchable_interp(
     }
     else
         filter_type_ctx += SWITCHABLE_FILTERS;
-    //  printf("\t %d\t %d\t %d",filter_type_ctx,left_type ,above_type);
+    //  SVT_LOG("\t %d\t %d\t %d",filter_type_ctx,left_type ,above_type);
 
     return filter_type_ctx;
 }
@@ -2218,7 +2219,7 @@ void write_mb_interp_filter(
     if (cm->interp_filter == SWITCHABLE) {
         int32_t dir;
         for (dir = 0; dir < 2; ++dir) {
-            // printf("\nP:%d\tX: %d\tY:%d\t %d",(pcs_ptr)->picture_number,blkOriginX,blkOriginY ,((ec_writer)->ec).rng);
+            // SVT_LOG("\nP:%d\tX: %d\tY:%d\t %d",(pcs_ptr)->picture_number,blkOriginX,blkOriginY ,((ec_writer)->ec).rng);
             const int32_t ctx = eb_av1_get_pred_context_switchable_interp(
                 ref_frame_type_neighbor_array,
                 rf0,
@@ -2753,7 +2754,7 @@ void av1_collect_neighbors_ref_counts(
             ref_counts[topRfType[1]]++;
             break;
         default:
-            printf("ERROR[AN]: Invalid Pred Direction\n");
+            SVT_LOG("ERROR[AN]: Invalid Pred Direction\n");
             break;
         }
     }
@@ -2776,7 +2777,7 @@ void av1_collect_neighbors_ref_counts(
             ref_counts[leftRfType[1]]++;
             break;
         default:
-            printf("ERROR[AN]: Invalid Pred Direction\n");
+            SVT_LOG("ERROR[AN]: Invalid Pred Direction\n");
             break;
         }
     }
@@ -3089,7 +3090,7 @@ static void encode_restoration_mode(PictureParentControlSet *pcs_ptr,
     struct AomWriteBitBuffer *wb) {
     Av1Common* cm = pcs_ptr->av1_cm;
     FrameHeader *frm_hdr = &pcs_ptr->frm_hdr;
-    //printf("ERROR[AN]: encode_restoration_mode might not work. Double check the reference code\n");
+    //SVT_LOG("ERROR[AN]: encode_restoration_mode might not work. Double check the reference code\n");
     assert(!frm_hdr->all_lossless);
     // move out side of the function
     //if (!cm->seq_params.enable_restoration) return;
@@ -3105,11 +3106,11 @@ static void encode_restoration_mode(PictureParentControlSet *pcs_ptr,
         RestorationInfo *rsi = &pcs_ptr->av1_cm->rst_info[p];
 
         //if (p==0)
-        //   printf("POC:%i Luma restType:%i\n", pcs_ptr->picture_number, rsi->frame_restoration_type);
+        //   SVT_LOG("POC:%i Luma restType:%i\n", pcs_ptr->picture_number, rsi->frame_restoration_type);
         //if (p == 1)
-        //    printf("POC:%i Cb restType:%i\n", pcs_ptr->picture_number, rsi->frame_restoration_type);
+        //    SVT_LOG("POC:%i Cb restType:%i\n", pcs_ptr->picture_number, rsi->frame_restoration_type);
         //if (p == 2)
-        //    printf("POC:%i Cr restType:%i\n", pcs_ptr->picture_number, rsi->frame_restoration_type);
+        //    SVT_LOG("POC:%i Cr restType:%i\n", pcs_ptr->picture_number, rsi->frame_restoration_type);
 
         if (rsi->frame_restoration_type != RESTORE_NONE) {
             all_none = 0;
@@ -3229,7 +3230,7 @@ static void encode_loopfilter(PictureParentControlSet *pcs_ptr, struct AomWriteB
     // ref frame (if they are enabled).
     eb_aom_wb_write_bit(wb, lf->mode_ref_delta_enabled);
     if (lf->mode_ref_delta_enabled) {
-        printf("ERROR[AN]: Loop Filter is not supported yet \n");
+        SVT_LOG("ERROR[AN]: Loop Filter is not supported yet \n");
         /* eb_aom_wb_write_bit(wb, lf->mode_ref_delta_update);
         if (lf->mode_ref_delta_update) {
         const int32_t prime_idx = pcs_ptr->primary_ref_frame;
@@ -3351,7 +3352,7 @@ static void write_tile_info_max_tile(const PictureParentControlSet *const pcs_pt
     }
     else {
         // Explicit tiles with configurable tile widths and heights
-        printf("ERROR[AN]:  NON uniform_tile_spacing_flag not supported yet\n");
+        SVT_LOG("ERROR[AN]:  NON uniform_tile_spacing_flag not supported yet\n");
         //// columns
         // int sb_size_log2 = pcs_ptr->sequence_control_set_ptr->seq_header.sb_size_log2;
         //for (i = 0; i < cm->tile_cols; i++) {
@@ -3610,7 +3611,7 @@ static void write_frame_size(PictureParentControlSet *pcs_ptr,
     //    eb_aom_wb_write_literal(wb, coded_height, num_bits_height);
     //}
     if (scs_ptr->seq_header.enable_superres) {
-        printf("ERROR[AN]: enable_superres not supported yet\n");
+        SVT_LOG("ERROR[AN]: enable_superres not supported yet\n");
         //write_superres_scale(cm, wb);
     }
 
@@ -3629,7 +3630,7 @@ static void write_bitdepth(SequenceControlSet *scs_ptr/*Av1Common *const cm*/,
     // Profile   2: [0] for 8 bit, [10] 10-bit, [11] - 12-bit
     eb_aom_wb_write_bit(wb, scs_ptr->static_config.encoder_bit_depth == EB_8BIT ? 0 : 1);
     if (scs_ptr->static_config.profile == PROFILE_2 && scs_ptr->static_config.encoder_bit_depth != EB_8BIT) {
-        printf("ERROR[AN]: Profile 2 Not supported\n");
+        SVT_LOG("ERROR[AN]: Profile 2 Not supported\n");
         eb_aom_wb_write_bit(wb, scs_ptr->static_config.encoder_bit_depth == EB_10BIT ? 0 : 1);
     }
 }
@@ -3656,7 +3657,7 @@ static void write_color_config(
         //eb_aom_wb_write_literal(wb, cm->matrix_coefficients, 8);
     }
     if (is_monochrome) {
-        printf("ERROR[AN]: is_monochrome not supported yet\n");
+        SVT_LOG("ERROR[AN]: is_monochrome not supported yet\n");
         return;
     }
     if (0/*cm->color_primaries == EB_CICP_CP_BT_709 &&
@@ -4047,7 +4048,7 @@ static void WriteGlobalMotion(
         }
         */
         /*
-        printf("Frame %d/%d: Enc Ref %d: %d %d %d %d\n",
+        SVT_LOG("Frame %d/%d: Enc Ref %d: %d %d %d %d\n",
         cm->current_video_frame, cm->show_frame, frame,
         cm->global_motion[frame].wmmat[0],
         cm->global_motion[frame].wmmat[1], cm->global_motion[frame].wmmat[2],
@@ -4186,7 +4187,7 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
     FrameHeader *frm_hdr = &pcs_ptr->frm_hdr;
     if (!scs_ptr->seq_header.reduced_still_picture_header) {
         if (showExisting) {
-            //printf("ERROR[AN]: show_existing_frame not supported yet\n");
+            //SVT_LOG("ERROR[AN]: show_existing_frame not supported yet\n");
             //RefCntBuffer *const frame_bufs = cm->buffer_pool->frame_bufs;
             //const int32_t frame_to_show = cm->ref_frame_map[cpi->show_existing_frame];
 
@@ -4200,7 +4201,7 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
             eb_aom_wb_write_bit(wb, 1);  // show_existing_frame
             eb_aom_wb_write_literal(wb, frm_hdr->show_existing_frame, 3);
             if (scs_ptr->seq_header.frame_id_numbers_present_flag) {
-                printf("ERROR[AN]: frame_id_numbers_present_flag not supported yet\n");
+                SVT_LOG("ERROR[AN]: frame_id_numbers_present_flag not supported yet\n");
                 /*int32_t frame_id_len = cm->seq_params.frame_id_length;
                 int32_t display_frame_id = cm->ref_frame_id[cpi->show_existing_frame];
                 eb_aom_wb_write_literal(wb, display_frame_id, frame_id_len);*/
@@ -4361,7 +4362,7 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
                         REF_FRAMES_LOG2);
 
                 if (scs_ptr->seq_header.frame_id_numbers_present_flag) {
-                    printf("ERROR[AN]: frame_id_numbers_present_flag not supported yet\n");
+                    SVT_LOG("ERROR[AN]: frame_id_numbers_present_flag not supported yet\n");
                     //int32_t i = get_ref_frame_map_idx(cpi, ref_frame);
                     //int32_t frame_id_len = cm->seq_params.frame_id_length;
                     //int32_t diff_len = cm->seq_params.delta_frame_id_length;
@@ -4378,7 +4379,7 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
             }
 
             if (!frm_hdr->error_resilient_mode && frame_size_override_flag) {
-                printf("ERROR[AN]: frame_size_override_flag not supported yet\n");
+                SVT_LOG("ERROR[AN]: frame_size_override_flag not supported yet\n");
                 //write_frame_size_with_refs(pcs_ptr, wb);
             }
             else
@@ -4441,7 +4442,7 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
                     pcs_ptr->prev_delta_lf[lf_id] = 0;
             }
 #else
-            printf("ERROR[AN]: delta_q_present_flag not supported yet\n");
+            SVT_LOG("ERROR[AN]: delta_q_present_flag not supported yet\n");
 #endif
             //                eb_aom_wb_write_literal(wb, OD_ILOG_NZ(frm_hdr->delta_q_params.delta_q_res) - 1, 2);
             //                xd->prev_qindex = frm_hdr->quantization_params.base_q_idx;
@@ -4461,7 +4462,7 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
         }
     }
     if (frm_hdr->all_lossless) {
-        printf("ERROR[AN]: all_lossless\n");
+        SVT_LOG("ERROR[AN]: all_lossless\n");
         //assert(av1_superres_unscaled(pcs_ptr));
     }
     else {
@@ -4494,7 +4495,7 @@ static void WriteUncompressedHeaderObu(SequenceControlSet *scs_ptr/*Av1Comp *cpi
     eb_aom_wb_write_bit(wb, frm_hdr->reduced_tx_set);
 
     if (!frame_is_intra_only(pcs_ptr)) {
-        //  printf("ERROR[AN]: Global motion not supported yet\n");
+        //  SVT_LOG("ERROR[AN]: Global motion not supported yet\n");
         WriteGlobalMotion(pcs_ptr, wb);
     }
     if (scs_ptr->seq_header.film_grain_params_present && (frm_hdr->show_frame || frm_hdr->showable_frame))
@@ -4579,7 +4580,7 @@ static uint32_t WriteSequenceHeaderObu(
     eb_aom_wb_write_bit(&wb, scs_ptr->seq_header.reduced_still_picture_header);
 
     if (scs_ptr->seq_header.reduced_still_picture_header) {
-        printf("ERROR[AN]: reduced_still_picture_hdr not supported\n");
+        SVT_LOG("ERROR[AN]: reduced_still_picture_hdr not supported\n");
         //write_bitstream_level(cm->seq_params.level[0], &wb);
     }
     else {
@@ -4587,7 +4588,7 @@ static uint32_t WriteSequenceHeaderObu(
 
         if (scs_ptr->seq_header.timing_info.timing_info_present) {
             // timing_info
-            printf("ERROR[AN]: timing_info_present not supported\n");
+            SVT_LOG("ERROR[AN]: timing_info_present not supported\n");
             /*write_timing_info_header(cm, &wb);
             eb_aom_wb_write_bit(&wb, cm->decoder_model_info_present_flag);
             if (cm->decoder_model_info_present_flag) write_decoder_model_info(cm, &wb);*/
@@ -4606,14 +4607,14 @@ static uint32_t WriteSequenceHeaderObu(
             if (scs_ptr->level[i].major > 3)
                 eb_aom_wb_write_bit(&wb, scs_ptr->seq_header.operating_point[i].seq_tier);
             if (scs_ptr->seq_header.decoder_model_info_present_flag) {
-                printf("ERROR[AN]: decoder_model_info_present_flag not supported\n");
+                SVT_LOG("ERROR[AN]: decoder_model_info_present_flag not supported\n");
                 //eb_aom_wb_write_bit(&wb,
                 //    cm->op_params[i].decoder_model_param_present_flag);
                 //if (cm->op_params[i].decoder_model_param_present_flag)
                 //    write_dec_model_op_parameters(cm, &wb, i);
             }
             if (scs_ptr->seq_header.initial_display_delay_present_flag) {
-                printf("ERROR[AN]: display_model_info_present_flag not supported\n");
+                SVT_LOG("ERROR[AN]: display_model_info_present_flag not supported\n");
                 //eb_aom_wb_write_bit(&wb,
                 //    cm->op_params[i].display_model_param_present_flag);
                 //if (cm->op_params[i].display_model_param_present_flag) {
@@ -4977,13 +4978,13 @@ static void loop_restoration_write_sb_coeffs(PictureControlSet     *piCSetPtr, F
         switch (unit_rtype) {
         case RESTORE_WIENER:
             write_wiener_filter(wiener_win, &rui->wiener_info, wiener_info, w);
-            //printf("POC:%i plane:%i v:%i %i %i  h:%i %i %i\n", piCSetPtr->picture_number, plane, rui->wiener_info.vfilter[0], rui->wiener_info.vfilter[1], rui->wiener_info.vfilter[2], rui->wiener_info.hfilter[0], rui->wiener_info.hfilter[1], rui->wiener_info.hfilter[2]);
+            //SVT_LOG("POC:%i plane:%i v:%i %i %i  h:%i %i %i\n", piCSetPtr->picture_number, plane, rui->wiener_info.vfilter[0], rui->wiener_info.vfilter[1], rui->wiener_info.vfilter[2], rui->wiener_info.hfilter[0], rui->wiener_info.hfilter[1], rui->wiener_info.hfilter[2]);
             break;
         case RESTORE_SGRPROJ:
             write_sgrproj_filter(&rui->sgrproj_info, sgrproj_info, w);
-            //printf("POC:%i plane:%i ep:%i xqd_0:%i  xqd_1:%i\n", piCSetPtr->picture_number, plane, rui->sgrproj_info.ep, rui->sgrproj_info.xqd[0], rui->sgrproj_info.xqd[1]);
+            //SVT_LOG("POC:%i plane:%i ep:%i xqd_0:%i  xqd_1:%i\n", piCSetPtr->picture_number, plane, rui->sgrproj_info.ep, rui->sgrproj_info.xqd[0], rui->sgrproj_info.xqd[1]);
             break;
-        default: assert(unit_rtype == RESTORE_NONE);// printf("POC:%i plane:%i OFF\n", piCSetPtr->picture_number, plane);
+        default: assert(unit_rtype == RESTORE_NONE);// SVT_LOG("POC:%i plane:%i OFF\n", piCSetPtr->picture_number, plane);
             break;
         }
     }
@@ -4995,10 +4996,10 @@ static void loop_restoration_write_sb_coeffs(PictureControlSet     *piCSetPtr, F
 #endif
         if (unit_rtype != RESTORE_NONE) {
             write_wiener_filter(wiener_win, &rui->wiener_info, wiener_info, w);
-            //printf("POC:%i plane:%i v:%i %i %i  h:%i %i %i\n", piCSetPtr->picture_number, plane, rui->wiener_info.vfilter[0], rui->wiener_info.vfilter[1], rui->wiener_info.vfilter[2], rui->wiener_info.hfilter[0], rui->wiener_info.hfilter[1], rui->wiener_info.hfilter[2]);
+            //SVT_LOG("POC:%i plane:%i v:%i %i %i  h:%i %i %i\n", piCSetPtr->picture_number, plane, rui->wiener_info.vfilter[0], rui->wiener_info.vfilter[1], rui->wiener_info.vfilter[2], rui->wiener_info.hfilter[0], rui->wiener_info.hfilter[1], rui->wiener_info.hfilter[2]);
         }
         //else
-            //printf("POC:%i plane:%i OFF\n", piCSetPtr->picture_number, plane);
+            //SVT_LOG("POC:%i plane:%i OFF\n", piCSetPtr->picture_number, plane);
     }
     else if (frame_rtype == RESTORE_SGRPROJ) {
         aom_write_symbol(w, unit_rtype != RESTORE_NONE,
@@ -5008,10 +5009,10 @@ static void loop_restoration_write_sb_coeffs(PictureControlSet     *piCSetPtr, F
 #endif
         if (unit_rtype != RESTORE_NONE) {
             write_sgrproj_filter(&rui->sgrproj_info, sgrproj_info, w);
-            //printf("POC:%i plane:%i ep:%i xqd_0:%i  xqd_1:%i\n", piCSetPtr->picture_number, plane, rui->sgrproj_info.ep, rui->sgrproj_info.xqd[0], rui->sgrproj_info.xqd[1]);
+            //SVT_LOG("POC:%i plane:%i ep:%i xqd_0:%i  xqd_1:%i\n", piCSetPtr->picture_number, plane, rui->sgrproj_info.ep, rui->sgrproj_info.xqd[0], rui->sgrproj_info.xqd[1]);
         }
         //else
-        //    printf("POC:%i plane:%i OFF\n", piCSetPtr->picture_number, plane);
+        //    SVT_LOG("POC:%i plane:%i OFF\n", piCSetPtr->picture_number, plane);
     }
 }
 
@@ -5967,7 +5968,7 @@ void write_inter_segment_id(PictureControlSet *picture_control_set_ptr,
                 write_segment_id(picture_control_set_ptr, frameContext, ecWriter, blockGeom->bsize, blkOriginX,
                                  blkOriginY, cu_ptr, 1);
                 if (segmentationParams->segmentation_temporal_update){
-                    printf("ERROR: Temporal update is not supported yet! \n");
+                    SVT_LOG("ERROR: Temporal update is not supported yet! \n");
                     assert(0);
 //                    cu_ptr->seg_id_predicted = 0;
                 }
@@ -5976,7 +5977,7 @@ void write_inter_segment_id(PictureControlSet *picture_control_set_ptr,
         }
 
         if (segmentationParams->segmentation_temporal_update) {
-            printf("ERROR: Temporal update is not supported yet! \n");
+            SVT_LOG("ERROR: Temporal update is not supported yet! \n");
             assert(0);
 //            const int pred_flag = cu_ptr->seg_id_predicted;
 //            aom_cdf_prob *pred_cdf = av1_get_pred_cdf_seg_id(picture_control_set_ptr, frameContext, cu_ptr, blkOriginX, blkOriginY);
@@ -6130,7 +6131,7 @@ assert(bsize < BlockSizeS_ALL);
                     reduced_delta_qindex,
                     ec_writer);
                 /*if (picture_control_set_ptr->picture_number == 0){
-                printf("%d\t%d\t%d\t%d\n",
+                SVT_LOG("%d\t%d\t%d\t%d\n",
                 blkOriginX,
                 blkOriginY,
                 current_q_index,
@@ -6273,7 +6274,7 @@ assert(bsize < BlockSizeS_ALL);
                 skip_flag_neighbor_array);
         }
         if (!picture_control_set_ptr->parent_pcs_ptr->skip_mode_flag && cu_ptr->skip_flag)
-            printf("ERROR[AN]: SKIP not supported\n");
+            SVT_LOG("ERROR[AN]: SKIP not supported\n");
         if (!cu_ptr->skip_flag) {
             //const int32_t skip = write_skip(cm, xd, mbmi->segment_id, mi, w);
             EncodeSkipCoeffAv1(

--- a/Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c
@@ -25,6 +25,7 @@
 #include "EbEntropyCodingResults.h"
 #include "EbRateControlTasks.h"
 #include "EbCabacContextModel.h"
+#include "EbLog.h"
 #define  AV1_MIN_TILE_SIZE_BYTES 1
 void eb_av1_reset_loop_restoration(PictureControlSet     *piCSetPtr);
 
@@ -394,7 +395,7 @@ void write_stat_to_file(
     eb_block_on_mutex(sequence_control_set_ptr->encode_context_ptr->stat_file_mutex);
     int32_t fseek_return_value = fseek(sequence_control_set_ptr->static_config.output_stat_file, (long)ref_poc * sizeof(stat_struct_t), SEEK_SET);
     if (fseek_return_value != 0)
-        printf("Error in fseek  returnVal %i\n", fseek_return_value);
+        SVT_LOG("Error in fseek  returnVal %i\n", fseek_return_value);
     fwrite(&stat_struct,
         sizeof(stat_struct_t),
         (size_t)1,

--- a/Source/Lib/Encoder/Codec/EbFullLoop.c
+++ b/Source/Lib/Encoder/Codec/EbFullLoop.c
@@ -185,7 +185,7 @@ void eb_quantize_b_helper_c(
             const int32_t coeff = coeff_ptr[rc] * wt;
 
             ////if (mapRc != NewTab[rc])
-            //printf("%d\n", coeff);
+            //SVT_LOG("%d\n", coeff);
 
             if (coeff < (zbins[rc != 0] * (1 << AOM_QM_BITS)) &&
                 coeff >(nzbins[rc != 0] * (1 << AOM_QM_BITS)))

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -969,7 +969,7 @@ void UpdateMotionFieldUniformityOverTime(
     uint32_t                                inputQueueIndex;
     uint32_t                              NoFramesToCheck;
     uint32_t                                framesToCheckIndex;
-    //printf("To update POC %d\tframesInSw = %d\n", picture_control_set_ptr->picture_number, picture_control_set_ptr->frames_in_sw);
+    //SVT_LOG("To update POC %d\tframesInSw = %d\n", picture_control_set_ptr->picture_number, picture_control_set_ptr->frames_in_sw);
 
     //Check conditions for statinary edge over time
     StationaryEdgeOverUpdateOverTimeLcuPart2(
@@ -1064,7 +1064,7 @@ void GetHistogramQueueData(
         sizeof(uint16_t) * NUMBER_OF_INTRA_SAD_INTERVALS);
 
     eb_release_mutex(sequence_control_set_ptr->encode_context_ptr->hl_rate_control_historgram_queue_mutex);
-    //printf("Test1 POC: %d\t POC: %d\t LifeCount: %d\n", histogramQueueEntryPtr->picture_number, picture_control_set_ptr->picture_number,  histogramQueueEntryPtr->life_count);
+    //SVT_LOG("Test1 POC: %d\t POC: %d\t LifeCount: %d\n", histogramQueueEntryPtr->picture_number, picture_control_set_ptr->picture_number,  histogramQueueEntryPtr->life_count);
 
     return;
 }

--- a/Source/Lib/Encoder/Codec/EbMdRateEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMdRateEstimation.c
@@ -413,20 +413,20 @@ void av1_estimate_coefficients_rate(
                 int32_t prev_cost = 0;
                 int32_t i, j;
                 av1_get_syntax_rate_from_cdf(br_rate, fc->coeff_br_cdf[tx_size][plane][ctx], NULL);
-                // printf("br_rate: ");
+                // SVT_LOG("br_rate: ");
                 // for(j = 0; j < BR_CDF_SIZE; j++)
-                //  printf("%4d ", br_rate[j]);
-                // printf("\n");
+                //  SVT_LOG("%4d ", br_rate[j]);
+                // SVT_LOG("\n");
                 for (i = 0; i < COEFF_BASE_RANGE; i += BR_CDF_SIZE - 1) {
                     for (j = 0; j < BR_CDF_SIZE - 1; j++)
                         pcost->lps_cost[ctx][i + j] = prev_cost + br_rate[j];
                     prev_cost += br_rate[j];
                 }
                 pcost->lps_cost[ctx][i] = prev_cost;
-                // printf("lps_cost: %d %d %2d : ", tx_size, plane, ctx);
+                // SVT_LOG("lps_cost: %d %d %2d : ", tx_size, plane, ctx);
                 // for (i = 0; i <= COEFF_BASE_RANGE; i++)
-                //  printf("%5d ", pcost->lps_cost[ctx][i]);
-                // printf("\n");
+                //  SVT_LOG("%5d ", pcost->lps_cost[ctx][i]);
+                // SVT_LOG("\n");
             }
             for (int ctx = 0; ctx < LEVEL_CONTEXTS; ++ctx) {
                 pcost->lps_cost[ctx][0 + COEFF_BASE_RANGE + 1] =

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -35,7 +35,8 @@
 #include "EbRateDistortionCost.h"
 #endif
 #include "aom_dsp_rtcd.h"
-#define  INCRMENT_CAND_TOTAL_COUNT(cnt) MULTI_LINE_MACRO_BEGIN cnt++; if(cnt>=MODE_DECISION_CANDIDATE_MAX_COUNT) printf(" ERROR: reaching limit for MODE_DECISION_CANDIDATE_MAX_COUNT %i\n",cnt); MULTI_LINE_MACRO_END
+#include "EbLog.h"
+#define  INCRMENT_CAND_TOTAL_COUNT(cnt) MULTI_LINE_MACRO_BEGIN cnt++; if(cnt>=MODE_DECISION_CANDIDATE_MAX_COUNT) SVT_LOG(" ERROR: reaching limit for MODE_DECISION_CANDIDATE_MAX_COUNT %i\n",cnt); MULTI_LINE_MACRO_END
 
 int8_t av1_ref_frame_type(const MvReferenceFrame *const rf);
 int av1_filter_intra_allowed_bsize(uint8_t enable_filter_intra, BlockSize bs);
@@ -592,7 +593,7 @@ void determine_compound_mode(
         candidatePtr->interinter_comp.wedge_sign = candidatePtr->interinter_comp.wedge_sign;
     }
     else {
-        printf("ERROR: not used comp type\n");
+        SVT_LOG("ERROR: not used comp type\n");
     }
 }
 
@@ -4587,7 +4588,7 @@ static INLINE int mv_check_bounds(const MvLimits *mv_limits, const MV *mv) {
 void assert_release(int statement)
 {
     if (statement == 0)
-        printf("ASSERT_ERRRR\n");
+        SVT_LOG("ASSERT_ERRRR\n");
 }
 
 void  intra_bc_search(
@@ -5684,7 +5685,7 @@ uint32_t product_full_mode_decision(
         cu_ptr->comp_group_idx = candidate_ptr->comp_group_idx;
         if (cu_ptr->interinter_comp.type == COMPOUND_AVERAGE){
             if (cu_ptr->comp_group_idx != 0 || cu_ptr->compound_idx != 1)
-                printf("Error: Compound combination not allowed\n");
+                SVT_LOG("Error: Compound combination not allowed\n");
         }
     }
 #if II_COMP_FLAG

--- a/Source/Lib/Encoder/Codec/EbModeDecisionConfiguration.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionConfiguration.c
@@ -13,6 +13,8 @@
 #include "aom_dsp_rtcd.h"
 #include "EbAdaptiveMotionVectorPrediction.h"
 #endif
+
+#include "EbLog.h"
 /********************************************
  * Constants
  ********************************************/

--- a/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
@@ -29,6 +29,7 @@
 #include "av1me.h"
 #include "EbCommonUtils.h"
 #include "EbQMatrices.h"
+#include "EbLog.h"
 
 #define MAX_MESH_SPEED 5  // Max speed setting for mesh motion method
 static MeshPattern
@@ -663,7 +664,7 @@ void set_reference_sg_ep(
         cm->sg_ref_frame_ep[1] = 0;
         break;
     default:
-        printf("SG: Not supported picture type");
+        SVT_LOG("SG: Not supported picture type");
         break;
     }
 }
@@ -696,7 +697,7 @@ void set_reference_cdef_strength(
         picture_control_set_ptr->parent_pcs_ptr->cdf_ref_frame_strenght = strength;
         break;
     default:
-        printf("CDEF: Not supported picture type");
+        SVT_LOG("CDEF: Not supported picture type");
         break;
     }
 }
@@ -1338,7 +1339,7 @@ uint8_t update_mdc_level(
     else if (s_depth == 0 && e_depth == 3)
         adjusted_depth_level = 3; // Pred + 3
     else
-        printf("Error: unvalid s_depth && e_depth");
+        SVT_LOG("Error: unvalid s_depth && e_depth");
 
     switch (adjusted_depth_level) {
     case 0:
@@ -1390,7 +1391,7 @@ uint8_t update_mdc_level(
         depth_refinement_mode = Predm3p1;
         break;
     default:
-        printf("Not supported refined mdc_depth_level");
+        SVT_LOG("Not supported refined mdc_depth_level");
         break;
     }
     return depth_refinement_mode;
@@ -1448,7 +1449,7 @@ void init_considered_block(
         depth_refinement_mode = AllD;
         break;
     default:
-        printf("not supported mdc_depth_level");
+        SVT_LOG("not supported mdc_depth_level");
         break;
     }
 #endif
@@ -1962,7 +1963,7 @@ void init_considered_block(
                     }
                     break;
                 default:
-                    printf("Error! invalid mdc_refinement_mode\n");
+                    SVT_LOG("Error! invalid mdc_refinement_mode\n");
                     break;
                 }
             }
@@ -2295,7 +2296,7 @@ void derive_search_method(
         else if (picture_control_set_ptr->parent_pcs_ptr->sb_depth_mode_array[sb_index] == SB_PRED_OPEN_LOOP_DEPTH_MODE)
             sequence_control_set_ptr->pred1_nfl_count[picture_control_set_ptr->parent_pcs_ptr->temporal_layer_index]  ++;
         else
-            SVT_LOG("error");
+            SVT_ERROR("error");
     }
 #endif
 }
@@ -2550,7 +2551,7 @@ void set_target_budget_oq(
         budget_per_sb = (((context_ptr->sb_average_score - MEDIUM_SB_SCORE) * (U_150 - U_125)) / (HIGH_SB_SCORE - MEDIUM_SB_SCORE)) + U_125;
     budget_per_sb = CLIP3(SB_PRED_OPEN_LOOP_COST, U_150, budget_per_sb + budget_per_sb_boost[context_ptr->adp_level] + luminosity_change_boost);
 
-    //printf("picture_number = %d\tsb_average_score = %d\n", picture_control_set_ptr->picture_number, budget_per_sb);
+    //SVT_LOG("picture_number = %d\tsb_average_score = %d\n", picture_control_set_ptr->picture_number, budget_per_sb);
     budget = sequence_control_set_ptr->sb_tot_cnt * budget_per_sb;
 
     context_ptr->budget = budget;

--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -23,6 +23,8 @@
 #include "EbIntraPrediction.h"
 #include "EbLambdaRateTables.h"
 
+#include "EbLog.h"
+
 #define OIS_TH_COUNT 4
 
 int32_t OisPointTh[3][MAX_TEMPORAL_LAYERS][OIS_TH_COUNT] = {
@@ -13460,7 +13462,7 @@ static void hme_mv_center_check(EbPictureBufferDesc *ref_pic_ptr,
     }
 
     else
-        SVT_LOG("error no center selected");
+        SVT_ERROR("no center selected");
     *xsc = search_center_x;
     *ysc = search_center_y;
 }

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -874,7 +874,7 @@ void* motion_estimation_kernel(void *input_ptr)
                             if (sb_width == BLOCK_SIZE_64 && sb_height == BLOCK_SIZE_64) {
                                 sadIntervalIndex = (uint16_t)(picture_control_set_ptr->rc_me_distortion[sb_index] >> (12 - SAD_PRECISION_INTERVAL));//change 12 to 2*log2(64)
 
-                                // printf("%d\n", sadIntervalIndex);
+                                // SVT_LOG("%d\n", sadIntervalIndex);
 
                                 sadIntervalIndex = (uint16_t)(sadIntervalIndex >> 2);
                                 if (sadIntervalIndex > (NUMBER_OF_SAD_INTERVALS >> 1) - 1) {

--- a/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
@@ -586,7 +586,7 @@ void* packetization_kernel(void *input_ptr)
                             uint8_t dpb_spot = queueEntryPtr->av1RefSignal.refDpbIndex[rr];
 
                             if (queueEntryPtr->ref_poc_array[rr] != context_ptr->dpbDispOrder[dpb_spot])
-                                printf("REF_POC MISMATCH POC:%i  ref:%i\n", (int32_t)queueEntryPtr->poc, rr);
+                                SVT_LOG("REF_POC MISMATCH POC:%i  ref:%i\n", (int32_t)queueEntryPtr->poc, rr);
                         }
                     }
                     else
@@ -595,7 +595,7 @@ void* packetization_kernel(void *input_ptr)
                             SVT_LOG("%i  %i  %c   showEx: %i ----INTRA---- %i frames \n", (int32_t)queueEntryPtr->picture_number, (int32_t)queueEntryPtr->poc,
                                 showTab[queueEntryPtr->show_frame], (int32_t)context_ptr->dpb_disp_order[queueEntryPtr->show_existing_frame], (int32_t)context_ptr->tot_shown_frames);
                         else
-                            printf("%i  %i  %c   ----INTRA---- %i frames\n", (int32_t)queueEntryPtr->picture_number, (int32_t)queueEntryPtr->poc,
+                            SVT_LOG("%i  %i  %c   ----INTRA---- %i frames\n", (int32_t)queueEntryPtr->picture_number, (int32_t)queueEntryPtr->poc,
                             (int32_t)showTab[queueEntryPtr->show_frame], (int32_t)context_ptr->tot_shown_frames);
                     }
 

--- a/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
@@ -2995,7 +2995,7 @@ EbErrorType SubSampleFilterNoise(
 
                 if (denBlkVar<denBlkVarTh && noiseBlkVar> noiseBlkVarTh) {
                     picture_control_set_ptr->sb_flat_noise_array[lcuCodingOrder] = 1;
-                    //printf("POC %i (%i,%i) denBlkVar: %i  noiseBlkVar :%i\n", picture_control_set_ptr->picture_number,sb_origin_x,sb_origin_y, denBlkVar, noiseBlkVar);
+                    //SVT_LOG("POC %i (%i,%i) denBlkVar: %i  noiseBlkVar :%i\n", picture_control_set_ptr->picture_number,sb_origin_x,sb_origin_y, denBlkVar, noiseBlkVar);
                     newTotFN++;
                 }
                 else

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -25,7 +25,7 @@
 #include "EbTemporalFiltering.h"
 #include "EbObject.h"
 #include "EbUtility.h"
-
+#include "EbLog.h"
 
 /************************************************
  * Defines
@@ -452,27 +452,27 @@ EbBool SceneTransitionDetector(
 
                 if (aidFuturePast < FLASH_TH && aidFuturePresent >= FLASH_TH && aidPresentPast >= FLASH_TH) {
                     isFlash = EB_TRUE;
-                    //printf ("\nFlash in frame# %i , %i\n", currentPictureControlSetPtr->picture_number,aidFuturePast);
+                    //SVT_LOG ("\nFlash in frame# %i , %i\n", currentPictureControlSetPtr->picture_number,aidFuturePast);
                 }
                 else if (aidFuturePresent < FADE_TH && aidPresentPast < FADE_TH) {
                     isFade = EB_TRUE;
-                    //printf ("\nFlash in frame# %i , %i\n", currentPictureControlSetPtr->picture_number,aidFuturePast);
+                    //SVT_LOG ("\nFlash in frame# %i , %i\n", currentPictureControlSetPtr->picture_number,aidFuturePast);
                 }
                 else {
                     is_scene_change = EB_TRUE;
-                    //printf ("\nScene Change in frame# %i , %i\n", currentPictureControlSetPtr->picture_number,aidFuturePast);
+                    //SVT_LOG ("\nScene Change in frame# %i , %i\n", currentPictureControlSetPtr->picture_number,aidFuturePast);
                 }
             }
             else if (gradualChange) {
                 aidFuturePast = (uint8_t)ABS((int16_t)futurePictureControlSetPtr->average_intensity_per_region[regionInPictureWidthIndex][regionInPictureHeightIndex][0] - (int16_t)previousPictureControlSetPtr->average_intensity_per_region[regionInPictureWidthIndex][regionInPictureHeightIndex][0]);
                 if (aidFuturePast < FLASH_TH) {
                     // proper action to be signalled
-                    //printf ("\nLight Flash in frame# %i , %i\n", currentPictureControlSetPtr->picture_number,aidFuturePast);
+                    //SVT_LOG ("\nLight Flash in frame# %i , %i\n", currentPictureControlSetPtr->picture_number,aidFuturePast);
                     ahd_running_avg[regionInPictureWidthIndex][regionInPictureHeightIndex] = (3 * ahd_running_avg[regionInPictureWidthIndex][regionInPictureHeightIndex] + ahd) / 4;
                 }
                 else {
                     // proper action to be signalled
-                    //printf ("\nLight Scene Change / fade detected in frame# %i , %i\n", currentPictureControlSetPtr->picture_number,aidFuturePast);
+                    //SVT_LOG ("\nLight Scene Change / fade detected in frame# %i , %i\n", currentPictureControlSetPtr->picture_number,aidFuturePast);
                     ahd_running_avg[regionInPictureWidthIndex][regionInPictureHeightIndex] = (3 * ahd_running_avg[regionInPictureWidthIndex][regionInPictureHeightIndex] + ahd) / 4;
                 }
             }
@@ -1104,7 +1104,7 @@ EbErrorType signal_derivation_multi_processes_oq(
         picture_control_set_ptr->nsq_max_shapes_md = 6;
         break;
     default:
-        printf("nsq_search_level is not supported\n");
+        SVT_LOG("nsq_search_level is not supported\n");
         break;
     }
 
@@ -1591,7 +1591,7 @@ static void set_all_ref_frame_type(SequenceControlSet *sequence_control_set_ptr,
     MvReferenceFrame rf[2];
     *tot_ref_frames = 0;
 
-    //printf("POC %i  totRef L0:%i   totRef L1: %i\n", parent_pcs_ptr->picture_number, parent_pcs_ptr->ref_list0_count, parent_pcs_ptr->ref_list1_count);
+    //SVT_LOG("POC %i  totRef L0:%i   totRef L1: %i\n", parent_pcs_ptr->picture_number, parent_pcs_ptr->ref_list0_count, parent_pcs_ptr->ref_list1_count);
 
     //single ref - List0
     for (uint8_t ref_idx0 = 0; ref_idx0 < parent_pcs_ptr->ref_list0_count; ++ref_idx0) {
@@ -1706,7 +1706,7 @@ static EbBool set_frame_display_params(
             }
         } else {
             if (context_ptr->mini_gop_length[0] != picture_control_set_ptr->pred_struct_ptr->pred_struct_period) {
-                printf("Error in GOP indexing3\n");
+                SVT_LOG("Error in GOP indexing3\n");
             }
             // Handle B frame of Random Access out
             return EB_FALSE;
@@ -1872,7 +1872,7 @@ static void  Av1GenerateRpsInfo(
             break;
 
         default:
-            printf("Error: unexpected picture mini Gop number\n");
+            SVT_LOG("Error: unexpected picture mini Gop number\n");
             break;
         }
 
@@ -1889,7 +1889,7 @@ static void  Av1GenerateRpsInfo(
                 if (picture_index == 0)
                     frm_hdr->show_existing_frame = base2_idx;
                 else
-                    printf("Error in GOP indexing for hierarchical level %d\n", picture_control_set_ptr->hierarchical_levels);
+                    SVT_LOG("Error in GOP indexing for hierarchical level %d\n", picture_control_set_ptr->hierarchical_levels);
             }
         }
 
@@ -2036,7 +2036,7 @@ static void  Av1GenerateRpsInfo(
                     av1_rps->ref_poc_array[ALT] = av1_rps->ref_poc_array[BWD];
                 }
                 else
-                    printf("Error in GOp indexing\n");
+                    SVT_LOG("Error in GOp indexing\n");
             }
 
             if (picture_index == 0 )
@@ -2046,7 +2046,7 @@ static void  Av1GenerateRpsInfo(
             break;
 
         default:
-            printf("Error: unexpected picture mini Gop number\n");
+            SVT_LOG("Error: unexpected picture mini Gop number\n");
             break;
         }
 
@@ -2065,7 +2065,7 @@ static void  Av1GenerateRpsInfo(
                 else if (picture_index == 2)
                     frm_hdr->show_existing_frame = base2_idx;
                 else
-                    printf("Error in GOP indexing for hierarchical level %d\n", picture_control_set_ptr->hierarchical_levels);
+                    SVT_LOG("Error in GOP indexing for hierarchical level %d\n", picture_control_set_ptr->hierarchical_levels);
             }
         }
 
@@ -2349,7 +2349,7 @@ static void  Av1GenerateRpsInfo(
                 av1_rps->ref_poc_array[ALT] = av1_rps->ref_poc_array[BWD];
             }
             else
-                printf("Error in GOp indexing\n");
+                SVT_LOG("Error in GOp indexing\n");
             if (picture_index == 0)
                 av1_rps->refresh_frame_mask = 1 << (lay3_idx);
             else
@@ -2357,7 +2357,7 @@ static void  Av1GenerateRpsInfo(
             break;
 
         default:
-            printf("Error: unexpected picture mini Gop number\n");
+            SVT_LOG("Error: unexpected picture mini Gop number\n");
             break;
         }
 
@@ -2381,7 +2381,7 @@ static void  Av1GenerateRpsInfo(
                 else if (picture_index == 6)
                     frm_hdr->show_existing_frame = base2_idx;
                 else
-                    printf("Error in GOP indexing for hierarchical level %d\n", picture_control_set_ptr->hierarchical_levels);
+                    SVT_LOG("Error in GOP indexing for hierarchical level %d\n", picture_control_set_ptr->hierarchical_levels);
             }
         }
 
@@ -2639,7 +2639,7 @@ static void  Av1GenerateRpsInfo(
                 av1_rps->ref_poc_array[ALT] = av1_rps->ref_poc_array[BWD];
             }
             else
-                printf("Error in GOp indexing\n");
+                SVT_LOG("Error in GOp indexing\n");
             av1_rps->refresh_frame_mask = 1 << (lay3_idx);
             break;
 
@@ -2826,7 +2826,7 @@ static void  Av1GenerateRpsInfo(
                 av1_rps->ref_poc_array[ALT] = av1_rps->ref_poc_array[BWD];
             }
             else
-                printf("Error in GOp indexing\n");
+                SVT_LOG("Error in GOp indexing\n");
             if (picture_index == 0 || picture_index == 8)
                 av1_rps->refresh_frame_mask = 1 << (lay4_idx);
             else
@@ -2834,7 +2834,7 @@ static void  Av1GenerateRpsInfo(
             break;
 
         default:
-            printf("Error: unexpected picture mini Gop number\n");
+            SVT_LOG("Error: unexpected picture mini Gop number\n");
             break;
         }
 
@@ -2867,7 +2867,7 @@ static void  Av1GenerateRpsInfo(
                 else if (picture_index == 14)
                     frm_hdr->show_existing_frame = base2_idx;
                 else
-                    printf("Error in GOP indexing for hierarchical level %d\n", picture_control_set_ptr->hierarchical_levels);
+                    SVT_LOG("Error in GOP indexing for hierarchical level %d\n", picture_control_set_ptr->hierarchical_levels);
             }
         }
 
@@ -2888,7 +2888,7 @@ static void  Av1GenerateRpsInfo(
             context_ptr->lay1_toggle = 1 - context_ptr->lay1_toggle;
         }
     } else {
-        printf("Error: Not supported GOP structure!");
+        SVT_LOG("Error: Not supported GOP structure!");
         exit(0);
     }
 }
@@ -3848,7 +3848,7 @@ void* picture_decision_kernel(void *input_ptr)
                                             break;
                                     }
                                     picture_control_set_ptr->future_altref_nframes = pic_itr - index_center;
-                                    //printf("\nPOC %d\t PAST %d\t FUTURE %d\n", picture_control_set_ptr->picture_number, picture_control_set_ptr->past_altref_nframes, picture_control_set_ptr->future_altref_nframes);
+                                    //SVT_LOG("\nPOC %d\t PAST %d\t FUTURE %d\n", picture_control_set_ptr->picture_number, picture_control_set_ptr->past_altref_nframes, picture_control_set_ptr->future_altref_nframes);
                                 }
                                 else
                                 {
@@ -3918,7 +3918,7 @@ void* picture_decision_kernel(void *input_ptr)
                                         break;
                                 }
                                 picture_control_set_ptr->future_altref_nframes = pic_itr - index_center;
-                                //printf("\nPOC %d\t PAST %d\t FUTURE %d\n", picture_control_set_ptr->picture_number, picture_control_set_ptr->past_altref_nframes, picture_control_set_ptr->future_altref_nframes);
+                                //SVT_LOG("\nPOC %d\t PAST %d\t FUTURE %d\n", picture_control_set_ptr->picture_number, picture_control_set_ptr->past_altref_nframes, picture_control_set_ptr->future_altref_nframes);
 
                                 // adjust the temporal filtering pcs buffer to remove unused past pictures
                                 if(actual_past_pics != num_past_pics) {
@@ -4105,7 +4105,7 @@ void* picture_decision_kernel(void *input_ptr)
 
                             picture_control_set_ptr->is_skip_mode_allowed = frm_hdr->skip_mode_params.skip_mode_allowed;
                             picture_control_set_ptr->skip_mode_flag = picture_control_set_ptr->is_skip_mode_allowed;
-                            //printf("POC:%i  skip_mode_allowed:%i  REF_SKIP_0: %i   REF_SKIP_1: %i \n",picture_control_set_ptr->picture_number, picture_control_set_ptr->skip_mode_info.skip_mode_allowed, picture_control_set_ptr->skip_mode_info.ref_frame_idx_0, picture_control_set_ptr->skip_mode_info.ref_frame_idx_1);
+                            //SVT_LOG("POC:%i  skip_mode_allowed:%i  REF_SKIP_0: %i   REF_SKIP_1: %i \n",picture_control_set_ptr->picture_number, picture_control_set_ptr->skip_mode_info.skip_mode_allowed, picture_control_set_ptr->skip_mode_info.ref_frame_idx_0, picture_control_set_ptr->skip_mode_info.ref_frame_idx_1);
 
                             {
                                 picture_control_set_ptr->intensity_transition_flag = EB_FALSE;

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -179,7 +179,7 @@ void* picture_manager_kernel(void *input_ptr)
             sequence_control_set_ptr = (SequenceControlSet*)picture_control_set_ptr->sequence_control_set_wrapper_ptr->object_ptr;
             encode_context_ptr = sequence_control_set_ptr->encode_context_ptr;
 
-            //printf("\nPicture Manager Process @ %d \n ", picture_control_set_ptr->picture_number);
+            //SVT_LOG("\nPicture Manager Process @ %d \n ", picture_control_set_ptr->picture_number);
 
             queueEntryIndex = (int32_t)(picture_control_set_ptr->picture_number_alt - encode_context_ptr->picture_manager_reorder_queue[encode_context_ptr->picture_manager_reorder_queue_head_index]->picture_number);
             queueEntryIndex += encode_context_ptr->picture_manager_reorder_queue_head_index;

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -34,6 +34,7 @@
 #include "aom_dsp_rtcd.h"
 #include "partition_model_weights.h"
 #include "ml.h"
+#include "EbLog.h"
 
 EbErrorType generate_md_stage_0_cand(
     SuperBlock          *sb_ptr,
@@ -1099,8 +1100,8 @@ void picture_addition_kernel(
     uint32_t          row_index = 0;
     //    const int32_t    maxValue = 0xFF;
 
-        //printf("\n");
-        //printf("Reconstruction---------------------------------------------------\n");
+        //SVT_LOG("\n");
+        //SVT_LOG("Reconstruction---------------------------------------------------\n");
 
     while (row_index < height) {
         columnIndex = 0;
@@ -1109,19 +1110,19 @@ void picture_addition_kernel(
             uint16_t rec = (uint16_t)pred_ptr[columnIndex];
             recon_ptr[columnIndex] = (uint8_t)highbd_clip_pixel_add(rec, (TranLow)residual_ptr[columnIndex], bd);
 
-            //printf("%d\t", recon_ptr[columnIndex]);
+            //SVT_LOG("%d\t", recon_ptr[columnIndex]);
             ++columnIndex;
         }
 
-        //printf("\n");
+        //SVT_LOG("\n");
         residual_ptr += residual_stride;
         pred_ptr += pred_stride;
         recon_ptr += recon_stride;
         ++row_index;
     }
-    //printf("-----------------------------------------------------------------\n");
-    //printf("\n");
-    //printf("\n");
+    //SVT_LOG("-----------------------------------------------------------------\n");
+    //SVT_LOG("\n");
+    //SVT_LOG("\n");
     return;
 }
 
@@ -1140,8 +1141,8 @@ void picture_addition_kernel16_bit(
     uint32_t          row_index = 0;
     //    const int32_t    maxValue = 0xFF;
 
-        //printf("\n");
-        //printf("Reconstruction---------------------------------------------------\n");
+        //SVT_LOG("\n");
+        //SVT_LOG("Reconstruction---------------------------------------------------\n");
 
     while (row_index < height) {
         columnIndex = 0;
@@ -1150,19 +1151,19 @@ void picture_addition_kernel16_bit(
             uint16_t rec = (uint16_t)pred_ptr[columnIndex];
             recon_ptr[columnIndex] = highbd_clip_pixel_add(rec, (TranLow)residual_ptr[columnIndex], bd);
 
-            //printf("%d\t", recon_ptr[columnIndex]);
+            //SVT_LOG("%d\t", recon_ptr[columnIndex]);
             ++columnIndex;
         }
 
-        //printf("\n");
+        //SVT_LOG("\n");
         residual_ptr += residual_stride;
         pred_ptr += pred_stride;
         recon_ptr += recon_stride;
         ++row_index;
     }
-    //    printf("-----------------------------------------------------------------\n");
-    //    printf("\n");
-    //    printf("\n");
+    //    SVT_LOG("-----------------------------------------------------------------\n");
+    //    SVT_LOG("\n");
+    //    SVT_LOG("\n");
     return;
 }
 
@@ -5224,7 +5225,7 @@ void move_cu_data(
             if(dst_cu->palette_info.color_idx_map != NULL)
                  memcpy(dst_cu->palette_info.color_idx_map, src_cu->palette_info.color_idx_map, MAX_PALETTE_SQUARE);
             else
-                printf("ERROR palette:Not-Enough-Memory\n");
+                SVT_LOG("ERROR palette:Not-Enough-Memory\n");
         }
 #endif
 #if OBMC_FLAG
@@ -5823,7 +5824,7 @@ uint8_t get_part_side(
         break;
     default:
         return 255;
-        printf("error: non supported partition!!\n");
+        SVT_LOG("error: non supported partition!!\n");
         break;
     }
 }
@@ -5852,7 +5853,7 @@ PART get_partition_shape(
         else if (left_size < height)
             part = PART_H;
         else
-            printf("error: unsupported left_size\n");
+            SVT_LOG("error: unsupported left_size\n");
     }
     else if (left_size > height) {
         if (above_size == width)
@@ -5862,7 +5863,7 @@ PART get_partition_shape(
         else if (above_size < width)
             part = PART_V;
         else
-            printf("error: unsupported above_size\n");
+            SVT_LOG("error: unsupported above_size\n");
     }
     else if (above_size < width) {
         if (left_size == height)
@@ -5870,7 +5871,7 @@ PART get_partition_shape(
         else if (left_size < height)
             part = PART_S;
         else
-            printf("error: unsupported left_size\n");
+            SVT_LOG("error: unsupported left_size\n");
     }
     else if (left_size < height) {
         if (above_size == width)
@@ -5878,22 +5879,22 @@ PART get_partition_shape(
         else if (above_size < width)
             part = PART_S;
         else
-            printf("error: unsupported above_size\n");
+            SVT_LOG("error: unsupported above_size\n");
     }
     else if (above_size == width) {
         if (left_size < height)
             part = PART_HB;
         else
-            printf("error: unsupported left_size\n");
+            SVT_LOG("error: unsupported left_size\n");
     }
     else if (left_size == height) {
         if (above_size == width)
             part = PART_HB;
         else
-            printf("error: unsupported above_size\n");
+            SVT_LOG("error: unsupported above_size\n");
     }
     else
-        printf("error: unsupported above_size && left_size\n");
+        SVT_LOG("error: unsupported above_size && left_size\n");
     return part;
 };
 

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -29,6 +29,7 @@
 #include "EbRateControlTasks.h"
 
 #include "EbSegmentation.h"
+#include "EbLog.h"
 
 static const uint32_t  rate_percentage_layer_array[EB_MAX_TEMPORAL_LAYERS][EB_MAX_TEMPORAL_LAYERS] =
 {
@@ -1095,7 +1096,7 @@ void frame_level_rc_input_picture_vbr(
             uint32_t         selected_ref_qp;
 
             if (sequence_control_set_ptr->static_config.look_ahead_distance == 0)
-                printf("ERROR: LAD=0 is not supported\n");
+                SVT_LOG("ERROR: LAD=0 is not supported\n");
             else {
                 selected_ref_qp = picture_control_set_ptr->parent_pcs_ptr->best_pred_qp;
                 picture_control_set_ptr->picture_qp = (uint8_t)selected_ref_qp;
@@ -1178,7 +1179,7 @@ void frame_level_rc_input_picture_vbr(
             uint32_t         selected_ref_qp;
 
             if (sequence_control_set_ptr->static_config.look_ahead_distance == 0)
-                printf("ERROR: LAD=0 is not supported\n");
+                SVT_LOG("ERROR: LAD=0 is not supported\n");
             else {
                 selected_ref_qp = picture_control_set_ptr->parent_pcs_ptr->best_pred_qp;
                 picture_control_set_ptr->picture_qp = (uint8_t)selected_ref_qp;
@@ -2338,7 +2339,7 @@ void frame_level_rc_input_picture_cvbr(
             uint32_t         selected_ref_qp;
 
             if (sequence_control_set_ptr->static_config.look_ahead_distance == 0)
-                printf("ERROR: LAD=0 is not supported\n");
+                SVT_LOG("ERROR: LAD=0 is not supported\n");
             else {
                 selected_ref_qp = picture_control_set_ptr->parent_pcs_ptr->best_pred_qp;
                 picture_control_set_ptr->picture_qp = (uint8_t)selected_ref_qp;
@@ -2538,7 +2539,7 @@ void frame_level_rc_input_picture_cvbr(
             uint32_t         selected_ref_qp;
 
             if (sequence_control_set_ptr->static_config.look_ahead_distance == 0)
-                printf("ERROR: LAD=0 is not supported\n");
+                SVT_LOG("ERROR: LAD=0 is not supported\n");
             else {
                 selected_ref_qp = picture_control_set_ptr->parent_pcs_ptr->best_pred_qp;
                 picture_control_set_ptr->picture_qp = (uint8_t)selected_ref_qp;

--- a/Source/Lib/Encoder/Codec/EbRateDistortionCost.c
+++ b/Source/Lib/Encoder/Codec/EbRateDistortionCost.c
@@ -21,6 +21,7 @@
 #include "EbRateDistortionCost.h"
 #include "EbCommonUtils.h"
 #include "aom_dsp_rtcd.h"
+#include "EbLog.h"
 
 #include <assert.h>
 #if TWO_PASS
@@ -903,7 +904,7 @@ uint64_t EstimateRefFramesNumBits(
                     2);*/
 
                 if (comp_ref_type == UNIDIR_COMP_REFERENCE) {
-                    //printf("ERROR[AN]: UNIDIR_COMP_REFERENCE not supported\n");
+                    //SVT_LOG("ERROR[AN]: UNIDIR_COMP_REFERENCE not supported\n");
                     const int bit = mbmi->block_mi.ref_frame[0] == BWDREF_FRAME;
 
                     const int pred_context = eb_av1_get_pred_context_uni_comp_ref_p(cu_ptr->av1xd);
@@ -1068,7 +1069,7 @@ uint64_t EstimateRefFramesNumBits(
             refRateB = candidate_ptr->md_rate_estimation_ptr->comp_ref_type_fac_bits[context][comp_ref_type];
 
             if (comp_ref_type == UNIDIR_COMP_REFERENCE) {
-                printf("ERROR[AN]: UNIDIR_COMP_REFERENCE not supported\n");
+                SVT_LOG("ERROR[AN]: UNIDIR_COMP_REFERENCE not supported\n");
                 //const int32_t bit = mbmi->block_mi.ref_frame[0] == BWDREF_FRAME;
                 //WRITE_REF_BIT(bit, uni_comp_ref_p);
 
@@ -2018,7 +2019,7 @@ uint64_t av1_inter_fast_cost(
         chromaSad = chroma_distortion << AV1_COST_PRECISION;
         totalDistortion = lumaSad + chromaSad;
         if (blk_geom->has_uv == 0 && chromaSad != 0)
-            printf("av1_inter_fast_cost: Chroma error");
+            SVT_LOG("av1_inter_fast_cost: Chroma error");
         rate = lumaRate + chromaRate;
         if (picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->use_output_stat_file) {
             two_pass_cost_update(
@@ -2640,7 +2641,7 @@ void coding_loop_context_generation(
         contextIndex = 0;
     cu_ptr->is_inter_ctx = contextIndex;
     //  if(cu_ptr->is_inter_ctx!=0) //
-    //      printf("ctx:%i \n",cu_ptr->is_inter_ctx);
+    //      SVT_LOG("ctx:%i \n",cu_ptr->is_inter_ctx);
 
       //   Top Intra Mode Neighbor Array instead of a Full
       // Skip Flag Context

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -18,6 +18,7 @@
 #include "EbTime.h"
 #include "EbEntropyCoding.h"
 #include "EbObject.h"
+#include "EbLog.h"
 
 typedef struct ResourceCoordinationContext
 {
@@ -598,14 +599,14 @@ static void read_stat_from_file(
     int32_t fseek_return_value = fseek(sequence_control_set_ptr->static_config.input_stat_file, (long)picture_control_set_ptr->picture_number * sizeof(stat_struct_t), SEEK_SET);
 
     if (fseek_return_value != 0) {
-        printf("Error in fseek  returnVal %i\n", (int)fseek_return_value);
+        SVT_LOG("Error in fseek  returnVal %i\n", (int)fseek_return_value);
     }
     size_t fread_return_value = fread(&picture_control_set_ptr->stat_struct,
         (size_t)1,
         sizeof(stat_struct_t),
         sequence_control_set_ptr->static_config.input_stat_file);
     if (fread_return_value != sizeof(stat_struct_t)) {
-        printf("Error in freed  returnVal %i\n", (int)fread_return_value);
+        SVT_LOG("Error in freed  returnVal %i\n", (int)fread_return_value);
     }
 
     uint64_t referenced_area_avg = 0;

--- a/Source/Lib/Encoder/Codec/EbRestoration.c
+++ b/Source/Lib/Encoder/Codec/EbRestoration.c
@@ -15,6 +15,7 @@
 #include "aom_dsp_rtcd.h"
 #include "EbRestoration.h"
 #include "EbUtility.h"
+#include "EbLog.h"
 
 void av1_upscale_normative_rows(const Av1Common *cm, const uint8_t *src,
     int src_stride, uint8_t *dst, int dst_stride, int rows, int sub_x, int bd);
@@ -1254,7 +1255,7 @@ void eb_av1_loop_restoration_filter_frame(Yv12BufferConfig *frame,
         cm->subsampling_x, cm->subsampling_y,
         cm->use_highbitdepth, AOM_BORDER_IN_PIXELS,
         cm->byte_alignment, NULL, NULL, NULL) < 0)
-        printf("Failed to allocate restoration dst buffer\n");
+        SVT_LOG("Failed to allocate restoration dst buffer\n");
 
     RestorationLineBuffers rlbs;
     const int32_t bit_depth = cm->bit_depth;

--- a/Source/Lib/Encoder/Codec/EbRestorationPick.c
+++ b/Source/Lib/Encoder/Codec/EbRestorationPick.c
@@ -19,6 +19,7 @@
 #include "EbRestorationPick.h"
 
 #include "EbRestProcess.h"
+#include "EbLog.h"
 
 void av1_foreach_rest_unit_in_frame_seg(Av1Common *cm, int32_t plane,
     RestTileStartVisitor on_tile,
@@ -1508,7 +1509,7 @@ static int64_t finer_tile_search_wiener(const RestSearchCtxt *rsc,
 
     WienerInfo *plane_wiener = &rui->wiener_info;
 
-    // printf("err  pre = %"PRId64"\n", err);
+    // SVT_LOG("err  pre = %"PRId64"\n", err);
     const int32_t start_step = 4;
     for (int32_t s = start_step; s >= 1; s >>= 1) {
         for (int32_t p = plane_off; p < WIENER_HALFWIN; ++p) {
@@ -1598,7 +1599,7 @@ static int64_t finer_tile_search_wiener(const RestSearchCtxt *rsc,
             } while (1);
         }
     }
-    // printf("err post = %"PRId64"\n", err);
+    // SVT_LOG("err post = %"PRId64"\n", err);
 #endif  // USE_WIENER_REFINEMENT_SEARCH
     return err;
 }
@@ -1618,7 +1619,7 @@ static int64_t finer_tile_search_wiener_seg(const RestSearchCtxt *rsc,
 
     WienerInfo *plane_wiener = &rui->wiener_info;
 
-    // printf("err  pre = %"PRId64"\n", err);
+    // SVT_LOG("err  pre = %"PRId64"\n", err);
     const int32_t start_step = 4;
     for (int32_t s = start_step; s >= 1; s >>= 1) {
         for (int32_t p = plane_off; p < WIENER_HALFWIN; ++p) {
@@ -1708,7 +1709,7 @@ static int64_t finer_tile_search_wiener_seg(const RestSearchCtxt *rsc,
             } while (1);
         }
     }
-    // printf("err post = %"PRId64"\n", err);
+    // SVT_LOG("err post = %"PRId64"\n", err);
 #endif  // USE_WIENER_REFINEMENT_SEARCH
     return err;
 }
@@ -2088,7 +2089,7 @@ static void search_wiener_seg(const RestorationTileLimits *limits,
     }
 
     if (!wiener_decompose_sep_sym(wiener_win, M, H, vfilterd, hfilterd)) {
-        printf("CHKN never get here\n");
+        SVT_LOG("CHKN never get here\n");
         rusi->best_rtype[RESTORE_WIENER - 1] = RESTORE_NONE;
         rusi->sse[RESTORE_WIENER] = INT64_MAX;
         return;

--- a/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
@@ -84,7 +84,7 @@ void save_YUV_to_file(char *filename, EbByte buffer_y, EbByte buffer_u, EbByte b
     FOPEN(fid, filename, "wb");
 
     if (!fid){
-        printf("Unable to open file %s to write.\n", "temp_picture.yuv");
+        SVT_LOG("Unable to open file %s to write.\n", "temp_picture.yuv");
     }else{
         // the source picture saved in the enchanced_picture_ptr contains a border in x and y dimensions
         pic_point = buffer_y + (origin_y*stride_y) + origin_x;
@@ -120,7 +120,7 @@ void save_YUV_to_file_highbd(char *filename, uint16_t* buffer_y, uint16_t* buffe
     FOPEN(fid, filename, "wb");
 
     if (!fid){
-        printf("Unable to open file %s to write.\n", "temp_picture.yuv");
+        SVT_LOG("Unable to open file %s to write.\n", "temp_picture.yuv");
     }else{
         // the source picture saved in the enchanced_picture_ptr contains a border in x and y dimensions
         pic_point = buffer_y + (origin_y*stride_y) + origin_x;
@@ -1967,7 +1967,7 @@ static void adjust_filter_strength(
         strength = strength + 2 * (encoder_bit_depth - 8);
 
 #if DEBUG_TF
-    printf("[DEBUG] noise level: %g, strength = %d, adj_strength = %d\n", noise_level, *altref_strength, strength);
+    SVT_LOG("[DEBUG] noise level: %g, strength = %d, adj_strength = %d\n", noise_level, *altref_strength, strength);
 #endif
 
     *altref_strength = (uint8_t)strength;

--- a/Source/Lib/Encoder/Codec/EbTransforms.c
+++ b/Source/Lib/Encoder/Codec/EbTransforms.c
@@ -8167,7 +8167,7 @@ static INLINE int32_t range_check_value(int32_t value, int8_t bit) {
     const int64_t max_value = (1LL << (bit - 1)) - 1;
     const int64_t min_value = -(1LL << (bit - 1));
     if (value < min_value || value > max_value) {
-        fprintf(stderr, "coeff out of bit range, value: %d bit %d\n", value, bit);
+        SVT_ERROR("coeff out of bit range, value: %d bit %d\n", value, bit);
         assert(0);
     }
 #endif  // CONFIG_COEFFICIENT_RANGE_CHECKING

--- a/Source/Lib/Encoder/Codec/corner_match.c
+++ b/Source/Lib/Encoder/Codec/corner_match.c
@@ -183,7 +183,7 @@ int av1_determine_correspondence(unsigned char *frm, int *frm_corners,
       correspondences[num_correspondences].ry =
           ref_corners[2 * best_match_j + 1];
 
-      /*printf("corresp: %d %d - %d %d\n",
+      /*SVT_LOG("corresp: %d %d - %d %d\n",
              correspondences[num_correspondences].x,
              correspondences[num_correspondences].y,
              correspondences[num_correspondences].rx,

--- a/Source/Lib/Encoder/Codec/noise_util.c
+++ b/Source/Lib/Encoder/Codec/noise_util.c
@@ -19,6 +19,7 @@
 #include "EbDefinitions.h"
 #include "noise_util.h"
 #include "aom_dsp_rtcd.h"
+#include "EbLog.h"
 
 void *eb_aom_memalign(size_t align, size_t size);
 void eb_aom_free(void *memblk);
@@ -66,7 +67,7 @@ struct aom_noise_tx_t *eb_aom_noise_tx_malloc(int32_t block_size) {
         break;
     default:
         free(noise_tx);
-        fprintf(stderr, "Unsupported block size %d\n", block_size);
+        SVT_ERROR("Unsupported block size %d\n", block_size);
         return NULL;
     }
     noise_tx->block_size = block_size;

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -49,6 +49,8 @@
 #include "EbDlfProcess.h"
 #include "EbRateControlResults.h"
 
+#include "EbLog.h"
+
 #ifdef _WIN32
 #include <windows.h>
 #else
@@ -591,7 +593,7 @@ EbErrorType load_default_buffer_configuration_settings(
     }
 
     sequence_control_set_ptr->total_process_init_count += 6; // single processes count
-    printf("Number of logical cores available: %u\nNumber of PPCS %u\n", core_count, sequence_control_set_ptr->picture_control_set_pool_init_count);
+    SVT_LOG("Number of logical cores available: %u\nNumber of PPCS %u\n", core_count, sequence_control_set_ptr->picture_control_set_pool_init_count);
 
     /******************************************************************
     * Platform detection, limit cpu flags to hardware available CPU
@@ -599,8 +601,8 @@ EbErrorType load_default_buffer_configuration_settings(
     const CPU_FLAGS cpu_flags = get_cpu_flags();
     const CPU_FLAGS cpu_flags_to_use = get_cpu_flags_to_use();
     sequence_control_set_ptr->static_config.use_cpu_flags &= cpu_flags_to_use;
-    printf("[asm level on system : up to %s]\n", get_asm_level_name_str(cpu_flags));
-    printf("[asm level selected : up to %s]\n", get_asm_level_name_str(sequence_control_set_ptr->static_config.use_cpu_flags));
+    SVT_LOG("[asm level on system : up to %s]\n", get_asm_level_name_str(cpu_flags));
+    SVT_LOG("[asm level selected : up to %s]\n", get_asm_level_name_str(sequence_control_set_ptr->static_config.use_cpu_flags));
 
     return return_error;
 }
@@ -1706,6 +1708,7 @@ EB_API EbErrorType eb_init_handle(
     EbErrorType           return_error = EB_ErrorNone;
     if(p_handle == NULL)
          return EB_ErrorBadParameter;
+    svt_log_init();
 
     #if defined(__linux__)
         if(lp_group == NULL) {
@@ -3472,19 +3475,19 @@ EbErrorType init_svt_av1_encoder_handle(
     EbComponentType  *svt_enc_component = (EbComponentType*)hComponent;
     EbEncHandle      *handle;
 
-    printf("SVT [version]:\tSVT-AV1 Encoder Lib v%d.%d.%d\n", SVT_VERSION_MAJOR, SVT_VERSION_MINOR, SVT_VERSION_PATCHLEVEL);
+    SVT_LOG("SVT [version]:\tSVT-AV1 Encoder Lib v%d.%d.%d\n", SVT_VERSION_MAJOR, SVT_VERSION_MINOR, SVT_VERSION_PATCHLEVEL);
 #if ( defined( _MSC_VER ) && (_MSC_VER < 1910) )
-    printf("SVT [build]  : Visual Studio 2013");
+    SVT_LOG("SVT [build]  : Visual Studio 2013");
 #elif ( defined( _MSC_VER ) && (_MSC_VER >= 1910) )
-    printf("SVT [build]  :\tVisual Studio 2017");
+    SVT_LOG("SVT [build]  :\tVisual Studio 2017");
 #elif defined(__GNUC__)
-    printf("SVT [build]  :\tGCC %s\t", __VERSION__);
+    SVT_LOG("SVT [build]  :\tGCC %s\t", __VERSION__);
 #else
-    printf("SVT [build]  :\tunknown compiler");
+    SVT_LOG("SVT [build]  :\tunknown compiler");
 #endif
-    printf(" %u bit\n", (unsigned) sizeof(void*) * 8);
-    printf("LIB Build date: %s %s\n", __DATE__, __TIME__);
-    printf("-------------------------------------------\n");
+    SVT_LOG(" %u bit\n", (unsigned) sizeof(void*) * 8);
+    SVT_LOG("LIB Build date: %s %s\n", __DATE__, __TIME__);
+    SVT_LOG("-------------------------------------------\n");
 
     SwitchToRealTime();
 


### PR DESCRIPTION
this will remove all printf to stdout, fixes https://github.com/OpenVisualCloud/SVT-AV1/issues/302

as applciation user,you have three options in env variables
SVT_LOG: control the log level
SVT_LOG_FILE: log file for svt library
SVT_APP_LOG_FILE: log file for svt applications
here is sample commandline:
```
1. SVT_LOG=4 SVT_LOG_FILE=lib.log SVT_APP_LOG_FILE=app.log SvtEncApp -i test.y4m -b test.ivf
2. SVT_LOG=4 SVT_LOG_FILE=lib.log SVT_APP_LOG_FILE=app.log ffmpeg -i test.y4m -c:v libsvt_av1 test.mp4
```

as developer, you can use following macros
```
SVT_LOG
SVT_DEBUG
SVT_INFO
SVT_WARN
SVT_ERROR
SVT_FATAL
```
please check EbMalloc.c for for usage