### PR TITLE
Update auto max partitioning to be performed only for M1 and higher

### DIFF
--- a/Source/Lib/Common/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Common/Codec/EbEncDecProcess.c
@@ -1957,7 +1957,8 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 
 #if AUTO_MAX_PARTITION
     // signal for enabling shortcut to skip search depths
-    if (MR_MODE || picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->static_config.encoder_bit_depth > EB_8BIT)
+    if (picture_control_set_ptr->enc_mode == ENC_M0 ||
+        picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->static_config.encoder_bit_depth > EB_8BIT)
         context_ptr->enable_auto_max_partition = 0;
     else
         context_ptr->enable_auto_max_partition = sequence_control_set_ptr->static_config.enable_auto_max_partition;


### PR DESCRIPTION
As auto max partitioning is a inference based feature using a neural network, it may not provide ideal predictions all the time and thus might impact quality. We are going to move this feature away from M0 to preserve stream quality and have this feature's shortcuts benefit higher enc-modes