### PR TITLE
Enhanced M0 Settings

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -33,6 +33,7 @@
 extern "C" {
 #endif
 
+#define ENHANCED_M0_SETTINGS         1 // Updated M0 settings(optimized independent chroma search for all layers, conservative coeff - based NSQ cands reduction, shut coeff - based skip tx size search, warped for all layers, SUB - SAD as ME search method for non - SC only)
 #define MULTI_PASS_PD                1 // Multi-Pass Partitioning Depth (Multi-Pass PD) performs multiple PD stages for the same SB towards 1 final Partitioning Structure. As we go from PDn to PDn + 1, the prediction accuracy of the MD feature(s) increases while the number of block(s) decreases
 
 #define HBD_CLEAN_UP                 1

--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1311,11 +1311,16 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
                 CHROMA_MODE_2 :
                 CHROMA_MODE_3;
     else
+#if ENHANCED_M0_SETTINGS
+        if (picture_control_set_ptr->enc_mode == ENC_M0)
+            context_ptr->chroma_level = CHROMA_MODE_0;
+#else
     if (MR_MODE)
         context_ptr->chroma_level = CHROMA_MODE_0;
     else
     if (picture_control_set_ptr->enc_mode == ENC_M0 && picture_control_set_ptr->temporal_layer_index == 0)
         context_ptr->chroma_level = CHROMA_MODE_0;
+#endif
     else
     if (picture_control_set_ptr->enc_mode <= ENC_M4)
         context_ptr->chroma_level = CHROMA_MODE_1;
@@ -1836,13 +1841,17 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 
 #if INTER_INTRA_CLASS_PRUNING
 
-    // TH_S (for single candidate removal per class)
-    // Remove candidate if deviation to the best is higher than TH_S
+    // md_stage_1_cand_prune_th (for single candidate removal per class)
+    // Remove candidate if deviation to the best is higher than md_stage_1_cand_prune_th
 #if MULTI_PASS_PD
     if (context_ptr->pd_pass == PD_PASS_0)
         context_ptr->md_stage_1_cand_prune_th = (uint64_t)~0;
     else if (context_ptr->pd_pass == PD_PASS_1)
+#if ENHANCED_M0_SETTINGS // lossless change - PD_PASS_2 and PD_PASS_1 should be completely decoupled: previous merge conflict
+        context_ptr->md_stage_1_cand_prune_th = 75;
+#else
         context_ptr->md_stage_1_cand_prune_th = sequence_control_set_ptr->static_config.md_stage_1_cand_prune_th;
+#endif
     else
 #endif
 #if M0_OPT
@@ -1865,13 +1874,17 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 
 #if INTER_INTRA_CLASS_PRUNING
 
-    // TH_C (for class removal)
+    // md_stage_1_class_prune_th (for class removal)
     // Remove class if deviation to the best higher than TH_C
 #if MULTI_PASS_PD
     if (context_ptr->pd_pass == PD_PASS_0)
         context_ptr->md_stage_1_class_prune_th = (uint64_t)~0;
     else if (context_ptr->pd_pass == PD_PASS_1)
+#if ENHANCED_M0_SETTINGS // lossless change - PD_PASS_2 and PD_PASS_1 should be completely decoupled: previous merge conflict
+        context_ptr->md_stage_1_class_prune_th = 100;
+#else
         context_ptr->md_stage_1_class_prune_th = sequence_control_set_ptr->static_config.md_stage_1_class_prune_th;
+#endif
     else
 #endif
 #if M0_OPT
@@ -1885,8 +1898,8 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     else
         context_ptr->md_stage_1_class_prune_th = (uint64_t)~0;
 
-    // TH_S (for single candidate removal per class)
-    // Remove candidate if deviation to the best is higher than TH_S
+    // md_stage_2_cand_prune_th (for single candidate removal per class)
+    // Remove candidate if deviation to the best is higher than md_stage_2_cand_prune_th
 #if MULTI_PASS_PD
     if (context_ptr->pd_pass == PD_PASS_0)
         context_ptr->md_stage_2_cand_prune_th = (uint64_t)~0;
@@ -1911,13 +1924,17 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     else
         context_ptr->md_stage_2_cand_prune_th = (uint64_t)~0;
 
-    // TH_C (for class removal)
-    // Remove class if deviation to the best is higher than TH_C
+    // md_stage_2_class_prune_th (for class removal)
+    // Remove class if deviation to the best is higher than md_stage_2_class_prune_th
 #if MULTI_PASS_PD
     if (context_ptr->pd_pass == PD_PASS_0)
         context_ptr->md_stage_2_class_prune_th = (uint64_t)~0;
     else if (context_ptr->pd_pass == PD_PASS_1)
+#if ENHANCED_M0_SETTINGS // lossless change - PD_PASS_2 and PD_PASS_1 should be completely decoupled: previous merge conflict
+        context_ptr->md_stage_2_class_prune_th = 25;
+#else
         context_ptr->md_stage_2_class_prune_th = sequence_control_set_ptr->static_config.md_stage_2_class_prune_th;
+#endif
     else
 #endif
 #if M0_OPT
@@ -1945,7 +1962,11 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     if (context_ptr->pd_pass == PD_PASS_0)
         context_ptr->sq_weight = (uint32_t)~0;
     else if (context_ptr->pd_pass == PD_PASS_1)
+#if ENHANCED_M0_SETTINGS // lossless change - PD_PASS_2 and PD_PASS_1 should be completely decoupled: previous merge conflict
+        context_ptr->sq_weight = 100;
+#else
         context_ptr->sq_weight = sequence_control_set_ptr->static_config.sq_weight;
+#endif
     else
 #endif
     if (MR_MODE)
@@ -1954,13 +1975,14 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         context_ptr->sq_weight = sequence_control_set_ptr->static_config.sq_weight;
 
 #endif
-
+#if !ENHANCED_M0_SETTINGS // lossless change - enable_auto_max_partition is properly derived using pd_pass @ the bottom: previous merge conflict
 #if AUTO_MAX_PARTITION
     // signal for enabling shortcut to skip search depths
     if (MR_MODE || picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->static_config.encoder_bit_depth > EB_8BIT)
         context_ptr->enable_auto_max_partition = 0;
     else
         context_ptr->enable_auto_max_partition = sequence_control_set_ptr->static_config.enable_auto_max_partition;
+#endif
 #endif
 #if MULTI_PASS_PD
     // Set pred ME full search area
@@ -1993,10 +2015,15 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         context_ptr->coeff_based_nsq_cand_reduction = EB_FALSE;
     else if (context_ptr->pd_pass == PD_PASS_1)
         context_ptr->coeff_based_nsq_cand_reduction = EB_FALSE;
+#if ENHANCED_M0_SETTINGS
+    else
+        context_ptr->coeff_based_nsq_cand_reduction = EB_TRUE;
+#else
     else if (MR_MODE)
         context_ptr->coeff_based_nsq_cand_reduction = EB_FALSE;
     else
         context_ptr->coeff_based_nsq_cand_reduction = EB_TRUE;
+#endif
 
     // Set rdoq_quantize_fp @ MD
     if (context_ptr->pd_pass == PD_PASS_0)

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -4326,6 +4326,9 @@ void  inject_inter_candidates(
     SsMeContext                  *ss_mecontext,
     const SequenceControlSet     *sequence_control_set_ptr,
     SuperBlock                   *sb_ptr,
+#if ENHANCED_M0_SETTINGS
+    EbBool                        coeff_based_nsq_cand_reduction,
+#endif
     uint32_t                       *candidateTotalCnt) {
 
     (void)sequence_control_set_ptr;
@@ -4347,6 +4350,7 @@ void  inject_inter_candidates(
 
     uint32_t close_loop_me_index = use_close_loop_me ? get_in_loop_me_info_index(MAX_SS_ME_PU_COUNT, sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128 ? 1 : 0, context_ptr->blk_geom) : 0;
     EbBool allow_bipred = (context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4) ? EB_FALSE : EB_TRUE;
+#if !ENHANCED_M0_SETTINGS
     uint8_t sq_index = LOG2F(context_ptr->blk_geom->sq_size) - 2;
     uint8_t inject_newmv_candidate = 1;
 #if MULTI_PASS_PD // Shut coef-based inter skip if 1st pass
@@ -4359,7 +4363,7 @@ void  inject_inter_candidates(
             inject_newmv_candidate = context_ptr->blk_geom->shape == PART_N ? 1 :
                 context_ptr->parent_sq_has_coeff[sq_index] != 0 ? inject_newmv_candidate : 0;
     }
-
+#endif
 #if FIX_COMPOUND
     BlockSize bsize = context_ptr->blk_geom->bsize;                       // bloc size
 #if MULTI_PASS_PD
@@ -4452,8 +4456,9 @@ void  inject_inter_candidates(
             }
         }
     }
-
+#if !ENHANCED_M0_SETTINGS
     if (inject_newmv_candidate) {
+#endif
 
         inject_new_candidates(
             sequence_control_set_ptr,
@@ -4517,8 +4522,9 @@ void  inject_inter_candidates(
                     &canTotalCnt);
             }
         }
+#if !ENHANCED_M0_SETTINGS
     }
-
+#endif
     if (context_ptr->global_mv_injection) {
 #if GLOBAL_WARPED_MOTION
 #if GM_OPT
@@ -4936,8 +4942,11 @@ void  inject_inter_candidates(
             use_close_loop_me,
             close_loop_me_index);
     }
-
+#if ENHANCED_M0_SETTINGS
+    if (!coeff_based_nsq_cand_reduction) {
+#else
     if (inject_newmv_candidate) {
+#endif
         if (isCompoundEnabled) {
             if (allow_bipred) {
 
@@ -5595,7 +5604,10 @@ void  inject_intra_candidates(
     ModeDecisionContext          *context_ptr,
     const SequenceControlSet     *sequence_control_set_ptr,
     SuperBlock                   *sb_ptr,
-    uint32_t                       *candidateTotalCnt){
+#if ENHANCED_M0_SETTINGS
+    EbBool                        dc_cand_only_flag,
+#endif
+    uint32_t                     *candidateTotalCnt){
     (void)sequence_control_set_ptr;
     (void)sb_ptr;
     FrameHeader *frm_hdr = &picture_control_set_ptr->parent_pcs_ptr->frm_hdr;
@@ -5605,7 +5617,11 @@ void  inject_intra_candidates(
     uint8_t                     intra_mode_start = DC_PRED;
 #if PAETH_HBD
 #if MULTI_PASS_PD
+#if ENHANCED_M0_SETTINGS
+    uint8_t                     intra_mode_end = dc_cand_only_flag ? DC_PRED : PAETH_PRED;
+#else
     uint8_t                     intra_mode_end = context_ptr->dc_cand_only_flag ? DC_PRED : PAETH_PRED;
+#endif
 #else
     uint8_t                     intra_mode_end   =  PAETH_PRED;
 #endif
@@ -6058,9 +6074,12 @@ EbErrorType generate_md_stage_0_cand(
     context_ptr->injected_mv_count_l1 = 0;
     context_ptr->injected_mv_count_bipred = 0;
     uint8_t sq_index = LOG2F(context_ptr->blk_geom->sq_size) - 2;
+#if ENHANCED_M0_SETTINGS
+    EbBool coeff_based_nsq_cand_reduction = EB_FALSE;
+#else
     uint8_t inject_intra_candidate = 1;
     uint8_t inject_inter_candidate = 1;
-
+#endif
     if (slice_type != I_SLICE) {
 #if MULTI_PASS_PD // Shut coef-based inter skip if 1st pass
         if (context_ptr->coeff_based_nsq_cand_reduction) {
@@ -6069,15 +6088,23 @@ EbErrorType generate_md_stage_0_cand(
             picture_control_set_ptr->parent_pcs_ptr->nsq_search_level < NSQ_SEARCH_FULL) {
 #endif
             if (context_ptr->md_local_cu_unit[context_ptr->blk_geom->sqi_mds].avail_blk_flag)
+#if ENHANCED_M0_SETTINGS
+                coeff_based_nsq_cand_reduction = context_ptr->blk_geom->shape == PART_N || context_ptr->parent_sq_has_coeff[sq_index] != 0 ? EB_FALSE : EB_TRUE;
+#else
                 inject_intra_candidate = context_ptr->blk_geom->shape == PART_N ? 1 :
                     context_ptr->parent_sq_has_coeff[sq_index] != 0 ? inject_intra_candidate : 0;
+#endif
         }
 }
     //----------------------
     // Intra
     if (context_ptr->blk_geom->sq_size < 128) {
 #if MULTI_PASS_PD
+#if ENHANCED_M0_SETTINGS
+        if (!context_ptr->dc_cand_only_flag && !coeff_based_nsq_cand_reduction && picture_control_set_ptr->parent_pcs_ptr->intra_pred_mode >= 5 && context_ptr->blk_geom->sq_size > 4 && context_ptr->blk_geom->shape == PART_N)
+#else
         if (!context_ptr->dc_cand_only_flag && picture_control_set_ptr->parent_pcs_ptr->intra_pred_mode >= 5 && context_ptr->blk_geom->sq_size > 4 && context_ptr->blk_geom->shape == PART_N)
+#endif
 #else
         if (picture_control_set_ptr->parent_pcs_ptr->intra_pred_mode >= 5 && context_ptr->blk_geom->sq_size > 4 && context_ptr->blk_geom->shape == PART_N)
 #endif
@@ -6087,16 +6114,24 @@ EbErrorType generate_md_stage_0_cand(
                 sb_ptr,
                 &canTotalCnt);
         else
+#if !ENHANCED_M0_SETTINGS
             if (inject_intra_candidate)
-            inject_intra_candidates(
-                picture_control_set_ptr,
-                context_ptr,
-                sequence_control_set_ptr,
-                sb_ptr,
+#endif
+                inject_intra_candidates(
+                    picture_control_set_ptr,
+                    context_ptr,
+                    sequence_control_set_ptr,
+                    sb_ptr,
+#if ENHANCED_M0_SETTINGS
+                    context_ptr->dc_cand_only_flag || coeff_based_nsq_cand_reduction,
+#endif
                 &canTotalCnt);
     }
 #if FILTER_INTRA_FLAG
 #if MULTI_PASS_PD
+#if ENHANCED_M0_SETTINGS
+    if (!coeff_based_nsq_cand_reduction)
+#endif
        if (context_ptr->md_filter_intra_mode > 0 && av1_filter_intra_allowed_bsize(sequence_control_set_ptr->seq_header.enable_filter_intra, context_ptr->blk_geom->bsize))
 #else
        if (picture_control_set_ptr->pic_filter_intra_mode > 0 && av1_filter_intra_allowed_bsize(sequence_control_set_ptr->seq_header.enable_filter_intra, context_ptr->blk_geom->bsize))
@@ -6135,13 +6170,18 @@ EbErrorType generate_md_stage_0_cand(
 #endif
 
     if (slice_type != I_SLICE) {
+#if !ENHANCED_M0_SETTINGS
         if (inject_inter_candidate)
+#endif
             inject_inter_candidates(
                 picture_control_set_ptr,
                 context_ptr,
                 ss_mecontext,
                 sequence_control_set_ptr,
                 sb_ptr,
+#if ENHANCED_M0_SETTINGS
+                coeff_based_nsq_cand_reduction,
+#endif
                 &canTotalCnt);
     }
 

--- a/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
@@ -2626,8 +2626,12 @@ EbErrorType signal_derivation_mode_decision_config_kernel_oq(
         enable_wm = EB_FALSE;
     else
 #if WARP_UPDATE
+#if ENHANCED_M0_SETTINGS
+        enable_wm = (picture_control_set_ptr->parent_pcs_ptr->enc_mode == ENC_M0 ||
+#else
         enable_wm = (MR_MODE ||
         (picture_control_set_ptr->parent_pcs_ptr->enc_mode == ENC_M0 && picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ||
+#endif
             (picture_control_set_ptr->parent_pcs_ptr->enc_mode <= ENC_M5 && picture_control_set_ptr->parent_pcs_ptr->temporal_layer_index == 0)) ? EB_TRUE : EB_FALSE;
 #else
         enable_wm = (picture_control_set_ptr->parent_pcs_ptr->enc_mode <= ENC_M5) || MR_MODE ? EB_TRUE : EB_FALSE;

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.c
@@ -554,8 +554,12 @@ void reset_mode_decision(
         enable_wm = EB_FALSE;
     else
 #if WARP_UPDATE
+#if ENHANCED_M0_SETTINGS
+        enable_wm = (picture_control_set_ptr->parent_pcs_ptr->enc_mode == ENC_M0 ||
+#else
         enable_wm = (MR_MODE ||
         (picture_control_set_ptr->parent_pcs_ptr->enc_mode == ENC_M0 && picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ||
+#endif
         (picture_control_set_ptr->parent_pcs_ptr->enc_mode <= ENC_M5 && picture_control_set_ptr->parent_pcs_ptr->temporal_layer_index == 0)) ? EB_TRUE : EB_FALSE;
 #else
         enable_wm = (picture_control_set_ptr->parent_pcs_ptr->enc_mode <= ENC_M5) || MR_MODE ? EB_TRUE : EB_FALSE;

--- a/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
@@ -235,7 +235,12 @@ EbErrorType signal_derivation_me_kernel_oq(
         else
             context_ptr->me_context_ptr->hme_search_method = SUB_SAD_SEARCH;
     else
+#if ENHANCED_M0_SETTINGS
+        context_ptr->me_context_ptr->hme_search_method = SUB_SAD_SEARCH;
+#else
         context_ptr->me_context_ptr->hme_search_method = FULL_SAD_SEARCH;
+#endif
+
     // ME Search Method
     if (picture_control_set_ptr->sc_content_detected)
         if (enc_mode <= ENC_M3)
@@ -243,9 +248,13 @@ EbErrorType signal_derivation_me_kernel_oq(
         else
             context_ptr->me_context_ptr->me_search_method = SUB_SAD_SEARCH;
     else
+#if ENHANCED_M0_SETTINGS
+        context_ptr->me_context_ptr->me_search_method = SUB_SAD_SEARCH;
+#else
         context_ptr->me_context_ptr->me_search_method = (enc_mode <= ENC_M1) ?
         FULL_SAD_SEARCH :
         SUB_SAD_SEARCH;
+#endif
 
     if (sequence_control_set_ptr->static_config.enable_global_motion == EB_TRUE)
     {

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -850,7 +850,6 @@ EbErrorType signal_derivation_multi_processes_oq(
             else
                 picture_control_set_ptr->pic_depth_mode = PIC_SB_SWITCH_DEPTH_MODE;
 
-
         if (picture_control_set_ptr->pic_depth_mode < PIC_SQ_DEPTH_MODE)
             assert(sequence_control_set_ptr->nsq_present == 1 && "use nsq_present 1");
 
@@ -1345,7 +1344,11 @@ EbErrorType signal_derivation_multi_processes_oq(
         // 1                                     ON
 
 #if SPEED_OPT
+#if ENHANCED_M0_SETTINGS
+        if (picture_control_set_ptr->enc_mode == ENC_M0 || picture_control_set_ptr->sc_content_detected)
+#else
         if (MR_MODE || picture_control_set_ptr->sc_content_detected)
+#endif
 #else
         if (MR_MODE || picture_control_set_ptr->enc_mode == ENC_M0 || picture_control_set_ptr->sc_content_detected)
 #endif


### PR DESCRIPTION
## Description

Updated M0 settings:

- Optimized independent chroma search for all layers.
- Conservative coeff-based NSQ cands reduction.
- Shut coeff-based skip tx size search, 
- Warped for all layers.
- SUB-SAD as ME search method for non-SC only.

solves #884
## Author(s)

@PhoenixWorthVCD 
@hguermaz 


## Type of change

Enhancement

## Tests and performance
8BIT data generated for full-list objective-1-fast dataset in context of enc-mode 0. Speed data is generated on the full-list objective-1-fast dataset in context of enc-mode 0 for 5QP in term of cycles on AWS ec2 48 vCPU instances.

| Cycle Increase | BD-Rate Gain|
| -- | --
| 5.5% | 0.20%|

10BIT and jctvc 240p, 480p and 720p clips in context of enc-mode 0. Speed data is generated on the same list for 5QP in term of cycles on AWS ec2 48 vCPU instances.


| Cycle Increase | BD-Rate Gain|
| -- | --
| 8.5% | 0.24%|

Evaluation performed in context of QPS/QPM OFF.
