### PR TITLE
Fixes for update_av1_mi_map() and update_mi_map() valgrind errors

### DIFF
--- a/Source/Lib/Common/Codec/EbModeDecision.c
+++ b/Source/Lib/Common/Codec/EbModeDecision.c
@@ -5715,6 +5715,9 @@ void  inject_intra_candidates(
                         candidateArray[canTotalCnt].ref_frame_type = INTRA_FRAME;
                         candidateArray[canTotalCnt].pred_mode = (PredictionMode)openLoopIntraCandidate;
                         candidateArray[canTotalCnt].motion_mode = SIMPLE_TRANSLATION;
+#if II_COMP_FLAG
+                        candidateArray[canTotalCnt].is_interintra_used = 0;
+#endif
                         INCRMENT_CAND_TOTAL_COUNT(canTotalCnt);
                     }
             }
@@ -5782,6 +5785,9 @@ void  inject_intra_candidates(
             candidateArray[canTotalCnt].ref_frame_type = INTRA_FRAME;
             candidateArray[canTotalCnt].pred_mode = (PredictionMode)openLoopIntraCandidate;
             candidateArray[canTotalCnt].motion_mode = SIMPLE_TRANSLATION;
+#if II_COMP_FLAG
+            candidateArray[canTotalCnt].is_interintra_used = 0;
+#endif
             INCRMENT_CAND_TOTAL_COUNT(canTotalCnt);
         }
     }
@@ -5872,6 +5878,9 @@ void  inject_filter_intra_candidates(
             candidateArray[canTotalCnt].pred_mode = DC_PRED;
             candidateArray[canTotalCnt].motion_mode = SIMPLE_TRANSLATION;
 
+#if II_COMP_FLAG
+            candidateArray[canTotalCnt].is_interintra_used = 0;
+#endif
             INCRMENT_CAND_TOTAL_COUNT(canTotalCnt);
     }
 


### PR DESCRIPTION
Github Issue: #733

Conditional jump or move depends on uninitialised value(s)
at 0x4F2AE52: update_av1_mi_map (EbAdaptiveMotionVectorPrediction.c:1504)
by 0x4F4AEFE: av1_encode_pass (EbCodingLoop.c:3805)
by 0x4F5F324: enc_dec_kernel (EbEncDecProcess.c:3189)
by 0x1012DDD4: start_thread (in /usr/lib64/libpthread-2.17.so)
by 0x10741EAC: clone (in /usr/lib64/libc-2.17.so)

Conditional jump or move depends on uninitialised value(s)
at 0x4F2B61F: update_mi_map (EbAdaptiveMotionVectorPrediction.c:1596)
by 0x5051495: md_update_all_neighbour_arrays (EbProductCodingLoop.c:673)
by 0x50514FD: md_update_all_neighbour_arrays_multiple (EbProductCodingLoop.c:694)
by 0x5066DE1: mode_decision_sb (EbProductCodingLoop.c:9779)
by 0x4F5F2D2: enc_dec_kernel (EbEncDecProcess.c:3160)
by 0x1012DDD4: start_thread (in /usr/lib64/libpthread-2.17.so)
by 0x10741EAC: clone (in /usr/lib64/libc-2.17.so)