### PR TITLE
Reduced malloc times to make eb_init_encoder faster

### DIFF
--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -160,6 +160,25 @@ int32_t main(int32_t argc, char* argv[])
 
                     return_errors[instanceCount] = init_encoder(configs[instanceCount], appCallbacks[instanceCount], instanceCount);
                     return_error = (EbErrorType)(return_error | return_errors[instanceCount]);
+                    
+                    uint64_t    finishsTime = 0;
+                    uint64_t    finishuTime = 0;
+                    double      duration;
+                    FinishTime((uint64_t*)&finishsTime, (uint64_t*)&finishuTime);
+
+                    // total execution time, inc init time
+                    ComputeOverallElapsedTime(
+                        configs[instanceCount]->performance_context.lib_start_time[0],
+                        configs[instanceCount]->performance_context.lib_start_time[1],
+                        finishsTime,
+                        finishuTime,
+                        &duration);
+                    // printf("%d, %d\n%d, %d\n",
+                    //     configs[instanceCount]->performance_context.lib_start_time[0],
+                    //     configs[instanceCount]->performance_context.lib_start_time[1],
+                    //     finishsTime,
+                    //     finishuTime);
+                    printf("Encoder init time: %.4f\n", duration);
                 }
                 else
                     channelActive[instanceCount] = EB_FALSE;

--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -160,7 +160,7 @@ int32_t main(int32_t argc, char* argv[])
 
                     return_errors[instanceCount] = init_encoder(configs[instanceCount], appCallbacks[instanceCount], instanceCount);
                     return_error = (EbErrorType)(return_error | return_errors[instanceCount]);
-                    
+#ifndef NDEBUG
                     uint64_t    finishsTime = 0;
                     uint64_t    finishuTime = 0;
                     double      duration;
@@ -173,12 +173,8 @@ int32_t main(int32_t argc, char* argv[])
                         finishsTime,
                         finishuTime,
                         &duration);
-                    // printf("%d, %d\n%d, %d\n",
-                    //     configs[instanceCount]->performance_context.lib_start_time[0],
-                    //     configs[instanceCount]->performance_context.lib_start_time[1],
-                    //     finishsTime,
-                    //     finishuTime);
                     printf("Encoder init time: %.4f\n", duration);
+#endif
                 }
                 else
                     channelActive[instanceCount] = EB_FALSE;

--- a/Source/Lib/Common/Codec/EbCodingUnit.c
+++ b/Source/Lib/Common/Codec/EbCodingUnit.c
@@ -13,9 +13,7 @@ void largest_coding_unit_dctor(EbPtr p)
 {
     SuperBlock* obj = (SuperBlock*)p;
     EB_DELETE(obj->quantized_coeff);
-    EB_FREE_ARRAY(obj->av1xd);
     EB_FREE_ARRAY(obj->final_cu_arr);
-    EB_FREE_ARRAY(obj->cu_partition_array);
 }
 /*
 Tasks & Questions
@@ -54,9 +52,11 @@ EbErrorType largest_coding_unit_ctor(
     uint32_t cu_i;
     uint32_t  tot_cu_num = sb_size_pix == 128 ? 1024 : 256;
     larget_coding_unit_ptr->final_cu_count = tot_cu_num;
+    uint32_t  max_block_count = sb_size_pix == 128 ? BLOCK_MAX_COUNT_SB_128 : BLOCK_MAX_COUNT_SB_64;
 
-    EB_MALLOC_ARRAY(larget_coding_unit_ptr->final_cu_arr, tot_cu_num);
-    EB_MALLOC_ARRAY(larget_coding_unit_ptr->av1xd, tot_cu_num);
+    EB_MALLOC(larget_coding_unit_ptr->final_cu_arr, (sizeof(CodingUnit) + sizeof(MacroBlockD)) * tot_cu_num + sizeof(PartitionType) * max_block_count);
+    larget_coding_unit_ptr->av1xd = (void *)(larget_coding_unit_ptr->final_cu_arr + tot_cu_num);
+    larget_coding_unit_ptr->cu_partition_array = (void *)(larget_coding_unit_ptr->av1xd + tot_cu_num);
 
     for (cu_i = 0; cu_i < tot_cu_num; ++cu_i) {
         for (tu_index = 0; tu_index < TRANSFORM_UNIT_MAX_COUNT; ++tu_index)
@@ -64,10 +64,6 @@ EbErrorType largest_coding_unit_ctor(
         larget_coding_unit_ptr->final_cu_arr[cu_i].leaf_index = cu_i;
         larget_coding_unit_ptr->final_cu_arr[cu_i].av1xd = larget_coding_unit_ptr->av1xd + cu_i;
     }
-
-    uint32_t  max_block_count = sb_size_pix == 128 ? BLOCK_MAX_COUNT_SB_128 : BLOCK_MAX_COUNT_SB_64;
-
-    EB_MALLOC_ARRAY(larget_coding_unit_ptr->cu_partition_array, max_block_count);
 
     coeffInitData.buffer_enable_mask = PICTURE_BUFFER_DESC_FULL_MASK;
     coeffInitData.max_width = SB_STRIDE_Y;

--- a/Source/Lib/Common/Codec/EbInitialRateControlReorderQueue.c
+++ b/Source/Lib/Common/Codec/EbInitialRateControlReorderQueue.c
@@ -20,7 +20,6 @@ static void hl_rate_control_histogram_entry_dctor(EbPtr p)
 {
     HlRateControlHistogramEntry* obj = (HlRateControlHistogramEntry*)p;
     EB_FREE_ARRAY(obj->me_distortion_histogram);
-    EB_FREE_ARRAY(obj->ois_distortion_histogram);
 }
 
 EbErrorType hl_rate_control_histogram_entry_ctor(
@@ -31,9 +30,8 @@ EbErrorType hl_rate_control_histogram_entry_ctor(
     entry_ptr->picture_number = picture_number;
 
     // ME and OIS Distortion Histograms
-    EB_MALLOC_ARRAY(entry_ptr->me_distortion_histogram, NUMBER_OF_SAD_INTERVALS);
-
-    EB_MALLOC_ARRAY(entry_ptr->ois_distortion_histogram, NUMBER_OF_INTRA_SAD_INTERVALS);
+    EB_MALLOC(entry_ptr->me_distortion_histogram, sizeof(uint16_t) * (NUMBER_OF_SAD_INTERVALS + NUMBER_OF_INTRA_SAD_INTERVALS));
+    entry_ptr->ois_distortion_histogram =  entry_ptr->me_distortion_histogram + NUMBER_OF_SAD_INTERVALS;
 
     return EB_ErrorNone;
 }

--- a/Source/Lib/Common/Codec/EbMalloc.c
+++ b/Source/Lib/Common/Codec/EbMalloc.c
@@ -318,7 +318,7 @@ static void print_top_10_locations() {
     qsort(g_profile_entry, MEM_ENTRY_SIZE, sizeof(MemoryEntry), compare_count);
 
     printf("top 10 %s size locations:\r\n", mem_type_name(type));
-    for (int i = 0; i < 15; i++) {
+    for (int i = 0; i < 10; i++) {
         double usage;
         char scale;
         MemoryEntry* e = g_profile_entry + i;
@@ -327,8 +327,9 @@ static void print_top_10_locations() {
     }
 
     qsort(g_profile_entry, MEM_ENTRY_SIZE, sizeof(MemoryEntry), compare_time);
+    printf("-------------------------------------------\n");
     printf("top 10 %s time locations:\r\n", mem_type_name(type));
-    for (int i = 0; i < 15; i++) {
+    for (int i = 0; i < 10; i++) {
         MemoryEntry* e = g_profile_entry + i;
         printf("(%d times): %s:%d\r\n", e->time, e->file, e->line);
     }

--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -697,6 +697,7 @@ void ChooseBestAv1MvPred(
 static void mode_decision_candidate_buffer_dctor(EbPtr p)
 {
     ModeDecisionCandidateBuffer *obj = (ModeDecisionCandidateBuffer*)p;
+    EB_FREE_ALIGNED_ARRAY(obj->eb_buffer_ptr);
     EB_DELETE(obj->prediction_ptr);
     EB_DELETE(obj->prediction_ptr_temp);
     EB_DELETE(obj->cfl_temp_prediction_ptr);
@@ -709,6 +710,7 @@ static void mode_decision_candidate_buffer_dctor(EbPtr p)
 static void mode_decision_scratch_candidate_buffer_dctor(EbPtr p)
 {
     ModeDecisionCandidateBuffer *obj = (ModeDecisionCandidateBuffer*)p;
+    EB_FREE_ALIGNED_ARRAY(obj->eb_buffer_ptr);
     EB_DELETE(obj->prediction_ptr);
     EB_DELETE(obj->prediction_ptr_temp);
     EB_DELETE(obj->cfl_temp_prediction_ptr);
@@ -774,40 +776,63 @@ EbErrorType mode_decision_candidate_buffer_ctor(
     buffer_ptr->candidate_ptr = (ModeDecisionCandidate*)EB_NULL;
 
     // Video Buffers
+    uint32_t buffer_size = (MAX_SB_SIZE * MAX_SB_SIZE) + (MAX_SB_SIZE * MAX_SB_SIZE) / 2;
+    EB_CALLOC_ALIGNED_ARRAY(buffer_ptr->eb_buffer_ptr, buffer_size * (4 + 2 + 8));
+    uint32_t eb_buffer_offset = 0;
     EB_NEW(
         buffer_ptr->prediction_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&pictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&pictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size;
 
     EB_NEW(
         buffer_ptr->prediction_ptr_temp,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&pictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&pictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size;
 
     EB_NEW(
         buffer_ptr->cfl_temp_prediction_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&pictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&pictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size;
 
     EB_NEW(
         buffer_ptr->residual_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&doubleWidthPictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&doubleWidthPictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size * 2;
 
     EB_NEW(
         buffer_ptr->residual_quant_coeff_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size * 3;
 
     EB_NEW(
         buffer_ptr->recon_coeff_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size * 3;
 
     EB_NEW(
         buffer_ptr->recon_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&pictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&pictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
 
     //Distortion
     buffer_ptr->residual_luma_sad = 0;
@@ -871,40 +896,64 @@ EbErrorType mode_decision_scratch_candidate_buffer_ctor(
     buffer_ptr->candidate_ptr = (ModeDecisionCandidate*)EB_NULL;
 
     // Video Buffers
+    uint32_t buffer_size = (MAX_SB_SIZE * MAX_SB_SIZE) + (MAX_SB_SIZE * MAX_SB_SIZE) / 2;
+    EB_CALLOC_ALIGNED_ARRAY(buffer_ptr->eb_buffer_ptr, buffer_size * (4 + 2 + 8));
+    uint32_t eb_buffer_offset = 0;
     EB_NEW(
         buffer_ptr->prediction_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&pictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&pictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size;
 
     EB_NEW(
         buffer_ptr->prediction_ptr_temp,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&pictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&pictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size;
 
     EB_NEW(
         buffer_ptr->cfl_temp_prediction_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&pictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&pictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size;
 
     EB_NEW(
         buffer_ptr->residual_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&doubleWidthPictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&doubleWidthPictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size * 2;
 
     EB_NEW(
         buffer_ptr->residual_quant_coeff_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size * 3;
 
     EB_NEW(
         buffer_ptr->recon_coeff_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&ThirtyTwoWidthPictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+    eb_buffer_offset += buffer_size * 3;
 
     EB_NEW(
         buffer_ptr->recon_ptr,
-        eb_picture_buffer_desc_ctor,
-        (EbPtr)&pictureBufferDescInitData);
+        eb_picture_buffer_desc_block_ctor,
+        (EbPtr)&pictureBufferDescInitData,
+        buffer_ptr->eb_buffer_ptr,
+        eb_buffer_offset);
+
     return EB_ErrorNone;
 }
 #endif

--- a/Source/Lib/Common/Codec/EbModeDecision.h
+++ b/Source/Lib/Common/Codec/EbModeDecision.h
@@ -239,6 +239,8 @@ extern "C" {
         // Candidate Ptr
         ModeDecisionCandidate                *candidate_ptr;
 
+        // for memory free only
+        EbByte                               eb_buffer_ptr;
         // Video Buffers
         EbPictureBufferDesc                  *prediction_ptr;
         EbPictureBufferDesc                  *prediction_ptr_temp;

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -173,6 +173,10 @@ extern "C" {
 #if PAL_SUP
         PALETTE_BUFFER            palette_buffer;
         PaletteInfo              palette_cand_array[MAX_PAL_CAND];
+        //for memory free only
+        uint8_t                       *fast_color_idx_map;
+        uint8_t                       *pal_color_idx_map;
+        uint8_t                       *md_color_idx_map;
 #endif
         // Entropy Coder
         EntropyCoder                 *coeff_est_entropy_coder_ptr;

--- a/Source/Lib/Common/Codec/EbMotionEstimationLcuResults.h
+++ b/Source/Lib/Common/Codec/EbMotionEstimationLcuResults.h
@@ -45,7 +45,6 @@ extern "C" {
         uint32_t          lcu_distortion;
         uint8_t          *total_me_candidate_index;
         MeCandidate     **me_candidate;
-        MeCandidate      *me_candidate_array;
         uint8_t          *me_nsq_0; // 2 Number of reference lists
         uint8_t          *me_nsq_1; // 2 Number of reference lists
 

--- a/Source/Lib/Common/Codec/EbPictureBufferDesc.h
+++ b/Source/Lib/Common/Codec/EbPictureBufferDesc.h
@@ -310,6 +310,12 @@ extern "C" {
         EbPictureBufferDesc *object_ptr,
         EbPtr  object_init_data_ptr);
 
+    extern EbErrorType eb_picture_buffer_desc_block_ctor(
+        EbPictureBufferDesc *object_ptr,
+        EbPtr  object_init_data_ptr,
+        EbByte eb_buffer_ptr,
+        uint32_t eb_buffer_offset);
+
     extern EbErrorType eb_recon_picture_buffer_desc_ctor(
         EbPictureBufferDesc *object_ptr,
         EbPtr  object_init_data_ptr);

--- a/Source/Lib/Common/Codec/EbPictureDecisionQueue.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionQueue.c
@@ -10,15 +10,14 @@ static void pa_reference_queue_entry_dctor(EbPtr p)
 {
     PaReferenceQueueEntry* obj = (PaReferenceQueueEntry*)p;
     EB_FREE(obj->list0.list);
-    EB_FREE(obj->list1.list);
 }
 
 EbErrorType pa_reference_queue_entry_ctor(
     PaReferenceQueueEntry   *entryPtr)
 {
     entryPtr->dctor = pa_reference_queue_entry_dctor;
-    EB_MALLOC(entryPtr->list0.list, sizeof(int32_t) * (1 << MAX_TEMPORAL_LAYERS));
-    EB_MALLOC(entryPtr->list1.list, sizeof(int32_t) * (1 << MAX_TEMPORAL_LAYERS));
+    EB_MALLOC(entryPtr->list0.list, 2 * sizeof(int32_t) * (1 << MAX_TEMPORAL_LAYERS));
+    entryPtr->list1.list =  entryPtr->list0.list + (1 << MAX_TEMPORAL_LAYERS);
 
     return EB_ErrorNone;
 }

--- a/Source/Lib/Common/Codec/EbPictureManagerQueue.c
+++ b/Source/Lib/Common/Codec/EbPictureManagerQueue.c
@@ -17,7 +17,6 @@ void reference_queue_entry_dctor(EbPtr p)
 {
     ReferenceQueueEntry* obj = (ReferenceQueueEntry*)p;
     EB_FREE(obj->list0.list);
-    EB_FREE(obj->list1.list);
 }
 
 EbErrorType reference_queue_entry_ctor(
@@ -29,9 +28,8 @@ EbErrorType reference_queue_entry_ctor(
     entryPtr->dependent_count = 0;
     entryPtr->reference_available = EB_FALSE;
 
-    EB_MALLOC(entryPtr->list0.list, sizeof(int32_t) * (1 << MAX_TEMPORAL_LAYERS));
-
-    EB_MALLOC(entryPtr->list1.list, sizeof(int32_t) * (1 << MAX_TEMPORAL_LAYERS));
+    EB_MALLOC(entryPtr->list0.list, 2 * sizeof(int32_t) * (1 << MAX_TEMPORAL_LAYERS));
+    entryPtr->list1.list =  entryPtr->list0.list + sizeof(int32_t) * (1 << MAX_TEMPORAL_LAYERS);
 
     return EB_ErrorNone;
 }


### PR DESCRIPTION
There are too many malloc times when initiate SvtAv1EncApp. It makes initiation too slow on server and this can be relieved by reduce malloc times in block way.

Vtune show that `mode_decision_context_ctor` takes 30.4% cpu time of eb_init_encoder's 83.5%; and `eb_object_wrapper_ctor` takes 28.2% cpu time of eb_init_encoder's 83.5%. I tried block way to reduce malloc times in this two functions.

Tested by:
```
SvtAv1EncApp -enc-mode 8 -w 1920 -h 1080 -fps 60 irefresh-type 2  -i 1920x1080.yuv 
-q 32 -b output.bin -bit-depth 8 -stat-report  -n 300 
```
Here are some result comparation:

|        | build_type | init_time | malloc_times |
| ------ | ---------- | --------- | ------------ |
| after  | Debug      | 6.4660s   | 331625       |
|        | Release    | 5.6350s   | 331625       |
| before | Debug      | 7.9340s   | 1964126      |
|        | Release    | 6.6300s   | 1964126      |

```
-------------------------------------------                      
SVT-AV1 Encoder                                                  
SVT [version]:  SVT-AV1 Encoder Lib v0.7.5                       
SVT [build]  :  GCC 7.4.0        64 bit                          
LIB Build date: Dec 13 2019 16:09:22                             
-------------------------------------------                      
Number of logical cores available: 112                           
Number of PPCS 159                                               
-------------------------------------------                      
SVT [config]: Main Profile      Tier (auto)     Level (auto)     
SVT [config]: EncoderMode                                       : 8                                                               
SVT [config]: EncoderBitDepth / EncoderColorFormat / CompressedTenBitFormat      : 8 / 1 / 0                                      
SVT [config]: SourceWidth / SourceHeight                        : 1920 / 1080                                                     
SVT [config]: FrameRate / Gop Size                              : 60 / 64                                                         
SVT [config]: HierarchicalLevels / BaseLayerSwitchMode / PredStructure           : 4 / 0 / 2                                      
SVT [config]: BRC Mode / QP  / LookaheadDistance / SceneChange  : CQP / 32 / 33 / 0            
SVT Memory Usage:                                                
    total allocated memory:       35.18 GB 1964126 times         
        malloced memory:          24.15 GB 1346516 times         
        callocated memory:        1.39 GB 266584 times           
        allocated aligned memory: 9.64 GB 351026 times           
    mutex count: 2865                                            
    semaphore count: 2008                                        
    thread count: 536                                            
    hash table fulless: 0.469574, hash bucket is too full
-----------------------------------------------------------
After optimization:
SVT Memory Usage:                                                
    total allocated memory:       35.39 GB 331625 times          
        malloced memory:          24.31 GB 125424 times          
        callocated memory:        1.39 GB 178961 times           
        allocated aligned memory: 9.69 GB 27240 times            
    mutex count: 2865                                            
    semaphore count: 2008                                        
    thread count: 536                                            
    hash table fulless: 0.080355, hash bucket is healthy
```