### PR TITLE
compile: fix build for gcc 7.4

### DIFF
--- a/Source/Lib/Decoder/Codec/EbDecParseObu.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseObu.c
@@ -1762,7 +1762,7 @@ static INLINE EbErrorType reallocate_parse_context_memory(
     return EB_ErrorNone;
 }
 
-INLINE EbErrorType reallocate_parse_tile_data(
+static INLINE EbErrorType reallocate_parse_tile_data(
     MasterParseCtxt *master_parse_ctx,
     int num_tiles)
 {


### PR DESCRIPTION
we will have following error on gcc 7.4
../../../../Bin/Debug/libSvtAv1Dec.so.0.7.5: undefined reference to `reallocate_parse_tile_data'