### PR TITLE
Tx_size search_early_exit

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -32,8 +32,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#define TX_SIZE_EARLY_EXIT1          1 // Skip depth 2 when depth 1 is not good as compared to depth 0.
-#define TX_SIZE_EARLY_EXIT2          1 // Exit tx size search when no coef is acheived.
+#define TX_SIZE_EARLY_EXIT          1 // Exit tx size search when no coef is acheived.
+
 #define MULTI_PASS_PD                1 // Multi-Pass Partitioning Depth (Multi-Pass PD) performs multiple PD stages for the same SB towards 1 final Partitioning Structure. As we go from PDn to PDn + 1, the prediction accuracy of the MD feature(s) increases while the number of block(s) decreases
 
 #define HBD_CLEAN_UP                 1

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -32,7 +32,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
+#define TX_SIZE_EARLY_EXIT1          1 // Skip depth 2 when depth 1 is not good as compared to depth 0.
+#define TX_SIZE_EARLY_EXIT2          1 // Exit tx size search when no coef is acheived.
 #define MULTI_PASS_PD                1 // Multi-Pass Partitioning Depth (Multi-Pass PD) performs multiple PD stages for the same SB towards 1 final Partitioning Structure. As we go from PDn to PDn + 1, the prediction accuracy of the MD feature(s) increases while the number of block(s) decreases
 
 #define HBD_CLEAN_UP                 1

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -32,7 +32,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#define TX_SIZE_EARLY_EXIT          1 // Exit tx size search when no coef is acheived.
+#define TX_SIZE_EARLY_EXIT          1 // Exit TX size search when all coefficients are zero.
 
 #define MULTI_PASS_PD                1 // Multi-Pass Partitioning Depth (Multi-Pass PD) performs multiple PD stages for the same SB towards 1 final Partitioning Structure. As we go from PDn to PDn + 1, the prediction accuracy of the MD feature(s) increases while the number of block(s) decreases
 

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -14339,6 +14339,9 @@ extern "C" {
 #if GM_OPT
         uint8_t                                gm_level;
 #endif
+#if TX_SIZE_EARLY_EXIT
+        uint8_t                                tx_size_early_exit;
+#endif
     } PictureParentControlSet;
 
     typedef struct PictureControlSetInitData

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -1413,7 +1413,7 @@ EbErrorType signal_derivation_multi_processes_oq(
         picture_control_set_ptr->gm_level = GM_FULL;
 #endif
 #if TX_SIZE_EARLY_EXIT
-        //Exit tx size search when no coef is acheived.
+        //Exit TX size search when all coefficients are zero
         // 0: OFF
         // 1: ON
         picture_control_set_ptr->tx_size_early_exit = 1;

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -1412,6 +1412,12 @@ EbErrorType signal_derivation_multi_processes_oq(
         // GM_TRAN_ONLY                               Translation only using ME MV.
         picture_control_set_ptr->gm_level = GM_FULL;
 #endif
+#if TX_SIZE_EARLY_EXIT
+        //Exit tx size search when no coef is acheived.
+        // 0: OFF
+        // 1: ON
+        picture_control_set_ptr->tx_size_early_exit = 1;
+#endif
     return return_error;
 }
 

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -5018,7 +5018,9 @@ void tx_partitioning_path(
 
     uint8_t  best_tx_depth = 0;
     uint64_t best_cost_search = (uint64_t)~0;
-
+#if TX_SIZE_EARLY_EXIT2
+    uint8_t is_best_has_coeff = 1;
+#endif
     // Fill the scratch buffer
     memcpy(context_ptr->scratch_candidate_buffer->candidate_ptr, candidate_buffer->candidate_ptr, sizeof(ModeDecisionCandidate));
 
@@ -5114,7 +5116,14 @@ void tx_partitioning_path(
 
     // Transform Depth Loop
     for (context_ptr->tx_depth = 0; context_ptr->tx_depth <= end_tx_depth; context_ptr->tx_depth++) {
-
+#if TX_SIZE_EARLY_EXIT1
+        if (best_tx_depth != 1 && context_ptr->tx_depth == 2)
+            continue;
+#endif
+#if TX_SIZE_EARLY_EXIT2
+        if (!is_best_has_coeff)
+            continue;
+#endif
         ModeDecisionCandidateBuffer *tx_candidate_buffer = (context_ptr->tx_depth == 0) ? candidate_buffer : context_ptr->scratch_candidate_buffer;
 
         tx_candidate_buffer->candidate_ptr->tx_depth = context_ptr->tx_depth;
@@ -5226,7 +5235,9 @@ void tx_partitioning_path(
         if (cost < best_cost_search) {
             best_cost_search = cost;
             best_tx_depth = context_ptr->tx_depth;
-
+#if TX_SIZE_EARLY_EXIT2
+            is_best_has_coeff = block_has_coeff;        
+#endif
             y_full_distortion[DIST_CALC_RESIDUAL] = tx_y_full_distortion[DIST_CALC_RESIDUAL];
             y_full_distortion[DIST_CALC_PREDICTION] = tx_y_full_distortion[DIST_CALC_PREDICTION];
             *y_coeff_bits = tx_y_coeff_bits;

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -5235,7 +5235,7 @@ void tx_partitioning_path(
             best_cost_search = cost;
             best_tx_depth = context_ptr->tx_depth;
 #if TX_SIZE_EARLY_EXIT
-            is_best_has_coeff = block_has_coeff;        
+            is_best_has_coeff = block_has_coeff;
 #endif
             y_full_distortion[DIST_CALC_RESIDUAL] = tx_y_full_distortion[DIST_CALC_RESIDUAL];
             y_full_distortion[DIST_CALC_PREDICTION] = tx_y_full_distortion[DIST_CALC_PREDICTION];

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -5018,7 +5018,7 @@ void tx_partitioning_path(
 
     uint8_t  best_tx_depth = 0;
     uint64_t best_cost_search = (uint64_t)~0;
-#if TX_SIZE_EARLY_EXIT2
+#if TX_SIZE_EARLY_EXIT
     uint8_t is_best_has_coeff = 1;
 #endif
     // Fill the scratch buffer
@@ -5116,11 +5116,10 @@ void tx_partitioning_path(
 
     // Transform Depth Loop
     for (context_ptr->tx_depth = 0; context_ptr->tx_depth <= end_tx_depth; context_ptr->tx_depth++) {
-#if TX_SIZE_EARLY_EXIT1
+#if TX_SIZE_EARLY_EXIT
+        if(picture_control_set_ptr->parent_pcs_ptr->tx_size_early_exit)
         if (best_tx_depth != 1 && context_ptr->tx_depth == 2)
             continue;
-#endif
-#if TX_SIZE_EARLY_EXIT2
         if (!is_best_has_coeff)
             continue;
 #endif
@@ -5235,7 +5234,7 @@ void tx_partitioning_path(
         if (cost < best_cost_search) {
             best_cost_search = cost;
             best_tx_depth = context_ptr->tx_depth;
-#if TX_SIZE_EARLY_EXIT2
+#if TX_SIZE_EARLY_EXIT
             is_best_has_coeff = block_has_coeff;        
 #endif
             y_full_distortion[DIST_CALC_RESIDUAL] = tx_y_full_distortion[DIST_CALC_RESIDUAL];

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -5117,11 +5117,12 @@ void tx_partitioning_path(
     // Transform Depth Loop
     for (context_ptr->tx_depth = 0; context_ptr->tx_depth <= end_tx_depth; context_ptr->tx_depth++) {
 #if TX_SIZE_EARLY_EXIT
-        if(picture_control_set_ptr->parent_pcs_ptr->tx_size_early_exit)
-        if (best_tx_depth != 1 && context_ptr->tx_depth == 2)
-            continue;
-        if (!is_best_has_coeff)
-            continue;
+        if (picture_control_set_ptr->parent_pcs_ptr->tx_size_early_exit) {
+            if (best_tx_depth != 1 && context_ptr->tx_depth == 2)
+                continue;
+            if (!is_best_has_coeff)
+                continue;
+        }
 #endif
         ModeDecisionCandidateBuffer *tx_candidate_buffer = (context_ptr->tx_depth == 0) ? candidate_buffer : context_ptr->scratch_candidate_buffer;
 


### PR DESCRIPTION
Early exit from tx_size search based on the data of already processed tx_size. This provided 0.044% BDrate gain for about 2% speed up on the full AOM clip set.