### PR TITLE
Implementation of function av1_k_means_dim1, av1_k_means_dim2 for AVX2

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/palette_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/palette_avx2.c
@@ -1,0 +1,438 @@
+/*
+* Copyright(c) 2019 Intel Corporation
+* SPDX - License - Identifier: BSD - 2 - Clause - Patent
+*/
+
+#include <immintrin.h>
+#include "EbDefinitions.h"
+
+#define DIVIDE_AND_ROUND(x, y) (((x) + ((y) >> 1)) / (y))
+
+static INLINE unsigned int lcg_rand16(unsigned int *state) {
+    *state = (unsigned int)(*state * 1103515245ULL + 12345);
+    return *state / 65536 % 32768;
+}
+
+/* That same calcualtion as: av1_calc_indices_dist_dim1_avx2(),
+   but not calculate sum at the end. */
+void av1_calc_indices_dim1_avx2(const int* data,
+    const int* centroids,
+    uint8_t* indices, int n, int k) {
+
+    int i = 0;
+    int results[MAX_SB_SQUARE];
+    memset(indices, 0, n * sizeof(uint8_t));
+
+    __m256i centroids_0 = _mm256_set1_epi32(centroids[0]);
+    for (i = 0; i < n; i += 8) {
+        __m256i data_dd = _mm256_loadu_si256((__m256i*)(data + i));
+        __m256i sub = _mm256_sub_epi32(data_dd, centroids_0);
+        __m256i dist = _mm256_mullo_epi32(sub, sub);
+        _mm256_storeu_si256((__m256i*)(results + i), dist);
+    }
+
+    for (int c = 1; c < k; c++) {
+        __m256i centroids_0 = _mm256_set1_epi32(centroids[c]);
+        __m256i indices_v = _mm256_set1_epi32(c);
+        for (i = 0; i < n; i += 16) {
+            __m256i data_d1 = _mm256_loadu_si256((__m256i*)(data + i));
+            __m256i data_d2 = _mm256_loadu_si256((__m256i*)(data + i + 8));
+            __m256i sub_1 = _mm256_sub_epi32(data_d1, centroids_0);
+            __m256i sub_2 = _mm256_sub_epi32(data_d2, centroids_0);
+            __m256i dist_1 = _mm256_mullo_epi32(sub_1, sub_1);
+            __m256i dist_2 = _mm256_mullo_epi32(sub_2, sub_2);
+
+            __m256i prev_1 = _mm256_loadu_si256((__m256i*)(results + i));
+            __m256i prev_2 = _mm256_loadu_si256((__m256i*)(results + i + 8));
+            __m256i cmp_1 = _mm256_cmpgt_epi32(prev_1, dist_1);
+            __m256i cmp_2 = _mm256_cmpgt_epi32(prev_2, dist_2);
+
+            _mm256_maskstore_epi32((results + i), cmp_1, dist_1);
+            _mm256_maskstore_epi32((results + i + 8), cmp_2, dist_2);
+
+            __m256i indices_v32_1 = _mm256_and_si256(indices_v, cmp_1);
+            __m256i indices_v32_2 = _mm256_and_si256(indices_v, cmp_2);
+
+            __m128i indices_v16_1 =
+                _mm_packus_epi32(_mm256_castsi256_si128(indices_v32_1),
+                    _mm256_extracti128_si256(indices_v32_1, 1));
+            __m128i indices_v16_2 =
+                _mm_packus_epi32(_mm256_castsi256_si128(indices_v32_2),
+                    _mm256_extracti128_si256(indices_v32_2, 1));
+
+            __m128i cmp8 = _mm_packs_epi16(indices_v16_1, indices_v16_2);
+
+            __m128i load_ind = _mm_loadu_si128((__m128i*)(indices + i));
+
+            load_ind = _mm_max_epi8(load_ind, cmp8);
+
+            _mm_storeu_si128((__m128i*)(indices + i), load_ind);
+        }
+    }
+}
+
+static INLINE int64_t av1_calc_indices_dist_dim1_avx2(const int *data,
+    const int *centroids,
+    uint8_t *indices, int n, int k) {
+    int64_t dist = 0;
+    int i = 0;
+    __m256i sum64 = _mm256_setzero_si256();
+    int results[MAX_SB_SQUARE];
+    memset(indices, 0, n * sizeof(uint8_t));
+
+    __m256i centroids_0 = _mm256_set1_epi32(centroids[0]);
+    for (i = 0; i < n; i += 8) {
+        __m256i data_dd = _mm256_loadu_si256((__m256i *)(data + i));
+        __m256i sub = _mm256_sub_epi32(data_dd, centroids_0);
+        __m256i dist = _mm256_mullo_epi32(sub, sub);
+        _mm256_storeu_si256((__m256i *)(results + i), dist);
+    }
+
+    for (int c = 1; c < k; c++) {
+        __m256i centroids_0 = _mm256_set1_epi32(centroids[c]);
+        __m256i indices_v = _mm256_set1_epi32(c);
+        for (i = 0; i < n; i += 16) {
+            __m256i data_d1 = _mm256_loadu_si256((__m256i *)(data + i));
+            __m256i data_d2 = _mm256_loadu_si256((__m256i *)(data + i + 8));
+            __m256i sub_1 = _mm256_sub_epi32(data_d1, centroids_0);
+            __m256i sub_2 = _mm256_sub_epi32(data_d2, centroids_0);
+            __m256i dist_1 = _mm256_mullo_epi32(sub_1, sub_1);
+            __m256i dist_2 = _mm256_mullo_epi32(sub_2, sub_2);
+
+            __m256i prev_1 = _mm256_loadu_si256((__m256i *)(results + i));
+            __m256i prev_2 = _mm256_loadu_si256((__m256i *)(results + i + 8));
+            __m256i cmp_1 = _mm256_cmpgt_epi32(prev_1, dist_1);
+            __m256i cmp_2 = _mm256_cmpgt_epi32(prev_2, dist_2);
+
+            _mm256_maskstore_epi32((results + i), cmp_1, dist_1);
+            _mm256_maskstore_epi32((results + i + 8), cmp_2, dist_2);
+
+            __m256i indices_v32_1 = _mm256_and_si256(indices_v, cmp_1);
+            __m256i indices_v32_2 = _mm256_and_si256(indices_v, cmp_2);
+
+            __m128i indices_v16_1 =
+                _mm_packus_epi32(_mm256_castsi256_si128(indices_v32_1),
+                    _mm256_extracti128_si256(indices_v32_1, 1));
+            __m128i indices_v16_2 =
+                _mm_packus_epi32(_mm256_castsi256_si128(indices_v32_2),
+                    _mm256_extracti128_si256(indices_v32_2, 1));
+
+            __m128i cmp8 = _mm_packs_epi16(indices_v16_1, indices_v16_2);
+
+            __m128i load_ind = _mm_loadu_si128((__m128i *)(indices + i));
+
+            load_ind = _mm_max_epi8(load_ind, cmp8);
+
+            _mm_storeu_si128((__m128i *)(indices + i), load_ind);
+        }
+    }
+
+    for (i = 0; i < n; i += 8) {
+        __m256i prev = _mm256_loadu_si256((__m256i *)(results + i));
+        sum64 = _mm256_add_epi64(
+            sum64, _mm256_unpacklo_epi32(prev, _mm256_setzero_si256()));
+        sum64 = _mm256_add_epi64(
+            sum64, _mm256_unpackhi_epi32(prev, _mm256_setzero_si256()));
+    }
+
+    __m128i s = _mm_add_epi64(_mm256_castsi256_si128(sum64),
+        _mm256_extracti128_si256(sum64, 1));
+    dist = _mm_extract_epi64(s, 0) + _mm_extract_epi64(s, 1);
+
+    return dist;
+}
+
+static INLINE void calc_centroids_1_avx2(const int *data, int *centroids,
+    const uint8_t *indices, int n, int k) {
+    int i;
+    int count[PALETTE_MAX_SIZE] = { 0 };
+    unsigned int rand_state = (unsigned int)data[0];
+    assert(n <= 32768);
+    memset(centroids, 0, sizeof(centroids[0]) * k);
+
+    for (i = 0; i < n; ++i) {
+        const int index = indices[i];
+        assert(index < k);
+        ++count[index];
+        centroids[index] += data[i];
+    }
+
+    for (i = 0; i < k; ++i) {
+        if (count[i] == 0) {
+            centroids[i] = *(data + (lcg_rand16(&rand_state) % n));
+        }
+        else {
+            centroids[i] = DIVIDE_AND_ROUND(centroids[i], count[i]);
+        }
+    }
+}
+
+void av1_k_means_dim1_avx2(const int *data, int *centroids, uint8_t *indices,
+                           int n, int k, int max_itr) {
+    int pre_centroids[2 * PALETTE_MAX_SIZE];
+    uint8_t pre_indices[MAX_SB_SQUARE];
+    assert((n & 15) == 0);
+
+    int64_t this_dist = av1_calc_indices_dist_dim1_avx2(data, centroids, indices, n, k);
+
+    for (int i = 0; i < max_itr; ++i) {
+        const int64_t pre_dist = this_dist;
+        memcpy(pre_centroids, centroids, sizeof(pre_centroids[0]) * k);
+        memcpy(pre_indices, indices, sizeof(pre_indices[0]) * n);
+
+        calc_centroids_1_avx2(data, centroids, indices, n, k);
+        this_dist = av1_calc_indices_dist_dim1_avx2(data, centroids, indices, n, k);
+
+        if (this_dist > pre_dist) {
+            memcpy(centroids, pre_centroids, sizeof(pre_centroids[0]) * k);
+            memcpy(indices, pre_indices, sizeof(pre_indices[0]) * n);
+            break;
+        }
+        if (!memcmp(centroids, pre_centroids, sizeof(pre_centroids[0]) * k))
+            break;
+    }
+}
+
+/* That same calcualtion as: av1_calc_indices_dist_dim2_avx2(),
+   but not calculate sum at the end. */
+void av1_calc_indices_dim2_avx2(const int *data, const int *centroids,
+    uint8_t *indices, int n, int k) {
+
+    int i = 0;
+    int results[MAX_SB_SQUARE];
+    memset(indices, 0, n * sizeof(uint8_t));
+
+    __m256i centroids_01 = _mm256_set1_epi64x(*((uint64_t*)&centroids[0]));
+
+    for (i = 0; i < n; i += 8) {
+        __m256i data_a = _mm256_loadu_si256((__m256i*)(data + 2 * i));
+        __m256i sub_a = _mm256_sub_epi32(data_a, centroids_01);
+        __m256i dist_a = _mm256_mullo_epi32(sub_a, sub_a);
+
+        __m256i data_b = _mm256_loadu_si256((__m256i*)(data + 2 * (i + 4)));
+        __m256i sub_b = _mm256_sub_epi32(data_b, centroids_01);
+        __m256i dist_b = _mm256_mullo_epi32(sub_b, sub_b);
+
+        __m256i dist = _mm256_hadd_epi32(dist_a, dist_b);
+        dist = _mm256_permute4x64_epi64(dist, 0xD8);
+        _mm256_storeu_si256((__m256i*)(results + i), dist);
+    }
+
+
+    for (int j = 1; j < k; ++j) {
+        __m256i centroids_01 = _mm256_set1_epi64x(*((uint64_t*)&centroids[2 * j]));
+        __m256i indices_v = _mm256_set1_epi32(j);
+
+        for (int i = 0; i < n; i += 16) {
+            __m256i data_1 = _mm256_loadu_si256(
+                (__m256i*)(data + 2 * i));
+            __m256i data_2 = _mm256_loadu_si256(
+                (__m256i*)(data + 2 * (i + 4)));
+            __m256i data_3 = _mm256_loadu_si256(
+                (__m256i*)(data + 2 * (i + 8)));
+            __m256i data_4 = _mm256_loadu_si256(
+                (__m256i*)(data + 2 * (i + 12)));
+
+            __m256i sub_1 = _mm256_sub_epi32(data_1, centroids_01);
+            __m256i sub_2 = _mm256_sub_epi32(data_2, centroids_01);
+            __m256i sub_3 = _mm256_sub_epi32(data_3, centroids_01);
+            __m256i sub_4 = _mm256_sub_epi32(data_4, centroids_01);
+
+            __m256i dist_1 = _mm256_mullo_epi32(sub_1, sub_1);
+            __m256i dist_2 = _mm256_mullo_epi32(sub_2, sub_2);
+            __m256i dist_3 = _mm256_mullo_epi32(sub_3, sub_3);
+            __m256i dist_4 = _mm256_mullo_epi32(sub_4, sub_4);
+
+            __m256i dist12 = _mm256_hadd_epi32(dist_1, dist_2);
+            dist12 = _mm256_permute4x64_epi64(dist12, 0xD8);
+
+            __m256i dist34 = _mm256_hadd_epi32(dist_3, dist_4);
+            dist34 = _mm256_permute4x64_epi64(dist34, 0xD8);
+
+            __m256i prev_12 = _mm256_loadu_si256((__m256i*)(results + i));
+            __m256i prev_34 = _mm256_loadu_si256((__m256i*)(results + i + 8));
+
+            __m256i cmp_12 = _mm256_cmpgt_epi32(prev_12, dist12);
+            __m256i cmp_34 = _mm256_cmpgt_epi32(prev_34, dist34);
+
+            _mm256_maskstore_epi32((results + i), cmp_12, dist12);
+            _mm256_maskstore_epi32((results + i + 8), cmp_34, dist34);
+
+            __m256i indices_v32_1 = _mm256_and_si256(indices_v, cmp_12);
+            __m256i indices_v32_2 = _mm256_and_si256(indices_v, cmp_34);
+
+            __m128i indices_v16_1 =
+                _mm_packus_epi32(_mm256_castsi256_si128(indices_v32_1),
+                    _mm256_extracti128_si256(indices_v32_1, 1));
+            __m128i indices_v16_2 =
+                _mm_packus_epi32(_mm256_castsi256_si128(indices_v32_2),
+                    _mm256_extracti128_si256(indices_v32_2, 1));
+
+            __m128i cmp8 = _mm_packs_epi16(indices_v16_1, indices_v16_2);
+            __m128i load_ind = _mm_loadu_si128((__m128i*)(indices + i));
+            load_ind = _mm_max_epi8(load_ind, cmp8);
+            _mm_storeu_si128((__m128i*)(indices + i), load_ind);
+        }
+    }
+
+}
+
+static INLINE int64_t av1_calc_indices_dist_dim2_avx2(const int *data,
+    const int *centroids,
+    uint8_t *indices, int n, int k)
+{
+
+    int i = 0;
+    int results[MAX_SB_SQUARE];
+    memset(indices, 0, n * sizeof(uint8_t));
+
+    __m256i centroids_01 = _mm256_set1_epi64x(*((uint64_t*)&centroids[0]));
+
+    for (i = 0; i < n; i += 8) {
+        __m256i data_a = _mm256_loadu_si256((__m256i*)(data + 2 * i));
+        __m256i sub_a = _mm256_sub_epi32(data_a, centroids_01);
+        __m256i dist_a = _mm256_mullo_epi32(sub_a, sub_a);
+
+        __m256i data_b = _mm256_loadu_si256((__m256i*)(data + 2 * (i + 4)));
+        __m256i sub_b = _mm256_sub_epi32(data_b, centroids_01);
+        __m256i dist_b = _mm256_mullo_epi32(sub_b, sub_b);
+
+        __m256i dist = _mm256_hadd_epi32(dist_a, dist_b);
+        dist = _mm256_permute4x64_epi64(dist, 0xD8);
+        _mm256_storeu_si256((__m256i*)(results + i), dist);
+    }
+
+    for (int j = 1; j < k; ++j) {
+        __m256i centroids_01 = _mm256_set1_epi64x(*((uint64_t*)&centroids[2 * j]));
+        __m256i indices_v = _mm256_set1_epi32(j);
+
+        for (int i = 0; i < n; i += 16) {
+            __m256i data_1 = _mm256_loadu_si256(
+                (__m256i*)(data + 2 * i));
+            __m256i data_2 = _mm256_loadu_si256(
+                (__m256i*)(data + 2 * (i + 4)));
+            __m256i data_3 = _mm256_loadu_si256(
+                (__m256i*)(data + 2 * (i + 8)));
+            __m256i data_4 = _mm256_loadu_si256(
+                (__m256i*)(data + 2 * (i + 12)));
+
+            __m256i sub_1 = _mm256_sub_epi32(data_1, centroids_01);
+            __m256i sub_2 = _mm256_sub_epi32(data_2, centroids_01);
+            __m256i sub_3 = _mm256_sub_epi32(data_3, centroids_01);
+            __m256i sub_4 = _mm256_sub_epi32(data_4, centroids_01);
+
+            __m256i dist_1 = _mm256_mullo_epi32(sub_1, sub_1);
+            __m256i dist_2 = _mm256_mullo_epi32(sub_2, sub_2);
+            __m256i dist_3 = _mm256_mullo_epi32(sub_3, sub_3);
+            __m256i dist_4 = _mm256_mullo_epi32(sub_4, sub_4);
+
+            __m256i dist12 = _mm256_hadd_epi32(dist_1, dist_2);
+            dist12 = _mm256_permute4x64_epi64(dist12, 0xD8);
+
+            __m256i dist34 = _mm256_hadd_epi32(dist_3, dist_4);
+            dist34 = _mm256_permute4x64_epi64(dist34, 0xD8);
+
+            __m256i prev_12 = _mm256_loadu_si256((__m256i*)(results + i));
+            __m256i prev_34 = _mm256_loadu_si256((__m256i*)(results + i + 8));
+
+            __m256i cmp_12 = _mm256_cmpgt_epi32(prev_12, dist12);
+            __m256i cmp_34 = _mm256_cmpgt_epi32(prev_34, dist34);
+
+            _mm256_maskstore_epi32((results + i), cmp_12, dist12);
+            _mm256_maskstore_epi32((results + i + 8), cmp_34, dist34);
+
+            __m256i indices_v32_1 = _mm256_and_si256(indices_v, cmp_12);
+            __m256i indices_v32_2 = _mm256_and_si256(indices_v, cmp_34);
+
+            __m128i indices_v16_1 =
+                _mm_packus_epi32(_mm256_castsi256_si128(indices_v32_1),
+                    _mm256_extracti128_si256(indices_v32_1, 1));
+            __m128i indices_v16_2 =
+                _mm_packus_epi32(_mm256_castsi256_si128(indices_v32_2),
+                    _mm256_extracti128_si256(indices_v32_2, 1));
+
+            __m128i cmp8 = _mm_packs_epi16(indices_v16_1, indices_v16_2);
+            __m128i load_ind = _mm_loadu_si128((__m128i*)(indices + i));
+            load_ind = _mm_max_epi8(load_ind, cmp8);
+            _mm_storeu_si128((__m128i*)(indices + i), load_ind);
+        }
+    }
+
+    int64_t dist = 0;
+    __m256i sum64 = _mm256_setzero_si256();
+    for (i = 0; i < n; i += 8) {
+        __m256i prev = _mm256_loadu_si256((__m256i *)(results + i));
+        sum64 = _mm256_add_epi64(
+            sum64, _mm256_unpacklo_epi32(prev, _mm256_setzero_si256()));
+        sum64 = _mm256_add_epi64(
+            sum64, _mm256_unpackhi_epi32(prev, _mm256_setzero_si256()));
+    }
+
+    __m128i s = _mm_add_epi64(_mm256_castsi256_si128(sum64),
+        _mm256_extracti128_si256(sum64, 1));
+    dist = _mm_extract_epi64(s, 0) + _mm_extract_epi64(s, 1);
+
+    return dist;
+}
+
+static INLINE void calc_centroids_2_avx2(const int *data, int *centroids,
+    const uint8_t *indices, int n, int k) {
+    int i;
+    int count[PALETTE_MAX_SIZE] = { 0 };
+    unsigned int rand_state = (unsigned int)data[0];
+    assert(n <= 32768);
+    memset(centroids, 0, sizeof(centroids[0]) * k * 2);
+
+    for (i = 0; i < n; ++i) {
+        const int index = indices[i];
+        assert(index < k);
+        ++count[index];
+        centroids[index * 2] += data[i * 2];
+        centroids[index * 2 + 1] += data[i * 2 + 1];
+    }
+
+    for (i = 0; i < k; ++i) {
+        if (count[i] == 0) {
+            memcpy(centroids + i * 2,
+                data + (lcg_rand16(&rand_state) % n) * 2,
+                sizeof(centroids[0]) * 2);
+        }
+        else {
+            centroids[i * 2] =
+                DIVIDE_AND_ROUND(centroids[i * 2], count[i]);
+            centroids[i * 2 + 1] =
+                DIVIDE_AND_ROUND(centroids[i * 2 + 1], count[i]);
+        }
+    }
+}
+
+void av1_k_means_dim2_avx2(const int *data, int *centroids, uint8_t *indices,
+    int n, int k, int max_itr) {
+    int pre_centroids[2 * PALETTE_MAX_SIZE];
+    uint8_t pre_indices[MAX_SB_SQUARE];
+
+    assert((n & 15) == 0);
+
+    int64_t this_dist = av1_calc_indices_dist_dim2_avx2(data, centroids, indices, n, k);
+
+    for (int i = 0; i < max_itr; ++i) {
+        const int64_t pre_dist = this_dist;
+        memcpy(pre_centroids, centroids,
+            sizeof(pre_centroids[0]) * k * 2);
+        memcpy(pre_indices, indices, sizeof(pre_indices[0]) * n);
+
+        calc_centroids_2_avx2(data, centroids, indices, n, k);
+        this_dist = av1_calc_indices_dist_dim2_avx2(data, centroids, indices, n, k);
+
+        if (this_dist > pre_dist) {
+            memcpy(centroids, pre_centroids,
+                sizeof(pre_centroids[0]) * k * 2);
+            memcpy(indices, pre_indices, sizeof(pre_indices[0]) * n);
+            break;
+        }
+        if (!memcmp(centroids, pre_centroids,
+            sizeof(pre_centroids[0]) * k * 2))
+            break;
+    }
+}
+

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.c
@@ -2000,6 +2000,18 @@ void setup_rtcd_internal(CPU_FLAGS flags)
     SET_SSE2(residual_kernel16bit,
              residual_kernel16bit_c,
              residual_kernel16bit_sse2_intrin);
+    SET_AVX2(av1_k_means_dim1,
+             av1_k_means_dim1_c,
+             av1_k_means_dim1_avx2);
+    SET_AVX2(av1_k_means_dim2,
+             av1_k_means_dim2_c,
+             av1_k_means_dim2_avx2);
+    SET_AVX2(av1_calc_indices_dim1,
+             av1_calc_indices_dim1_c,
+             av1_calc_indices_dim1_avx2);
+    SET_AVX2(av1_calc_indices_dim2,
+             av1_calc_indices_dim2_c,
+             av1_calc_indices_dim2_avx2);
 
 #if AUTO_MAX_PARTITION
     av1_nn_predict = av1_nn_predict_c;

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -2921,6 +2921,22 @@ extern "C" {
     double av1_compute_cross_correlation_avx2(unsigned char *im1, int stride1, int x1, int y1, unsigned char *im2, int stride2, int x2, int y2);
     RTCD_EXTERN double(*av1_compute_cross_correlation)(unsigned char *im1, int stride1, int x1, int y1, unsigned char *im2, int stride2, int x2, int y2);
 
+    void av1_k_means_dim1_c(const int* data, int* centroids, uint8_t* indices, int n, int k, int max_itr);
+    void av1_k_means_dim1_avx2(const int* data, int* centroids, uint8_t* indices, int n, int k, int max_itr);
+    RTCD_EXTERN void(*av1_k_means_dim1)(const int* data, int* centroids, uint8_t* indices, int n, int k, int max_itr);
+
+    void av1_k_means_dim2_c(const int* data, int* centroids, uint8_t* indices, int n, int k, int max_itr);
+    void av1_k_means_dim2_avx2(const int* data, int* centroids, uint8_t* indices, int n, int k, int max_itr);
+    RTCD_EXTERN void(*av1_k_means_dim2)(const int* data, int* centroids, uint8_t* indices, int n, int k, int max_itr);
+
+    void av1_calc_indices_dim1_c(const int* data, const int* centroids, uint8_t* indices, int n, int k);
+    void av1_calc_indices_dim1_avx2(const int* data, const int* centroids, uint8_t* indices, int n, int k);
+    RTCD_EXTERN void(*av1_calc_indices_dim1)(const int* data, const int* centroids, uint8_t* indices, int n, int k);
+
+    void av1_calc_indices_dim2_c(const int* data, const int* centroids, uint8_t* indices, int n, int k);
+    void av1_calc_indices_dim2_avx2(const int* data, const int* centroids, uint8_t* indices, int n, int k);
+    RTCD_EXTERN void(*av1_calc_indices_dim2)(const int* data, const int* centroids, uint8_t* indices, int n, int k);
+
     RTCD_EXTERN void(*noise_extract_luma_weak)(EbPictureBufferDesc *input_picture_ptr, EbPictureBufferDesc *denoised_picture_ptr, EbPictureBufferDesc *noise_picture_ptr, uint32_t sb_origin_y, uint32_t sb_origin_x);
     RTCD_EXTERN void(*noise_extract_luma_weak_lcu)(EbPictureBufferDesc *input_picture_ptr, EbPictureBufferDesc *denoised_picture_ptr, EbPictureBufferDesc *noise_picture_ptr, uint32_t sb_origin_y, uint32_t sb_origin_x);
     RTCD_EXTERN void(*noise_extract_luma_strong)(EbPictureBufferDesc *input_picture_ptr, EbPictureBufferDesc *denoised_picture_ptr, uint32_t sb_origin_y, uint32_t sb_origin_x);

--- a/Source/Lib/Common/Codec/k_means_template.h
+++ b/Source/Lib/Common/Codec/k_means_template.h
@@ -20,7 +20,7 @@
 #define RENAME_(x, y) AV1_K_MEANS_RENAME(x, y)
 #define RENAME(x) RENAME_(x, AV1_K_MEANS_DIM)
 
-static int RENAME(calc_dist)(const int *p1, const int *p2) {
+static INLINE int RENAME(calc_dist)(const int *p1, const int *p2) {
   int dist = 0;
   for (int i = 0; i < AV1_K_MEANS_DIM; ++i) {
     const int diff = p1[i] - p2[i];
@@ -29,7 +29,7 @@ static int RENAME(calc_dist)(const int *p1, const int *p2) {
   return dist;
 }
 
-void RENAME(av1_calc_indices)(const int *data, const int *centroids,
+INLINE void RENAME(av1_calc_indices)(const int *data, const int *centroids,
                               uint8_t *indices, int n, int k) {
   for (int i = 0; i < n; ++i) {
     int min_dist = RENAME(calc_dist)(data + i * AV1_K_MEANS_DIM, centroids);
@@ -45,7 +45,7 @@ void RENAME(av1_calc_indices)(const int *data, const int *centroids,
   }
 }
 
-static void RENAME(calc_centroids)(const int *data, int *centroids,
+static INLINE void RENAME(calc_centroids)(const int *data, int *centroids,
                                    const uint8_t *indices, int n, int k) {
   int i, j;
   int count[PALETTE_MAX_SIZE] = { 0 };
@@ -76,7 +76,7 @@ static void RENAME(calc_centroids)(const int *data, int *centroids,
   }
 }
 
-static int64_t RENAME(calc_total_dist)(const int *data, const int *centroids,
+static INLINE int64_t RENAME(calc_total_dist)(const int *data, const int *centroids,
                                        const uint8_t *indices, int n, int k) {
   int64_t dist = 0;
   (void)k;

--- a/Source/Lib/Common/Codec/palette.c
+++ b/Source/Lib/Common/Codec/palette.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include "EbDefinitions.h"
 #include "EbModeDecisionProcess.h"
+#include "aom_dsp_rtcd.h"
 
 #if PAL_SUP
 
@@ -24,7 +25,7 @@ static INLINE unsigned int lcg_rand16(unsigned int *state) {
     return *state / 65536 % 32768;
 }
 
-#define AV1_K_MEANS_RENAME(func, dim) func##_dim##dim
+#define AV1_K_MEANS_RENAME(func, dim) func##_dim##dim##_c
 
 void AV1_K_MEANS_RENAME(av1_calc_indices, 1)(const int *data,
     const int *centroids,
@@ -44,10 +45,10 @@ void AV1_K_MEANS_RENAME(av1_k_means, 2)(const int *data, int *centroids,
 static inline void av1_calc_indices(const int *data, const int *centroids,
     uint8_t *indices, int n, int k, int dim) {
     if (dim == 1) {
-        AV1_K_MEANS_RENAME(av1_calc_indices, 1)(data, centroids, indices, n, k);
+        av1_calc_indices_dim1(data, centroids, indices, n, k);
     }
     else if (dim == 2) {
-        AV1_K_MEANS_RENAME(av1_calc_indices, 2)(data, centroids, indices, n, k);
+        av1_calc_indices_dim2(data, centroids, indices, n, k);
     }
     else {
         assert(0 && "Untemplated k means dimension");
@@ -62,10 +63,10 @@ static inline void av1_k_means(const int *data, int *centroids,
     uint8_t *indices, int n, int k, int dim,
     int max_itr) {
     if (dim == 1) {
-        AV1_K_MEANS_RENAME(av1_k_means, 1)(data, centroids, indices, n, k, max_itr);
+        av1_k_means_dim1(data, centroids, indices, n, k, max_itr);
     }
     else if (dim == 2) {
-        AV1_K_MEANS_RENAME(av1_k_means, 2)(data, centroids, indices, n, k, max_itr);
+        av1_k_means_dim2(data, centroids, indices, n, k, max_itr);
     }
     else {
         assert(0 && "Untemplated k means dimension");


### PR DESCRIPTION
Add AVX2 implementation for kernels av1_k_means_dim1(), av1_k_means_dim2() and similar kernels 
av1_calc_indices_dim1() av1_calc_indices_dim2().

Based on command line below, we have 23% performance improvement.
 ```-enable-altrefs 0 -pred-struct 0 -bit-depth 8 -b out.ivf  -enc-mode 8 -w 1920 -h 1080 -i 1080p.yuv -palette 1 -scm 1 ```


