### PR TITLE
remove useless Fifo* in EbEncHandle.

### DIFF
--- a/Source/Lib/Common/Codec/CMakeLists.txt
+++ b/Source/Lib/Common/Codec/CMakeLists.txt
@@ -13,6 +13,7 @@ include_directories(${PROJECT_SOURCE_DIR}/Source/API/
     ${PROJECT_SOURCE_DIR}/Source/Lib/Common/ASM_SSE4_1/
     ${PROJECT_SOURCE_DIR}/Source/Lib/Common/ASM_AVX2/
     ${PROJECT_SOURCE_DIR}/Source/Lib/Common/ASM_AVX512/
+    ${PROJECT_SOURCE_DIR}/Source/Lib/Encoder/Codec/
     ${PROJECT_SOURCE_DIR}/third_party/fastfeat/)
 
 file(GLOB all_files

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -4036,6 +4036,8 @@ memset(dst, val, count)
         83,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0 ,
         84,0 ,0 ,0 ,0 ,0 ,0 ,0 ,0
     };
+typedef struct _EbEncHandle EbEncHandle;
+typedef struct _EbThreadContext EbThreadContext;
 #ifdef __cplusplus
 }
 #endif

--- a/Source/Lib/Common/Codec/EbDlfProcess.h
+++ b/Source/Lib/Common/Codec/EbDlfProcess.h
@@ -17,7 +17,6 @@
  **************************************/
 typedef struct DlfContext
 {
-    EbDctor              dctor;
     EbFifo              *dlf_input_fifo_ptr;
     EbFifo              *dlf_output_fifo_ptr;
     EbPictureBufferDesc *temp_lf_recon_picture_ptr;
@@ -28,14 +27,9 @@ typedef struct DlfContext
  * Extern Function Declarations
  **************************************/
 extern EbErrorType dlf_context_ctor(
-    DlfContext                   *context_ptr,
-    EbFifo                       *dlf_input_fifo_ptr,
-    EbFifo                       *dlf_output_fifo_ptr,
-    EbBool                  is16bit,
-    EbColorFormat           color_format,
-    uint32_t                max_input_luma_width,
-    uint32_t                max_input_luma_height
-   );
+    EbThreadContext   *thread_context_ptr,
+    const EbEncHandle *enc_handle_ptr,
+    int               index);
 
 extern void* dlf_kernel(void *input_ptr);
 

--- a/Source/Lib/Common/Codec/EbEncDecProcess.h
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.h
@@ -42,7 +42,6 @@ extern "C" {
      **************************************/
     typedef struct EncDecContext
     {
-        EbDctor                              dctor;
         EbFifo                              *mode_decision_input_fifo_ptr;
         EbFifo                              *enc_dec_output_fifo_ptr;
         EbFifo                              *enc_dec_feedback_fifo_ptr;
@@ -123,19 +122,11 @@ extern "C" {
      * Extern Function Declarations
      **************************************/
     extern EbErrorType enc_dec_context_ctor(
-        EncDecContext         *context_ptr,
-        EbFifo                *mode_decision_configuration_input_fifo_ptr,
-        EbFifo                *packetization_output_fifo_ptr,
-        EbFifo                *feedback_fifo_ptr,
-        EbFifo                *picture_demux_fifo_ptr,
-#if PAL_SUP
-        uint8_t                 cfg_palette,
-#endif
-        EbBool                   is16bit,
-        EbColorFormat            color_format,
-        uint8_t                  enable_hbd_mode_decision,
-        uint32_t                 max_input_luma_width,
-        uint32_t                 max_input_luma_height);
+        EbThreadContext     *thread_context_ptr,
+        const EbEncHandle   *enc_handle_ptr,
+        int                 index,
+        int                 tasks_index,
+        int                 demux_index);
 
     extern void* enc_dec_kernel(void *input_ptr);
 

--- a/Source/Lib/Common/Codec/EbEntropyCodingProcess.h
+++ b/Source/Lib/Common/Codec/EbEntropyCodingProcess.h
@@ -77,11 +77,10 @@ typedef struct EntropyCodingContext
  * Extern Function Declarations
  **************************************/
 extern EbErrorType entropy_coding_context_ctor(
-    EntropyCodingContext  *context_ptr,
-    EbFifo                *enc_dec_input_fifo_ptr,
-    EbFifo                *packetization_output_fifo_ptr,
-    EbFifo                *rate_control_output_fifo_ptr,
-    EbBool                   is16bit);
+    EbThreadContext     *thread_context_ptr,
+    const EbEncHandle   *enc_handle_ptr,
+    int                 index,
+    int                 rate_control_index);
 
 extern void* entropy_coding_kernel(void *input_ptr);
 

--- a/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.h
@@ -43,7 +43,6 @@ extern "C" {
 
     typedef struct ModeDecisionConfigurationContext
     {
-        EbDctor                              dctor;
         EbFifo                              *rate_control_input_fifo_ptr;
         EbFifo                              *mode_decision_configuration_output_fifo_ptr;
 
@@ -119,11 +118,11 @@ extern "C" {
     /**************************************
      * Extern Function Declarations
      **************************************/
-    extern EbErrorType mode_decision_configuration_context_ctor(
-        ModeDecisionConfigurationContext  *context_ptr,
-        EbFifo                            *rate_control_input_fifo_ptr,
-        EbFifo                            *mode_decision_configuration_output_fifo_ptr,
-        uint16_t                           sb_total_count);
+    EbErrorType mode_decision_configuration_context_ctor(
+        EbThreadContext   *thread_context_ptr,
+        const EbEncHandle *enc_handle_ptr,
+        int input_index,
+        int output_index);
 
     extern void* mode_decision_configuration_kernel(void *input_ptr);
 #ifdef __cplusplus

--- a/Source/Lib/Common/Codec/EbMotionEstimationProcess.h
+++ b/Source/Lib/Common/Codec/EbMotionEstimationProcess.h
@@ -8,17 +8,14 @@
 #define EbEstimationProcess_h
 
 #include "EbDefinitions.h"
-#include "EbSystemResourceManager.h"
 #include "EbSequenceControlSet.h"
 #include "EbMotionEstimationContext.h"
-#include "EbObject.h"
 
 /**************************************
  * Context
  **************************************/
 typedef struct MotionEstimationContext
 {
-    EbDctor                       dctor;
     EbFifo                        *picture_decision_results_input_fifo_ptr;
     EbFifo                        *motion_estimation_results_output_fifo_ptr;
     MeContext                     *me_context_ptr;
@@ -30,14 +27,10 @@ typedef struct MotionEstimationContext
 /***************************************
  * Extern Function Declaration
  ***************************************/
-extern EbErrorType motion_estimation_context_ctor(
-    MotionEstimationContext_t  *context_ptr,
-    EbFifo                     *picture_decision_results_input_fifo_ptr,
-    EbFifo                     *motion_estimation_results_output_fifo_ptr,
-    uint16_t                    max_input_luma_width,
-    uint16_t                    max_input_luma_height,
-    uint8_t                     nsq_present,
-    uint8_t                     mrp_mode);
+EbErrorType motion_estimation_context_ctor(
+    EbThreadContext    *thread_context_ptr,
+    const EbEncHandle  *enc_handle_ptr,
+    int index);
 
 extern void* motion_estimation_kernel(void *input_ptr);
 

--- a/Source/Lib/Common/Codec/EbPacketizationProcess.h
+++ b/Source/Lib/Common/Codec/EbPacketizationProcess.h
@@ -8,45 +8,18 @@
 #define EbPacketization_h
 
 #include "EbDefinitions.h"
-#include "EbSystemResourceManager.h"
-#include "EbObject.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
 
     /**************************************
-     * Type Declarations
-     **************************************/
-    typedef struct EbPPSConfig
-    {
-        uint8_t pps_id;
-        uint8_t constrained_flag;
-    } EbPPSConfig;
-
-    /**************************************
-     * Context
-     **************************************/
-    typedef struct PacketizationContext
-    {
-        EbDctor      dctor;
-        EbFifo      *entropy_coding_input_fifo_ptr;
-        EbFifo      *rate_control_tasks_output_fifo_ptr;
-        EbPPSConfig *pps_config;
-        EbFifo      *picture_manager_input_fifo_ptr;   // to picture-manager
-        uint64_t   dpb_disp_order[8], dpb_dec_order[8];
-        uint64_t   tot_shown_frames;
-        uint64_t   disp_order_continuity_count;
-    } PacketizationContext;
-
-    /**************************************
      * Extern Function Declarations
      **************************************/
-    extern EbErrorType packetization_context_ctor(
-        PacketizationContext  *context_ptr,
-        EbFifo                *entropy_coding_input_fifo_ptr,
-        EbFifo                *rate_control_tasks_output_fifo_ptr,
-        EbFifo              *picture_manager_input_fifo_ptr
-    );
+    EbErrorType packetization_context_ctor(
+        EbThreadContext     *thread_context_ptr,
+        const EbEncHandle   *enc_handle_ptr,
+        int                 rate_control_index,
+        int                 demux_index);
 
     extern void* packetization_kernel(void *input_ptr);
 #ifdef __cplusplus

--- a/Source/Lib/Common/Codec/EbPictureAnalysisProcess.h
+++ b/Source/Lib/Common/Codec/EbPictureAnalysisProcess.h
@@ -8,34 +8,16 @@
 #define EbPictureAnalysis_h
 
 #include "EbDefinitions.h"
-#include "EbSystemResourceManager.h"
 #include "EbNoiseExtractAVX2.h"
-#include "EbObject.h"
 #include "EbPictureControlSet.h"
-
-/**************************************
- * Context
- **************************************/
-typedef struct PictureAnalysisContext
-{
-    EbDctor                     dctor;
-    EB_ALIGN(64) uint8_t            local_cache[64];
-    EbFifo                     *resource_coordination_results_input_fifo_ptr;
-    EbFifo                     *picture_analysis_results_output_fifo_ptr;
-    EbPictureBufferDesc        *denoised_picture_ptr;
-    EbPictureBufferDesc        *noise_picture_ptr;
-    double                          pic_noise_variance_float;
-} PictureAnalysisContext;
 
 /***************************************
  * Extern Function Declaration
  ***************************************/
-extern EbErrorType picture_analysis_context_ctor(
-    PictureAnalysisContext     *context_ptr,
-    EbPictureBufferDescInitData *input_picture_buffer_desc_init_data,
-    EbBool                         denoise_flag,
-    EbFifo                      *resource_coordination_results_input_fifo_ptr,
-    EbFifo                      *picture_analysis_results_output_fifo_ptr);
+EbErrorType picture_analysis_context_ctor(
+    EbThreadContext   *thread_context_ptr,
+    const EbEncHandle *enc_handle_ptr,
+    int               index);
 
 extern void* picture_analysis_kernel(void *input_ptr);
 

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.h
@@ -8,61 +8,15 @@
 #define EbPictureDecision_h
 
 #include "EbDefinitions.h"
-#include "EbSystemResourceManager.h"
 #include "EbPictureControlSet.h"
 #include "EbSequenceControlSet.h"
-#include "EbObject.h"
-#include "EbUtility.h"
-
-/**************************************
- * Context
- **************************************/
-typedef struct PictureDecisionContext
-{
-    EbDctor      dctor;
-    EbFifo       *picture_analysis_results_input_fifo_ptr;
-    EbFifo       *picture_decision_results_output_fifo_ptr;
-
-    uint64_t      last_solid_color_frame_poc;
-
-    EbBool        reset_running_avg;
-
-    uint32_t    **ahd_running_avg_cb;
-    uint32_t    **ahd_running_avg_cr;
-    uint32_t    **ahd_running_avg;
-    EbBool        is_scene_change_detected;
-
-    // Dynamic GOP
-    uint32_t        totalRegionActivityCost[MAX_NUMBER_OF_REGIONS_IN_WIDTH][MAX_NUMBER_OF_REGIONS_IN_HEIGHT];
-
-    uint32_t      total_number_of_mini_gops;
-
-    uint32_t      mini_gop_start_index[MINI_GOP_WINDOW_MAX_COUNT];
-    uint32_t      mini_gop_end_index[MINI_GOP_WINDOW_MAX_COUNT];
-    uint32_t      mini_gop_length[MINI_GOP_WINDOW_MAX_COUNT];
-    uint32_t      mini_gop_intra_count[MINI_GOP_WINDOW_MAX_COUNT];
-    uint32_t      mini_gop_idr_count[MINI_GOP_WINDOW_MAX_COUNT];
-    uint32_t      mini_gop_hierarchical_levels[MINI_GOP_WINDOW_MAX_COUNT];
-    EbBool        mini_gop_activity_array[MINI_GOP_MAX_COUNT];
-    uint32_t        mini_gop_region_activity_cost_array[MINI_GOP_MAX_COUNT][MAX_NUMBER_OF_REGIONS_IN_WIDTH][MAX_NUMBER_OF_REGIONS_IN_HEIGHT];
-
-    uint32_t        mini_gop_group_faded_in_pictures_count[MINI_GOP_MAX_COUNT];
-    uint32_t        mini_gop_group_faded_out_pictures_count[MINI_GOP_MAX_COUNT];
-    uint8_t     lay0_toggle; //3 way toggle 0->1->2
-    uint8_t     lay1_toggle; //2 way toggle 0->1
-    uint8_t     lay2_toggle; //2 way toggle 0->1
-    EbBool        mini_gop_toggle;    //mini GOP toggling since last Key Frame  K-0-1-0-1-0-K-0-1-0-1-K-0-1.....
-    uint8_t       last_i_picture_sc_detection;
-    uint64_t         key_poc;
-} PictureDecisionContext;
 
 /***************************************
  * Extern Function Declaration
  ***************************************/
-extern EbErrorType picture_decision_context_ctor(
-    PictureDecisionContext  *context_ptr,
-    EbFifo                  *picture_analysis_results_input_fifo_ptr,
-    EbFifo                  *picture_decision_results_output_fifo_ptr);
+EbErrorType picture_decision_context_ctor(
+    EbThreadContext     *thread_context_ptr,
+    const EbEncHandle   *enc_handle_ptr);
 
 extern void* picture_decision_kernel(void *input_ptr);
 

--- a/Source/Lib/Common/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Common/Codec/EbRateControlProcess.c
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 
 #include "EbDefinitions.h"
+#include "EbEncHandle.h"
 #include "EbRateControlProcess.h"
 #include "EbSequenceControlSet.h"
 #include "EbPictureControlSet.h"
@@ -28,6 +29,145 @@
 #include "EbRateControlTasks.h"
 
 #include "EbSegmentation.h"
+
+static const uint32_t  rate_percentage_layer_array[EB_MAX_TEMPORAL_LAYERS][EB_MAX_TEMPORAL_LAYERS] =
+{
+    {100,  0,  0,  0,  0,  0 },
+    { 70, 30,  0,  0,  0,  0 },
+    { 70, 15, 15,  0,  0,  0 },
+    { 55, 15, 15, 15,  0,  0 },
+    { 40, 15, 15, 15, 15,  0 },
+    { 30, 10, 15, 15, 15, 15 }
+};
+
+// range from 0 to 51
+// precision is 16 bits
+static const uint64_t two_to_power_qp_over_three[] =
+{
+         0x10000,      0x1428A,     0x19660,     0x20000,
+         0x28514,      0x32CC0,     0x40000,     0x50A29,
+         0x65980,      0x80000,     0xA1451,     0xCB2FF,
+        0x100000,     0x1428A3,    0x1965FF,    0x200000,
+        0x285146,     0x32CBFD,    0x400000,    0x50A28C,
+        0x6597FB,     0x800000,    0xA14518,    0xCB2FF5,
+       0x1000000,    0x1428A30,   0x1965FEA,   0x2000000,
+       0x285145F,    0x32CBFD5,   0x4000000,   0x50A28BE,
+       0x6597FA9,    0x8000000,   0xA14517D,   0xCB2FF53,
+      0x10000000,   0x1428A2FA,  0x1965FEA5,  0x20000000,
+      0x285145F3,   0x32CBFD4A,  0x40000000,  0x50A28BE6,
+      0x6597FA95,   0x80000000,  0xA14517CC,  0xCB2FF52A,
+     0x100000000,  0x1428A2F99, 0x1965FEA54, 0x200000000
+};
+
+
+/**************************************
+ * Coded Frames Stats
+ **************************************/
+typedef struct CodedFramesStatsEntry
+{
+    EbDctor                dctor;
+    uint64_t               picture_number;
+    int64_t               frame_total_bit_actual;
+    EbBool              end_of_sequence_flag;
+} CodedFramesStatsEntry;
+
+
+typedef struct RateControlIntervalParamContext
+{
+    EbDctor                      dctor;
+    uint64_t                     first_poc;
+    uint64_t                     last_poc;
+    EbBool                       in_use;
+    EbBool                       was_used;
+    uint64_t                     processed_frames_number;
+    EbBool                       last_gop;
+    RateControlLayerContext   **rate_control_layer_array;
+
+    int64_t                      virtual_buffer_level;
+    int64_t                      previous_virtual_buffer_level;
+    uint32_t                     intra_frames_qp;
+    uint8_t                      intra_frames_qp_bef_scal;
+
+    uint32_t                     next_gop_intra_frame_qp;
+    uint64_t                     first_pic_pred_bits;
+    uint64_t                     first_pic_actual_bits;
+    uint16_t                     first_pic_pred_qp;
+    uint16_t                     first_pic_actual_qp;
+    EbBool                       first_pic_actual_qp_assigned;
+    EbBool                       scene_change_in_gop;
+    EbBool                       min_target_rate_assigned;
+    int64_t                      extra_ap_bit_ratio_i;
+} RateControlIntervalParamContext;
+
+typedef struct HighLevelRateControlContext
+{
+    EbDctor  dctor;
+    uint64_t target_bit_rate;
+    uint64_t frame_rate;
+    uint64_t channel_bit_rate_per_frame;
+    uint64_t channel_bit_rate_per_sw;
+    uint64_t bit_constraint_per_sw;
+    uint64_t pred_bits_ref_qpPerSw[MAX_REF_QP_NUM];
+#if RC_UPDATE_TARGET_RATE
+    uint32_t prev_intra_selected_ref_qp;
+    uint32_t prev_intra_org_selected_ref_qp;
+    uint64_t previous_updated_bit_constraint_per_sw;
+#endif
+} HighLevelRateControlContext;
+
+typedef struct RateControlContext
+{
+    EbFifo                            *rate_control_input_tasks_fifo_ptr;
+    EbFifo                            *rate_control_output_results_fifo_ptr;
+
+    HighLevelRateControlContext       *high_level_rate_control_ptr;
+
+    RateControlIntervalParamContext  **rate_control_param_queue;
+    uint64_t                           rate_control_param_queue_head_index;
+
+    uint64_t                           frame_rate;
+
+    uint64_t                           virtual_buffer_size;
+
+    int64_t                            virtual_buffer_level_initial_value;
+    int64_t                            previous_virtual_buffer_level;
+
+    int64_t                            virtual_buffer_level;
+
+    //Virtual Buffer Thresholds
+    int64_t                            vb_fill_threshold1;
+    int64_t                            vb_fill_threshold2;
+
+    // Rate Control Previous Bits Queue
+#if OVERSHOOT_STAT_PRINT
+    CodedFramesStatsEntry            **coded_frames_stat_queue;
+    uint32_t                           coded_frames_stat_queue_head_index;
+    uint32_t                           coded_frames_stat_queue_tail_index;
+
+    uint64_t                           total_bit_actual_per_sw;
+    uint64_t                           max_bit_actual_per_sw;
+    uint64_t                           max_bit_actual_per_gop;
+    uint64_t                           min_bit_actual_per_gop;
+    uint64_t                           avg_bit_actual_per_gop;
+
+#endif
+
+    uint64_t                           rate_average_periodin_frames;
+    uint32_t                           base_layer_frames_avg_qp;
+    uint32_t                           base_layer_intra_frames_avg_qp;
+
+    EbBool                             end_of_sequence_region;
+
+    uint32_t                           intra_coef_rate;
+
+    uint64_t                           frames_in_interval[EB_MAX_TEMPORAL_LAYERS];
+    int64_t                            extra_bits;
+    int64_t                            extra_bits_gen;
+    int16_t                            max_rate_adjust_delta_qp;
+
+    uint32_t                           qp_scaling_map[EB_MAX_TEMPORAL_LAYERS][MAX_REF_QP_NUM];
+    uint32_t                           qp_scaling_map_I_SLICE[MAX_REF_QP_NUM];
+} RateControlContext;
 
 // calculate the QP based on the QP scaling
 uint32_t qp_scaling_calc(
@@ -234,30 +374,37 @@ EbErrorType rate_control_coded_frames_stats_context_ctor(
 
 void rate_control_context_dctor(EbPtr p)
 {
-    RateControlContext* obj = (RateControlContext*)p;
+    EbThreadContext*    thread_context_ptr = (EbThreadContext*)p;
+    RateControlContext* obj = (RateControlContext*)thread_context_ptr->priv;
 #if OVERSHOOT_STAT_PRINT
     EB_DELETE_PTR_ARRAY(obj->coded_frames_stat_queue, CODED_FRAMES_STAT_QUEUE_MAX_DEPTH);
 #endif
     EB_DELETE_PTR_ARRAY(obj->rate_control_param_queue, PARALLEL_GOP_MAX_NUMBER);
     EB_DELETE(obj->high_level_rate_control_ptr);
-
+    EB_FREE_ARRAY(obj);
 }
 
 EbErrorType rate_control_context_ctor(
-    RateControlContext *context_ptr,
-    EbFifo             *rate_control_input_tasks_fifo_ptr,
-    EbFifo             *rate_control_output_results_fifo_ptr,
-    int32_t             intra_period)
+    EbThreadContext     *thread_context_ptr,
+    const EbEncHandle   *enc_handle_ptr)
 {
     uint32_t interval_index;
 
 #if OVERSHOOT_STAT_PRINT
     uint32_t picture_index;
 #endif
+    int32_t             intra_period = enc_handle_ptr->sequence_control_set_instance_array[0]->sequence_control_set_ptr->intra_period_length;
 
-    context_ptr->dctor = rate_control_context_dctor;
-    context_ptr->rate_control_input_tasks_fifo_ptr = rate_control_input_tasks_fifo_ptr;
-    context_ptr->rate_control_output_results_fifo_ptr = rate_control_output_results_fifo_ptr;
+    RateControlContext *context_ptr;
+    EB_CALLOC_ARRAY(context_ptr, 1);
+    thread_context_ptr->priv = context_ptr;
+    thread_context_ptr->dctor = rate_control_context_dctor;
+
+    context_ptr->rate_control_input_tasks_fifo_ptr =
+        eb_system_resource_get_consumer_fifo(enc_handle_ptr->rate_control_tasks_resource_ptr, 0);
+    context_ptr->rate_control_output_results_fifo_ptr =
+        eb_system_resource_get_producer_fifo(enc_handle_ptr->rate_control_results_resource_ptr, 0);
+
 
     // High level RC
     EB_NEW(
@@ -4129,7 +4276,8 @@ static void sb_qp_derivation(
 void* rate_control_kernel(void *input_ptr)
 {
     // Context
-    RateControlContext                *context_ptr = (RateControlContext  *)input_ptr;
+    EbThreadContext                   *thread_context_ptr = (EbThreadContext*)input_ptr;
+    RateControlContext                *context_ptr = (RateControlContext  *)thread_context_ptr->priv;
 
     RateControlIntervalParamContext   *rate_control_param_ptr;
 

--- a/Source/Lib/Common/Codec/EbRateControlProcess.h
+++ b/Source/Lib/Common/Codec/EbRateControlProcess.h
@@ -33,34 +33,6 @@
 
 #define RC_QPMOD_MAXQP             54
 
-static const uint32_t  rate_percentage_layer_array[EB_MAX_TEMPORAL_LAYERS][EB_MAX_TEMPORAL_LAYERS] =
-{
-    {100,  0,  0,  0,  0,  0 },
-    { 70, 30,  0,  0,  0,  0 },
-    { 70, 15, 15,  0,  0,  0 },
-    { 55, 15, 15, 15,  0,  0 },
-    { 40, 15, 15, 15, 15,  0 },
-    { 30, 10, 15, 15, 15, 15 }
-};
-
-// range from 0 to 51
-// precision is 16 bits
-static const uint64_t two_to_power_qp_over_three[] =
-{
-         0x10000,      0x1428A,     0x19660,     0x20000,
-         0x28514,      0x32CC0,     0x40000,     0x50A29,
-         0x65980,      0x80000,     0xA1451,     0xCB2FF,
-        0x100000,     0x1428A3,    0x1965FF,    0x200000,
-        0x285146,     0x32CBFD,    0x400000,    0x50A28C,
-        0x6597FB,     0x800000,    0xA14518,    0xCB2FF5,
-       0x1000000,    0x1428A30,   0x1965FEA,   0x2000000,
-       0x285145F,    0x32CBFD5,   0x4000000,   0x50A28BE,
-       0x6597FA9,    0x8000000,   0xA14517D,   0xCB2FF53,
-      0x10000000,   0x1428A2FA,  0x1965FEA5,  0x20000000,
-      0x285145F3,   0x32CBFD4A,  0x40000000,  0x50A28BE6,
-      0x6597FA95,   0x80000000,  0xA14517CC,  0xCB2FF52A,
-     0x100000000,  0x1428A2F99, 0x1965FEA54, 0x200000000
-};
 /**************************************
  * Input Port Types
  **************************************/
@@ -82,16 +54,6 @@ typedef struct RateControlPorts
     uint32_t                           count;
 } RateControlPorts;
 
-/**************************************
- * Coded Frames Stats
- **************************************/
-typedef struct CodedFramesStatsEntry
-{
-    EbDctor                dctor;
-    uint64_t               picture_number;
-    int64_t               frame_total_bit_actual;
-    EbBool              end_of_sequence_flag;
-} CodedFramesStatsEntry;
 /**************************************
  * Context
  **************************************/
@@ -150,122 +112,12 @@ typedef struct RateControlLayerContext
 
 } RateControlLayerContext;
 
-typedef struct RateControlIntervalParamContext
-{
-    EbDctor                      dctor;
-    uint64_t                     first_poc;
-    uint64_t                     last_poc;
-    EbBool                       in_use;
-    EbBool                       was_used;
-    uint64_t                     processed_frames_number;
-    EbBool                       last_gop;
-    RateControlLayerContext   **rate_control_layer_array;
-
-    int64_t                      virtual_buffer_level;
-    int64_t                      previous_virtual_buffer_level;
-    uint32_t                     intra_frames_qp;
-    uint8_t                      intra_frames_qp_bef_scal;
-
-    uint32_t                     next_gop_intra_frame_qp;
-    uint64_t                     first_pic_pred_bits;
-    uint64_t                     first_pic_actual_bits;
-    uint16_t                     first_pic_pred_qp;
-    uint16_t                     first_pic_actual_qp;
-    EbBool                       first_pic_actual_qp_assigned;
-    EbBool                       scene_change_in_gop;
-    EbBool                       min_target_rate_assigned;
-    int64_t                      extra_ap_bit_ratio_i;
-} RateControlIntervalParamContext;
-
-typedef struct HighLevelRateControlContext
-{
-    EbDctor  dctor;
-    uint64_t target_bit_rate;
-    uint64_t frame_rate;
-    uint64_t channel_bit_rate_per_frame;
-    uint64_t channel_bit_rate_per_sw;
-    uint64_t bit_constraint_per_sw;
-    uint64_t pred_bits_ref_qpPerSw[MAX_REF_QP_NUM];
-#if RC_UPDATE_TARGET_RATE
-    uint32_t prev_intra_selected_ref_qp;
-    uint32_t prev_intra_org_selected_ref_qp;
-    uint64_t previous_updated_bit_constraint_per_sw;
-#endif
-} HighLevelRateControlContext;
-
-
-typedef struct RateControlContext
-{
-    EbDctor                            dctor;
-    EbFifo                            *rate_control_input_tasks_fifo_ptr;
-    EbFifo                            *rate_control_output_results_fifo_ptr;
-
-    HighLevelRateControlContext       *high_level_rate_control_ptr;
-
-    RateControlIntervalParamContext  **rate_control_param_queue;
-    uint64_t                           rate_control_param_queue_head_index;
-
-    uint64_t                           frame_rate;
-
-    uint64_t                           virtual_buffer_size;
-
-    int64_t                            virtual_buffer_level_initial_value;
-    int64_t                            previous_virtual_buffer_level;
-
-    int64_t                            virtual_buffer_level;
-
-    //Virtual Buffer Thresholds
-    int64_t                            vb_fill_threshold1;
-    int64_t                            vb_fill_threshold2;
-
-    // Rate Control Previous Bits Queue
-#if OVERSHOOT_STAT_PRINT
-    CodedFramesStatsEntry            **coded_frames_stat_queue;
-    uint32_t                           coded_frames_stat_queue_head_index;
-    uint32_t                           coded_frames_stat_queue_tail_index;
-
-    uint64_t                           total_bit_actual_per_sw;
-    uint64_t                           max_bit_actual_per_sw;
-    uint64_t                           max_bit_actual_per_gop;
-    uint64_t                           min_bit_actual_per_gop;
-    uint64_t                           avg_bit_actual_per_gop;
-
-#endif
-
-    uint64_t                           rate_average_periodin_frames;
-    uint32_t                           base_layer_frames_avg_qp;
-    uint32_t                           base_layer_intra_frames_avg_qp;
-
-    EbBool                            end_of_sequence_region;
-
-    uint32_t                           intra_coef_rate;
-
-    uint64_t                           frames_in_interval[EB_MAX_TEMPORAL_LAYERS];
-    int64_t                            extra_bits;
-    int64_t                            extra_bits_gen;
-    int16_t                            max_rate_adjust_delta_qp;
-
-    uint32_t                           qp_scaling_map[EB_MAX_TEMPORAL_LAYERS][MAX_REF_QP_NUM];
-    uint32_t                           qp_scaling_map_I_SLICE[MAX_REF_QP_NUM];
-} RateControlContext;
 /**************************************
  * Extern Function Declarations
  **************************************/
-extern EbErrorType rate_control_layer_context_ctor(
-    RateControlLayerContext *entry_ptr);
-
-extern EbErrorType rate_control_interval_param_context_ctor(
-    RateControlIntervalParamContext *entry_ptr);
-
-extern EbErrorType rate_control_coded_frames_stats_context_ctor(
-    CodedFramesStatsEntry  *entry_ptr,
-    uint64_t                  picture_number);
-
-extern EbErrorType rate_control_context_ctor(
-    RateControlContext  *context_ptr,
-    EbFifo              *rate_control_input_tasks_fifo_ptr,
-    EbFifo              *rate_control_output_results_fifo_ptr,
-    int32_t                intra_period_length);
+EbErrorType rate_control_context_ctor(
+    EbThreadContext     *thread_context_ptr,
+    const EbEncHandle   *enc_handle_ptr);
 
 extern void* rate_control_kernel(void *input_ptr);
 

--- a/Source/Lib/Common/Codec/EbRestProcess.h
+++ b/Source/Lib/Common/Codec/EbRestProcess.h
@@ -9,47 +9,14 @@
 
 #include "EbDefinitions.h"
 
-#include "EbSystemResourceManager.h"
-#include "EbPictureBufferDesc.h"
-#include "EbSequenceControlSet.h"
-#include "EbUtility.h"
-#include "EbObject.h"
-
-/**************************************
- * Rest Context
- **************************************/
-typedef struct RestContext
-{
-    EbDctor                       dctor;
-    EbFifo                       *rest_input_fifo_ptr;
-    EbFifo                       *rest_output_fifo_ptr;
-    EbFifo                       *picture_demux_fifo_ptr;
-
-    EbPictureBufferDesc          *trial_frame_rst;
-
-    EbPictureBufferDesc          *temp_lf_recon_picture_ptr;
-    EbPictureBufferDesc          *temp_lf_recon_picture16bit_ptr;
-
-    EbPictureBufferDesc           *org_rec_frame; // while doing the filtering recon gets updated uisng setup/restore processing_stripe_bounadaries
-                                                    // many threads doing the above will result in race condition.
-                                                    // each thread will hence have his own copy of recon to work on.
-                                                    // later we can have a search version that does not need the exact right recon
-    int32_t *rst_tmpbuf;
-} RestContext;
-
 /**************************************
  * Extern Function Declarations
  **************************************/
 extern EbErrorType rest_context_ctor(
-    RestContext                  *context_ptr,
-    EbFifo                       *rest_input_fifo_ptr,
-    EbFifo                       *rest_output_fifo_ptr,
-    EbFifo                      *picture_demux_fifo_ptr,
-    EbBool                  is16bit,
-    EbColorFormat           color_format,
-    uint32_t                max_input_luma_width,
-    uint32_t                max_input_luma_height
-   );
+    EbThreadContext   *thread_context_ptr,
+    const EbEncHandle *enc_handle_ptr,
+    int               index,
+    int               demux_index);
 
 extern void* rest_kernel(void *input_ptr);
 

--- a/Source/Lib/Common/Codec/EbRestorationPick.c
+++ b/Source/Lib/Common/Codec/EbRestorationPick.c
@@ -2216,7 +2216,7 @@ static double search_rest_type_finish(RestSearchCtxt *rsc, RestorationType rtype
 }
 
 void restoration_seg_search(
-    RestContext          *context_ptr,
+    int32_t                *rst_tmpbuf,
     Yv12BufferConfig       *org_fts,
     const Yv12BufferConfig *src,
     Yv12BufferConfig       *trial_frame_rst ,
@@ -2244,7 +2244,7 @@ void restoration_seg_search(
 
         init_rsc_seg(org_fts,src, cm, x, plane, rusi, trial_frame_rst, &rsc);
 
-        rsc_p->tmpbuf = context_ptr->rst_tmpbuf;
+        rsc_p->tmpbuf = rst_tmpbuf;
 
         const int32_t highbd = rsc.cm->use_highbitdepth;
         eb_extend_frame(rsc.dgd_buffer, rsc.plane_width, rsc.plane_height,

--- a/Source/Lib/Common/Codec/EbSystemResourceManager.c
+++ b/Source/Lib/Common/Codec/EbSystemResourceManager.c
@@ -199,8 +199,7 @@ void EbMuxingQueueDctor(EbPtr p)
 static EbErrorType EbMuxingQueueCtor(
     EbMuxingQueue        *queue_ptr,
     uint32_t              object_total_count,
-    uint32_t              process_total_count,
-    EbFifo         ***processFifoPtrArrayPtr)
+    uint32_t              process_total_count)
 {
     uint32_t processIndex;
     EbErrorType     return_error = EB_ErrorNone;
@@ -234,8 +233,6 @@ static EbErrorType EbMuxingQueueCtor(
             (EbObjectWrapper *)EB_NULL,
             queue_ptr);
     }
-
-    *processFifoPtrArrayPtr = queue_ptr->process_fifo_ptr_array;
 
     return return_error;
 }
@@ -349,6 +346,15 @@ static EbErrorType EbMuxingQueueObjectPushFront(
 
     return return_error;
 }
+
+static EbFifo* eb_muxing_queue_get_fifo(
+    EbMuxingQueue        *queue_ptr,
+    uint32_t index)
+{
+    assert(queue_ptr->process_fifo_ptr_array && (queue_ptr->process_total_count > index));
+    return queue_ptr->process_fifo_ptr_array[index];
+}
+
 
 /*********************************************************************
  * eb_object_release_enable
@@ -494,11 +500,6 @@ static void eb_system_resource_dctor(EbPtr p)
  *   object_total_count
  *     Number of objects to be managed by the SystemResource.
  *
- *   full_fifo_enabled
- *     Bool that describes if the SystemResource is to have an output
- *     fifo.  An outputFifo is not used by certain objects (e.g.
- *     SequenceControlSet).
- *
  *   object_ctor
  *     Function pointer to the constructor of the object managed by
  *     SystemResource referenced by resource_ptr. No object level
@@ -517,9 +518,6 @@ EbErrorType eb_system_resource_ctor(
     uint32_t               object_total_count,
     uint32_t               producer_process_total_count,
     uint32_t               consumer_process_total_count,
-    EbFifo          ***producer_fifo_ptr_array_ptr,
-    EbFifo          ***consumer_fifo_ptr_array_ptr,
-    EbBool              full_fifo_enabled,
     EbCreator           object_creator,
     EbPtr               object_init_data_ptr,
     EbDctor             object_destroyer)
@@ -544,8 +542,7 @@ EbErrorType eb_system_resource_ctor(
         resource_ptr->empty_queue,
         EbMuxingQueueCtor,
         resource_ptr->object_total_count,
-        producer_process_total_count,
-        producer_fifo_ptr_array_ptr);
+        producer_process_total_count);
     // Fill the Empty Fifo with every ObjectWrapper
     for (wrapperIndex = 0; wrapperIndex < resource_ptr->object_total_count; ++wrapperIndex) {
         EbMuxingQueueObjectPushBack(
@@ -554,23 +551,30 @@ EbErrorType eb_system_resource_ctor(
     }
 
     // Initialize the Full Queue
-    if (full_fifo_enabled == EB_TRUE) {
+    if (consumer_process_total_count) {
         EB_NEW(
             resource_ptr->full_queue,
             EbMuxingQueueCtor,
             resource_ptr->object_total_count,
-            consumer_process_total_count,
-            consumer_fifo_ptr_array_ptr);
-        if (return_error == EB_ErrorInsufficientResources)
-            return EB_ErrorInsufficientResources;
+            consumer_process_total_count);
     }
     else {
         resource_ptr->full_queue = (EbMuxingQueue *)EB_NULL;
-        consumer_fifo_ptr_array_ptr = (EbFifo ***)EB_NULL;
     }
 
     return return_error;
 }
+
+EbFifo* eb_system_resource_get_producer_fifo(const EbSystemResource *resource_ptr, uint32_t index)
+{
+    return eb_muxing_queue_get_fifo(resource_ptr->empty_queue, index);
+}
+
+EbFifo* eb_system_resource_get_consumer_fifo(const EbSystemResource *resource_ptr, uint32_t index)
+{
+    return eb_muxing_queue_get_fifo(resource_ptr->full_queue, index);
+}
+
 
 /*********************************************************************
  * EbSystemResourceReleaseProcess

--- a/Source/Lib/Common/Codec/EbSystemResourceManager.h
+++ b/Source/Lib/Common/Codec/EbSystemResourceManager.h
@@ -200,11 +200,6 @@ extern "C" {
      *   object_total_count
      *     Number of objects to be managed by the SystemResource.
      *
-     *   full_fifo_enabled
-     *     Bool that describes if the SystemResource is to have an output
-     *     fifo.  An outputFifo is not used by certain objects (e.g.
-     *     SequenceControlSet).
-     *
      *   object_ctor
      *     Function pointer to the constructor of the object managed by
      *     SystemResource referenced by resource_ptr. No object level
@@ -220,12 +215,33 @@ extern "C" {
         uint32_t            object_total_count,
         uint32_t            producer_process_total_count,
         uint32_t            consumer_process_total_count,
-        EbFifo         ***producer_fifo_ptr_array_ptr,
-        EbFifo         ***consumer_fifo_ptr_array_ptr,
-        EbBool              full_fifo_enabled,
         EbCreator             object_ctor,
         EbPtr               object_init_data_ptr,
         EbDctor             object_destroyer);
+
+    /*********************************************************************
+     * eb_system_resource_get_producer_fifo
+     *   get producer fifo
+     *
+     *   resource_ptr
+     *     pointer to SystemResource
+     *
+     *   index
+     *     index to the producer fifo
+     */
+    EbFifo* eb_system_resource_get_producer_fifo(const EbSystemResource *resource_ptr, uint32_t index);
+
+    /*********************************************************************
+     * eb_system_resource_get_consumer_fifo
+     *   get producer fifo
+     *
+     *   resource_ptr
+     *     pointer to SystemResource
+     *
+     *   index
+     *     index to the consumer fifo
+     */
+    EbFifo* eb_system_resource_get_consumer_fifo(const EbSystemResource *resource_ptr, uint32_t index);
 
     /*********************************************************************
      * EbSystemResourceGetEmptyObject

--- a/Source/Lib/Decoder/Codec/EbDecProcess.c
+++ b/Source/Lib/Decoder/Codec/EbDecProcess.c
@@ -98,12 +98,12 @@ EbErrorType DecSystemResourceInit(EbDecHandle *dec_handle_ptr,
         num_tiles, /* object_total_count */
         1, /* producer procs cnt : 1 Q per cnt is created inside, so kept 1*/
         1, /* consumer prcos cnt : 1 Q per cnt is created inside, so kept 1*/
-        &dec_mt_frame_data->parse_tile_producer_fifo_ptr, /* producer_fifo */
-        &dec_mt_frame_data->parse_tile_consumer_fifo_ptr, /* consumer_fifo */
-        EB_TRUE, /* Full Queue*/
         DecDummyCreator,
         &node_idx,
         NULL);
+
+    dec_mt_frame_data->parse_tile_producer_fifo_ptr = eb_system_resource_get_producer_fifo(dec_mt_frame_data->parse_tile_resource_ptr, 0); /* producer_fifo */
+    dec_mt_frame_data->parse_tile_consumer_fifo_ptr = eb_system_resource_get_consumer_fifo(dec_mt_frame_data->parse_tile_resource_ptr, 0); /* consumer_fifo */
 
     /* Recon queue */
     EB_NEW(dec_mt_frame_data->recon_tile_resource_ptr,
@@ -111,12 +111,12 @@ EbErrorType DecSystemResourceInit(EbDecHandle *dec_handle_ptr,
         num_tiles, /* object_total_count */
         1, /* producer procs cnt : 1 Q per cnt is created inside, so kept 1*/
         1, /* consumer prcos cnt : 1 Q per cnt is created inside, so kept 1*/
-        &dec_mt_frame_data->recon_tile_producer_fifo_ptr, /* producer_fifo */
-        &dec_mt_frame_data->recon_tile_consumer_fifo_ptr, /* consumer_fifo */
-        EB_TRUE, /* Full Queue*/
         DecDummyCreator,
         &node_idx,
         NULL);
+
+    dec_mt_frame_data->recon_tile_producer_fifo_ptr = eb_system_resource_get_producer_fifo(dec_mt_frame_data->recon_tile_resource_ptr, 0);
+    dec_mt_frame_data->recon_tile_consumer_fifo_ptr = eb_system_resource_get_consumer_fifo(dec_mt_frame_data->recon_tile_resource_ptr, 0);
 
     int32_t sb_size_h = block_size_high[dec_handle_ptr->seq_header.sb_size];
     uint32_t picture_height_in_sb =
@@ -128,12 +128,12 @@ EbErrorType DecSystemResourceInit(EbDecHandle *dec_handle_ptr,
         picture_height_in_sb, /* object_total_count */
         1, /* producer procs cnt : 1 Q per cnt is created inside, so kept 1*/
         1, /* consumer prcos cnt : 1 Q per cnt is created inside, so kept 1*/
-        &dec_mt_frame_data->lf_frame_info.lf_row_producer_fifo_ptr, /* producer_fifo */
-        &dec_mt_frame_data->lf_frame_info.lf_row_consumer_fifo_ptr, /* consumer_fifo */
-        EB_TRUE, /* Full Queue*/
         DecDummyCreator,
         &node_idx,
         NULL);
+
+    dec_mt_frame_data->lf_frame_info.lf_row_producer_fifo_ptr = eb_system_resource_get_producer_fifo(dec_mt_frame_data->lf_frame_info.lf_resource_ptr, 0);
+    dec_mt_frame_data->lf_frame_info.lf_row_consumer_fifo_ptr = eb_system_resource_get_consumer_fifo(dec_mt_frame_data->lf_frame_info.lf_resource_ptr, 0);
 
     /* CDEF queue */
     EB_NEW(dec_mt_frame_data->cdef_resource_ptr,
@@ -141,12 +141,12 @@ EbErrorType DecSystemResourceInit(EbDecHandle *dec_handle_ptr,
         picture_height_in_sb, /* object_total_count */
         1, /* producer procs cnt : 1 Q per cnt is created inside, so kept 1*/
         1, /* consumer prcos cnt : 1 Q per cnt is created inside, so kept 1*/
-        &dec_mt_frame_data->cdef_row_producer_fifo_ptr, /* producer_fifo */
-        &dec_mt_frame_data->cdef_row_consumer_fifo_ptr, /* consumer_fifo */
-        EB_TRUE, /* Full Queue*/
         DecDummyCreator,
         &node_idx,
         NULL);
+    dec_mt_frame_data->cdef_row_producer_fifo_ptr = eb_system_resource_get_producer_fifo(dec_mt_frame_data->cdef_resource_ptr, 0);
+    dec_mt_frame_data->cdef_row_consumer_fifo_ptr = eb_system_resource_get_consumer_fifo(dec_mt_frame_data->cdef_resource_ptr, 0);
+
 #if LR_PAD_MT
     /* LR queue */
     EB_NEW(dec_mt_frame_data->cdef_resource_ptr,
@@ -154,12 +154,12 @@ EbErrorType DecSystemResourceInit(EbDecHandle *dec_handle_ptr,
         picture_height_in_sb, /* object_total_count */
         1, /* producer procs cnt : 1 Q per cnt is created inside, so kept 1*/
         1, /* consumer prcos cnt : 1 Q per cnt is created inside, so kept 1*/
-        &dec_mt_frame_data->lr_row_producer_fifo_ptr, /* producer_fifo */
-        &dec_mt_frame_data->lr_row_consumer_fifo_ptr, /* consumer_fifo */
-        EB_TRUE, /* Full Queue*/
         DecDummyCreator,
         &node_idx,
         NULL);
+
+    dec_mt_frame_data->lr_row_producer_fifo_ptr = eb_system_resource_get_producer_fifo(dec_mt_frame_data->cdef_resource_ptr, 0);
+    dec_mt_frame_data->lr_row_consumer_fifo_ptr = eb_system_resource_get_consumer_fifo(dec_mt_frame_data->cdef_resource_ptr, 0);
 
     /* Pad queue */
     EB_NEW(dec_mt_frame_data->cdef_resource_ptr,
@@ -167,12 +167,11 @@ EbErrorType DecSystemResourceInit(EbDecHandle *dec_handle_ptr,
         picture_height_in_sb, /* object_total_count */
         1, /* producer procs cnt : 1 Q per cnt is created inside, so kept 1*/
         1, /* consumer prcos cnt : 1 Q per cnt is created inside, so kept 1*/
-        &dec_mt_frame_data->pad_row_producer_fifo_ptr, /* producer_fifo */
-        &dec_mt_frame_data->pad_row_consumer_fifo_ptr, /* consumer_fifo */
-        EB_TRUE, /* Full Queue*/
         DecDummyCreator,
         &node_idx,
         NULL);
+    dec_mt_frame_data->pad_row_producer_fifo_ptr = eb_system_resource_get_producer_fifo(dec_mt_frame_data->cdef_resource_ptr, 0);
+    dec_mt_frame_data->pad_row_consumer_fifo_ptr = eb_system_resource_get_consumer_fifo(dec_mt_frame_data->cdef_resource_ptr, 0);
 #endif
     /************************************
     * Contexts
@@ -386,7 +385,7 @@ void svt_av1_queue_parse_jobs(EbDecHandle *dec_handle_ptr,
         picture_height_in_sb * tiles_info->tile_cols * sizeof(uint32_t));
     for (uint32_t tile_num = tg_start; tile_num <= tg_end; tile_num++) {
         // Get Empty Parse Tile Job
-        eb_get_empty_object(dec_mt_frame_data->parse_tile_producer_fifo_ptr[0],
+        eb_get_empty_object(dec_mt_frame_data->parse_tile_producer_fifo_ptr,
                             &parse_results_wrapper_ptr);
 
         DecMTNode *context_ptr = (DecMTNode*)parse_results_wrapper_ptr->object_ptr;
@@ -423,7 +422,7 @@ void recon_tile_job_post(DecMTFrameData  *dec_mt_frame_data, uint32_t    node_in
 {
     EbObjectWrapper *recon_results_wrapper_ptr;
     // Get Empty Recon Tile Job
-    eb_get_empty_object(dec_mt_frame_data->recon_tile_producer_fifo_ptr[0],
+    eb_get_empty_object(dec_mt_frame_data->recon_tile_producer_fifo_ptr,
         &recon_results_wrapper_ptr);
 
     DecMTNode *recon_context_ptr =
@@ -454,7 +453,7 @@ void parse_frame_tiles(EbDecHandle     *dec_handle_ptr, int th_cnt) {
 
     while (1) {
         eb_dec_get_full_object_non_blocking(dec_mt_frame_data->
-            parse_tile_consumer_fifo_ptr[0],
+            parse_tile_consumer_fifo_ptr,
             &parse_results_wrapper_ptr);
 
         if (NULL != parse_results_wrapper_ptr) {
@@ -515,7 +514,7 @@ void decode_frame_tiles(EbDecHandle *dec_handle_ptr, DecThreadCtxt *thread_ctxt)
         DecModCtxt *dec_mod_ctxt = (DecModCtxt*)dec_handle_ptr->pv_dec_mod_ctxt;
 
         eb_dec_get_full_object_non_blocking(dec_mt_frame_data->
-            recon_tile_consumer_fifo_ptr[0],
+            recon_tile_consumer_fifo_ptr,
             &recon_results_wrapper_ptr);
 
         if (thread_ctxt != NULL) {
@@ -630,7 +629,7 @@ void svt_av1_queue_lf_jobs(EbDecHandle *dec_handle_ptr)
 
     for (y_lcu_index = 0; y_lcu_index < picture_height_in_sb; ++y_lcu_index) {
         // Get Empty LF Frame Row Job
-        eb_get_empty_object(lf_frame_info->lf_row_producer_fifo_ptr[0],
+        eb_get_empty_object(lf_frame_info->lf_row_producer_fifo_ptr,
             &lf_results_wrapper_ptr);
 
         DecMTNode *context_ptr = (DecMTNode*)lf_results_wrapper_ptr->object_ptr;
@@ -763,7 +762,7 @@ void dec_av1_loop_filter_frame_mt(
 
     while (1) {
         eb_dec_get_full_object_non_blocking(dec_mt_frame_data->lf_frame_info.
-            lf_row_consumer_fifo_ptr[0], &lf_results_wrapper_ptr);
+            lf_row_consumer_fifo_ptr, &lf_results_wrapper_ptr);
 
         if (NULL != lf_results_wrapper_ptr) {
             context_ptr = (DecMTNode*)lf_results_wrapper_ptr->object_ptr;
@@ -839,7 +838,7 @@ void svt_av1_queue_cdef_jobs(EbDecHandle *dec_handle_ptr) {
 
     for (uint32_t sb_fbr = 0; sb_fbr < picture_height_in_sb; ++sb_fbr) {
         // Get Empty LF Frame Row Job
-        eb_get_empty_object(dec_mt_frame_data->cdef_row_producer_fifo_ptr[0],
+        eb_get_empty_object(dec_mt_frame_data->cdef_row_producer_fifo_ptr,
             &cdef_results_wrapper_ptr);
 
         DecMTNode *context_ptr = (DecMTNode*)cdef_results_wrapper_ptr->object_ptr;
@@ -911,7 +910,7 @@ void svt_cdef_frame_mt(EbDecHandle *dec_handle_ptr) {
 
     while (1) {
         eb_dec_get_full_object_non_blocking(dec_mt_frame_data->
-            cdef_row_consumer_fifo_ptr[0], &cdef_results_wrapper_ptr);
+            cdef_row_consumer_fifo_ptr, &cdef_results_wrapper_ptr);
 
         if (NULL != cdef_results_wrapper_ptr) {
             context_ptr = (DecMTNode*)cdef_results_wrapper_ptr->object_ptr;
@@ -1001,7 +1000,7 @@ void svt_av1_queue_lr_jobs(EbDecHandle *dec_handle_ptr)
 
     for (uint32_t y_index = 0; y_index < picture_height_in_sb; ++y_index) {
         // Get Empty LR Frame Row Job
-        eb_get_empty_object(dec_mt_frame_data->lr_row_producer_fifo_ptr[0],
+        eb_get_empty_object(dec_mt_frame_data->lr_row_producer_fifo_ptr,
             &lr_results_wrapper_ptr);
 
         DecMTNode *context_ptr = (DecMTNode*)lr_results_wrapper_ptr->object_ptr;
@@ -1033,7 +1032,7 @@ void dec_av1_loop_restoration_filter_frame_mt(EbDecHandle *dec_handle
 
     while (1) {
         eb_dec_get_full_object_non_blocking(dec_mt_frame_data->
-            lr_row_consumer_fifo_ptr[0], &lr_results_wrapper_ptr);
+            lr_row_consumer_fifo_ptr, &lr_results_wrapper_ptr);
 
         if (NULL != lr_results_wrapper_ptr) {
             context_ptr = (DecMTNode*)lr_results_wrapper_ptr->object_ptr;
@@ -1067,7 +1066,7 @@ void svt_av1_queue_pad_jobs(EbDecHandle *dec_handle_ptr)
 
     for (uint32_t y_index = 0; y_index < picture_height_in_sb; ++y_index) {
         // Get Empty Pad Frame Row Job
-        eb_get_empty_object(dec_mt_frame_data->pad_row_producer_fifo_ptr[0],
+        eb_get_empty_object(dec_mt_frame_data->pad_row_producer_fifo_ptr,
             &pad_results_wrapper_ptr);
 
         DecMTNode *context_ptr = (DecMTNode*)pad_results_wrapper_ptr->object_ptr;
@@ -1099,7 +1098,7 @@ void dec_pad_frame_mt(EbDecHandle *dec_handle
 
     while (1) {
         eb_dec_get_full_object_non_blocking(dec_mt_frame_data->
-            pad_row_consumer_fifo_ptr[0], &pad_results_wrapper_ptr);
+            pad_row_consumer_fifo_ptr, &pad_results_wrapper_ptr);
 
         if (NULL != pad_results_wrapper_ptr) {
             context_ptr = (DecMTNode*)pad_results_wrapper_ptr->object_ptr;

--- a/Source/Lib/Decoder/Codec/EbDecProcess.h
+++ b/Source/Lib/Decoder/Codec/EbDecProcess.h
@@ -82,8 +82,8 @@ typedef struct DecMTLFFrameInfo {
     // System Resource Managers
     EbSystemResource    *lf_resource_ptr;
     /* EbFifo at Frame Row level */
-    EbFifo              **lf_row_producer_fifo_ptr;
-    EbFifo              **lf_row_consumer_fifo_ptr;
+    EbFifo              *lf_row_producer_fifo_ptr;
+    EbFifo              *lf_row_consumer_fifo_ptr;
 
     /* Array to store SBs completed in every SB row of LF stage.
        Used for top sync */
@@ -142,15 +142,15 @@ typedef struct DecMTFrameData {
     // System Resource Managers
     EbSystemResource    *parse_tile_resource_ptr;
     /* EbFifo at Tile level : Parse Stage */
-    EbFifo              **parse_tile_producer_fifo_ptr;
-    EbFifo              **parse_tile_consumer_fifo_ptr;
+    EbFifo              *parse_tile_producer_fifo_ptr;
+    EbFifo              *parse_tile_consumer_fifo_ptr;
 
     // System Resource Managers
     EbSystemResource    *recon_tile_resource_ptr;
 
     /* EbFifo at Tile level : Recon Stage */
-    EbFifo              **recon_tile_producer_fifo_ptr;
-    EbFifo              **recon_tile_consumer_fifo_ptr;
+    EbFifo              *recon_tile_producer_fifo_ptr;
+    EbFifo              *recon_tile_consumer_fifo_ptr;
 
     /* To prevent more than 1 thread from mod. recon_row_started simult. */
     EbHandle                recon_mutex;
@@ -171,8 +171,8 @@ typedef struct DecMTFrameData {
     // System Resource Managers
     EbSystemResource        *cdef_resource_ptr;
     /* EbFifo at Frame Row level */
-    EbFifo                  **cdef_row_producer_fifo_ptr;
-    EbFifo                  **cdef_row_consumer_fifo_ptr;
+    EbFifo                  *cdef_row_producer_fifo_ptr;
+    EbFifo                  *cdef_row_consumer_fifo_ptr;
     /* Array to store 64x64s completed in every 64x64 row of CDEF stage.
        Used for top-right sync */
     uint32_t                *cdef_completed_in_row;
@@ -191,8 +191,8 @@ typedef struct DecMTFrameData {
     // System Resource Managers
     EbSystemResource        *lr_resource_ptr;
     /* EbFifo at Frame Row level */
-    EbFifo                  **lr_row_producer_fifo_ptr;
-    EbFifo                  **lr_row_consumer_fifo_ptr;
+    EbFifo                  *lr_row_producer_fifo_ptr;
+    EbFifo                  *lr_row_consumer_fifo_ptr;
     /* Array to store SBs completed in every SB row of LR stage.
        Used for top sync */
     int32_t                 *sb_lr_completed_in_row;
@@ -206,8 +206,8 @@ typedef struct DecMTFrameData {
     // System Resource Managers
     EbSystemResource        *pad_resource_ptr;
     /* EbFifo at Frame Row level */
-    EbFifo                  **pad_row_producer_fifo_ptr;
-    EbFifo                  **pad_row_consumer_fifo_ptr;
+    EbFifo                  *pad_row_producer_fifo_ptr;
+    EbFifo                  *pad_row_consumer_fifo_ptr;
 #endif
     /* EbFifo at Frame Row level : Pad Stage */
     EbFifo                  *pad_fifo_ptr;

--- a/Source/Lib/Encoder/Codec/EbCdefProcess.h
+++ b/Source/Lib/Encoder/Codec/EbCdefProcess.h
@@ -8,27 +8,14 @@
 
 #include "EbSystemResourceManager.h"
 #include "EbObject.h"
-/**************************************
- * Cdef Context
- **************************************/
-typedef struct CdefContext_s
-{
-    EbDctor                       dctor;
-    EbFifo                       *cdef_input_fifo_ptr;
-    EbFifo                       *cdef_output_fifo_ptr;
-} CdefContext_t;
 
 /**************************************
  * Extern Function Declarations
  **************************************/
 extern EbErrorType cdef_context_ctor(
-    CdefContext_t           *context_ptr,
-    EbFifo                       *cdef_input_fifo_ptr,
-    EbFifo                       *cdef_output_fifo_ptr,
-    EbBool                  is16bit,
-    uint32_t                max_input_luma_width,
-    uint32_t                max_input_luma_height
-   );
+    EbThreadContext     *thread_context_ptr,
+    const EbEncHandle   *enc_handle_ptr,
+    int                 index);
 
 extern void* cdef_kernel(void *input_ptr);
 

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.h
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.h
@@ -9,25 +9,13 @@
 #include "EbDefinitions.h"
 #include "EbSystemResourceManager.h"
 #include "EbRateControlProcess.h"
-#include "EbObject.h"
-
-/**************************************
- * Context
- **************************************/
-typedef struct InitialRateControlContext
-{
-    EbDctor                    dctor;
-    EbFifo                    *motion_estimation_results_input_fifo_ptr;
-    EbFifo                    *initialrate_control_results_output_fifo_ptr;
-} InitialRateControlContext;
 
 /***************************************
  * Extern Function Declaration
  ***************************************/
-extern EbErrorType initial_rate_control_context_ctor(
-    InitialRateControlContext  *context_ptr,
-    EbFifo                     *motion_estimation_results_input_fifo_ptr,
-    EbFifo                     *picture_demux_results_output_fifo_ptr);
+EbErrorType initial_rate_control_context_ctor(
+    EbThreadContext     *thread_context_ptr,
+    const EbEncHandle   *enc_handle_ptr);
 
 extern void* initial_rate_control_kernel(void *input_ptr);
 

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.h
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.h
@@ -12,25 +12,14 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-    /***************************************
-     * Context
-     ***************************************/
-    typedef struct PictureManagerContext
-    {
-        EbDctor  dctor;
-        EbFifo  *picture_input_fifo_ptr;
-        EbFifo  *picture_manager_output_fifo_ptr;
-        EbFifo **picture_control_set_fifo_ptr_array;
-    } PictureManagerContext;
 
     /***************************************
      * Extern Function Declaration
      ***************************************/
-    extern EbErrorType picture_manager_context_ctor(
-        PictureManagerContext  *context_ptr,
-        EbFifo                 *pictureInputFifoPtr,
-        EbFifo                 *picture_manager_output_fifo_ptr,
-        EbFifo                **picture_control_set_fifo_ptr_array);
+    EbErrorType picture_manager_context_ctor(
+        EbThreadContext     *thread_context_ptr,
+        const EbEncHandle   *enc_handle_ptr,
+        int rate_control_index);
 
     extern void* picture_manager_kernel(void *input_ptr);
 

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.h
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.h
@@ -7,67 +7,16 @@
 #define EbResourceCoordination_h
 
 #include "EbDefinitions.h"
-#include "EbSystemResourceManager.h"
-#include "EbObject.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
     /***************************************
-     * Context
-     ***************************************/
-    typedef struct ResourceCoordinationContext
-    {
-        EbDctor                               dctor;
-        EbFifo                                *input_buffer_fifo_ptr;
-        EbFifo                                *resource_coordination_results_output_fifo_ptr;
-        EbFifo                               **picture_control_set_fifo_ptr_array;
-        EbSequenceControlSetInstance         **sequence_control_set_instance_array;
-        EbObjectWrapper                      **sequenceControlSetActiveArray;
-        EbFifo                                *sequence_control_set_empty_fifo_ptr;
-        EbCallback                           **app_callback_ptr_array;
-
-        // Compute Segments
-        uint32_t                               compute_segments_total_count_array;
-        uint32_t                               encode_instances_total_count;
-
-        // Picture Number Array
-        uint64_t                              *picture_number_array;
-
-        uint64_t                               average_enc_mod;
-        uint8_t                                prev_enc_mod;
-        int8_t                                 prev_enc_mode_delta;
-        uint8_t                                prev_change_cond;
-
-        int64_t                                previous_mode_change_buffer;
-        int64_t                                previous_mode_change_frame_in;
-        int64_t                                previous_buffer_check1;
-        int64_t                                previous_frame_in_check1;
-        int64_t                                previous_frame_in_check2;
-        int64_t                                previous_frame_in_check3;
-
-        uint64_t                               cur_speed; // speed x 1000
-        uint64_t                               prevs_time_seconds;
-        uint64_t                               prevs_timeu_seconds;
-        int64_t                                prev_frame_out;
-
-        uint64_t                               first_in_pic_arrived_time_seconds;
-        uint64_t                               first_in_pic_arrived_timeu_seconds;
-        EbBool                                 start_flag;
-    } ResourceCoordinationContext;
-
-    /***************************************
      * Extern Function Declaration
      ***************************************/
-    extern EbErrorType resource_coordination_context_ctor(
-        ResourceCoordinationContext  *context_ptr,
-        EbFifo                        *input_buffer_fifo_ptr,
-        EbFifo                        *resource_coordination_results_output_fifo_ptr,
-        EbFifo                       **picture_control_set_fifo_ptr_array,
-        EbSequenceControlSetInstance **sequence_control_set_instance_array,
-        EbFifo                        *sequence_control_set_empty_fifo_ptr,
-        EbCallback                   **app_callback_ptr_array,
-        uint32_t                       compute_segments_total_count_array,
-        uint32_t                       encode_instances_total_count);
+    EbErrorType resource_coordination_context_ctor(
+        EbThreadContext *thread_context_ptr,
+        EbEncHandle* enc_handle_ptr);
+
 
     extern void* resource_coordination_kernel(void *input_ptr);
 #ifdef __cplusplus

--- a/Source/Lib/Encoder/Codec/EbSourceBasedOperationsProcess.c
+++ b/Source/Lib/Encoder/Codec/EbSourceBasedOperationsProcess.c
@@ -11,21 +11,51 @@
 #include "EbInitialRateControlResults.h"
 #include "EbPictureDemuxResults.h"
 #include "emmintrin.h"
+#include "EbEncHandle.h"
 #include "EbUtility.h"
 
+/**************************************
+ * Context
+ **************************************/
+
+typedef struct SourceBasedOperationsContext
+{
+    EbDctor  dctor;
+    EbFifo  *initial_rate_control_results_input_fifo_ptr;
+    EbFifo  *picture_demux_results_output_fifo_ptr;
+    // local zz cost array
+    uint32_t    sb_high_contrast_count;
+    uint32_t    complete_sb_count;
+    uint32_t    sb_cmplx_contrast_count;
+    uint8_t    *y_mean_ptr;
+    uint8_t    *cr_mean_ptr;
+    uint8_t    *cb_mean_ptr;
+} SourceBasedOperationsContext;
+
+static void source_based_operations_context_dctor(EbPtr p)
+{
+    EbThreadContext   *thread_context_ptr = (EbThreadContext*)p;
+    SourceBasedOperationsContext* obj = (SourceBasedOperationsContext*)thread_context_ptr->priv;
+    EB_FREE_ARRAY(obj);
+}
+
 /************************************************
-* Initial Rate Control Context Constructor
+* Source Based Operation Context Constructor
 ************************************************/
 EbErrorType source_based_operations_context_ctor(
-    SourceBasedOperationsContext  *context_ptr,
-    EbFifo                        *initialRateControlResultsInputFifoPtr,
-    EbFifo                        *picture_demux_results_output_fifo_ptr,
-    SequenceControlSet            *sequence_control_set_ptr)
+    EbThreadContext     *thread_context_ptr,
+    const EbEncHandle   *enc_handle_ptr,
+    int index)
 {
-    UNUSED(sequence_control_set_ptr);
+    SourceBasedOperationsContext  *context_ptr;
+    EB_CALLOC_ARRAY(context_ptr, 1);
+    thread_context_ptr->priv = context_ptr;
+    thread_context_ptr->dctor = source_based_operations_context_dctor;
 
-    context_ptr->initial_rate_control_results_input_fifo_ptr = initialRateControlResultsInputFifoPtr;
-    context_ptr->picture_demux_results_output_fifo_ptr       = picture_demux_results_output_fifo_ptr;
+    context_ptr->initial_rate_control_results_input_fifo_ptr =
+        eb_system_resource_get_consumer_fifo(enc_handle_ptr->initial_rate_control_results_resource_ptr, index);
+    context_ptr->picture_demux_results_output_fifo_ptr       =
+        eb_system_resource_get_producer_fifo(enc_handle_ptr->picture_demux_results_resource_ptr, index);
     return EB_ErrorNone;
 }
 
@@ -82,7 +112,8 @@ void DerivePictureActivityStatistics(
  ************************************************/
 void* source_based_operations_kernel(void *input_ptr)
 {
-    SourceBasedOperationsContext    *context_ptr = (SourceBasedOperationsContext*)input_ptr;
+    EbThreadContext                 *thread_context_ptr = (EbThreadContext*)input_ptr;
+    SourceBasedOperationsContext    *context_ptr = (SourceBasedOperationsContext*)thread_context_ptr->priv;
     PictureParentControlSet       *picture_control_set_ptr;
     SequenceControlSet            *sequence_control_set_ptr;
     EbObjectWrapper               *inputResultsWrapperPtr;

--- a/Source/Lib/Encoder/Codec/EbSourceBasedOperationsProcess.h
+++ b/Source/Lib/Encoder/Codec/EbSourceBasedOperationsProcess.h
@@ -18,35 +18,15 @@
 #define EbSourceBasedOperations_h
 
 #include "EbDefinitions.h"
-#include "EbSystemResourceManager.h"
 #include "EbNoiseExtractAVX2.h"
-#include "EbObject.h"
-/**************************************
- * Context
- **************************************/
-
-typedef struct SourceBasedOperationsContext
-{
-    EbDctor  dctor;
-    EbFifo  *initial_rate_control_results_input_fifo_ptr;
-    EbFifo  *picture_demux_results_output_fifo_ptr;
-    // local zz cost array
-    uint32_t    sb_high_contrast_count;
-    uint32_t    complete_sb_count;
-    uint32_t    sb_cmplx_contrast_count;
-    uint8_t    *y_mean_ptr;
-    uint8_t    *cr_mean_ptr;
-    uint8_t    *cb_mean_ptr;
-} SourceBasedOperationsContext;
 
 /***************************************
  * Extern Function Declaration
  ***************************************/
-extern EbErrorType source_based_operations_context_ctor(
-    SourceBasedOperationsContext  *context_ptr,
-    EbFifo                        *initial_rate_control_results_input_fifo_ptr,
-    EbFifo                        *picture_demux_results_output_fifo_ptr,
-    SequenceControlSet            *sequence_control_set_ptr);
+EbErrorType source_based_operations_context_ctor(
+    EbThreadContext     *thread_context_ptr,
+    const EbEncHandle   *enc_handle_ptr,
+    int index);
 
 extern void* source_based_operations_kernel(void *input_ptr);
 


### PR DESCRIPTION
There are many double and triple Fifo pointer in EbEncHandle.
It makes code very hard to read.
Actually, we just get the Fifo from system resource EbSystemResource and set them to different contexts.
We can add a simple eb_system_resource_get_producer_fifo & eb_system_resource_get_consumer_fifo to make code more readable.

These patch serials also hide the construction details in the constructor.
take PAL_SUP as an example, we do not need change conductor like https://github.com/OpenVisualCloud/SVT-AV1/commit/fb6a3f155c08fc5d3d0eaed2051a26d6448eaac4#diff-89b879cd97bff7a8dcfea93083d2ffc2L1539 any more.
all details are hidden in enc_dec_context_ctor


I have tested follow commandlines
```
SvtAv1EncApp -enc-mode 7 -b test.ivf  -o test.yuv -i test.y4m -n 100
SvtAv1EncApp -enc-mode 7 -b test.ivf   -i test.y4m   -n 100
```

