### PR TITLE
Update cost calculation for cdef filtering

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -87,6 +87,7 @@ extern "C" {
 #define MR_MODE                           0
 
 #define WARP_UPDATE                       1 // Modified Warp settings: ON for MR mode. ON for ref frames in M0
+#define UPDATE_CDEF                       1 // Update bit cost estimation for CDEF filter
 #define EIGTH_PEL_MV                      1
 #define EIGHT_PEL_PREDICTIVE_ME           1
 #define EIGHT_PEL_FIX                     1 // Improve the 8th pel performance by shutting it based on the qindex and bug fixes

--- a/Source/Lib/Encoder/Codec/EbCdefProcess.c
+++ b/Source/Lib/Encoder/Codec/EbCdefProcess.c
@@ -39,10 +39,8 @@ int32_t eb_sb_compute_cdef_list(PictureControlSet   *picture_control_set_ptr, co
     cdef_list *dlist, BlockSize bs);
 void finish_cdef_search(
     EncDecContext                *context_ptr,
-    SequenceControlSet           *sequence_control_set_ptr,
-    PictureControlSet            *picture_control_set_ptr
-    ,int32_t                         selected_strength_cnt[64]
-   );
+    PictureControlSet            *picture_control_set_ptr,
+    int32_t                      selected_strength_cnt[64]);
 void av1_cdef_frame16bit(
     EncDecContext                *context_ptr,
     SequenceControlSet           *sequence_control_set_ptr,
@@ -472,7 +470,6 @@ void* cdef_kernel(void *input_ptr)
         if (sequence_control_set_ptr->seq_header.enable_cdef && picture_control_set_ptr->parent_pcs_ptr->cdef_filter_mode) {
                 finish_cdef_search(
                     0,
-                    sequence_control_set_ptr,
                     picture_control_set_ptr,
                     selected_strength_cnt);
 


### PR DESCRIPTION
## Description 
- Update rate estimation, cost calculation equation, and lambda to match lambda from MD

## Type of change

- Optimization / enhancement

## Performance 

Tested on Objective-fast1 test-set in context of M5M2 where there was a gain of 0.1%. Going to re-run a simulation over M0.

## Author
@NaderMahdi @anaghdin 