### PR TITLE
Global Motion Estimation Opt

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -83,6 +83,7 @@ extern "C" {
 #define PRED_CHANGE_MOD              1 // Reorder the references for MRP
 #define SPEED_OPT                    1 // Speed optimization(s)
 #define GLOBAL_WARPED_MOTION         1 // Global warped motion detection and insertion
+#define GM_OPT                       1 // Perform global motion estimation on a down-sampled version of the input picture
 
 #ifndef NON_AVX512_SUPPORT
 #define NON_AVX512_SUPPORT
@@ -138,6 +139,13 @@ typedef enum ME_QP_MODE {
     EX_QP_MODE = 0,       // Exhaustive  1/4-pel serach mode.
     REFINMENT_QP_MODE = 1 // Refinement 1/4-pel serach mode.
 } ME_QP_MODE;
+#if GM_OPT
+typedef enum GM_LEVEL {
+    GM_FULL         = 0,       // Exhaustive search mode.
+    GM_DOWN         = 1,       // Downsampled search mode, with a downsampling factor of 2 in each dimension
+    GM_TRAN_ONLY    = 2        // Translation only using ME MV.
+} GM_LEVEL;
+#endif
 struct Buf2D
 {
     uint8_t *buf;

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -4152,6 +4152,9 @@ void  inject_inter_candidates(
     uint32_t                   canTotalCnt = *candidateTotalCnt;
     ModeDecisionCandidate    *candidateArray = context_ptr->fast_candidate_array;
     EbBool isCompoundEnabled = (frm_hdr->reference_mode == SINGLE_REFERENCE) ? 0 : 1;
+#if GM_OPT
+    uint8_t inj_mv = 1;
+#endif
     int inside_tile = 1;
     MacroBlockD  *xd = context_ptr->cu_ptr->av1xd;
     int umv0tile = (sequence_control_set_ptr->static_config.unrestricted_motion_vector == 0);
@@ -4310,6 +4313,9 @@ void  inject_inter_candidates(
 
     if (context_ptr->global_mv_injection) {
 #if GLOBAL_WARPED_MOTION
+#if GM_OPT
+        if (picture_control_set_ptr->parent_pcs_ptr->gm_level <= GM_DOWN) {
+#endif
         for (unsigned list_ref_index_l0 = 0; list_ref_index_l0 < 1; ++list_ref_index_l0)
         for (unsigned list_ref_index_l1 = 0; list_ref_index_l1 < 1; ++list_ref_index_l1) {
 
@@ -4517,7 +4523,11 @@ void  inject_inter_candidates(
                 }
             }
         }
-#else
+#endif
+#if GM_OPT && GLOBAL_WARPED_MOTION || !GLOBAL_WARPED_MOTION
+#if GM_OPT && GLOBAL_WARPED_MOTION
+    }else{
+#endif
         /**************
          GLOBALMV L0
         ************* */
@@ -4692,6 +4702,9 @@ void  inject_inter_candidates(
                 }
             }
         }
+#if GM_OPT && GLOBAL_WARPED_MOTION
+    }
+#endif
 #endif
     }
 

--- a/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
@@ -872,11 +872,17 @@ void* motion_estimation_kernel(void *input_ptr)
             // Global motion estimation
             // Compute only for the first fragment.
             // TODO: create an other kernel ?
+#if GM_OPT
+        if (picture_control_set_ptr->gm_level == GM_FULL || picture_control_set_ptr->gm_level == GM_DOWN) {
+#endif
             if (context_ptr->me_context_ptr->compute_global_motion
                 && inputResultsPtr->segment_index == 0)
                 global_motion_estimation(picture_control_set_ptr,
                                          context_ptr->me_context_ptr,
                                          input_picture_ptr);
+#if GM_OPT
+        }
+#endif
 #endif
 
             // Segments

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -14309,6 +14309,9 @@ extern "C" {
 #if MDC_ADAPTIVE_LEVEL
         uint8_t                                enable_adaptive_ol_partitioning;
 #endif
+#if GM_OPT
+        uint8_t                                gm_level;
+#endif
     } PictureParentControlSet;
 
     typedef struct PictureControlSetInitData

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -1381,6 +1381,14 @@ EbErrorType signal_derivation_multi_processes_oq(
             picture_control_set_ptr->frm_hdr.use_ref_frame_mvs = 0;
         else
             picture_control_set_ptr->frm_hdr.use_ref_frame_mvs = sequence_control_set_ptr->mfmv_enabled;
+
+#if GM_OPT
+        // Global motion level                        Settings
+        // GM_FULL                                    Exhaustive search mode.
+        // GM_DOWN                                    Downsampled resolution with a downsampling factor of 2 in each dimension
+        // GM_TRAN_ONLY                               Translation only using ME MV.
+        picture_control_set_ptr->gm_level = GM_FULL;
+#endif
     return return_error;
 }
 

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -220,6 +220,9 @@ void DetectGlobalMotion(
     PictureParentControlSet    *picture_control_set_ptr)
 {
 #if GLOBAL_WARPED_MOTION
+#if GM_OPT
+    if (picture_control_set_ptr->gm_level <= GM_DOWN) {
+#endif
     uint32_t numOfListToSearch = (picture_control_set_ptr->slice_type == P_SLICE)
         ? (uint32_t)REF_LIST_0 : (uint32_t)REF_LIST_1;
 
@@ -244,7 +247,12 @@ void DetectGlobalMotion(
                 picture_control_set_ptr->is_global_motion[listIndex][ref_pic_index] = EB_TRUE;
         }
     }
-#else
+#endif
+#if GM_OPT && GLOBAL_WARPED_MOTION || !GLOBAL_WARPED_MOTION
+#if GM_OPT && GLOBAL_WARPED_MOTION
+    }
+    else {
+#endif
     uint32_t    sb_count;
     uint32_t    picture_width_in_sb = (picture_control_set_ptr->enhanced_picture_ptr->width + BLOCK_SIZE_64 - 1) / BLOCK_SIZE_64;
     uint32_t    sb_origin_x;
@@ -369,6 +377,9 @@ void DetectGlobalMotion(
             picture_control_set_ptr->tiltMvy = (int16_t)(yTiltMvSum / totalTiltLcus);
         }
     }
+#if GM_OPT && GLOBAL_WARPED_MOTION
+    }
+#endif
 #endif
 }
 


### PR DESCRIPTION
## Description

Perform the global motion estimation on a down-sampled version of the input picture.

Closes #835 
## Type of Feature

New feature

## Author

@NaderMahdi 

## Testing and Performance

- 0.04% BD rate difference to AOM averaged over 360p, 720p, and 1080p clips in M0
- 3.1% speed gain averaged over 360p, 720p, and 1080p clips in M0
