### PR TITLE
Update the signal presets

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -51,6 +51,9 @@ extern "C" {
 #define ATB_FIX                      1
 
 #define M0_OPT                       1
+#define PRESETS_TUNE                 1
+#define PRESETS_OPT                  1
+
 /* Note: shutting the macro PAL_SUP will not give SS as pcs->palette_mode = 0
    rate estimation is changed for I frame + enabled sc for P (rate estimation
    is a result changed for P frames)
@@ -3436,15 +3439,22 @@ typedef struct stat_struct_t
 //     M0    M1    M2    M3    M4    M5    M6    M7    M8    M9    M10    M11    M12
 static const uint8_t enable_hme_flag[SC_MAX_LEVEL][INPUT_SIZE_COUNT][MAX_SUPPORTED_MODES] = {
     {
+#if PRESETS_TUNE
+        {   0,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_576p_RANGE_OR_LOWER
+        {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_720P_RANGE/INPUT_SIZE_1080i_RANGE
+        {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_1080p_RANGE
+        {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 }       // INPUT_SIZE_4K_RANGE
+#else
         {   0,    0,    0,    0,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_576p_RANGE_OR_LOWER
         {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_720P_RANGE/INPUT_SIZE_1080i_RANGE
         {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_1080p_RANGE
-        {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_4K_RANGE
+        {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 }       // INPUT_SIZE_4K_RANGE
+#endif
     },{
         {   0,    0,    0,    0,    0,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_576p_RANGE_OR_LOWER
         {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_720P_RANGE/INPUT_SIZE_1080i_RANGE
         {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_1080p_RANGE
-        {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_4K_RANGE
+        {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 }       // INPUT_SIZE_4K_RANGE
     }
 };
 //     M0    M1    M2    M3    M4    M5    M6    M7    M8    M9    M10    M11    M12
@@ -3453,21 +3463,28 @@ static const uint8_t enable_hme_level0_flag[SC_MAX_LEVEL][INPUT_SIZE_COUNT][MAX_
         {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_576p_RANGE_OR_LOWER
         {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_720P_RANGE/INPUT_SIZE_1080i_RANGE
         {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_1080p_RANGE
-        {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_4K_RANGE
+        {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 }       // INPUT_SIZE_4K_RANGE
     },{
         {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_576p_RANGE_OR_LOWER
         {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_720P_RANGE/INPUT_SIZE_1080i_RANGE
         {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_1080p_RANGE
-        {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 },      // INPUT_SIZE_4K_RANGE
+        {   1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1 }       // INPUT_SIZE_4K_RANGE
     }
 };
 
 static const uint16_t hme_level0_total_search_area_width[SC_MAX_LEVEL][INPUT_SIZE_COUNT][MAX_SUPPORTED_MODES] = {
     {
+#if PRESETS_TUNE
+        {  48,   48,   48,   48,   48,   48,   48,   48,   48,   48,   48,   48,   48 },
+        {  96,   96,   96,   96,   96,   48,   48,   48,   48,   48,   48,   48,   48 },
+        { 112,  128,  128,  128,  128,   48,   48,   48,   48,   48,   48,   48,   48 },
+        { 128,  128,  128,  128,  128,   96,   96,   96,   96,   96,   96,   96,   96 }
+#else
         {  48,   48,   48,   48,   48,   48,   48,   48,   48,   48,   48,   48,   48 },
         {  96,  96,    96,   96,  112,   48,   48,   48,   48,   48,   48,   48,   48 },
         { 112,  128,  128,  128,  128,   48,   48,   48,   48,   48,   48,   48,   48 },
-        { 128,  128,  128,  128,  128,   96,   96,   96,   96,   96,   96,   96,   96 },
+        { 128,  128,  128,  128,  128,   96,   96,   96,   96,   96,   96,   96,   96 }
+#endif
      } , {
         { 128,  128,  128,  128,  128,  128,  128,  128,  128,  128,  128,  128,  128 },
         { 128,  128,  128,  128,  128,  128,  128,  128,  128,  128,  128,  128,  128 },
@@ -3478,10 +3495,18 @@ static const uint16_t hme_level0_total_search_area_width[SC_MAX_LEVEL][INPUT_SIZ
 
 static const uint16_t hme_level0_search_area_in_width_array_left[SC_MAX_LEVEL][INPUT_SIZE_COUNT][MAX_SUPPORTED_MODES] = {
     {
+#if PRESETS_TUNE
+        { 24,   24,   24,   24,   24,   24,   24,   24,   24,   24,   24,   24,   24 },
+        { 56,   56,   56,   56,   56,   24,   24,   24,   24,   24,   24,   24,   24 },
+        { 64,   64,   64,   64,   64,   24,   24,   24,   24,   24,   24,   24,   24 },
+        { 64,   64,   64,   64,   64,   48,   48,   48,   48,   48,   48,   48,   48 }
+
+#else
         {  24,   24,   24,   24,   24,   24,   24,   24,   24,   24,   24,   24,   24 },
         {  48,   48,   56,   56,   56,   24,   24,   24,   24,   24,   24,   24,   24 },
         {  64,   64,   64,   64,   64,   24,   24,   24,   24,   24,   24,   24,   24 },
         {  64,   64,   64,   64,   64,   48,   48,   48,   48,   48,   48,   48,   48 }
+#endif
     } , {
         {  64,   64,   64,   64,   64,   64,   64,   64,   64,   64,   64,   64,   64 },
         {  64,   64,   64,   64,   64,   64,   64,   64,   64,   64,   64,   64,   64 },
@@ -3491,10 +3516,18 @@ static const uint16_t hme_level0_search_area_in_width_array_left[SC_MAX_LEVEL][I
 };
 static const uint16_t hme_level0_search_area_in_width_array_right[SC_MAX_LEVEL][INPUT_SIZE_COUNT][MAX_SUPPORTED_MODES] = {
     {
+#if PRESETS_TUNE
+        { 24,   24,   24,   24,   24,   24,   24,   24,   24,   24,   24,   24,   24 },
+        { 56,   56,   56,   56,   56,   24,   24,   24,   24,   24,   24,   24,   24 },
+        { 64,   64,   64,   64,   64,   24,   24,   24,   24,   24,   24,   24,   24 },
+        { 64,   64,   64,   64,   64,   48,   48,   48,   48,   48,   48,   48,   48 }
+
+#else
         {  24,   24,   24,   24,   24,   24,   24,   24,   24,   24,   24,   24,   24 },
         {  56,   56,   56,   56,   56,   24,   24,   24,   24,   24,   24,   24,   24 },
         {  64,   64,   64,   64,   64,   24,   24,   24,   24,   24,   24,   24,   24 },
         {  64,   64,   64,   64,   64,   48,   48,   48,   48,   48,   48,   48,   48 }
+#endif
     } , {
         {  64,   64,   64,   64,   64,   64,   64,   64,   64,   64,   64,   64,   64 },
         {  64,   64,   64,   64,   64,   64,   64,   64,   64,   64,   64,   64,   64 },
@@ -3551,10 +3584,17 @@ static const uint8_t enable_hme_level1_flag[SC_MAX_LEVEL][INPUT_SIZE_COUNT][MAX_
         {   1,    1,    1,    1,    1,    1,    1,    1,    1,    0,    0,     0,    0 },      // INPUT_SIZE_1080p_RANGE
         {   1,    1,    1,    1,    1,    1,    1,    1,    1,    0,    0,     0,    0 }       // INPUT_SIZE_4K_RANGE
     }, {
+#if PRESETS_TUNE
+        {   1,    1,    1,    0,    0,    0,    0,    0,    1,    0,    0,     0,    0 },      // INPUT_SIZE_576p_RANGE_OR_LOWER
+        {   1,    1,    1,    0,    0,    0,    0,    0,    1,    0,    0,     0,    0 },      // INPUT_SIZE_720P_RANGE/INPUT_SIZE_1080i_RANGE
+        {   1,    1,    1,    0,    0,    0,    0,    0,    1,    0,    0,     0,    0 },      // INPUT_SIZE_1080p_RANGE
+        {   1,    1,    1,    0,    0,    0,    0,    0,    1,    0,    0,     0,    0 }       // INPUT_SIZE_4K_RANGE
+#else
         {   1,    1,    0,    0,    0,    0,    0,    0,    1,    0,    0,     0,    0 },      // INPUT_SIZE_576p_RANGE_OR_LOWER
         {   1,    1,    0,    0,    0,    0,    0,    0,    1,    0,    0,     0,    0 },      // INPUT_SIZE_720P_RANGE/INPUT_SIZE_1080i_RANGE
         {   1,    1,    0,    0,    0,    0,    0,    0,    1,    0,    0,     0,    0 },      // INPUT_SIZE_1080p_RANGE
         {   1,    1,    0,    0,    0,    0,    0,    0,    1,    0,    0,     0,    0 }       // INPUT_SIZE_4K_RANGE
+#endif
     }
 };
 static const uint16_t hme_level1_search_area_in_width_array_left[SC_MAX_LEVEL][INPUT_SIZE_COUNT][MAX_SUPPORTED_MODES] = {
@@ -3618,10 +3658,17 @@ static const uint8_t enable_hme_level2_flag[SC_MAX_LEVEL][INPUT_SIZE_COUNT][MAX_
         {   1,    1,    1,    1,    1,    1,    1,    1,    1,    0,    0,     0,    0 },      // INPUT_SIZE_1080p_RANGE
         {   1,    1,    1,    1,    1,    1,    1,    1,    1,    0,    0,     0,    0 }       // INPUT_SIZE_4K_RANGE
     },{
+#if PRESETS_TUNE
+        {   1,    1,    1,    0,    0,    0,    0,    0,    0,    0,    0,     0,    0 },      // INPUT_SIZE_576p_RANGE_OR_LOWER
+        {   1,    1,    1,    0,    0,    0,    0,    0,    0,    0,    0,     0,    0 },      // INPUT_SIZE_720P_RANGE/INPUT_SIZE_1080i_RANGE
+        {   1,    1,    1,    0,    0,    0,    0,    0,    0,    0,    0,     0,    0 },      // INPUT_SIZE_1080p_RANGE
+        {   1,    1,    1,    0,    0,    0,    0,    0,    0,    0,    0,     0,    0 }       // INPUT_SIZE_4K_RANGE
+#else
         {   1,    1,    0,    0,    0,    0,    0,    0,    0,    0,    0,     0,    0 },      // INPUT_SIZE_576p_RANGE_OR_LOWER
         {   1,    1,    0,    0,    0,    0,    0,    0,    0,    0,    0,     0,    0 },      // INPUT_SIZE_720P_RANGE/INPUT_SIZE_1080i_RANGE
         {   1,    1,    0,    0,    0,    0,    0,    0,    0,    0,    0,     0,    0 },      // INPUT_SIZE_1080p_RANGE
         {   1,    1,    0,    0,    0,    0,    0,    0,    0,    0,    0,     0,    0 }       // INPUT_SIZE_4K_RANGE
+#endif
     }
 };
 static const uint16_t hme_level2_search_area_in_width_array_left[SC_MAX_LEVEL][INPUT_SIZE_COUNT][MAX_SUPPORTED_MODES] = {
@@ -3679,10 +3726,17 @@ static const uint16_t hme_level2_search_area_in_height_array_bottom[SC_MAX_LEVEL
 
 static const uint16_t search_area_width[SC_MAX_LEVEL][INPUT_SIZE_COUNT][MAX_SUPPORTED_MODES] = {
     {
+#if PRESETS_TUNE
+        { 128,  64,  64,  64,   64,   64,   64,   64,   48,   16,   16,    16,   16 },
+        { 160,  64,  64,  64,   64,   64,   64,   64,   48,   16,   16,    16,   16 },
+        { 192,  64,  64,  64,   64,   64,   64,   64,   48,   16,   16,    16,   16 },
+        { 192,  64,  64,  64,   64,   64,   64,   64,   48,   16,   16,    16,   16 }
+#else
         { 128,  128,  128,  128,   64,   64,   64,   64,   48,   16,   16,    16,   16 },
         { 160,  160,  160,  160,   64,   64,   64,   64,   48,   16,   16,    16,   16 },
         { 192,  192,  192,  192,   64,   64,   64,   64,   48,   16,   16,    16,   16 },
-        { 192,  192,  192,  192,   64,   64,   64,   64,   48,   16,   16,    16,   16 },
+        { 192,  192,  192,  192,   64,   64,   64,   64,   48,   16,   16,    16,   16 }
+#endif
     } , {
 #if M0_OPT
         {480 ,  480,  480,  144,  144,   88,   48,   48,   48,   48,   48,    48,   48 },
@@ -3699,10 +3753,17 @@ static const uint16_t search_area_width[SC_MAX_LEVEL][INPUT_SIZE_COUNT][MAX_SUPP
 };
 static const uint16_t search_area_height[SC_MAX_LEVEL][INPUT_SIZE_COUNT][MAX_SUPPORTED_MODES] = {
     {
+#if PRESETS_TUNE
+        { 128,  32,  32,  32,   32,   32,   32,   32,   16,    9,    9,     9,    9 },
+        { 160,  32,  32,  32,   32,   32,   32,   32,   16,    9,    9,     9,    9 },
+        { 192,  32,  32,  32,   32,   32,   32,   32,   16,    9,    9,     9,    9 },
+        { 192,  32,  32,  32,   32,   32,   32,   32,   16,    9,    9,     9,    9 }
+#else
         { 128,  128,  128,  128,   32,   32,   32,   32,   16,    9,    9,     9,    9 },
         { 160,  160,  160,  160,   32,   32,   32,   32,   16,    9,    9,     9,    9 },
         { 192,  192,  192,  192,   32,   32,   32,   32,   16,    9,    9,     9,    9 },
         { 192,  192,  192,  192,   32,   32,   32,   32,   16,    9,    9,     9,    9 }
+#endif
     } , {
 #if M0_OPT
         {480 ,  480,  480,  144,  144,   88,   48,   48,   48,   48,   48,    48,   48 },

--- a/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
@@ -2616,7 +2616,15 @@ EbErrorType signal_derivation_mode_decision_config_kernel_oq(
 #if EIGHT_PEL_FIX
     FrameHeader *frm_hdr = &picture_control_set_ptr->parent_pcs_ptr->frm_hdr;
     frm_hdr->allow_high_precision_mv =
+#if PRESETS_TUNE
+#if PRESETS_OPT
+        picture_control_set_ptr->enc_mode <= ENC_M7 && frm_hdr->quantization_params.base_q_idx < HIGH_PRECISION_MV_QTHRESH &&
+#else
+        picture_control_set_ptr->enc_mode <= ENC_M1 && frm_hdr->quantization_params.base_q_idx < HIGH_PRECISION_MV_QTHRESH &&
+#endif
+#else
         picture_control_set_ptr->enc_mode == ENC_M0 && frm_hdr->quantization_params.base_q_idx < HIGH_PRECISION_MV_QTHRESH &&
+#endif
         (sequence_control_set_ptr->input_resolution == INPUT_SIZE_576p_RANGE_OR_LOWER) ? 1 : 0;
 #endif
 #if MULTI_PASS_PD
@@ -2630,6 +2638,9 @@ EbErrorType signal_derivation_mode_decision_config_kernel_oq(
 #else
         enable_wm = (MR_MODE ||
         (picture_control_set_ptr->parent_pcs_ptr->enc_mode == ENC_M0 && picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ||
+#endif
+#if PRESETS_TUNE && !PRESETS_OPT
+            (picture_control_set_ptr->parent_pcs_ptr->enc_mode <= ENC_M1 && picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ||
 #endif
             (picture_control_set_ptr->parent_pcs_ptr->enc_mode <= ENC_M5 && picture_control_set_ptr->parent_pcs_ptr->temporal_layer_index == 0)) ? EB_TRUE : EB_FALSE;
 #else
@@ -2650,6 +2661,19 @@ EbErrorType signal_derivation_mode_decision_config_kernel_oq(
     // 3                                            OBMC @(MVP, PME ) + Opt NICs
     // 4                                            OBMC @(MVP, PME ) + Opt2 NICs
     if (sequence_control_set_ptr->static_config.enable_obmc) {
+#if PRESETS_TUNE
+#if M0_OPT
+        if (picture_control_set_ptr->parent_pcs_ptr->enc_mode == ENC_M0)
+            picture_control_set_ptr->parent_pcs_ptr->pic_obmc_mode =
+            picture_control_set_ptr->slice_type != I_SLICE ? 2 : 0;
+        else
+#endif
+            if (picture_control_set_ptr->parent_pcs_ptr->enc_mode <= ENC_M2)
+                picture_control_set_ptr->parent_pcs_ptr->pic_obmc_mode =
+                picture_control_set_ptr->parent_pcs_ptr->sc_content_detected == 0 && picture_control_set_ptr->slice_type != I_SLICE ? 2 : 0;
+        else
+            picture_control_set_ptr->parent_pcs_ptr->pic_obmc_mode = 0;
+#else
         if (picture_control_set_ptr->parent_pcs_ptr->enc_mode <= ENC_M0)
             picture_control_set_ptr->parent_pcs_ptr->pic_obmc_mode =
 #if M0_OPT
@@ -2659,6 +2683,7 @@ EbErrorType signal_derivation_mode_decision_config_kernel_oq(
 #endif
         else
             picture_control_set_ptr->parent_pcs_ptr->pic_obmc_mode = 0;
+#endif
 
 #if MR_MODE
         picture_control_set_ptr->parent_pcs_ptr->pic_obmc_mode =

--- a/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
@@ -102,6 +102,10 @@ void* set_me_hme_params_oq(
 #else
     uint8_t  hmeMeLevel =  picture_control_set_ptr->enc_mode; // OMK to be revised after new presets
 #endif
+#if PRESETS_OPT
+    if (hmeMeLevel <= ENC_M1)
+        hmeMeLevel = ENC_M0;
+#endif
     // HME/ME default settings
     me_context_ptr->number_hme_search_region_in_width = 2;
     me_context_ptr->number_hme_search_region_in_height = 2;
@@ -166,8 +170,13 @@ EbErrorType signal_derivation_me_kernel_oq(
         set_me_hme_params_from_config(
             sequence_control_set_ptr,
             context_ptr->me_context_ptr);
+
     if (picture_control_set_ptr->sc_content_detected)
+#if PRESETS_TUNE
+        context_ptr->me_context_ptr->fractional_search_method = (enc_mode == ENC_M0) ? FULL_SAD_SEARCH : SUB_SAD_SEARCH;
+#else
         context_ptr->me_context_ptr->fractional_search_method = SUB_SAD_SEARCH;
+#endif
     else
         if (enc_mode <= ENC_M6)
             context_ptr->me_context_ptr->fractional_search_method = SSD_SEARCH;
@@ -186,10 +195,15 @@ EbErrorType signal_derivation_me_kernel_oq(
     context_ptr->me_context_ptr->enable_hme_level0_flag = picture_control_set_ptr->enable_hme_level0_flag;
     context_ptr->me_context_ptr->enable_hme_level1_flag = picture_control_set_ptr->enable_hme_level1_flag;
     context_ptr->me_context_ptr->enable_hme_level2_flag = picture_control_set_ptr->enable_hme_level2_flag;
+
     if (sequence_control_set_ptr->static_config.enable_subpel == DEFAULT)
         // Set the default settings of subpel
         if (picture_control_set_ptr->sc_content_detected)
+#if PRESETS_TUNE
+            if (enc_mode <= ENC_M5)
+#else
             if (enc_mode <= ENC_M1)
+#endif
                 context_ptr->me_context_ptr->use_subpel_flag = 1;
             else
                 context_ptr->me_context_ptr->use_subpel_flag = 0;
@@ -248,7 +262,11 @@ EbErrorType signal_derivation_me_kernel_oq(
 
     // ME Search Method
     if (picture_control_set_ptr->sc_content_detected)
+#if PRESETS_TUNE
+        if (enc_mode <= ENC_M5)
+#else
         if (enc_mode <= ENC_M3)
+#endif
             context_ptr->me_context_ptr->me_search_method = FULL_SAD_SEARCH;
         else
             context_ptr->me_context_ptr->me_search_method = SUB_SAD_SEARCH;
@@ -256,14 +274,22 @@ EbErrorType signal_derivation_me_kernel_oq(
 #if ENHANCED_M0_SETTINGS
         context_ptr->me_context_ptr->me_search_method = SUB_SAD_SEARCH;
 #else
+#if PRESETS_TUNE
+        context_ptr->me_context_ptr->me_search_method = (enc_mode <= ENC_M4) ?
+#else
         context_ptr->me_context_ptr->me_search_method = (enc_mode <= ENC_M1) ?
+#endif
         FULL_SAD_SEARCH :
         SUB_SAD_SEARCH;
 #endif
 
     if (sequence_control_set_ptr->static_config.enable_global_motion == EB_TRUE)
     {
+#if PRESETS_OPT
+        if (enc_mode <= ENC_M1)
+#else
         if (enc_mode == ENC_M0)
+#endif
             context_ptr->me_context_ptr->compute_global_motion = EB_TRUE;
         else
             context_ptr->me_context_ptr->compute_global_motion = EB_FALSE;
@@ -482,9 +508,14 @@ EbErrorType tf_signal_derivation_me_kernel_oq(
             context_ptr->me_context_ptr->fractional_search_method = SSD_SEARCH;
         else
             context_ptr->me_context_ptr->fractional_search_method = FULL_SAD_SEARCH;
+
     if (sequence_control_set_ptr->static_config.fract_search_64 == DEFAULT)
         if (picture_control_set_ptr->sc_content_detected)
+#if PRESETS_TUNE
+            if (enc_mode <= ENC_M5)
+#else
             if (enc_mode <= ENC_M1)
+#endif
                 context_ptr->me_context_ptr->fractional_search64x64 = EB_TRUE;
             else
                 context_ptr->me_context_ptr->fractional_search64x64 = EB_FALSE;
@@ -560,7 +591,11 @@ EbErrorType tf_signal_derivation_me_kernel_oq(
         else
             context_ptr->me_context_ptr->me_search_method = SUB_SAD_SEARCH;
     else
+#if PRESETS_TUNE
+        context_ptr->me_context_ptr->me_search_method = (enc_mode <= ENC_M4) ?
+#else
         context_ptr->me_context_ptr->me_search_method = (enc_mode <= ENC_M1) ?
+#endif
         FULL_SAD_SEARCH :
         SUB_SAD_SEARCH;
     return return_error;

--- a/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureDecisionProcess.c
@@ -797,6 +797,18 @@ EbErrorType signal_derivation_multi_processes_oq(
 #endif
 
         if (sc_content_detected)
+#if PRESETS_TUNE
+            if (picture_control_set_ptr->enc_mode <= ENC_M2)
+                picture_control_set_ptr->pic_depth_mode = PIC_ALL_DEPTH_MODE;
+            else if (picture_control_set_ptr->enc_mode <= ENC_M5)
+                if (picture_control_set_ptr->slice_type == I_SLICE)
+                    picture_control_set_ptr->pic_depth_mode = PIC_ALL_DEPTH_MODE;
+                else
+                    picture_control_set_ptr->pic_depth_mode = PIC_SQ_NON4_DEPTH_MODE;
+            else
+                picture_control_set_ptr->pic_depth_mode = PIC_SQ_NON4_DEPTH_MODE;
+
+#else
             if (picture_control_set_ptr->enc_mode <= ENC_M1)
                 picture_control_set_ptr->pic_depth_mode = PIC_ALL_DEPTH_MODE;
             else if (picture_control_set_ptr->enc_mode <= ENC_M3)
@@ -813,6 +825,7 @@ EbErrorType signal_derivation_multi_processes_oq(
                     picture_control_set_ptr->pic_depth_mode = PIC_SQ_NON4_DEPTH_MODE;
             else
                 picture_control_set_ptr->pic_depth_mode = PIC_SQ_NON4_DEPTH_MODE;
+#endif
 #if MULTI_PASS_PD
         else if (MR_MODE)
             picture_control_set_ptr->pic_depth_mode = PIC_ALL_DEPTH_MODE;
@@ -824,6 +837,26 @@ EbErrorType signal_derivation_multi_processes_oq(
             picture_control_set_ptr->pic_depth_mode = (picture_control_set_ptr->slice_type == I_SLICE) ? PIC_ALL_DEPTH_MODE : PIC_MULTI_PASS_PD_MODE_2;
 #endif
 
+#if PRESETS_TUNE
+#if !MULTI_PASS_PD
+        else if (picture_control_set_ptr->enc_mode <= ENC_M1)
+            picture_control_set_ptr->pic_depth_mode = PIC_ALL_DEPTH_MODE;
+        else if (picture_control_set_ptr->enc_mode <= ENC_M2)
+            if (picture_control_set_ptr->slice_type == I_SLICE)
+                picture_control_set_ptr->pic_depth_mode = PIC_ALL_DEPTH_MODE;
+            else
+                picture_control_set_ptr->pic_depth_mode = PIC_ALL_C_DEPTH_MODE;
+        //Jing: TODO:
+        //In M3, sb_sz may be 128x128, and init_sq_non4_block only works for 64x64 sb size
+#endif
+        else if (picture_control_set_ptr->enc_mode <= ENC_M6)
+            picture_control_set_ptr->pic_depth_mode = PIC_SQ_NON4_DEPTH_MODE;
+        else
+            if (picture_control_set_ptr->slice_type == I_SLICE)
+                picture_control_set_ptr->pic_depth_mode = PIC_SQ_NON4_DEPTH_MODE;
+            else
+                picture_control_set_ptr->pic_depth_mode = PIC_SB_SWITCH_DEPTH_MODE;
+#else
 // These are the default settings to use
 #if !MULTI_PASS_PD
         else if (picture_control_set_ptr->enc_mode <= ENC_M2)
@@ -849,6 +882,7 @@ EbErrorType signal_derivation_multi_processes_oq(
                 picture_control_set_ptr->pic_depth_mode = PIC_SQ_NON4_DEPTH_MODE;
             else
                 picture_control_set_ptr->pic_depth_mode = PIC_SB_SWITCH_DEPTH_MODE;
+#endif
 
         if (picture_control_set_ptr->pic_depth_mode < PIC_SQ_DEPTH_MODE)
             assert(sequence_control_set_ptr->nsq_present == 1 && "use nsq_present 1");
@@ -924,6 +958,25 @@ EbErrorType signal_derivation_multi_processes_oq(
         }
 #endif
         else if (sc_content_detected)
+#if PRESETS_TUNE
+#if M0_OPT
+            if (picture_control_set_ptr->enc_mode <= ENC_M1)
+#else
+            if (picture_control_set_ptr->enc_mode == ENC_M0)
+                picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_LEVEL6;
+            else if (picture_control_set_ptr->enc_mode <= ENC_M1)
+#endif
+                picture_control_set_ptr->nsq_search_level = (picture_control_set_ptr->is_used_as_reference_flag) ?
+                NSQ_SEARCH_LEVEL6 : NSQ_SEARCH_LEVEL3;
+            else if (picture_control_set_ptr->enc_mode <= ENC_M2)
+                if (picture_control_set_ptr->is_used_as_reference_flag)
+                    picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_LEVEL5;
+                else
+                    picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_LEVEL2;
+            else
+                picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_OFF;
+
+#else
             if (picture_control_set_ptr->enc_mode <= ENC_M1)
 #if M0_OPT
                 picture_control_set_ptr->nsq_search_level = (picture_control_set_ptr->is_used_as_reference_flag) ?
@@ -947,11 +1000,24 @@ EbErrorType signal_derivation_multi_processes_oq(
                     picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_OFF;
             else
                     picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_OFF;
+#endif
 #if PREDICT_NSQ_SHAPE && !MDC_ADAPTIVE_LEVEL
         else if (picture_control_set_ptr->mdc_depth_level == (MAX_MDC_LEVEL - 1))
             picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_LEVEL7;
 #endif
-
+#if PRESETS_TUNE
+        else if (picture_control_set_ptr->enc_mode <= ENC_M0)
+            picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_LEVEL6;
+        else if (picture_control_set_ptr->enc_mode <= ENC_M1)
+            picture_control_set_ptr->nsq_search_level = (picture_control_set_ptr->is_used_as_reference_flag) ? NSQ_SEARCH_LEVEL6 : NSQ_SEARCH_LEVEL3;
+        else if (picture_control_set_ptr->enc_mode <= ENC_M2)
+            if (picture_control_set_ptr->is_used_as_reference_flag)
+                picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_LEVEL3;
+            else
+                picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_LEVEL1;
+        else
+            picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_OFF;
+#else
         else if (picture_control_set_ptr->enc_mode <= ENC_M1)
             picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_LEVEL6;
 
@@ -962,6 +1028,7 @@ EbErrorType signal_derivation_multi_processes_oq(
                 picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_LEVEL3;
         else
             picture_control_set_ptr->nsq_search_level = NSQ_SEARCH_OFF;
+#endif
 
     if (picture_control_set_ptr->nsq_search_level > NSQ_SEARCH_OFF)
         assert(sequence_control_set_ptr->nsq_present == 1 && "use nsq_present 1");
@@ -1048,7 +1115,11 @@ EbErrorType signal_derivation_multi_processes_oq(
             frm_hdr->allow_intrabc =  0;
 
         //IBC Modes:   0:Slow   1:Fast   2:Faster
+#if PRESETS_TUNE
+        if (picture_control_set_ptr->enc_mode <= ENC_M5)
+#else
         if (picture_control_set_ptr->enc_mode <= ENC_M2)
+#endif
             picture_control_set_ptr->ibc_mode = 0;
         else
             picture_control_set_ptr->ibc_mode = 1;
@@ -1101,11 +1172,19 @@ EbErrorType signal_derivation_multi_processes_oq(
         else
             picture_control_set_ptr->loop_filter_mode = 0;
     else
-
+#if PRESETS_OPT
+        if (picture_control_set_ptr->enc_mode <= ENC_M7)
+            picture_control_set_ptr->loop_filter_mode = 3;
+#else
+#if PRESETS_TUNE
+        if (picture_control_set_ptr->enc_mode <= ENC_M2)
+#else
         if (picture_control_set_ptr->enc_mode == ENC_M0)
+#endif
             picture_control_set_ptr->loop_filter_mode = 3;
         else if (picture_control_set_ptr->enc_mode <= ENC_M5)
             picture_control_set_ptr->loop_filter_mode = picture_control_set_ptr->is_used_as_reference_flag ? 3 : 0;
+#endif
         else
             picture_control_set_ptr->loop_filter_mode = picture_control_set_ptr->is_used_as_reference_flag ? 1 : 0;
     }
@@ -1120,14 +1199,26 @@ EbErrorType signal_derivation_multi_processes_oq(
     // 5                                            64 step refinement
     if (sequence_control_set_ptr->seq_header.enable_cdef && frm_hdr->allow_intrabc == 0) {
         if (sc_content_detected)
+#if PRESETS_TUNE
+            if (picture_control_set_ptr->enc_mode <= ENC_M5)
+#else
             if (picture_control_set_ptr->enc_mode <= ENC_M1)
+#endif
                 picture_control_set_ptr->cdef_filter_mode = 4;
             else
                 picture_control_set_ptr->cdef_filter_mode = 0;
         else
         if (picture_control_set_ptr->enc_mode <= ENC_M7)
 #if M0_OPT
+#if PRESETS_TUNE
+#if PRESETS_OPT
+            picture_control_set_ptr->cdef_filter_mode = 5;
+#else
+            picture_control_set_ptr->cdef_filter_mode = (picture_control_set_ptr->enc_mode <= ENC_M1) ? 5 : 4;
+#endif
+#else
             picture_control_set_ptr->cdef_filter_mode = (picture_control_set_ptr->enc_mode <= ENC_M0) ? 5 : 4;
+#endif
 #else
             picture_control_set_ptr->cdef_filter_mode = 4;
 #endif
@@ -1146,12 +1237,20 @@ EbErrorType signal_derivation_multi_processes_oq(
 
     Av1Common* cm = picture_control_set_ptr->av1_cm;
     if (sc_content_detected)
+#if PRESETS_TUNE
+        if (picture_control_set_ptr->enc_mode <= ENC_M5)
+#else
         if (picture_control_set_ptr->enc_mode <= ENC_M1)
+#endif
             cm->sg_filter_mode = 4;
         else
             cm->sg_filter_mode = 0;
     else
-    if (picture_control_set_ptr->enc_mode <= ENC_M4)
+#if PRESETS_TUNE
+        if (picture_control_set_ptr->enc_mode <= ENC_M2)
+#else
+        if (picture_control_set_ptr->enc_mode <= ENC_M4)
+#endif
         cm->sg_filter_mode = 4;
     else if (picture_control_set_ptr->enc_mode <= ENC_M6)
         cm->sg_filter_mode = 3;
@@ -1165,7 +1264,11 @@ EbErrorType signal_derivation_multi_processes_oq(
     // 3                                            7-Tap luma/ 5-Tap chroma
 
     if (sc_content_detected)
+#if PRESETS_TUNE
+        if (picture_control_set_ptr->enc_mode <= ENC_M5)
+#else
         if (picture_control_set_ptr->enc_mode <= ENC_M1)
+#endif
             cm->wn_filter_mode = 3;
         else
             cm->wn_filter_mode = 0;
@@ -1257,7 +1360,11 @@ EbErrorType signal_derivation_multi_processes_oq(
         else
             picture_control_set_ptr->intra_pred_mode = 4;
     else
+#if PRESETS_OPT
+        if (picture_control_set_ptr->enc_mode <= ENC_M7)
+#else
         if (picture_control_set_ptr->enc_mode <= ENC_M6)
+#endif
             picture_control_set_ptr->intra_pred_mode = 0;
         else
             picture_control_set_ptr->intra_pred_mode = 4;
@@ -1283,7 +1390,10 @@ EbErrorType signal_derivation_multi_processes_oq(
         else
             picture_control_set_ptr->intra_pred_mode = 4;
     else
-
+#if PRESETS_TUNE
+        if ((picture_control_set_ptr->enc_mode <= ENC_M1) || (picture_control_set_ptr->enc_mode <= ENC_M2 && picture_control_set_ptr->temporal_layer_index == 0))
+            picture_control_set_ptr->intra_pred_mode = 0;
+#else
         if (picture_control_set_ptr->enc_mode == ENC_M0)
             picture_control_set_ptr->intra_pred_mode = 0;
         else if (picture_control_set_ptr->enc_mode  <= ENC_M1)
@@ -1291,7 +1401,12 @@ EbErrorType signal_derivation_multi_processes_oq(
                 picture_control_set_ptr->intra_pred_mode = 1;
             else
                 picture_control_set_ptr->intra_pred_mode = 2;
+#endif
+#if PRESETS_OPT
+        else if (picture_control_set_ptr->enc_mode <= ENC_M7)
+#else
         else if(picture_control_set_ptr->enc_mode <= ENC_M6)
+#endif
             if (picture_control_set_ptr->temporal_layer_index == 0)
                 picture_control_set_ptr->intra_pred_mode = 1;
             else
@@ -1325,7 +1440,11 @@ EbErrorType signal_derivation_multi_processes_oq(
         // 1                 ON for INTRA blocks
 #if ATB_10_BIT
 #if ATB_HBD
+#if PRESETS_OPT
+        if (picture_control_set_ptr->enc_mode <= ENC_M2)
+#else
         if (picture_control_set_ptr->enc_mode <= ENC_M1)
+#endif
 #else
         if (picture_control_set_ptr->enc_mode <= ENC_M1 &&  !sequence_control_set_ptr->static_config.enable_hbd_mode_decision)
 #endif
@@ -1344,7 +1463,13 @@ EbErrorType signal_derivation_multi_processes_oq(
         // Set skip atb                          Settings
         // 0                                     OFF
         // 1                                     ON
-
+#if PRESETS_OPT
+        // Phoenix: Active only when atb compound is on
+        if (picture_control_set_ptr->enc_mode <= ENC_M7)
+            picture_control_set_ptr->coeff_based_skip_atb = 0;
+        else
+            picture_control_set_ptr->coeff_based_skip_atb = 1;
+#else
 #if SPEED_OPT
 #if ENHANCED_M0_SETTINGS
         if (picture_control_set_ptr->enc_mode == ENC_M0 || picture_control_set_ptr->sc_content_detected)
@@ -1357,6 +1482,7 @@ EbErrorType signal_derivation_multi_processes_oq(
             picture_control_set_ptr->coeff_based_skip_atb = 0;
         else
             picture_control_set_ptr->coeff_based_skip_atb = 1;
+#endif
 
         // Set Wedge mode      Settings
         // 0                 FULL: Full search
@@ -1382,8 +1508,15 @@ EbErrorType signal_derivation_multi_processes_oq(
         // 2                 ON: AVG/DIST/DIFF/WEDGE
         if (sequence_control_set_ptr->static_config.compound_level == DEFAULT) {
             if (sequence_control_set_ptr->compound_mode)
+#if PRESETS_TUNE
+                if (picture_control_set_ptr->sc_content_detected)
+                    picture_control_set_ptr->compound_mode = (picture_control_set_ptr->enc_mode <= ENC_M0) ? 2 : 0;
+                else
+                    picture_control_set_ptr->compound_mode = picture_control_set_ptr->enc_mode <= ENC_M1 ? 2 : 1;
+#else
                 picture_control_set_ptr->compound_mode = picture_control_set_ptr->sc_content_detected ? 0 :
                 picture_control_set_ptr->enc_mode <= ENC_M1 ? 2 : 1;
+#endif
             else
                 picture_control_set_ptr->compound_mode = 0;
 #if !MULTI_PASS_PD
@@ -1401,10 +1534,14 @@ EbErrorType signal_derivation_multi_processes_oq(
         // 0                                     OFF
         // 1                                     ON
         if (sequence_control_set_ptr->static_config.frame_end_cdf_update == DEFAULT)
+#if PRESETS_TUNE
+            picture_control_set_ptr->frame_end_cdf_update_mode = 1;
+#else
             if (picture_control_set_ptr->enc_mode == ENC_M0)
                 picture_control_set_ptr->frame_end_cdf_update_mode = 1;
             else
                 picture_control_set_ptr->frame_end_cdf_update_mode = 0;
+#endif
         else
             picture_control_set_ptr->frame_end_cdf_update_mode = sequence_control_set_ptr->static_config.frame_end_cdf_update;
 

--- a/Source/Lib/Common/Codec/EbPredictionStructure.c
+++ b/Source/Lib/Common/Codec/EbPredictionStructure.c
@@ -1742,6 +1742,25 @@ EbErrorType prediction_structure_group_ctor(
 
     predictionStructureGroupPtr->dctor = prediction_structure_group_dctor;
 
+#if PRESETS_TUNE
+    uint8_t ref_count_used = enc_mode <= ENC_M1 ? MAX_REF_IDX : enc_mode <= ENC_M2 ? 2 : 1;
+
+    if (ref_count_used > 0 && ref_count_used < MAX_REF_IDX) {
+        for (int gop_i = 1; gop_i < 8; ++gop_i) {
+            for (int i = ref_count_used; i < MAX_REF_IDX; ++i) {
+                four_level_hierarchical_pred_struct[gop_i].ref_list0[i] = 0;
+                four_level_hierarchical_pred_struct[gop_i].ref_list1[i] = 0;
+            }
+        }
+
+        for (int gop_i = 1; gop_i < 16; ++gop_i) {
+            for (int i = ref_count_used; i < MAX_REF_IDX; ++i) {
+                five_level_hierarchical_pred_struct[gop_i].ref_list0[i] = 0;
+                five_level_hierarchical_pred_struct[gop_i].ref_list1[i] = 0;
+            }
+        }
+    }
+#else
     if (enc_mode > ENC_M0) {
         for (int gop_i = 1; gop_i < 8; ++gop_i) {
             for (int i = 1; i < 4; ++i) {
@@ -1757,6 +1776,7 @@ EbErrorType prediction_structure_group_ctor(
             }
         }
     }
+#endif
 
     // Count the number of Prediction Structures
     while ((PredictionStructureConfigArray[predStructIndex].entry_array != 0) && (PredictionStructureConfigArray[predStructIndex].entry_count != 0)) {

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -1675,7 +1675,11 @@ void set_md_stage_counts(
     if (context_ptr->combine_class12) {
         context_ptr->md_stage_1_count[CAND_CLASS_1] = context_ptr->md_stage_1_count[CAND_CLASS_1] * 2;
     }
+#if PRESETS_TUNE
+    if (picture_control_set_ptr->enc_mode >= ENC_M3) {
+#else
     if (picture_control_set_ptr->enc_mode >= ENC_M2) {
+#endif
         context_ptr->md_stage_1_count[CAND_CLASS_1] = context_ptr->md_stage_1_count[CAND_CLASS_1] / 2;
         context_ptr->md_stage_1_count[CAND_CLASS_2] = context_ptr->md_stage_1_count[CAND_CLASS_2] / 2;
         context_ptr->md_stage_1_count[CAND_CLASS_3] = context_ptr->md_stage_1_count[CAND_CLASS_3] / 2;
@@ -1739,10 +1743,20 @@ void set_md_stage_counts(
 #endif
     }
 
+#if PRESETS_OPT
+    if (picture_control_set_ptr->enc_mode >= ENC_M8)
+#elif PRESETS_TUNE
+    if (picture_control_set_ptr->enc_mode >= ENC_M2)
+#else
     if (picture_control_set_ptr->enc_mode >= ENC_M1)
+#endif
         context_ptr->md_stage_2_count[CAND_CLASS_0] = (picture_control_set_ptr->slice_type == I_SLICE) ? 10 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 4 : 1;
 
+#if PRESETS_TUNE
+    if (picture_control_set_ptr->enc_mode >= ENC_M3 && picture_control_set_ptr->enc_mode <= ENC_M4) {
+#else
     if (picture_control_set_ptr->enc_mode >= ENC_M2 && picture_control_set_ptr->enc_mode <= ENC_M4) {
+#endif
         context_ptr->md_stage_2_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 4 : 2;
         context_ptr->md_stage_2_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 2 : 1;
         if (!context_ptr->combine_class12) {

--- a/Source/Lib/Encoder/Codec/EbEncHandle.c
+++ b/Source/Lib/Encoder/Codec/EbEncHandle.c
@@ -1997,7 +1997,13 @@ void SetParamBasedOnInput(SequenceControlSet *sequence_control_set_ptr)
 
     //0: MRP Mode 0 (4,3)
     //1: MRP Mode 1 (2,2)
+#if PRESETS_OPT
+    sequence_control_set_ptr->mrp_mode = (uint8_t)(sequence_control_set_ptr->static_config.enc_mode <= ENC_M7) ? 0 : 1;
+#elif PRESETS_TUNE
+    sequence_control_set_ptr->mrp_mode = (uint8_t)(sequence_control_set_ptr->static_config.enc_mode <= ENC_M2) ? 0 : 1;
+#else
     sequence_control_set_ptr->mrp_mode = (uint8_t) (sequence_control_set_ptr->static_config.enc_mode == ENC_M0) ? 0 : 1;
+#endif
 
     //0: ON
     //1: OFF
@@ -2010,16 +2016,33 @@ void SetParamBasedOnInput(SequenceControlSet *sequence_control_set_ptr)
     // Set down-sampling method     Settings
     // 0                            0: filtering
     // 1                            1: decimation
+#if PRESETS_TUNE
+    if (sequence_control_set_ptr->static_config.screen_content_mode == 1)
+        if (sequence_control_set_ptr->static_config.enc_mode <= ENC_M4)
+            sequence_control_set_ptr->down_sampling_method_me_search = ME_FILTERED_DOWNSAMPLED;
+        else
+            sequence_control_set_ptr->down_sampling_method_me_search = ME_DECIMATED_DOWNSAMPLED;
+    else
+        if (sequence_control_set_ptr->static_config.enc_mode <= ENC_M4)
+            sequence_control_set_ptr->down_sampling_method_me_search = ME_FILTERED_DOWNSAMPLED;
+        else
+            sequence_control_set_ptr->down_sampling_method_me_search = ME_DECIMATED_DOWNSAMPLED;
+#else
     if (sequence_control_set_ptr->static_config.enc_mode == ENC_M0)
         sequence_control_set_ptr->down_sampling_method_me_search = ME_FILTERED_DOWNSAMPLED;
     else
         sequence_control_set_ptr->down_sampling_method_me_search = ME_DECIMATED_DOWNSAMPLED;
+#endif
 
     // Set over_boundary_block_mode     Settings
     // 0                            0: not allowed
     // 1                            1: allowed
     if (sequence_control_set_ptr->static_config.over_bndry_blk == DEFAULT)
+#if PRESETS_TUNE
+        if (sequence_control_set_ptr->static_config.enc_mode <= ENC_M5)
+#else
         if (sequence_control_set_ptr->static_config.enc_mode == ENC_M0)
+#endif
             sequence_control_set_ptr->over_boundary_block_mode = 1;
         else
             sequence_control_set_ptr->over_boundary_block_mode = 0;
@@ -2027,16 +2050,27 @@ void SetParamBasedOnInput(SequenceControlSet *sequence_control_set_ptr)
         sequence_control_set_ptr->over_boundary_block_mode = sequence_control_set_ptr->static_config.over_bndry_blk;
 
     if (sequence_control_set_ptr->static_config.enable_mfmv == DEFAULT)
+#if PRESETS_TUNE
+        if (sequence_control_set_ptr->static_config.screen_content_mode == 1)
+            sequence_control_set_ptr->mfmv_enabled = 0;
+        else
+            sequence_control_set_ptr->mfmv_enabled = (uint8_t)(sequence_control_set_ptr->static_config.enc_mode <= ENC_M1) ? 1 : 0;
+#else
 #if M0_OPT
         sequence_control_set_ptr->mfmv_enabled = (uint8_t)(sequence_control_set_ptr->static_config.enc_mode == ENC_M0 && sequence_control_set_ptr->static_config.screen_content_mode != 1) ? 1 : 0;
 #else
         sequence_control_set_ptr->mfmv_enabled = (uint8_t)(sequence_control_set_ptr->static_config.enc_mode == ENC_M0) ? 1 : 0;
 #endif
+#endif
     else
         sequence_control_set_ptr->mfmv_enabled = sequence_control_set_ptr->static_config.enable_mfmv;
 
     // Set hbd_mode_decision OFF for high encode modes or bitdepth < 10
+#if PRESETS_TUNE
+    if (sequence_control_set_ptr->static_config.encoder_bit_depth < 10)
+#else
     if (sequence_control_set_ptr->static_config.enc_mode > ENC_M0 || sequence_control_set_ptr->static_config.encoder_bit_depth < 10)
+#endif
         sequence_control_set_ptr->static_config.enable_hbd_mode_decision = 0;
 }
 

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -696,10 +696,14 @@ void* resource_coordination_kernel(void *input_ptr)
             sb_params_init(sequence_control_set_ptr);
             sb_geom_init(sequence_control_set_ptr);
 
+#if PRESETS_TUNE // this should be updated to support hbd
+            sequence_control_set_ptr->enable_altrefs = sequence_control_set_ptr->static_config.enable_altrefs ? EB_TRUE : EB_FALSE;
+#else
             sequence_control_set_ptr->enable_altrefs = sequence_control_set_ptr->static_config.enable_altrefs &&
-                    sequence_control_set_ptr->static_config.altref_nframes > 1 &&
-                    ((sequence_control_set_ptr->static_config.encoder_bit_depth >= 8 && sequence_control_set_ptr->static_config.enc_mode == ENC_M0) ||
+                sequence_control_set_ptr->static_config.altref_nframes > 1 &&
+                ((sequence_control_set_ptr->static_config.encoder_bit_depth >= 8 && sequence_control_set_ptr->static_config.enc_mode == ENC_M0) ||
                     sequence_control_set_ptr->static_config.encoder_bit_depth == 8) ? EB_TRUE : EB_FALSE;
+#endif
 
             if (sequence_control_set_ptr->static_config.inter_intra_compound == DEFAULT) {
 #if II_COMP_FLAG
@@ -709,7 +713,11 @@ void* resource_coordination_kernel(void *input_ptr)
             // 1                 ON
 #if INTERINTRA_HBD
 #if M0_OPT
-            sequence_control_set_ptr->seq_header.enable_interintra_compound = MR_MODE || (sequence_control_set_ptr->static_config.enc_mode == ENC_M0 && sequence_control_set_ptr->static_config.screen_content_mode != 1) ? 1 : 0;
+#if PRESETS_TUNE
+                sequence_control_set_ptr->seq_header.enable_interintra_compound = MR_MODE || (sequence_control_set_ptr->static_config.enc_mode <= ENC_M1 && sequence_control_set_ptr->static_config.screen_content_mode != 1) ? 1 : 0;
+#else
+                sequence_control_set_ptr->seq_header.enable_interintra_compound = MR_MODE || (sequence_control_set_ptr->static_config.enc_mode == ENC_M0 && sequence_control_set_ptr->static_config.screen_content_mode != 1) ? 1 : 0;
+#endif
 #else
             sequence_control_set_ptr->seq_header.enable_interintra_compound = (sequence_control_set_ptr->static_config.enc_mode == ENC_M0) ? 1 : 0;
 #endif
@@ -735,7 +743,11 @@ void* resource_coordination_kernel(void *input_ptr)
             // 0                 OFF
             // 1                 ON
             if (sequence_control_set_ptr->static_config.enable_filter_intra)
-                sequence_control_set_ptr->seq_header.enable_filter_intra        = (sequence_control_set_ptr->static_config.enc_mode <= ENC_M2) ? 1 : 0;
+#if PRESETS_TUNE
+                sequence_control_set_ptr->seq_header.enable_filter_intra = (sequence_control_set_ptr->static_config.enc_mode <= ENC_M4) ? 1 : 0;
+#else
+                sequence_control_set_ptr->seq_header.enable_filter_intra = (sequence_control_set_ptr->static_config.enc_mode <= ENC_M2) ? 1 : 0;
+#endif
             else
                 sequence_control_set_ptr->seq_header.enable_filter_intra        =  0;
 #endif


### PR DESCRIPTION
## Description

This PR ports the signal presets from the ms-dec1 branch, which are tuned for better M1 to M8 performance.  These changes (under the PRESETS_TUNE macro) will give the same bitstreams as the ms-dec1 branch under the following conditions:

- RATE_ESTIMATION_UPDATE off
- TX_SIZE_EARLY_EXIT off
- HBD2_COMP off
- HBD2_PME off
- HBD2_OBMC off
- AUTO_MAX_PARTITION off
- config_ptr->enable_hbd_mode_decision = 1
- PRESETS_OPT off

Additionally, the signal presets are further updated (under the PRESETS_OPT macro), based on recent testing data, for better M1-M3 performance.

Closes #902 

## Type of Change

Enhancement

## Author

@PhoenixWorthVCD 

## Testing and Performance

The data was generated using the optimizations on top of the ms-dec1 branch settings (listed above), and compared to the ms-dec1 branch (difference to AOM).  NB: a negative speed indicates a slow-down.  M0 bitstreams are not affected.

8-bit data was obtained for the objective-1-fast dataset, without screen content.

Mode | BDR | speed
-- | -- | --
M1 | -0.52% | -14.7%
M2 | -1.24% | -10.8%
M3 | -0.64% | -7.8%

10-bit data was obtained using fourteen 720p true 10-bit clips without screen content.

Mode | BDR | speed
-- | -- | --
M1 | -0.51% | expected: -6%
M2 | -0.77% | expected: -7%
M3 | -0.22% | 
