### PR TITLE
Set RANSAC_NUM_MOTIONS to 1 to speedup global motion estimation

### DIFF
--- a/Source/Lib/Common/Codec/global_motion.h
+++ b/Source/Lib/Common/Codec/global_motion.h
@@ -34,7 +34,7 @@ extern "C" {
 #endif
 
 #define MAX_CORNERS 4096
-#define RANSAC_NUM_MOTIONS 100
+#define RANSAC_NUM_MOTIONS 1
 
 typedef enum {
   GLOBAL_MOTION_FEATURE_BASED,


### PR DESCRIPTION
This PR just decreases the RANSAC_NUM_MOTIONS macro parameter from 100 to 1.
This parameter corresponds to the number of different motions tested by the RANSAC algorithm that estimates the global motion parameters.
Setting it to 1 leads to a decrease of the compression time while slightly increasing the BD-RATE.

Here are the performance results with the full objective-1-fast dataset:


Metric | deviation
-- | --
Average BD-PSNR | -1.01157208449589E-05
Average BD-RATE | 0.002265293304234
Compression time | -2.13%

