### PR TITLE
Fix build error when UPDATE_CDEF is 0

### DIFF
--- a/Source/Lib/Common/Codec/EbCdef.c
+++ b/Source/Lib/Common/Codec/EbCdef.c
@@ -1433,6 +1433,9 @@ uint64_t compute_cdef_dist_8bit_c(const uint8_t *dst8, int32_t dstride, const ui
 
 void finish_cdef_search(
     EncDecContext       *context_ptr,
+#if !UPDATE_CDEF
+    SequenceControlSet           *sequence_control_set_ptr,
+#endif
     PictureControlSet   *picture_control_set_ptr,
     int32_t             selected_strength_cnt[64])
 {

--- a/Source/Lib/Encoder/Codec/EbCdefProcess.c
+++ b/Source/Lib/Encoder/Codec/EbCdefProcess.c
@@ -39,6 +39,9 @@ int32_t eb_sb_compute_cdef_list(PictureControlSet   *picture_control_set_ptr, co
     cdef_list *dlist, BlockSize bs);
 void finish_cdef_search(
     EncDecContext                *context_ptr,
+#if !UPDATE_CDEF
+    SequenceControlSet           *sequence_control_set_ptr,
+#endif
     PictureControlSet            *picture_control_set_ptr,
     int32_t                      selected_strength_cnt[64]);
 void av1_cdef_frame16bit(
@@ -470,6 +473,9 @@ void* cdef_kernel(void *input_ptr)
         if (sequence_control_set_ptr->seq_header.enable_cdef && picture_control_set_ptr->parent_pcs_ptr->cdef_filter_mode) {
                 finish_cdef_search(
                     0,
+#if !UPDATE_CDEF
+                    sequence_control_set_ptr,
+#endif
                     picture_control_set_ptr,
                     selected_strength_cnt);
 


### PR DESCRIPTION
In a previous commit, Travis CI reports that `SequenceControlSet *sequence_control_set_ptr` was an unused variable during the build stage. Warnings were treated as errors and I had it removed. 

In the current master, if we set the flag UPDATE_CDEF to 0, `SequenceControlSet *sequence_control_set_ptr` is referenced again and will result in a build error. Added pre-processor statements to restore the missing parameter.