### PR TITLE
EbPictureBufferDesc: fix crash for none 16 aligned 10bits input

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/EbHighbdIntraPrediction_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbHighbdIntraPrediction_AVX2.c
@@ -80,7 +80,7 @@ static INLINE __m128i dc_sum_4_16(const uint16_t *const src_4, const uint16_t *c
 }
 
 static INLINE __m128i dc_sum_8_16(const uint16_t *const src_8, const uint16_t *const src_16) {
-    const __m128i s_8      = _mm_load_si128((const __m128i *)src_8);
+    const __m128i s_8      = _mm_loadu_si128((const __m128i *)src_8);
     const __m256i s_16     = _mm256_loadu_si256((const __m256i *)src_16);
     const __m128i s_lo     = _mm256_extracti128_si256(s_16, 0);
     const __m128i s_hi     = _mm256_extracti128_si256(s_16, 1);
@@ -817,7 +817,7 @@ static INLINE void h_pred_16(uint16_t **const dst, const ptrdiff_t stride, const
 
 // Process 8 rows.
 static INLINE void h_pred_16x8(uint16_t **dst, const ptrdiff_t stride, const uint16_t *const left) {
-    const __m128i left_u16 = _mm_load_si128((const __m128i *)left);
+    const __m128i left_u16 = _mm_loadu_si128((const __m128i *)left);
 
     h_pred_16(dst, stride, _mm_srli_si128(left_u16, 0));
     h_pred_16(dst, stride, _mm_srli_si128(left_u16, 2));
@@ -1438,9 +1438,9 @@ static INLINE void smooth_pred_8x2(const __m256i *const weights_w, const __m256i
                                    uint16_t **const dst, const ptrdiff_t stride) {
     // 00 01 02 03 04 05 06 07  10 11 12 13 14 15 16 17
     const __m256i d = smooth_pred_kernel(weights_w, weights_h, rep, ab, lr);
-    _mm_store_si128((__m128i *)*dst, _mm256_extracti128_si256(d, 0));
+    _mm_storeu_si128((__m128i *)*dst, _mm256_extracti128_si256(d, 0));
     *dst += stride;
-    _mm_store_si128((__m128i *)*dst, _mm256_extracti128_si256(d, 1));
+    _mm_storeu_si128((__m128i *)*dst, _mm256_extracti128_si256(d, 1));
     *dst += stride;
 }
 
@@ -1950,9 +1950,9 @@ static INLINE void smooth_h_pred_8x2(const __m256i *const weights, __m256i *cons
     const __m256i t = _mm256_shuffle_epi8(*lr, rep); // 0 0 0 0  1 1 1 1
     // 00 01 02 03 04 05 06 07  10 11 12 13 14 15 16 17
     const __m256i d = smooth_h_pred_kernel(weights, t);
-    _mm_store_si128((__m128i *)*dst, _mm256_extracti128_si256(d, 0));
+    _mm_storeu_si128((__m128i *)*dst, _mm256_extracti128_si256(d, 0));
     *dst += stride;
-    _mm_store_si128((__m128i *)*dst, _mm256_extracti128_si256(d, 1));
+    _mm_storeu_si128((__m128i *)*dst, _mm256_extracti128_si256(d, 1));
     *dst += stride;
     *lr = _mm256_srli_si256(*lr, 8); // 2 3 x x  3 4 x x
 }
@@ -1966,7 +1966,7 @@ static INLINE void smooth_h_pred_8x4(const __m256i *const weights, __m256i *cons
 static INLINE void smooth_h_pred_8x8(const uint16_t *const left, const __m256i r,
                                      const __m256i *const weights, uint16_t **const dst,
                                      const ptrdiff_t stride) {
-    const __m128i l0 = _mm_load_si128((const __m128i *)left);
+    const __m128i l0 = _mm_loadu_si128((const __m128i *)left);
     const __m128i l1 = _mm_srli_si128(l0, 2);
     // 0 1 2 3 4 5 6 7  1 2 3 4 5 6 7 x
     const __m256i l = _mm256_inserti128_si256(_mm256_castsi128_si256(l0), l1, 1);
@@ -2340,9 +2340,9 @@ static INLINE void smooth_v_pred_8x2(const __m256i weights, const __m256i rep,
                                      const ptrdiff_t stride) {
     // 00 01 02 03 04 05 06 07  10 11 12 13 14 15 16 17
     const __m256i d = smooth_v_pred_kernel(weights, rep, ab);
-    _mm_store_si128((__m128i *)*dst, _mm256_extracti128_si256(d, 0));
+    _mm_storeu_si128((__m128i *)*dst, _mm256_extracti128_si256(d, 0));
     *dst += stride;
-    _mm_store_si128((__m128i *)*dst, _mm256_extracti128_si256(d, 1));
+    _mm_storeu_si128((__m128i *)*dst, _mm256_extracti128_si256(d, 1));
     *dst += stride;
 }
 

--- a/Source/Lib/Common/ASM_AVX2/EbIntraPrediction_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbIntraPrediction_Intrinsic_AVX2.c
@@ -405,7 +405,7 @@ static INLINE void highbd_transpose8x16_16x8_avx2(__m256i *x, __m256i *d) {
 // TODO(luoyi) The following two functions are shared with intrapred_sse2.c.
 // Use a header file, intrapred_common_x86.h
 static INLINE __m128i dc_sum_16_sse2(const uint8_t *ref) {
-    __m128i       x    = _mm_load_si128((__m128i const *)ref);
+    __m128i       x    = _mm_loadu_si128((__m128i const *)ref);
     const __m128i zero = _mm_setzero_si128();
     x                  = _mm_sad_epu8(x, zero);
     const __m128i high = _mm_unpackhi_epi64(x, x);
@@ -413,8 +413,8 @@ static INLINE __m128i dc_sum_16_sse2(const uint8_t *ref) {
 }
 
 static INLINE __m128i dc_sum_32_sse2(const uint8_t *ref) {
-    __m128i       x0   = _mm_load_si128((__m128i const *)ref);
-    __m128i       x1   = _mm_load_si128((__m128i const *)(ref + 16));
+    __m128i       x0   = _mm_loadu_si128((__m128i const *)ref);
+    __m128i       x1   = _mm_loadu_si128((__m128i const *)(ref + 16));
     const __m128i zero = _mm_setzero_si128();
     x0                 = _mm_sad_epu8(x0, zero);
     x1                 = _mm_sad_epu8(x1, zero);
@@ -1858,7 +1858,7 @@ static void dr_prediction_z2_nx4_avx2(int32_t N, uint8_t *dst, ptrdiff_t stride,
             base_y_c128 = _mm_srai_epi16(y_c128, frac_bits_y);
             mask128     = _mm_cmpgt_epi16(min_base_y128, base_y_c128);
             base_y_c128 = _mm_andnot_si128(mask128, base_y_c128);
-            _mm_store_si128((__m128i *)base_y_c, base_y_c128);
+            _mm_storeu_si128((__m128i *)base_y_c, base_y_c128);
 
             a0_y        = _mm_setr_epi16(left[base_y_c[0]],
                                   left[base_y_c[1]],
@@ -1869,7 +1869,7 @@ static void dr_prediction_z2_nx4_avx2(int32_t N, uint8_t *dst, ptrdiff_t stride,
                                   0,
                                   0);
             base_y_c128 = _mm_add_epi16(base_y_c128, _mm_srli_epi16(a16, 4));
-            _mm_store_si128((__m128i *)base_y_c, base_y_c128);
+            _mm_storeu_si128((__m128i *)base_y_c, base_y_c128);
             a1_y = _mm_setr_epi16(left[base_y_c[0]],
                                   left[base_y_c[1]],
                                   left[base_y_c[2]],
@@ -1984,7 +1984,7 @@ static void dr_prediction_z2_nx8_avx2(int32_t N, uint8_t *dst, ptrdiff_t stride,
             base_y_c128 = _mm_srai_epi16(y_c128, frac_bits_y);
             mask128     = _mm_cmpgt_epi16(min_base_y128, base_y_c128);
             base_y_c128 = _mm_andnot_si128(mask128, base_y_c128);
-            _mm_store_si128((__m128i *)base_y_c, base_y_c128);
+            _mm_storeu_si128((__m128i *)base_y_c, base_y_c128);
 
             a0_y = _mm_setr_epi16(left[base_y_c[0]],
                                   left[base_y_c[1]],
@@ -1996,7 +1996,7 @@ static void dr_prediction_z2_nx8_avx2(int32_t N, uint8_t *dst, ptrdiff_t stride,
                                   left[base_y_c[7]]);
             base_y_c128 =
                 _mm_add_epi16(base_y_c128, _mm_srli_epi16(_mm256_castsi256_si128(a16), 4));
-            _mm_store_si128((__m128i *)base_y_c, base_y_c128);
+            _mm_storeu_si128((__m128i *)base_y_c, base_y_c128);
 
             a1_y = _mm_setr_epi16(left[base_y_c[0]],
                                   left[base_y_c[1]],
@@ -3018,7 +3018,7 @@ static void highbd_dr_prediction_z2_nx4_avx2(int32_t N, uint16_t *dst, ptrdiff_t
             base_y_c128 = _mm_srai_epi16(y_c128, frac_bits_y);
             mask128     = _mm_cmpgt_epi16(min_base_y128, base_y_c128);
             base_y_c128 = _mm_andnot_si128(mask128, base_y_c128);
-            _mm_store_si128((__m128i *)base_y_c, base_y_c128);
+            _mm_storeu_si128((__m128i *)base_y_c, base_y_c128);
 
             a0_y = _mm_setr_epi16(left[base_y_c[0]],
                                   left[base_y_c[1]],
@@ -3168,7 +3168,7 @@ static void highbd_dr_prediction_z2_nx8_avx2(int32_t N, uint16_t *dst, ptrdiff_t
             base_y_c128 = _mm_srai_epi16(y_c128, frac_bits_y);
             mask128     = _mm_cmpgt_epi16(min_base_y128, base_y_c128);
             base_y_c128 = _mm_andnot_si128(mask128, base_y_c128);
-            _mm_store_si128((__m128i *)base_y_c, base_y_c128);
+            _mm_storeu_si128((__m128i *)base_y_c, base_y_c128);
 
             a0_y = _mm_setr_epi16(left[base_y_c[0]],
                                   left[base_y_c[1]],
@@ -4226,7 +4226,7 @@ static INLINE __m128i paeth_16x1_pred(const __m256i *left, const __m256i *top,
 }
 
 static INLINE __m256i get_top_vector(const uint8_t *above) {
-    const __m128i x    = _mm_load_si128((const __m128i *)above);
+    const __m128i x    = _mm_loadu_si128((const __m128i *)above);
     const __m128i zero = _mm_setzero_si128();
     const __m128i t0   = _mm_unpacklo_epi8(x, zero);
     const __m128i t1   = _mm_unpackhi_epi8(x, zero);
@@ -4254,7 +4254,7 @@ void eb_aom_paeth_predictor_16x8_avx2(uint8_t *dst, ptrdiff_t stride, const uint
 }
 
 static INLINE __m256i get_left_vector(const uint8_t *left) {
-    const __m128i x = _mm_load_si128((const __m128i *)left);
+    const __m128i x = _mm_loadu_si128((const __m128i *)left);
     return _mm256_inserti128_si256(_mm256_castsi128_si256(x), x, 1);
 }
 

--- a/Source/Lib/Common/ASM_AVX2/EbMemory_AVX2.h
+++ b/Source/Lib/Common/ASM_AVX2/EbMemory_AVX2.h
@@ -50,8 +50,8 @@ static INLINE __m256i load_u8_8x4_avx2(const uint8_t *const src, const ptrdiff_t
 }
 
 static INLINE __m256i load_u8_16x2_avx2(const uint8_t *const src, const ptrdiff_t stride) {
-    const __m128i src0 = _mm_load_si128((__m128i *)(src + 0 * stride));
-    const __m128i src1 = _mm_load_si128((__m128i *)(src + 1 * stride));
+    const __m128i src0 = _mm_loadu_si128((__m128i *)(src + 0 * stride));
+    const __m128i src1 = _mm_loadu_si128((__m128i *)(src + 1 * stride));
     return _mm256_setr_m128i(src0, src1);
 }
 

--- a/Source/Lib/Common/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
@@ -633,7 +633,7 @@ void unpack_avg_avx2_intrin(uint16_t *ref16_l0, uint32_t ref_l0_stride, uint16_t
             //AVG
             avg8_0_u8 = _mm_avg_epu8(out8_0_u8_l0, out8_0_u8_l1);
 #if ALSTORE
-            _mm_store_si128((__m128i *)dst_ptr, avg8_0_u8);
+            _mm_storeu_si128((__m128i *)dst_ptr, avg8_0_u8);
 #else
             _mm_storeu_si128((__m128i *)dst_ptr, avg8_0_u8);
 #endif
@@ -661,7 +661,7 @@ void unpack_avg_avx2_intrin(uint16_t *ref16_l0, uint32_t ref_l0_stride, uint16_t
             //AVG
             avg8_2_u8 = _mm_avg_epu8(out8_2_u8_l0, out8_2_u8_l1);
 #if ALSTORE
-            _mm_store_si128((__m128i *)(dst_ptr + dst_stride), avg8_2_u8);
+            _mm_storeu_si128((__m128i *)(dst_ptr + dst_stride), avg8_2_u8);
 #else
             _mm_storeu_si128((__m128i *)(dst_ptr + dst_stride), avg8_2_u8);
 #endif
@@ -762,8 +762,8 @@ void unpack_avg_avx2_intrin(uint16_t *ref16_l0, uint32_t ref_l0_stride, uint16_t
             avg8_0_u8 = _mm_avg_epu8(out8_0_u8_l0, out8_0_u8_l1);
             avg8_1_u8 = _mm_avg_epu8(out8_1_u8_l0, out8_1_u8_l1);
 #if ALSTORE
-            _mm_store_si128((__m128i *)dst_ptr, avg8_0_u8);
-            _mm_store_si128((__m128i *)(dst_ptr + 16), avg8_1_u8);
+            _mm_storeu_si128((__m128i *)dst_ptr, avg8_0_u8);
+            _mm_storeu_si128((__m128i *)(dst_ptr + 16), avg8_1_u8);
 #else
             _mm_storeu_si128((__m128i *)dst_ptr, avg8_0_u8);
             _mm_storeu_si128((__m128i *)(dst_ptr + 16), avg8_1_u8);
@@ -801,8 +801,8 @@ void unpack_avg_avx2_intrin(uint16_t *ref16_l0, uint32_t ref_l0_stride, uint16_t
             avg8_2_u8 = _mm_avg_epu8(out8_2_u8_l0, out8_2_u8_l1);
             avg8_3_u8 = _mm_avg_epu8(out8_3_u8_l0, out8_3_u8_l1);
 #if ALSTORE
-            _mm_store_si128((__m128i *)(dst_ptr + dst_stride), avg8_2_u8);
-            _mm_store_si128((__m128i *)(dst_ptr + dst_stride + 16), avg8_3_u8);
+            _mm_storeu_si128((__m128i *)(dst_ptr + dst_stride), avg8_2_u8);
+            _mm_storeu_si128((__m128i *)(dst_ptr + dst_stride + 16), avg8_3_u8);
 #else
             _mm_storeu_si128((__m128i *)(dst_ptr + dst_stride), avg8_2_u8);
             _mm_storeu_si128((__m128i *)(dst_ptr + dst_stride + 16), avg8_3_u8);
@@ -903,10 +903,10 @@ void unpack_avg_avx2_intrin(uint16_t *ref16_l0, uint32_t ref_l0_stride, uint16_t
             avg8_2_u8 = _mm_avg_epu8(out8_2_u8_l0, out8_2_u8_l1);
             avg8_3_u8 = _mm_avg_epu8(out8_3_u8_l0, out8_3_u8_l1);
 #if ALSTORE
-            _mm_store_si128((__m128i *)dst_ptr, avg8_0_u8);
-            _mm_store_si128((__m128i *)(dst_ptr + 16), avg8_1_u8);
-            _mm_store_si128((__m128i *)(dst_ptr + 32), avg8_2_u8);
-            _mm_store_si128((__m128i *)(dst_ptr + 48), avg8_3_u8);
+            _mm_storeu_si128((__m128i *)dst_ptr, avg8_0_u8);
+            _mm_storeu_si128((__m128i *)(dst_ptr + 16), avg8_1_u8);
+            _mm_storeu_si128((__m128i *)(dst_ptr + 32), avg8_2_u8);
+            _mm_storeu_si128((__m128i *)(dst_ptr + 48), avg8_3_u8);
 #else
             _mm_storeu_si128((__m128i *)dst_ptr, avg8_0_u8);
             _mm_storeu_si128((__m128i *)(dst_ptr + 16), avg8_1_u8);
@@ -1031,7 +1031,7 @@ void unpack_avg_safe_sub_avx2_intrin(uint16_t *ref16_l0, uint32_t ref_l0_stride,
             //AVG
             avg8_0_u8 = _mm_avg_epu8(out8_0_u8_l0, out8_0_u8_l1);
 
-            _mm_store_si128((__m128i *)dst_ptr, avg8_0_u8);
+            _mm_storeu_si128((__m128i *)dst_ptr, avg8_0_u8);
 
             //--------
             //Line Two
@@ -1056,7 +1056,7 @@ void unpack_avg_safe_sub_avx2_intrin(uint16_t *ref16_l0, uint32_t ref_l0_stride,
             //AVG
             avg8_2_u8 = _mm_avg_epu8(out8_2_u8_l0, out8_2_u8_l1);
 
-            _mm_store_si128((__m128i *)(dst_ptr + dst_stride), avg8_2_u8);
+            _mm_storeu_si128((__m128i *)(dst_ptr + dst_stride), avg8_2_u8);
 
             dst_ptr += 2 * dst_stride;
             ref16_l0 += 2 * ref_l0_stride;
@@ -1079,7 +1079,7 @@ void unpack_avg_safe_sub_avx2_intrin(uint16_t *ref16_l0, uint32_t ref_l0_stride,
                 _mm_packus_epi16(_mm_srli_epi16(in_pixel0, 2), _mm_srli_epi16(in_pixel1, 2));
             //AVG
             avg8_0_u8 = _mm_avg_epu8(out8_0_u8_l0, out8_0_u8_l1);
-            _mm_store_si128((__m128i *)dst_ptr, avg8_0_u8);
+            _mm_storeu_si128((__m128i *)dst_ptr, avg8_0_u8);
         }
     } else if (width == 32) {
         __m256i in_val_16b_0, in_val_16b_1;

--- a/Source/Lib/Common/ASM_AVX2/aom_subpixel_8t_intrin_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/aom_subpixel_8t_intrin_avx2.c
@@ -213,8 +213,8 @@ static INLINE __m256i xx_loadu2_mi128(const void *hi, const void *lo) {
 
 static INLINE void xx_store2_mi128(const uint8_t *output_ptr, const ptrdiff_t stride,
                                    const __m256i *a) {
-    _mm_store_si128((__m128i *)output_ptr, _mm256_castsi256_si128(*a));
-    _mm_store_si128((__m128i *)(output_ptr + stride), _mm256_extractf128_si256(*a, 1));
+    _mm_storeu_si128((__m128i *)output_ptr, _mm256_castsi256_si128(*a));
+    _mm_storeu_si128((__m128i *)(output_ptr + stride), _mm256_extractf128_si256(*a, 1));
 }
 
 static void aom_filter_block1d4_h4_avx2(const uint8_t *src_ptr, ptrdiff_t src_pixels_per_line,
@@ -719,7 +719,7 @@ static void aom_filter_block1d16_h4_avx2(const uint8_t *src_ptr, ptrdiff_t src_p
         src_reg_filt1_1 = _mm256_permute4x64_epi64(src_reg_filt1_1, 0x8);
 
         // save 16 bytes
-        _mm_store_si128((__m128i *)output_ptr, _mm256_castsi256_si128(src_reg_filt1_1));
+        _mm_storeu_si128((__m128i *)output_ptr, _mm256_castsi256_si128(src_reg_filt1_1));
     }
 }
 
@@ -904,7 +904,7 @@ static void aom_filter_block1d16_h8_avx2(const uint8_t *src_ptr, ptrdiff_t src_p
         src_reg_filt1_1 = _mm_packus_epi16(src_reg_filt1_1, src_reg_filt2_1);
 
         // save 16 bytes
-        _mm_store_si128((__m128i *)output_ptr, src_reg_filt1_1);
+        _mm_storeu_si128((__m128i *)output_ptr, src_reg_filt1_1);
     }
 }
 
@@ -1415,7 +1415,7 @@ static void aom_filter_block1d16_v8_avx2(const uint8_t *src_ptr, ptrdiff_t src_p
         src_reg_filt1 = _mm_packus_epi16(src_reg_filt1, src_reg_filt3);
 
         // save 16 bytes
-        _mm_store_si128((__m128i *)output_ptr, src_reg_filt1);
+        _mm_storeu_si128((__m128i *)output_ptr, src_reg_filt1);
     }
 }
 

--- a/Source/Lib/Common/ASM_AVX2/convolve_2d_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/convolve_2d_avx2.c
@@ -306,7 +306,7 @@ static void convolve_2d_sr_ver_2tap_avx2(const int16_t *const im_block, const in
             __m128i s_128[2];
             __m256i r[2];
 
-            s_128[0] = _mm_load_si128((__m128i *)im);
+            s_128[0] = _mm_loadu_si128((__m128i *)im);
 
             do {
                 xy_y_convolve_2tap_8x2_avx2(im, s_128, &coeffs_256, r);
@@ -434,7 +434,7 @@ static void convolve_2d_sr_ver_2tap_half_avx2(const int16_t *const im_block, con
     } else if (w == 8) {
         __m128i s_128[2];
 
-        s_128[0] = _mm_load_si128((__m128i *)im);
+        s_128[0] = _mm_loadu_si128((__m128i *)im);
 
         do {
             const __m256i res = xy_y_convolve_2tap_8x2_half_pel_avx2(im, s_128);

--- a/Source/Lib/Common/ASM_AVX2/convolve_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/convolve_avx2.c
@@ -1299,7 +1299,7 @@ void eb_av1_convolve_x_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *
 
 // Loads and stores to do away with the tedium of casting the address
 // to the right type.
-static INLINE __m128i xx_load_128(const void *a) { return _mm_load_si128((const __m128i *)a); }
+static INLINE __m128i xx_load_128(const void *a) { return _mm_loadu_si128((const __m128i *)a); }
 
 static INLINE __m256i calc_mask_avx2(const __m256i mask_base, const __m256i s0, const __m256i s1) {
     const __m256i diff = _mm256_abs_epi16(_mm256_sub_epi16(s0, s1));

--- a/Source/Lib/Common/ASM_AVX2/convolve_avx2.h
+++ b/Source/Lib/Common/ASM_AVX2/convolve_avx2.h
@@ -151,7 +151,7 @@ static INLINE void prepare_half_coeffs_4tap_ssse3(const InterpFilterParams *cons
                                                   __m128i *const coeffs /* [2] */) {
     const int16_t *const filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
-    const __m128i coeffs_8 = _mm_load_si128((__m128i *)filter);
+    const __m128i coeffs_8 = _mm_loadu_si128((__m128i *)filter);
 
     // right shift all filter co-efficients by 1 to reduce the bits required.
     // This extra right shift will be taken care of at the end while rounding
@@ -174,7 +174,7 @@ static INLINE void prepare_half_coeffs_6tap_ssse3(const InterpFilterParams *cons
                                                   __m128i *const coeffs /* [3] */) {
     const int16_t *const filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
-    const __m128i coeffs_8 = _mm_load_si128((__m128i *)filter);
+    const __m128i coeffs_8 = _mm_loadu_si128((__m128i *)filter);
 
     // right shift all filter co-efficients by 1 to reduce the bits required.
     // This extra right shift will be taken care of at the end while rounding
@@ -199,7 +199,7 @@ static INLINE void prepare_half_coeffs_8tap_ssse3(const InterpFilterParams *cons
                                                   __m128i *const coeffs /* [4] */) {
     const int16_t *const filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
-    const __m128i coeffs_8 = _mm_load_si128((__m128i *)filter);
+    const __m128i coeffs_8 = _mm_loadu_si128((__m128i *)filter);
 
     // right shift all filter co-efficients by 1 to reduce the bits required.
     // This extra right shift will be taken care of at the end while rounding
@@ -248,7 +248,7 @@ static INLINE void prepare_half_coeffs_4tap_avx2(const InterpFilterParams *const
                                                  __m256i *const                  coeffs /* [2] */) {
     const int16_t *const filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
-    const __m128i coeffs_8 = _mm_load_si128((__m128i *)filter);
+    const __m128i coeffs_8 = _mm_loadu_si128((__m128i *)filter);
 
     // right shift all filter co-efficients by 1 to reduce the bits required.
     // This extra right shift will be taken care of at the end while rounding
@@ -266,7 +266,7 @@ static INLINE void prepare_half_coeffs_6tap_avx2(const InterpFilterParams *const
                                                  __m256i *const                  coeffs /* [3] */) {
     const int16_t *const filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
-    const __m128i coeffs_8 = _mm_load_si128((__m128i *)filter);
+    const __m128i coeffs_8 = _mm_loadu_si128((__m128i *)filter);
 
     // right shift all filter co-efficients by 1 to reduce the bits required.
     // This extra right shift will be taken care of at the end while rounding
@@ -284,7 +284,7 @@ static INLINE void prepare_half_coeffs_8tap_avx2(const InterpFilterParams *const
                                                  __m256i *const                  coeffs /* [4] */) {
     const int16_t *const filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
-    const __m128i coeffs_8 = _mm_load_si128((__m128i *)filter);
+    const __m128i coeffs_8 = _mm_loadu_si128((__m128i *)filter);
 
     // right shift all filter co-efficients by 1 to reduce the bits required.
     // This extra right shift will be taken care of at the end while rounding
@@ -315,7 +315,7 @@ static INLINE void prepare_coeffs_4tap_sse2(const InterpFilterParams *const filt
     const int16_t *filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
 
-    const __m128i coeff = _mm_load_si128((__m128i *)filter);
+    const __m128i coeff = _mm_loadu_si128((__m128i *)filter);
 
     // coeffs 2 3 2 3 2 3 2 3
     coeffs[0] = _mm_shuffle_epi32(coeff, 0x55);
@@ -328,7 +328,7 @@ static INLINE void prepare_coeffs_6tap_ssse3(const InterpFilterParams *const fil
                                              __m128i *const                  coeffs /* [3] */) {
     const int16_t *const filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
-    const __m128i coeff = _mm_load_si128((__m128i *)filter);
+    const __m128i coeff = _mm_loadu_si128((__m128i *)filter);
 
     // coeffs 1 2 1 2 1 2 1 2
     coeffs[0] = _mm_shuffle_epi8(coeff, _mm_set1_epi32(0x05040302u));
@@ -344,7 +344,7 @@ static INLINE void prepare_coeffs_8tap_sse2(const InterpFilterParams *const filt
     const int16_t *filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
 
-    const __m128i coeff = _mm_load_si128((__m128i *)filter);
+    const __m128i coeff = _mm_loadu_si128((__m128i *)filter);
 
     // coeffs 0 1 0 1 0 1 0 1
     coeffs[0] = _mm_shuffle_epi32(coeff, 0x00);
@@ -375,7 +375,7 @@ static INLINE void prepare_coeffs_4tap_avx2(const InterpFilterParams *const filt
     const int16_t *filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
 
-    const __m128i coeff_8 = _mm_load_si128((__m128i *)filter);
+    const __m128i coeff_8 = _mm_loadu_si128((__m128i *)filter);
     const __m256i coeff   = _mm256_broadcastsi128_si256(coeff_8);
 
     // coeffs 2 3 2 3 2 3 2 3
@@ -389,7 +389,7 @@ static INLINE void prepare_coeffs_6tap_avx2(const InterpFilterParams *const filt
                                             __m256i *const                  coeffs /* [3] */) {
     const int16_t *const filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
-    const __m128i coeffs_8 = _mm_load_si128((__m128i *)filter);
+    const __m128i coeffs_8 = _mm_loadu_si128((__m128i *)filter);
     const __m256i coeff    = _mm256_broadcastsi128_si256(coeffs_8);
 
     // coeffs 1 2 1 2 1 2 1 2
@@ -406,7 +406,7 @@ static INLINE void prepare_coeffs_8tap_avx2(const InterpFilterParams *const filt
     const int16_t *filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
 
-    const __m128i coeff_8 = _mm_load_si128((__m128i *)filter);
+    const __m128i coeff_8 = _mm_loadu_si128((__m128i *)filter);
     const __m256i coeff   = _mm256_broadcastsi128_si256(coeff_8);
 
     // coeffs 0 1 0 1 0 1 0 1
@@ -664,7 +664,7 @@ static INLINE void xy_x_round_store_2x2_sse2(const __m128i res, int16_t *const d
 
 static INLINE void xy_x_round_store_4x2_sse2(const __m128i res, int16_t *const dst) {
     const __m128i d = xy_x_round_sse2(res);
-    _mm_store_si128((__m128i *)dst, d);
+    _mm_storeu_si128((__m128i *)dst, d);
 }
 
 static INLINE void xy_x_round_store_8x2_sse2(const __m128i res[2], int16_t *const dst) {
@@ -672,8 +672,8 @@ static INLINE void xy_x_round_store_8x2_sse2(const __m128i res[2], int16_t *cons
 
     r[0] = xy_x_round_sse2(res[0]);
     r[1] = xy_x_round_sse2(res[1]);
-    _mm_store_si128((__m128i *)dst, r[0]);
-    _mm_store_si128((__m128i *)(dst + 8), r[1]);
+    _mm_storeu_si128((__m128i *)dst, r[0]);
+    _mm_storeu_si128((__m128i *)(dst + 8), r[1]);
 }
 
 static INLINE void xy_x_round_store_8x2_avx2(const __m256i res, int16_t *const dst) {
@@ -1398,9 +1398,9 @@ static INLINE void xy_y_convolve_2tap_16_avx2(const __m256i s0, const __m256i s1
 static INLINE void xy_y_convolve_2tap_8x2_avx2(const int16_t *const src, __m128i s_128[2],
                                                const __m256i coeffs[1], __m256i r[2]) {
     __m256i s_256[2];
-    s_128[1] = _mm_load_si128((__m128i *)(src + 8));
+    s_128[1] = _mm_loadu_si128((__m128i *)(src + 8));
     s_256[0] = _mm256_setr_m128i(s_128[0], s_128[1]);
-    s_128[0] = _mm_load_si128((__m128i *)(src + 2 * 8));
+    s_128[0] = _mm_loadu_si128((__m128i *)(src + 2 * 8));
     s_256[1] = _mm256_setr_m128i(s_128[1], s_128[0]);
     xy_y_convolve_2tap_16_avx2(s_256[0], s_256[1], coeffs, r);
 }
@@ -1408,9 +1408,9 @@ static INLINE void xy_y_convolve_2tap_8x2_avx2(const int16_t *const src, __m128i
 static INLINE __m256i xy_y_convolve_2tap_8x2_half_pel_avx2(const int16_t *const src,
                                                            __m128i              s_128[2]) {
     __m256i s_256[2];
-    s_128[1] = _mm_load_si128((__m128i *)(src + 8));
+    s_128[1] = _mm_loadu_si128((__m128i *)(src + 8));
     s_256[0] = _mm256_setr_m128i(s_128[0], s_128[1]);
-    s_128[0] = _mm_load_si128((__m128i *)(src + 2 * 8));
+    s_128[0] = _mm_loadu_si128((__m128i *)(src + 2 * 8));
     s_256[1] = _mm256_setr_m128i(s_128[1], s_128[0]);
     return _mm256_add_epi16(s_256[0], s_256[1]);
 }

--- a/Source/Lib/Common/ASM_AVX2/highbd_convolve_2d_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/highbd_convolve_2d_avx2.c
@@ -222,11 +222,6 @@ void eb_av1_highbd_convolve_2d_copy_sr_avx2(const uint16_t *src, int32_t src_str
     (void)conv_params;
     (void)bd;
 
-    if (w >= 16) {
-        assert(!((intptr_t)dst % 16));
-        assert(!(dst_stride % 16));
-    }
-
     if (w == 2) {
         do {
             memcpy(dst, src, 2 * sizeof(*src));
@@ -257,9 +252,9 @@ void eb_av1_highbd_convolve_2d_copy_sr_avx2(const uint16_t *src, int32_t src_str
             src += src_stride;
             s[1] = _mm_loadu_si128((__m128i *)src);
             src += src_stride;
-            _mm_store_si128((__m128i *)dst, s[0]);
+            _mm_storeu_si128((__m128i *)dst, s[0]);
             dst += dst_stride;
-            _mm_store_si128((__m128i *)dst, s[1]);
+            _mm_storeu_si128((__m128i *)dst, s[1]);
             dst += dst_stride;
             h -= 2;
         } while (h);

--- a/Source/Lib/Common/ASM_AVX2/highbd_jnt_convolve_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/highbd_jnt_convolve_avx2.c
@@ -184,16 +184,16 @@ void eb_av1_highbd_jnt_convolve_2d_copy_avx2(const uint16_t *src, int32_t src_st
                         const __m128i res_0 = _mm256_castsi256_si128(res_clip);
                         const __m128i res_1 = _mm256_extracti128_si256(res_clip, 1);
 
-                        _mm_store_si128((__m128i *)(&dst0[i * dst_stride0 + j]), res_0);
-                        _mm_store_si128((__m128i *)(&dst0[i * dst_stride0 + j + dst_stride0]),
+                        _mm_storeu_si128((__m128i *)(&dst0[i * dst_stride0 + j]), res_0);
+                        _mm_storeu_si128((__m128i *)(&dst0[i * dst_stride0 + j + dst_stride0]),
                                         res_1);
                     } else {
                         const __m256i res_unsigned_16b = _mm256_adds_epu16(res, offset_const_16b);
                         const __m128i res_0            = _mm256_castsi256_si128(res_unsigned_16b);
                         const __m128i res_1 = _mm256_extracti128_si256(res_unsigned_16b, 1);
 
-                        _mm_store_si128((__m128i *)(&dst[i * dst_stride + j]), res_0);
-                        _mm_store_si128((__m128i *)(&dst[i * dst_stride + j + dst_stride]), res_1);
+                        _mm_storeu_si128((__m128i *)(&dst[i * dst_stride + j]), res_0);
+                        _mm_storeu_si128((__m128i *)(&dst[i * dst_stride + j + dst_stride]), res_1);
                     }
                 }
             }
@@ -403,16 +403,16 @@ void eb_av1_highbd_jnt_convolve_2d_avx2(const uint16_t *src, int32_t src_stride,
                         const __m128i res_0 = _mm256_castsi256_si128(res_clip);
                         const __m128i res_1 = _mm256_extracti128_si256(res_clip, 1);
 
-                        _mm_store_si128((__m128i *)(&dst0[i * dst_stride0 + j]), res_0);
-                        _mm_store_si128((__m128i *)(&dst0[i * dst_stride0 + j + dst_stride0]),
+                        _mm_storeu_si128((__m128i *)(&dst0[i * dst_stride0 + j]), res_0);
+                        _mm_storeu_si128((__m128i *)(&dst0[i * dst_stride0 + j + dst_stride0]),
                                         res_1);
                     } else {
                         __m256i res_16b     = _mm256_packus_epi32(res_unsigned_lo, res_unsigned_hi);
                         const __m128i res_0 = _mm256_castsi256_si128(res_16b);
                         const __m128i res_1 = _mm256_extracti128_si256(res_16b, 1);
 
-                        _mm_store_si128((__m128i *)(&dst[i * dst_stride + j]), res_0);
-                        _mm_store_si128((__m128i *)(&dst[i * dst_stride + j + dst_stride]), res_1);
+                        _mm_storeu_si128((__m128i *)(&dst[i * dst_stride + j]), res_0);
+                        _mm_storeu_si128((__m128i *)(&dst[i * dst_stride + j + dst_stride]), res_1);
                     }
                 }
 
@@ -577,15 +577,15 @@ void eb_av1_highbd_jnt_convolve_x_avx2(const uint16_t *src, int32_t src_stride, 
                     const __m128i res_0 = _mm256_castsi256_si128(res_clip);
                     const __m128i res_1 = _mm256_extracti128_si256(res_clip, 1);
 
-                    _mm_store_si128((__m128i *)(&dst0[i * dst_stride0 + j]), res_0);
-                    _mm_store_si128((__m128i *)(&dst0[i * dst_stride0 + j + dst_stride0]), res_1);
+                    _mm_storeu_si128((__m128i *)(&dst0[i * dst_stride0 + j]), res_0);
+                    _mm_storeu_si128((__m128i *)(&dst0[i * dst_stride0 + j + dst_stride0]), res_1);
                 } else {
                     __m256i       res_16b = _mm256_packus_epi32(res_unsigned_lo, res_unsigned_hi);
                     const __m128i res_0   = _mm256_castsi256_si128(res_16b);
                     const __m128i res_1   = _mm256_extracti128_si256(res_16b, 1);
 
-                    _mm_store_si128((__m128i *)(&dst[i * dst_stride + j]), res_0);
-                    _mm_store_si128((__m128i *)(&dst[i * dst_stride + j + dst_stride]), res_1);
+                    _mm_storeu_si128((__m128i *)(&dst[i * dst_stride + j]), res_0);
+                    _mm_storeu_si128((__m128i *)(&dst[i * dst_stride + j + dst_stride]), res_1);
                 }
             }
         }
@@ -777,16 +777,16 @@ void eb_av1_highbd_jnt_convolve_y_avx2(const uint16_t *src, int32_t src_stride, 
                         const __m128i res_0 = _mm256_castsi256_si128(res_clip);
                         const __m128i res_1 = _mm256_extracti128_si256(res_clip, 1);
 
-                        _mm_store_si128((__m128i *)(&dst0[i * dst_stride0 + j]), res_0);
-                        _mm_store_si128((__m128i *)(&dst0[i * dst_stride0 + j + dst_stride0]),
+                        _mm_storeu_si128((__m128i *)(&dst0[i * dst_stride0 + j]), res_0);
+                        _mm_storeu_si128((__m128i *)(&dst0[i * dst_stride0 + j + dst_stride0]),
                                         res_1);
                     } else {
                         __m256i res_16b     = _mm256_packus_epi32(res_unsigned_lo, res_unsigned_hi);
                         const __m128i res_0 = _mm256_castsi256_si128(res_16b);
                         const __m128i res_1 = _mm256_extracti128_si256(res_16b, 1);
 
-                        _mm_store_si128((__m128i *)(&dst[i * dst_stride + j]), res_0);
-                        _mm_store_si128((__m128i *)(&dst[i * dst_stride + j + dst_stride]), res_1);
+                        _mm_storeu_si128((__m128i *)(&dst[i * dst_stride + j]), res_0);
+                        _mm_storeu_si128((__m128i *)(&dst[i * dst_stride + j + dst_stride]), res_1);
                     }
                 }
                 s[0] = s[1];

--- a/Source/Lib/Common/ASM_AVX2/jnt_convolve_2d_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/jnt_convolve_2d_avx2.c
@@ -379,7 +379,7 @@ static void jnt_convolve_2d_ver_2tap_avx2(const int16_t *const im_block, const i
             __m128i s_128[2];
             __m256i r[2];
 
-            s_128[0] = _mm_load_si128((__m128i *)im);
+            s_128[0] = _mm_loadu_si128((__m128i *)im);
 
             if (conv_params->do_average) {
                 if (conv_params->use_jnt_comp_avg) {
@@ -942,7 +942,7 @@ static void jnt_convolve_2d_ver_2tap_half_avx2(const int16_t *const im_block, co
         if (w == 8) {
             __m128i s_128[2];
 
-            s_128[0] = _mm_load_si128((__m128i *)im);
+            s_128[0] = _mm_loadu_si128((__m128i *)im);
 
             if (conv_params->do_average) {
                 if (conv_params->use_jnt_comp_avg) {

--- a/Source/Lib/Common/ASM_AVX2/txfm_common_avx2.h
+++ b/Source/Lib/Common/ASM_AVX2/txfm_common_avx2.h
@@ -273,8 +273,8 @@ static INLINE void store_rect_16bit_to_32bit_w8_avx2(const __m256i a, int32_t *c
     const __m256i b_lo = scale_round_avx2(a_lo, new_sqrt2);
     const __m256i b_hi = scale_round_avx2(a_hi, new_sqrt2);
     const __m256i temp = _mm256_permute2f128_si256(b_lo, b_hi, 0x31);
-    _mm_store_si128((__m128i *)b, _mm256_castsi256_si128(b_lo));
-    _mm_store_si128((__m128i *)(b + 4), _mm256_castsi256_si128(b_hi));
+    _mm_storeu_si128((__m128i *)b, _mm256_castsi256_si128(b_lo));
+    _mm_storeu_si128((__m128i *)(b + 4), _mm256_castsi256_si128(b_hi));
     _mm256_store_si256((__m256i *)(b + 64), temp);
 }
 

--- a/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
@@ -640,7 +640,7 @@ static INLINE void h_pred_32x8(uint16_t **dst, const ptrdiff_t stride, const uin
     assert(!((intptr_t)*dst % 32));
     assert(!(stride % 32));
 
-    const __m128i left_u16 = _mm_load_si128((const __m128i *)left);
+    const __m128i left_u16 = _mm_loadu_si128((const __m128i *)left);
 
     h_pred_32(dst, stride, _mm_srli_si128(left_u16, 0));
     h_pred_32(dst, stride, _mm_srli_si128(left_u16, 2));
@@ -688,7 +688,7 @@ static INLINE void h_store_32_unpackhi(uint16_t **dst, const ptrdiff_t stride, c
 }
 
 static INLINE void h_predictor_32x8(uint16_t *dst, ptrdiff_t stride, const uint16_t *left) {
-    const __m128i left_u16 = _mm_load_si128((const __m128i *)left);
+    const __m128i left_u16 = _mm_loadu_si128((const __m128i *)left);
     const __m128i row0     = _mm_shufflelo_epi16(left_u16, 0x0);
     const __m128i row1     = _mm_shufflelo_epi16(left_u16, 0x55);
     const __m128i row2     = _mm_shufflelo_epi16(left_u16, 0xaa);
@@ -751,7 +751,7 @@ static INLINE void h_pred_64x8(uint16_t **dst, const ptrdiff_t stride, const uin
     assert(!((intptr_t)*dst % 32));
     assert(!(stride % 32));
 
-    __m128i left_u16 = _mm_load_si128((const __m128i *)left);
+    __m128i left_u16 = _mm_loadu_si128((const __m128i *)left);
 
     for (int16_t j = 0; j < 8; j++) {
         h_pred_64(dst, stride, left_u16);

--- a/Source/Lib/Common/ASM_AVX512/convolve_2d_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/convolve_2d_avx512.c
@@ -301,7 +301,7 @@ static void convolve_2d_sr_ver_2tap_avx512(const int16_t *const im_block, const 
             __m128i s_128[2];
             __m256i r[2];
 
-            s_128[0] = _mm_load_si128((__m128i *)im);
+            s_128[0] = _mm_loadu_si128((__m128i *)im);
 
             do {
                 xy_y_convolve_2tap_8x2_avx2(im, s_128, &coeffs_256, r);
@@ -420,7 +420,7 @@ static void convolve_2d_sr_ver_2tap_half_avx512(const int16_t *const im_block, c
     } else if (w == 8) {
         __m128i s_128[2];
 
-        s_128[0] = _mm_load_si128((__m128i *)im);
+        s_128[0] = _mm_loadu_si128((__m128i *)im);
 
         do {
             const __m256i res = xy_y_convolve_2tap_8x2_half_pel_avx2(im, s_128);

--- a/Source/Lib/Common/ASM_AVX512/convolve_avx512.h
+++ b/Source/Lib/Common/ASM_AVX512/convolve_avx512.h
@@ -116,7 +116,7 @@ static INLINE void prepare_half_coeffs_4tap_avx512(const InterpFilterParams *con
                                                    __m512i *const coeffs /* [2] */) {
     const int16_t *const filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
-    const __m128i coeffs_8 = _mm_load_si128((__m128i *)filter);
+    const __m128i coeffs_8 = _mm_loadu_si128((__m128i *)filter);
 
     // right shift all filter co-efficients by 1 to reduce the bits required.
     // This extra right shift will be taken care of at the end while rounding
@@ -134,7 +134,7 @@ static INLINE void prepare_half_coeffs_6tap_avx512(const InterpFilterParams *con
                                                    __m512i *const coeffs /* [3] */) {
     const int16_t *const filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
-    const __m128i coeffs_8 = _mm_load_si128((__m128i *)filter);
+    const __m128i coeffs_8 = _mm_loadu_si128((__m128i *)filter);
 
     // right shift all filter co-efficients by 1 to reduce the bits required.
     // This extra right shift will be taken care of at the end while rounding
@@ -152,7 +152,7 @@ SIMD_INLINE void prepare_half_coeffs_8tap_avx512(const InterpFilterParams *const
                                                  __m512i *const                  coeffs /* [4] */) {
     const int16_t *const filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
-    const __m128i coeffs_8 = _mm_load_si128((__m128i *)filter);
+    const __m128i coeffs_8 = _mm_loadu_si128((__m128i *)filter);
 
     // right shift all filter co-efficients by 1 to reduce the bits required.
     // This extra right shift will be taken care of at the end while rounding
@@ -184,7 +184,7 @@ static INLINE void prepare_coeffs_4tap_avx512(const InterpFilterParams *const fi
     const int16_t *filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
 
-    const __m128i coeff_8 = _mm_load_si128((__m128i *)filter);
+    const __m128i coeff_8 = _mm_loadu_si128((__m128i *)filter);
     const __m512i coeff   = eb_mm512_broadcast_i64x2(coeff_8);
 
     // coeffs 2 3 2 3 2 3 2 3
@@ -198,7 +198,7 @@ static INLINE void prepare_coeffs_6tap_avx512(const InterpFilterParams *const fi
                                               __m512i *const                  coeffs /* [3] */) {
     const int16_t *const filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
-    const __m128i coeffs_8 = _mm_load_si128((__m128i *)filter);
+    const __m128i coeffs_8 = _mm_loadu_si128((__m128i *)filter);
     const __m512i coeff    = eb_mm512_broadcast_i64x2(coeffs_8);
 
     // coeffs 1 2 1 2 1 2 1 2
@@ -215,7 +215,7 @@ static INLINE void prepare_coeffs_8tap_avx512(const InterpFilterParams *const fi
     const int16_t *filter =
         av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
 
-    const __m128i coeff_8 = _mm_load_si128((__m128i *)filter);
+    const __m128i coeff_8 = _mm_loadu_si128((__m128i *)filter);
     const __m512i coeff   = eb_mm512_broadcast_i64x2(coeff_8);
 
     // coeffs 0 1 0 1 0 1 0 1

--- a/Source/Lib/Common/ASM_AVX512/jnt_convolve_2d_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/jnt_convolve_2d_avx512.c
@@ -598,7 +598,7 @@ static void jnt_convolve_2d_ver_2tap_avx512(const int16_t *const im_block, const
             __m128i s_128[2];
             __m256i r[2];
 
-            s_128[0] = _mm_load_si128((__m128i *)im);
+            s_128[0] = _mm_loadu_si128((__m128i *)im);
 
             if (conv_params->do_average) {
                 if (conv_params->use_jnt_comp_avg) {
@@ -1033,7 +1033,7 @@ static void jnt_convolve_2d_ver_2tap_half_avx512(const int16_t *const im_block, 
         if (w == 8) {
             __m128i s_128[2];
 
-            s_128[0] = _mm_load_si128((__m128i *)im);
+            s_128[0] = _mm_loadu_si128((__m128i *)im);
 
             if (conv_params->do_average) {
                 if (conv_params->use_jnt_comp_avg) {

--- a/Source/Lib/Common/ASM_SSE2/EbDeblockingFilter_Intrinsic_SSE2.c
+++ b/Source/Lib/Common/ASM_SSE2/EbDeblockingFilter_Intrinsic_SSE2.c
@@ -620,9 +620,9 @@ static AOM_FORCE_INLINE void lpf_internal_14_sse2(__m128i *q6p6, __m128i *q5p5, 
 void aom_lpf_horizontal_14_sse2(uint8_t *s, int32_t p, const uint8_t *_blimit,
                                 const uint8_t *_limit, const uint8_t *_thresh) {
     __m128i q6p6, q5p5, q4p4, q3p3, q2p2, q1p1, q0p0;
-    __m128i blimit = _mm_load_si128((const __m128i *)_blimit);
-    __m128i limit  = _mm_load_si128((const __m128i *)_limit);
-    __m128i thresh = _mm_load_si128((const __m128i *)_thresh);
+    __m128i blimit = _mm_loadu_si128((const __m128i *)_blimit);
+    __m128i limit  = _mm_loadu_si128((const __m128i *)_limit);
+    __m128i thresh = _mm_loadu_si128((const __m128i *)_thresh);
 
     q4p4 = _mm_unpacklo_epi32(xx_loadl_32(s - 5 * p), xx_loadl_32(s + 4 * p));
     q3p3 = _mm_unpacklo_epi32(xx_loadl_32(s - 4 * p), xx_loadl_32(s + 3 * p));
@@ -650,9 +650,9 @@ static AOM_FORCE_INLINE void lpf_internal_6_sse2(__m128i *p2, __m128i *q2, __m12
                                                  __m128i *p1p0, const uint8_t *_blimit,
                                                  const uint8_t *_limit, const uint8_t *_thresh) {
     const __m128i zero   = _mm_setzero_si128();
-    const __m128i blimit = _mm_load_si128((const __m128i *)_blimit);
-    const __m128i limit  = _mm_load_si128((const __m128i *)_limit);
-    const __m128i thresh = _mm_load_si128((const __m128i *)_thresh);
+    const __m128i blimit = _mm_loadu_si128((const __m128i *)_blimit);
+    const __m128i limit  = _mm_loadu_si128((const __m128i *)_limit);
+    const __m128i thresh = _mm_loadu_si128((const __m128i *)_thresh);
     __m128i       mask, hev, flat;
     __m128i       q2p2, q1p1, q0p0, p1q1, p0q0, flat_p1p0, flat_q0q1;
     __m128i       p2_16, q2_16, p1_16, q1_16, p0_16, q0_16;
@@ -806,9 +806,9 @@ static AOM_FORCE_INLINE void lpf_internal_8_sse2(__m128i *p3_8, __m128i *q3_8, _
                                                  __m128i *q2_out, const uint8_t *_blimit,
                                                  const uint8_t *_limit, const uint8_t *_thresh) {
     const __m128i zero   = _mm_setzero_si128();
-    const __m128i blimit = _mm_load_si128((const __m128i *)_blimit);
-    const __m128i limit  = _mm_load_si128((const __m128i *)_limit);
-    const __m128i thresh = _mm_load_si128((const __m128i *)_thresh);
+    const __m128i blimit = _mm_loadu_si128((const __m128i *)_blimit);
+    const __m128i limit  = _mm_loadu_si128((const __m128i *)_limit);
+    const __m128i thresh = _mm_loadu_si128((const __m128i *)_thresh);
     __m128i       mask, hev, flat;
     __m128i       p2, q2, p1, p0, q0, q1, p3, q3, q3p3, flat_p1p0, flat_q0q1;
     __m128i       q2p2, q1p1, q0p0, p1q1, p0q0;
@@ -1164,10 +1164,10 @@ void aom_lpf_vertical_6_sse2(uint8_t *s, int32_t p, const uint8_t *blimit, const
 
     transpose6x6_sse2(&d0d1, &p0, &p1p0, &q1q0, &q0, &d5, &d0d1, &d2d3, &d4d5);
 
-    _mm_store_si128((__m128i *)(temp_dst), d0d1);
+    _mm_storeu_si128((__m128i *)(temp_dst), d0d1);
     memcpy((s - 3) + 0 * p, temp_dst, 6);
     memcpy((s - 3) + 1 * p, temp_dst + 8, 6);
-    _mm_store_si128((__m128i *)(temp_dst), d2d3);
+    _mm_storeu_si128((__m128i *)(temp_dst), d2d3);
     memcpy((s - 3) + 2 * p, temp_dst, 6);
     memcpy((s - 3) + 3 * p, temp_dst + 8, 6);
 }
@@ -1229,9 +1229,9 @@ void aom_lpf_vertical_14_sse2(uint8_t *s, int32_t p, const uint8_t *_blimit, con
     __m128i q7p7, q6p6, q5p5, q4p4, q3p3, q2p2, q1p1, q0p0;
     __m128i x6, x5, x4, x3;
     __m128i pq0, pq1, pq2, pq3;
-    __m128i blimit = _mm_load_si128((__m128i *)_blimit);
-    __m128i limit  = _mm_load_si128((__m128i *)_limit);
-    __m128i thresh = _mm_load_si128((__m128i *)_thresh);
+    __m128i blimit = _mm_loadu_si128((__m128i *)_blimit);
+    __m128i limit  = _mm_loadu_si128((__m128i *)_limit);
+    __m128i thresh = _mm_loadu_si128((__m128i *)_thresh);
 
     x6 = _mm_loadu_si128((__m128i *)((s - 8) + 0 * p));
     x5 = _mm_loadu_si128((__m128i *)((s - 8) + 1 * p));
@@ -1266,13 +1266,13 @@ static INLINE void get_limit(const uint8_t *bl, const uint8_t *l, const uint8_t 
     const int32_t shift = bd - 8;
     const __m128i zero  = _mm_setzero_si128();
 
-    __m128i x = _mm_unpacklo_epi8(_mm_load_si128((const __m128i *)bl), zero);
+    __m128i x = _mm_unpacklo_epi8(_mm_loadu_si128((const __m128i *)bl), zero);
     *blt      = _mm_slli_epi16(x, shift);
 
-    x   = _mm_unpacklo_epi8(_mm_load_si128((const __m128i *)l), zero);
+    x   = _mm_unpacklo_epi8(_mm_loadu_si128((const __m128i *)l), zero);
     *lt = _mm_slli_epi16(x, shift);
 
-    x    = _mm_unpacklo_epi8(_mm_load_si128((const __m128i *)t), zero);
+    x    = _mm_unpacklo_epi8(_mm_loadu_si128((const __m128i *)t), zero);
     *thr = _mm_slli_epi16(x, shift);
 
     *t80_out = _mm_set1_epi16(1 << (bd - 1));

--- a/Source/Lib/Common/ASM_SSE2/EbIntraPrediction_AV1_Intrinsic_SSE2.c
+++ b/Source/Lib/Common/ASM_SSE2/EbIntraPrediction_AV1_Intrinsic_SSE2.c
@@ -25,8 +25,8 @@ static INLINE void dc_store_4xh(uint32_t dc, int32_t height, uint8_t *dst, ptrdi
 }
 
 static INLINE __m128i dc_sum_32(const uint8_t *ref) {
-    __m128i       x0   = _mm_load_si128((__m128i const *)ref);
-    __m128i       x1   = _mm_load_si128((__m128i const *)(ref + 16));
+    __m128i       x0   = _mm_loadu_si128((__m128i const *)ref);
+    __m128i       x1   = _mm_loadu_si128((__m128i const *)(ref + 16));
     const __m128i zero = _mm_setzero_si128();
     x0                 = _mm_sad_epu8(x0, zero);
     x1                 = _mm_sad_epu8(x1, zero);
@@ -36,10 +36,10 @@ static INLINE __m128i dc_sum_32(const uint8_t *ref) {
 }
 
 static INLINE __m128i dc_sum_64(const uint8_t *ref) {
-    __m128i       x0   = _mm_load_si128((__m128i const *)ref);
-    __m128i       x1   = _mm_load_si128((__m128i const *)(ref + 16));
-    __m128i       x2   = _mm_load_si128((__m128i const *)(ref + 32));
-    __m128i       x3   = _mm_load_si128((__m128i const *)(ref + 48));
+    __m128i       x0   = _mm_loadu_si128((__m128i const *)ref);
+    __m128i       x1   = _mm_loadu_si128((__m128i const *)(ref + 16));
+    __m128i       x2   = _mm_loadu_si128((__m128i const *)(ref + 32));
+    __m128i       x3   = _mm_loadu_si128((__m128i const *)(ref + 48));
     const __m128i zero = _mm_setzero_si128();
     x0                 = _mm_sad_epu8(x0, zero);
     x1                 = _mm_sad_epu8(x1, zero);
@@ -101,8 +101,8 @@ static INLINE int32_t divide_using_multiply_shift(int32_t num, int32_t shift1, i
 
 static INLINE void v_predictor_32xh(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                     int32_t height) {
-    const __m128i row0 = _mm_load_si128((__m128i const *)above);
-    const __m128i row1 = _mm_load_si128((__m128i const *)(above + 16));
+    const __m128i row0 = _mm_loadu_si128((__m128i const *)above);
+    const __m128i row1 = _mm_loadu_si128((__m128i const *)(above + 16));
     for (int32_t i = 0; i < height; ++i) {
         _mm_storeu_si128((__m128i *)dst, row0);
         _mm_storeu_si128((__m128i *)(dst + 16), row1);
@@ -160,7 +160,7 @@ static INLINE void h_predictor_16xh(uint8_t *dst, ptrdiff_t stride, const uint8_
                                     int32_t count) {
     int32_t i = 0;
     do {
-        const __m128i left_col       = _mm_load_si128((const __m128i *)left);
+        const __m128i left_col       = _mm_loadu_si128((const __m128i *)left);
         const __m128i left_col_8p_lo = _mm_unpacklo_epi8(left_col, left_col);
         h_prediction_16x8_1(&left_col_8p_lo, dst, stride);
         dst += stride << 2;
@@ -232,7 +232,7 @@ static INLINE void h_predictor_8x16xc(uint8_t *dst, ptrdiff_t stride, const uint
                                       const uint8_t *left, int32_t count) {
     (void)above;
     for (int32_t i = 0; i < count; ++i) {
-        const __m128i left_col      = _mm_load_si128((__m128i const *)left);
+        const __m128i left_col      = _mm_loadu_si128((__m128i const *)left);
         __m128i       left_col_low  = _mm_unpacklo_epi8(left_col, left_col);
         __m128i       left_col_high = _mm_unpackhi_epi8(left_col, left_col);
 
@@ -366,7 +366,7 @@ void eb_aom_h_predictor_32x16_sse2(uint8_t *dst, ptrdiff_t stride, const uint8_t
     __m128i left_col, left_col_8p;
     (void)above;
 
-    left_col = _mm_load_si128((const __m128i *)left);
+    left_col = _mm_loadu_si128((const __m128i *)left);
 
     left_col_8p = _mm_unpacklo_epi8(left_col, left_col);
     h_prediction_32x8_1(&left_col_8p, dst, stride);
@@ -403,7 +403,7 @@ void eb_aom_h_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride, const uint8_t 
     __m128i left_col, left_col_8p;
     (void)above;
 
-    left_col = _mm_load_si128((const __m128i *)left);
+    left_col = _mm_loadu_si128((const __m128i *)left);
 
     left_col_8p = _mm_unpacklo_epi8(left_col, left_col);
     h_prediction_32x8_1(&left_col_8p, dst, stride);
@@ -414,7 +414,7 @@ void eb_aom_h_predictor_32x8_sse2(uint8_t *dst, ptrdiff_t stride, const uint8_t 
 void eb_aom_h_predictor_4x16_sse2(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                   const uint8_t *left) {
     (void)above;
-    const __m128i left_col      = _mm_load_si128((__m128i const *)left);
+    const __m128i left_col      = _mm_loadu_si128((__m128i const *)left);
     __m128i       left_col_low  = _mm_unpacklo_epi8(left_col, left_col);
     __m128i       left_col_high = _mm_unpackhi_epi8(left_col, left_col);
 
@@ -531,27 +531,27 @@ void eb_aom_h_predictor_8x4_sse2(uint8_t *dst, ptrdiff_t stride, const uint8_t *
 
 void eb_aom_v_predictor_16x32_sse2(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                    const uint8_t *left) {
-    const __m128i row = _mm_load_si128((__m128i const *)above);
+    const __m128i row = _mm_loadu_si128((__m128i const *)above);
     (void)left;
     dc_store_16xh(&row, 32, dst, stride);
 }
 
 void eb_aom_v_predictor_16x4_sse2(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                   const uint8_t *left) {
-    const __m128i row = _mm_load_si128((__m128i const *)above);
+    const __m128i row = _mm_loadu_si128((__m128i const *)above);
     (void)left;
     dc_store_16xh(&row, 4, dst, stride);
 }
 
 void eb_aom_v_predictor_16x64_sse2(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                    const uint8_t *left) {
-    const __m128i row = _mm_load_si128((__m128i const *)above);
+    const __m128i row = _mm_loadu_si128((__m128i const *)above);
     (void)left;
     dc_store_16xh(&row, 64, dst, stride);
 }
 void eb_aom_v_predictor_16x8_sse2(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                   const uint8_t *left) {
-    const __m128i row = _mm_load_si128((__m128i const *)above);
+    const __m128i row = _mm_loadu_si128((__m128i const *)above);
     (void)left;
     dc_store_16xh(&row, 8, dst, stride);
 }

--- a/Source/Lib/Common/ASM_SSE2/av1_txfm_sse2.h
+++ b/Source/Lib/Common/ASM_SSE2/av1_txfm_sse2.h
@@ -75,12 +75,12 @@ static INLINE void btf_16_w4_sse2(const __m128i *const w0, const __m128i *const 
     }
 
 static INLINE __m128i load_32bit_to_16bit(const int32_t *a) {
-    const __m128i a_low = _mm_load_si128((const __m128i *)a);
+    const __m128i a_low = _mm_loadu_si128((const __m128i *)a);
     return _mm_packs_epi32(a_low, *(const __m128i *)(a + 4));
 }
 
 static INLINE __m128i load_32bit_to_16bit_w4(const int32_t *a) {
-    const __m128i a_low = _mm_load_si128((const __m128i *)a);
+    const __m128i a_low = _mm_loadu_si128((const __m128i *)a);
     return _mm_packs_epi32(a_low, a_low);
 }
 

--- a/Source/Lib/Common/ASM_SSE2/highbd_intrapred_sse2.c
+++ b/Source/Lib/Common/ASM_SSE2/highbd_intrapred_sse2.c
@@ -59,25 +59,25 @@ void eb_aom_highbd_h_predictor_4x16_sse2(uint16_t *dst, ptrdiff_t stride, const 
 
 void eb_aom_highbd_h_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride, const uint16_t *above,
                                         const uint16_t *left, int32_t bd) {
-    const __m128i left_u16 = _mm_load_si128((const __m128i *)left);
+    const __m128i left_u16 = _mm_loadu_si128((const __m128i *)left);
     const __m128i row0     = _mm_shufflelo_epi16(left_u16, 0x0);
     const __m128i row1     = _mm_shufflelo_epi16(left_u16, 0x55);
     const __m128i row2     = _mm_shufflelo_epi16(left_u16, 0xaa);
     const __m128i row3     = _mm_shufflelo_epi16(left_u16, 0xff);
     (void)above;
     (void)bd;
-    _mm_store_si128((__m128i *)dst, _mm_unpacklo_epi64(row0, row0));
+    _mm_storeu_si128((__m128i *)dst, _mm_unpacklo_epi64(row0, row0));
     dst += stride;
-    _mm_store_si128((__m128i *)dst, _mm_unpacklo_epi64(row1, row1));
+    _mm_storeu_si128((__m128i *)dst, _mm_unpacklo_epi64(row1, row1));
     dst += stride;
-    _mm_store_si128((__m128i *)dst, _mm_unpacklo_epi64(row2, row2));
+    _mm_storeu_si128((__m128i *)dst, _mm_unpacklo_epi64(row2, row2));
     dst += stride;
-    _mm_store_si128((__m128i *)dst, _mm_unpacklo_epi64(row3, row3));
+    _mm_storeu_si128((__m128i *)dst, _mm_unpacklo_epi64(row3, row3));
 }
 
 void eb_aom_highbd_h_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t stride, const uint16_t *above,
                                         const uint16_t *left, int32_t bd) {
-    const __m128i left_u16 = _mm_load_si128((const __m128i *)left);
+    const __m128i left_u16 = _mm_loadu_si128((const __m128i *)left);
     const __m128i row0     = _mm_shufflelo_epi16(left_u16, 0x0);
     const __m128i row1     = _mm_shufflelo_epi16(left_u16, 0x55);
     const __m128i row2     = _mm_shufflelo_epi16(left_u16, 0xaa);
@@ -88,21 +88,21 @@ void eb_aom_highbd_h_predictor_8x8_sse2(uint16_t *dst, ptrdiff_t stride, const u
     const __m128i row7     = _mm_shufflehi_epi16(left_u16, 0xff);
     (void)above;
     (void)bd;
-    _mm_store_si128((__m128i *)dst, _mm_unpacklo_epi64(row0, row0));
+    _mm_storeu_si128((__m128i *)dst, _mm_unpacklo_epi64(row0, row0));
     dst += stride;
-    _mm_store_si128((__m128i *)dst, _mm_unpacklo_epi64(row1, row1));
+    _mm_storeu_si128((__m128i *)dst, _mm_unpacklo_epi64(row1, row1));
     dst += stride;
-    _mm_store_si128((__m128i *)dst, _mm_unpacklo_epi64(row2, row2));
+    _mm_storeu_si128((__m128i *)dst, _mm_unpacklo_epi64(row2, row2));
     dst += stride;
-    _mm_store_si128((__m128i *)dst, _mm_unpacklo_epi64(row3, row3));
+    _mm_storeu_si128((__m128i *)dst, _mm_unpacklo_epi64(row3, row3));
     dst += stride;
-    _mm_store_si128((__m128i *)dst, _mm_unpackhi_epi64(row4, row4));
+    _mm_storeu_si128((__m128i *)dst, _mm_unpackhi_epi64(row4, row4));
     dst += stride;
-    _mm_store_si128((__m128i *)dst, _mm_unpackhi_epi64(row5, row5));
+    _mm_storeu_si128((__m128i *)dst, _mm_unpackhi_epi64(row5, row5));
     dst += stride;
-    _mm_store_si128((__m128i *)dst, _mm_unpackhi_epi64(row6, row6));
+    _mm_storeu_si128((__m128i *)dst, _mm_unpackhi_epi64(row6, row6));
     dst += stride;
-    _mm_store_si128((__m128i *)dst, _mm_unpackhi_epi64(row7, row7));
+    _mm_storeu_si128((__m128i *)dst, _mm_unpackhi_epi64(row7, row7));
 }
 
 void eb_aom_highbd_h_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride, const uint16_t *above,
@@ -129,20 +129,20 @@ void eb_aom_highbd_h_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t stride, const 
 
 static INLINE void h_store_16_unpacklo(uint16_t **dst, const ptrdiff_t stride, const __m128i *row) {
     const __m128i val = _mm_unpacklo_epi64(*row, *row);
-    _mm_store_si128((__m128i *)*dst, val);
-    _mm_store_si128((__m128i *)(*dst + 8), val);
+    _mm_storeu_si128((__m128i *)*dst, val);
+    _mm_storeu_si128((__m128i *)(*dst + 8), val);
     *dst += stride;
 }
 
 static INLINE void h_store_16_unpackhi(uint16_t **dst, const ptrdiff_t stride, const __m128i *row) {
     const __m128i val = _mm_unpackhi_epi64(*row, *row);
-    _mm_store_si128((__m128i *)(*dst), val);
-    _mm_store_si128((__m128i *)(*dst + 8), val);
+    _mm_storeu_si128((__m128i *)(*dst), val);
+    _mm_storeu_si128((__m128i *)(*dst + 8), val);
     *dst += stride;
 }
 
 static INLINE void h_predictor_16x8(uint16_t *dst, ptrdiff_t stride, const uint16_t *left) {
-    const __m128i left_u16 = _mm_load_si128((const __m128i *)left);
+    const __m128i left_u16 = _mm_loadu_si128((const __m128i *)left);
     const __m128i row0     = _mm_shufflelo_epi16(left_u16, 0x0);
     const __m128i row1     = _mm_shufflelo_epi16(left_u16, 0x55);
     const __m128i row2     = _mm_shufflelo_epi16(left_u16, 0xaa);
@@ -194,19 +194,19 @@ void eb_aom_highbd_h_predictor_16x32_sse2(uint16_t *dst, ptrdiff_t stride, const
 
 static INLINE void h_store_32_unpacklo(uint16_t **dst, const ptrdiff_t stride, const __m128i *row) {
     const __m128i val = _mm_unpacklo_epi64(*row, *row);
-    _mm_store_si128((__m128i *)(*dst), val);
-    _mm_store_si128((__m128i *)(*dst + 8), val);
-    _mm_store_si128((__m128i *)(*dst + 16), val);
-    _mm_store_si128((__m128i *)(*dst + 24), val);
+    _mm_storeu_si128((__m128i *)(*dst), val);
+    _mm_storeu_si128((__m128i *)(*dst + 8), val);
+    _mm_storeu_si128((__m128i *)(*dst + 16), val);
+    _mm_storeu_si128((__m128i *)(*dst + 24), val);
     *dst += stride;
 }
 
 static INLINE void h_store_32_unpackhi(uint16_t **dst, const ptrdiff_t stride, const __m128i *row) {
     const __m128i val = _mm_unpackhi_epi64(*row, *row);
-    _mm_store_si128((__m128i *)(*dst), val);
-    _mm_store_si128((__m128i *)(*dst + 8), val);
-    _mm_store_si128((__m128i *)(*dst + 16), val);
-    _mm_store_si128((__m128i *)(*dst + 24), val);
+    _mm_storeu_si128((__m128i *)(*dst), val);
+    _mm_storeu_si128((__m128i *)(*dst + 8), val);
+    _mm_storeu_si128((__m128i *)(*dst + 16), val);
+    _mm_storeu_si128((__m128i *)(*dst + 24), val);
     *dst += stride;
 }
 
@@ -331,8 +331,8 @@ void eb_aom_highbd_dc_128_predictor_4x8_sse2(uint16_t *dst, ptrdiff_t stride, co
 // 4x16
 
 static INLINE __m128i dc_sum_16(const uint16_t *const src) {
-    const __m128i s_lo = _mm_load_si128((const __m128i *)(src + 0));
-    const __m128i s_hi = _mm_load_si128((const __m128i *)(src + 8));
+    const __m128i s_lo = _mm_loadu_si128((const __m128i *)(src + 0));
+    const __m128i s_hi = _mm_loadu_si128((const __m128i *)(src + 8));
     __m128i       sum, sum_hi;
     sum    = _mm_add_epi16(s_lo, s_hi);
     sum_hi = _mm_srli_si128(sum, 8);
@@ -383,7 +383,7 @@ static INLINE void dc_store_8xh(uint16_t *dst, ptrdiff_t stride, int32_t height,
     const __m128i dc_dup_lo = _mm_shufflelo_epi16(*dc, 0);
     const __m128i dc_dup    = _mm_unpacklo_epi64(dc_dup_lo, dc_dup_lo);
     int32_t       i;
-    for (i = 0; i < height; ++i, dst += stride) _mm_store_si128((__m128i *)dst, dc_dup);
+    for (i = 0; i < height; ++i, dst += stride) _mm_storeu_si128((__m128i *)dst, dc_dup);
 }
 
 // -----------------------------------------------------------------------------
@@ -550,24 +550,24 @@ void eb_aom_highbd_v_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride, const u
                                         const uint16_t *left, int32_t bd) {
     (void)left;
     (void)bd;
-    const __m128i above_u16 = _mm_load_si128((const __m128i *)above);
-    _mm_store_si128((__m128i *)dst, above_u16);
-    _mm_store_si128((__m128i *)(dst + stride), above_u16);
-    _mm_store_si128((__m128i *)(dst + 2 * stride), above_u16);
-    _mm_store_si128((__m128i *)(dst + 3 * stride), above_u16);
+    const __m128i above_u16 = _mm_loadu_si128((const __m128i *)above);
+    _mm_storeu_si128((__m128i *)dst, above_u16);
+    _mm_storeu_si128((__m128i *)(dst + stride), above_u16);
+    _mm_storeu_si128((__m128i *)(dst + 2 * stride), above_u16);
+    _mm_storeu_si128((__m128i *)(dst + 3 * stride), above_u16);
 }
 
 void eb_aom_highbd_v_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride, const uint16_t *above,
                                          const uint16_t *left, int32_t bd) {
     (void)left;
     (void)bd;
-    const __m128i above_u16 = _mm_load_si128((const __m128i *)above);
+    const __m128i above_u16 = _mm_loadu_si128((const __m128i *)above);
     int32_t       i;
     for (i = 0; i < 4; ++i) {
-        _mm_store_si128((__m128i *)dst, above_u16);
-        _mm_store_si128((__m128i *)(dst + stride), above_u16);
-        _mm_store_si128((__m128i *)(dst + 2 * stride), above_u16);
-        _mm_store_si128((__m128i *)(dst + 3 * stride), above_u16);
+        _mm_storeu_si128((__m128i *)dst, above_u16);
+        _mm_storeu_si128((__m128i *)(dst + stride), above_u16);
+        _mm_storeu_si128((__m128i *)(dst + 2 * stride), above_u16);
+        _mm_storeu_si128((__m128i *)(dst + 3 * stride), above_u16);
         dst += stride << 2;
     }
 }
@@ -576,13 +576,13 @@ void eb_aom_highbd_v_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t stride, const 
                                          const uint16_t *left, int32_t bd) {
     (void)left;
     (void)bd;
-    const __m128i above_u16 = _mm_load_si128((const __m128i *)above);
+    const __m128i above_u16 = _mm_loadu_si128((const __m128i *)above);
     int32_t       i;
     for (i = 0; i < 8; ++i) {
-        _mm_store_si128((__m128i *)dst, above_u16);
-        _mm_store_si128((__m128i *)(dst + stride), above_u16);
-        _mm_store_si128((__m128i *)(dst + 2 * stride), above_u16);
-        _mm_store_si128((__m128i *)(dst + 3 * stride), above_u16);
+        _mm_storeu_si128((__m128i *)dst, above_u16);
+        _mm_storeu_si128((__m128i *)(dst + stride), above_u16);
+        _mm_storeu_si128((__m128i *)(dst + 2 * stride), above_u16);
+        _mm_storeu_si128((__m128i *)(dst + 3 * stride), above_u16);
         dst += stride << 2;
     }
 }
@@ -591,11 +591,11 @@ void eb_aom_highbd_v_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t stride, const 
 // DC_PRED
 
 static INLINE __m128i dc_sum_8_32(const uint16_t *const src_8, const uint16_t *const src_32) {
-    const __m128i s_8       = _mm_load_si128((const __m128i *)src_8);
-    const __m128i s_32_0    = _mm_load_si128((const __m128i *)(src_32 + 0x00));
-    const __m128i s_32_1    = _mm_load_si128((const __m128i *)(src_32 + 0x08));
-    const __m128i s_32_2    = _mm_load_si128((const __m128i *)(src_32 + 0x10));
-    const __m128i s_32_3    = _mm_load_si128((const __m128i *)(src_32 + 0x18));
+    const __m128i s_8       = _mm_loadu_si128((const __m128i *)src_8);
+    const __m128i s_32_0    = _mm_loadu_si128((const __m128i *)(src_32 + 0x00));
+    const __m128i s_32_1    = _mm_loadu_si128((const __m128i *)(src_32 + 0x08));
+    const __m128i s_32_2    = _mm_loadu_si128((const __m128i *)(src_32 + 0x10));
+    const __m128i s_32_3    = _mm_loadu_si128((const __m128i *)(src_32 + 0x18));
     const __m128i s_32_sum0 = _mm_add_epi16(s_32_0, s_32_1);
     const __m128i s_32_sum1 = _mm_add_epi16(s_32_2, s_32_3);
     const __m128i s_32_sum  = _mm_add_epi16(s_32_sum0, s_32_sum1);
@@ -655,13 +655,13 @@ void eb_aom_highbd_dc_predictor_8x4_sse2(uint16_t *dst, ptrdiff_t stride, const 
     sum32 /= 12;
     const __m128i row = _mm_set1_epi16((uint16_t)sum32);
 
-    _mm_store_si128((__m128i *)dst, row);
+    _mm_storeu_si128((__m128i *)dst, row);
     dst += stride;
-    _mm_store_si128((__m128i *)dst, row);
+    _mm_storeu_si128((__m128i *)dst, row);
     dst += stride;
-    _mm_store_si128((__m128i *)dst, row);
+    _mm_storeu_si128((__m128i *)dst, row);
     dst += stride;
-    _mm_store_si128((__m128i *)dst, row);
+    _mm_storeu_si128((__m128i *)dst, row);
 }
 
 void eb_aom_highbd_dc_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride, const uint16_t *above,
@@ -679,13 +679,13 @@ void eb_aom_highbd_dc_predictor_8x16_sse2(uint16_t *dst, ptrdiff_t stride, const
     const __m128i row = _mm_set1_epi16((uint16_t)sum32);
     int32_t       i;
     for (i = 0; i < 4; ++i) {
-        _mm_store_si128((__m128i *)dst, row);
+        _mm_storeu_si128((__m128i *)dst, row);
         dst += stride;
-        _mm_store_si128((__m128i *)dst, row);
+        _mm_storeu_si128((__m128i *)dst, row);
         dst += stride;
-        _mm_store_si128((__m128i *)dst, row);
+        _mm_storeu_si128((__m128i *)dst, row);
         dst += stride;
-        _mm_store_si128((__m128i *)dst, row);
+        _mm_storeu_si128((__m128i *)dst, row);
         dst += stride;
     }
 }
@@ -700,13 +700,13 @@ void eb_aom_highbd_dc_predictor_8x32_sse2(uint16_t *dst, ptrdiff_t stride, const
     const __m128i row = _mm_set1_epi16((uint16_t)sum32);
     int32_t       i;
     for (i = 0; i < 8; ++i) {
-        _mm_store_si128((__m128i *)dst, row);
+        _mm_storeu_si128((__m128i *)dst, row);
         dst += stride;
-        _mm_store_si128((__m128i *)dst, row);
+        _mm_storeu_si128((__m128i *)dst, row);
         dst += stride;
-        _mm_store_si128((__m128i *)dst, row);
+        _mm_storeu_si128((__m128i *)dst, row);
         dst += stride;
-        _mm_store_si128((__m128i *)dst, row);
+        _mm_storeu_si128((__m128i *)dst, row);
         dst += stride;
     }
 }

--- a/Source/Lib/Common/ASM_SSE2/highbd_intrapred_sse2_.asm
+++ b/Source/Lib/Common/ASM_SSE2/highbd_intrapred_sse2_.asm
@@ -48,8 +48,8 @@ cglobal highbd_dc_predictor_8x8, 4, 5, 4, dst, stride, above, left, goffset
   GET_GOT     goffsetq
 
   pxor                  m1, m1
-  mova                  m0, [aboveq]
-  mova                  m2, [leftq]
+  movu                  m0, [aboveq]
+  movu                  m2, [leftq]
   DEFINE_ARGS dst, stride, stride3, one
   mov                 oned, 0x00010001
   lea             stride3q, [strideq*3]
@@ -65,15 +65,15 @@ cglobal highbd_dc_predictor_8x8, 4, 5, 4, dst, stride, above, left, goffset
   psrlw                 m0, 4
   pshuflw               m0, m0, 0x0
   punpcklqdq            m0, m0
-  mova   [dstq           ], m0
-  mova   [dstq+strideq*2 ], m0
-  mova   [dstq+strideq*4 ], m0
-  mova   [dstq+stride3q*2], m0
+  movu   [dstq           ], m0
+  movu   [dstq+strideq*2 ], m0
+  movu   [dstq+strideq*4 ], m0
+  movu   [dstq+stride3q*2], m0
   lea                 dstq, [dstq+strideq*8]
-  mova   [dstq           ], m0
-  mova   [dstq+strideq*2 ], m0
-  mova   [dstq+strideq*4 ], m0
-  mova   [dstq+stride3q*2], m0
+  movu   [dstq           ], m0
+  movu   [dstq+strideq*2 ], m0
+  movu   [dstq+strideq*4 ], m0
+  movu   [dstq+stride3q*2], m0
 
   RESTORE_GOT
   RET
@@ -90,18 +90,18 @@ cglobal highbd_v_predictor_4x4, 3, 3, 1, dst, stride, above
 
 INIT_XMM sse2
 cglobal highbd_v_predictor_8x8, 3, 3, 1, dst, stride, above
-  mova                  m0, [aboveq]
+  movu                  m0, [aboveq]
   DEFINE_ARGS dst, stride, stride3
   lea             stride3q, [strideq*3]
-  mova   [dstq           ], m0
-  mova   [dstq+strideq*2 ], m0
-  mova   [dstq+strideq*4 ], m0
-  mova   [dstq+stride3q*2], m0
+  movu   [dstq           ], m0
+  movu   [dstq+strideq*2 ], m0
+  movu   [dstq+strideq*4 ], m0
+  movu   [dstq+stride3q*2], m0
   lea                 dstq, [dstq+strideq*8]
-  mova   [dstq           ], m0
-  mova   [dstq+strideq*2 ], m0
-  mova   [dstq+strideq*4 ], m0
-  mova   [dstq+stride3q*2], m0
+  movu   [dstq           ], m0
+  movu   [dstq+strideq*2 ], m0
+  movu   [dstq+strideq*4 ], m0
+  movu   [dstq+stride3q*2], m0
   RET
 
 

--- a/Source/Lib/Common/ASM_SSE2/subtract_sse2.asm
+++ b/Source/Lib/Common/ASM_SSE2/subtract_sse2.asm
@@ -38,10 +38,10 @@ cglobal subtract_block, 7, 7, 8, \
   je .case_64
 
 %macro loop16 6
-  mova                  m0, [srcq+%1]
-  mova                  m4, [srcq+%2]
-  mova                  m1, [predq+%3]
-  mova                  m5, [predq+%4]
+  movu                  m0, [srcq+%1]
+  movu                  m4, [srcq+%2]
+  movu                  m1, [predq+%3]
+  movu                  m5, [predq+%4]
   punpckhbw             m2, m0, m7
   punpckhbw             m3, m1, m7
   punpcklbw             m0, m7
@@ -54,10 +54,10 @@ cglobal subtract_block, 7, 7, 8, \
   punpcklbw             m5, m7
   psubw                 m1, m3
   psubw                 m4, m5
-  mova [diffq+mmsize*0+%5], m0
-  mova [diffq+mmsize*1+%5], m2
-  mova [diffq+mmsize*0+%6], m4
-  mova [diffq+mmsize*1+%6], m1
+  movu [diffq+mmsize*0+%5], m0
+  movu [diffq+mmsize*1+%5], m2
+  movu [diffq+mmsize*0+%6], m4
+  movu [diffq+mmsize*1+%6], m1
 %endmacro
 
   mov             pred_str, pred_stridemp
@@ -118,8 +118,8 @@ cglobal subtract_block, 7, 7, 8, \
   punpcklbw             m3, m7
   psubw                 m0, m1
   psubw                 m2, m3
-  mova             [diffq], m0
-  mova [diffq+diff_strideq*2], m2
+  movu             [diffq], m0
+  movu [diffq+diff_strideq*2], m2
 %endmacro
 
 .case_8:

--- a/Source/Lib/Common/ASM_SSE4_1/filterintra_sse4.c
+++ b/Source/Lib/Common/ASM_SSE4_1/filterintra_sse4.c
@@ -16,7 +16,7 @@
 extern const int8_t eb_av1_filter_intra_taps[FILTER_INTRA_MODES][8][8];
 #define FILTER_INTRA_SCALE_BITS 4
 
-static INLINE __m128i xx_load_128(const void *a) { return _mm_load_si128((const __m128i *)a); }
+static INLINE __m128i xx_load_128(const void *a) { return _mm_loadu_si128((const __m128i *)a); }
 
 void eb_av1_filter_intra_predictor_sse4_1(uint8_t *dst, ptrdiff_t stride, TxSize tx_size,
                                           const uint8_t *above, const uint8_t *left, int mode) {

--- a/Source/Lib/Common/ASM_SSE4_1/highbd_inv_txfm_sse4.c
+++ b/Source/Lib/Common/ASM_SSE4_1/highbd_inv_txfm_sse4.c
@@ -73,10 +73,10 @@ typedef void (*Transform1dSse41)(__m128i *in, __m128i *out, int32_t bit, int32_t
                                  int32_t bd, int32_t out_shift);
 
 static INLINE void load_buffer_4x4(const int32_t *coeff, __m128i *in) {
-    in[0] = _mm_load_si128((const __m128i *)(coeff + 0));
-    in[1] = _mm_load_si128((const __m128i *)(coeff + 4));
-    in[2] = _mm_load_si128((const __m128i *)(coeff + 8));
-    in[3] = _mm_load_si128((const __m128i *)(coeff + 12));
+    in[0] = _mm_loadu_si128((const __m128i *)(coeff + 0));
+    in[1] = _mm_loadu_si128((const __m128i *)(coeff + 4));
+    in[2] = _mm_loadu_si128((const __m128i *)(coeff + 8));
+    in[3] = _mm_loadu_si128((const __m128i *)(coeff + 12));
 }
 
 static void addsub_sse4_1(const __m128i in0, const __m128i in1, __m128i *out0, __m128i *out1,
@@ -378,22 +378,22 @@ void eb_av1_inv_txfm2d_add_4x4_sse4_1(const int32_t *input, uint16_t *output_r, 
 
 // 8x8
 static void load_buffer_8x8(const int32_t *coeff, __m128i *in) {
-    in[0]  = _mm_load_si128((const __m128i *)(coeff + 0));
-    in[1]  = _mm_load_si128((const __m128i *)(coeff + 4));
-    in[2]  = _mm_load_si128((const __m128i *)(coeff + 8));
-    in[3]  = _mm_load_si128((const __m128i *)(coeff + 12));
-    in[4]  = _mm_load_si128((const __m128i *)(coeff + 16));
-    in[5]  = _mm_load_si128((const __m128i *)(coeff + 20));
-    in[6]  = _mm_load_si128((const __m128i *)(coeff + 24));
-    in[7]  = _mm_load_si128((const __m128i *)(coeff + 28));
-    in[8]  = _mm_load_si128((const __m128i *)(coeff + 32));
-    in[9]  = _mm_load_si128((const __m128i *)(coeff + 36));
-    in[10] = _mm_load_si128((const __m128i *)(coeff + 40));
-    in[11] = _mm_load_si128((const __m128i *)(coeff + 44));
-    in[12] = _mm_load_si128((const __m128i *)(coeff + 48));
-    in[13] = _mm_load_si128((const __m128i *)(coeff + 52));
-    in[14] = _mm_load_si128((const __m128i *)(coeff + 56));
-    in[15] = _mm_load_si128((const __m128i *)(coeff + 60));
+    in[0]  = _mm_loadu_si128((const __m128i *)(coeff + 0));
+    in[1]  = _mm_loadu_si128((const __m128i *)(coeff + 4));
+    in[2]  = _mm_loadu_si128((const __m128i *)(coeff + 8));
+    in[3]  = _mm_loadu_si128((const __m128i *)(coeff + 12));
+    in[4]  = _mm_loadu_si128((const __m128i *)(coeff + 16));
+    in[5]  = _mm_loadu_si128((const __m128i *)(coeff + 20));
+    in[6]  = _mm_loadu_si128((const __m128i *)(coeff + 24));
+    in[7]  = _mm_loadu_si128((const __m128i *)(coeff + 28));
+    in[8]  = _mm_loadu_si128((const __m128i *)(coeff + 32));
+    in[9]  = _mm_loadu_si128((const __m128i *)(coeff + 36));
+    in[10] = _mm_loadu_si128((const __m128i *)(coeff + 40));
+    in[11] = _mm_loadu_si128((const __m128i *)(coeff + 44));
+    in[12] = _mm_loadu_si128((const __m128i *)(coeff + 48));
+    in[13] = _mm_loadu_si128((const __m128i *)(coeff + 52));
+    in[14] = _mm_loadu_si128((const __m128i *)(coeff + 56));
+    in[15] = _mm_loadu_si128((const __m128i *)(coeff + 60));
 }
 
 static void idct8x8_sse4_1(__m128i *in, __m128i *out, int32_t bit) {
@@ -850,14 +850,14 @@ static void write_buffer_8x8(__m128i *in, uint16_t *output_r, int32_t stride_r, 
 
     round_shift_8x8(in, shift);
 
-    v0 = _mm_load_si128((__m128i const *)(output_r + 0 * stride_r));
-    v1 = _mm_load_si128((__m128i const *)(output_r + 1 * stride_r));
-    v2 = _mm_load_si128((__m128i const *)(output_r + 2 * stride_r));
-    v3 = _mm_load_si128((__m128i const *)(output_r + 3 * stride_r));
-    v4 = _mm_load_si128((__m128i const *)(output_r + 4 * stride_r));
-    v5 = _mm_load_si128((__m128i const *)(output_r + 5 * stride_r));
-    v6 = _mm_load_si128((__m128i const *)(output_r + 6 * stride_r));
-    v7 = _mm_load_si128((__m128i const *)(output_r + 7 * stride_r));
+    v0 = _mm_loadu_si128((__m128i const *)(output_r + 0 * stride_r));
+    v1 = _mm_loadu_si128((__m128i const *)(output_r + 1 * stride_r));
+    v2 = _mm_loadu_si128((__m128i const *)(output_r + 2 * stride_r));
+    v3 = _mm_loadu_si128((__m128i const *)(output_r + 3 * stride_r));
+    v4 = _mm_loadu_si128((__m128i const *)(output_r + 4 * stride_r));
+    v5 = _mm_loadu_si128((__m128i const *)(output_r + 5 * stride_r));
+    v6 = _mm_loadu_si128((__m128i const *)(output_r + 6 * stride_r));
+    v7 = _mm_loadu_si128((__m128i const *)(output_r + 7 * stride_r));
 
     if (flipud) {
         u0 = get_recon_8x8(v0, in[14], in[15], fliplr, bd);
@@ -879,14 +879,14 @@ static void write_buffer_8x8(__m128i *in, uint16_t *output_r, int32_t stride_r, 
         u7 = get_recon_8x8(v7, in[14], in[15], fliplr, bd);
     }
 
-    _mm_store_si128((__m128i *)(output_w + 0 * stride_w), u0);
-    _mm_store_si128((__m128i *)(output_w + 1 * stride_w), u1);
-    _mm_store_si128((__m128i *)(output_w + 2 * stride_w), u2);
-    _mm_store_si128((__m128i *)(output_w + 3 * stride_w), u3);
-    _mm_store_si128((__m128i *)(output_w + 4 * stride_w), u4);
-    _mm_store_si128((__m128i *)(output_w + 5 * stride_w), u5);
-    _mm_store_si128((__m128i *)(output_w + 6 * stride_w), u6);
-    _mm_store_si128((__m128i *)(output_w + 7 * stride_w), u7);
+    _mm_storeu_si128((__m128i *)(output_w + 0 * stride_w), u0);
+    _mm_storeu_si128((__m128i *)(output_w + 1 * stride_w), u1);
+    _mm_storeu_si128((__m128i *)(output_w + 2 * stride_w), u2);
+    _mm_storeu_si128((__m128i *)(output_w + 3 * stride_w), u3);
+    _mm_storeu_si128((__m128i *)(output_w + 4 * stride_w), u4);
+    _mm_storeu_si128((__m128i *)(output_w + 5 * stride_w), u5);
+    _mm_storeu_si128((__m128i *)(output_w + 6 * stride_w), u6);
+    _mm_storeu_si128((__m128i *)(output_w + 7 * stride_w), u7);
 }
 
 void eb_av1_inv_txfm2d_add_8x8_sse4_1(const int32_t *input, uint16_t *output_r, int32_t stride_r,
@@ -986,7 +986,7 @@ void eb_av1_inv_txfm2d_add_8x8_sse4_1(const int32_t *input, uint16_t *output_r, 
 // 16x16
 static void load_buffer_16x16(const int32_t *coeff, __m128i *in) {
     int32_t i;
-    for (i = 0; i < 64; ++i) in[i] = _mm_load_si128((const __m128i *)(coeff + (i << 2)));
+    for (i = 0; i < 64; ++i) in[i] = _mm_loadu_si128((const __m128i *)(coeff + (i << 2)));
 }
 
 static void assign_8x8_input_from_16x16(const __m128i *in, __m128i *in8x8, int32_t col) {

--- a/Source/Lib/Common/ASM_SSSE3/EbAvcStyleMcp_Intrinsic_SSSE3.c
+++ b/Source/Lib/Common/ASM_SSSE3/EbAvcStyleMcp_Intrinsic_SSSE3.c
@@ -287,8 +287,8 @@ void avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(
     pu_height >>= skip;
     frac_pos <<= 5;
     if_offset    = _mm_set1_epi16(0x0010);
-    if_coeff_1_0 = _mm_load_si128((__m128i *)(avc_style_luma_if_coeff8_ssse3 + frac_pos - 32));
-    if_coeff_3_2 = _mm_load_si128((__m128i *)(avc_style_luma_if_coeff8_ssse3 + frac_pos - 16));
+    if_coeff_1_0 = _mm_loadu_si128((__m128i *)(avc_style_luma_if_coeff8_ssse3 + frac_pos - 32));
+    if_coeff_3_2 = _mm_loadu_si128((__m128i *)(avc_style_luma_if_coeff8_ssse3 + frac_pos - 16));
 
     if (!(pu_width & 15)) { // 16x
         __m128i ref0, ref1, ref2, ref3, ref01_lo, ref01_hi, ref23_lo, ref23_hi, sum_lo, sum_hi;
@@ -415,8 +415,8 @@ void avc_style_luma_interpolation_filter_vertical_ssse3_intrin(EbByte ref_pic, u
     frac_pos <<= 5;
     ref_pic -= src_stride;
     if_offset    = _mm_set1_epi16(0x0010);
-    if_coeff_1_0 = _mm_load_si128((__m128i *)(avc_style_luma_if_coeff8_ssse3 + frac_pos - 32));
-    if_coeff_3_2 = _mm_load_si128((__m128i *)(avc_style_luma_if_coeff8_ssse3 + frac_pos - 16));
+    if_coeff_1_0 = _mm_loadu_si128((__m128i *)(avc_style_luma_if_coeff8_ssse3 + frac_pos - 32));
+    if_coeff_3_2 = _mm_loadu_si128((__m128i *)(avc_style_luma_if_coeff8_ssse3 + frac_pos - 16));
     dst_stride <<= skip;
     pu_height >>= skip;
     if (!(pu_width & 15)) { //16x

--- a/Source/Lib/Common/ASM_SSSE3/EbHighbdIntraPrediction_Intrinsic_SSSE3.c
+++ b/Source/Lib/Common/ASM_SSSE3/EbHighbdIntraPrediction_Intrinsic_SSSE3.c
@@ -32,7 +32,7 @@ static const uint16_t sm_weights_16[32] = {
 static INLINE void load_right_weights_4(const uint16_t *const above, __m128i *const r,
                                         __m128i *const weights) {
     *r       = _mm_set1_epi16((uint16_t)above[3]);
-    *weights = _mm_load_si128((const __m128i *)sm_weights_4);
+    *weights = _mm_loadu_si128((const __m128i *)sm_weights_4);
 }
 
 static INLINE void init_4(const uint16_t *const above, const uint16_t *const left, const int32_t h,
@@ -50,7 +50,7 @@ static INLINE void init_4(const uint16_t *const above, const uint16_t *const lef
 }
 
 static INLINE void load_left_8(const uint16_t *const left, const __m128i r, __m128i *const lr) {
-    const __m128i l = _mm_load_si128((const __m128i *)left);
+    const __m128i l = _mm_loadu_si128((const __m128i *)left);
     lr[0]           = _mm_unpacklo_epi16(l, r); // 0 1 2 3
     lr[1]           = _mm_unpackhi_epi16(l, r); // 4 5 6 7
 }
@@ -113,9 +113,9 @@ void eb_aom_highbd_smooth_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t stride,
 
     init_4(above, left, 8, &ab, &r, &weights_w, rep);
     load_left_8(left, r, lr);
-    weights_h = _mm_load_si128((const __m128i *)(sm_weights_8 + 0));
+    weights_h = _mm_loadu_si128((const __m128i *)(sm_weights_8 + 0));
     smooth_pred_4x4(weights_w, weights_h, rep, ab, lr[0], &dst, stride);
-    weights_h = _mm_load_si128((const __m128i *)(sm_weights_8 + 8));
+    weights_h = _mm_loadu_si128((const __m128i *)(sm_weights_8 + 8));
     smooth_pred_4x4(weights_w, weights_h, rep, ab, lr[1], &dst, stride);
 }
 
@@ -130,15 +130,15 @@ void eb_aom_highbd_smooth_predictor_4x16_ssse3(uint16_t *dst, ptrdiff_t stride,
     init_4(above, left, 16, &ab, &r, &weights_w, rep);
 
     load_left_8(left + 0, r, lr);
-    weights_h = _mm_load_si128((const __m128i *)(sm_weights_16 + 0));
+    weights_h = _mm_loadu_si128((const __m128i *)(sm_weights_16 + 0));
     smooth_pred_4x4(weights_w, weights_h, rep, ab, lr[0], &dst, stride);
-    weights_h = _mm_load_si128((const __m128i *)(sm_weights_16 + 8));
+    weights_h = _mm_loadu_si128((const __m128i *)(sm_weights_16 + 8));
     smooth_pred_4x4(weights_w, weights_h, rep, ab, lr[1], &dst, stride);
 
     load_left_8(left + 8, r, lr);
-    weights_h = _mm_load_si128((const __m128i *)(sm_weights_16 + 16));
+    weights_h = _mm_loadu_si128((const __m128i *)(sm_weights_16 + 16));
     smooth_pred_4x4(weights_w, weights_h, rep, ab, lr[0], &dst, stride);
-    weights_h = _mm_load_si128((const __m128i *)(sm_weights_16 + 24));
+    weights_h = _mm_loadu_si128((const __m128i *)(sm_weights_16 + 24));
     smooth_pred_4x4(weights_w, weights_h, rep, ab, lr[1], &dst, stride);
 }
 
@@ -278,7 +278,7 @@ void eb_aom_highbd_smooth_v_predictor_4x4_ssse3(uint16_t *dst, ptrdiff_t stride,
     (void)bd;
 
     smooth_v_init_4(above, left, 4, &ab, rep);
-    const __m128i weights = _mm_load_si128((const __m128i *)sm_weights_4);
+    const __m128i weights = _mm_loadu_si128((const __m128i *)sm_weights_4);
     smooth_v_pred_4x4(weights, rep, ab, &dst, stride);
 }
 
@@ -291,9 +291,9 @@ void eb_aom_highbd_smooth_v_predictor_4x8_ssse3(uint16_t *dst, ptrdiff_t stride,
     (void)bd;
 
     smooth_v_init_4(above, left, 8, &ab, rep);
-    weights = _mm_load_si128((const __m128i *)(sm_weights_8 + 0));
+    weights = _mm_loadu_si128((const __m128i *)(sm_weights_8 + 0));
     smooth_v_pred_4x4(weights, rep, ab, &dst, stride);
-    weights = _mm_load_si128((const __m128i *)(sm_weights_8 + 8));
+    weights = _mm_loadu_si128((const __m128i *)(sm_weights_8 + 8));
     smooth_v_pred_4x4(weights, rep, ab, &dst, stride);
 }
 
@@ -307,14 +307,14 @@ void eb_aom_highbd_smooth_v_predictor_4x16_ssse3(uint16_t *dst, ptrdiff_t stride
 
     smooth_v_init_4(above, left, 16, &ab, rep);
 
-    weights = _mm_load_si128((const __m128i *)(sm_weights_16 + 0));
+    weights = _mm_loadu_si128((const __m128i *)(sm_weights_16 + 0));
     smooth_v_pred_4x4(weights, rep, ab, &dst, stride);
-    weights = _mm_load_si128((const __m128i *)(sm_weights_16 + 8));
+    weights = _mm_loadu_si128((const __m128i *)(sm_weights_16 + 8));
     smooth_v_pred_4x4(weights, rep, ab, &dst, stride);
 
-    weights = _mm_load_si128((const __m128i *)(sm_weights_16 + 16));
+    weights = _mm_loadu_si128((const __m128i *)(sm_weights_16 + 16));
     smooth_v_pred_4x4(weights, rep, ab, &dst, stride);
-    weights = _mm_load_si128((const __m128i *)(sm_weights_16 + 24));
+    weights = _mm_loadu_si128((const __m128i *)(sm_weights_16 + 24));
     smooth_v_pred_4x4(weights, rep, ab, &dst, stride);
 }
 
@@ -385,7 +385,7 @@ void eb_aom_paeth_predictor_4x8_ssse3(uint8_t *dst, ptrdiff_t stride, const uint
 
 void eb_aom_paeth_predictor_4x16_ssse3(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                        const uint8_t *left) {
-    __m128i       l    = _mm_load_si128((const __m128i *)left);
+    __m128i       l    = _mm_loadu_si128((const __m128i *)left);
     const __m128i t    = _mm_cvtsi32_si128(((const uint32_t *)above)[0]);
     const __m128i zero = _mm_setzero_si128();
     const __m128i t16  = _mm_unpacklo_epi8(t, zero);
@@ -447,7 +447,7 @@ void eb_aom_paeth_predictor_8x8_ssse3(uint8_t *dst, ptrdiff_t stride, const uint
 
 void eb_aom_paeth_predictor_8x16_ssse3(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                        const uint8_t *left) {
-    __m128i       l    = _mm_load_si128((const __m128i *)left);
+    __m128i       l    = _mm_loadu_si128((const __m128i *)left);
     const __m128i t    = _mm_loadl_epi64((const __m128i *)above);
     const __m128i zero = _mm_setzero_si128();
     const __m128i t16  = _mm_unpacklo_epi8(t, zero);
@@ -475,7 +475,7 @@ void eb_aom_paeth_predictor_8x32_ssse3(uint8_t *dst, ptrdiff_t stride, const uin
     const __m128i one  = _mm_set1_epi16(1);
 
     for (int j = 0; j < 2; ++j) {
-        const __m128i l   = _mm_load_si128((const __m128i *)(left + j * 16));
+        const __m128i l   = _mm_loadu_si128((const __m128i *)(left + j * 16));
         __m128i       rep = _mm_set1_epi16(0x8000);
         for (int i = 0; i < 16; ++i) {
             const __m128i l16 = _mm_shuffle_epi8(l, rep);
@@ -499,7 +499,7 @@ static INLINE __m128i paeth_16x1_pred(const __m128i *left, const __m128i *top0, 
 void eb_aom_paeth_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                        const uint8_t *left) {
     __m128i       l    = _mm_cvtsi32_si128(((const uint32_t *)left)[0]);
-    const __m128i t    = _mm_load_si128((const __m128i *)above);
+    const __m128i t    = _mm_loadu_si128((const __m128i *)above);
     const __m128i zero = _mm_setzero_si128();
     const __m128i top0 = _mm_unpacklo_epi8(t, zero);
     const __m128i top1 = _mm_unpackhi_epi8(t, zero);
@@ -520,7 +520,7 @@ void eb_aom_paeth_predictor_16x4_ssse3(uint8_t *dst, ptrdiff_t stride, const uin
 void eb_aom_paeth_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                        const uint8_t *left) {
     __m128i       l    = _mm_loadl_epi64((const __m128i *)left);
-    const __m128i t    = _mm_load_si128((const __m128i *)above);
+    const __m128i t    = _mm_loadu_si128((const __m128i *)above);
     const __m128i zero = _mm_setzero_si128();
     const __m128i top0 = _mm_unpacklo_epi8(t, zero);
     const __m128i top1 = _mm_unpackhi_epi8(t, zero);
@@ -541,8 +541,8 @@ void eb_aom_paeth_predictor_16x8_ssse3(uint8_t *dst, ptrdiff_t stride, const uin
 
 void eb_aom_paeth_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                         const uint8_t *left) {
-    __m128i       l    = _mm_load_si128((const __m128i *)left);
-    const __m128i t    = _mm_load_si128((const __m128i *)above);
+    __m128i       l    = _mm_loadu_si128((const __m128i *)left);
+    const __m128i t    = _mm_loadu_si128((const __m128i *)above);
     const __m128i zero = _mm_setzero_si128();
     const __m128i top0 = _mm_unpacklo_epi8(t, zero);
     const __m128i top1 = _mm_unpackhi_epi8(t, zero);
@@ -563,8 +563,8 @@ void eb_aom_paeth_predictor_16x16_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
 
 void eb_aom_paeth_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                         const uint8_t *left) {
-    __m128i       l    = _mm_load_si128((const __m128i *)left);
-    const __m128i t    = _mm_load_si128((const __m128i *)above);
+    __m128i       l    = _mm_loadu_si128((const __m128i *)left);
+    const __m128i t    = _mm_loadu_si128((const __m128i *)above);
     const __m128i zero = _mm_setzero_si128();
     const __m128i top0 = _mm_unpacklo_epi8(t, zero);
     const __m128i top1 = _mm_unpackhi_epi8(t, zero);
@@ -583,7 +583,7 @@ void eb_aom_paeth_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
         rep = _mm_add_epi16(rep, one);
     }
 
-    l   = _mm_load_si128((const __m128i *)(left + 16));
+    l   = _mm_loadu_si128((const __m128i *)(left + 16));
     rep = _mm_set1_epi16(0x8000);
     for (i = 0; i < 16; ++i) {
         l16               = _mm_shuffle_epi8(l, rep);
@@ -597,7 +597,7 @@ void eb_aom_paeth_predictor_16x32_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
 
 void eb_aom_paeth_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                         const uint8_t *left) {
-    const __m128i t    = _mm_load_si128((const __m128i *)above);
+    const __m128i t    = _mm_loadu_si128((const __m128i *)above);
     const __m128i zero = _mm_setzero_si128();
     const __m128i top0 = _mm_unpacklo_epi8(t, zero);
     const __m128i top1 = _mm_unpackhi_epi8(t, zero);
@@ -605,7 +605,7 @@ void eb_aom_paeth_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
     const __m128i one  = _mm_set1_epi16(1);
 
     for (int j = 0; j < 4; ++j) {
-        const __m128i l   = _mm_load_si128((const __m128i *)(left + j * 16));
+        const __m128i l   = _mm_loadu_si128((const __m128i *)(left + j * 16));
         __m128i       rep = _mm_set1_epi16(0x8000);
         for (int i = 0; i < 16; ++i) {
             const __m128i l16 = _mm_shuffle_epi8(l, rep);
@@ -619,8 +619,8 @@ void eb_aom_paeth_predictor_16x64_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
 
 void eb_aom_paeth_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                        const uint8_t *left) {
-    const __m128i a    = _mm_load_si128((const __m128i *)above);
-    const __m128i b    = _mm_load_si128((const __m128i *)(above + 16));
+    const __m128i a    = _mm_loadu_si128((const __m128i *)above);
+    const __m128i b    = _mm_loadu_si128((const __m128i *)(above + 16));
     const __m128i zero = _mm_setzero_si128();
     const __m128i al   = _mm_unpacklo_epi8(a, zero);
     const __m128i ah   = _mm_unpackhi_epi8(a, zero);
@@ -647,8 +647,8 @@ void eb_aom_paeth_predictor_32x8_ssse3(uint8_t *dst, ptrdiff_t stride, const uin
 
 void eb_aom_paeth_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                         const uint8_t *left) {
-    const __m128i a    = _mm_load_si128((const __m128i *)above);
-    const __m128i b    = _mm_load_si128((const __m128i *)(above + 16));
+    const __m128i a    = _mm_loadu_si128((const __m128i *)above);
+    const __m128i b    = _mm_loadu_si128((const __m128i *)(above + 16));
     const __m128i zero = _mm_setzero_si128();
     const __m128i al   = _mm_unpacklo_epi8(a, zero);
     const __m128i ah   = _mm_unpackhi_epi8(a, zero);
@@ -658,7 +658,7 @@ void eb_aom_paeth_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
     const __m128i tl16 = _mm_set1_epi16((uint16_t)above[-1]);
     __m128i       rep  = _mm_set1_epi16(0x8000);
     const __m128i one  = _mm_set1_epi16(1);
-    __m128i       l    = _mm_load_si128((const __m128i *)left);
+    __m128i       l    = _mm_loadu_si128((const __m128i *)left);
     __m128i       l16;
 
     int i;
@@ -676,8 +676,8 @@ void eb_aom_paeth_predictor_32x16_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
 
 void eb_aom_paeth_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                         const uint8_t *left) {
-    const __m128i a    = _mm_load_si128((const __m128i *)above);
-    const __m128i b    = _mm_load_si128((const __m128i *)(above + 16));
+    const __m128i a    = _mm_loadu_si128((const __m128i *)above);
+    const __m128i b    = _mm_loadu_si128((const __m128i *)(above + 16));
     const __m128i zero = _mm_setzero_si128();
     const __m128i al   = _mm_unpacklo_epi8(a, zero);
     const __m128i ah   = _mm_unpackhi_epi8(a, zero);
@@ -687,7 +687,7 @@ void eb_aom_paeth_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
     const __m128i tl16 = _mm_set1_epi16((uint16_t)above[-1]);
     __m128i       rep  = _mm_set1_epi16(0x8000);
     const __m128i one  = _mm_set1_epi16(1);
-    __m128i       l    = _mm_load_si128((const __m128i *)left);
+    __m128i       l    = _mm_loadu_si128((const __m128i *)left);
     __m128i       l16;
 
     int i;
@@ -703,7 +703,7 @@ void eb_aom_paeth_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
     }
 
     rep = _mm_set1_epi16(0x8000);
-    l   = _mm_load_si128((const __m128i *)(left + 16));
+    l   = _mm_loadu_si128((const __m128i *)(left + 16));
     for (i = 0; i < 16; ++i) {
         l16                = _mm_shuffle_epi8(l, rep);
         const __m128i r32l = paeth_16x1_pred(&l16, &al, &ah, &tl16);
@@ -718,8 +718,8 @@ void eb_aom_paeth_predictor_32x32_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
 
 void eb_aom_paeth_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                         const uint8_t *left) {
-    const __m128i a    = _mm_load_si128((const __m128i *)above);
-    const __m128i b    = _mm_load_si128((const __m128i *)(above + 16));
+    const __m128i a    = _mm_loadu_si128((const __m128i *)above);
+    const __m128i b    = _mm_loadu_si128((const __m128i *)(above + 16));
     const __m128i zero = _mm_setzero_si128();
     const __m128i al   = _mm_unpacklo_epi8(a, zero);
     const __m128i ah   = _mm_unpackhi_epi8(a, zero);
@@ -732,7 +732,7 @@ void eb_aom_paeth_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
 
     int i, j;
     for (j = 0; j < 4; ++j) {
-        const __m128i l   = _mm_load_si128((const __m128i *)(left + j * 16));
+        const __m128i l   = _mm_loadu_si128((const __m128i *)(left + j * 16));
         __m128i       rep = _mm_set1_epi16(0x8000);
         for (i = 0; i < 16; ++i) {
             l16                = _mm_shuffle_epi8(l, rep);
@@ -749,10 +749,10 @@ void eb_aom_paeth_predictor_32x64_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
 
 void eb_aom_paeth_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                         const uint8_t *left) {
-    const __m128i a    = _mm_load_si128((const __m128i *)above);
-    const __m128i b    = _mm_load_si128((const __m128i *)(above + 16));
-    const __m128i c    = _mm_load_si128((const __m128i *)(above + 32));
-    const __m128i d    = _mm_load_si128((const __m128i *)(above + 48));
+    const __m128i a    = _mm_loadu_si128((const __m128i *)above);
+    const __m128i b    = _mm_loadu_si128((const __m128i *)(above + 16));
+    const __m128i c    = _mm_loadu_si128((const __m128i *)(above + 32));
+    const __m128i d    = _mm_loadu_si128((const __m128i *)(above + 48));
     const __m128i zero = _mm_setzero_si128();
     const __m128i al   = _mm_unpacklo_epi8(a, zero);
     const __m128i ah   = _mm_unpackhi_epi8(a, zero);
@@ -769,7 +769,7 @@ void eb_aom_paeth_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
 
     int i, j;
     for (j = 0; j < 2; ++j) {
-        const __m128i l   = _mm_load_si128((const __m128i *)(left + j * 16));
+        const __m128i l   = _mm_loadu_si128((const __m128i *)(left + j * 16));
         __m128i       rep = _mm_set1_epi16(0x8000);
         for (i = 0; i < 16; ++i) {
             l16              = _mm_shuffle_epi8(l, rep);
@@ -790,10 +790,10 @@ void eb_aom_paeth_predictor_64x32_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
 
 void eb_aom_paeth_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                         const uint8_t *left) {
-    const __m128i a    = _mm_load_si128((const __m128i *)above);
-    const __m128i b    = _mm_load_si128((const __m128i *)(above + 16));
-    const __m128i c    = _mm_load_si128((const __m128i *)(above + 32));
-    const __m128i d    = _mm_load_si128((const __m128i *)(above + 48));
+    const __m128i a    = _mm_loadu_si128((const __m128i *)above);
+    const __m128i b    = _mm_loadu_si128((const __m128i *)(above + 16));
+    const __m128i c    = _mm_loadu_si128((const __m128i *)(above + 32));
+    const __m128i d    = _mm_loadu_si128((const __m128i *)(above + 48));
     const __m128i zero = _mm_setzero_si128();
     const __m128i al   = _mm_unpacklo_epi8(a, zero);
     const __m128i ah   = _mm_unpackhi_epi8(a, zero);
@@ -810,7 +810,7 @@ void eb_aom_paeth_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
 
     int i, j;
     for (j = 0; j < 4; ++j) {
-        const __m128i l   = _mm_load_si128((const __m128i *)(left + j * 16));
+        const __m128i l   = _mm_loadu_si128((const __m128i *)(left + j * 16));
         __m128i       rep = _mm_set1_epi16(0x8000);
         for (i = 0; i < 16; ++i) {
             l16              = _mm_shuffle_epi8(l, rep);
@@ -831,10 +831,10 @@ void eb_aom_paeth_predictor_64x64_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
 
 void eb_aom_paeth_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t stride, const uint8_t *above,
                                         const uint8_t *left) {
-    const __m128i a    = _mm_load_si128((const __m128i *)above);
-    const __m128i b    = _mm_load_si128((const __m128i *)(above + 16));
-    const __m128i c    = _mm_load_si128((const __m128i *)(above + 32));
-    const __m128i d    = _mm_load_si128((const __m128i *)(above + 48));
+    const __m128i a    = _mm_loadu_si128((const __m128i *)above);
+    const __m128i b    = _mm_loadu_si128((const __m128i *)(above + 16));
+    const __m128i c    = _mm_loadu_si128((const __m128i *)(above + 32));
+    const __m128i d    = _mm_loadu_si128((const __m128i *)(above + 48));
     const __m128i zero = _mm_setzero_si128();
     const __m128i al   = _mm_unpacklo_epi8(a, zero);
     const __m128i ah   = _mm_unpackhi_epi8(a, zero);
@@ -850,7 +850,7 @@ void eb_aom_paeth_predictor_64x16_ssse3(uint8_t *dst, ptrdiff_t stride, const ui
     __m128i       l16;
 
     int           i;
-    const __m128i l   = _mm_load_si128((const __m128i *)left);
+    const __m128i l   = _mm_loadu_si128((const __m128i *)left);
     __m128i       rep = _mm_set1_epi16(0x8000);
     for (i = 0; i < 16; ++i) {
         l16              = _mm_shuffle_epi8(l, rep);

--- a/Source/Lib/Common/ASM_SSSE3/intrapred_ssse3.c
+++ b/Source/Lib/Common/ASM_SSSE3/intrapred_ssse3.c
@@ -190,12 +190,12 @@ static INLINE void load_pixel_w8(const uint8_t *above, const uint8_t *left,
     else if (height == 8)
         pixels[2] = _mm_loadl_epi64((const __m128i *)left);
     else if (height == 16)
-        pixels[2] = _mm_load_si128((const __m128i *)left);
+        pixels[2] = _mm_loadu_si128((const __m128i *)left);
     else {
-        pixels[2] = _mm_load_si128((const __m128i *)left);
+        pixels[2] = _mm_loadu_si128((const __m128i *)left);
         pixels[4] = pixels[0];
         pixels[5] = pixels[1];
-        pixels[6] = _mm_load_si128((const __m128i *)(left + 16));
+        pixels[6] = _mm_loadu_si128((const __m128i *)(left + 16));
         pixels[7] = pixels[3];
     }
 }
@@ -945,10 +945,10 @@ static INLINE void load_pixel_h_w8(const uint8_t *above, const uint8_t *left,
     else if (height == 8)
         pixels[0] = _mm_loadl_epi64((const __m128i *)left);
     else if (height == 16)
-        pixels[0] = _mm_load_si128((const __m128i *)left);
+        pixels[0] = _mm_loadu_si128((const __m128i *)left);
     else {
-        pixels[0] = _mm_load_si128((const __m128i *)left);
-        pixels[2] = _mm_load_si128((const __m128i *)(left + 16));
+        pixels[0] = _mm_loadu_si128((const __m128i *)left);
+        pixels[2] = _mm_loadu_si128((const __m128i *)(left + 16));
         pixels[3] = pixels[1];
     }
 }

--- a/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -4141,7 +4141,7 @@ void get_eight_horizontal_search_point_results_8x8_16x16_pu_avx2_intrin(
     s16_128  = _mm_adds_epu16(s16_128, s_128[3]);
 
     //sotore the 8 SADs(16x16 SADs)
-    _mm_store_si128((__m128i *)p_sad16x16, s16_128);
+    _mm_storeu_si128((__m128i *)p_sad16x16, s16_128);
 
     //find the best for 16x16
     const __m128i  minpos16 = _mm_minpos_epu16(s16_128);

--- a/Source/Lib/Encoder/ASM_AVX2/corner_match_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/corner_match_avx2.c
@@ -28,7 +28,7 @@ double av1_compute_cross_correlation_avx2(unsigned char *im1, int stride1, int x
                                           unsigned char *im2, int stride2, int x2, int y2) {
     int           i, stride1_i = 0, stride2_i = 0;
     __m256i       temp1, sum_vec, sumsq2_vec, cross_vec, v, v1_1, v2_1;
-    const __m128i mask = _mm_load_si128((__m128i *)byte_mask);
+    const __m128i mask = _mm_loadu_si128((__m128i *)byte_mask);
     const __m256i zero = _mm256_setzero_si256();
     __m128i       v1, v2;
 

--- a/Source/Lib/Encoder/ASM_AVX2/highbd_fwd_txfm_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/highbd_fwd_txfm_avx2.c
@@ -292,22 +292,22 @@ static INLINE void load_buffer_8x8(const int16_t *input, __m256i *in, int32_t st
     __m128i temp[8];
     if (!flipud) {
         temp[0] = _mm_loadu_si128((const __m128i *)(input + 0 * stride));
-        temp[1] = _mm_load_si128((const __m128i *)(input + 1 * stride));
-        temp[2] = _mm_load_si128((const __m128i *)(input + 2 * stride));
-        temp[3] = _mm_load_si128((const __m128i *)(input + 3 * stride));
-        temp[4] = _mm_load_si128((const __m128i *)(input + 4 * stride));
-        temp[5] = _mm_load_si128((const __m128i *)(input + 5 * stride));
-        temp[6] = _mm_load_si128((const __m128i *)(input + 6 * stride));
-        temp[7] = _mm_load_si128((const __m128i *)(input + 7 * stride));
+        temp[1] = _mm_loadu_si128((const __m128i *)(input + 1 * stride));
+        temp[2] = _mm_loadu_si128((const __m128i *)(input + 2 * stride));
+        temp[3] = _mm_loadu_si128((const __m128i *)(input + 3 * stride));
+        temp[4] = _mm_loadu_si128((const __m128i *)(input + 4 * stride));
+        temp[5] = _mm_loadu_si128((const __m128i *)(input + 5 * stride));
+        temp[6] = _mm_loadu_si128((const __m128i *)(input + 6 * stride));
+        temp[7] = _mm_loadu_si128((const __m128i *)(input + 7 * stride));
     } else {
-        temp[0] = _mm_load_si128((const __m128i *)(input + 7 * stride));
-        temp[1] = _mm_load_si128((const __m128i *)(input + 6 * stride));
-        temp[2] = _mm_load_si128((const __m128i *)(input + 5 * stride));
-        temp[3] = _mm_load_si128((const __m128i *)(input + 4 * stride));
-        temp[4] = _mm_load_si128((const __m128i *)(input + 3 * stride));
-        temp[5] = _mm_load_si128((const __m128i *)(input + 2 * stride));
-        temp[6] = _mm_load_si128((const __m128i *)(input + 1 * stride));
-        temp[7] = _mm_load_si128((const __m128i *)(input + 0 * stride));
+        temp[0] = _mm_loadu_si128((const __m128i *)(input + 7 * stride));
+        temp[1] = _mm_loadu_si128((const __m128i *)(input + 6 * stride));
+        temp[2] = _mm_loadu_si128((const __m128i *)(input + 5 * stride));
+        temp[3] = _mm_loadu_si128((const __m128i *)(input + 4 * stride));
+        temp[4] = _mm_loadu_si128((const __m128i *)(input + 3 * stride));
+        temp[5] = _mm_loadu_si128((const __m128i *)(input + 2 * stride));
+        temp[6] = _mm_loadu_si128((const __m128i *)(input + 1 * stride));
+        temp[7] = _mm_loadu_si128((const __m128i *)(input + 0 * stride));
     }
 
     if (fliplr) {
@@ -4009,9 +4009,9 @@ static INLINE void load_buffer_32x32_avx2(const int16_t *input, __m256i *output,
 
     for (i = 0; i < 32; ++i) {
         temp[0] = _mm_loadu_si128((const __m128i *)(input + 0 * 8));
-        temp[1] = _mm_load_si128((const __m128i *)(input + 1 * 8));
-        temp[2] = _mm_load_si128((const __m128i *)(input + 2 * 8));
-        temp[3] = _mm_load_si128((const __m128i *)(input + 3 * 8));
+        temp[1] = _mm_loadu_si128((const __m128i *)(input + 1 * 8));
+        temp[2] = _mm_loadu_si128((const __m128i *)(input + 2 * 8));
+        temp[3] = _mm_loadu_si128((const __m128i *)(input + 3 * 8));
 
         output[0] = _mm256_cvtepi16_epi32(temp[0]);
         output[1] = _mm256_cvtepi16_epi32(temp[1]);
@@ -4139,14 +4139,14 @@ static INLINE void load_buffer_32_avx2(const int16_t *input, __m256i *in, int32_
     __m128i temp[4];
     if (!flipud) {
         temp[0] = _mm_loadu_si128((const __m128i *)(input + 0 * stride));
-        temp[1] = _mm_load_si128((const __m128i *)(input + 1 * stride));
-        temp[2] = _mm_load_si128((const __m128i *)(input + 2 * stride));
-        temp[3] = _mm_load_si128((const __m128i *)(input + 3 * stride));
+        temp[1] = _mm_loadu_si128((const __m128i *)(input + 1 * stride));
+        temp[2] = _mm_loadu_si128((const __m128i *)(input + 2 * stride));
+        temp[3] = _mm_loadu_si128((const __m128i *)(input + 3 * stride));
     } else {
-        temp[0] = _mm_load_si128((const __m128i *)(input + 3 * stride));
-        temp[1] = _mm_load_si128((const __m128i *)(input + 2 * stride));
-        temp[2] = _mm_load_si128((const __m128i *)(input + 1 * stride));
-        temp[3] = _mm_load_si128((const __m128i *)(input + 0 * stride));
+        temp[0] = _mm_loadu_si128((const __m128i *)(input + 3 * stride));
+        temp[1] = _mm_loadu_si128((const __m128i *)(input + 2 * stride));
+        temp[2] = _mm_loadu_si128((const __m128i *)(input + 1 * stride));
+        temp[3] = _mm_loadu_si128((const __m128i *)(input + 0 * stride));
     }
 
     if (fliplr) {
@@ -4172,10 +4172,10 @@ static INLINE void load_buffer_16_avx2(const int16_t *input, __m256i *in, int32_
     __m128i temp[2];
     if (!flipud) {
         temp[0] = _mm_loadu_si128((const __m128i *)(input + 0 * stride));
-        temp[1] = _mm_load_si128((const __m128i *)(input + 1 * stride));
+        temp[1] = _mm_loadu_si128((const __m128i *)(input + 1 * stride));
     } else {
-        temp[0] = _mm_load_si128((const __m128i *)(input + 1 * stride));
-        temp[1] = _mm_load_si128((const __m128i *)(input + 0 * stride));
+        temp[0] = _mm_loadu_si128((const __m128i *)(input + 1 * stride));
+        temp[1] = _mm_loadu_si128((const __m128i *)(input + 0 * stride));
     }
 
     if (fliplr) {

--- a/Source/Lib/Encoder/ASM_AVX2/obmc_variance_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/obmc_variance_avx2.c
@@ -34,8 +34,8 @@ static INLINE void obmc_variance_w4(const uint8_t *pre, const int pre_stride, co
 
     do {
         const __m128i v_p_b = _mm_cvtsi32_si128(*(const uint32_t *)(pre + n));
-        const __m128i v_m_d = _mm_load_si128((const __m128i *)(mask + n));
-        const __m128i v_w_d = _mm_load_si128((const __m128i *)(wsrc + n));
+        const __m128i v_m_d = _mm_loadu_si128((const __m128i *)(mask + n));
+        const __m128i v_w_d = _mm_loadu_si128((const __m128i *)(wsrc + n));
 
         const __m128i v_p_d = _mm_cvtepu8_epi32(v_p_b);
 

--- a/Source/Lib/Encoder/ASM_AVX2/pickrst_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/pickrst_avx2.c
@@ -48,9 +48,9 @@ static INLINE uint8_t find_average_avx2(const uint8_t *src, int32_t h_start, int
 
         if (leftover >= 16) {
             mask_l = _mm_set1_epi8(-1);
-            mask_h = _mm_load_si128((__m128i *)(mask_8bit[leftover - 16]));
+            mask_h = _mm_loadu_si128((__m128i *)(mask_8bit[leftover - 16]));
         } else {
-            mask_l = _mm_load_si128((__m128i *)(mask_8bit[leftover]));
+            mask_l = _mm_loadu_si128((__m128i *)(mask_8bit[leftover]));
             mask_h = _mm_setzero_si128();
         }
         const __m256i mask = _mm256_inserti128_si256(_mm256_castsi128_si256(mask_l), mask_h, 1);

--- a/Source/Lib/Encoder/ASM_AVX2/pickrst_avx2.h
+++ b/Source/Lib/Encoder/ASM_AVX2/pickrst_avx2.h
@@ -423,7 +423,7 @@ static INLINE __m256i load_win7_avx2(const int16_t *const d, const int32_t width
                                          14,
                                          15);
     // 00s 01s 02s 03s 04s 05s 06s 07s
-    const __m128i ds = _mm_load_si128((__m128i *)d);
+    const __m128i ds = _mm_loadu_si128((__m128i *)d);
     // 00e 01e 02e 03e 04e 05e 06e 07e
     const __m128i de = _mm_loadu_si128((__m128i *)(d + width));
     const __m256i t0 = _mm256_inserti128_si256(_mm256_castsi128_si256(ds), de, 1);

--- a/Source/Lib/Encoder/ASM_AVX512/pickrst_avx512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/pickrst_avx512.c
@@ -57,9 +57,9 @@ static INLINE uint8_t find_average_avx512(const uint8_t *src, int32_t h_start, i
 
             if (leftover >= 48) {
                 maskL128 = _mm_set1_epi8(-1);
-                maskH128 = _mm_load_si128((__m128i *)(mask_8bit[leftover - 48]));
+                maskH128 = _mm_loadu_si128((__m128i *)(mask_8bit[leftover - 48]));
             } else {
-                maskL128 = _mm_load_si128((__m128i *)(mask_8bit[leftover - 32]));
+                maskL128 = _mm_loadu_si128((__m128i *)(mask_8bit[leftover - 32]));
                 maskH128 = _mm_setzero_si128();
             }
 
@@ -69,9 +69,9 @@ static INLINE uint8_t find_average_avx512(const uint8_t *src, int32_t h_start, i
 
             if (leftover >= 16) {
                 maskL128 = _mm_set1_epi8(-1);
-                maskH128 = _mm_load_si128((__m128i *)(mask_8bit[leftover - 16]));
+                maskH128 = _mm_loadu_si128((__m128i *)(mask_8bit[leftover - 16]));
             } else {
-                maskL128 = _mm_load_si128((__m128i *)(mask_8bit[leftover]));
+                maskL128 = _mm_loadu_si128((__m128i *)(mask_8bit[leftover]));
                 maskH128 = _mm_setzero_si128();
             }
 

--- a/Source/Lib/Encoder/ASM_SSE2/encodetxb_sse2.c
+++ b/Source/Lib/Encoder/ASM_SSE2/encodetxb_sse2.c
@@ -101,7 +101,7 @@ static INLINE void get_4_nz_map_contexts_2d(const uint8_t *levels, const int32_t
         load_levels_4x4x5_sse2(levels, stride, offsets, level);
         count = get_coeff_contexts_kernel_sse2(level);
         count = _mm_add_epi8(count, pos_to_offset);
-        _mm_store_si128((__m128i *)cc, count);
+        _mm_storeu_si128((__m128i *)cc, count);
         pos_to_offset = pos_to_offset_large;
         levels += 4 * stride;
         cc += 16;
@@ -143,7 +143,7 @@ static INLINE void get_8_coeff_contexts_2d(const uint8_t *levels, const int32_t 
         load_levels_8x2x5_sse2(levels, stride, offsets, level);
         count = get_coeff_contexts_kernel_sse2(level);
         count = _mm_add_epi8(count, pos_to_offset[0]);
-        _mm_store_si128((__m128i *)cc, count);
+        _mm_storeu_si128((__m128i *)cc, count);
         pos_to_offset[0] = pos_to_offset[1];
         pos_to_offset[1] = pos_to_offset[2];
         levels += 2 * stride;
@@ -205,7 +205,7 @@ static INLINE void get_16n_coeff_contexts_2d(const uint8_t *levels, const int32_
             load_levels_16x1x5_sse2(levels, stride, offsets, level);
             count = get_coeff_contexts_kernel_sse2(level);
             count = _mm_add_epi8(count, pos_to_offset[0]);
-            _mm_store_si128((__m128i *)cc, count);
+            _mm_storeu_si128((__m128i *)cc, count);
             levels += 16;
             cc += 16;
             w -= 16;
@@ -254,7 +254,7 @@ static INLINE void get_4_nz_map_contexts_hor(const uint8_t *levels, const int32_
         load_levels_4x4x5_sse2(levels, stride, offsets, level);
         count = get_coeff_contexts_kernel_sse2(level);
         count = _mm_add_epi8(count, pos_to_offset);
-        _mm_store_si128((__m128i *)coeff_contexts, count);
+        _mm_storeu_si128((__m128i *)coeff_contexts, count);
         levels += 4 * stride;
         coeff_contexts += 16;
         row -= 4;
@@ -292,7 +292,7 @@ static INLINE void get_4_nz_map_contexts_ver(const uint8_t *levels, const int32_
         load_levels_4x4x5_sse2(levels, stride, offsets, level);
         count = get_coeff_contexts_kernel_sse2(level);
         count = _mm_add_epi8(count, pos_to_offset);
-        _mm_store_si128((__m128i *)coeff_contexts, count);
+        _mm_storeu_si128((__m128i *)coeff_contexts, count);
         pos_to_offset = pos_to_offset_large;
         levels += 4 * stride;
         coeff_contexts += 16;
@@ -330,7 +330,7 @@ static INLINE void get_8_coeff_contexts_hor(const uint8_t *levels, const int32_t
         load_levels_8x2x5_sse2(levels, stride, offsets, level);
         count = get_coeff_contexts_kernel_sse2(level);
         count = _mm_add_epi8(count, pos_to_offset);
-        _mm_store_si128((__m128i *)coeff_contexts, count);
+        _mm_storeu_si128((__m128i *)coeff_contexts, count);
         levels += 2 * stride;
         coeff_contexts += 16;
         row -= 2;
@@ -368,7 +368,7 @@ static INLINE void get_8_coeff_contexts_ver(const uint8_t *levels, const int32_t
         load_levels_8x2x5_sse2(levels, stride, offsets, level);
         count = get_coeff_contexts_kernel_sse2(level);
         count = _mm_add_epi8(count, pos_to_offset);
-        _mm_store_si128((__m128i *)coeff_contexts, count);
+        _mm_storeu_si128((__m128i *)coeff_contexts, count);
         pos_to_offset = pos_to_offset_large;
         levels += 2 * stride;
         coeff_contexts += 16;
@@ -425,7 +425,7 @@ static INLINE void get_16n_coeff_contexts_hor(const uint8_t *levels, const int32
             load_levels_16x1x5_sse2(levels, stride, offsets, level);
             count = get_coeff_contexts_kernel_sse2(level);
             count = _mm_add_epi8(count, pos_to_offset);
-            _mm_store_si128((__m128i *)coeff_contexts, count);
+            _mm_storeu_si128((__m128i *)coeff_contexts, count);
             pos_to_offset = pos_to_offset_large;
             levels += 16;
             coeff_contexts += 16;
@@ -458,7 +458,7 @@ static INLINE void get_16n_coeff_contexts_ver(const uint8_t *levels, const int32
             load_levels_16x1x5_sse2(levels, stride, offsets, level);
             count = get_coeff_contexts_kernel_sse2(level);
             count = _mm_add_epi8(count, pos_to_offset[0]);
-            _mm_store_si128((__m128i *)coeff_contexts, count);
+            _mm_storeu_si128((__m128i *)coeff_contexts, count);
             levels += 16;
             coeff_contexts += 16;
             w -= 16;

--- a/Source/Lib/Encoder/ASM_SSE4_1/EbComputeSAD_Intrinsic_SSE4_1.c
+++ b/Source/Lib/Encoder/ASM_SSE4_1/EbComputeSAD_Intrinsic_SSE4_1.c
@@ -4480,7 +4480,7 @@ void get_eight_horizontal_search_point_results_8x8_16x16_pu_sse41_intrin(
         s1 = _mm_adds_epu16(sad[2], sad[3]);
         s3 = _mm_adds_epu16(s0, s1);
         //sotore the 8 SADs(16x16 SADs)
-        _mm_store_si128((__m128i *)p_sad16x16, s3);
+        _mm_storeu_si128((__m128i *)p_sad16x16, s3);
         //find the best for 16x16
         s3      = _mm_minpos_epu16(s3);
         tem_sum = _mm_extract_epi16(s3, 0);

--- a/Source/Lib/Encoder/ASM_SSE4_1/highbd_fwd_txfm_sse4.c
+++ b/Source/Lib/Encoder/ASM_SSE4_1/highbd_fwd_txfm_sse4.c
@@ -149,10 +149,10 @@ static void fdct4x4_sse4_1(__m128i *in, __m128i *out, int32_t bit, const int32_t
 }
 
 static INLINE void write_buffer_4x4(__m128i *res, int32_t *output) {
-    _mm_store_si128((__m128i *)(output + 0 * 4), res[0]);
-    _mm_store_si128((__m128i *)(output + 1 * 4), res[1]);
-    _mm_store_si128((__m128i *)(output + 2 * 4), res[2]);
-    _mm_store_si128((__m128i *)(output + 3 * 4), res[3]);
+    _mm_storeu_si128((__m128i *)(output + 0 * 4), res[0]);
+    _mm_storeu_si128((__m128i *)(output + 1 * 4), res[1]);
+    _mm_storeu_si128((__m128i *)(output + 2 * 4), res[2]);
+    _mm_storeu_si128((__m128i *)(output + 3 * 4), res[3]);
 }
 
 static void fadst4x4_sse4_1(__m128i *in, __m128i *out, int32_t bit, const int32_t num_col) {


### PR DESCRIPTION
example commandline

> SvtAv1EncApp -i 424x240.yuv -w 424  -h 240 -bit-depth 10 -fps 24.0  -n 2877 -rc 2 -tbr 200000  -irefresh-type 2 -enc-mode 5 -b test.ivf

you will get following crash stack.

> 
> [Switching to Thread 0x7ffdbe66b700 (LWP 170530)]
> 0x00007fffed3d0966 in dc_store_8xh (dst=0x7fff74424c68, stride=372, height=8, dc=0x7ffdbe6687f0) at /home/thomas/codec/SVT-AV1/Source/Lib/Common/ASM_SSE2/highbd_intrapred_sse2.c:410
> 410             _mm_store_si128((__m128i *)dst, dc_dup);
> (gdb) bt
> 0  0x00007fffed3d0966 in dc_store_8xh (dst=0x7fff74424c68, stride=372, height=8, dc=0x7ffdbe6687f0) at /home/thomas/codec/SVT-AV1/Source/Lib/Common/ASM_SSE2/highbd_intrapred_sse2.c:410
> 1  0x00007fffed3d0a63 in eb_aom_highbd_dc_left_predictor_8x8_sse2 (dst=0x7fff74424980, stride=372, above=0x7ffdbe668a10, left=0x7ffdbe668b50, bd=10) at /home/thomas/codec/SVT-AV1/Source/Lib/Common/ASM_SSE2/highbd_intrapred_sse2.c:479
> 2  0x00007fffed1d469a in build_intra_predictors_high (xd=0x7ffdbe668f88, topNeighArray=0x7ffdbe669ab2, leftNeighArray=0x7ffdbe6699a2, dst=0x7fff74424980, dst_stride=372, mode=DC_PRED, angle_delta=0, filter_intra_mode=FILTER_INTRA_MODES, tx_size=TX_8X8, disable_edge_filter=0, n_top_px=0, n_topright_px=0,
>     n_left_px=8, n_bottomleft_px=8, plane=1, bd=10) at /home/thomas/codec/SVT-AV1/Source/Lib/Common/Codec/EbIntraPrediction.c:3892
> 3  0x00007fffed1d3698 in eb_av1_predict_intra_block_16bit (tile=0x555559dca700, stage=1 '\001', blk_geom=0x7ffff7aa1fcc <blk_geom_mds+72732>, cm=0x5555562bcb00, wpx=8, hpx=8, tx_size=TX_8X8, mode=DC_PRED, angle_delta=0, use_palette=0, palette_info=0x7ffea492ffd0, filter_intra_mode=FILTER_INTRA_MODES,
>     topNeighArray=0x7ffdbe669ab2, leftNeighArray=0x7ffdbe6699a2, recon_buffer=0x55555d90cac0, col_off=0, row_off=0, plane=1, bsize=BLOCK_16X16, tu_org_x_pict=32, tu_org_y_pict=0, bl_org_x_pict=32, bl_org_y_pict=0, bl_org_x_mb=0, bl_org_y_mb=0)
>     at /home/thomas/codec/SVT-AV1/Source/Lib/Common/Codec/EbIntraPrediction.c:4391
> 4  0x00007fffed14b88b in perform_intra_coding_loop (picture_control_set_ptr=0x7fffdb5f2010, sb_ptr=0x555559dca680, tbAddr=0, cu_ptr=0x7ffea492fcd0, pu_ptr=0x7ffea492fd11, context_ptr=0x555724c0ce90, dZoffset=0) at /home/thomas/codec/SVT-AV1/Source/Lib/Common/Codec/EbCodingLoop.c:1820
> 5  0x00007fffed14e790 in av1_encode_pass (sequence_control_set_ptr=0x55555622fd80, picture_control_set_ptr=0x7fffdb5f2010, sb_ptr=0x555559dca680, tbAddr=0, sb_origin_x=0, sb_origin_y=0, context_ptr=0x555724c0ce90) at /home/thomas/codec/SVT-AV1/Source/Lib/Common/Codec/EbCodingLoop.c:2429
> 6  0x00007fffed168fc0 in enc_dec_kernel (input_ptr=0x555564e54360) at /home/thomas/codec/SVT-AV1/Source/Lib/Common/Codec/EbEncDecProcess.c:1917
> 7  0x00007fffece876db in start_thread (arg=0x7ffdbe66b700) at pthread_create.c:463
> 8  0x00007fffec81288f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95

The root cause is dc_store_8xh need a 16 bytes aligned dst. but we did not align uv line start address to 16 bytes.

this will fixes https://github.com/OpenVisualCloud/SVT-AV1/issues/760