### PR TITLE
Protect the AVX512 code in encodetxb_avx512.c

### DIFF
--- a/Source/Lib/Common/ASM_AVX512/encodetxb_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/encodetxb_avx512.c
@@ -9,6 +9,7 @@
 #include "synonyms.h"
 #include "synonyms_avx2.h"
 
+#ifndef NON_AVX512_SUPPORT
 static INLINE __m256i txb_init_levels_32_avx512(const TranLow *const coeff) {
     const __m512i idx =
         _mm512_setr_epi32(0, 4, 8, 12, 1, 5, 9, 13, 0, 0, 0, 0, 0, 0, 0, 0);
@@ -145,3 +146,4 @@ void eb_av1_txb_init_levels_avx512(const TranLow *const coeff,
         xx_storeu_128(ls + 2 * 64, x_zeros);
     }
 }
+#endif  // !NON_AVX512_SUPPORT


### PR DESCRIPTION
Protect the AVX512 code in encodetxb_avx512.c by NON_AVX512_SUPPORT to avoid compiling it when AVX512 is disabled