### PR TITLE
fix deadlock in vbr mode:

### DIFF
--- a/Source/Lib/Common/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Common/Codec/EbPacketizationProcess.c
@@ -316,14 +316,15 @@ void* packetization_kernel(void *input_ptr)
         rateControlTasksPtr = (RateControlTasks*)rateControlTasksWrapperPtr->object_ptr;
         rateControlTasksPtr->picture_control_set_wrapper_ptr = picture_control_set_ptr->picture_parent_control_set_wrapper_ptr;
         rateControlTasksPtr->task_type = RC_PACKETIZATION_FEEDBACK_RESULT;
-        if (picture_control_set_ptr->parent_pcs_ptr->frame_end_cdf_update_mode &&
-            picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&
+
+        if (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&
             picture_control_set_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr) {
 
-            eb_av1_reset_cdf_symbol_counters(picture_control_set_ptr->entropy_coder_ptr->fc);
-            ((EbReferenceObject*)picture_control_set_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)->frame_context
-                = (*picture_control_set_ptr->entropy_coder_ptr->fc);
-
+            if (picture_control_set_ptr->parent_pcs_ptr->frame_end_cdf_update_mode) {
+                eb_av1_reset_cdf_symbol_counters(picture_control_set_ptr->entropy_coder_ptr->fc);
+                ((EbReferenceObject*)picture_control_set_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)->frame_context
+                    = (*picture_control_set_ptr->entropy_coder_ptr->fc);
+            }
             // Get Empty Results Object
             eb_get_empty_object(
                 context_ptr->picture_manager_input_fifo_ptr,
@@ -432,8 +433,7 @@ void* packetization_kernel(void *input_ptr)
 
         // Post Rate Control Taks
         eb_post_full_object(rateControlTasksWrapperPtr);
-        if (picture_control_set_ptr->parent_pcs_ptr->frame_end_cdf_update_mode &&
-            picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&
+        if (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&
             picture_control_set_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr)
             // Post the Full Results Object
             eb_post_full_object(picture_manager_results_wrapper_ptr);

--- a/Source/Lib/Common/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Common/Codec/EbRateControlProcess.c
@@ -4478,23 +4478,7 @@ void* rate_control_kernel(void *input_ptr)
 
             parentpicture_control_set_ptr = (PictureParentControlSet  *)rate_control_tasks_ptr->picture_control_set_wrapper_ptr->object_ptr;
             sequence_control_set_ptr = (SequenceControlSet *)parentpicture_control_set_ptr->sequence_control_set_wrapper_ptr->object_ptr;
-            if (sequence_control_set_ptr->static_config.rate_control_mode) {
-                ReferenceQueueEntry           *reference_entry_ptr;
-                uint32_t                          reference_queue_index;
-                EncodeContext             *encode_context_ptr = sequence_control_set_ptr->encode_context_ptr;
-                reference_queue_index = encode_context_ptr->reference_picture_queue_head_index;
-                // Find the Reference in the Reference Queue
-                do {
-                    reference_entry_ptr = encode_context_ptr->reference_picture_queue[reference_queue_index];
-                    if (reference_entry_ptr->picture_number == parentpicture_control_set_ptr->picture_number) {
-                        // Set the feedback arrived
-                        reference_entry_ptr->feedback_arrived = EB_TRUE;
-                    }
 
-                    // Increment the reference_queue_index Iterator
-                    reference_queue_index = (reference_queue_index == REFERENCE_QUEUE_MAX_DEPTH - 1) ? 0 : reference_queue_index + 1;
-                } while ((reference_queue_index != encode_context_ptr->reference_picture_queue_tail_index) && (reference_entry_ptr->picture_number != parentpicture_control_set_ptr->picture_number));
-            }
             // Frame level RC
             if (sequence_control_set_ptr->intra_period_length == -1 || sequence_control_set_ptr->static_config.rate_control_mode == 0) {
                 rate_control_param_ptr = context_ptr->rate_control_param_queue[0];

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -1899,7 +1899,7 @@ void SetDefaultConfigurationParameters(
 static uint32_t compute_default_look_ahead(
     EbSvtAv1EncConfiguration*   config){
     int32_t lad = 0;
-    if (config->rate_control_mode == 0)
+    if (config->rate_control_mode == 0 || config->intra_period_length < 0)
         lad = (2 << config->hierarchical_levels)+1;
     else
         lad = config->intra_period_length;
@@ -2476,9 +2476,8 @@ static EbErrorType VerifySettings(
         SVT_LOG("Error Instance %u: The rate control mode must be [0 - 2] \n", channelNumber + 1);
         return_error = EB_ErrorBadParameter;
     }
-    if ((config->rate_control_mode == 1 || config->rate_control_mode == 2) && config->look_ahead_distance != (uint32_t)config->intra_period_length) {
-        SVT_LOG("Error Instance %u: The rate control mode 1/2 LAD must be equal to intra_period \n", channelNumber + 1);
-
+    if ((config->rate_control_mode == 3|| config->rate_control_mode == 2) && config->look_ahead_distance != (uint32_t)config->intra_period_length && config->intra_period_length >= 0) {
+        SVT_LOG("Error Instance %u: The rate control mode 2/3 LAD must be equal to intra_period \n", channelNumber + 1);
         return_error = EB_ErrorBadParameter;
     }
     if (config->look_ahead_distance > MAX_LAD && config->look_ahead_distance != (uint32_t)~0) {

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -487,9 +487,11 @@ void* picture_manager_kernel(void *input_ptr)
             // Find the Reference in the Reference Queue
             do {
                 referenceEntryPtr = encode_context_ptr->reference_picture_queue[referenceQueueIndex];
-                if (referenceEntryPtr->picture_number == inputPictureDemuxPtr->picture_number)
+                if (referenceEntryPtr->picture_number == inputPictureDemuxPtr->picture_number) {
                     // Set the feedback arrived
+                    referenceEntryPtr->feedback_arrived = EB_TRUE;
                     referenceEntryPtr->frame_context_updated = EB_TRUE;
+                }
                 // Increment the referenceQueueIndex Iterator
                 referenceQueueIndex = (referenceQueueIndex == REFERENCE_QUEUE_MAX_DEPTH - 1) ? 0 : referenceQueueIndex + 1;
 


### PR DESCRIPTION
1、setting feedback_arrived flag should not be in RateControl process，but in PictureManager process before using it.
2、modifying the look_ahead_period, when both intra_period and look_ahead_period are equal to -1.