### PR TITLE
Reduce malloc times to make eb_init_encoder faster

### DIFF
--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -160,6 +160,25 @@ int32_t main(int32_t argc, char* argv[])
 
                     return_errors[instanceCount] = init_encoder(configs[instanceCount], appCallbacks[instanceCount], instanceCount);
                     return_error = (EbErrorType)(return_error | return_errors[instanceCount]);
+                    
+                    uint64_t    finishsTime = 0;
+                    uint64_t    finishuTime = 0;
+                    double      duration;
+                    FinishTime((uint64_t*)&finishsTime, (uint64_t*)&finishuTime);
+
+                    // total execution time, inc init time
+                    ComputeOverallElapsedTime(
+                        configs[instanceCount]->performance_context.lib_start_time[0],
+                        configs[instanceCount]->performance_context.lib_start_time[1],
+                        finishsTime,
+                        finishuTime,
+                        &duration);
+                    // printf("%d, %d\n%d, %d\n",
+                    //     configs[instanceCount]->performance_context.lib_start_time[0],
+                    //     configs[instanceCount]->performance_context.lib_start_time[1],
+                    //     finishsTime,
+                    //     finishuTime);
+                    printf("Encoder init time: %.4f\n", duration);
                 }
                 else
                     channelActive[instanceCount] = EB_FALSE;

--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -160,7 +160,7 @@ int32_t main(int32_t argc, char* argv[])
 
                     return_errors[instanceCount] = init_encoder(configs[instanceCount], appCallbacks[instanceCount], instanceCount);
                     return_error = (EbErrorType)(return_error | return_errors[instanceCount]);
-                    
+#ifndef NDEBUG
                     uint64_t    finishsTime = 0;
                     uint64_t    finishuTime = 0;
                     double      duration;
@@ -173,12 +173,8 @@ int32_t main(int32_t argc, char* argv[])
                         finishsTime,
                         finishuTime,
                         &duration);
-                    // printf("%d, %d\n%d, %d\n",
-                    //     configs[instanceCount]->performance_context.lib_start_time[0],
-                    //     configs[instanceCount]->performance_context.lib_start_time[1],
-                    //     finishsTime,
-                    //     finishuTime);
                     printf("Encoder init time: %.4f\n", duration);
+#endif
                 }
                 else
                     channelActive[instanceCount] = EB_FALSE;

--- a/Source/Lib/Common/Codec/EbCodingUnit.c
+++ b/Source/Lib/Common/Codec/EbCodingUnit.c
@@ -15,9 +15,7 @@ void largest_coding_unit_dctor(EbPtr p)
 {
     LargestCodingUnit* obj = (LargestCodingUnit*)p;
     EB_DELETE(obj->quantized_coeff);
-    EB_FREE_ARRAY(obj->av1xd);
     EB_FREE_ARRAY(obj->final_cu_arr);
-    EB_FREE_ARRAY(obj->cu_partition_array);
 }
 /*
 Tasks & Questions
@@ -56,9 +54,11 @@ EbErrorType largest_coding_unit_ctor(
     uint32_t cu_i;
     uint32_t  tot_cu_num = sb_size_pix == 128 ? 1024 : 256;
     larget_coding_unit_ptr->final_cu_count = tot_cu_num;
+    uint32_t  max_block_count = sb_size_pix == 128 ? BLOCK_MAX_COUNT_SB_128 : BLOCK_MAX_COUNT_SB_64;
 
-    EB_MALLOC_ARRAY(larget_coding_unit_ptr->final_cu_arr, tot_cu_num);
-    EB_MALLOC_ARRAY(larget_coding_unit_ptr->av1xd, tot_cu_num);
+    EB_MALLOC_ARRAY_BLOCK(larget_coding_unit_ptr->final_cu_arr, (sizeof(CodingUnit) + sizeof(MacroBlockD)) * tot_cu_num + sizeof(PartitionType) * max_block_count);
+    larget_coding_unit_ptr->av1xd = (void *)(larget_coding_unit_ptr->final_cu_arr + tot_cu_num);
+    larget_coding_unit_ptr->cu_partition_array = (void *)(larget_coding_unit_ptr->av1xd + tot_cu_num);
 
     for (cu_i = 0; cu_i < tot_cu_num; ++cu_i) {
         for (tu_index = 0; tu_index < TRANSFORM_UNIT_MAX_COUNT; ++tu_index)
@@ -66,10 +66,6 @@ EbErrorType largest_coding_unit_ctor(
         larget_coding_unit_ptr->final_cu_arr[cu_i].leaf_index = cu_i;
         larget_coding_unit_ptr->final_cu_arr[cu_i].av1xd = larget_coding_unit_ptr->av1xd + cu_i;
     }
-
-    uint32_t  max_block_count = sb_size_pix == 128 ? BLOCK_MAX_COUNT_SB_128 : BLOCK_MAX_COUNT_SB_64;
-
-    EB_MALLOC_ARRAY(larget_coding_unit_ptr->cu_partition_array, max_block_count);
 
     coeffInitData.buffer_enable_mask = PICTURE_BUFFER_DESC_FULL_MASK;
     coeffInitData.max_width = SB_STRIDE_Y;

--- a/Source/Lib/Common/Codec/EbInitialRateControlReorderQueue.c
+++ b/Source/Lib/Common/Codec/EbInitialRateControlReorderQueue.c
@@ -20,7 +20,6 @@ static void hl_rate_control_histogram_entry_dctor(EbPtr p)
 {
     HlRateControlHistogramEntry* obj = (HlRateControlHistogramEntry*)p;
     EB_FREE_ARRAY(obj->me_distortion_histogram);
-    EB_FREE_ARRAY(obj->ois_distortion_histogram);
 }
 
 EbErrorType hl_rate_control_histogram_entry_ctor(
@@ -31,9 +30,8 @@ EbErrorType hl_rate_control_histogram_entry_ctor(
     entry_ptr->picture_number = picture_number;
 
     // ME and OIS Distortion Histograms
-    EB_MALLOC_ARRAY(entry_ptr->me_distortion_histogram, NUMBER_OF_SAD_INTERVALS);
-
-    EB_MALLOC_ARRAY(entry_ptr->ois_distortion_histogram, NUMBER_OF_INTRA_SAD_INTERVALS);
+    EB_MALLOC_ARRAY_BLOCK(entry_ptr->me_distortion_histogram, sizeof(uint16_t) * (NUMBER_OF_SAD_INTERVALS + NUMBER_OF_INTRA_SAD_INTERVALS));
+    entry_ptr->ois_distortion_histogram =  entry_ptr->me_distortion_histogram + NUMBER_OF_SAD_INTERVALS;
 
     return EB_ErrorNone;
 }

--- a/Source/Lib/Common/Codec/EbMalloc.c
+++ b/Source/Lib/Common/Codec/EbMalloc.c
@@ -305,7 +305,7 @@ static int compare_time(const void* a,const void* b)
 
 static void print_top_10_locations() {
     EbHandle m = get_malloc_mutex();
-    EbPtrType type = EB_N_PTR;
+    EbPtrType type = EB_C_PTR;//EB_N_PTR;
     eb_block_on_mutex(m);
     g_profile_entry = (MemoryEntry*)calloc(MEM_ENTRY_SIZE, sizeof(MemoryEntry));
     if (!g_profile_entry) {

--- a/Source/Lib/Common/Codec/EbMalloc.c
+++ b/Source/Lib/Common/Codec/EbMalloc.c
@@ -305,7 +305,7 @@ static int compare_time(const void* a,const void* b)
 
 static void print_top_10_locations() {
     EbHandle m = get_malloc_mutex();
-    EbPtrType type = EB_C_PTR;//EB_N_PTR;
+    EbPtrType type = EB_N_PTR;
     eb_block_on_mutex(m);
     g_profile_entry = (MemoryEntry*)calloc(MEM_ENTRY_SIZE, sizeof(MemoryEntry));
     if (!g_profile_entry) {
@@ -318,7 +318,7 @@ static void print_top_10_locations() {
     qsort(g_profile_entry, MEM_ENTRY_SIZE, sizeof(MemoryEntry), compare_count);
 
     printf("top 10 %s size locations:\r\n", mem_type_name(type));
-    for (int i = 0; i < 15; i++) {
+    for (int i = 0; i < 10; i++) {
         double usage;
         char scale;
         MemoryEntry* e = g_profile_entry + i;
@@ -327,8 +327,9 @@ static void print_top_10_locations() {
     }
 
     qsort(g_profile_entry, MEM_ENTRY_SIZE, sizeof(MemoryEntry), compare_time);
+    printf("-------------------------------------------\n");
     printf("top 10 %s time locations:\r\n", mem_type_name(type));
-    for (int i = 0; i < 15; i++) {
+    for (int i = 0; i < 10; i++) {
         MemoryEntry* e = g_profile_entry + i;
         printf("(%d times): %s:%d\r\n", e->time, e->file, e->line);
     }

--- a/Source/Lib/Common/Codec/EbMalloc.h
+++ b/Source/Lib/Common/Codec/EbMalloc.h
@@ -93,6 +93,11 @@ void eb_remove_mem_entry(void* ptr, EbPtrType type);
         EB_MALLOC(pa, (count)*size); \
     } while (0)
 
+#define EB_MALLOC_ARRAY_BLOCK(pa, size) \
+    do {\
+        EB_MALLOC(pa, size); \
+    } while (0)
+
 #define EB_CALLOC_ARRAY(pa, count) \
     do {\
         size_t size = sizeof(*(pa)); \

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -658,6 +658,7 @@ void ChooseBestAv1MvPred(
 static void mode_decision_candidate_buffer_dctor(EbPtr p)
 {
     ModeDecisionCandidateBuffer *obj = (ModeDecisionCandidateBuffer*)p;
+    EB_FREE_ALIGNED_ARRAY(obj->eb_buffer_ptr);
     EB_DELETE(obj->prediction_ptr);
     EB_DELETE(obj->prediction_ptr_temp);
     EB_DELETE(obj->cfl_temp_prediction_ptr);
@@ -670,6 +671,7 @@ static void mode_decision_candidate_buffer_dctor(EbPtr p)
 static void mode_decision_scratch_candidate_buffer_dctor(EbPtr p)
 {
     ModeDecisionCandidateBuffer *obj = (ModeDecisionCandidateBuffer*)p;
+    EB_FREE_ALIGNED_ARRAY(obj->eb_buffer_ptr);
     EB_DELETE(obj->prediction_ptr);
     EB_DELETE(obj->prediction_ptr_temp);
     EB_DELETE(obj->cfl_temp_prediction_ptr);
@@ -735,40 +737,63 @@ EbErrorType mode_decision_candidate_buffer_ctor(
     buffer_ptr->candidate_ptr = (ModeDecisionCandidate*)EB_NULL;
 
     // Video Buffers
+    uint32_t buffer_size = (MAX_SB_SIZE * MAX_SB_SIZE) + (MAX_SB_SIZE * MAX_SB_SIZE) / 2;
+    EB_CALLOC_ALIGNED_ARRAY(buffer_ptr->eb_buffer_ptr, buffer_size * (4 + 2 + 8));
+    uint32_t eb_buffer_offset = 0;
     EB_NEW(
         buffer_ptr->prediction_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&pictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&pictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size;
 
     EB_NEW(
         buffer_ptr->prediction_ptr_temp,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&pictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&pictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size;
 
     EB_NEW(
         buffer_ptr->cfl_temp_prediction_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&pictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&pictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size;
 
     EB_NEW(
         buffer_ptr->residual_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&doubleWidthPictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&doubleWidthPictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size * 2;
 
     EB_NEW(
         buffer_ptr->residual_quant_coeff_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size * 3;
 
     EB_NEW(
         buffer_ptr->recon_coeff_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size * 3;
 
     EB_NEW(
         buffer_ptr->recon_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&pictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&pictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
 
     //Distortion
     buffer_ptr->residual_luma_sad = 0;
@@ -832,40 +857,64 @@ EbErrorType mode_decision_scratch_candidate_buffer_ctor(
     buffer_ptr->candidate_ptr = (ModeDecisionCandidate*)EB_NULL;
 
     // Video Buffers
+    uint32_t buffer_size = (MAX_SB_SIZE * MAX_SB_SIZE) + (MAX_SB_SIZE * MAX_SB_SIZE) / 2;
+    EB_CALLOC_ALIGNED_ARRAY(buffer_ptr->eb_buffer_ptr, buffer_size * (4 + 2 + 8));
+    uint32_t eb_buffer_offset = 0;
     EB_NEW(
         buffer_ptr->prediction_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&pictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&pictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size;
 
     EB_NEW(
         buffer_ptr->prediction_ptr_temp,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&pictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&pictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size;
 
     EB_NEW(
         buffer_ptr->cfl_temp_prediction_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&pictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&pictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size;
 
     EB_NEW(
         buffer_ptr->residual_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&doubleWidthPictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&doubleWidthPictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size * 2;
 
     EB_NEW(
         buffer_ptr->residual_quant_coeff_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size * 3;
 
     EB_NEW(
         buffer_ptr->recon_coeff_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size * 3;
 
     EB_NEW(
         buffer_ptr->recon_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&pictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&pictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+
     return EB_ErrorNone;
 }
 #endif

--- a/Source/Lib/Common/Codec/EbModeDecision.h
+++ b/Source/Lib/Common/Codec/EbModeDecision.h
@@ -233,6 +233,8 @@ extern "C" {
         // Candidate Ptr
         ModeDecisionCandidate                *candidate_ptr;
 
+        // for memory free only
+        EbByte                               eb_buffer_ptr;
         // Video Buffers
         EbPictureBufferDesc                  *prediction_ptr;
         EbPictureBufferDesc                  *prediction_ptr_temp;

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.c
@@ -13,15 +13,24 @@ static void mode_decision_context_dctor(EbPtr p)
 {
     ModeDecisionContext* obj = (ModeDecisionContext*)p;
 #if PAL_SUP
-    for (int cd = 0; cd < MAX_PAL_CAND; cd++)
-        if (obj->palette_cand_array[cd].color_idx_map)
-            EB_FREE_ARRAY(obj->palette_cand_array[cd].color_idx_map);
-    for (uint32_t candidateIndex = 0; candidateIndex < MODE_DECISION_CANDIDATE_MAX_COUNT; ++candidateIndex)
-        if (obj->fast_candidate_ptr_array[candidateIndex]->palette_info.color_idx_map)
-            EB_FREE_ARRAY(obj->fast_candidate_ptr_array[candidateIndex]->palette_info.color_idx_map);
-    for (uint32_t codedLeafIndex = 0; codedLeafIndex < BLOCK_MAX_COUNT_SB_128; ++codedLeafIndex)
-        if (obj->md_cu_arr_nsq[codedLeafIndex].palette_info.color_idx_map)
-            EB_FREE_ARRAY(obj->md_cu_arr_nsq[codedLeafIndex].palette_info.color_idx_map);
+    if (obj->fast_color_idx_map) {
+        EB_FREE_ARRAY(obj->fast_color_idx_map);
+    }
+    if (obj->pal_color_idx_map) {
+        EB_FREE_ARRAY(obj->pal_color_idx_map);
+    }
+    if (obj->md_color_idx_map) {
+        EB_FREE_ARRAY(obj->md_color_idx_map);
+    }
+    // for (int cd = 0; cd < MAX_PAL_CAND; cd++)
+    //     if (obj->palette_cand_array[cd].color_idx_map)
+    //         EB_FREE_ARRAY(obj->palette_cand_array[cd].color_idx_map);
+    // for (uint32_t candidateIndex = 0; candidateIndex < MODE_DECISION_CANDIDATE_MAX_COUNT; ++candidateIndex)
+    //     if (obj->fast_candidate_ptr_array[candidateIndex]->palette_info.color_idx_map)
+    //         EB_FREE_ARRAY(obj->fast_candidate_ptr_array[candidateIndex]->palette_info.color_idx_map);
+    // for (uint32_t codedLeafIndex = 0; codedLeafIndex < BLOCK_MAX_COUNT_SB_128; ++codedLeafIndex)
+    //     if (obj->md_cu_arr_nsq[codedLeafIndex].palette_info.color_idx_map)
+    //         EB_FREE_ARRAY(obj->md_cu_arr_nsq[codedLeafIndex].palette_info.color_idx_map);
 #endif
     EB_FREE_ARRAY(obj->ref_best_ref_sq_table);
     EB_FREE_ARRAY(obj->ref_best_cost_sq_table);
@@ -149,22 +158,29 @@ EbErrorType mode_decision_context_ctor(
     EB_MALLOC_ARRAY(context_ptr->fast_candidate_array, MODE_DECISION_CANDIDATE_MAX_COUNT);
 
     EB_MALLOC_ARRAY(context_ptr->fast_candidate_ptr_array, MODE_DECISION_CANDIDATE_MAX_COUNT);
-
+#if PAL_SUP
+    if (cfg_palette) {
+        EB_MALLOC_ARRAY(context_ptr->fast_color_idx_map, MAX_PALETTE_SQUARE * MODE_DECISION_CANDIDATE_MAX_COUNT);
+    }
+#endif
     for (candidateIndex = 0; candidateIndex < MODE_DECISION_CANDIDATE_MAX_COUNT; ++candidateIndex) {
         context_ptr->fast_candidate_ptr_array[candidateIndex] = &context_ptr->fast_candidate_array[candidateIndex];
         context_ptr->fast_candidate_ptr_array[candidateIndex]->md_rate_estimation_ptr = context_ptr->md_rate_estimation_ptr;
 #if PAL_SUP
         if (cfg_palette)
-            EB_MALLOC_ARRAY(context_ptr->fast_candidate_ptr_array[candidateIndex]->palette_info.color_idx_map, MAX_PALETTE_SQUARE);
+            context_ptr->fast_candidate_ptr_array[candidateIndex]->palette_info.color_idx_map = context_ptr->fast_color_idx_map + candidateIndex * MAX_PALETTE_SQUARE;
         else
             context_ptr->fast_candidate_ptr_array[candidateIndex]->palette_info.color_idx_map = NULL;
 #endif
     }
 
 #if PAL_SUP
+    if (cfg_palette) {
+        EB_MALLOC_ARRAY(context_ptr->pal_color_idx_map, MAX_PALETTE_SQUARE * MAX_PAL_CAND);
+    }
     for (int cd = 0; cd < MAX_PAL_CAND; cd++)
         if (cfg_palette)
-            EB_MALLOC_ARRAY(context_ptr->palette_cand_array[cd].color_idx_map, MAX_PALETTE_SQUARE);
+            context_ptr->palette_cand_array[cd].color_idx_map = context_ptr->pal_color_idx_map + cd * MAX_PALETTE_SQUARE;
         else
             context_ptr->palette_cand_array[cd].color_idx_map = NULL;
 #endif
@@ -223,6 +239,11 @@ EbErrorType mode_decision_context_ctor(
         EB_MALLOC_ARRAY(context_ptr->md_cu_arr_nsq[0].neigh_left_recon[0], BLOCK_MAX_COUNT_SB_128 * 128 * 3);
         EB_MALLOC_ARRAY(context_ptr->md_cu_arr_nsq[0].neigh_top_recon[0], BLOCK_MAX_COUNT_SB_128 * 128 * 3);
     }
+#if PAL_SUP
+    if (cfg_palette) {
+        EB_MALLOC_ARRAY(context_ptr->md_color_idx_map, MAX_PALETTE_SQUARE * BLOCK_MAX_COUNT_SB_128);
+    }
+#endif
     uint32_t codedLeafIndex, tu_index;
     for (codedLeafIndex = 0; codedLeafIndex < BLOCK_MAX_COUNT_SB_128; ++codedLeafIndex) {
         for (tu_index = 0; tu_index < TRANSFORM_UNIT_MAX_COUNT; ++tu_index)
@@ -251,7 +272,7 @@ EbErrorType mode_decision_context_ctor(
         }
 #if PAL_SUP
         if (cfg_palette)
-            EB_MALLOC_ARRAY(context_ptr->md_cu_arr_nsq[codedLeafIndex].palette_info.color_idx_map, MAX_PALETTE_SQUARE);
+            context_ptr->md_cu_arr_nsq[codedLeafIndex].palette_info.color_idx_map = context_ptr->md_color_idx_map + codedLeafIndex * MAX_PALETTE_SQUARE;
         else
             context_ptr->md_cu_arr_nsq[codedLeafIndex].palette_info.color_idx_map = NULL;
 #endif

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -157,6 +157,10 @@ extern "C" {
 #if PAL_SUP
         PALETTE_BUFFER            palette_buffer;
         PaletteInfo              palette_cand_array[MAX_PAL_CAND];
+        //for memory free only
+        uint8_t                       *fast_color_idx_map;
+        uint8_t                       *pal_color_idx_map;
+        uint8_t                       *md_color_idx_map;        
 #endif
         // Entropy Coder
         EntropyCoder                 *coeff_est_entropy_coder_ptr;

--- a/Source/Lib/Common/Codec/EbMotionEstimationLcuResults.h
+++ b/Source/Lib/Common/Codec/EbMotionEstimationLcuResults.h
@@ -45,7 +45,6 @@ extern "C" {
         uint32_t          lcu_distortion;
         uint8_t          *total_me_candidate_index;
         MeCandidate     **me_candidate;
-        MeCandidate      *me_candidate_array;
         uint8_t          *me_nsq_0; // 2 Number of reference lists
         uint8_t          *me_nsq_1; // 2 Number of reference lists
 

--- a/Source/Lib/Common/Codec/EbPictureBufferDesc.h
+++ b/Source/Lib/Common/Codec/EbPictureBufferDesc.h
@@ -310,6 +310,12 @@ extern "C" {
         EbPictureBufferDesc *object_ptr,
         EbPtr  object_init_data_ptr);
 
+    extern EbErrorType eb_picture_buffer_desc_block_ctor(
+        EbPictureBufferDesc *object_ptr,
+        EbPtr  object_init_data_ptr,
+        EbByte eb_buffer_ptr,
+        uint32_t eb_buffer_offset);
+
     extern EbErrorType eb_recon_picture_buffer_desc_ctor(
         EbPictureBufferDesc *object_ptr,
         EbPtr  object_init_data_ptr);

--- a/Source/Lib/Common/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.c
@@ -68,15 +68,6 @@ static void me_sb_results_dctor(EbPtr p)
     MeLcuResults* obj = (MeLcuResults*)p;
 
     EB_FREE_ARRAY(obj->me_candidate);
-    if (obj->me_mv_array) {
-        EB_FREE_ARRAY(obj->me_mv_array[0]);
-    }
-    EB_FREE_ARRAY(obj->me_mv_array);
-    EB_FREE_ARRAY(obj->me_candidate_array);
-    EB_FREE_ARRAY(obj->total_me_candidate_index);
-
-    EB_FREE_ARRAY(obj->me_nsq_0);
-    EB_FREE_ARRAY(obj->me_nsq_1);
 }
 
 EbErrorType me_sb_results_ctor(
@@ -90,17 +81,18 @@ EbErrorType me_sb_results_ctor(
     objectPtr->dctor = me_sb_results_dctor;
     objectPtr->max_number_of_pus_per_lcu = maxNumberOfPusPerLcu;
 
-    EB_MALLOC_ARRAY(objectPtr->me_candidate, maxNumberOfPusPerLcu);
-    EB_MALLOC_ARRAY(objectPtr->me_mv_array, maxNumberOfPusPerLcu);
-#if ALIGN_MEM
-    objectPtr->meCandidateArray = (MeCandidate_t*)EB_aligned_malloc(sizeof(MeCandidate_t) * maxNumberOfPusPerLcu * maxNumberOfMeCandidatesPerPU, 64);
-#else
-    EB_MALLOC_ARRAY(objectPtr->me_candidate_array, maxNumberOfPusPerLcu * maxNumberOfMeCandidatesPerPU);
-#endif
-    EB_MALLOC_ARRAY(objectPtr->me_mv_array[0], maxNumberOfPusPerLcu * count);
-
+    EB_MALLOC_ARRAY_BLOCK(objectPtr->me_candidate, maxNumberOfPusPerLcu *
+            (sizeof(MeCandidate*) + sizeof(MvCandidate*) + sizeof(uint8_t) * 3 +
+             (sizeof(MeCandidate) + sizeof(MvCandidate)) * maxNumberOfMeCandidatesPerPU));
+    objectPtr->me_candidate[0] = (void *)(objectPtr->me_candidate + maxNumberOfPusPerLcu);
+    objectPtr->me_mv_array = (void *)(objectPtr->me_candidate[0] + maxNumberOfPusPerLcu * maxNumberOfMeCandidatesPerPU);
+    objectPtr->me_mv_array[0] = (void *)(objectPtr->me_mv_array + maxNumberOfPusPerLcu);
+    objectPtr->total_me_candidate_index = (void *)(objectPtr->me_mv_array[0] + maxNumberOfPusPerLcu * maxNumberOfMeCandidatesPerPU);
+    objectPtr->me_nsq_0 = (void *)(objectPtr->total_me_candidate_index + maxNumberOfPusPerLcu);
+    objectPtr->me_nsq_1 = (void *)(objectPtr->me_nsq_0 + maxNumberOfPusPerLcu);
     for (puIndex = 0; puIndex < maxNumberOfPusPerLcu; ++puIndex) {
-        objectPtr->me_candidate[puIndex] = &objectPtr->me_candidate_array[puIndex * maxNumberOfMeCandidatesPerPU];
+        objectPtr->me_candidate[puIndex] = objectPtr->me_candidate[0] + puIndex * maxNumberOfMeCandidatesPerPU;
+        objectPtr->me_mv_array[puIndex] = objectPtr->me_mv_array[0] + puIndex * count;
 
         objectPtr->me_candidate[puIndex][0].ref_idx_l0 = 0;
         objectPtr->me_candidate[puIndex][0].ref_idx_l1 = 0;
@@ -112,13 +104,7 @@ EbErrorType me_sb_results_ctor(
         objectPtr->me_candidate[puIndex][0].direction = 0;
         objectPtr->me_candidate[puIndex][1].direction = 1;
         objectPtr->me_candidate[puIndex][2].direction = 2;
-        objectPtr->me_mv_array[puIndex] = objectPtr->me_mv_array[0] + puIndex * count;
     }
-    EB_MALLOC_ARRAY(objectPtr->total_me_candidate_index, maxNumberOfPusPerLcu);
-
-    EB_MALLOC_ARRAY(objectPtr->me_nsq_0, maxNumberOfPusPerLcu);
-    EB_MALLOC_ARRAY(objectPtr->me_nsq_1, maxNumberOfPusPerLcu);
-
     //objectPtr->lcuDistortion = 0;
     return EB_ErrorNone;
 }
@@ -1091,7 +1077,7 @@ static void picture_parent_control_set_dctor(EbPtr p)
 
     EB_DELETE(obj->denoise_and_model);
 
-    EB_DELETE_PTR_ARRAY(obj->me_results, obj->sb_total_count);
+    EB_DELETE_PTR_BLOCK_ARRAY(obj->me_results, obj->sb_total_count);
     if (obj->is_chroma_downsampled_picture_ptr_owner)
         EB_DELETE(obj->chroma_downsampled_picture_ptr);
 
@@ -1243,14 +1229,13 @@ EbErrorType picture_parent_control_set_ctor(
 
     EB_ALLOC_PTR_ARRAY(object_ptr->me_results, object_ptr->sb_total_count);
 
-    for (sb_index = 0; sb_index < object_ptr->sb_total_count; ++sb_index) {
-        EB_NEW(
-            object_ptr->me_results[sb_index],
-            me_sb_results_ctor,
-            (initDataPtr->nsq_present) ? MAX_ME_PU_COUNT : SQUARE_PU_COUNT,
-            initDataPtr->mrp_mode,
-            object_ptr->max_number_of_candidates_per_block);
-    }
+    EB_NEW_BLOCK_ARRAY(
+        object_ptr->me_results,
+        me_sb_results_ctor,
+        object_ptr->sb_total_count,
+        (initDataPtr->nsq_present) ? MAX_ME_PU_COUNT : SQUARE_PU_COUNT,
+        initDataPtr->mrp_mode,
+        object_ptr->max_number_of_candidates_per_block);
 
     EB_MALLOC_ARRAY(object_ptr->rc_me_distortion, object_ptr->sb_total_count);
     // ME and OIS Distortion Histograms

--- a/Source/Lib/Common/Codec/EbPictureDecisionQueue.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionQueue.c
@@ -10,15 +10,14 @@ static void pa_reference_queue_entry_dctor(EbPtr p)
 {
     PaReferenceQueueEntry* obj = (PaReferenceQueueEntry*)p;
     EB_FREE(obj->list0.list);
-    EB_FREE(obj->list1.list);
 }
 
 EbErrorType pa_reference_queue_entry_ctor(
     PaReferenceQueueEntry   *entryPtr)
 {
     entryPtr->dctor = pa_reference_queue_entry_dctor;
-    EB_MALLOC(entryPtr->list0.list, sizeof(int32_t) * (1 << MAX_TEMPORAL_LAYERS));
-    EB_MALLOC(entryPtr->list1.list, sizeof(int32_t) * (1 << MAX_TEMPORAL_LAYERS));
+    EB_MALLOC_ARRAY_BLOCK(entryPtr->list0.list, 2 * sizeof(int32_t) * (1 << MAX_TEMPORAL_LAYERS));
+    entryPtr->list1.list =  entryPtr->list0.list + (1 << MAX_TEMPORAL_LAYERS);
 
     return EB_ErrorNone;
 }

--- a/Source/Lib/Common/Codec/EbPictureManagerQueue.c
+++ b/Source/Lib/Common/Codec/EbPictureManagerQueue.c
@@ -17,7 +17,6 @@ void reference_queue_entry_dctor(EbPtr p)
 {
     ReferenceQueueEntry* obj = (ReferenceQueueEntry*)p;
     EB_FREE(obj->list0.list);
-    EB_FREE(obj->list1.list);
 }
 
 EbErrorType reference_queue_entry_ctor(
@@ -29,9 +28,8 @@ EbErrorType reference_queue_entry_ctor(
     entryPtr->dependent_count = 0;
     entryPtr->reference_available = EB_FALSE;
 
-    EB_MALLOC(entryPtr->list0.list, sizeof(int32_t) * (1 << MAX_TEMPORAL_LAYERS));
-
-    EB_MALLOC(entryPtr->list1.list, sizeof(int32_t) * (1 << MAX_TEMPORAL_LAYERS));
+    EB_MALLOC_ARRAY_BLOCK(entryPtr->list0.list, 2 * sizeof(int32_t) * (1 << MAX_TEMPORAL_LAYERS));
+    entryPtr->list1.list =  entryPtr->list0.list + sizeof(int32_t) * (1 << MAX_TEMPORAL_LAYERS);
 
     return EB_ErrorNone;
 }

--- a/Source/Lib/Common/Codec/EbSystemResourceManager.c
+++ b/Source/Lib/Common/Codec/EbSystemResourceManager.c
@@ -184,7 +184,7 @@ static EbErrorType EbCircularBufferPushFront(
 void EbMuxingQueueDctor(EbPtr p)
 {
     EbMuxingQueue* obj = (EbMuxingQueue*)p;
-    EB_DELETE_PTR_ARRAY(obj->process_fifo_ptr_array, obj->process_total_count);
+    EB_DELETE_PTR_BLOCK_ARRAY(obj->process_fifo_ptr_array, obj->process_total_count);
     EB_DELETE(obj->object_queue);
     EB_DELETE(obj->process_queue);
     EB_DESTROY_MUTEX(obj->lockout_mutex);
@@ -199,7 +199,6 @@ static EbErrorType EbMuxingQueueCtor(
     uint32_t              process_total_count,
     EbFifo         ***processFifoPtrArrayPtr)
 {
-    uint32_t processIndex;
     EbErrorType     return_error = EB_ErrorNone;
 
     queue_ptr->dctor = EbMuxingQueueDctor;
@@ -221,16 +220,15 @@ static EbErrorType EbMuxingQueueCtor(
     // Construct the Process Fifos
     EB_ALLOC_PTR_ARRAY(queue_ptr->process_fifo_ptr_array, queue_ptr->process_total_count);
 
-    for (processIndex = 0; processIndex < queue_ptr->process_total_count; ++processIndex) {
-        EB_NEW(
-            queue_ptr->process_fifo_ptr_array[processIndex],
-            EbFifoCtor,
-            0,
-            object_total_count,
-            (EbObjectWrapper *)EB_NULL,
-            (EbObjectWrapper *)EB_NULL,
-            queue_ptr);
-    }
+    EB_NEW_BLOCK_ARRAY(
+        queue_ptr->process_fifo_ptr_array,
+        EbFifoCtor,
+        queue_ptr->process_total_count,
+        0,
+        object_total_count,
+        (EbObjectWrapper *)EB_NULL,
+        (EbObjectWrapper *)EB_NULL,
+        queue_ptr);
 
     *processFifoPtrArrayPtr = queue_ptr->process_fifo_ptr_array;
 
@@ -443,7 +441,7 @@ static void eb_system_resource_dctor(EbPtr p)
     EbSystemResource* obj = (EbSystemResource*)p;
     EB_DELETE(obj->full_queue);
     EB_DELETE(obj->empty_queue);
-    EB_DELETE_PTR_ARRAY(obj->wrapper_ptr_pool, obj->object_total_count);
+    EB_DELETE_PTR_BLOCK_ARRAY(obj->wrapper_ptr_pool, obj->object_total_count);
 }
 
 /*********************************************************************
@@ -498,10 +496,14 @@ EbErrorType eb_system_resource_ctor(
     EB_ALLOC_PTR_ARRAY(resource_ptr->wrapper_ptr_pool, resource_ptr->object_total_count);
 
     // Initialize each wrapper
-    for (wrapperIndex = 0; wrapperIndex < resource_ptr->object_total_count; ++wrapperIndex) {
-        EB_NEW(resource_ptr->wrapper_ptr_pool[wrapperIndex], eb_object_wrapper_ctor, resource_ptr,
-            object_creator, object_init_data_ptr, object_destroyer);
-    }
+    EB_NEW_BLOCK_ARRAY(
+        resource_ptr->wrapper_ptr_pool,
+        eb_object_wrapper_ctor,
+        resource_ptr->object_total_count,
+        resource_ptr,
+        object_creator,
+        object_init_data_ptr,
+        object_destroyer);
 
     // Initialize the Empty Queue
     EB_NEW(


### PR DESCRIPTION
There are too many malloc times when initiate SvtAv1EncApp. It makes initiation too slow on server and this can be relieved by reduce malloc times in block way.

Tested by:
```
SvtAv1EncApp -enc-mode 8 -w 1920 -h 1080 -fps 60 irefresh-type 2  -i 1920x1080.yuv 
-q 32 -b output.bin -bit-depth 8 -stat-report  -n 300 
```
Here are some result comparation:

|        | build_type | init_time | malloc_times |
| ------ | ---------- | --------- | ------------ |
| after  | Debug      | 6.4660s   | 331625       |
|        | Release    | 5.6350s   | 331625       |
| before | Debug      | 7.9340s   | 1964126      |
|        | Release    | 6.6300s   | 1964126      |

```
-------------------------------------------                      
SVT-AV1 Encoder                                                  
SVT [version]:  SVT-AV1 Encoder Lib v0.7.5                       
SVT [build]  :  GCC 7.4.0        64 bit                          
LIB Build date: Dec 13 2019 16:09:22                             
-------------------------------------------                      
Number of logical cores available: 112                           
Number of PPCS 159                                               
-------------------------------------------                      
SVT [config]: Main Profile      Tier (auto)     Level (auto)     
SVT [config]: EncoderMode                                       : 8                                                               
SVT [config]: EncoderBitDepth / EncoderColorFormat / CompressedTenBitFormat      : 8 / 1 / 0                                      
SVT [config]: SourceWidth / SourceHeight                        : 1920 / 1080                                                     
SVT [config]: FrameRate / Gop Size                              : 60 / 64                                                         
SVT [config]: HierarchicalLevels / BaseLayerSwitchMode / PredStructure           : 4 / 0 / 2                                      
SVT [config]: BRC Mode / QP  / LookaheadDistance / SceneChange  : CQP / 32 / 33 / 0            
SVT Memory Usage:                                                
    total allocated memory:       35.18 GB 1964126 times         
        malloced memory:          24.15 GB 1346516 times         
        callocated memory:        1.39 GB 266584 times           
        allocated aligned memory: 9.64 GB 351026 times           
    mutex count: 2865                                            
    semaphore count: 2008                                        
    thread count: 536                                            
    hash table fulless: 0.469574, hash bucket is too full
-----------------------------------------------------------
After optimization:
SVT Memory Usage:                                                
    total allocated memory:       35.39 GB 331625 times          
        malloced memory:          24.31 GB 125424 times          
        callocated memory:        1.39 GB 178961 times           
        allocated aligned memory: 9.69 GB 27240 times            
    mutex count: 2865                                            
    semaphore count: 2008                                        
    thread count: 536                                            
    hash table fulless: 0.080355, hash bucket is healthy
```