### PR TITLE
EbPictureControlSet: fix rst_frame leak

### DIFF
--- a/Source/Lib/Common/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.c
@@ -1133,7 +1133,7 @@ static void picture_parent_control_set_dctor(EbPtr p)
 
     EB_FREE_ARRAY(obj->sb_depth_mode_array);
 
-    {
+    if (obj->av1_cm) {
         const int32_t num_planes = 3;// av1_num_planes(cm);
         for (int32_t p = 0; p < num_planes; ++p) {
             RestorationInfo* ri =obj->av1_cm->rst_info + p;
@@ -1142,11 +1142,13 @@ static void picture_parent_control_set_dctor(EbPtr p)
             EB_FREE(boundaries->stripe_boundary_above);
             EB_FREE(boundaries->stripe_boundary_below);
         }
+        EB_FREE_ARRAY(obj->av1_cm->frame_to_show);
+        EB_FREE_ALIGNED(obj->av1_cm->rst_tmpbuf);
+        if (obj->av1_cm->rst_frame.buffer_alloc_sz) {
+            EB_FREE_ARRAY(obj->av1_cm->rst_frame.buffer_alloc);
+        }
+        EB_FREE_ARRAY(obj->av1_cm);
     }
-
-    EB_FREE_ARRAY(obj->av1_cm->frame_to_show);
-    EB_FREE_ALIGNED(obj->av1_cm->rst_tmpbuf);
-    EB_FREE_ARRAY(obj->av1_cm);
     EB_FREE_ARRAY(obj->rusi_picture[0]);
     EB_FREE_ARRAY(obj->rusi_picture[1]);
     EB_FREE_ARRAY(obj->rusi_picture[2]);


### PR DESCRIPTION
steps to reproduce:
run Bin/Debug/SvtAv1EncApp -i test.y4m -enc-mode 7 -b test.ivf

you will see memory leak at EbPictureBufferDesc.c:L354