### PR TITLE
reduce_inter_modes

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -32,7 +32,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
+#define REDUCE_INTER_MODES           1
 #define MULTI_PASS_PD                1 // Multi-Pass Partitioning Depth (Multi-Pass PD) performs multiple PD stages for the same SB towards 1 final Partitioning Structure. As we go from PDn to PDn + 1, the prediction accuracy of the MD feature(s) increases while the number of block(s) decreases
 
 #define HBD_CLEAN_UP                 1

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -1032,6 +1032,20 @@ static bool ref_mv_idx_early_breakout(
                 }
             }
         }
+    }else if (inter_direction == BI_PRED) {
+        if ((picture_control_set_ptr->parent_pcs_ptr->reduce_inter_modes > 1) && ref_mv_idx > 0) {
+            MvReferenceFrame rf[2];
+            rf[0] = svt_get_ref_frame_type(list_idx0, ref_idx0);
+            rf[1] = svt_get_ref_frame_type(list_idx1, ref_idx1);
+            MvReferenceFrame ref_frame_type = av1_ref_frame_type(rf);
+            if (rf[0] == LAST2_FRAME || rf[0] == LAST3_FRAME || rf[1] == ALTREF2_FRAME ) {
+                const int has_nearmv = have_nearmv_in_inter_mode(pred_mode) ? 1 : 0;
+                int32_t weight = context_ptr->md_local_cu_unit[context_ptr->blk_geom->blkidx_mds].ed_ref_mv_stack[ref_frame_type][ref_mv_idx + has_nearmv].weight;
+                if (weight < REF_CAT_LEVEL) {
+                    return true;
+                }
+            }
+        }
     }
     return false;
 }

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -996,7 +996,7 @@ int8_t ALLOW_REFINEMENT_FLAG[BIPRED_3x3_REFINMENT_POSITIONS] = {  1, 0, 1, 0, 1,
 int8_t BIPRED_3x3_X_POS[BIPRED_3x3_REFINMENT_POSITIONS] = { -1, -1, 0, 1, 1, 1, 0, -1 };
 int8_t BIPRED_3x3_Y_POS[BIPRED_3x3_REFINMENT_POSITIONS] = { 0, 1, 1, 1, 0, -1, -1, -1 };
 #if REDUCE_INTER_MODES
-// Whether this reference motion vector can be skipped, based on initial
+// Decide whether this candidate can be skipped, based on initial
 // heuristics.
 static bool ref_mv_idx_early_breakout(
     PictureControlSet            *picture_control_set_ptr,
@@ -1008,7 +1008,6 @@ static bool ref_mv_idx_early_breakout(
     const int8_t                 ref_idx1,
     const int8_t                 ref_mv_idx,
     PredictionMode               pred_mode) {
-
     int  is_comp_pred = inter_direction == 2 ? 1 : 0;
     if (inter_direction == 0) {
         if (picture_control_set_ptr->parent_pcs_ptr->reduce_inter_modes && ref_mv_idx > 0) {
@@ -1172,9 +1171,7 @@ void Unipred3x3CandidatesInjection(
                 &candidateArray[canTotalCnt].drl_index,
                 bestPredmv);
 #if REDUCE_INTER_MODES
-                // Whether this reference motion vector can be skipped, based on initial
-                // heuristics.
-                uint8_t bypass_candidate = ref_mv_idx_early_breakout(
+            uint8_t bypass_candidate = ref_mv_idx_early_breakout(
                 picture_control_set_ptr,
                 context_ptr,
                 candidateArray[canTotalCnt].prediction_direction[0],
@@ -1336,18 +1333,16 @@ void Unipred3x3CandidatesInjection(
                     &candidateArray[canTotalCnt].drl_index,
                     bestPredmv);
 #if REDUCE_INTER_MODES
-                // Whether this reference motion vector can be skipped, based on initial
-                // heuristics.
                 uint8_t bypass_candidate = ref_mv_idx_early_breakout(
-                picture_control_set_ptr,
-                context_ptr,
-                candidateArray[canTotalCnt].prediction_direction[0],
-                -1,
-                REF_LIST_1,
-                -1,
-                list1_ref_index,
-                candidateArray[canTotalCnt].drl_index,
-                candidateArray[canTotalCnt].pred_mode);
+                    picture_control_set_ptr,
+                    context_ptr,
+                    candidateArray[canTotalCnt].prediction_direction[0],
+                    -1,
+                    REF_LIST_1,
+                    -1,
+                    list1_ref_index,
+                    candidateArray[canTotalCnt].drl_index,
+                    candidateArray[canTotalCnt].pred_mode);
                 if (bypass_candidate)
                     continue;
 #endif
@@ -1576,9 +1571,7 @@ void Bipred3x3CandidatesInjection(
                 &candidateArray[canTotalCnt].drl_index,
                 bestPredmv);
 #if REDUCE_INTER_MODES
-                // Whether this reference motion vector can be skipped, based on initial
-                // heuristics.
-                uint8_t bypass_candidate = ref_mv_idx_early_breakout(
+            uint8_t bypass_candidate = ref_mv_idx_early_breakout(
                 picture_control_set_ptr,
                 context_ptr,
                 candidateArray[canTotalCnt].prediction_direction[0],
@@ -1714,18 +1707,16 @@ void Bipred3x3CandidatesInjection(
                     &candidateArray[canTotalCnt].drl_index,
                     bestPredmv);
 #if REDUCE_INTER_MODES
-                // Whether this reference motion vector can be skipped, based on initial
-                // heuristics.
                 uint8_t bypass_candidate = ref_mv_idx_early_breakout(
-                picture_control_set_ptr,
-                context_ptr,
-                candidateArray[canTotalCnt].prediction_direction[0],
-                me_block_results_ptr->ref0_list,
-                me_block_results_ptr->ref1_list,
-                list0_ref_index,
-                list1_ref_index,
-                candidateArray[canTotalCnt].drl_index,
-                candidateArray[canTotalCnt].pred_mode);
+                    picture_control_set_ptr,
+                    context_ptr,
+                    candidateArray[canTotalCnt].prediction_direction[0],
+                    me_block_results_ptr->ref0_list,
+                    me_block_results_ptr->ref1_list,
+                    list0_ref_index,
+                    list1_ref_index,
+                    candidateArray[canTotalCnt].drl_index,
+                    candidateArray[canTotalCnt].pred_mode);
                 if (bypass_candidate)
                     continue;
 #endif
@@ -3756,8 +3747,6 @@ void inject_new_candidates(
                     bestPredmv);
 
 #if REDUCE_INTER_MODES
-             // Whether this reference motion vector can be skipped, based on initial
-             // heuristics.
                 uint8_t bypass_candidate = ref_mv_idx_early_breakout(
                     picture_control_set_ptr,
                     context_ptr,
@@ -3917,8 +3906,6 @@ void inject_new_candidates(
                         &candidateArray[canTotalCnt].drl_index,
                         bestPredmv);
 #if REDUCE_INTER_MODES
-             // Whether this reference motion vector can be skipped, based on initial
-             // heuristics.
                     uint8_t bypass_candidate = ref_mv_idx_early_breakout(
                         picture_control_set_ptr,
                         context_ptr,
@@ -4079,8 +4066,6 @@ void inject_new_candidates(
                             &candidateArray[canTotalCnt].drl_index,
                             bestPredmv);
 #if REDUCE_INTER_MODES
-                     // Whether this reference motion vector can be skipped, based on initial
-                     // heuristics.
                         uint8_t bypass_candidate = ref_mv_idx_early_breakout(
                             picture_control_set_ptr,
                             context_ptr,
@@ -4232,9 +4217,7 @@ void inject_new_candidates(
                                 &candidateArray[canTotalCnt].drl_index,
                                 bestPredmv);
 #if REDUCE_INTER_MODES
-                             // Whether this reference motion vector can be skipped, based on initial
-                             // heuristics.
-                               uint8_t bypass_candidate = ref_mv_idx_early_breakout(
+                            uint8_t bypass_candidate = ref_mv_idx_early_breakout(
                                 picture_control_set_ptr,
                                 context_ptr,
                                 candidateArray[canTotalCnt].prediction_direction[0],
@@ -4347,18 +4330,16 @@ void inject_new_candidates(
                                     &candidateArray[canTotalCnt].drl_index,
                                     bestPredmv);
 #if REDUCE_INTER_MODES
-                             // Whether this reference motion vector can be skipped, based on initial
-                             // heuristics.
-                               uint8_t bypass_candidate = ref_mv_idx_early_breakout(
-                                picture_control_set_ptr,
-                                context_ptr,
-                                candidateArray[canTotalCnt].prediction_direction[0],
-                                -1,
-                                REF_LIST_1,
-                                -1,
-                                ref_pic_index,
-                                candidateArray[canTotalCnt].drl_index,
-                                candidateArray[canTotalCnt].pred_mode);
+                                uint8_t bypass_candidate = ref_mv_idx_early_breakout(
+                                    picture_control_set_ptr,
+                                    context_ptr,
+                                    candidateArray[canTotalCnt].prediction_direction[0],
+                                    -1,
+                                    REF_LIST_1,
+                                    -1,
+                                    ref_pic_index,
+                                    candidateArray[canTotalCnt].drl_index,
+                                    candidateArray[canTotalCnt].pred_mode);
                                if (bypass_candidate)
                                    continue;
 #endif
@@ -4474,18 +4455,16 @@ void inject_new_candidates(
                                             &candidateArray[canTotalCnt].drl_index,
                                             bestPredmv);
 #if REDUCE_INTER_MODES
-                                     // Whether this reference motion vector can be skipped, based on initial
-                                     // heuristics.
-                                       uint8_t bypass_candidate = ref_mv_idx_early_breakout(
-                                        picture_control_set_ptr,
-                                        context_ptr,
-                                        candidateArray[canTotalCnt].prediction_direction[0],
-                                        REF_LIST_0,
-                                        REF_LIST_1,
-                                        ref_pic_index_l0,
-                                        ref_pic_index_l1,
-                                        candidateArray[canTotalCnt].drl_index,
-                                        candidateArray[canTotalCnt].pred_mode);
+                                        uint8_t bypass_candidate = ref_mv_idx_early_breakout(
+                                            picture_control_set_ptr,
+                                            context_ptr,
+                                            candidateArray[canTotalCnt].prediction_direction[0],
+                                            REF_LIST_0,
+                                            REF_LIST_1,
+                                            ref_pic_index_l0,
+                                            ref_pic_index_l1,
+                                            candidateArray[canTotalCnt].drl_index,
+                                            candidateArray[canTotalCnt].pred_mode);
                                        if (bypass_candidate)
                                            continue;
 #endif

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -1008,8 +1008,8 @@ static bool ref_mv_idx_early_breakout(
     const int8_t                 ref_idx1,
     const int8_t                 ref_mv_idx,
     PredictionMode               pred_mode) {
-    //int  is_comp_pred = inter_direction == 2 ? 1 : 0;
-    if (inter_direction == 0) {
+
+    if (inter_direction == UNI_PRED_LIST_0) {
         if (picture_control_set_ptr->parent_pcs_ptr->reduce_inter_modes && ref_mv_idx > 0) {
             MvReferenceFrame ref_frame_type = svt_get_ref_frame_type(list_idx0, ref_idx0);
             if (ref_frame_type == LAST2_FRAME ||
@@ -1021,7 +1021,7 @@ static bool ref_mv_idx_early_breakout(
                 }
             }
         }
-    }else if (inter_direction == 1) {
+    }else if (inter_direction == UNI_PRED_LIST_1) {
         if (picture_control_set_ptr->parent_pcs_ptr->reduce_inter_modes && ref_mv_idx > 0) {
             MvReferenceFrame ref_frame_type = svt_get_ref_frame_type(list_idx1, ref_idx1);
             if (ref_frame_type == ALTREF2_FRAME ) {

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -1008,7 +1008,7 @@ static bool ref_mv_idx_early_breakout(
     const int8_t                 ref_idx1,
     const int8_t                 ref_mv_idx,
     PredictionMode               pred_mode) {
-    int  is_comp_pred = inter_direction == 2 ? 1 : 0;
+    //int  is_comp_pred = inter_direction == 2 ? 1 : 0;
     if (inter_direction == 0) {
         if (picture_control_set_ptr->parent_pcs_ptr->reduce_inter_modes && ref_mv_idx > 0) {
             MvReferenceFrame ref_frame_type = svt_get_ref_frame_type(list_idx0, ref_idx0);
@@ -1023,7 +1023,7 @@ static bool ref_mv_idx_early_breakout(
         }
     }else if (inter_direction == 1) {
         if (picture_control_set_ptr->parent_pcs_ptr->reduce_inter_modes && ref_mv_idx > 0) {
-            MvReferenceFrame ref_frame_type = svt_get_ref_frame_type(ref_idx1, ref_idx1);
+            MvReferenceFrame ref_frame_type = svt_get_ref_frame_type(list_idx1, ref_idx1);
             if (ref_frame_type == ALTREF2_FRAME ) {
                 const int has_nearmv = have_nearmv_in_inter_mode(pred_mode) ? 1 : 0;
                 int32_t weight = context_ptr->md_local_cu_unit[context_ptr->blk_geom->blkidx_mds].ed_ref_mv_stack[ref_frame_type][ref_mv_idx + has_nearmv].weight;

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -14339,6 +14339,9 @@ extern "C" {
 #if GM_OPT
         uint8_t                                gm_level;
 #endif
+#if REDUCE_INTER_MODES
+        uint8_t                                reduce_inter_modes;
+#endif
     } PictureParentControlSet;
 
     typedef struct PictureControlSetInitData

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -1413,7 +1413,7 @@ EbErrorType signal_derivation_multi_processes_oq(
         picture_control_set_ptr->gm_level = GM_FULL;
 #endif
 #if REDUCE_INTER_MODES
-        picture_control_set_ptr->reduce_inter_modes = 1;
+        picture_control_set_ptr->reduce_inter_modes = 0;
 #endif
     return return_error;
 }

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -1412,6 +1412,9 @@ EbErrorType signal_derivation_multi_processes_oq(
         // GM_TRAN_ONLY                               Translation only using ME MV.
         picture_control_set_ptr->gm_level = GM_FULL;
 #endif
+#if REDUCE_INTER_MODES
+        picture_control_set_ptr->reduce_inter_modes = 1;
+#endif
     return return_error;
 }
 


### PR DESCRIPTION
Reduce the number of candidates with new mv based on the weight computed in mv pred. When it is ON, 3% speed gain for 0.085% Bdrate loss is reported for M0.
