### PR TITLE
Travis: run coveralls for unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -203,17 +203,12 @@ matrix:
         - &coveralls_script |
           pip3 install --user cpp-coveralls
           export PATH=/Users/travis/Library/Python/3.7/bin:${PATH}
-          SvtAv1EncApp -enc-mode 8 -i akiyo_cif.y4m -n 150 -b test1.ivf
-          git clone https://github.com/FFmpeg/FFmpeg ffmpeg --depth=1 --branch release/4.2 && cd ffmpeg &&
-          git apply $TRAVIS_BUILD_DIR/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch &&
-          ffmpegconfig=(--disable-everything --enable-{libsvtav1,encoder={libaom_av1,libsvt_av1,rawvideo},decoder={h264,rawvideo,yuv4,libaom_av1},muxer={fifo,matroska,ivf,mp4,rawvideo,webm,yuv4mpegpipe},demuxer={h264,ivf,matroska,mpegts,rawvideo,yuv4mpegpipe},parser={av1,h264,mpeg4video},bsf={av1_metadata,h264_metadata},protocol={data,file,pipe,unix},filter={fifo,fps,libvmaf,psnr,ssim,vmafmotion}})
-          sudo chown -R travis: $HOME/.ccache
-          export CFLAGS=""
-          if ! ./configure ${ffmpegconfig[@]}; then cat ffbuild/config.log; fi &&
-          make -s -j$(if [ $TRAVIS_OS_NAME = osx ]; then sysctl -n hw.ncpu; else nproc; fi) >/dev/null &&
-          sudo make install && cd $TRAVIS_BUILD_DIR &&
-          ffmpeg -i akiyo_cif.y4m -vframes 150 -c:v libsvt_av1 test.mp4 &&
-          ffmpeg -i bus_cif.y4m -nostdin -f rawvideo -pix_fmt yuv420p - | SvtAv1EncApp -i stdin -w 352 -h 288 -fps 30 -n 150 -b test2.ivf
+          cd $TRAVIS_BUILD_DIR/Build/linux/${build_type:-Release}
+          make TestVectors
+          cd $TRAVIS_BUILD_DIR
+          SvtAv1UnitTests
+          SvtAv1ApiTests
+          SvtAv1E2ETests
       after_script: &after_coveralls_script |
         if [ $CC = "clang" ] && [ $TRAVIS_OS_NAME = linux ]; then
           GCOV_FILE=llvm-cov GCOV_OPTIONS='gcov -pl'

--- a/.travis.yml
+++ b/.travis.yml
@@ -202,7 +202,7 @@ matrix:
     # Unittests on Linux and macOS
     - name: Unit Tests Linux+gcc
       stage: unittest
-      env: build_type=debug CMAKE_EFLAGS="-DBUILD_TESTING=ON -DCOVERAGE=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/ COVERALLS_PARALLEL=true 
+      env: build_type=debug CMAKE_EFLAGS="-DBUILD_TESTING=ON -DCOVERAGE=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/ COVERALLS_PARALLEL=true
       script:
         - *base_script
         - &unittests |
@@ -224,7 +224,7 @@ matrix:
     - name: Unit Tests osx+clang
       os: osx
       compiler: clang
-      env: build_type=debug CMAKE_EFLAGS="-DBUILD_TESTING=ON -DCOVERAGE=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/ COVERALLS_PARALLEL=true 
+      env: build_type=debug CMAKE_EFLAGS="-DBUILD_TESTING=ON -DCOVERAGE=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/ COVERALLS_PARALLEL=true
       script:
         - *base_script
         - *unittests

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,8 +90,6 @@ matrix:
   allow_failures:
     - name: Binary Identical?
     - name: Valgrind
-    - name: Coveralls Linux+gcc
-    - name: Coveralls osx+clang
     - name: Unit Tests Linux+gcc
     - name: Unit Tests osx+clang
     # Exclude these because if the encoder can run with a release build, the commit is probably fine. Also required for fast_finish.
@@ -204,7 +202,7 @@ matrix:
     # Unittests on Linux and macOS
     - name: Unit Tests Linux+gcc
       stage: unittest
-      env: CMAKE_EFLAGS="-DBUILD_TESTING=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/ COVERALLS_PARALLEL=true build_type=debug CMAKE_EFLAGS="-DCOVERAGE=ON"
+      env: build_type=debug CMAKE_EFLAGS="-DBUILD_TESTING=ON -DCOVERAGE=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/ COVERALLS_PARALLEL=true 
       script:
         - *base_script
         - &unittests |
@@ -222,11 +220,11 @@ matrix:
         else
           GCOV_FILE=gcov GCOV_OPTIONS='\-lp'
         fi
-        coveralls --root $TRAVIS_BUILD_DIR -i Source -E ".*gtest.*" -E ".*CMakeFiles.*" -E ".*third_party.*" -E ".*test/FilmGrainTest.cc" --gcov $GCOV_FILE --gcov-options "$GCOV_OPTIONS"
+        coveralls --root $TRAVIS_BUILD_DIR -i Source -E ".*gtest.*" -E ".*CMakeFiles.*" -E ".*third_party.*"  -E ".*ffmpeg.*" --gcov $GCOV_FILE --gcov-options "$GCOV_OPTIONS"
     - name: Unit Tests osx+clang
       os: osx
       compiler: clang
-      env: CMAKE_EFLAGS="-DBUILD_TESTING=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/ COVERALLS_PARALLEL=true build_type=debug CMAKE_EFLAGS="-DCOVERAGE=ON"
+      env: build_type=debug CMAKE_EFLAGS="-DBUILD_TESTING=ON -DCOVERAGE=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/ COVERALLS_PARALLEL=true 
       script:
         - *base_script
         - *unittests

--- a/.travis.yml
+++ b/.travis.yml
@@ -194,13 +194,20 @@ matrix:
         - diff test-pr-m8.ivf test-master-m8.ivf
         - diff test-pr-m0.ivf test-master-m0.ivf
 
-    # Coveralls on Linux and macOS
-    - name: Coveralls Linux+gcc
-      stage: coveralls+valgrind
-      env: COVERALLS_PARALLEL=true build_type=debug CMAKE_EFLAGS="-DCOVERAGE=ON"
+    # Valgrind on Linux and macOS
+    - name: Valgrind
+      env: build_type=debug
       script:
         - *base_script
-        - &coveralls_script |
+        - travis_wait 60 valgrind -- SvtAv1EncApp -enc-mode 4 -i akiyo_cif.y4m -n 20 -b test1.ivf
+
+    # Unittests on Linux and macOS
+    - name: Unit Tests Linux+gcc
+      stage: unittest
+      env: CMAKE_EFLAGS="-DBUILD_TESTING=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/ COVERALLS_PARALLEL=true build_type=debug CMAKE_EFLAGS="-DCOVERAGE=ON"
+      script:
+        - *base_script
+        - &unittests |
           pip3 install --user cpp-coveralls
           export PATH=/Users/travis/Library/Python/3.7/bin:${PATH}
           cd $TRAVIS_BUILD_DIR/Build/linux/${build_type:-Release}
@@ -215,40 +222,12 @@ matrix:
         else
           GCOV_FILE=gcov GCOV_OPTIONS='\-lp'
         fi
-        coveralls --root $TRAVIS_BUILD_DIR -i Source -E ".*gtest.*" -E ".*CMakeFiles.*" -E ".*third_party.*" -E ".*test/FilmGrainTest.cc" -E ".*ffmpeg.*" --gcov $GCOV_FILE --gcov-options "$GCOV_OPTIONS"
-    - name: Coveralls osx+clang
-      os: osx
-      compiler: clang
-      env: COVERALLS_PARALLEL=true build_type=debug CMAKE_EFLAGS="-DCOVERAGE=ON"
-      script:
-        - *base_script
-        - *coveralls_script
-      after_script: *after_coveralls_script
-
-    # Valgrind on Linux and macOS
-    - name: Valgrind
-      env: build_type=debug
-      script:
-        - *base_script
-        - travis_wait 60 valgrind -- SvtAv1EncApp -enc-mode 4 -i akiyo_cif.y4m -n 20 -b test1.ivf
-
-    # Unittests on Linux and macOS
-    - name: Unit Tests Linux+gcc
-      stage: unittest
-      env: build_type=release CMAKE_EFLAGS="-DBUILD_TESTING=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/
-      script:
-        - *base_script
-        - &unittests |
-          cd $TRAVIS_BUILD_DIR/Build/linux/${build_type:-Release}
-          make TestVectors
-          cd $TRAVIS_BUILD_DIR
-          SvtAv1UnitTests
-          SvtAv1ApiTests
-          SvtAv1E2ETests
+        coveralls --root $TRAVIS_BUILD_DIR -i Source -E ".*gtest.*" -E ".*CMakeFiles.*" -E ".*third_party.*" -E ".*test/FilmGrainTest.cc" --gcov $GCOV_FILE --gcov-options "$GCOV_OPTIONS"
     - name: Unit Tests osx+clang
       os: osx
       compiler: clang
-      env: build_type=release CMAKE_EFLAGS="-DBUILD_TESTING=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/
+      env: CMAKE_EFLAGS="-DBUILD_TESTING=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/ COVERALLS_PARALLEL=true build_type=debug CMAKE_EFLAGS="-DCOVERAGE=ON"
       script:
         - *base_script
         - *unittests
+      after_script: *after_coveralls_script


### PR DESCRIPTION
Looks like coveralls isn't being run for unit tests. We want to see the code coverage for the unit tests, not the code coverage for a run of `SvtAv1EncApp`.