### PR TITLE
Fixes for avx512 UT

### DIFF
--- a/test/EbHighbdIntraPredictionTests.cc
+++ b/test/EbHighbdIntraPredictionTests.cc
@@ -18,8 +18,8 @@ static void init_data(uint16_t **input, uint16_t **above, uint16_t **left, ptrdi
     TEST_ALLIGN_MALLOC(uint16_t*, *input, sizeof(uint16_t) * MAX_SB_SIZE * input_stride);
     memset(*input, 0, MAX_SB_SIZE * input_stride);
     eb_buf_random_u16(*input, (uint32_t)(MAX_SB_SIZE * input_stride));
-    *above = *input + rand() % (MAX_SB_SIZE * input_stride / 2);
-    *left = *input + rand() % (MAX_SB_SIZE * input_stride / 4);
+    *above = *input + ((rand() % (MAX_SB_SIZE * input_stride / 2)) >> 4 << 4); //align to 16
+    *left = *input + ((rand() % (MAX_SB_SIZE * input_stride / 4)) >> 4 << 4); //align to 16
 }
 
 static void uninit_data(uint16_t *input) {

--- a/test/InversetransformTests.cc
+++ b/test/InversetransformTests.cc
@@ -58,14 +58,14 @@ static void init_output_r(uint16_t **output_r, uint16_t **output_opt_r, int32_t 
     TEST_ALLIGN_MALLOC(uint16_t*, *output_r, sizeof(uint16_t) * MAX_SB_SIZE * num);
     TEST_ALLIGN_MALLOC(uint16_t*, *output_opt_r, sizeof(uint16_t) * MAX_SB_SIZE * num);
     eb_buf_random_u16(*output_r, MAX_SB_SIZE * num);
-    memcpy(*output_opt_r, *output_r, sizeof(**output_r) * MAX_SB_SIZE * num);
+    memcpy(*output_opt_r, *output_r, sizeof(uint16_t) * MAX_SB_SIZE * num);
 }
 
 static void init_output_w(uint16_t **output_w, uint16_t **output_opt_w, int32_t num) {
     TEST_ALLIGN_MALLOC(uint16_t*, *output_w, sizeof(uint16_t) * MAX_SB_SIZE * num);
     TEST_ALLIGN_MALLOC(uint16_t*, *output_opt_w, sizeof(uint16_t) * MAX_SB_SIZE * num);
-    memset(*output_w, 0, MAX_SB_SIZE * num);
-    memset(*output_opt_w, 0, MAX_SB_SIZE * num);
+    memset(*output_w, 0, sizeof(uint16_t) *MAX_SB_SIZE * num);
+    memset(*output_opt_w, 0, sizeof(uint16_t) *MAX_SB_SIZE * num);
 }
 
 TEST(InverseTransformTest, av1_inv_txfm_2d_square_kernels)

--- a/test/MotionEstimationTest.cc
+++ b/test/MotionEstimationTest.cc
@@ -114,6 +114,8 @@ void sadMxN_match_test(const aom_sad_fn_t *const func_table) {
         init_data_sadMxN(&src_ptr, &src_stride, &ref_ptr, &ref_stride);
 
         for (int j = 0; j < num_sad; j++) {
+            if(func_table[j] == NULL)
+                continue;
             const uint32_t sad_org = aom_sad_c_func_ptr_array[j](
                 src_ptr, src_stride, ref_ptr, ref_stride);
             const uint32_t sad_opt =
@@ -135,6 +137,8 @@ void sadMxNx4d_match_test(const aom_sad_multi_d_fn_t *const func_table) {
         init_data_sadMxNx4d(&src_ptr, &src_stride, ref_ptr, &ref_stride);
 
         for (int j = 0; j < num_sad; j++) {
+            if(func_table[j] == NULL)
+                continue;
             eb_buf_random_u32(sad_array_opt, 4);
             aom_sad_4d_c_func_ptr_array[j](
                 src_ptr, src_stride, ref_ptr, ref_stride, sad_array_org);
@@ -160,6 +164,8 @@ void sadMxN_speed_test(const aom_sad_fn_t *const func_table) {
     init_data_sadMxN(&src_ptr, &src_stride, &ref_ptr, &ref_stride);
 
     for (int j = 0; j < num_sad; j++) {
+        if(func_table[j] == NULL)
+            continue;
         const uint32_t width = sad_size_info[j].width;
         const uint32_t height = sad_size_info[j].height;
         const uint64_t num_loop = 100000000 / (width + height);
@@ -220,6 +226,8 @@ void sadMxNx4d_speed_test(const aom_sad_multi_d_fn_t *const func_table) {
     eb_buf_random_u32(sad_array_opt, 4);
 
     for (int j = 0; j < num_sad; j++) {
+        if(func_table[j] == NULL)
+            continue;
         const uint32_t width = sad_size_info[j].width;
         const uint32_t height = sad_size_info[j].height;
         const uint64_t num_loop = 20000000 / (width + height);
@@ -286,21 +294,27 @@ TEST(MotionEstimation_avx2, DISABLED_sadMxNx4d_speed) {
 
 #ifndef NON_AVX512_SUPPORT
 
+//NULL means not implemented
 aom_sad_fn_t aom_sad_avx512_func_ptr_array[num_sad] = {
-    eb_aom_sad64x16_avx512,
-    eb_aom_sad64x32_avx512,
-    eb_aom_sad64x64_avx512,
-    eb_aom_sad64x128_avx512,
-    eb_aom_sad128x64_avx512,
-    eb_aom_sad128x128_avx512};
+    NULL, NULL, NULL,
+    NULL, NULL, NULL,
+    NULL, NULL, NULL,
+    NULL, NULL, NULL,
+    NULL, NULL, NULL,
+    NULL, eb_aom_sad64x16_avx512, eb_aom_sad64x32_avx512,
+    eb_aom_sad64x64_avx512, eb_aom_sad64x128_avx512,
+    eb_aom_sad128x64_avx512, eb_aom_sad128x128_avx512};
 
+//NULL means not implemented
 aom_sad_multi_d_fn_t aom_sad_4d_avx512_func_ptr_array[num_sad] = {
-    eb_aom_sad64x16x4d_avx2,
-    eb_aom_sad64x32x4d_avx2,
-    eb_aom_sad64x64x4d_avx2,
-    eb_aom_sad64x128x4d_avx2,
-    eb_aom_sad128x64x4d_avx512,
-    eb_aom_sad128x128x4d_avx512};
+    NULL, NULL, NULL,
+    NULL, NULL, NULL,
+    NULL, NULL, NULL,
+    NULL, NULL, NULL,
+    NULL, NULL, NULL,
+    NULL, eb_aom_sad64x16x4d_avx2, eb_aom_sad64x32x4d_avx2,
+    eb_aom_sad64x64x4d_avx2, eb_aom_sad64x128x4d_avx2,
+    eb_aom_sad128x64x4d_avx512, eb_aom_sad128x128x4d_avx512};
 
 TEST(MotionEstimation_avx512, sadMxN_match) {
     sadMxN_match_test(aom_sad_avx512_func_ptr_array);


### PR DESCRIPTION
This PR fixes UT for avx512 : 
    [  FAILED  ] InverseTransformTest.av1_inv_txfm_2d_square_kernels
    [  FAILED  ] InverseTransformTest.av1_inv_txfm_2d_rect_kernels
    [  FAILED  ] MotionEstimation_avx512.sadMxN_match
    [  FAILED  ] MotionEstimation_avx512.sadMxNx4d_match
HighbdIntraPredictionTest.aom_h_predictor_kernels (which failed only on linux due to unaligned memory)

Combined with: #786, #793, #801 allow to pass all tests from SvtAv1UnitTests