### PR TITLE
Code cleanup for cdef filtering

### DIFF
--- a/Source/Lib/Common/Codec/EbCdef.c
+++ b/Source/Lib/Common/Codec/EbCdef.c
@@ -322,8 +322,8 @@ void eb_cdef_filter_fb(uint8_t *dst8, uint16_t *dst16, int32_t dstride, uint16_t
     }
     if (pli == 1 && xdec != ydec) {
         for (bi = 0; bi < cdef_count; bi++) {
-            /*static*/ const int32_t conv422[8] = { 7, 0, 2, 4, 5, 6, 6, 6 };
-            /*static*/ const int32_t conv440[8] = { 1, 2, 2, 2, 3, 4, 6, 0 };
+            const int32_t conv422[8] = { 7, 0, 2, 4, 5, 6, 6, 6 };
+            const int32_t conv440[8] = { 1, 2, 2, 2, 3, 4, 6, 0 };
             by = dlist[bi].by;
             bx = dlist[bi].bx;
             dir[by][bx] = (xdec ? conv422 : conv440)[dir[by][bx]];
@@ -370,7 +370,6 @@ int32_t eb_sb_all_skip(PictureControlSet   *picture_control_set_ptr, const Av1Co
             skip =
                 skip &&
                 picture_control_set_ptr->mi_grid_base[(mi_row + r) * picture_control_set_ptr->mi_stride + mi_col + c]->mbmi.block_mi.skip;
-            /// cm->mi_grid_visible[(mi_row + r) * cm->mi_stride + mi_col + c]->skip;
         }
     }
     return skip;
@@ -481,7 +480,7 @@ void eb_av1_cdef_frame(
     EbByte  reconBufferCb = &((recon_picture_ptr->buffer_cb)[recon_picture_ptr->origin_x / 2 + recon_picture_ptr->origin_y / 2 * recon_picture_ptr->stride_cb]);
     EbByte  reconBufferCr = &((recon_picture_ptr->buffer_cr)[recon_picture_ptr->origin_x / 2 + recon_picture_ptr->origin_y / 2 * recon_picture_ptr->stride_cr]);
 
-    const int32_t num_planes = 3;// av1_num_planes(cm);
+    const int32_t num_planes = av1_num_planes(&sequence_control_set_ptr->seq_header.color_config);
     DECLARE_ALIGNED(16, uint16_t, src[CDEF_INBUF_SIZE]);
     uint16_t *linebuf[3];
     uint16_t *colbuf[3];
@@ -646,17 +645,17 @@ void eb_av1_cdef_frame(
 
                 /* Copy in the pixels we need from the current superblock for
                    deringing.*/
-                copy_sb8_16(//cm,
+                copy_sb8_16(
                     &src[CDEF_VBORDER * CDEF_BSTRIDE + CDEF_HBORDER + cstart],
-                    CDEF_BSTRIDE, recBuff/*xd->plane[pli].dst.buf*/,
+                    CDEF_BSTRIDE, recBuff,
                     (MI_SIZE_64X64 << mi_high_l2[pli]) * fbr, coffset + cstart,
-                    recStride/*xd->plane[pli].dst.stride*/, rend, cend - cstart);
+                    recStride, rend, cend - cstart);
                 if (!prev_row_cdef[fbc]) {
-                    copy_sb8_16(//cm,
+                    copy_sb8_16(
                         &src[CDEF_HBORDER], CDEF_BSTRIDE,
-                        recBuff/*xd->plane[pli].dst.buf*/,
+                        recBuff,
                         (MI_SIZE_64X64 << mi_high_l2[pli]) * fbr - CDEF_VBORDER,
-                        coffset, recStride/*xd->plane[pli].dst.stride*/, CDEF_VBORDER, hsize);
+                        coffset, recStride, CDEF_VBORDER, hsize);
                 }
                 else if (fbr > 0) {
                     copy_rect(&src[CDEF_HBORDER], CDEF_BSTRIDE, &linebuf[pli][coffset],
@@ -668,10 +667,10 @@ void eb_av1_cdef_frame(
                 }
 
                 if (!prev_row_cdef[fbc - 1]) {
-                    copy_sb8_16(//cm,
-                        src, CDEF_BSTRIDE, recBuff/*xd->plane[pli].dst.buf*/,
+                    copy_sb8_16(
+                        src, CDEF_BSTRIDE, recBuff,
                         (MI_SIZE_64X64 << mi_high_l2[pli]) * fbr - CDEF_VBORDER,
-                        coffset - CDEF_HBORDER, recStride/*xd->plane[pli].dst.stride*/,
+                        coffset - CDEF_HBORDER, recStride,
                         CDEF_VBORDER, CDEF_HBORDER);
                 }
                 else if (fbr > 0 && fbc > 0) {
@@ -684,11 +683,11 @@ void eb_av1_cdef_frame(
                 }
 
                 if (!prev_row_cdef[fbc + 1]) {
-                    copy_sb8_16(//cm,
+                    copy_sb8_16(
                         &src[CDEF_HBORDER + (nhb << mi_wide_l2[pli])],
-                        CDEF_BSTRIDE, recBuff/*xd->plane[pli].dst.buf*/,
+                        CDEF_BSTRIDE, recBuff,
                         (MI_SIZE_64X64 << mi_high_l2[pli]) * fbr - CDEF_VBORDER,
-                        coffset + hsize, recStride/*xd->plane[pli].dst.stride*/, CDEF_VBORDER,
+                        coffset + hsize, recStride, CDEF_VBORDER,
                         CDEF_HBORDER);
                 }
                 else if (fbr > 0 && fbc < nhfb - 1) {
@@ -716,10 +715,9 @@ void eb_av1_cdef_frame(
 
                 if (fbr < nvfb - 1)
                     copy_sb8_16(
-                        //cm,
-                        &linebuf[pli][coffset], stride, recBuff/*xd->plane[pli].dst.buf*/,
+                        &linebuf[pli][coffset], stride, recBuff,
                         (MI_SIZE_64X64 << mi_high_l2[pli]) * (fbr + 1) - CDEF_VBORDER,
-                        coffset, recStride/*xd->plane[pli].dst.stride*/, CDEF_VBORDER, hsize);
+                        coffset, recStride, CDEF_VBORDER, hsize);
 
                 if (frame_top) {
                     fill_rect(src, CDEF_BSTRIDE, CDEF_VBORDER, hsize + 2 * CDEF_HBORDER,
@@ -738,24 +736,10 @@ void eb_av1_cdef_frame(
                         vsize + 2 * CDEF_VBORDER, CDEF_HBORDER, CDEF_VERY_LARGE);
                 }
 
-                //if (cm->use_highbitdepth) {
-                //  eb_cdef_filter_fb(
-                //      NULL,
-                //      &CONVERT_TO_SHORTPTR(
-                //          xd->plane[pli]
-                //              .dst.buf)[xd->plane[pli].dst.stride *
-                //                            (MI_SIZE_64X64 * fbr << mi_high_l2[pli]) +
-                //                        (fbc * MI_SIZE_64X64 << mi_wide_l2[pli])],
-                //      xd->plane[pli].dst.stride,
-                //      &src[CDEF_VBORDER * CDEF_BSTRIDE + CDEF_HBORDER], xdec[pli],
-                //      ydec[pli], dir, NULL, var, pli, dlist, cdef_count, level,
-                //      sec_strength, pri_damping, sec_damping, coeff_shift);
-                //} else
                 {
                     eb_cdef_filter_fb(
                         &recBuff[recStride *(MI_SIZE_64X64 * fbr << mi_high_l2[pli]) + (fbc * MI_SIZE_64X64 << mi_wide_l2[pli])],
-                        //&xd->plane[pli].dst.buf[xd->plane[pli].dst.stride *(MI_SIZE_64X64 * fbr << mi_high_l2[pli]) +(fbc * MI_SIZE_64X64 << mi_wide_l2[pli])],
-                        NULL, recStride/*xd->plane[pli].dst.stride*/,
+                        NULL, recStride,
                         &src[CDEF_VBORDER * CDEF_BSTRIDE + CDEF_HBORDER], xdec[pli],
                         ydec[pli], dir, NULL, var, pli, dlist, cdef_count, level,
                         sec_strength, pri_damping, sec_damping, coeff_shift);
@@ -797,7 +781,7 @@ void av1_cdef_frame16bit(
     uint16_t*  reconBufferCb = (uint16_t*)recon_picture_ptr->buffer_cb + (recon_picture_ptr->origin_x / 2 + recon_picture_ptr->origin_y / 2 * recon_picture_ptr->stride_cb);
     uint16_t*  reconBufferCr = (uint16_t*)recon_picture_ptr->buffer_cr + (recon_picture_ptr->origin_x / 2 + recon_picture_ptr->origin_y / 2 * recon_picture_ptr->stride_cr);
 
-    const int32_t num_planes = 3;// av1_num_planes(cm);
+    const int32_t num_planes = av1_num_planes(&sequence_control_set_ptr->seq_header.color_config);
     DECLARE_ALIGNED(16, uint16_t, src[CDEF_INBUF_SIZE]);
     uint16_t *linebuf[3];
     uint16_t *colbuf[3];
@@ -813,7 +797,6 @@ void av1_cdef_frame16bit(
     int32_t coeff_shift = AOMMAX(sequence_control_set_ptr->static_config.encoder_bit_depth/*cm->bit_depth*/ - 8, 0);
     const int32_t nvfb = (cm->mi_rows + MI_SIZE_64X64 - 1) / MI_SIZE_64X64;
     const int32_t nhfb = (cm->mi_cols + MI_SIZE_64X64 - 1) / MI_SIZE_64X64;
-    //eb_av1_setup_dst_planes(xd->plane, cm->seq_params.sb_size, frame, 0, 0, 0, num_planes);
     row_cdef = (uint8_t *)eb_aom_malloc(sizeof(*row_cdef) * (nhfb + 2) * 2);
     assert(row_cdef);
     memset(row_cdef, 1, sizeof(*row_cdef) * (nhfb + 2) * 2);
@@ -960,22 +943,21 @@ void av1_cdef_frame16bit(
                     break;
                 }
 
-                //--ok
-                                /* Copy in the pixels we need from the current superblock for
-                                deringing.*/
+                /* Copy in the pixels we need from the current superblock for
+                deringing.*/
 
-                copy_sb16_16(//cm,
+                copy_sb16_16(
                     &src[CDEF_VBORDER * CDEF_BSTRIDE + CDEF_HBORDER + cstart],
-                    CDEF_BSTRIDE, recBuff/*xd->plane[pli].dst.buf*/,
+                    CDEF_BSTRIDE, recBuff,
                     (MI_SIZE_64X64 << mi_high_l2[pli]) * fbr, coffset + cstart,
-                    recStride/*xd->plane[pli].dst.stride*/, rend, cend - cstart);
+                    recStride, rend, cend - cstart);
 
                 if (!prev_row_cdef[fbc]) {
-                    copy_sb16_16(//cm,
+                    copy_sb16_16(
                         &src[CDEF_HBORDER], CDEF_BSTRIDE,
-                        recBuff/*xd->plane[pli].dst.buf*/,
+                        recBuff,
                         (MI_SIZE_64X64 << mi_high_l2[pli]) * fbr - CDEF_VBORDER,
-                        coffset, recStride/*xd->plane[pli].dst.stride*/, CDEF_VBORDER, hsize);
+                        coffset, recStride, CDEF_VBORDER, hsize);
                 }
                 else if (fbr > 0) {
                     copy_rect(&src[CDEF_HBORDER], CDEF_BSTRIDE, &linebuf[pli][coffset],
@@ -987,10 +969,10 @@ void av1_cdef_frame16bit(
                 }
 
                 if (!prev_row_cdef[fbc - 1]) {
-                    copy_sb16_16(//cm,
-                        src, CDEF_BSTRIDE, recBuff/*xd->plane[pli].dst.buf*/,
+                    copy_sb16_16(
+                        src, CDEF_BSTRIDE, recBuff,
                         (MI_SIZE_64X64 << mi_high_l2[pli]) * fbr - CDEF_VBORDER,
-                        coffset - CDEF_HBORDER, recStride/*xd->plane[pli].dst.stride*/,
+                        coffset - CDEF_HBORDER, recStride,
                         CDEF_VBORDER, CDEF_HBORDER);
                 }
                 else if (fbr > 0 && fbc > 0) {
@@ -1003,11 +985,11 @@ void av1_cdef_frame16bit(
                 }
 
                 if (!prev_row_cdef[fbc + 1]) {
-                    copy_sb16_16(//cm,
+                    copy_sb16_16(
                         &src[CDEF_HBORDER + (nhb << mi_wide_l2[pli])],
-                        CDEF_BSTRIDE, recBuff/*xd->plane[pli].dst.buf*/,
+                        CDEF_BSTRIDE, recBuff,
                         (MI_SIZE_64X64 << mi_high_l2[pli]) * fbr - CDEF_VBORDER,
-                        coffset + hsize, recStride/*xd->plane[pli].dst.stride*/, CDEF_VBORDER,
+                        coffset + hsize, recStride, CDEF_VBORDER,
                         CDEF_HBORDER);
                 }
                 else if (fbr > 0 && fbc < nhfb - 1) {
@@ -1034,10 +1016,9 @@ void av1_cdef_frame16bit(
                         rend + CDEF_VBORDER, CDEF_HBORDER);
                 if (fbr < nvfb - 1)
                     copy_sb16_16(
-                        //cm,
-                        &linebuf[pli][coffset], stride, recBuff/*xd->plane[pli].dst.buf*/,
+                        &linebuf[pli][coffset], stride, recBuff,
                         (MI_SIZE_64X64 << mi_high_l2[pli]) * (fbr + 1) - CDEF_VBORDER,
-                        coffset, recStride/*xd->plane[pli].dst.stride*/, CDEF_VBORDER, hsize);
+                        coffset, recStride, CDEF_VBORDER, hsize);
                 if (frame_top) {
                     fill_rect(src, CDEF_BSTRIDE, CDEF_VBORDER, hsize + 2 * CDEF_HBORDER,
                         CDEF_VERY_LARGE);
@@ -1055,29 +1036,13 @@ void av1_cdef_frame16bit(
                         vsize + 2 * CDEF_VBORDER, CDEF_HBORDER, CDEF_VERY_LARGE);
                 }
 
-                //if (cm->use_highbitdepth) {
-                //  eb_cdef_filter_fb(
-                //      NULL,
-                //      &CONVERT_TO_SHORTPTR(
-                //          xd->plane[pli]
-                //              .dst.buf)[xd->plane[pli].dst.stride *
-                //                            (MI_SIZE_64X64 * fbr << mi_high_l2[pli]) +
-                //                        (fbc * MI_SIZE_64X64 << mi_wide_l2[pli])],
-                //      xd->plane[pli].dst.stride,
-                //      &src[CDEF_VBORDER * CDEF_BSTRIDE + CDEF_HBORDER], xdec[pli],
-                //      ydec[pli], dir, NULL, var, pli, dlist, cdef_count, level,
-                //      sec_strength, pri_damping, sec_damping, coeff_shift);
-                //} else
-                {
-                    eb_cdef_filter_fb(
-                        NULL,
-                        &recBuff[recStride *(MI_SIZE_64X64 * fbr << mi_high_l2[pli]) + (fbc * MI_SIZE_64X64 << mi_wide_l2[pli])],
-                        //&xd->plane[pli].dst.buf[xd->plane[pli].dst.stride *(MI_SIZE_64X64 * fbr << mi_high_l2[pli]) +(fbc * MI_SIZE_64X64 << mi_wide_l2[pli])],
-                        recStride/*xd->plane[pli].dst.stride*/,
-                        &src[CDEF_VBORDER * CDEF_BSTRIDE + CDEF_HBORDER], xdec[pli],
-                        ydec[pli], dir, NULL, var, pli, dlist, cdef_count, level,
-                        sec_strength, pri_damping, sec_damping, coeff_shift);
-                }
+                eb_cdef_filter_fb(
+                    NULL,
+                    &recBuff[recStride *(MI_SIZE_64X64 * fbr << mi_high_l2[pli]) + (fbc * MI_SIZE_64X64 << mi_wide_l2[pli])],
+                    recStride,
+                    &src[CDEF_VBORDER * CDEF_BSTRIDE + CDEF_HBORDER], xdec[pli],
+                    ydec[pli], dir, NULL, var, pli, dlist, cdef_count, level,
+                    sec_strength, pri_damping, sec_damping, coeff_shift);
             }
             cdef_left = 1;  //CHKN filtered data is written back directy to recFrame.
         }
@@ -1473,7 +1438,6 @@ void finish_cdef_search(
 
     uint64_t(*mse[2])[TOTAL_STRENGTHS];
     int32_t pri_damping = 3 + (frm_hdr->quantization_params.base_q_idx >> 6);
-    //int32_t sec_damping = 3 + (frm_hdr->quantization_params.base_q_idx >> 6);
     int32_t i;
     int32_t nb_strengths;
     int32_t nb_strength_bits;
@@ -1483,7 +1447,7 @@ void finish_cdef_search(
     int32_t quantizer;
     double lambda;
 #endif
-    const int32_t num_planes = 3;
+    const int32_t num_planes = 3; // av1_num_planes(cm);
 #if UPDATE_CDEF
     uint16_t qp_index = (uint8_t)picture_control_set_ptr->parent_pcs_ptr->frm_hdr.quantization_params.base_q_idx;
     uint32_t fast_lambda, full_lambda, fast_chroma_lambda, full_chroma_lambda;
@@ -1617,8 +1581,6 @@ void finish_cdef_search(
     }
     //cdef_pri_damping & cdef_sec_damping consolidated to cdef_damping
     frm_hdr->CDEF_params.cdef_damping = pri_damping;
-    //pPcs->cdef_pri_damping = pri_damping;
-    //pPcs->cdef_sec_damping = sec_damping;
     for (int i = 0; i < total_strengths; i++)
         best_frame_gi_cnt += selected_strength_cnt[i] > best_frame_gi_cnt ? 1 : 0;
     pPcs->cdef_frame_strength = ((best_frame_gi_cnt + 4) / 4) * 4;
@@ -1627,684 +1589,4 @@ void finish_cdef_search(
     free(mse[1]);
     free(sb_index);
     free(selected_strength);
-}
-
-void eb_av1_cdef_search(
-    EncDecContext                *context_ptr,
-    SequenceControlSet           *sequence_control_set_ptr,
-    PictureControlSet            *picture_control_set_ptr
-    //Yv12BufferConfig *frame,
-    //const Yv12BufferConfig *ref,
-    //Av1Common *cm,
-    //MacroBlockD *xd,
-    //int32_t fast
-)
-{
-    (void)context_ptr;
-    int32_t fast = 0;
-    struct PictureParentControlSet     *pPcs = picture_control_set_ptr->parent_pcs_ptr;
-    FrameHeader *frm_hdr = &pPcs->frm_hdr;
-    Av1Common*   cm = pPcs->av1_cm;
-    int32_t mi_rows = pPcs->av1_cm->mi_rows;
-    int32_t mi_cols = pPcs->av1_cm->mi_cols;
-
-    EbPictureBufferDesc  * recon_picture_ptr;
-    if (pPcs->is_used_as_reference_flag == EB_TRUE)
-        recon_picture_ptr = ((EbReferenceObject*)picture_control_set_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)->reference_picture;
-    else
-        recon_picture_ptr = picture_control_set_ptr->recon_picture_ptr;
-
-    EbByte  reconBufferY = &((recon_picture_ptr->buffer_y)[recon_picture_ptr->origin_x + recon_picture_ptr->origin_y * recon_picture_ptr->stride_y]);
-    EbByte  reconBufferCb = &((recon_picture_ptr->buffer_cb)[recon_picture_ptr->origin_x / 2 + recon_picture_ptr->origin_y / 2 * recon_picture_ptr->stride_cb]);
-    EbByte  reconBufferCr = &((recon_picture_ptr->buffer_cr)[recon_picture_ptr->origin_x / 2 + recon_picture_ptr->origin_y / 2 * recon_picture_ptr->stride_cr]);
-
-    EbPictureBufferDesc *input_picture_ptr = (EbPictureBufferDesc*)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
-    EbByte  inputBufferY = &((input_picture_ptr->buffer_y)[input_picture_ptr->origin_x + input_picture_ptr->origin_y * input_picture_ptr->stride_y]);
-    EbByte  inputBufferCb = &((input_picture_ptr->buffer_cb)[input_picture_ptr->origin_x / 2 + input_picture_ptr->origin_y / 2 * input_picture_ptr->stride_cb]);
-    EbByte  inputBufferCr = &((input_picture_ptr->buffer_cr)[input_picture_ptr->origin_x / 2 + input_picture_ptr->origin_y / 2 * input_picture_ptr->stride_cr]);
-
-    int32_t r, c;
-    int32_t fbr, fbc;
-    uint16_t *src[3];
-    uint16_t *ref_coeff[3];
-    /*static*/ cdef_list dlist[MI_SIZE_128X128 * MI_SIZE_128X128];
-    int32_t dir[CDEF_NBLOCKS][CDEF_NBLOCKS] = { { 0 } };
-    int32_t var[CDEF_NBLOCKS][CDEF_NBLOCKS] = { { 0 } };
-    int32_t stride[3];
-    int32_t bsize[3];
-    int32_t mi_wide_l2[3];
-    int32_t mi_high_l2[3];
-    int32_t xdec[3];
-    int32_t ydec[3];
-    int32_t pli;
-    int32_t cdef_count;
-
-    //CHKN int32_t coeff_shift = AOMMAX(cm->bit_depth - 8, 0);
-    int32_t coeff_shift = AOMMAX(sequence_control_set_ptr->static_config.encoder_bit_depth - 8, 0);
-
-    uint64_t best_tot_mse = (uint64_t)1 << 63;
-    uint64_t tot_mse;
-    int32_t sb_count;
-
-    int32_t nvfb = (mi_rows /*cm->mi_rows*/ + MI_SIZE_64X64 - 1) / MI_SIZE_64X64;
-    int32_t nhfb = (mi_cols/*cm->mi_cols*/ + MI_SIZE_64X64 - 1) / MI_SIZE_64X64;
-
-    int32_t *sb_index = (int32_t *)eb_aom_malloc(nvfb * nhfb * sizeof(*sb_index));       //CHKN add cast
-    int32_t *selected_strength = (int32_t *)eb_aom_malloc(nvfb * nhfb * sizeof(*sb_index));
-
-    assert(sb_index != NULL);
-    assert(selected_strength != NULL);
-
-    uint64_t(*mse[2])[TOTAL_STRENGTHS];
-    int32_t pri_damping = 3 + (frm_hdr->quantization_params.base_q_idx /*cm->quant_param.base_q_idx*/ >> 6);
-    int32_t sec_damping = 3 + (frm_hdr->quantization_params.base_q_idx /*cm->quant_param.base_q_idx*/ >> 6);
-    int32_t i;
-    int32_t nb_strengths;
-    int32_t nb_strength_bits;
-    int32_t quantizer;
-    double lambda;
-    const int32_t num_planes = 3;// av1_num_planes(cm);
-    const int32_t total_strengths = fast ? REDUCED_TOTAL_STRENGTHS : TOTAL_STRENGTHS;
-    DECLARE_ALIGNED(32, uint16_t, inbuf[CDEF_INBUF_SIZE]);
-    uint16_t *in;
-    DECLARE_ALIGNED(32, uint16_t, tmp_dst[1 << (MAX_SB_SIZE_LOG2 * 2)]);
-
-    int32_t selected_strength_cnt[TOTAL_STRENGTHS] = { 0 };
-    int32_t best_frame_gi_cnt = 0;
-    int32_t gi_step = get_cdef_gi_step(pPcs->cdef_filter_mode);
-    int32_t mid_gi = pPcs->cdf_ref_frame_strenght;
-    int32_t start_gi = pPcs->use_ref_frame_cdef_strength && pPcs->cdef_filter_mode == 1 ? (AOMMAX(0, mid_gi - gi_step)) : 0;
-    int32_t end_gi = pPcs->use_ref_frame_cdef_strength ? AOMMIN(total_strengths, mid_gi + gi_step) : pPcs->cdef_filter_mode == 1 ? 8 : total_strengths;
-
-    quantizer =
-        //CHKN av1_ac_quant_Q3(cm->quant_param.base_q_idx, 0, cm->bit_depth) >> (cm->bit_depth - 8);
-        eb_av1_ac_quant_Q3(frm_hdr->quantization_params.base_q_idx, 0, (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth) >> (sequence_control_set_ptr->static_config.encoder_bit_depth - 8);
-    lambda = .12 * quantizer * quantizer / 256.;
-
-    //eb_av1_setup_dst_planes(xd->plane, cm->seq_params.sb_size, frame, 0, 0, 0,    num_planes);
-
-    mse[0] = (uint64_t(*)[64])eb_aom_malloc(sizeof(**mse) * nvfb * nhfb);
-    mse[1] = (uint64_t(*)[64])eb_aom_malloc(sizeof(**mse) * nvfb * nhfb);
-
-    for (pli = 0; pli < num_planes; pli++) {
-        uint8_t *in_buffer = 0;
-        int32_t in_stride = 0;
-
-        uint8_t *ref_buffer = 0;
-        int32_t ref_stride = 0;
-        switch (pli) {
-        case 0:
-            ref_buffer = inputBufferY;
-            ref_stride = input_picture_ptr->stride_y;
-            in_buffer = reconBufferY;
-            in_stride = recon_picture_ptr->stride_y;
-            break;
-        case 1:
-            ref_buffer = inputBufferCb;
-            ref_stride = input_picture_ptr->stride_cb;
-            in_buffer = reconBufferCb;
-            in_stride = recon_picture_ptr->stride_cb;
-            break;
-        case 2:
-            ref_buffer = inputBufferCr;
-            ref_stride = input_picture_ptr->stride_cr;
-            in_buffer = reconBufferCr;
-            in_stride = recon_picture_ptr->stride_cr;
-            break;
-        }
-
-        ///CHKN: allocate one frame 16bit for src and recon!!
-        src[pli] = (uint16_t*)eb_aom_memalign(32, sizeof(*src)       * mi_rows * mi_cols * MI_SIZE * MI_SIZE);
-        ref_coeff[pli] = (uint16_t*)eb_aom_memalign(32, sizeof(*ref_coeff) * mi_rows * mi_cols * MI_SIZE * MI_SIZE);
-
-        int32_t subsampling_x = (pli == 0) ? 0 : 1;
-        int32_t subsampling_y = (pli == 0) ? 0 : 1;
-
-        xdec[pli] = subsampling_x; //CHKN  xd->plane[pli].subsampling_x;
-        ydec[pli] = subsampling_y; //CHKN  xd->plane[pli].subsampling_y;
-        bsize[pli] = ydec[pli] ? (xdec[pli] ? BLOCK_4X4 : BLOCK_8X4)
-            : (xdec[pli] ? BLOCK_4X8 : BLOCK_8X8);
-
-        stride[pli] = cm->mi_cols << MI_SIZE_LOG2;
-        mi_wide_l2[pli] = MI_SIZE_LOG2 - subsampling_x;  //CHKN MI_SIZE_LOG2 - xd->plane[pli].subsampling_x;
-        mi_high_l2[pli] = MI_SIZE_LOG2 - subsampling_y;  //CHKN MI_SIZE_LOG2 - xd->plane[pli].subsampling_y;
-
-        const int32_t frame_height = (cm->mi_rows * MI_SIZE) >> subsampling_y;//CHKN  xd->plane[pli].subsampling_y;
-        const int32_t frame_width = (cm->mi_cols * MI_SIZE) >> subsampling_x;//CHKN  xd->plane[pli].subsampling_x;
-
-        for (r = 0; r < frame_height; ++r) {
-            for (c = 0; c < frame_width; ++c) {
-                //if (cm->use_highbitdepth) {
-                //    src[pli][r * stride[pli] + c] = CONVERT_TO_SHORTPTR(
-                //        xd->plane[pli].dst.buf)[r * xd->plane[pli].dst.stride + c];
-                //    ref_coeff[pli][r * stride[pli] + c] =
-                //        CONVERT_TO_SHORTPTR(ref_buffer)[r * ref_stride + c];
-                //}
-                //else
-                {
-                    src[pli][r * stride[pli] + c] = in_buffer[r * in_stride + c];//CHKN xd->plane[pli].dst.buf[r * xd->plane[pli].dst.stride + c];
-                    ref_coeff[pli][r * stride[pli] + c] = ref_buffer[r * ref_stride + c];
-                }
-            }
-        }
-    }
-
-    in = inbuf + CDEF_VBORDER * CDEF_BSTRIDE + CDEF_HBORDER;
-    sb_count = 0;
-    for (fbr = 0; fbr < nvfb; ++fbr) {
-        for (fbc = 0; fbc < nhfb; ++fbc) {
-            int32_t nvb, nhb;
-            int32_t gi;
-            int32_t dirinit = 0;
-            nhb = AOMMIN(MI_SIZE_64X64, cm->mi_cols - MI_SIZE_64X64 * fbc);
-            nvb = AOMMIN(MI_SIZE_64X64, cm->mi_rows - MI_SIZE_64X64 * fbr);
-            int32_t hb_step = 1; //CHKN these should be all time with 64x64 LCUs
-            int32_t vb_step = 1;
-            BlockSize bs = BLOCK_64X64;
-            ModeInfo **mi = picture_control_set_ptr->mi_grid_base + MI_SIZE_64X64 * fbr * cm->mi_stride + MI_SIZE_64X64 * fbc;
-            const MbModeInfo *mbmi = &mi[0]->mbmi;
-
-            //MbModeInfo *const mbmi =
-            //    cm->mi_grid_visible[MI_SIZE_64X64 * fbr * cm->mi_stride +
-            //    MI_SIZE_64X64 * fbc];
-
-            if (((fbc & 1) &&
-                (mbmi->block_mi.sb_type == BLOCK_128X128 || mbmi->block_mi.sb_type == BLOCK_128X64)) ||
-                ((fbr & 1) &&
-                (mbmi->block_mi.sb_type == BLOCK_128X128 || mbmi->block_mi.sb_type == BLOCK_64X128)))
-                continue;
-            if (mbmi->block_mi.sb_type == BLOCK_128X128 || mbmi->block_mi.sb_type == BLOCK_128X64 ||
-                mbmi->block_mi.sb_type == BLOCK_64X128)
-                bs = mbmi->block_mi.sb_type;
-            if (bs == BLOCK_128X128 || bs == BLOCK_128X64) {
-                nhb = AOMMIN(MI_SIZE_128X128, cm->mi_cols - MI_SIZE_64X64 * fbc);
-                hb_step = 2;
-            }
-            if (bs == BLOCK_128X128 || bs == BLOCK_64X128) {
-                nvb = AOMMIN(MI_SIZE_128X128, cm->mi_rows - MI_SIZE_64X64 * fbr);
-                vb_step = 2;
-            }
-
-            // No filtering if the entire filter block is skipped
-            if (eb_sb_all_skip(picture_control_set_ptr, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64))
-                continue;
-
-            cdef_count = eb_sb_compute_cdef_list(picture_control_set_ptr, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64, dlist, bs);
-
-            for (pli = 0; pli < num_planes; pli++) {
-                for (i = 0; i < CDEF_INBUF_SIZE; i++)
-                    inbuf[i] = CDEF_VERY_LARGE;
-                int32_t yoff = CDEF_VBORDER * (fbr != 0);
-                int32_t xoff = CDEF_HBORDER * (fbc != 0);
-                int32_t ysize = (nvb << mi_high_l2[pli]) + CDEF_VBORDER * (fbr + vb_step < nvfb) + yoff;
-                int32_t xsize = (nhb << mi_wide_l2[pli]) + CDEF_HBORDER * (fbc + hb_step < nhfb) + xoff;
-
-                copy_sb16_16(
-                    &in[(-yoff * CDEF_BSTRIDE - xoff)], CDEF_BSTRIDE,
-                    src[pli],
-                    (fbr * MI_SIZE_64X64 << mi_high_l2[pli]) - yoff,
-                    (fbc * MI_SIZE_64X64 << mi_wide_l2[pli]) - xoff,
-                    stride[pli], ysize, xsize);
-
-                for (gi = start_gi; gi < end_gi; gi++) {
-                    int32_t threshold;
-                    uint64_t curr_mse;
-                    int32_t sec_strength;
-                    threshold = gi / CDEF_SEC_STRENGTHS;
-                    if (fast) threshold = priconv[threshold];
-                    /* We avoid filtering the pixels for which some of the pixels to
-                    average are outside the frame. We could change the filter instead, but it would add special cases for any future vectorization. */
-                    sec_strength = gi % CDEF_SEC_STRENGTHS;
-                    eb_cdef_filter_fb(NULL, tmp_dst, CDEF_BSTRIDE, in, xdec[pli], ydec[pli],
-                        dir, &dirinit, var, pli, dlist, cdef_count, threshold,
-                        sec_strength + (sec_strength == 3), pri_damping,
-                        sec_damping, coeff_shift);
-
-                    curr_mse = eb_compute_cdef_dist(
-                        ref_coeff[pli] +
-                        (fbr * MI_SIZE_64X64 << mi_high_l2[pli]) * stride[pli] +
-                        (fbc * MI_SIZE_64X64 << mi_wide_l2[pli]),
-                        stride[pli], tmp_dst, dlist, cdef_count, (BlockSize)bsize[pli], coeff_shift,
-                        pli);
-
-                    if (pli < 2)
-                        mse[pli][sb_count][gi] = curr_mse;
-                    else
-                        mse[1][sb_count][gi] += curr_mse;
-
-                    sb_index[sb_count] = MI_SIZE_64X64 * fbr * picture_control_set_ptr->mi_stride + MI_SIZE_64X64 * fbc;//CHKN
-                }
-            }
-            sb_count++;
-        }
-    }
-
-    nb_strength_bits = 0;
-    /* Search for different number of signalling bits. */
-    for (i = 0; i <= 3; i++) {
-        int32_t j;
-        int32_t best_lev0[CDEF_MAX_STRENGTHS];
-        int32_t best_lev1[CDEF_MAX_STRENGTHS] = { 0 };
-        nb_strengths = 1 << i;
-        if (num_planes >= 3)
-            tot_mse = joint_strength_search_dual(best_lev0, best_lev1, nb_strengths, mse, sb_count, fast, start_gi, end_gi);
-        else
-            tot_mse = joint_strength_search(best_lev0, nb_strengths, mse[0], sb_count, fast, start_gi, end_gi);
-        /* Count superblock signalling cost. */
-        tot_mse += (uint64_t)(sb_count * lambda * i);
-        /* Count header signalling cost. */
-        tot_mse += (uint64_t)(nb_strengths * lambda * CDEF_STRENGTH_BITS);
-        if (tot_mse < best_tot_mse) {
-            best_tot_mse = tot_mse;
-            nb_strength_bits = i;
-            for (j = 0; j < 1 << nb_strength_bits; j++) {
-                frm_hdr->CDEF_params.cdef_y_strength[j] = best_lev0[j];
-                frm_hdr->CDEF_params.cdef_uv_strength[j] = best_lev1[j];
-            }
-        }
-    }
-    nb_strengths = 1 << nb_strength_bits;
-
-    /*cm*/frm_hdr->CDEF_params.cdef_bits = nb_strength_bits;
-    /*cm*/pPcs->nb_cdef_strengths = nb_strengths;
-    for (i = 0; i < sb_count; i++) {
-        int32_t gi;
-        int32_t best_gi;
-        uint64_t best_mse = (uint64_t)1 << 63;
-        best_gi = 0;
-        for (gi = 0; gi < /*cm*/pPcs->nb_cdef_strengths; gi++) {
-            uint64_t curr = mse[0][i][/*cm*/frm_hdr->CDEF_params.cdef_y_strength[gi]];
-            if (num_planes >= 3) curr += mse[1][i][/*cm*/frm_hdr->CDEF_params.cdef_uv_strength[gi]];
-            if (curr < best_mse) {
-                best_gi = gi;
-                best_mse = curr;
-            }
-        }
-        selected_strength[i] = best_gi;
-        selected_strength_cnt[best_gi]++;
-
-        //CHKN cm->mi_grid_visible[sb_index[i]]->cdef_strength = best_gi;
-        picture_control_set_ptr->mi_grid_base[sb_index[i]]->mbmi.cdef_strength = (int8_t)best_gi;
-        //in case the fb is within a block=128x128 or 128x64, or 64x128, then we genrate param only for the first 64x64.
-        //since our mi map deos not have the multi pointer single data assignment, we need to duplicate data.
-        BlockSize sb_type = picture_control_set_ptr->mi_grid_base[sb_index[i]]->mbmi.block_mi.sb_type;
-
-        if (sb_type == BLOCK_128X128)
-        {
-            picture_control_set_ptr->mi_grid_base[sb_index[i] + MI_SIZE_64X64]->mbmi.cdef_strength = (int8_t)best_gi;
-            picture_control_set_ptr->mi_grid_base[sb_index[i] + MI_SIZE_64X64 * picture_control_set_ptr->mi_stride]->mbmi.cdef_strength = (int8_t)best_gi;
-            picture_control_set_ptr->mi_grid_base[sb_index[i] + MI_SIZE_64X64 * picture_control_set_ptr->mi_stride + MI_SIZE_64X64]->mbmi.cdef_strength = (int8_t)best_gi;
-        }
-        else if (sb_type == BLOCK_128X64)
-            picture_control_set_ptr->mi_grid_base[sb_index[i] + MI_SIZE_64X64]->mbmi.cdef_strength = (int8_t)best_gi;
-        else if (sb_type == BLOCK_64X128)
-            picture_control_set_ptr->mi_grid_base[sb_index[i] + MI_SIZE_64X64 * picture_control_set_ptr->mi_stride]->mbmi.cdef_strength = (int8_t)best_gi;
-    }
-
-    if (fast) {
-        for (int32_t j = 0; j < nb_strengths; j++) {
-            frm_hdr->CDEF_params.cdef_y_strength[j] = priconv[frm_hdr->CDEF_params.cdef_y_strength[j] / CDEF_SEC_STRENGTHS] * CDEF_SEC_STRENGTHS + (frm_hdr->CDEF_params.cdef_y_strength[j] % CDEF_SEC_STRENGTHS);
-            frm_hdr->CDEF_params.cdef_uv_strength[j] = priconv[frm_hdr->CDEF_params.cdef_uv_strength[j] / CDEF_SEC_STRENGTHS] * CDEF_SEC_STRENGTHS + (frm_hdr->CDEF_params.cdef_uv_strength[j] % CDEF_SEC_STRENGTHS);
-        }
-    }
-
-    for (int i = 0; i < total_strengths; i++)
-        best_frame_gi_cnt += selected_strength_cnt[i] > best_frame_gi_cnt ? 1 : 0;
-    pPcs->cdef_frame_strength = ((best_frame_gi_cnt + 4) / 4) * 4;
-
-    frm_hdr->CDEF_params.cdef_damping = pri_damping;
-    //pPcs->cdef_pri_damping = pri_damping;
-    //pPcs->cdef_sec_damping = sec_damping;
-
-    eb_aom_free(mse[0]);
-    eb_aom_free(mse[1]);
-    for (pli = 0; pli < num_planes; pli++) {
-        eb_aom_free(src[pli]);
-        eb_aom_free(ref_coeff[pli]);
-    }
-    eb_aom_free(sb_index);
-    eb_aom_free(selected_strength);
-}
-
-void av1_cdef_search16bit(
-    EncDecContext                *context_ptr,
-    SequenceControlSet           *sequence_control_set_ptr,
-    PictureControlSet            *picture_control_set_ptr
-    //Yv12BufferConfig *frame,
-    //const Yv12BufferConfig *ref,
-    //Av1Common *cm,
-    //MacroBlockD *xd,
-    //int32_t fast
-)
-{
-    (void)context_ptr;
-    int32_t fast = 0;
-    struct PictureParentControlSet     *pPcs = picture_control_set_ptr->parent_pcs_ptr;
-    FrameHeader *frm_hdr = &pPcs->frm_hdr;
-    Av1Common*   cm = pPcs->av1_cm;
-    int32_t mi_rows = pPcs->av1_cm->mi_rows;
-    int32_t mi_cols = pPcs->av1_cm->mi_cols;
-
-    EbPictureBufferDesc  * recon_picture_ptr;
-    if (pPcs->is_used_as_reference_flag == EB_TRUE)
-        recon_picture_ptr = ((EbReferenceObject*)picture_control_set_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)->reference_picture16bit;
-    else
-        recon_picture_ptr = picture_control_set_ptr->recon_picture16bit_ptr;
-
-    uint16_t*  reconBufferY = (uint16_t*)recon_picture_ptr->buffer_y + (recon_picture_ptr->origin_x + recon_picture_ptr->origin_y     * recon_picture_ptr->stride_y);
-    uint16_t*  reconBufferCb = (uint16_t*)recon_picture_ptr->buffer_cb + (recon_picture_ptr->origin_x / 2 + recon_picture_ptr->origin_y / 2 * recon_picture_ptr->stride_cb);
-    uint16_t*  reconBufferCr = (uint16_t*)recon_picture_ptr->buffer_cr + (recon_picture_ptr->origin_x / 2 + recon_picture_ptr->origin_y / 2 * recon_picture_ptr->stride_cr);
-
-    EbPictureBufferDesc *input_picture_ptr = picture_control_set_ptr->input_frame16bit;
-    uint16_t*  inputBufferY = (uint16_t*)input_picture_ptr->buffer_y + (input_picture_ptr->origin_x + input_picture_ptr->origin_y * input_picture_ptr->stride_y);
-    uint16_t*  inputBufferCb = (uint16_t*)input_picture_ptr->buffer_cb + (input_picture_ptr->origin_x / 2 + input_picture_ptr->origin_y / 2 * input_picture_ptr->stride_cb);
-    uint16_t*  inputBufferCr = (uint16_t*)input_picture_ptr->buffer_cr + (input_picture_ptr->origin_x / 2 + input_picture_ptr->origin_y / 2 * input_picture_ptr->stride_cr);
-
-    int32_t r, c;
-    int32_t fbr, fbc;
-    uint16_t *src[3];
-    uint16_t *ref_coeff[3];
-    /*static*/ cdef_list dlist[MI_SIZE_128X128 * MI_SIZE_128X128];
-    int32_t dir[CDEF_NBLOCKS][CDEF_NBLOCKS] = { { 0 } };
-    int32_t var[CDEF_NBLOCKS][CDEF_NBLOCKS] = { { 0 } };
-    int32_t stride[3];
-    int32_t bsize[3];
-    int32_t mi_wide_l2[3];
-    int32_t mi_high_l2[3];
-    int32_t xdec[3];
-    int32_t ydec[3];
-    int32_t pli;
-    int32_t cdef_count;
-
-    //CHKN int32_t coeff_shift = AOMMAX(cm->bit_depth - 8, 0);
-    int32_t coeff_shift = AOMMAX(sequence_control_set_ptr->static_config.encoder_bit_depth - 8, 0);
-
-    uint64_t best_tot_mse = (uint64_t)1 << 63;
-    uint64_t tot_mse;
-    int32_t sb_count;
-
-    int32_t nvfb = (mi_rows /*cm->mi_rows*/ + MI_SIZE_64X64 - 1) / MI_SIZE_64X64;
-    int32_t nhfb = (mi_cols/*cm->mi_cols*/ + MI_SIZE_64X64 - 1) / MI_SIZE_64X64;
-
-    int32_t *sb_index = (int32_t *)eb_aom_malloc(nvfb * nhfb * sizeof(*sb_index));       //CHKN add cast
-    int32_t *selected_strength = (int32_t *)eb_aom_malloc(nvfb * nhfb * sizeof(*sb_index));
-
-    assert(sb_index);
-    assert(selected_strength);
-
-    uint64_t(*mse[2])[TOTAL_STRENGTHS];
-
-    int32_t pri_damping = 3 + (frm_hdr->quantization_params.base_q_idx /*cm->quant_param.base_q_idx*/ >> 6);
-    int32_t sec_damping = 3 + (frm_hdr->quantization_params.base_q_idx /*cm->quant_param.base_q_idx*/ >> 6);
-    int32_t i;
-    int32_t nb_strengths;
-    int32_t nb_strength_bits;
-    int32_t quantizer;
-    double lambda;
-    const int32_t num_planes = 3;// av1_num_planes(cm);
-    const int32_t total_strengths = fast ? REDUCED_TOTAL_STRENGTHS : TOTAL_STRENGTHS;
-    DECLARE_ALIGNED(32, uint16_t, inbuf[CDEF_INBUF_SIZE]);
-    uint16_t *in;
-    DECLARE_ALIGNED(32, uint16_t, tmp_dst[1 << (MAX_SB_SIZE_LOG2 * 2)]);
-
-    int32_t selected_strength_cnt[TOTAL_STRENGTHS] = { 0 };
-    int32_t best_frame_gi_cnt = 0;
-    int32_t gi_step = get_cdef_gi_step(pPcs->cdef_filter_mode);
-    int32_t mid_gi = pPcs->cdf_ref_frame_strenght;
-    int32_t start_gi = pPcs->use_ref_frame_cdef_strength && pPcs->cdef_filter_mode == 1 ? (AOMMAX(0, mid_gi - gi_step)) : 0;
-    int32_t end_gi = pPcs->use_ref_frame_cdef_strength ? AOMMIN(total_strengths, mid_gi + gi_step) : pPcs->cdef_filter_mode == 1 ? 8 : total_strengths;
-
-    quantizer =
-        //CHKN av1_ac_quant_Q3(cm->quant_param.base_q_idx, 0, cm->bit_depth) >> (cm->bit_depth - 8);
-        eb_av1_ac_quant_Q3(frm_hdr->quantization_params.base_q_idx, 0, (AomBitDepth)sequence_control_set_ptr->static_config.encoder_bit_depth) >> (sequence_control_set_ptr->static_config.encoder_bit_depth - 8);
-    lambda = .12 * quantizer * quantizer / 256.;
-
-    //eb_av1_setup_dst_planes(xd->plane, cm->seq_params.sb_size, frame, 0, 0, 0,    num_planes);
-
-    mse[0] = (uint64_t(*)[64])eb_aom_malloc(sizeof(**mse) * nvfb * nhfb);
-    mse[1] = (uint64_t(*)[64])eb_aom_malloc(sizeof(**mse) * nvfb * nhfb);
-
-    for (pli = 0; pli < num_planes; pli++) {
-        uint16_t *in_buffer = 0;
-        int32_t in_stride = 0;
-
-        uint16_t *ref_buffer = 0;
-        int32_t ref_stride = 0;
-        switch (pli) {
-        case 0:
-            ref_buffer = inputBufferY;
-            ref_stride = input_picture_ptr->stride_y;
-            in_buffer = reconBufferY;
-            in_stride = recon_picture_ptr->stride_y;
-            break;
-        case 1:
-            ref_buffer = inputBufferCb;
-            ref_stride = input_picture_ptr->stride_cb;
-            in_buffer = reconBufferCb;
-            in_stride = recon_picture_ptr->stride_cb;
-            break;
-        case 2:
-            ref_buffer = inputBufferCr;
-            ref_stride = input_picture_ptr->stride_cr;
-            in_buffer = reconBufferCr;
-            in_stride = recon_picture_ptr->stride_cr;
-            break;
-        }
-
-        ///CHKN: allocate one frame 16bit for src and recon!!
-        src[pli] = (uint16_t*)eb_aom_memalign(32, sizeof(*src)       * mi_rows * mi_cols * MI_SIZE * MI_SIZE);
-        ref_coeff[pli] = (uint16_t*)eb_aom_memalign(32, sizeof(*ref_coeff) * mi_rows * mi_cols * MI_SIZE * MI_SIZE);
-
-        int32_t subsampling_x = (pli == 0) ? 0 : 1;
-        int32_t subsampling_y = (pli == 0) ? 0 : 1;
-
-        xdec[pli] = subsampling_x; //CHKN  xd->plane[pli].subsampling_x;
-        ydec[pli] = subsampling_y; //CHKN  xd->plane[pli].subsampling_y;
-        bsize[pli] = ydec[pli] ? (xdec[pli] ? BLOCK_4X4 : BLOCK_8X4)
-            : (xdec[pli] ? BLOCK_4X8 : BLOCK_8X8);
-
-        stride[pli] = cm->mi_cols << MI_SIZE_LOG2;
-        mi_wide_l2[pli] = MI_SIZE_LOG2 - subsampling_x;  //CHKN MI_SIZE_LOG2 - xd->plane[pli].subsampling_x;
-        mi_high_l2[pli] = MI_SIZE_LOG2 - subsampling_y;  //CHKN MI_SIZE_LOG2 - xd->plane[pli].subsampling_y;
-
-        const int32_t frame_height = (cm->mi_rows * MI_SIZE) >> subsampling_y;//CHKN  xd->plane[pli].subsampling_y;
-        const int32_t frame_width = (cm->mi_cols * MI_SIZE) >> subsampling_x;//CHKN  xd->plane[pli].subsampling_x;
-
-        for (r = 0; r < frame_height; ++r) {
-            for (c = 0; c < frame_width; ++c) {
-                //if (cm->use_highbitdepth) {
-                //    src[pli][r * stride[pli] + c] = CONVERT_TO_SHORTPTR(
-                //        xd->plane[pli].dst.buf)[r * xd->plane[pli].dst.stride + c];
-                //    ref_coeff[pli][r * stride[pli] + c] =
-                //        CONVERT_TO_SHORTPTR(ref_buffer)[r * ref_stride + c];
-                //}
-                //else
-                {
-                    src[pli][r * stride[pli] + c] = in_buffer[r * in_stride + c];//CHKN xd->plane[pli].dst.buf[r * xd->plane[pli].dst.stride + c];
-                    ref_coeff[pli][r * stride[pli] + c] = ref_buffer[r * ref_stride + c];
-                }
-            }
-        }
-    }
-
-    in = inbuf + CDEF_VBORDER * CDEF_BSTRIDE + CDEF_HBORDER;
-    sb_count = 0;
-    for (fbr = 0; fbr < nvfb; ++fbr) {
-        for (fbc = 0; fbc < nhfb; ++fbc) {
-            int32_t nvb, nhb;
-            int32_t gi;
-            int32_t dirinit = 0;
-            nhb = AOMMIN(MI_SIZE_64X64, cm->mi_cols - MI_SIZE_64X64 * fbc);
-            nvb = AOMMIN(MI_SIZE_64X64, cm->mi_rows - MI_SIZE_64X64 * fbr);
-            int32_t hb_step = 1; //CHKN these should be all time with 64x64 LCUs
-            int32_t vb_step = 1;
-            BlockSize bs = BLOCK_64X64;
-            ModeInfo **mi = picture_control_set_ptr->mi_grid_base + MI_SIZE_64X64 * fbr * cm->mi_stride + MI_SIZE_64X64 * fbc;
-            const MbModeInfo *mbmi = &mi[0]->mbmi;
-
-            //MbModeInfo *const mbmi =
-            //    cm->mi_grid_visible[MI_SIZE_64X64 * fbr * cm->mi_stride +
-            //    MI_SIZE_64X64 * fbc];
-
-            if (((fbc & 1) &&
-                (mbmi->block_mi.sb_type == BLOCK_128X128 || mbmi->block_mi.sb_type == BLOCK_128X64)) ||
-                ((fbr & 1) &&
-                (mbmi->block_mi.sb_type == BLOCK_128X128 || mbmi->block_mi.sb_type == BLOCK_64X128)))
-                continue;
-            if (mbmi->block_mi.sb_type == BLOCK_128X128 || mbmi->block_mi.sb_type == BLOCK_128X64 ||
-                mbmi->block_mi.sb_type == BLOCK_64X128)
-                bs = mbmi->block_mi.sb_type;
-            if (bs == BLOCK_128X128 || bs == BLOCK_128X64) {
-                nhb = AOMMIN(MI_SIZE_128X128, cm->mi_cols - MI_SIZE_64X64 * fbc);
-                hb_step = 2;
-            }
-            if (bs == BLOCK_128X128 || bs == BLOCK_64X128) {
-                nvb = AOMMIN(MI_SIZE_128X128, cm->mi_rows - MI_SIZE_64X64 * fbr);
-                vb_step = 2;
-            }
-
-            // No filtering if the entire filter block is skipped
-            if (eb_sb_all_skip(picture_control_set_ptr, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64))
-                continue;
-
-            cdef_count = eb_sb_compute_cdef_list(picture_control_set_ptr, cm, fbr * MI_SIZE_64X64, fbc * MI_SIZE_64X64, dlist, bs);
-
-            for (pli = 0; pli < num_planes; pli++) {
-                for (i = 0; i < CDEF_INBUF_SIZE; i++)
-                    inbuf[i] = CDEF_VERY_LARGE;
-                for (gi = start_gi; gi < end_gi; gi++) {
-                    int32_t threshold;
-                    uint64_t curr_mse;
-                    int32_t sec_strength;
-                    threshold = gi / CDEF_SEC_STRENGTHS;
-                    if (fast) threshold = priconv[threshold];
-                    /* We avoid filtering the pixels for which some of the pixels to
-                    average are outside the frame. We could change the filter instead, but it would add special cases for any future vectorization. */
-                    int32_t yoff = CDEF_VBORDER * (fbr != 0);
-                    int32_t xoff = CDEF_HBORDER * (fbc != 0);
-                    int32_t ysize = (nvb << mi_high_l2[pli]) + CDEF_VBORDER * (fbr + vb_step < nvfb) + yoff;
-                    int32_t xsize = (nhb << mi_wide_l2[pli]) + CDEF_HBORDER * (fbc + hb_step < nhfb) + xoff;
-                    sec_strength = gi % CDEF_SEC_STRENGTHS;
-
-                    copy_sb16_16(
-                        &in[(-yoff * CDEF_BSTRIDE - xoff)], CDEF_BSTRIDE,
-                        src[pli],
-                        (fbr * MI_SIZE_64X64 << mi_high_l2[pli]) - yoff,
-                        (fbc * MI_SIZE_64X64 << mi_wide_l2[pli]) - xoff,
-                        stride[pli], ysize, xsize);
-
-                    eb_cdef_filter_fb(NULL, tmp_dst, CDEF_BSTRIDE, in, xdec[pli], ydec[pli],
-                        dir, &dirinit, var, pli, dlist, cdef_count, threshold,
-                        sec_strength + (sec_strength == 3), pri_damping,
-                        sec_damping, coeff_shift);
-
-                    curr_mse = eb_compute_cdef_dist(
-                        ref_coeff[pli] +
-                        (fbr * MI_SIZE_64X64 << mi_high_l2[pli]) * stride[pli] +
-                        (fbc * MI_SIZE_64X64 << mi_wide_l2[pli]),
-                        stride[pli], tmp_dst, dlist, cdef_count, (BlockSize)bsize[pli], coeff_shift,
-                        pli);
-
-                    if (pli < 2)
-                        mse[pli][sb_count][gi] = curr_mse;
-                    else
-                        mse[1][sb_count][gi] += curr_mse;
-
-                    sb_index[sb_count] = MI_SIZE_64X64 * fbr * picture_control_set_ptr->mi_stride + MI_SIZE_64X64 * fbc;//CHKN
-                }
-            }
-            sb_count++;
-        }
-    }
-
-    nb_strength_bits = 0;
-    /* Search for different number of signalling bits. */
-    for (i = 0; i <= 3; i++) {
-        int32_t j;
-        int32_t best_lev0[CDEF_MAX_STRENGTHS];
-        int32_t best_lev1[CDEF_MAX_STRENGTHS] = { 0 };
-        nb_strengths = 1 << i;
-        if (num_planes >= 3)
-            tot_mse = joint_strength_search_dual(best_lev0, best_lev1, nb_strengths, mse, sb_count, fast, start_gi, end_gi);
-        else
-            tot_mse = joint_strength_search(best_lev0, nb_strengths, mse[0], sb_count, fast, start_gi, end_gi);
-        /* Count superblock signalling cost. */
-        tot_mse += (uint64_t)(sb_count * lambda * i);
-        /* Count header signalling cost. */
-        tot_mse += (uint64_t)(nb_strengths * lambda * CDEF_STRENGTH_BITS);
-        if (tot_mse < best_tot_mse) {
-            best_tot_mse = tot_mse;
-            nb_strength_bits = i;
-            for (j = 0; j < 1 << nb_strength_bits; j++) {
-                frm_hdr->CDEF_params.cdef_y_strength[j] = best_lev0[j];
-                frm_hdr->CDEF_params.cdef_uv_strength[j] = best_lev1[j];
-            }
-        }
-    }
-    nb_strengths = 1 << nb_strength_bits;
-
-    /*cm*/frm_hdr->CDEF_params.cdef_bits = nb_strength_bits;
-    /*cm*/pPcs->nb_cdef_strengths = nb_strengths;
-    for (i = 0; i < sb_count; i++) {
-        int32_t gi;
-        int32_t best_gi;
-        uint64_t best_mse = (uint64_t)1 << 63;
-        best_gi = 0;
-        for (gi = 0; gi < /*cm*/pPcs->nb_cdef_strengths; gi++) {
-            uint64_t curr = mse[0][i][/*cm*/frm_hdr->CDEF_params.cdef_y_strength[gi]];
-            if (num_planes >= 3) curr += mse[1][i][/*cm*/frm_hdr->CDEF_params.cdef_uv_strength[gi]];
-            if (curr < best_mse) {
-                best_gi = gi;
-                best_mse = curr;
-            }
-        }
-        selected_strength[i] = best_gi;
-        selected_strength_cnt[best_gi]++;
-        //CHKN cm->mi_grid_visible[sb_index[i]]->cdef_strength = best_gi;
-        picture_control_set_ptr->mi_grid_base[sb_index[i]]->mbmi.cdef_strength = (int8_t)best_gi;
-        //in case the fb is within a block=128x128 or 128x64, or 64x128, then we genrate param only for the first 64x64.
-        //since our mi map deos not have the multi pointer single data assignment, we need to duplicate data.
-        BlockSize sb_type = picture_control_set_ptr->mi_grid_base[sb_index[i]]->mbmi.block_mi.sb_type;
-
-        if (sb_type == BLOCK_128X128)
-        {
-            picture_control_set_ptr->mi_grid_base[sb_index[i] + MI_SIZE_64X64]->mbmi.cdef_strength = (int8_t)best_gi;
-            picture_control_set_ptr->mi_grid_base[sb_index[i] + MI_SIZE_64X64 * picture_control_set_ptr->mi_stride]->mbmi.cdef_strength = (int8_t)best_gi;
-            picture_control_set_ptr->mi_grid_base[sb_index[i] + MI_SIZE_64X64 * picture_control_set_ptr->mi_stride + MI_SIZE_64X64]->mbmi.cdef_strength = (int8_t)best_gi;
-        }
-        else if (sb_type == BLOCK_128X64)
-            picture_control_set_ptr->mi_grid_base[sb_index[i] + MI_SIZE_64X64]->mbmi.cdef_strength = (int8_t)best_gi;
-        else if (sb_type == BLOCK_64X128)
-            picture_control_set_ptr->mi_grid_base[sb_index[i] + MI_SIZE_64X64 * picture_control_set_ptr->mi_stride]->mbmi.cdef_strength = (int8_t)best_gi;
-        //ModeInfo *miPtr = *(picture_control_set_ptr->mi_grid_base + sb_index[i]);
-        //uint8_t  miX, miY;
-        //for (miY = 0; miY < (block_size_high[sb_type] >> MI_SIZE_LOG2); miY++) {
-        //    for (miX = 0; miX < (block_size_wide[sb_type] >> MI_SIZE_LOG2); miX++) {
-        //        miPtr[miX + miY * picture_control_set_ptr->mi_stride].mbmi.cdef_strength = (int8_t)best_gi;
-        //    }
-        //}
-    }
-
-    if (fast) {
-        for (int32_t j = 0; j < nb_strengths; j++) {
-            frm_hdr->CDEF_params.cdef_y_strength[j] = priconv[frm_hdr->CDEF_params.cdef_y_strength[j] / CDEF_SEC_STRENGTHS] * CDEF_SEC_STRENGTHS + (frm_hdr->CDEF_params.cdef_y_strength[j] % CDEF_SEC_STRENGTHS);
-            frm_hdr->CDEF_params.cdef_uv_strength[j] = priconv[frm_hdr->CDEF_params.cdef_uv_strength[j] / CDEF_SEC_STRENGTHS] * CDEF_SEC_STRENGTHS + (frm_hdr->CDEF_params.cdef_uv_strength[j] % CDEF_SEC_STRENGTHS);
-        }
-    }
-    frm_hdr->CDEF_params.cdef_damping = pri_damping;
-    //pPcs->cdef_pri_damping = pri_damping;
-    //pPcs->cdef_sec_damping = sec_damping;
-
-    for (int i = 0; i < total_strengths; i++)
-        best_frame_gi_cnt += selected_strength_cnt[i] > best_frame_gi_cnt ? 1 : 0;
-    pPcs->cdef_frame_strength = ((best_frame_gi_cnt + 4) / 4) * 4;
-
-    eb_aom_free(mse[0]);
-    eb_aom_free(mse[1]);
-    for (pli = 0; pli < num_planes; pli++) {
-        eb_aom_free(src[pli]);
-        eb_aom_free(ref_coeff[pli]);
-    }
-    eb_aom_free(sb_index);
-    eb_aom_free(selected_strength);
 }

--- a/Source/Lib/Common/Codec/EbCdef.h
+++ b/Source/Lib/Common/Codec/EbCdef.h
@@ -21,14 +21,12 @@ extern "C" {
 #define CDEF_PRI_STRENGTHS 16
 #define CDEF_SEC_STRENGTHS 4
 
-#define _CDEF_BLOCK_H (1)
-
 #define CDEF_BLOCKSIZE 64
 #define CDEF_BLOCKSIZE_LOG2 6
 #define CDEF_NBLOCKS ((1 << MAX_SB_SIZE_LOG2) / 8)
 #define CDEF_SB_SHIFT (MAX_SB_SIZE_LOG2 - CDEF_BLOCKSIZE_LOG2)
 
-    /* We need to buffer three vertical lines. */
+/* We need to buffer three vertical lines. */
 #define CDEF_VBORDER (3)
 /* We only need to buffer three horizontal pixels too, but let's align to
 16 bytes (8 x 16 bits) to make vectorization easier. */
@@ -54,6 +52,7 @@ extern "C" {
         int32_t dir, int32_t pri_damping,
         int32_t sec_damping, int32_t bsize,
         int32_t coeff_shift);
+
     void copy_cdef_16bit_to_16bit(uint16_t *dst, int32_t dstride, uint16_t *src,
         cdef_list *dlist, int32_t cdef_count, int32_t bsize);
 
@@ -67,22 +66,16 @@ extern "C" {
     int32_t get_cdef_gi_step(
         int8_t   cdef_filter_mode);
 
-    //int32_t eb_sb_all_skip(const Av1Common *const cm, int32_t mi_row, int32_t mi_col);
-    //int32_t eb_sb_compute_cdef_list(const Av1Common *const cm, int32_t mi_row, int32_t mi_col,
-    //                         cdef_list *dlist, BlockSize bsize);
-
-    //void eb_av1_cdef_frame(Yv12BufferConfig *frame, Av1Common *cm, MacroBlockD *xd);
-    //
-    //void eb_av1_cdef_search(Yv12BufferConfig *frame, const Yv12BufferConfig *ref,
-    //                     Av1Common *cm, MacroBlockD *xd, int32_t fast);
-
     void fill_rect(uint16_t *dst, int32_t dstride, int32_t v, int32_t h,
         uint16_t x);
+
     void copy_sb8_16(uint16_t *dst, int32_t dstride, const uint8_t *src,
         int32_t src_voffset, int32_t src_hoffset,
         int32_t sstride, int32_t vsize, int32_t hsize);
+
     void copy_rect(uint16_t *dst, int32_t dstride, const uint16_t *src,
         int32_t sstride, int32_t v, int32_t h);
+
     void copy_sb16_16(uint16_t *dst, int32_t dstride, const uint16_t *src,
         int32_t src_voffset, int32_t src_hoffset, int32_t sstride,
         int32_t vsize, int32_t hsize);

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -533,6 +533,11 @@ static INLINE uint16_t clip_pixel_highbd(int32_t val, int32_t bd) {
 static INLINE unsigned int negative_to_zero(int value) {
     return value & ~(value >> (sizeof(value) * 8 - 1));
 }
+
+static INLINE int av1_num_planes(EbColorConfig   *color_info) {
+    return color_info->mono_chrome ? 1 : MAX_MB_PLANE;
+}
+
 //*********************************************************************************************************************//
 // enums.h
 /*!\brief Decorator indicating that given struct/union/enum is packed */

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -24,23 +24,12 @@
 #include "EbUtility.h"
 #include "grainSynthesis.h"
 
-void eb_av1_cdef_search(
-    EncDecContext                *context_ptr,
-    SequenceControlSet           *sequence_control_set_ptr,
-    PictureControlSet            *picture_control_set_ptr
-);
-
 void eb_av1_cdef_frame(
     EncDecContext                *context_ptr,
     SequenceControlSet           *sequence_control_set_ptr,
     PictureControlSet            *pCs
 );
 
-void av1_cdef_search16bit(
-    EncDecContext                *context_ptr,
-    SequenceControlSet           *sequence_control_set_ptr,
-    PictureControlSet            *picture_control_set_ptr
-);
 void av1_cdef_frame16bit(
     uint8_t is16bit,
     SequenceControlSet           *sequence_control_set_ptr,

--- a/Source/Lib/Decoder/Codec/EbDecInverseQuantize.h
+++ b/Source/Lib/Decoder/Codec/EbDecInverseQuantize.h
@@ -5,11 +5,6 @@
 #ifndef EbDecInverseQuantize_h
 #define EbDecInverseQuantize_h
 
-// TODO: Need to sync with encoder
-static INLINE int av1_num_planes(EbColorConfig   *color_info) {
-    return color_info->mono_chrome ? 1 : MAX_MB_PLANE;
-}
-
 int16_t eb_av1_dc_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth);
 int16_t eb_av1_ac_quant_Q3(int32_t qindex, int32_t delta, AomBitDepth bit_depth);
 int16_t get_dc_quant(int32_t qindex, int32_t delta, AomBitDepth bit_depth);


### PR DESCRIPTION
This pull request aims to improve code quality related to cdef filtering and to refactor code so it adheres to STYLE.md. Feedback or suggestions are appreciated! 

- remove unused functions `void eb_av1_cdef_search()` and `void av1_cdef_search16bit()`
- remove unused macro _CDEF_BLOCK_H (1)
- remove commented out code

closes #833 