### PR TITLE
Cleanup Phase I 

### DIFF
--- a/Source/Lib/Common/Codec/EbCdef.c
+++ b/Source/Lib/Common/Codec/EbCdef.c
@@ -1592,4 +1592,6 @@ void finish_cdef_search(
     free(mse[1]);
     free(sb_index);
     free(selected_strength);
+
 }
+

--- a/Source/Lib/Common/Codec/EbCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbCodingLoop.c
@@ -59,7 +59,7 @@ static EB_AV1_INTER_PREDICTION_FUNC_PTR   av1_inter_prediction_function_table[2]
 typedef void(*EB_AV1_ENCODE_LOOP_FUNC_PTR)(
     PictureControlSet    *picture_control_set_ptr,
     EncDecContext       *context_ptr,
-    LargestCodingUnit   *sb_ptr,
+    SuperBlock          *sb_ptr,
     uint32_t                 origin_x,
     uint32_t                 origin_y,
     uint32_t                 cb_qp,
@@ -412,7 +412,7 @@ void GeneratePuIntraLumaNeighborModes(
 void encode_pass_tx_search(
     PictureControlSet            *picture_control_set_ptr,
     EncDecContext                *context_ptr,
-    LargestCodingUnit            *sb_ptr,
+    SuperBlock                   *sb_ptr,
     uint32_t                       cb_qp,
     EbPictureBufferDesc          *coeffSamplesTB,
     EbPictureBufferDesc          *residual16bit,
@@ -446,7 +446,7 @@ void encode_pass_tx_search(
 static void Av1EncodeLoop(
     PictureControlSet    *picture_control_set_ptr,
     EncDecContext       *context_ptr,
-    LargestCodingUnit   *sb_ptr,
+    SuperBlock          *sb_ptr,
     uint32_t                 origin_x,   //pic based tx org x
     uint32_t                 origin_y,   //pic based tx org y
     uint32_t                 cb_qp,
@@ -822,7 +822,7 @@ static void Av1EncodeLoop(
 void encode_pass_tx_search_hbd(
     PictureControlSet            *picture_control_set_ptr,
     EncDecContext                *context_ptr,
-    LargestCodingUnit            *sb_ptr,
+    SuperBlock                   *sb_ptr,
     uint32_t                       cb_qp,
     EbPictureBufferDesc          *coeffSamplesTB,
     EbPictureBufferDesc          *residual16bit,
@@ -856,7 +856,7 @@ void encode_pass_tx_search_hbd(
 static void Av1EncodeLoop16bit(
     PictureControlSet    *picture_control_set_ptr,
     EncDecContext       *context_ptr,
-    LargestCodingUnit   *sb_ptr,
+    SuperBlock          *sb_ptr,
     uint32_t                 origin_x,
     uint32_t                 origin_y,
     uint32_t                 cb_qp,
@@ -1472,7 +1472,7 @@ void move_cu_data(
 
 void perform_intra_coding_loop(
     PictureControlSet  *picture_control_set_ptr,
-    LargestCodingUnit  *sb_ptr,
+    SuperBlock         *sb_ptr,
     uint32_t            tbAddr,
     CodingUnit         *cu_ptr,
     PredictionUnit     *pu_ptr,
@@ -2124,7 +2124,7 @@ void av1_copy_frame_mvs(PictureControlSet *picture_control_set_ptr, const Av1Com
 EB_EXTERN void av1_encode_pass(
     SequenceControlSet      *sequence_control_set_ptr,
     PictureControlSet       *picture_control_set_ptr,
-    LargestCodingUnit       *sb_ptr,
+    SuperBlock              *sb_ptr,
     uint32_t                 tbAddr,
     uint32_t                 sb_origin_x,
     uint32_t                 sb_origin_y,
@@ -3864,7 +3864,7 @@ EB_EXTERN void av1_encode_pass(
 EB_EXTERN void no_enc_dec_pass(
     SequenceControlSet    *sequence_control_set_ptr,
     PictureControlSet     *picture_control_set_ptr,
-    LargestCodingUnit     *sb_ptr,
+    SuperBlock            *sb_ptr,
     uint32_t                   tbAddr,
     uint32_t                   sb_origin_x,
     uint32_t                   sb_origin_y,

--- a/Source/Lib/Common/Codec/EbCodingLoop.h
+++ b/Source/Lib/Common/Codec/EbCodingLoop.h
@@ -23,7 +23,7 @@ extern "C" {
         SequenceControlSet                *sequence_control_set_ptr,
         PictureControlSet                 *picture_control_set_ptr,
         const MdcLcuData * const           mdcResultTbPtr,
-        LargestCodingUnit                 *sb_ptr,
+        SuperBlock                         *sb_ptr,
         uint32_t                             sb_origin_x,
         uint32_t                             sb_origin_y,
         uint32_t                             lcuAddr,
@@ -33,7 +33,7 @@ extern "C" {
         SequenceControlSet                *sequence_control_set_ptr,
         PictureControlSet                 *picture_control_set_ptr,
         const MdcLcuData * const           mdcResultTbPtr,
-        LargestCodingUnit                 *sb_ptr,
+        SuperBlock                        *sb_ptr,
         uint32_t                             sb_origin_x,
         uint32_t                             sb_origin_y,
         uint32_t                             lcuAddr,
@@ -53,7 +53,7 @@ extern "C" {
         SequenceControlSet                *sequence_control_set_ptr,
         PictureControlSet                 *picture_control_set_ptr,
         const MdcLcuData * const           mdcResultTbPtr,
-        LargestCodingUnit                 *sb_ptr,
+        SuperBlock                        *sb_ptr,
         uint16_t                             sb_origin_x,
         uint16_t                             sb_origin_y,
         uint32_t                             lcuAddr,
@@ -63,7 +63,7 @@ extern "C" {
     extern EbErrorType ModeDecisionRefinementLcu(
         SequenceControlSet                *sequence_control_set_ptr,
         PictureControlSet                 *picture_control_set_ptr,
-        LargestCodingUnit                 *sb_ptr,
+        SuperBlock                        *sb_ptr,
         uint32_t                               sb_origin_x,
         uint32_t                               sb_origin_y,
         ModeDecisionContext               *context_ptr);
@@ -76,7 +76,7 @@ extern "C" {
     extern void av1_encode_pass(
         SequenceControlSet    *sequence_control_set_ptr,
         PictureControlSet     *picture_control_set_ptr,
-        LargestCodingUnit     *sb_ptr,
+        SuperBlock            *sb_ptr,
         uint32_t                   tbAddr,
         uint32_t                   sb_origin_x,
         uint32_t                   sb_origin_y,
@@ -87,7 +87,7 @@ extern "C" {
     void no_enc_dec_pass(
         SequenceControlSet    *sequence_control_set_ptr,
         PictureControlSet     *picture_control_set_ptr,
-        LargestCodingUnit     *sb_ptr,
+        SuperBlock            *sb_ptr,
         uint32_t                   tbAddr,
         uint32_t                   sb_origin_x,
         uint32_t                   sb_origin_y,

--- a/Source/Lib/Common/Codec/EbCodingUnit.c
+++ b/Source/Lib/Common/Codec/EbCodingUnit.c
@@ -13,7 +13,7 @@
 
 void largest_coding_unit_dctor(EbPtr p)
 {
-    LargestCodingUnit* obj = (LargestCodingUnit*)p;
+    SuperBlock* obj = (SuperBlock*)p;
     EB_DELETE(obj->quantized_coeff);
     EB_FREE_ARRAY(obj->av1xd);
     EB_FREE_ARRAY(obj->final_cu_arr);
@@ -29,7 +29,7 @@ Tasks & Questions
     -I don't see a way around doing the copies in temp memory and then copying it in...
 */
 EbErrorType largest_coding_unit_ctor(
-    LargestCodingUnit             *larget_coding_unit_ptr,
+    SuperBlock                     *larget_coding_unit_ptr,
     uint8_t                        sb_size_pix,
     uint16_t                       sb_origin_x,
     uint16_t                       sb_origin_y,

--- a/Source/Lib/Common/Codec/EbCodingUnit.h
+++ b/Source/Lib/Common/Codec/EbCodingUnit.h
@@ -555,7 +555,7 @@ extern "C" {
         uint8_t  isolated_high_intensity_sb; // to be cleanedup
     } EdgeLcuResults;
 
-    typedef struct LargestCodingUnit
+    typedef struct SuperBlock
     {
         EbDctor                       dctor;
         struct PictureControlSet     *picture_control_set_ptr;
@@ -588,10 +588,10 @@ extern "C" {
         uint64_t                      depth_cost[NUMBER_OF_DEPTH];
 #endif
         TileInfo tile_info;
-    } LargestCodingUnit;
+    } SuperBlock;
 
     extern EbErrorType largest_coding_unit_ctor(
-        LargestCodingUnit             *larget_coding_unit_ptr,
+        SuperBlock                  *larget_coding_unit_ptr,
         uint8_t                        sb_sz,
         uint16_t                       sb_origin_x,
         uint16_t                       sb_origin_y,

--- a/Source/Lib/Common/Codec/EbDeblockingFilter.c
+++ b/Source/Lib/Common/Codec/EbDeblockingFilter.c
@@ -1362,7 +1362,7 @@ void eb_av1_loop_filter_frame(
     PictureControlSet *picture_control_set_ptr,
     int32_t plane_start, int32_t plane_end) {
     SequenceControlSet *scs_ptr = (SequenceControlSet*)picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_wrapper_ptr->object_ptr;
-    //LargestCodingUnit                     *sb_ptr;
+    //SuperBlock                     *sb_ptr;
     //uint16_t                                   sb_index;
     uint8_t                                   sb_size_Log2 = (uint8_t)Log2f(scs_ptr->sb_size_pix);
     uint32_t                                   x_lcu_index;

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -287,7 +287,7 @@ static void ResetEncDec(
  ******************************************************/
 static void EncDecConfigureLcu(
     EncDecContext         *context_ptr,
-    LargestCodingUnit     *sb_ptr,
+    SuperBlock            *sb_ptr,
     PictureControlSet     *picture_control_set_ptr,
     uint8_t                    sb_qp)
 {
@@ -1195,32 +1195,6 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
             CHROMA_MODE_2 :
             CHROMA_MODE_3 ;
 
-    // Set fast loop method
-    // 1 fast loop: SSD_SEARCH not supported
-    // Level                Settings
-    //  0                   Collapsed fast loop
-    //  1                   Decoupled fast loops ( intra/inter)
-    if (picture_control_set_ptr->parent_pcs_ptr->sc_content_detected)
-        if (picture_control_set_ptr->enc_mode <= ENC_M1)
-            context_ptr->decouple_intra_inter_fast_loop = 0;
-        else
-            context_ptr->decouple_intra_inter_fast_loop = 1;
-    else
-    context_ptr->decouple_intra_inter_fast_loop = 0;
-
-    // Set the search method when decoupled fast loop is used
-    // Hsan: FULL_SAD_SEARCH not supported
-    if (picture_control_set_ptr->parent_pcs_ptr->sc_content_detected)
-        if (picture_control_set_ptr->enc_mode <= ENC_M1)
-            context_ptr->decoupled_fast_loop_search_method = SSD_SEARCH;
-        else
-            context_ptr->decoupled_fast_loop_search_method = FULL_SAD_SEARCH;
-    else
-        if (picture_control_set_ptr->enc_mode <= ENC_M4)
-            context_ptr->decoupled_fast_loop_search_method = SSD_SEARCH;
-        else
-            context_ptr->decoupled_fast_loop_search_method = FULL_SAD_SEARCH;
-
     // Set the full loop escape level
     // Level                Settings
     // 0                    Off
@@ -1693,7 +1667,7 @@ void* enc_dec_kernel(void *input_ptr)
     EbObjectWrapper                       *encDecResultsWrapperPtr;
     EncDecResults                         *encDecResultsPtr;
     // SB Loop variables
-    LargestCodingUnit                       *sb_ptr;
+    SuperBlock                               *sb_ptr;
     uint16_t                                 sb_index;
     uint8_t                                  sb_sz;
     uint8_t                                  lcuSizeLog2;

--- a/Source/Lib/Common/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Common/Codec/EbEntropyCoding.c
@@ -6049,7 +6049,7 @@ EbErrorType write_modes_b(
     PictureControlSet     *picture_control_set_ptr,
     EntropyCodingContext  *context_ptr,
     EntropyCoder          *entropy_coder_ptr,
-    LargestCodingUnit     *tb_ptr,
+    SuperBlock            *tb_ptr,
     CodingUnit            *cu_ptr,
     EbPictureBufferDesc   *coeff_ptr)
 {
@@ -6717,7 +6717,7 @@ assert(bsize < BlockSizeS_ALL);
 **********************************************/
 EB_EXTERN EbErrorType write_sb(
     EntropyCodingContext  *context_ptr,
-    LargestCodingUnit     *tb_ptr,
+    SuperBlock            *tb_ptr,
     PictureControlSet     *picture_control_set_ptr,
     EntropyCoder          *entropy_coder_ptr,
     EbPictureBufferDesc   *coeff_ptr)

--- a/Source/Lib/Common/Codec/EbEntropyCoding.h
+++ b/Source/Lib/Common/Codec/EbEntropyCoding.h
@@ -50,7 +50,7 @@ extern "C" {
     struct EntropyCodingContext;
     extern EbErrorType write_sb(
         struct EntropyCodingContext   *context_ptr,
-        LargestCodingUnit     *tb_ptr,
+        SuperBlock            *tb_ptr,
         PictureControlSet     *picture_control_set_ptr,
         EntropyCoder          *entropy_coder_ptr,
         EbPictureBufferDesc   *coeff_ptr);

--- a/Source/Lib/Common/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Common/Codec/EbEntropyCodingProcess.c
@@ -402,7 +402,7 @@ void* entropy_coding_kernel(void *input_ptr)
     EntropyCodingResults                  *entropyCodingResultsPtr;
 
     // SB Loop variables
-    LargestCodingUnit                     *sb_ptr;
+    SuperBlock                                 *sb_ptr;
     uint16_t                                   sb_index;
     uint8_t                                    sb_sz;
     uint8_t                                    lcuSizeLog2;

--- a/Source/Lib/Common/Codec/EbFullLoop.c
+++ b/Source/Lib/Common/Codec/EbFullLoop.c
@@ -2275,7 +2275,7 @@ void product_full_loop_tx_search(
 void encode_pass_tx_search(
     PictureControlSet            *picture_control_set_ptr,
     EncDecContext                *context_ptr,
-    LargestCodingUnit            *sb_ptr,
+    SuperBlock                   *sb_ptr,
     uint32_t                      cb_qp,
     EbPictureBufferDesc          *coeffSamplesTB,
     EbPictureBufferDesc          *residual16bit,
@@ -2472,7 +2472,7 @@ void encode_pass_tx_search(
 void encode_pass_tx_search_hbd(
     PictureControlSet            *picture_control_set_ptr,
     EncDecContext                *context_ptr,
-    LargestCodingUnit            *sb_ptr,
+    SuperBlock                   *sb_ptr,
     uint32_t                       cb_qp,
     EbPictureBufferDesc          *coeffSamplesTB,
     EbPictureBufferDesc          *residual16bit,
@@ -2703,7 +2703,7 @@ void inv_transform_recon_wrapper(
  ************  Full loop ****************
 ****************************************/
 void full_loop_r(
-    LargestCodingUnit            *sb_ptr,
+    SuperBlock                   *sb_ptr,
     ModeDecisionCandidateBuffer  *candidate_buffer,
     ModeDecisionContext          *context_ptr,
     EbPictureBufferDesc          *input_picture_ptr,
@@ -2962,7 +2962,7 @@ void full_loop_r(
 // ************ CuFullDistortionFastTuMode ****************
 //****************************************/
 void cu_full_distortion_fast_tu_mode_r(
-    LargestCodingUnit            *sb_ptr,
+    SuperBlock                   *sb_ptr,
     ModeDecisionCandidateBuffer  *candidate_buffer,
     ModeDecisionContext          *context_ptr,
     ModeDecisionCandidate        *candidate_ptr,
@@ -3370,7 +3370,7 @@ void   compute_depth_costs(
 uint32_t d2_inter_depth_block_decision(
     ModeDecisionContext          *context_ptr,
     uint32_t                        blk_mds,
-    LargestCodingUnit            *tb_ptr,
+    SuperBlock                      *tb_ptr,
     uint32_t                          lcuAddr,
     uint32_t                          tbOriginX,
     uint32_t                          tbOriginY,

--- a/Source/Lib/Common/Codec/EbFullLoop.h
+++ b/Source/Lib/Common/Codec/EbFullLoop.h
@@ -28,7 +28,7 @@ extern "C" {
     };
 
     void full_loop_r(
-        LargestCodingUnit            *sb_ptr,
+        SuperBlock                   *sb_ptr,
         ModeDecisionCandidateBuffer  *candidate_buffer,
         ModeDecisionContext          *context_ptr,
         EbPictureBufferDesc          *input_picture_ptr,
@@ -40,7 +40,7 @@ extern "C" {
         uint32_t                          *cr_count_non_zero_coeffs);
 
     void cu_full_distortion_fast_tu_mode_r(
-        LargestCodingUnit            *sb_ptr,
+        SuperBlock                   *sb_ptr,
         ModeDecisionCandidateBuffer  *candidate_buffer,
         ModeDecisionContext            *context_ptr,
         ModeDecisionCandidate           *candidate_ptr,
@@ -102,7 +102,7 @@ extern "C" {
     extern uint32_t d2_inter_depth_block_decision(
         ModeDecisionContext          *context_ptr,
         uint32_t                        blk_mds,
-        LargestCodingUnit            *tb_ptr,
+        SuperBlock                   *tb_ptr,
         uint32_t                          lcuAddr,
         uint32_t                          tbOriginX,
         uint32_t                          tbOriginY,

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -957,7 +957,7 @@ void Unipred3x3CandidatesInjection(
     const SequenceControlSet  *sequence_control_set_ptr,
     PictureControlSet         *picture_control_set_ptr,
     ModeDecisionContext       *context_ptr,
-    LargestCodingUnit         *sb_ptr,
+    SuperBlock                *sb_ptr,
     uint32_t                   me_sb_addr,
     SsMeContext               *inloop_me_context,
     EbBool                     use_close_loop_me,
@@ -1283,7 +1283,7 @@ void Bipred3x3CandidatesInjection(
     const SequenceControlSet *sequence_control_set_ptr,
     PictureControlSet        *picture_control_set_ptr,
     ModeDecisionContext      *context_ptr,
-    LargestCodingUnit        *sb_ptr,
+    SuperBlock               *sb_ptr,
     uint32_t                  me_sb_addr,
     SsMeContext              *inloop_me_context,
     EbBool                    use_close_loop_me,
@@ -4143,7 +4143,7 @@ void  inject_inter_candidates(
     ModeDecisionContext          *context_ptr,
     SsMeContext                  *ss_mecontext,
     const SequenceControlSet     *sequence_control_set_ptr,
-    LargestCodingUnit            *sb_ptr,
+    SuperBlock                   *sb_ptr,
     uint32_t                       *candidateTotalCnt) {
 
     (void)sequence_control_set_ptr;
@@ -4861,7 +4861,7 @@ static INLINE TxType av1_get_tx_type(
 void  inject_intra_candidates_ois(
     PictureControlSet            *picture_control_set_ptr,
     ModeDecisionContext          *context_ptr,
-    LargestCodingUnit            *sb_ptr,
+    SuperBlock                   *sb_ptr,
     uint32_t                       *candidate_total_cnt){
     uint8_t                     intra_candidate_counter;
     uint8_t                     intra_mode;
@@ -5369,7 +5369,7 @@ void  inject_intra_candidates(
     PictureControlSet            *picture_control_set_ptr,
     ModeDecisionContext          *context_ptr,
     const SequenceControlSet     *sequence_control_set_ptr,
-    LargestCodingUnit            *sb_ptr,
+    SuperBlock                   *sb_ptr,
     uint32_t                       *candidateTotalCnt){
     (void)sequence_control_set_ptr;
     (void)sb_ptr;
@@ -5803,7 +5803,7 @@ void  inject_palette_candidates(
 }
 #endif
 EbErrorType generate_md_stage_0_cand(
-    LargestCodingUnit   *sb_ptr,
+    SuperBlock          *sb_ptr,
     ModeDecisionContext *context_ptr,
     SsMeContext         *ss_mecontext,
     uint32_t            *candidate_total_count_ptr,
@@ -5882,9 +5882,6 @@ EbErrorType generate_md_stage_0_cand(
         assert(context_ptr->fast_candidate_array[i].palette_info.pmi.palette_size[1] == 0);
     }
 #endif
-
-    // Track the total number of fast intra candidates
-    context_ptr->fast_candidate_intra_count = canTotalCnt;
 
     if (slice_type != I_SLICE) {
         if (inject_inter_candidate)

--- a/Source/Lib/Common/Codec/EbModeDecision.h
+++ b/Source/Lib/Common/Codec/EbModeDecision.h
@@ -172,7 +172,7 @@ extern "C" {
         uint32_t                                top_neighbor_mode);
 
     typedef EbErrorType(*EB_FULL_COST_FUNC)(
-        LargestCodingUnit                    *sb_ptr,
+        SuperBlock                          *sb_ptr,
         CodingUnit                           *cu_ptr,
         uint32_t                                cu_size,
         uint32_t                                cu_size_log2,

--- a/Source/Lib/Common/Codec/EbModeDecisionConfiguration.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfiguration.c
@@ -1218,7 +1218,7 @@ EB_EXTERN EbErrorType open_loop_partitioning_sb(
 #endif
     uint64_t tot_me_sb;
 #if MDC_ADAPTIVE_LEVEL
-    LargestCodingUnit  *sb_ptr = picture_control_set_ptr->sb_ptr_array[sb_index];
+    SuperBlock  *sb_ptr = picture_control_set_ptr->sb_ptr_array[sb_index];
     uint64_t depth_cost[NUMBER_OF_DEPTH] = { 0 };
     uint8_t depth_table[NUMBER_OF_DEPTH] = { 0, 1, 2 , 3 ,4 ,5 };
 #endif
@@ -1764,7 +1764,7 @@ void PredictionPartitionLoop(
 EbErrorType early_mode_decision_lcu(
     SequenceControlSet                   *sequence_control_set_ptr,
     PictureControlSet                    *picture_control_set_ptr,
-    LargestCodingUnit                    *sb_ptr,
+    SuperBlock                           *sb_ptr,
     uint32_t                                  sb_index,
     ModeDecisionConfigurationContext     *context_ptr){
     EbErrorType    return_error = EB_ErrorNone;

--- a/Source/Lib/Common/Codec/EbModeDecisionConfiguration.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfiguration.h
@@ -20,7 +20,7 @@ extern "C" {
 extern EbErrorType early_mode_decision_lcu(
     SequenceControlSet                   *sequence_control_set_ptr,
     PictureControlSet                    *picture_control_set_ptr,
-    LargestCodingUnit                    *sb_ptr,
+    SuperBlock                           *sb_ptr,
     uint32_t                                  sb_index,
     ModeDecisionConfigurationContext     *context_ptr);
 
@@ -31,7 +31,7 @@ extern EbErrorType early_mode_decision_lcu(
 extern EbErrorType derive_delta_qp_for_each_leaf_lcu(
     SequenceControlSet                   *sequence_control_set_ptr,
     PictureControlSet                    *picture_control_set_ptr,
-    LargestCodingUnit                    *sb_ptr,
+    SuperBlock                           *sb_ptr,
     uint32_t                                  sb_index,
     int32_t                                  intra_min_distance,
     int32_t                                  intra_max_distance,

--- a/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
@@ -765,7 +765,7 @@ void PerformEarlyLcuPartitionning(
     ModeDecisionConfigurationContext     *context_ptr,
     SequenceControlSet                   *sequence_control_set_ptr,
     PictureControlSet                    *picture_control_set_ptr) {
-    LargestCodingUnit            *sb_ptr;
+    SuperBlock                           *sb_ptr;
     uint32_t                         sb_index;
     picture_control_set_ptr->parent_pcs_ptr->average_qp = (uint8_t)picture_control_set_ptr->parent_pcs_ptr->picture_qp;
 
@@ -785,7 +785,7 @@ void PerformEarlyLcuPartitionningLcu(
     SequenceControlSet                   *sequence_control_set_ptr,
     PictureControlSet                    *picture_control_set_ptr,
     uint32_t                                    sb_index) {
-    LargestCodingUnit            *sb_ptr;
+    SuperBlock                           *sb_ptr;
 
     // SB Loop : Partitionnig Decision
     sb_ptr = picture_control_set_ptr->sb_ptr_array[sb_index];
@@ -1206,7 +1206,7 @@ uint64_t  mdc_tab[9][2][3] = {
 // Update MDC refinement
 uint8_t update_mdc_level(
     PictureControlSet  *picture_control_set_ptr,
-    LargestCodingUnit  *sb_ptr,
+    SuperBlock         *sb_ptr,
     uint32_t sb_size,
     const BlockGeom * blk_geom,
     uint8_t mdc_depth_level) {
@@ -1360,7 +1360,7 @@ void init_considered_block(
     uint32_t  blk_index = 0;
 
 #if MDC_ADAPTIVE_LEVEL
-    LargestCodingUnit  *sb_ptr = picture_control_set_ptr->sb_ptr_array[sb_index];
+    SuperBlock  *sb_ptr = picture_control_set_ptr->sb_ptr_array[sb_index];
 #else
     uint32_t  parent_depth_idx_mds, sparent_depth_idx_mds, ssparent_depth_idx_mds, child_block_idx_1, child_block_idx_2, child_block_idx_3, child_block_idx_4;
 #endif
@@ -2004,7 +2004,7 @@ void open_loop_partitioning_pass(
         blk_index++;
     }
     if (picture_control_set_ptr->slice_type != I_SLICE) {
-        LargestCodingUnit            *sb_ptr;
+        SuperBlock            *sb_ptr;
         // SB Loop : Partitionnig Decision
         sb_ptr = picture_control_set_ptr->sb_ptr_array[sb_index];
         sb_ptr->qp = (uint8_t)picture_control_set_ptr->parent_pcs_ptr->picture_qp;
@@ -2262,7 +2262,7 @@ void derive_search_method(
 void set_sb_budget(
     SequenceControlSet               *sequence_control_set_ptr,
     PictureControlSet                *picture_control_set_ptr,
-    LargestCodingUnit                *sb_ptr,
+    SuperBlock                       *sb_ptr,
     ModeDecisionConfigurationContext *context_ptr)
 {
     const uint32_t sb_index = sb_ptr->index;
@@ -2338,7 +2338,7 @@ void  derive_optimal_budget_per_sb(
         context_ptr->predicted_cost = 0;
 
         for (sb_index = 0; sb_index < picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->sb_tot_cnt; sb_index++) {
-            LargestCodingUnit* sb_ptr = picture_control_set_ptr->sb_ptr_array[sb_index];
+            SuperBlock* sb_ptr = picture_control_set_ptr->sb_ptr_array[sb_index];
 
             set_sb_budget(
                 sequence_control_set_ptr,
@@ -3152,7 +3152,7 @@ void* mode_decision_configuration_kernel(void *input_ptr)
                 for (uint32_t y_lcu_index = 0; y_lcu_index < picture_height_in_sb; ++y_lcu_index) {
                     for (uint32_t x_lcu_index = 0; x_lcu_index < picture_width_in_sb; ++x_lcu_index) {
                         uint32_t sb_index = (uint16_t)(y_lcu_index * picture_width_in_sb + x_lcu_index);
-                        LargestCodingUnit  *sb_ptr = picture_control_set_ptr->sb_ptr_array[sb_index];
+                        SuperBlock  *sb_ptr = picture_control_set_ptr->sb_ptr_array[sb_index];
 #if MDC_ADAPTIVE_LEVEL
                         uint32_t is_complete_sb = sequence_control_set_ptr->sb_geom[sb_index].is_complete_sb;
 #endif

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -147,7 +147,7 @@ extern "C" {
         uint32_t                        full_chroma_lambda_sao;
 
         //  Context Variables---------------------------------
-        LargestCodingUnit            *sb_ptr;
+        SuperBlock                   *sb_ptr;
         TransformUnit                *txb_ptr;
         CodingUnit                   *cu_ptr;
         const BlockGeom                *blk_geom;
@@ -215,7 +215,6 @@ extern "C" {
         int16_t                         injected_mv_x_bipred_l1_array[MODE_DECISION_CANDIDATE_MAX_COUNT]; // used to do not inject existing MV
         int16_t                         injected_mv_y_bipred_l1_array[MODE_DECISION_CANDIDATE_MAX_COUNT]; // used to do not inject existing MV
         uint8_t                         injected_mv_count_bipred;
-        uint32_t                        fast_candidate_intra_count;
         uint32_t                        fast_candidate_inter_count;
         uint32_t                        me_block_offset;
         uint8_t                         tx_depth;
@@ -448,7 +447,7 @@ extern "C" {
     extern void cfl_rd_pick_alpha(
         PictureControlSet             *picture_control_set_ptr,
         ModeDecisionCandidateBuffer   *candidate_buffer,
-        LargestCodingUnit             *sb_ptr,
+        SuperBlock                    *sb_ptr,
         ModeDecisionContext           *context_ptr,
         EbPictureBufferDesc           *input_picture_ptr,
         uint32_t                         inputCbOriginIndex,

--- a/Source/Lib/Common/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Common/Codec/EbPacketizationProcess.c
@@ -95,7 +95,7 @@ void update_rc_rate_tables(
     uint32_t  intra_sad_interval_index;
     uint32_t  sad_interval_index;
 
-    LargestCodingUnit   *sb_ptr;
+    SuperBlock   *sb_ptr;
     SbParams *sb_params_ptr;
 
     uint32_t  sb_index;

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -13668,7 +13668,7 @@ extern "C" {
      * Picture Control Set
      **************************************/
     struct CodedTreeblock_s;
-    struct LargestCodingUnit;
+    struct SuperBlock;
 #define MAX_MESH_STEP 4
 
     typedef struct MeshPattern
@@ -13777,7 +13777,7 @@ extern "C" {
         // SB Array
         uint8_t                               sb_max_depth;
         uint16_t                              sb_total_count;
-        LargestCodingUnit                 **sb_ptr_array;
+        SuperBlock                            **sb_ptr_array;
         // DLF
         uint8_t                              *qp_array;
         uint16_t                              qp_array_stride;

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -46,7 +46,7 @@
 #define EIGHT_PEL_REF_WINDOW          3
 #endif
 EbErrorType generate_md_stage_0_cand(
-    LargestCodingUnit   *sb_ptr,
+    SuperBlock          *sb_ptr,
     ModeDecisionContext *context_ptr,
     SsMeContext         *ss_mecontext,
     uint32_t            *fast_candidate_total_count,
@@ -3205,7 +3205,7 @@ void predictive_me_search(
 void AV1CostCalcCfl(
     PictureControlSet                *picture_control_set_ptr,
     ModeDecisionCandidateBuffer      *candidate_buffer,
-    LargestCodingUnit                *sb_ptr,
+    SuperBlock                       *sb_ptr,
     ModeDecisionContext              *context_ptr,
     uint32_t                            component_mask,
     EbPictureBufferDesc              *input_picture_ptr,
@@ -3409,7 +3409,7 @@ void AV1CostCalcCfl(
 void cfl_rd_pick_alpha(
     PictureControlSet     *picture_control_set_ptr,
     ModeDecisionCandidateBuffer  *candidate_buffer,
-    LargestCodingUnit     *sb_ptr,
+    SuperBlock            *sb_ptr,
     ModeDecisionContext   *context_ptr,
     EbPictureBufferDesc   *input_picture_ptr,
     uint32_t                   inputCbOriginIndex,
@@ -3572,7 +3572,7 @@ void cfl_rd_pick_alpha(
 static void CflPrediction(
     PictureControlSet     *picture_control_set_ptr,
     ModeDecisionCandidateBuffer  *candidate_buffer,
-    LargestCodingUnit     *sb_ptr,
+    SuperBlock            *sb_ptr,
     ModeDecisionContext   *context_ptr,
     EbPictureBufferDesc   *input_picture_ptr,
     uint32_t                   inputCbOriginIndex,
@@ -5826,7 +5826,7 @@ void perform_intra_tx_partitioning(
 
 void full_loop_core(
     PictureControlSet           *picture_control_set_ptr,
-    LargestCodingUnit           *sb_ptr,
+    SuperBlock                  *sb_ptr,
     CodingUnit                  *cu_ptr,
     ModeDecisionContext         *context_ptr,
     ModeDecisionCandidateBuffer *candidate_buffer,
@@ -6145,7 +6145,7 @@ void md_stage_1(
 void md_stage_2(
 #endif
     PictureControlSet     *picture_control_set_ptr,
-    LargestCodingUnit     *sb_ptr,
+    SuperBlock            *sb_ptr,
     CodingUnit            *cu_ptr,
     ModeDecisionContext   *context_ptr,
     EbPictureBufferDesc   *input_picture_ptr,
@@ -6217,7 +6217,7 @@ void md_stage_2(
 void md_stage_3(
 #endif
     PictureControlSet     *picture_control_set_ptr,
-    LargestCodingUnit     *sb_ptr,
+    SuperBlock            *sb_ptr,
     CodingUnit            *cu_ptr,
     ModeDecisionContext   *context_ptr,
     EbPictureBufferDesc   *input_picture_ptr,
@@ -7015,7 +7015,7 @@ void  adjust_nsq_rank(
     PictureControlSet            *picture_control_set_ptr,
     ModeDecisionContext          *context_ptr,
     const SequenceControlSet     *sequence_control_set_ptr,
-    LargestCodingUnit            *sb_ptr,
+    SuperBlock                   *sb_ptr,
     NeighborArrayUnit            *leaf_partition_neighbor_array) {
     const uint32_t                lcu_addr = sb_ptr->index;
     uint8_t ol_part1 = context_ptr->best_nsq_sahpe1;
@@ -7253,7 +7253,7 @@ void  order_nsq_table(
     PictureControlSet            *picture_control_set_ptr,
     ModeDecisionContext          *context_ptr,
     const SequenceControlSet     *sequence_control_set_ptr,
-    LargestCodingUnit            *sb_ptr,
+    SuperBlock                   *sb_ptr,
     NeighborArrayUnit            *leaf_partition_neighbor_array) {
     FrameHeader *frm_hdr = &picture_control_set_ptr->parent_pcs_ptr->frm_hdr;
     const uint32_t             lcuAddr = sb_ptr->index;
@@ -8464,7 +8464,7 @@ EB_EXTERN EbErrorType mode_decision_sb(
     SequenceControlSet                *sequence_control_set_ptr,
     PictureControlSet                 *picture_control_set_ptr,
     const MdcLcuData * const           mdcResultTbPtr,
-    LargestCodingUnit                 *sb_ptr,
+    SuperBlock                        *sb_ptr,
     uint16_t                             sb_origin_x,
     uint16_t                             sb_origin_y,
     uint32_t                             lcuAddr,

--- a/Source/Lib/Common/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Common/Codec/EbRateControlProcess.c
@@ -3916,7 +3916,7 @@ static void sb_qp_derivation_two_pass(
     PictureControlSet         *picture_control_set_ptr) {
 
     SequenceControlSet        *sequence_control_set_ptr = picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr;
-    LargestCodingUnit         *sb_ptr;
+    SuperBlock                *sb_ptr;
     uint32_t                  sb_addr;
 
     picture_control_set_ptr->parent_pcs_ptr->average_qp = 0;
@@ -4044,7 +4044,7 @@ static void sb_qp_derivation(
     PictureControlSet         *picture_control_set_ptr) {
 
     SequenceControlSet        *sequence_control_set_ptr = picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr;
-    LargestCodingUnit         *sb_ptr;
+    SuperBlock                *sb_ptr;
     uint32_t                  sb_addr;
     RATE_CONTROL               rc;
     picture_control_set_ptr->parent_pcs_ptr->average_qp = 0;
@@ -4447,7 +4447,7 @@ void* rate_control_kernel(void *input_ptr)
                     sb_qp_derivation(picture_control_set_ptr);
             else {
                 picture_control_set_ptr->parent_pcs_ptr->frm_hdr.delta_q_params.delta_q_present = 0;
-                LargestCodingUnit  *sb_ptr;
+                SuperBlock      *sb_ptr;
                 picture_control_set_ptr->parent_pcs_ptr->average_qp = 0;
                 for (int sb_addr = 0; sb_addr < sequence_control_set_ptr->sb_tot_cnt; ++sb_addr) {
                     sb_ptr = picture_control_set_ptr->sb_ptr_array[sb_addr];

--- a/Source/Lib/Common/Codec/EbRateDistortionCost.h
+++ b/Source/Lib/Common/Codec/EbRateDistortionCost.h
@@ -108,7 +108,7 @@ extern "C" {
         uint64_t                               lambda,
         PictureControlSet                   *picture_control_set_ptr);
     extern EbErrorType  merge_skip_full_cost(
-        LargestCodingUnit           *sb_ptr,
+        SuperBlock                  *sb_ptr,
         CodingUnit                  *cu_ptr,
         uint32_t                       cu_size,
         uint32_t                       cu_size_log2,

--- a/Source/Lib/Common/Codec/EbSegmentation.c
+++ b/Source/Lib/Common/Codec/EbSegmentation.c
@@ -120,7 +120,7 @@ uint16_t get_variance_for_cu(const BlockGeom *blk_geom,
 void apply_segmentation_based_quantization(
         const BlockGeom *blk_geom,
         PictureControlSet *picture_control_set_ptr,
-        LargestCodingUnit *sb_ptr,
+    SuperBlock            *sb_ptr,
         CodingUnit *cu_ptr) {
     uint16_t *variance_ptr = picture_control_set_ptr->parent_pcs_ptr->variance[sb_ptr->index];
     SegmentationParams *segmentation_params = &picture_control_set_ptr->parent_pcs_ptr->frm_hdr.segmentation_params;

--- a/Source/Lib/Common/Codec/EbSegmentation.h
+++ b/Source/Lib/Common/Codec/EbSegmentation.h
@@ -27,7 +27,7 @@
 void apply_segmentation_based_quantization(
         const BlockGeom *blk_geom,
         PictureControlSet *picture_control_set_ptr,
-        LargestCodingUnit *sb_ptr,
+        SuperBlock        *sb_ptr,
         CodingUnit *cu_ptr
 );
 


### PR DESCRIPTION
## Description
remove decoupled_fast_loop_search_method and decouple_intra_inter_fast_loop
remove fast_candidate_intra_count
replace LargestCodingUnit by SuperBlock
remove unused functions void eb_av1_cdef_search() and void av1_cdef_search16bit()
 
## Related Issue
#668

## Performance 
No Impact