### PR TITLE
Add missing palette size initialization in search_best_independent_uv_mode

### DIFF
--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -7599,6 +7599,10 @@ void search_best_independent_uv_mode(
             int32_t angle_delta = CLIP(angle_delta_shift * (angleDeltaCandidateCount == 1 ? 0 : angleDeltaCounter - (angleDeltaCandidateCount >> 1)), -MAX_ANGLE_DELTA, MAX_ANGLE_DELTA);
 
             candidate_buffer->candidate_ptr->type = INTRA_MODE;
+#if PAL_SUP
+            candidate_buffer->candidate_ptr->palette_info.pmi.palette_size[0] = 0;
+            candidate_buffer->candidate_ptr->palette_info.pmi.palette_size[1] = 0;
+#endif
             candidate_buffer->candidate_ptr->intra_luma_mode = intra_mode;
             candidate_buffer->candidate_ptr->distortion_ready = 0;
             candidate_buffer->candidate_ptr->use_intrabc = 0;


### PR DESCRIPTION
This fixes the following error reported by LLVM memory sanitizer:

```          ==15704==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x7f8fea199f72 in av1_filter_intra_allowed /home/magsoft/trunks/SVT-AV1/Source/Lib/Common/Codec/EbEntropyCoding.c:1338:25
    #1 0x7f8fea8e6c66 in av1_intra_fast_cost /home/magsoft/trunks/SVT-AV1/Source/Lib/Common/Codec/EbRateDistortionCost.c:757:9
    #2 0x7f8fea7dea42 in search_best_independent_uv_mode /home/magsoft/trunks/SVT-AV1/Source/Lib/Common/Codec/EbProductCodingLoop.c:7644:58
    #3 0x7f8fea7e418a in md_encode_block /home/magsoft/trunks/SVT-AV1/Source/Lib/Common/Codec/EbProductCodingLoop.c:7884:21
    #4 0x7f8fea7f6fdf in mode_decision_sb /home/magsoft/trunks/SVT-AV1/Source/Lib/Common/Codec/EbProductCodingLoop.c:8769:17
    #5 0x7f8fea174ba6 in enc_dec_kernel /home/magsoft/trunks/SVT-AV1/Source/Lib/Common/Codec/EbEncDecProcess.c:1897:21
    #6 0x7f8fe9e72668 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x9668)
    #7 0x7f8fe9c1e322 in clone /build/glibc-4WA41p/glibc-2.30/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:95

SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/magsoft/trunks/SVT-AV1/Source/Lib/Common/Codec/EbEntropyCoding.c:1338:25 in av1_filter_intra_allowed