### PR TITLE
Rate est update

### DIFF
--- a/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
+++ b/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
@@ -1539,6 +1539,17 @@ void update_av1_mi_map(
 #endif
             //needed for CDEF
             miPtr[miX + miY * mi_stride].mbmi.block_mi.skip = cu_ptr->block_has_coeff ? EB_FALSE : EB_TRUE;
+#if RATE_ESTIMATION_UPDATE
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.skip_mode = (int8_t)cu_ptr->skip_flag;
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.segment_id = cu_ptr->segment_id;
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.seg_id_predicted = cu_ptr->seg_id_predicted;
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.ref_mv_idx = cu_ptr->drl_index;
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.motion_mode = cu_ptr->prediction_unit_array[0].motion_mode;
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.cfl_alpha_idx = cu_ptr->prediction_unit_array->cfl_alpha_idx;
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.cfl_alpha_signs = cu_ptr->prediction_unit_array->cfl_alpha_signs;
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.angle_delta[PLANE_TYPE_Y] = cu_ptr->prediction_unit_array[0].angle_delta[PLANE_TYPE_Y];
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.angle_delta[PLANE_TYPE_UV] = cu_ptr->prediction_unit_array[0].angle_delta[PLANE_TYPE_UV];
+#endif
         }
     }
 }
@@ -1621,6 +1632,17 @@ void update_mi_map(
 #endif
 #if PAL_SUP
             memcpy(&miPtr[miX + miY * mi_stride].mbmi.palette_mode_info, &cu_ptr->palette_info.pmi, sizeof(PaletteModeInfo));
+#endif
+#if RATE_ESTIMATION_UPDATE
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.skip_mode = (int8_t)cu_ptr->skip_flag;
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.segment_id = cu_ptr->segment_id;
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.seg_id_predicted = cu_ptr->seg_id_predicted;
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.ref_mv_idx = cu_ptr->drl_index;
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.motion_mode = cu_ptr->prediction_unit_array[0].motion_mode;
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.cfl_alpha_idx = cu_ptr->prediction_unit_array->cfl_alpha_idx;
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.cfl_alpha_signs = cu_ptr->prediction_unit_array->cfl_alpha_signs;
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.angle_delta[PLANE_TYPE_Y] = cu_ptr->prediction_unit_array[0].angle_delta[PLANE_TYPE_Y];
+            miPtr[miX + miY * mi_stride].mbmi.block_mi.angle_delta[PLANE_TYPE_UV] = cu_ptr->prediction_unit_array[0].angle_delta[PLANE_TYPE_UV];
 #endif
         }
     }

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -36,7 +36,7 @@ extern "C" {
 
 #define ENHANCED_M0_SETTINGS         1 // Updated M0 settings(optimized independent chroma search for all layers, conservative coeff - based NSQ cands reduction, shut coeff - based skip tx size search, warped for all layers, SUB - SAD as ME search method for non - SC only)
 #define MULTI_PASS_PD                1 // Multi-Pass Partitioning Depth (Multi-Pass PD) performs multiple PD stages for the same SB towards 1 final Partitioning Structure. As we go from PDn to PDn + 1, the prediction accuracy of the MD feature(s) increases while the number of block(s) decreases
-
+#define RATE_ESTIMATION_UPDATE       1 // Adding the rate estimation updates used in MD for missing syntax elements
 #define HBD_CLEAN_UP                 1
 
 #define HBD2_COMP                    1 // Inter-Inter compound mode HBD2

--- a/Source/Lib/Common/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Common/Codec/EbEntropyCoding.c
@@ -43,7 +43,15 @@ int32_t eb_av1_loop_restoration_corners_in_sb(Av1Common *cm, int32_t plane,
     int32_t mi_row, int32_t mi_col, BlockSize bsize,
     int32_t *rcol0, int32_t *rcol1, int32_t *rrow0,
     int32_t *rrow1, int32_t *tile_tl_idx);
-
+#if RATE_ESTIMATION_UPDATE
+int has_second_ref(const MbModeInfo *mbmi) {
+    return mbmi->block_mi.ref_frame[1] > INTRA_FRAME;
+}
+int has_uni_comp_refs(const MbModeInfo *mbmi) {
+    return has_second_ref(mbmi) && (!((mbmi->block_mi.ref_frame[0] >= BWDREF_FRAME) ^
+        (mbmi->block_mi.ref_frame[1] >= BWDREF_FRAME)));
+}
+#else
 static INLINE int has_second_ref(const MbModeInfo *mbmi) {
     return mbmi->block_mi.ref_frame[1] > INTRA_FRAME;
 }
@@ -52,6 +60,7 @@ static INLINE int has_uni_comp_refs(const MbModeInfo *mbmi) {
     return has_second_ref(mbmi) && (!((mbmi->block_mi.ref_frame[0] >= BWDREF_FRAME) ^
         (mbmi->block_mi.ref_frame[1] >= BWDREF_FRAME)));
 }
+#endif
 int32_t is_inter_block(const BlockModeInfo *mbmi);
 #if(CHAR_BIT!=8)
 #undef CHAR_BIT
@@ -1196,7 +1205,11 @@ static EbErrorType Av1EncodeCoeff1D(
 *********************************************************************/
 // Return the number of elements in the partition CDF when
 // partitioning the (square) block with luma block size of bsize.
+#if RATE_ESTIMATION_UPDATE
+int32_t partition_cdf_length(BlockSize bsize) {
+#else
 static INLINE int32_t partition_cdf_length(BlockSize bsize) {
+#endif
     if (bsize <= BLOCK_8X8)
         return PARTITION_TYPES;
     else if (bsize == BLOCK_128X128)
@@ -1688,7 +1701,6 @@ static void write_motion_mode(
 
     return;
 }
-
 //****************************************************************************************************//
 extern  int8_t av1_ref_frame_type(const MvReferenceFrame *const rf);
 uint16_t compound_mode_ctx_map[3][COMP_NEWMV_CTXS] = {
@@ -2341,10 +2353,12 @@ int32_t eb_av1_get_reference_mode_context(
     return ctx;
 }
 int av1_get_intra_inter_context(const MacroBlockD *xd);
-
 int av1_get_reference_mode_context_new(const MacroBlockD *xd);
-
+#if RATE_ESTIMATION_UPDATE
+AomCdfProb *av1_get_reference_mode_cdf(const MacroBlockD *xd) {
+#else
 static INLINE AomCdfProb *av1_get_reference_mode_cdf(const MacroBlockD *xd) {
+#endif
     return xd->tile_ctx->comp_inter_cdf[av1_get_reference_mode_context_new(xd)];
 }
 
@@ -2357,7 +2371,60 @@ int eb_av1_get_pred_context_uni_comp_ref_p(const MacroBlockD *xd);
 int eb_av1_get_pred_context_uni_comp_ref_p1(const MacroBlockD *xd);
 
 int eb_av1_get_pred_context_uni_comp_ref_p2(const MacroBlockD *xd);
+#if RATE_ESTIMATION_UPDATE
+AomCdfProb *av1_get_comp_reference_type_cdf(
+    const MacroBlockD *xd) {
+    const int pred_context = av1_get_comp_reference_type_context_new(xd);
+    return xd->tile_ctx->comp_ref_type_cdf[pred_context];
+}
 
+AomCdfProb *av1_get_pred_cdf_uni_comp_ref_p(
+    const MacroBlockD *xd) {
+    const int pred_context = eb_av1_get_pred_context_uni_comp_ref_p(xd);
+    return xd->tile_ctx->uni_comp_ref_cdf[pred_context][0];
+}
+
+AomCdfProb *av1_get_pred_cdf_uni_comp_ref_p1(
+    const MacroBlockD *xd) {
+    const int pred_context = eb_av1_get_pred_context_uni_comp_ref_p1(xd);
+    return xd->tile_ctx->uni_comp_ref_cdf[pred_context][1];
+}
+
+AomCdfProb *av1_get_pred_cdf_uni_comp_ref_p2(
+    const MacroBlockD *xd) {
+    const int pred_context = eb_av1_get_pred_context_uni_comp_ref_p2(xd);
+    return xd->tile_ctx->uni_comp_ref_cdf[pred_context][2];
+}
+
+AomCdfProb *av1_get_pred_cdf_comp_ref_p(const MacroBlockD *xd) {
+    const int pred_context = eb_av1_get_pred_context_comp_ref_p(xd);
+    return xd->tile_ctx->comp_ref_cdf[pred_context][0];
+}
+
+AomCdfProb *av1_get_pred_cdf_comp_ref_p1(
+    const MacroBlockD *xd) {
+    const int pred_context = eb_av1_get_pred_context_comp_ref_p1(xd);
+    return xd->tile_ctx->comp_ref_cdf[pred_context][1];
+}
+
+AomCdfProb *av1_get_pred_cdf_comp_ref_p2(
+    const MacroBlockD *xd) {
+    const int pred_context = eb_av1_get_pred_context_comp_ref_p2(xd);
+    return xd->tile_ctx->comp_ref_cdf[pred_context][2];
+}
+
+AomCdfProb *av1_get_pred_cdf_comp_bwdref_p(
+    const MacroBlockD *xd) {
+    const int pred_context = eb_av1_get_pred_context_comp_bwdref_p(xd);
+    return xd->tile_ctx->comp_bwdref_cdf[pred_context][0];
+}
+
+AomCdfProb *av1_get_pred_cdf_comp_bwdref_p1(
+    const MacroBlockD *xd) {
+    const int pred_context = eb_av1_get_pred_context_comp_bwdref_p1(xd);
+    return xd->tile_ctx->comp_bwdref_cdf[pred_context][1];
+}
+#else
 static INLINE AomCdfProb *av1_get_comp_reference_type_cdf(
     const MacroBlockD *xd) {
     const int pred_context = av1_get_comp_reference_type_context_new(xd);
@@ -2410,7 +2477,7 @@ static INLINE AomCdfProb *av1_get_pred_cdf_comp_bwdref_p1(
     const int pred_context = eb_av1_get_pred_context_comp_bwdref_p1(xd);
     return xd->tile_ctx->comp_bwdref_cdf[pred_context][1];
 }
-
+#endif
 int av1_get_comp_reference_type_context_new(const MacroBlockD *xd) {
     int pred_context;
     const MbModeInfo *const above_mbmi = xd->above_mbmi;
@@ -2947,6 +3014,38 @@ int32_t eb_av1_get_pred_context_single_ref_p1(const MacroBlockD *xd) {
     assert(pred_context >= 0 && pred_context < REF_CONTEXTS);
     return pred_context;
 }
+#if RATE_ESTIMATION_UPDATE
+AomCdfProb *av1_get_pred_cdf_single_ref_p1(
+    const MacroBlockD *xd) {
+    return xd->tile_ctx
+        ->single_ref_cdf[eb_av1_get_pred_context_single_ref_p1(xd)][0];
+}
+AomCdfProb *av1_get_pred_cdf_single_ref_p2(
+    const MacroBlockD *xd) {
+    return xd->tile_ctx
+        ->single_ref_cdf[eb_av1_get_pred_context_single_ref_p2(xd)][1];
+}
+AomCdfProb *av1_get_pred_cdf_single_ref_p3(
+    const MacroBlockD *xd) {
+    return xd->tile_ctx
+        ->single_ref_cdf[eb_av1_get_pred_context_single_ref_p3(xd)][2];
+}
+AomCdfProb *av1_get_pred_cdf_single_ref_p4(
+    const MacroBlockD *xd) {
+    return xd->tile_ctx
+        ->single_ref_cdf[eb_av1_get_pred_context_single_ref_p4(xd)][3];
+}
+AomCdfProb *av1_get_pred_cdf_single_ref_p5(
+    const MacroBlockD *xd) {
+    return xd->tile_ctx
+        ->single_ref_cdf[eb_av1_get_pred_context_single_ref_p5(xd)][4];
+}
+AomCdfProb *av1_get_pred_cdf_single_ref_p6(
+    const MacroBlockD *xd) {
+    return xd->tile_ctx
+        ->single_ref_cdf[eb_av1_get_pred_context_single_ref_p6(xd)][5];
+}
+#else
 static INLINE AomCdfProb *av1_get_pred_cdf_single_ref_p1(
     const MacroBlockD *xd) {
     return xd->tile_ctx
@@ -2977,7 +3076,7 @@ static INLINE AomCdfProb *av1_get_pred_cdf_single_ref_p6(
     return xd->tile_ctx
         ->single_ref_cdf[eb_av1_get_pred_context_single_ref_p6(xd)][5];
 }
-
+#endif
 // For the bit to signal whether the single reference is ALTREF_FRAME or
 // non-ALTREF backward reference frame, knowing that it shall be either of
 // these 2 choices.
@@ -6028,6 +6127,24 @@ void write_inter_segment_id(PictureControlSet *picture_control_set_ptr,
 }
 
 #if II_COMP_FLAG
+#if RATE_ESTIMATION_UPDATE
+int is_interintra_allowed_bsize(const BlockSize bsize) {
+    return (bsize >= BLOCK_8X8) && (bsize <= BLOCK_32X32);
+}
+
+int is_interintra_allowed_mode(const PredictionMode mode) {
+    return (mode >= SINGLE_INTER_MODE_START) && (mode < SINGLE_INTER_MODE_END);
+}
+
+int is_interintra_allowed_ref(const MvReferenceFrame rf[2]) {
+    return (rf[0] > INTRA_FRAME) && (rf[1] <= INTRA_FRAME);
+}
+int is_interintra_allowed(const MbModeInfo *mbmi) {
+    return is_interintra_allowed_bsize(mbmi->block_mi.sb_type) &&
+        is_interintra_allowed_mode(mbmi->block_mi.mode) &&
+        is_interintra_allowed_ref(mbmi->block_mi.ref_frame);
+}
+#else
 static INLINE int is_interintra_allowed_bsize(const BlockSize bsize) {
     return (bsize >= BLOCK_8X8) && (bsize <= BLOCK_32X32);
 }
@@ -6039,13 +6156,12 @@ static INLINE int is_interintra_allowed_mode(const PredictionMode mode) {
 static INLINE int is_interintra_allowed_ref(const MvReferenceFrame rf[2]) {
     return (rf[0] > INTRA_FRAME) && (rf[1] <= INTRA_FRAME);
 }
-
 static INLINE int is_interintra_allowed(const MbModeInfo *mbmi) {
   return is_interintra_allowed_bsize(mbmi->block_mi.sb_type) &&
          is_interintra_allowed_mode(mbmi->block_mi.mode) &&
          is_interintra_allowed_ref(mbmi->block_mi.ref_frame);
 }
-
+#endif
 int is_interintra_wedge_used(BlockSize sb_type);
 #endif
 
@@ -6754,7 +6870,7 @@ EB_EXTERN EbErrorType write_sb(
 
         cu_ptr = &tb_ptr->final_cu_arr[final_cu_index];
 
-        blk_geom = get_blk_geom_mds(cu_index); // AMIR to be replaced with /*cu_ptr->mds_idx*/
+        blk_geom = get_blk_geom_mds(cu_index);
 
         bsize = blk_geom->bsize;
         assert(bsize < BlockSizeS_ALL);

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -59,7 +59,6 @@ static EB_AV1_INTER_PREDICTION_FUNC_PTR   av1_inter_prediction_function_table[2]
 void av1_set_ref_frame(MvReferenceFrame *rf,
     int8_t ref_frame_type);
 
-
 static INLINE int is_interintra_allowed_bsize(const BlockSize bsize) {
     return (bsize >= BLOCK_8X8) && (bsize <= BLOCK_32X32);
 }
@@ -71,9 +70,6 @@ static INLINE int is_interintra_allowed_mode(const PredictionMode mode) {
 static INLINE int is_interintra_allowed_ref(const MvReferenceFrame rf[2]) {
     return (rf[0] > INTRA_FRAME) && (rf[1] <= INTRA_FRAME);
 }
-
-
-
 int svt_is_interintra_allowed(
     uint8_t enable_inter_intra,
     BlockSize sb_type,
@@ -156,7 +152,11 @@ void precompute_obmc_data(
 #endif
 //static uint32_t  AntiContouringIntraMode[11] = { EB_INTRA_PLANAR, EB_INTRA_DC, EB_INTRA_HORIZONTAL, EB_INTRA_VERTICAL,
 //EB_INTRA_MODE_2, EB_INTRA_MODE_6, EB_INTRA_MODE_14, EB_INTRA_MODE_18, EB_INTRA_MODE_22, EB_INTRA_MODE_30, EB_INTRA_MODE_34 };
+#if RATE_ESTIMATION_UPDATE
+int32_t have_newmv_in_inter_mode(PredictionMode mode) {
+#else
 static int32_t have_newmv_in_inter_mode(PredictionMode mode) {
+#endif
     return (mode == NEWMV || mode == NEW_NEWMV || mode == NEAREST_NEWMV ||
         mode == NEW_NEARESTMV || mode == NEAR_NEWMV || mode == NEW_NEARMV);
 }

--- a/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
@@ -2604,7 +2604,6 @@ EbErrorType signal_derivation_mode_decision_config_kernel_oq(
             picture_control_set_ptr->update_cdf = 0;
     else
         picture_control_set_ptr->update_cdf = (picture_control_set_ptr->parent_pcs_ptr->enc_mode <= ENC_M5) ? 1 : 0;
-
     if(picture_control_set_ptr->update_cdf)
         assert(sequence_control_set_ptr->cdf_mode == 0 && "use cdf_mode 0");
 #if FILTER_INTRA_FLAG
@@ -3138,26 +3137,30 @@ void* mode_decision_configuration_kernel(void *input_ptr)
                 entropyCodingQp,
                 picture_control_set_ptr->slice_type);
 
-        // Initial Rate Estimatimation of the syntax elements
+        // Initial Rate Estimation of the syntax elements
         av1_estimate_syntax_rate(
             md_rate_estimation_array,
             picture_control_set_ptr->slice_type == I_SLICE ? EB_TRUE : EB_FALSE,
             picture_control_set_ptr->coeff_est_entropy_coder_ptr->fc);
 #if !FIX_ENABLE_CDF_UPDATE
-        // Initial Rate Estimatimation of the syntax elements
+        // Initial Rate Estimation of the syntax elements
         if (!md_rate_estimation_array->initialized)
             av1_estimate_syntax_rate(
                 md_rate_estimation_array,
                 picture_control_set_ptr->slice_type == I_SLICE ? EB_TRUE : EB_FALSE,
                 picture_control_set_ptr->coeff_est_entropy_coder_ptr->fc);
 #endif
-        // Initial Rate Estimatimation of the Motion vectors
+        // Initial Rate Estimation of the Motion vectors
         av1_estimate_mv_rate(
             picture_control_set_ptr,
             md_rate_estimation_array,
+#if RATE_ESTIMATION_UPDATE
+            picture_control_set_ptr->coeff_est_entropy_coder_ptr->fc);
+#else
             &picture_control_set_ptr->coeff_est_entropy_coder_ptr->fc->nmvc);
+#endif
 
-        // Initial Rate Estimatimation of the quantized coefficients
+        // Initial Rate Estimation of the quantized coefficients
         av1_estimate_coefficients_rate(
             md_rate_estimation_array,
             picture_control_set_ptr->coeff_est_entropy_coder_ptr->fc);

--- a/Source/Lib/Common/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimation.c
@@ -12475,12 +12475,6 @@ EbErrorType CheckZeroZeroCenter(EbPictureBufferDesc *refPicPtr,
     hmeMvSad = hmeMvSad << subsampleSad;
 
     hmeMvdRate = 0;
-    // AMIR use AV1 rate estimation functions
-    // MeGetMvdFractionBits(
-    //    ABS(*x_search_center << 2),
-    //    ABS(*y_search_center << 2),
-    //    context_ptr->mvd_bits_array,
-    //    &hmeMvdRate);
 
     hmeMvCost = (hmeMvSad << COST_PRECISION) +
                 (((context_ptr->lambda * hmeMvdRate) + MD_OFFSET) >> MD_SHIFT);

--- a/Source/Lib/Common/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.c
@@ -142,6 +142,9 @@ void picture_control_set_dctor(EbPtr p)
     EB_DELETE(obj->ep_luma_dc_sign_level_coeff_neighbor_array);
     EB_DELETE(obj->ep_cb_dc_sign_level_coeff_neighbor_array);
     EB_DELETE(obj->ep_cr_dc_sign_level_coeff_neighbor_array);
+#if RATE_ESTIMATION_UPDATE
+    EB_DELETE(obj->ep_partition_context_neighbor_array);
+#endif
     EB_DELETE(obj->mode_type_neighbor_array);
     EB_DELETE(obj->partition_context_neighbor_array);
     EB_DELETE(obj->skip_flag_neighbor_array);
@@ -838,7 +841,18 @@ EbErrorType picture_control_set_ctor(
                 PU_NEIGHBOR_ARRAY_GRANULARITY,
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK,
             },
-
+#if RATE_ESTIMATION_UPDATE
+            // Encode pass partition neighbor array
+            {
+                &object_ptr->ep_partition_context_neighbor_array,
+                MAX_PICTURE_WIDTH_SIZE,
+                MAX_PICTURE_HEIGHT_SIZE,
+                sizeof(struct PartitionContext),
+                PU_NEIGHBOR_ARRAY_GRANULARITY,
+                PU_NEIGHBOR_ARRAY_GRANULARITY,
+                NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK,
+            },
+#endif
             // Entropy Coding Neighbor Arrays
             {
                 &object_ptr->mode_type_neighbor_array,

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -13853,6 +13853,9 @@ extern "C" {
         NeighborArrayUnit                  *ep_luma_dc_sign_level_coeff_neighbor_array;
         NeighborArrayUnit                  *ep_cr_dc_sign_level_coeff_neighbor_array;
         NeighborArrayUnit                  *ep_cb_dc_sign_level_coeff_neighbor_array;
+#if RATE_ESTIMATION_UPDATE
+        NeighborArrayUnit                  *ep_partition_context_neighbor_array;
+#endif
         // Entropy Coding Neighbor Arrays
         NeighborArrayUnit                  *mode_type_neighbor_array;
         NeighborArrayUnit                  *partition_context_neighbor_array;

--- a/Source/Lib/Common/Codec/EbUtility.c
+++ b/Source/Lib/Common/Codec/EbUtility.c
@@ -705,7 +705,7 @@ void md_scan_all_blks(uint32_t *idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
             blk_geom_mds[*idx_mds].bwidth_log2 = Log2f(blk_geom_mds[*idx_mds].bwidth);
             blk_geom_mds[*idx_mds].bheight_log2 = Log2f(blk_geom_mds[*idx_mds].bheight);
             blk_geom_mds[*idx_mds].bsize = hvsize_to_bsize[blk_geom_mds[*idx_mds].bwidth_log2 - 2][blk_geom_mds[*idx_mds].bheight_log2 - 2];
-            blk_geom_mds[*idx_mds].bwidth_uv = MAX(4, blk_geom_mds[*idx_mds].bwidth >> 1); // AMIR to clean to check for 4x4
+            blk_geom_mds[*idx_mds].bwidth_uv = MAX(4, blk_geom_mds[*idx_mds].bwidth >> 1);
             blk_geom_mds[*idx_mds].bheight_uv = MAX(4, blk_geom_mds[*idx_mds].bheight >> 1);
             blk_geom_mds[*idx_mds].has_uv = 1;
 


### PR DESCRIPTION
**Description:**
Adding the modes and MVs CDF updates. The CDFs are used to generate the rate/cost tables, which are used in mode decision. Initially for each SB, the CDF is equal to the weighted average of left CDF (3x) and top CDF (1x).

**Authors**
@anaghdin

**Type of change**
Enhancement

**Tests and performance**
Expected Average PSNR-SSIM BD-rate gain in the range of -0.7% (8 bit and 10 bit) over the fast objective list, using 5 QP values: {20, 32, 43, 55 and 63}.
Speed impact is negligible (<1%)
