### PR TITLE
Memory efficient single core mode

### DIFF
--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -193,6 +193,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **SceneChangeDetection** | -scd | [0 - 1] | 1 | Enables or disables the scene change detection algorithm |
 | **AsmType** | -asm | [0 - 1] | 1 | Assembly instruction set (0: Automatically select lowest assembly instruction set supported, 1: Automatically select highest assembly instruction set supported,) |
 | **LogicalProcessorNumber** | -lp | [0, total number of logical processor] | 0 | The number of logical processor which encoder threads run on.Refer to Appendix A.1 |
+| **UnpinSingleCoreExecution** | -unpin-lp1 | [0, 1] | 1 | Unpin the execution . If logical_processors is set to 1, this option does not set the execution to be pinned to core #0 when set to 1. this allows the execution of multiple encodes on the CPU without having to pin them to a specific mask  0=OFF, 1= ON |
 | **TargetSocket** | -ss | [-1,1] | -1 | For dual socket systems, this can specify which socket the encoder runs on.Refer to Appendix A.1 |
 | **ReconFile** | -o | any string | null | Recon file path. Optional output of recon. |
 | **TileRow** | -tile-rows | [0-6] | 0 | log2 of tile rows |

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -514,6 +514,15 @@ typedef struct EbSvtAv1EncConfiguration
      * OS thread scheduler. */
     uint32_t                logical_processors;
 
+    /* Unpin the execution . If logical_processors is set to 1, this option does not
+    * set the execution to be pinned to core #0 when set to 1. this allows the execution
+    * of multiple encodes on the CPU wihtout having to pin them to a specific mask
+    * 1: unpinned from core 0
+    * 0: pinned to core 0
+    *
+    * Default is 1. */
+    uint32_t                unpin_lp1;
+
     /* Target socket to run on. For dual socket systems, this can specify which
      * socket the encoder runs on.
      *

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -138,6 +138,7 @@
 #define SPEED_CONTROL_TOKEN             "-speed-ctrl"
 #define ASM_TYPE_TOKEN                  "-asm"
 #define THREAD_MGMNT                    "-lp"
+#define UNPIN_LP1_TOKEN                 "-unpin-lp1"
 #define TARGET_SOCKET                   "-ss"
 #define UNRESTRICTED_MOTION_VECTOR      "-umv"
 #define CONFIG_FILE_COMMENT_CHAR    '#'
@@ -378,6 +379,7 @@ static void SetAsmType                          (const char *value, EbConfig *cf
     cfg->cpu_flags_limit = CPU_FLAGS_INVALID;
 };
 static void SetLogicalProcessors                (const char *value, EbConfig *cfg)  {cfg->logical_processors         = (uint32_t)strtoul(value, NULL, 0);};
+static void SetUnpinSingleCoreExecution         (const char *value, EbConfig *cfg)  {cfg->unpin_lp1                  = (uint32_t)strtoul(value, NULL, 0);};
 static void SetTargetSocket                     (const char *value, EbConfig *cfg)  {cfg->target_socket              = (int32_t)strtol(value, NULL, 0);};
 static void SetUnrestrictedMotionVector         (const char *value, EbConfig *cfg)  {cfg->unrestricted_motion_vector = (EbBool)strtol(value, NULL, 0);};
 
@@ -547,7 +549,8 @@ config_entry_t config_entry[] = {
     { SINGLE_INPUT, OLPD_REFINEMENT_TOKEN, "OlpdRefinement", SetEnableOlpdRefinement },
     { SINGLE_INPUT, CONSTRAINED_INTRA_ENABLE_TOKEN, "ConstrainedIntra", SetEnableConstrainedIntra},
     // Thread Management
-    { SINGLE_INPUT, THREAD_MGMNT, "logicalProcessors", SetLogicalProcessors },
+    { SINGLE_INPUT, THREAD_MGMNT,    "LogicalProcessors", SetLogicalProcessors },
+    { SINGLE_INPUT, UNPIN_LP1_TOKEN, "UnpinSingleCoreExecution", SetUnpinSingleCoreExecution },
     { SINGLE_INPUT, TARGET_SOCKET, "TargetSocket", SetTargetSocket },
     // Optional Features
     { SINGLE_INPUT, UNRESTRICTED_MOTION_VECTOR, "UnrestrictedMotionVector", SetUnrestrictedMotionVector },
@@ -675,6 +678,7 @@ void eb_config_ctor(EbConfig *config_ptr)
     // ASM Type
     config_ptr->cpu_flags_limit                         = CPU_FLAGS_ALL;
 
+    config_ptr->unpin_lp1                           = 1;
     config_ptr->target_socket                         = -1;
 
     config_ptr->unrestricted_motion_vector           = EB_TRUE;

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -447,6 +447,7 @@ typedef struct EbConfig
     uint32_t                channel_id;
     uint32_t                active_channel_count;
     uint32_t                logical_processors;
+    uint32_t                unpin_lp1;
     int32_t                 target_socket;
     EbBool                  stop_encoder;         // to signal CTRL+C Event, need to stop encoding.
 

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -244,6 +244,7 @@ EbErrorType CopyConfigurationParameters(
     callback_data->eb_enc_parameters.speed_control_flag = config->speed_control_flag;
     callback_data->eb_enc_parameters.use_cpu_flags = config->cpu_flags_limit;
     callback_data->eb_enc_parameters.logical_processors = config->logical_processors;
+    callback_data->eb_enc_parameters.unpin_lp1 = config->unpin_lp1;
     callback_data->eb_enc_parameters.target_socket = config->target_socket;
     callback_data->eb_enc_parameters.unrestricted_motion_vector = config->unrestricted_motion_vector;
     callback_data->eb_enc_parameters.recon_enabled = config->recon_file ? EB_TRUE : EB_FALSE;

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -34,6 +34,15 @@ extern "C" {
 #endif
 #define TX_SIZE_EARLY_EXIT          1 // Exit TX size search when all coefficients are zero.
 
+#define   SINGLE_CORE_ENCODE   1
+#if SINGLE_CORE_ENCODE
+#define SERIAL_MODE                  1 // change ressource allocations  to optimize single core operating mode
+#define OUT_ALLOC                    1 // output bitsream allocation at run time for both single/multi core
+#define PAREF_OUT                    1 // disconnect pa ref  from input for both single/multi core
+#endif
+#define INIT_GM_FIX           1 // initilize global motion to be OFF for all references frames.
+#define REVERT_ALTREF_FIX     1 // put back padding r2r fix for altref
+
 #define ENHANCED_M0_SETTINGS         1 // Updated M0 settings(optimized independent chroma search for all layers, conservative coeff - based NSQ cands reduction, shut coeff - based skip tx size search, warped for all layers, SUB - SAD as ME search method for non - SC only)
 #define MULTI_PASS_PD                1 // Multi-Pass Partitioning Depth (Multi-Pass PD) performs multiple PD stages for the same SB towards 1 final Partitioning Structure. As we go from PDn to PDn + 1, the prediction accuracy of the MD feature(s) increases while the number of block(s) decreases
 #define RATE_ESTIMATION_UPDATE       1 // Adding the rate estimation updates used in MD for missing syntax elements

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -36,9 +36,10 @@ extern "C" {
 
 #define   SINGLE_CORE_ENCODE   1
 #if SINGLE_CORE_ENCODE
-#define SERIAL_MODE                  1 // change ressource allocations  to optimize single core operating mode
-#define OUT_ALLOC                    1 // output bitsream allocation at run time for both single/multi core
-#define PAREF_OUT                    1 // disconnect pa ref  from input for both single/multi core
+#define SERIAL_MODE                  1 // Change ressource allocations  to optimize single core operating mode
+#define OUT_ALLOC                    1 // Output bitsream allocation at run time for both single/multi core
+#define PAREF_OUT                    1 // Disconnect pa ref  from input for both single/multi core
+#define NO_THREAD_PIN                1 // Adding the ability to not pin the -lp 1 use case to core 0
 #endif
 #define INIT_GM_FIX           1 // initilize global motion to be OFF for all references frames.
 #define REVERT_ALTREF_FIX     1 // put back padding r2r fix for altref

--- a/Source/Lib/Common/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Common/Codec/EbPacketizationProcess.c
@@ -281,11 +281,22 @@ void* packetization_kernel(void *input_ptr)
         queueEntryPtr->start_time_seconds = picture_control_set_ptr->parent_pcs_ptr->start_time_seconds;
         queueEntryPtr->start_time_u_seconds = picture_control_set_ptr->parent_pcs_ptr->start_time_u_seconds;
         queueEntryPtr->is_alt_ref = picture_control_set_ptr->parent_pcs_ptr->is_alt_ref;
-
+#if OUT_ALLOC
+        eb_get_empty_object(
+            sequence_control_set_ptr->encode_context_ptr->stream_output_fifo_ptr,
+            &picture_control_set_ptr->parent_pcs_ptr->output_stream_wrapper_ptr);
+        output_stream_wrapper_ptr = picture_control_set_ptr->parent_pcs_ptr->output_stream_wrapper_ptr;
+        output_stream_ptr = (EbBufferHeaderType*)output_stream_wrapper_ptr->object_ptr;
+        output_stream_ptr->p_buffer =(uint8_t*)malloc(output_stream_ptr->n_alloc_len);
+        assert(output_stream_ptr->p_buffer != NULL && "bit-stream memory allocation failure");
+#else
         //TODO: The output buffer should be big enough to avoid a deadlock here. Add an assert that make the warning
         // Get  Output Bitstream buffer
         output_stream_wrapper_ptr = picture_control_set_ptr->parent_pcs_ptr->output_stream_wrapper_ptr;
         output_stream_ptr = (EbBufferHeaderType*)output_stream_wrapper_ptr->object_ptr;
+#endif
+
+
         output_stream_ptr->flags = 0;
         output_stream_ptr->flags |= (encode_context_ptr->terminating_sequence_flag_received == EB_TRUE && picture_control_set_ptr->parent_pcs_ptr->decode_order == encode_context_ptr->terminating_picture_number) ? EB_BUFFERFLAG_EOS : 0;
         output_stream_ptr->n_filled_len = 0;

--- a/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
@@ -4300,6 +4300,25 @@ void* picture_analysis_kernel(void *input_ptr)
             pictureHeighInLcu = (sequence_control_set_ptr->seq_header.max_frame_height + sequence_control_set_ptr->sb_sz - 1) / sequence_control_set_ptr->sb_sz;
             sb_total_count = picture_width_in_sb * pictureHeighInLcu;
 
+#if PAREF_OUT
+            generate_padding(
+                input_picture_ptr->buffer_y,
+                input_picture_ptr->stride_y,
+                input_picture_ptr->width,
+                input_picture_ptr->height,
+                input_picture_ptr->origin_x,
+                input_picture_ptr->origin_y);
+            {
+                uint8_t* pa = input_padded_picture_ptr->buffer_y + input_padded_picture_ptr->origin_x + input_padded_picture_ptr->origin_y * input_padded_picture_ptr->stride_y;
+                uint8_t* in = input_picture_ptr->buffer_y        + input_picture_ptr->origin_x        + input_picture_ptr->origin_y * input_picture_ptr->stride_y;
+                for (uint32_t row = 0; row < input_picture_ptr->height; row++)
+                    EB_MEMCPY(
+                        pa + row * input_padded_picture_ptr->stride_y,
+                        in + row * input_picture_ptr->stride_y,
+                        sizeof(uint8_t)* input_picture_ptr->width);
+            }
+
+#endif
             // Set picture parameters to account for subpicture, picture scantype, and set regions by resolutions
             SetPictureParametersForStatisticsGathering(
                 sequence_control_set_ptr);

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -3459,7 +3459,11 @@ void* picture_decision_kernel(void *input_ptr)
 
                 ParentPcsWindow[0] = queueEntryPtr->picture_number > 0 ? (PictureParentControlSet *)encode_context_ptr->picture_decision_reorder_queue[previousEntryIndex]->parent_pcs_wrapper_ptr->object_ptr : NULL;
                 ParentPcsWindow[1] = (PictureParentControlSet *)encode_context_ptr->picture_decision_reorder_queue[encode_context_ptr->picture_decision_reorder_queue_head_index]->parent_pcs_wrapper_ptr->object_ptr;
+#if SERIAL_MODE
+                for (windowIndex = 0; windowIndex < sequence_control_set_ptr->scd_delay; windowIndex++) {
+#else
                 for (windowIndex = 0; windowIndex < FUTURE_WINDOW_WIDTH; windowIndex++) {
+#endif
                     entryIndex = QUEUE_GET_NEXT_SPOT(encode_context_ptr->picture_decision_reorder_queue_head_index, windowIndex + 1);
                     if (encode_context_ptr->picture_decision_reorder_queue[entryIndex]->parent_pcs_wrapper_ptr == NULL) {
                         windowAvail = EB_FALSE;

--- a/Source/Lib/Common/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Common/Codec/EbSequenceControlSet.c
@@ -298,6 +298,10 @@ EbErrorType copy_sequence_control_set(
     dst->use_input_stat_file = src->use_input_stat_file;
     dst->use_output_stat_file = src->use_output_stat_file;
 #endif
+
+#if SERIAL_MODE
+    dst->scd_delay = src->scd_delay;
+#endif
     return EB_ErrorNone;
 }
 

--- a/Source/Lib/Common/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Common/Codec/EbSequenceControlSet.h
@@ -117,6 +117,10 @@ extern "C" {
         uint32_t                                tf_segment_column_count;
         uint32_t                                tf_segment_row_count;
         EbBool                                  enable_altrefs;
+
+#if SERIAL_MODE
+        uint32_t                                scd_delay; //Number of delay frames needed to implement future window for algorithms such as SceneChange or TemporalFiltering
+#endif
         // Buffers
         uint32_t                                picture_control_set_pool_init_count;
         uint32_t                                picture_control_set_pool_init_count_child;

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -216,6 +216,12 @@ void CheckForNonUniformMotionVectorField(
 void DetectGlobalMotion(
     PictureParentControlSet    *picture_control_set_ptr)
 {
+
+#if  INIT_GM_FIX
+    //initilize global motion to be OFF for all references frames.
+    memset(picture_control_set_ptr->is_global_motion, EB_FALSE, MAX_NUM_OF_REF_PIC_LIST*REF_LIST_MAX_DEPTH);
+#endif
+
 #if GLOBAL_WARPED_MOTION
 #if GM_OPT
     if (picture_control_set_ptr->gm_level <= GM_DOWN) {
@@ -1227,9 +1233,9 @@ void* initial_rate_control_kernel(void *input_ptr)
 
     // Segments
     uint32_t                              segment_index;
-
+#if ! OUT_ALLOC
     EbObjectWrapper                *output_stream_wrapper_ptr;
-
+#endif
     for (;;) {
         // Get Input Full Object
         eb_get_full_object(
@@ -1429,13 +1435,14 @@ void* initial_rate_control_kernel(void *input_ptr)
                         if (sequence_control_set_ptr->use_output_stat_file)
                             memset(picture_control_set_ptr->stat_struct_first_pass_ptr, 0, sizeof(stat_struct_t));
 #endif
+#if ! OUT_ALLOC
                         //OPTION 1:  get the output stream buffer in ressource coordination
                         eb_get_empty_object(
                             sequence_control_set_ptr->encode_context_ptr->stream_output_fifo_ptr,
                             &output_stream_wrapper_ptr);
 
                         picture_control_set_ptr->output_stream_wrapper_ptr = output_stream_wrapper_ptr;
-
+#endif
                         // Get Empty Results Object
                         eb_get_empty_object(
                             context_ptr->initialrate_control_results_output_fifo_ptr,

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -962,7 +962,9 @@ void* resource_coordination_kernel(void *input_ptr)
                 eb_object_inc_live_count(
                     picture_control_set_ptr->pa_reference_picture_wrapper_ptr,
                     2);
+#if !PAREF_OUT
             ((EbPaReferenceObject*)picture_control_set_ptr->pa_reference_picture_wrapper_ptr->object_ptr)->input_padded_picture_ptr->buffer_y = picture_control_set_ptr->enhanced_picture_ptr->buffer_y;
+#endif
 
             set_tile_info(picture_control_set_ptr);
             if(sequence_control_set_ptr->static_config.unrestricted_motion_vector == 0)


### PR DESCRIPTION
## Description

- Use the least possible resource allocation  to have an efficient single core operating mode.
- Fix deadlock with -lad 0
- Latency(controlled by number of parent pcs = number of input) went down from 72 frames to 24 frames:
24 = 17(GOP) + 6(SCD/ALTREF) +1(EOS) + 0 (Needed Pictures for Look-Ahead)
Ref = 17 assuming a 5L GOP.  
Pa-Ref = 25  + 6(SCD/ALTREF) +1(EOS) ,  assuming a 5L GOP. 

- Change output bistream allocation to be done at run time to serve a single threaded app.
- Changes have been made to picture decision to remove the 6-frames delay in case  Scene-Change and ALTREF are OFF.
- Added the ability to unpin the single core execution to allow multiple single core encodes on the same machine without them being pinned to all core 0 [execution is unpinned by default]

## Performance
- For a 5L GOP,  1080p single core mode (fixed QP). Memory allocation went down from 4405 MB to 2032 MB.
- 100% memory reduction with -lad 0 and -lp 1