### PR TITLE
CI: Create initial GitHub Actions workflow

### DIFF
--- a/.github/workflows/svt-av1.yml
+++ b/.github/workflows/svt-av1.yml
@@ -1,0 +1,17 @@
+name: svt-av1
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install dependencies
+      run: sudo apt-get install -y gcc-9 g++-9 nasm yasm cmake
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Compile SVT-AV1
+      run: |
+        export CC=gcc-9 CXX=g++-9
+        ./Build/linux/build.sh release
+        ./Bin/Release/SvtAv1EncApp -help


### PR DESCRIPTION
GitHub Actions is weird. But it looks quite powerful, so here's an initial setup for a GitHub Actions Workflow.

This Action (I don't even know what it's called anymore) does nothing more than build SVT-AV1 on Ubuntu 18.04 LTS with GCC 9. This is an initial setup, the fact that this passes or not means nothing for now.

@kylophone @1480c1 Feel free to build out from here! I will probably try to port a lot of stuff over from Travis around Christmas.

Part of #4.