### PR TITLE
Macro cleanup 

### DIFF
--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -17,7 +17,6 @@ extern "C" {
 #include <stdio.h>
 #endif
 #define TILES    1
-#define TWO_PASS_USE_2NDP_ME_IN_1STP                1
 #define TWO_PASS                                    1
 #define ALT_REF_OVERLAY_APP                         1
     //***HME***
@@ -46,13 +45,11 @@ typedef struct EbSvtAv1EncConfiguration
      *
      * Default is defined as MAX_ENC_PRESET. */
     uint8_t                  enc_mode;
-#if TWO_PASS_USE_2NDP_ME_IN_1STP
     /* For two pass encoding, the enc_mod of the second pass is passed in the first pass.
     * First pass has the option to run with second pass ME settings.
     *
     * Default is defined as MAX_ENC_PRESET. */
     uint8_t                  snd_pass_enc_mode;
-#endif
     // GOP Structure
 
     /* The intra period defines the interval of frames after which you insert an

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -50,9 +50,7 @@
 #define ENCODER_COLOR_FORMAT            "-color-format"
 #define INPUT_COMPRESSED_TEN_BIT_FORMAT "-compressed-ten-bit-format"
 #define ENCMODE_TOKEN                   "-enc-mode"
-#if TWO_PASS_USE_2NDP_ME_IN_1STP
 #define ENCMODE2P_TOKEN                 "-enc-mode-2p"
-#endif
 #define HIERARCHICAL_LEVELS_TOKEN       "-hierarchical-levels" // no Eval
 #define PRED_STRUCT_TOKEN               "-pred-struct"
 #define INTRA_PERIOD_TOKEN              "-intra-period"
@@ -217,7 +215,6 @@ static void SetCfgQpFile                        (const char *value, EbConfig *cf
     if (cfg->qp_file) { fclose(cfg->qp_file); }
     FOPEN(cfg->qp_file,value, "r");
 };
-#if TWO_PASS
 static void set_input_stat_file(const char *value, EbConfig *cfg)
 {
     if (cfg->input_stat_file) { fclose(cfg->input_stat_file); }
@@ -228,10 +225,7 @@ static void set_output_stat_file(const char *value, EbConfig *cfg)
     if (cfg->output_stat_file) { fclose(cfg->output_stat_file); }
     FOPEN(cfg->output_stat_file, value, "wb");
 };
-#if TWO_PASS_USE_2NDP_ME_IN_1STP
 static void set_snd_pass_enc_mode(const char *value, EbConfig *cfg) { cfg->snd_pass_enc_mode = (uint8_t)strtoul(value, NULL, 0); };
-#endif
-#endif
 static void SetCfgStatFile(const char *value, EbConfig *cfg)
 {
     if (cfg->stat_file) { fclose(cfg->stat_file); }
@@ -451,9 +445,7 @@ config_entry_t config_entry[] = {
     { SINGLE_INPUT, BUFFERED_INPUT_TOKEN, "BufferedInput", SetBufferedInput },
     { SINGLE_INPUT, BASE_LAYER_SWITCH_MODE_TOKEN, "BaseLayerSwitchMode", SetBaseLayerSwitchMode },
     { SINGLE_INPUT, ENCMODE_TOKEN, "EncoderMode", SetencMode},
-#if TWO_PASS_USE_2NDP_ME_IN_1STP
     { SINGLE_INPUT, ENCMODE2P_TOKEN, "EncoderMode2p", set_snd_pass_enc_mode},
-#endif
     { SINGLE_INPUT, INTRA_PERIOD_TOKEN, "IntraPeriod", SetCfgIntraPeriod },
     { SINGLE_INPUT, INTRA_REFRESH_TYPE_TOKEN, "IntraRefreshType", SetCfgIntraRefreshType },
     { SINGLE_INPUT, FRAME_RATE_TOKEN, "FrameRate", SetFrameRate },
@@ -619,9 +611,7 @@ void eb_config_ctor(EbConfig *config_ptr)
 
     config_ptr->enable_adaptive_quantization         = 2;
     config_ptr->enc_mode                              = MAX_ENC_PRESET;
-#if TWO_PASS_USE_2NDP_ME_IN_1STP
     config_ptr->snd_pass_enc_mode                     = MAX_ENC_PRESET + 1;
-#endif
     config_ptr->intra_period                          = -2;
     config_ptr->intra_refresh_type                     = 1;
     config_ptr->hierarchical_levels                   = 4;

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -213,9 +213,7 @@ typedef struct EbConfig
      *****************************************/
     uint32_t                 base_layer_switch_mode;
     uint8_t                  enc_mode;
-#if TWO_PASS_USE_2NDP_ME_IN_1STP
     uint8_t                  snd_pass_enc_mode;
-#endif
     int32_t                  intra_period;
     uint32_t                 intra_refresh_type;
     uint32_t                 hierarchical_levels;

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -150,19 +150,15 @@ EbErrorType CopyConfigurationParameters(
 
     // Initialize Port Activity Flags
     callback_data->output_stream_port_active = APP_PortActive;
-
     callback_data->eb_enc_parameters.source_width = config->source_width;
     callback_data->eb_enc_parameters.source_height = config->source_height;
     callback_data->eb_enc_parameters.render_width = config->input_padded_width;
     callback_data->eb_enc_parameters.render_height = config->input_padded_height;
-
     callback_data->eb_enc_parameters.intra_period_length = config->intra_period;
     callback_data->eb_enc_parameters.intra_refresh_type = config->intra_refresh_type;
     callback_data->eb_enc_parameters.base_layer_switch_mode = config->base_layer_switch_mode;
     callback_data->eb_enc_parameters.enc_mode = (EbBool)config->enc_mode;
-#if TWO_PASS_USE_2NDP_ME_IN_1STP
     callback_data->eb_enc_parameters.snd_pass_enc_mode = (EbBool)config->snd_pass_enc_mode;
-#endif
     callback_data->eb_enc_parameters.frame_rate = config->frame_rate;
     callback_data->eb_enc_parameters.frame_rate_denominator = config->frame_rate_denominator;
     callback_data->eb_enc_parameters.frame_rate_numerator = config->frame_rate_numerator;
@@ -171,7 +167,6 @@ EbErrorType CopyConfigurationParameters(
     callback_data->eb_enc_parameters.ext_block_flag = config->ext_block_flag;
     callback_data->eb_enc_parameters.tile_rows = config->tile_rows;
     callback_data->eb_enc_parameters.tile_columns = config->tile_columns;
-
     callback_data->eb_enc_parameters.scene_change_detection = config->scene_change_detection;
     callback_data->eb_enc_parameters.look_ahead_distance = config->look_ahead_distance;
     callback_data->eb_enc_parameters.frames_to_be_encoded = config->frames_to_be_encoded;

--- a/Source/Lib/Common/ASM_AVX2/convolve_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/convolve_avx2.c
@@ -1552,8 +1552,6 @@ static INLINE __m256i calc_mask_avx2(const __m256i mask_base, const __m256i s0,
         _mm256_add_epi16(mask_base, _mm256_srli_epi16(diff, 4)));
     // clamp(diff, 0, 64) can be skiped for diff is always in the range ( 38, 54)
 }
-#if COMP_HBD
-
 void av1_build_compound_diffwtd_mask_highbd_avx2(
     uint8_t *mask, DIFFWTD_MASK_TYPE mask_type, const uint8_t *src0,
     int src0_stride, const uint8_t *src1, int src1_stride, int h, int w,
@@ -1661,7 +1659,7 @@ void av1_build_compound_diffwtd_mask_highbd_avx2(
 }
 
 
-#endif
+
 void av1_build_compound_diffwtd_mask_avx2(uint8_t *mask,
     DIFFWTD_MASK_TYPE mask_type,
     const uint8_t *src0, int src0_stride,

--- a/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
+++ b/Source/Lib/Common/Codec/EbAdaptiveMotionVectorPrediction.c
@@ -1538,7 +1538,6 @@ void update_av1_mi_map(
 #endif
             //needed for CDEF
             miPtr[miX + miY * mi_stride].mbmi.block_mi.skip = cu_ptr->block_has_coeff ? EB_FALSE : EB_TRUE;
-#if RATE_ESTIMATION_UPDATE
             miPtr[miX + miY * mi_stride].mbmi.block_mi.skip_mode = (int8_t)cu_ptr->skip_flag;
             miPtr[miX + miY * mi_stride].mbmi.block_mi.segment_id = cu_ptr->segment_id;
             miPtr[miX + miY * mi_stride].mbmi.block_mi.seg_id_predicted = cu_ptr->seg_id_predicted;
@@ -1548,7 +1547,7 @@ void update_av1_mi_map(
             miPtr[miX + miY * mi_stride].mbmi.block_mi.cfl_alpha_signs = cu_ptr->prediction_unit_array->cfl_alpha_signs;
             miPtr[miX + miY * mi_stride].mbmi.block_mi.angle_delta[PLANE_TYPE_Y] = cu_ptr->prediction_unit_array[0].angle_delta[PLANE_TYPE_Y];
             miPtr[miX + miY * mi_stride].mbmi.block_mi.angle_delta[PLANE_TYPE_UV] = cu_ptr->prediction_unit_array[0].angle_delta[PLANE_TYPE_UV];
-#endif
+
         }
     }
 }
@@ -1632,7 +1631,6 @@ void update_mi_map(
 #if PAL_SUP
             memcpy(&miPtr[miX + miY * mi_stride].mbmi.palette_mode_info, &cu_ptr->palette_info.pmi, sizeof(PaletteModeInfo));
 #endif
-#if RATE_ESTIMATION_UPDATE
             miPtr[miX + miY * mi_stride].mbmi.block_mi.skip_mode = (int8_t)cu_ptr->skip_flag;
             miPtr[miX + miY * mi_stride].mbmi.block_mi.segment_id = cu_ptr->segment_id;
             miPtr[miX + miY * mi_stride].mbmi.block_mi.seg_id_predicted = cu_ptr->seg_id_predicted;
@@ -1642,7 +1640,7 @@ void update_mi_map(
             miPtr[miX + miY * mi_stride].mbmi.block_mi.cfl_alpha_signs = cu_ptr->prediction_unit_array->cfl_alpha_signs;
             miPtr[miX + miY * mi_stride].mbmi.block_mi.angle_delta[PLANE_TYPE_Y] = cu_ptr->prediction_unit_array[0].angle_delta[PLANE_TYPE_Y];
             miPtr[miX + miY * mi_stride].mbmi.block_mi.angle_delta[PLANE_TYPE_UV] = cu_ptr->prediction_unit_array[0].angle_delta[PLANE_TYPE_UV];
-#endif
+
         }
     }
 }

--- a/Source/Lib/Common/Codec/EbCodingUnit.h
+++ b/Source/Lib/Common/Codec/EbCodingUnit.h
@@ -503,9 +503,7 @@ extern "C" {
         int32_t                     interintra_wedge_index;
         int32_t                     ii_wedge_sign;
 #endif
-#if FILTER_INTRA_FLAG
        uint8_t                      filter_intra_mode;
-#endif
 #if PAL_SUP
        PaletteInfo                          palette_info;
 #endif

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -32,34 +32,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#define TX_SIZE_EARLY_EXIT          1 // Exit TX size search when all coefficients are zero.
-
-#define   SINGLE_CORE_ENCODE   1
-#if SINGLE_CORE_ENCODE
-#define SERIAL_MODE                  1 // Change ressource allocations  to optimize single core operating mode
-#define OUT_ALLOC                    1 // Output bitsream allocation at run time for both single/multi core
-#define PAREF_OUT                    1 // Disconnect pa ref  from input for both single/multi core
-#define NO_THREAD_PIN                1 // Adding the ability to not pin the -lp 1 use case to core 0
-#endif
 #define INIT_GM_FIX           1 // initilize global motion to be OFF for all references frames.
-#define REVERT_ALTREF_FIX     1 // put back padding r2r fix for altref
 
 #define ENHANCED_M0_SETTINGS         1 // Updated M0 settings(optimized independent chroma search for all layers, conservative coeff - based NSQ cands reduction, shut coeff - based skip tx size search, warped for all layers, SUB - SAD as ME search method for non - SC only)
 #define MULTI_PASS_PD                1 // Multi-Pass Partitioning Depth (Multi-Pass PD) performs multiple PD stages for the same SB towards 1 final Partitioning Structure. As we go from PDn to PDn + 1, the prediction accuracy of the MD feature(s) increases while the number of block(s) decreases
-#define RATE_ESTIMATION_UPDATE       1 // Adding the rate estimation updates used in MD for missing syntax elements
-#define HBD_CLEAN_UP                 1
-
-#define HBD2_COMP                    1 // Inter-Inter compound mode HBD2
-#define HBD2_PME                     1 // Predictive ME (PME) HBD2
-#define HBD2_OBMC                    1 // OBMC semi-lossless for HBD1 & HBD2
-
-#define IFS_8BIT_MD                  1
-
-#define COMP_HBD                     1
-#define INTERINTRA_HBD               1
-#define ATB_HBD                      1
-#define ATB_FIX                      1
-
 #define M0_OPT                       1
 #define PRESETS_TUNE                 1
 #define PRESETS_OPT                  1
@@ -72,40 +48,8 @@ extern "C" {
 #if PAL_SUP
 #define PAL_CLASS   1
 #endif
-
-#define AUTO_MAX_PARTITION           1 // Shortcut to skip search depths depending on motion estimation info and statistics
-
-#define LESS_RECTANGULAR_CHECK_LEVEL 1 // Shortcut to skip a/b shapes depending on SQ/H/V shape costs
-
-#define INTER_INTRA_CLASS_PRUNING    1
-
-#define FIX_ALTREF                   1 // Address ALTREF mismatch between rtime-m0-test and master: fixed actual_future_pics derivation, shut padding of the central frame, fixed end past frame index prior to window shrinking
-#define FIX_NEAREST_NEW              1 // Address NEAREST_NEW mismatch between rtime-m0-test and master: fixed injection and fixed settings
-#define FIX_ESTIMATE_INTRA           1 // Address ESTIMATE_INTRA mismatch between rtime-m0-test and master: fixed settings
-#define FIX_SKIP_REDUNDANT_BLOCK     1 // Address SKIP_REDUNDANT_BLOCK mismatch between rtime-m0-test and master: fixed the action to bypass MD
-#define FIX_COEF_BASED_ATB_SKIP      1 // Address COEF_BASED_ATB_SKIP mismatch between rtime-m0-test and master: reset coeff_based_skip_atb @ each SB
-#define FIX_WM_SETTINGS              1 // Address WM_SETTINGS mismatch between rtime-m0-test and master: fixed settings
-#define FIX_ENABLE_CDF_UPDATE        1 // Address ENABLE_CDF_UPDATE mismatch between rtime-m0-test and master: removed useless update
-#define FIX_SORTING_METHOD           1 // Address SORTING mismatch between rtime-m0-test and master: used same method
-#define FIX_SETTINGS_RESET           1 // Address SEGMENT_RESET mismatch between rtime-m0-test and master: only @ 1st segment
-#define FIX_COMPOUND                 1 // Address COMPOUND mismatch between rtime-m0-test and master: used block size @ the derivation of compound count
-
 #define OBMC_FLAG            1 // OBMC motion mode flag
-
-#define INJECT_NEW_NEAR_NEAR_NEW   1   // Inject NEW_NEAR / NEAR_NEW inter prediction
-#define FILTER_INTRA_FLAG    1 // Filter intra prediction
-
-
 #define II_COMP_FLAG                 1 // InterIntra compound
-#define PAETH_HBD                    1 // Enbale Intra PAETH for 10bit
-#define INTER_INTER_HBD              1 // Upgrade InterInter compound 10bit
-#define INTER_INTRA_HBD              1 // Upgrade InterIntra compound 10bit
-#define ATB_10_BIT                   1 // Upgrade ATB  10bit
-
-#define PRED_CHANGE                  1 // Change the MRP in 4L Pictures 3, 5 , 7 and 9 use 1 as the reference
-#define PRED_CHANGE_5L               1 // Change the MRP in 5L Pictures 3, 5 , 7 and 9 use 1 as the reference, 11, 13, 15 and 17 use 9 as the reference
-#define PRED_CHANGE_MOD              1 // Reorder the references for MRP
-#define SPEED_OPT                    1 // Speed optimization(s)
 #define GLOBAL_WARPED_MOTION         1 // Global warped motion detection and insertion
 #define GM_OPT                       1 // Perform global motion estimation on a down-sampled version of the input picture
 
@@ -115,27 +59,13 @@ extern "C" {
 
 #define MR_MODE                           0
 
-#define WARP_UPDATE                       1 // Modified Warp settings: ON for MR mode. ON for ref frames in M0
-#define UPDATE_CDEF                       1 // Update bit cost estimation for CDEF filter
-#define EIGTH_PEL_MV                      1
-#define EIGHT_PEL_PREDICTIVE_ME           1
-#define EIGHT_PEL_FIX                     1 // Improve the 8th pel performance by shutting it based on the qindex and bug fixes
 #define HIGH_PRECISION_MV_QTHRESH         150
-#define COMP_INTERINTRA                   1 // InterIntra mode support
 
-#define ENHANCE_ATB                       1
 
-#define RDOQ_CHROMA                       1
 
 
 #define TWO_PASS                          1 // Two pass encoding. For now, the encoder is called two times and data transfered using file.
                                             // Actions in the second pass: Frame and SB QP assignment and temporal filtering strenght change
-#define TWO_PASS_USE_2NDP_ME_IN_1STP      1 // Add a config parameter to the first pass to use the ME settings of the second pass
-
-#define REMOVE_MD_STAGE_1                 1 // Simplified MD Staging; removed md_stage_1
-#define NON_KF_INTRA_TF_FIX               1 // Fix temporal filtering for non-key Intra frames
-
-#define TWO_PASS_IMPROVEMENT              1 // Tune 2 pass for better Luma by adjusting the reference area and the actions
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC                         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch
 
@@ -252,11 +182,7 @@ enum {
 #define MAX_TXB_COUNT                             4 // Maximum number of transform blocks.
 #if II_COMP_FLAG
 #if OBMC_FLAG
-#if FILTER_INTRA_FLAG
 #define MAX_NFL                                 125 // Maximum number of candidates MD can support
-#else
-#define MAX_NFL                                 120 // Maximum number of candidates MD can support
-#endif
 #else
 #define MAX_NFL                                  95
 #endif
@@ -317,11 +243,7 @@ enum {
 // Maximum number of tile rows and tile columns
 #define MAX_TILE_ROWS 64
 #define MAX_TILE_COLS 64
-#if ENHANCE_ATB
 #define MAX_VARTX_DEPTH 2
-#else
-#define MAX_VARTX_DEPTH 1
-#endif
 #define MI_SIZE_64X64 (64 >> MI_SIZE_LOG2)
 #define MI_SIZE_128X128 (128 >> MI_SIZE_LOG2)
 #define MAX_PALETTE_SQUARE (64 * 64)
@@ -608,9 +530,8 @@ typedef enum CAND_CLASS {
 #if OBMC_FLAG
     CAND_CLASS_5,
 #endif
-#if FILTER_INTRA_FLAG
     CAND_CLASS_6,
-#endif
+
 #if PAL_CLASS
     CAND_CLASS_7,
 #endif
@@ -625,15 +546,8 @@ typedef enum MD_STAGE {
     MD_STAGE_3,
     MD_STAGE_TOTAL
 } MD_STAGE;
-#if REMOVE_MD_STAGE_1
 #define MD_STAGING_MODE_0    0
 #define MD_STAGING_MODE_1    1
-#else
-#define MD_STAGING_MODE_0    0
-#define MD_STAGING_MODE_1    1
-#define MD_STAGING_MODE_2    2
-#define MD_STAGING_MODE_3    3
-#endif
 #define INTRA_NFL           16
 #define INTER_NEW_NFL       16
 #define INTER_PRED_NFL      16
@@ -643,9 +557,6 @@ typedef enum MD_STAGE {
 #define MAX_REF_TYPE_CAND   30
 #define PRUNE_REC_TH         5
 #define PRUNE_REF_ME_TH      2
-#if !SPEED_OPT
-#define MD_EXIT_THSL         0 // MD_EXIT_THSL -->0 is lossless 100 is maximum. Increase with a step of 10-20.
-#endif
 typedef enum
 {
     EIGHTTAP_REGULAR,
@@ -1295,11 +1206,9 @@ typedef enum ATTRIBUTE_PACKED
     FILTER_INTRA_MODES,
 } FilterIntraMode;
 
-#if FILTER_INTRA_FLAG
 static const PredictionMode fimode_to_intramode[FILTER_INTRA_MODES] = {
   DC_PRED, V_PRED, H_PRED, D157_PRED, PAETH_PRED
 };
-#endif
 #define DIRECTIONAL_MODES 8
 #define MAX_ANGLE_DELTA 3
 #define ANGLE_STEP 3
@@ -2247,7 +2156,6 @@ typedef enum EbBitDepthEnum
     EB_16BIT = 16,
     EB_32BIT = 32
 } EbBitDepthEnum;
-#if HBD_CLEAN_UP
 /** The MD_BIT_DEPTH_MODE type is used to describe the bitdepth of MD path.
 */
 
@@ -2257,7 +2165,7 @@ typedef enum MD_BIT_DEPTH_MODE
     EB_10_BIT_MD    = 1,    // 10bit mode decision
     EB_DUAL_BIT_MD  = 2     // Auto: 8bit & 10bit mode decision
 } MD_BIT_DEPTH_MODE;
-#endif
+
 /** The EB_GOP type is used to describe the hierarchical coding structure of
 Groups of Pictures (GOP) units.
 */
@@ -2661,9 +2569,6 @@ void(*ErrorHandler)(
 #define LOG2F_MAX_LCU_SIZE                          6u
 #define LOG2_64_SIZE                                6 // log2(BLOCK_SIZE_64)
 #define MAX_LEVEL_COUNT                             5 // log2(BLOCK_SIZE_64) - log2(MIN_BLOCK_SIZE)
-#if !ENHANCE_ATB
-#define MAX_TU_DEPTH                                2
-#endif
 #define LOG_MIN_BLOCK_SIZE                          3
 #define MIN_BLOCK_SIZE                              (1 << LOG_MIN_BLOCK_SIZE)
 #define LOG_MIN_PU_SIZE                             2
@@ -3410,17 +3315,13 @@ static const uint32_t MD_SCAN_TO_OIS_32x32_SCAN[CU_MAX_COUNT] =
     /*84 */3,
 };
 
-#if TWO_PASS
 typedef struct stat_struct_t
 {
     uint32_t                        referenced_area[MAX_NUMBER_OF_TREEBLOCKS_PER_PICTURE];
 } stat_struct_t;
-#if TWO_PASS_IMPROVEMENT
 #define TWO_PASS_IR_THRSHLD 40  // Intra refresh threshold used to reduce the reference area.
                                 // If the periodic Intra refresh is less than the threshold,
                                 // the referenced area is normalized
-#endif
-#endif
 #define SC_MAX_LEVEL 2 // 2 sets of HME/ME settings are used depending on the scene content mode
 
 /******************************************************************************

--- a/Source/Lib/Common/Codec/EbInterPrediction.h
+++ b/Source/Lib/Common/Codec/EbInterPrediction.h
@@ -199,7 +199,6 @@ EbErrorType av1_inter_prediction_hbd(
         InterpFilterParams *params_x, InterpFilterParams *params_y,
         int32_t w, int32_t h);
 
-#if COMP_INTERINTRA
     /* Mapping of interintra to intra mode for use in the intra component */
     static const PredictionMode interintra_to_intra_mode[INTERINTRA_MODES] = {
       DC_PRED, V_PRED, H_PRED, SMOOTH_PRED
@@ -222,7 +221,6 @@ EbErrorType av1_inter_prediction_hbd(
         uint8_t *comppred8, int compstride, const uint8_t *interpred8,
         int interstride, const uint8_t *intrapred8, int intrastride, int bd);
 
-#endif //comp_interintra
 
     void av1_setup_scale_factors_for_frame(ScaleFactors *sf, int other_w,
         int other_h, int this_w, int this_h);

--- a/Source/Lib/Common/Codec/EbIntraPrediction.c
+++ b/Source/Lib/Common/Codec/EbIntraPrediction.c
@@ -3625,19 +3625,12 @@ static void build_intra_predictors(
             above_row[-1] = 128;
         left_col[-1] = above_row[-1];
     }
-#if FILTER_INTRA_FLAG
   if (use_filter_intra) {
     eb_av1_filter_intra_predictor(dst, dst_stride, tx_size, above_row, left_col,
                                filter_intra_mode);
     return;
   }
-#else
-    //    if (use_filter_intra) {
-    ////        eb_av1_filter_intra_predictor(dst, dst_stride, tx_size, above_row, left_col,
-    ////CHKN            filter_intra_mode);
-    //        return;
-    //    }
-#endif
+
     if (is_dr_mode) {
         int32_t upsample_above = 0;
         int32_t upsample_left = 0;
@@ -3823,20 +3816,11 @@ static void build_intra_predictors_high(
             above_row[-1] = (uint16_t)base;
         left_col[-1] = above_row[-1];
     }
-#if FILTER_INTRA_FLAG
 if (use_filter_intra) {
     highbd_filter_intra_predictor(dst, dst_stride, tx_size, above_row, left_col,
                                filter_intra_mode,10);
     return;
   }
-#else
-    // not added yet
-    //if (use_filter_intra) {
-    //    highbd_filter_intra_predictor(dst, dst_stride, tx_size, above_row, left_col,
-    //        filter_intra_mode, xd->bd);
-    //    return;
-    //}
-#endif
     if (is_dr_mode) {
         int32_t upsample_above = 0;
         int32_t upsample_left = 0;
@@ -4505,17 +4489,9 @@ EbErrorType eb_av1_intra_prediction_cl(
                 plane ? tx_size_Chroma : tx_size,                                               //TxSize tx_size,
                 mode,                                                                           //PredictionMode mode,
                 plane ? candidate_buffer_ptr->candidate_ptr->angle_delta[PLANE_TYPE_UV] : candidate_buffer_ptr->candidate_ptr->angle_delta[PLANE_TYPE_Y],
-#if PAL_SUP
                 plane==0 ? (candidate_buffer_ptr->candidate_ptr->palette_info.pmi.palette_size[0]>0) : 0,
                 plane==0 ? &candidate_buffer_ptr->candidate_ptr->palette_info : NULL,    //MD
-#else
-                0,                                                                              //int32_t use_palette,
-#endif
-#if FILTER_INTRA_FLAG
                 plane ? FILTER_INTRA_MODES : candidate_buffer_ptr->candidate_ptr->filter_intra_mode,
-#else
-                FILTER_INTRA_MODES,                                                             //CHKN FilterIntraMode filter_intra_mode,
-#endif
                 topNeighArray + 1,
                 leftNeighArray + 1,
                 candidate_buffer_ptr->prediction_ptr,                                              //uint8_t *dst,
@@ -4586,17 +4562,9 @@ EbErrorType eb_av1_intra_prediction_cl(
                 plane ? tx_size_Chroma : tx_size,                                               //TxSize tx_size,
                 mode,                                                                           //PredictionMode mode,
                 plane ? candidate_buffer_ptr->candidate_ptr->angle_delta[PLANE_TYPE_UV] : candidate_buffer_ptr->candidate_ptr->angle_delta[PLANE_TYPE_Y],
-#if PAL_SUP
                 plane == 0 ? (candidate_buffer_ptr->candidate_ptr->palette_info.pmi.palette_size[0] > 0) : 0,
                 plane == 0 ? &candidate_buffer_ptr->candidate_ptr->palette_info : NULL,    //MD
-#else
-                0,                                                                              //int32_t use_palette,
-#endif
-#if FILTER_INTRA_FLAG
                 plane ? FILTER_INTRA_MODES : candidate_buffer_ptr->candidate_ptr->filter_intra_mode,
-#else
-                FILTER_INTRA_MODES,                                                             //CHKN FilterIntraMode filter_intra_mode,
-#endif
                 topNeighArray + 1,
                 leftNeighArray + 1,
                 candidate_buffer_ptr->prediction_ptr,                                              //uint8_t *dst,

--- a/Source/Lib/Common/Codec/EbMdRateEstimation.h
+++ b/Source/Lib/Common/Codec/EbMdRateEstimation.h
@@ -8,9 +8,7 @@
 
 #include "EbCabacContextModel.h"
 #include "EbPictureControlSet.h"
-#if RATE_ESTIMATION_UPDATE
 #include "EbCodingUnit.h"
-#endif
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -327,12 +325,7 @@ extern "C" {
 extern void av1_estimate_mv_rate(
         struct PictureControlSet *picture_control_set_ptr,
         MdRateEstimationContext  *md_rate_estimation_array,
-#if RATE_ESTIMATION_UPDATE
         FRAME_CONTEXT            *fc);
-#else
-        NmvContext                *nmv_ctx);
-#endif
-#if RATE_ESTIMATION_UPDATE
 #define AVG_CDF_WEIGHT_LEFT      3
 #define AVG_CDF_WEIGHT_TOP       1
 
@@ -527,7 +520,7 @@ void update_part_stats(
     struct CodingUnit          *cu_ptr,
     int                         mi_row,
     int                         mi_col);
-#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/Lib/Common/Codec/EbModeDecision.h
+++ b/Source/Lib/Common/Codec/EbModeDecision.h
@@ -101,9 +101,7 @@ extern "C" {
         int32_t                                angle_delta[PLANE_TYPES];
         EbBool                                 is_directional_mode_flag;
         EbBool                                 is_directional_chroma_mode_flag;
-#if FILTER_INTRA_FLAG
         uint8_t                                filter_intra_mode;
-#endif
         uint32_t                               intra_chroma_mode; // AV1 mode, no need to convert
 
         // Index of the alpha Cb and alpha Cr combination
@@ -281,12 +279,10 @@ extern "C" {
         uint64_t                       *full_cost_merge_ptr
     );
 
-#if ENHANCE_ATB
     extern EbErrorType mode_decision_scratch_candidate_buffer_ctor(
         ModeDecisionCandidateBuffer    *buffer_ptr,
         EbBitDepthEnum                  max_bitdepth
     );
-#endif
 
     uint32_t product_full_mode_decision(
          struct ModeDecisionContext  *context_ptr,

--- a/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Common/Codec/EbModeDecisionConfigurationProcess.c
@@ -2605,14 +2605,11 @@ EbErrorType signal_derivation_mode_decision_config_kernel_oq(
         picture_control_set_ptr->update_cdf = (picture_control_set_ptr->parent_pcs_ptr->enc_mode <= ENC_M5) ? 1 : 0;
     if(picture_control_set_ptr->update_cdf)
         assert(sequence_control_set_ptr->cdf_mode == 0 && "use cdf_mode 0");
-#if FILTER_INTRA_FLAG
     //Filter Intra Mode : 0: OFF  1: ON
     if (sequence_control_set_ptr->seq_header.enable_filter_intra)
         picture_control_set_ptr->pic_filter_intra_mode = picture_control_set_ptr->parent_pcs_ptr->sc_content_detected == 0 && picture_control_set_ptr->temporal_layer_index == 0 ? 1 : 0;
     else
         picture_control_set_ptr->pic_filter_intra_mode = 0;
-#endif
-#if EIGHT_PEL_FIX
     FrameHeader *frm_hdr = &picture_control_set_ptr->parent_pcs_ptr->frm_hdr;
     frm_hdr->allow_high_precision_mv =
 #if PRESETS_TUNE
@@ -2625,13 +2622,11 @@ EbErrorType signal_derivation_mode_decision_config_kernel_oq(
         picture_control_set_ptr->enc_mode == ENC_M0 && frm_hdr->quantization_params.base_q_idx < HIGH_PRECISION_MV_QTHRESH &&
 #endif
         (sequence_control_set_ptr->input_resolution == INPUT_SIZE_576p_RANGE_OR_LOWER) ? 1 : 0;
-#endif
 #if MULTI_PASS_PD
     EbBool enable_wm;
     if (picture_control_set_ptr->parent_pcs_ptr->sc_content_detected)
         enable_wm = EB_FALSE;
     else
-#if WARP_UPDATE
 #if ENHANCED_M0_SETTINGS
         enable_wm = (picture_control_set_ptr->parent_pcs_ptr->enc_mode == ENC_M0 ||
 #else
@@ -2642,12 +2637,6 @@ EbErrorType signal_derivation_mode_decision_config_kernel_oq(
             (picture_control_set_ptr->parent_pcs_ptr->enc_mode <= ENC_M1 && picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ||
 #endif
             (picture_control_set_ptr->parent_pcs_ptr->enc_mode <= ENC_M5 && picture_control_set_ptr->parent_pcs_ptr->temporal_layer_index == 0)) ? EB_TRUE : EB_FALSE;
-#else
-        enable_wm = (picture_control_set_ptr->parent_pcs_ptr->enc_mode <= ENC_M5) || MR_MODE ? EB_TRUE : EB_FALSE;
-#endif
-#if !FIX_WM_SETTINGS
-    enable_wm = picture_control_set_ptr->parent_pcs_ptr->temporal_layer_index > 0 ? EB_FALSE : enable_wm;
-#endif
     frm_hdr->allow_warped_motion = enable_wm
         && !(frm_hdr->frame_type == KEY_FRAME || frm_hdr->frame_type == INTRA_ONLY_FRAME)
         && !frm_hdr->error_resilient_mode;
@@ -3166,24 +3155,11 @@ void* mode_decision_configuration_kernel(void *input_ptr)
             md_rate_estimation_array,
             picture_control_set_ptr->slice_type == I_SLICE ? EB_TRUE : EB_FALSE,
             picture_control_set_ptr->coeff_est_entropy_coder_ptr->fc);
-#if !FIX_ENABLE_CDF_UPDATE
-        // Initial Rate Estimation of the syntax elements
-        if (!md_rate_estimation_array->initialized)
-            av1_estimate_syntax_rate(
-                md_rate_estimation_array,
-                picture_control_set_ptr->slice_type == I_SLICE ? EB_TRUE : EB_FALSE,
-                picture_control_set_ptr->coeff_est_entropy_coder_ptr->fc);
-#endif
         // Initial Rate Estimation of the Motion vectors
         av1_estimate_mv_rate(
             picture_control_set_ptr,
             md_rate_estimation_array,
-#if RATE_ESTIMATION_UPDATE
             picture_control_set_ptr->coeff_est_entropy_coder_ptr->fc);
-#else
-            &picture_control_set_ptr->coeff_est_entropy_coder_ptr->fc->nmvc);
-#endif
-
         // Initial Rate Estimation of the quantized coefficients
         av1_estimate_coefficients_rate(
             md_rate_estimation_array,

--- a/Source/Lib/Common/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Common/Codec/EbModeDecisionProcess.h
@@ -40,9 +40,7 @@ extern "C" {
 #define FULL_PEL_REF_WINDOW_WIDTH_EXTENDED  15
 #define FULL_PEL_REF_WINDOW_HEIGHT_EXTENDED 15
 #endif
-#if EIGHT_PEL_PREDICTIVE_ME
 #define EIGHT_PEL_REF_WINDOW 3
-#endif
 #endif
 
      /**************************************
@@ -104,9 +102,7 @@ extern "C" {
         ModeDecisionCandidate       **fast_candidate_ptr_array;
         ModeDecisionCandidate        *fast_candidate_array;
         ModeDecisionCandidateBuffer **candidate_buffer_ptr_array;
-#if ENHANCE_ATB
         ModeDecisionCandidateBuffer  *scratch_candidate_buffer;
-#endif
         MdRateEstimationContext      *md_rate_estimation_ptr;
         EbBool                        is_md_rate_estimation_ptr_owner;
         InterPredictionContext       *inter_prediction_context;
@@ -129,9 +125,7 @@ extern "C" {
         NeighborArrayUnit            *tx_search_luma_recon_neighbor_array16bit;
         NeighborArrayUnit            *skip_coeff_neighbor_array;
         NeighborArrayUnit            *luma_dc_sign_level_coeff_neighbor_array; // Stored per 4x4. 8 bit: lower 6 bits (COEFF_CONTEXT_BITS), shows if there is at least one Coef. Top 2 bit store the sign of DC as follow: 0->0,1->-1,2-> 1
-#if ENHANCE_ATB
         NeighborArrayUnit            *full_loop_luma_dc_sign_level_coeff_neighbor_array; // Stored per 4x4. 8 bit: lower 6 bits (COEFF_CONTEXT_BITS), shows if there is at least one Coef. Top 2 bit store the sign of DC as follow: 0->0,1->-1,2-> 1
-#endif
         NeighborArrayUnit            *tx_search_luma_dc_sign_level_coeff_neighbor_array; // Stored per 4x4. 8 bit: lower 6 bits (COEFF_CONTEXT_BITS), shows if there is at least one Coef. Top 2 bit store the sign of DC as follow: 0->0,1->-1,2-> 1
         NeighborArrayUnit            *cr_dc_sign_level_coeff_neighbor_array; // Stored per 4x4. 8 bit: lower 6 bits(COEFF_CONTEXT_BITS), shows if there is at least one Coef. Top 2 bit store the sign of DC as follow: 0->0,1->-1,2-> 1
         NeighborArrayUnit            *cb_dc_sign_level_coeff_neighbor_array; // Stored per 4x4. 8 bit: lower 6 bits(COEFF_CONTEXT_BITS), shows if there is at least one Coef. Top 2 bit store the sign of DC as follow: 0->0,1->-1,2-> 1
@@ -197,9 +191,7 @@ extern "C" {
         uint8_t                         hbd_mode_decision;
         uint16_t                        qp_index;
         uint64_t                        three_quad_energy;
-#if ENHANCE_ATB
         uint32_t                        txb_1d_offset;
-#endif
         EbBool                          uv_search_path;
         UvPredictionMode                best_uv_mode    [UV_PAETH_PRED + 1][(MAX_ANGLE_DELTA << 1) + 1];
         int32_t                         best_uv_angle   [UV_PAETH_PRED + 1][(MAX_ANGLE_DELTA << 1) + 1];
@@ -278,7 +270,6 @@ extern "C" {
     unsigned int prediction_mse ;
     EbBool      variance_ready;
 
-#if REMOVE_MD_STAGE_1
     uint32_t                            cand_buff_indices[CAND_CLASS_TOTAL][MAX_NFL_BUFF];
     uint8_t                             md_staging_mode;
 #if MULTI_PASS_PD
@@ -294,25 +285,7 @@ extern "C" {
     uint32_t                            md_stage_2_total_count;
 
     uint8_t                             combine_class12; // 1:class1 and 2 are combined.
-#else
-    MD_STAGE                            md_stage;
 
-    uint32_t                            cand_buff_indices[CAND_CLASS_TOTAL][MAX_NFL_BUFF];
-
-
-    uint8_t                             md_staging_mode;
-    uint8_t                             bypass_stage1[CAND_CLASS_TOTAL];
-    uint8_t                             bypass_stage2[CAND_CLASS_TOTAL];
-
-    uint32_t                            md_stage_0_count[CAND_CLASS_TOTAL]; // how many fast candiates per class
-    uint32_t                            md_stage_1_count[CAND_CLASS_TOTAL]; //how many candiates will be tested per md level and  per class
-    uint32_t                            md_stage_2_count[CAND_CLASS_TOTAL]; //how many full candiates per class @ md_stage_2
-    uint32_t                            md_stage_3_count[CAND_CLASS_TOTAL]; //how many full candiates per class @ md_stage_3
-
-    uint32_t                            md_stage_2_total_count;
-    uint32_t                            md_stage_3_total_count;
-    uint8_t                             combine_class12; //1:class1 and 2 are combined.
-#endif
     CAND_CLASS                          target_class;
 
     // fast_loop_core signals
@@ -328,51 +301,29 @@ extern "C" {
     EbBool                              md_staging_skip_rdoq;
 
 #if II_COMP_FLAG
-#if INTERINTRA_HBD
     DECLARE_ALIGNED(16, uint8_t,      intrapred_buf[INTERINTRA_MODES][2 * 32 * 32]); //MAX block size for inter intra is 32x32
-#else
-   DECLARE_ALIGNED(16, uint8_t,        intrapred_buf[INTERINTRA_MODES][32 * 32]); //MAX block size for inter intra is 32x32
-#endif
 #endif
     uint64_t                           *ref_best_cost_sq_table;
     uint32_t                           *ref_best_ref_sq_table;
     uint8_t                             edge_based_skip_angle_intra;
     EbBool                              coeff_based_skip_atb;
     uint8_t                             prune_ref_frame_for_rec_partitions;
-
-#if SPEED_OPT
     unsigned int                        source_variance; // input block variance
     unsigned int                        inter_inter_wedge_variance_th;
     uint64_t                            md_exit_th;
-#if INTER_INTRA_CLASS_PRUNING
     uint64_t                            md_stage_1_cand_prune_th;
     uint64_t                            md_stage_1_class_prune_th;
-#else
-    uint64_t                            dist_base_md_stage_0_count_th;
-#endif
-#endif
-#if INTER_INTRA_CLASS_PRUNING
     uint64_t                            md_stage_2_cand_prune_th;
     uint64_t                            md_stage_2_class_prune_th;
-#endif
-#if OBMC_FLAG
-#if HBD2_OBMC
     DECLARE_ALIGNED(16, uint8_t, obmc_buff_0[2* 2 * MAX_MB_PLANE * MAX_SB_SQUARE]);
     DECLARE_ALIGNED(16, uint8_t, obmc_buff_1[2* 2 * MAX_MB_PLANE * MAX_SB_SQUARE]);
     DECLARE_ALIGNED(16, uint8_t, obmc_buff_0_8b[2 * MAX_MB_PLANE * MAX_SB_SQUARE]);
     DECLARE_ALIGNED(16, uint8_t, obmc_buff_1_8b[2 * MAX_MB_PLANE * MAX_SB_SQUARE]);
-#else
-    DECLARE_ALIGNED(16, uint8_t, obmc_buff_0[2 * MAX_MB_PLANE * MAX_SB_SQUARE]);
-    DECLARE_ALIGNED(16, uint8_t, obmc_buff_1[2 * MAX_MB_PLANE * MAX_SB_SQUARE]);
-#endif
     DECLARE_ALIGNED(16, int32_t, wsrc_buf[MAX_SB_SQUARE]);
     DECLARE_ALIGNED(16, int32_t, mask_buf[MAX_SB_SQUARE]);
     unsigned int pred_sse[REF_FRAMES];
-#endif
-#if ENHANCE_ATB
     uint8_t                            *above_txfm_context;
     uint8_t                            *left_txfm_context;
-#endif
 #if COMBINE_MDC_NSQ_TABLE
     PART best_nsq_sahpe1;
     PART best_nsq_sahpe2;
@@ -383,16 +334,12 @@ extern "C" {
     PART best_nsq_sahpe7;
     PART best_nsq_sahpe8;
 #endif
-
-#if LESS_RECTANGULAR_CHECK_LEVEL
     // square cost weighting for deciding if a/b shapes could be skipped
     uint32_t sq_weight;
-#endif
 
-#if AUTO_MAX_PARTITION
     // signal for enabling shortcut to skip search depths
     uint8_t enable_auto_max_partition;
-#endif
+
 
 #if MULTI_PASS_PD
     MD_COMP_TYPE compound_types_to_try;
@@ -489,9 +436,7 @@ extern "C" {
         208, 212, 216, 220, 224, 228, 232, 236, 240, 244, 249, 255};
 
     extern void reset_mode_decision(
-#if EIGHT_PEL_PREDICTIVE_ME
         SequenceControlSet    *sequence_control_set_ptr,
-#endif
         ModeDecisionContext   *context_ptr,
         PictureControlSet     *picture_control_set_ptr,
         uint32_t                 segment_index);

--- a/Source/Lib/Common/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimation.c
@@ -15415,10 +15415,6 @@ EbErrorType open_loop_intra_search_sb(
     uint32_t cu_origin_x;
     uint32_t cu_origin_y;
     uint32_t pa_blk_index = 0;
-#if !PAETH_HBD
-    uint8_t is_16_bit =
-        (sequence_control_set_ptr->static_config.encoder_bit_depth > EB_8BIT);
-#endif
     SbParams *sb_params = &sequence_control_set_ptr->sb_params_array[sb_index];
     OisSbResults *ois_sb_results_ptr =
         picture_control_set_ptr->ois_sb_results[sb_index];
@@ -15458,11 +15454,7 @@ EbErrorType open_loop_intra_search_sb(
             uint8_t best_intra_ois_index = 0;
             uint32_t best_intra_ois_distortion = 64 * 64 * 255;
             uint8_t intra_mode_start = DC_PRED;
-#if PAETH_HBD
             uint8_t intra_mode_end = PAETH_PRED;
-#else
-            uint8_t intra_mode_end = is_16_bit ? SMOOTH_H_PRED : PAETH_PRED;
-#endif
             uint8_t angle_delta_counter = 0;
             uint8_t angle_delta_shift = 1;
             EbBool use_angle_delta = (bsize >= 8);
@@ -15494,20 +15486,12 @@ EbErrorType open_loop_intra_search_sb(
                 angle_delta_shift = 1;
             } else {
                 if (picture_control_set_ptr->slice_type == I_SLICE) {
-#if PAETH_HBD
                     intra_mode_end = /*is_16_bit ? SMOOTH_H_PRED :*/ PAETH_PRED;
-#else
-                    intra_mode_end = is_16_bit ? SMOOTH_H_PRED : PAETH_PRED;
-#endif
                     angle_delta_candidate_count = use_angle_delta ? 5 : 1;
                     disable_angular_prediction = 0;
                     angle_delta_shift = 1;
                 } else if (picture_control_set_ptr->temporal_layer_index == 0) {
-#if PAETH_HBD
                     intra_mode_end = /*is_16_bit ? SMOOTH_H_PRED :*/ PAETH_PRED;
-#else
-                    intra_mode_end = is_16_bit ? SMOOTH_H_PRED : PAETH_PRED;
-#endif
                     angle_delta_candidate_count =
                         (bsize > 16) ? 1 : use_angle_delta ? 2 : 1;
                     disable_angular_prediction = 0;

--- a/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Common/Codec/EbMotionEstimationProcess.c
@@ -95,11 +95,7 @@ void* set_me_hme_params_oq(
     EbInputResolution                 input_resolution)
 {
     UNUSED(sequence_control_set_ptr);
-#if TWO_PASS_USE_2NDP_ME_IN_1STP
     uint8_t  hmeMeLevel = sequence_control_set_ptr->use_output_stat_file ? picture_control_set_ptr->snd_pass_enc_mode : picture_control_set_ptr->enc_mode;
-#else
-    uint8_t  hmeMeLevel =  picture_control_set_ptr->enc_mode; // OMK to be revised after new presets
-#endif
 #if PRESETS_OPT
     if (hmeMeLevel <= ENC_M1)
         hmeMeLevel = ENC_M0;
@@ -148,7 +144,6 @@ void* set_me_hme_params_oq(
   Input   : encoder mode and tune
   Output  : ME Kernel signal(s)
 ******************************************************/
-#if TWO_PASS_USE_2NDP_ME_IN_1STP
 EbErrorType signal_derivation_me_kernel_oq(
     SequenceControlSet        *sequence_control_set_ptr,
     PictureParentControlSet   *picture_control_set_ptr,
@@ -297,125 +292,7 @@ EbErrorType signal_derivation_me_kernel_oq(
 
     return return_error;
 };
-#else
-EbErrorType signal_derivation_me_kernel_oq(
-    SequenceControlSet        *sequence_control_set_ptr,
-    PictureParentControlSet   *picture_control_set_ptr,
-    MotionEstimationContext_t   *context_ptr) {
-    EbErrorType return_error = EB_ErrorNone;
 
-    // Set ME/HME search regions
-    if (sequence_control_set_ptr->static_config.use_default_me_hme)
-        set_me_hme_params_oq(
-            context_ptr->me_context_ptr,
-            picture_control_set_ptr,
-            sequence_control_set_ptr,
-            sequence_control_set_ptr->input_resolution);
-
-    else
-        set_me_hme_params_from_config(
-            sequence_control_set_ptr,
-            context_ptr->me_context_ptr);
-    if (picture_control_set_ptr->sc_content_detected)
-        context_ptr->me_context_ptr->fractional_search_method = SUB_SAD_SEARCH;
-    else
-        if (picture_control_set_ptr->enc_mode <= ENC_M6)
-            context_ptr->me_context_ptr->fractional_search_method = SSD_SEARCH ;
-        else
-            context_ptr->me_context_ptr->fractional_search_method = FULL_SAD_SEARCH;
-    if (sequence_control_set_ptr->static_config.fract_search_64 == DEFAULT)
-        if (picture_control_set_ptr->sc_content_detected)
-            context_ptr->me_context_ptr->fractional_search64x64 = EB_FALSE;
-        else
-            context_ptr->me_context_ptr->fractional_search64x64 = EB_TRUE;
-    else
-        context_ptr->me_context_ptr->fractional_search64x64 = sequence_control_set_ptr->static_config.fract_search_64;
-
-        // Set HME flags
-    context_ptr->me_context_ptr->enable_hme_flag = picture_control_set_ptr->enable_hme_flag;
-    context_ptr->me_context_ptr->enable_hme_level0_flag = picture_control_set_ptr->enable_hme_level0_flag;
-    context_ptr->me_context_ptr->enable_hme_level1_flag = picture_control_set_ptr->enable_hme_level1_flag;
-    context_ptr->me_context_ptr->enable_hme_level2_flag = picture_control_set_ptr->enable_hme_level2_flag;
-
-    if (sequence_control_set_ptr->static_config.enable_subpel == DEFAULT)
-        // Set the default settings of subpel
-        if (picture_control_set_ptr->sc_content_detected)
-            if (picture_control_set_ptr->enc_mode <= ENC_M1)
-                context_ptr->me_context_ptr->use_subpel_flag = 1;
-            else
-                context_ptr->me_context_ptr->use_subpel_flag = 0;
-        else
-            context_ptr->me_context_ptr->use_subpel_flag = 1;
-    else
-        context_ptr->me_context_ptr->use_subpel_flag = sequence_control_set_ptr->static_config.enable_subpel;
-    if (MR_MODE) {
-        context_ptr->me_context_ptr->half_pel_mode =
-            EX_HP_MODE;
-        context_ptr->me_context_ptr->quarter_pel_mode =
-            EX_QP_MODE;
-    }
-    else if (picture_control_set_ptr->enc_mode ==
-        ENC_M0) {
-        context_ptr->me_context_ptr->half_pel_mode =
-            EX_HP_MODE;
-        context_ptr->me_context_ptr->quarter_pel_mode =
-            REFINMENT_QP_MODE;
-    }
-    else {
-        context_ptr->me_context_ptr->half_pel_mode =
-            REFINMENT_HP_MODE;
-        context_ptr->me_context_ptr->quarter_pel_mode =
-            REFINMENT_QP_MODE;
-    }
-
-
-
-    // Set fractional search model
-    // 0: search all blocks
-    // 1: selective based on Full-Search SAD & MV.
-    // 2: off
-    if (context_ptr->me_context_ptr->use_subpel_flag == 1) {
-        if (picture_control_set_ptr->enc_mode <= ENC_M6)
-            context_ptr->me_context_ptr->fractional_search_model = 0;
-        else
-            context_ptr->me_context_ptr->fractional_search_model = 1;
-    }
-    else
-        context_ptr->me_context_ptr->fractional_search_model = 2;
-
-    // HME Search Method
-    if (picture_control_set_ptr->sc_content_detected)
-        if (picture_control_set_ptr->enc_mode <= ENC_M6)
-            context_ptr->me_context_ptr->hme_search_method = FULL_SAD_SEARCH;
-        else
-            context_ptr->me_context_ptr->hme_search_method = SUB_SAD_SEARCH;
-    else
-        context_ptr->me_context_ptr->hme_search_method = FULL_SAD_SEARCH;
-    // ME Search Method
-    if (picture_control_set_ptr->sc_content_detected)
-        if (picture_control_set_ptr->enc_mode <= ENC_M3)
-            context_ptr->me_context_ptr->me_search_method = FULL_SAD_SEARCH;
-        else
-            context_ptr->me_context_ptr->me_search_method = SUB_SAD_SEARCH;
-    else
-    context_ptr->me_context_ptr->me_search_method = (picture_control_set_ptr->enc_mode <= ENC_M1) ?
-        FULL_SAD_SEARCH :
-        SUB_SAD_SEARCH;
-
-    if (sequence_control_set_ptr->static_config.enable_global_warped_motion == EB_TRUE)
-    {
-        if (enc_mode == ENC_M0
-            && sequence_control_set_ptr->encoder_bit_depth == EB_8BIT)
-            context_ptr->me_context_ptr->compute_global_motion = EB_TRUE;
-        else
-            context_ptr->me_context_ptr->compute_global_motion = EB_FALSE;
-    }
-    else
-        context_ptr->me_context_ptr->compute_global_motion = EB_FALSE;
-
-    return return_error;
-};
-#endif
 
 /************************************************
  * Set ME/HME Params for Altref Temporal Filtering
@@ -427,12 +304,7 @@ void* tf_set_me_hme_params_oq(
     EbInputResolution        input_resolution)
 {
     UNUSED(sequence_control_set_ptr);
-#if TWO_PASS_USE_2NDP_ME_IN_1STP
     uint8_t  hmeMeLevel = sequence_control_set_ptr->use_output_stat_file ? picture_control_set_ptr->snd_pass_enc_mode : picture_control_set_ptr->enc_mode;
-#else
-    uint8_t  hmeMeLevel = picture_control_set_ptr->enc_mode; // OMK to be revised after new presets
-#endif
-
     // HME/ME default settings
     me_context_ptr->number_hme_search_region_in_width = 2;
     me_context_ptr->number_hme_search_region_in_height = 2;
@@ -477,7 +349,6 @@ void* tf_set_me_hme_params_oq(
   Input   : encoder mode and tune
   Output  : ME Kernel signal(s)
 ******************************************************/
-#if TWO_PASS_USE_2NDP_ME_IN_1STP
 EbErrorType tf_signal_derivation_me_kernel_oq(
     SequenceControlSet        *sequence_control_set_ptr,
     PictureParentControlSet   *picture_control_set_ptr,
@@ -598,113 +469,7 @@ EbErrorType tf_signal_derivation_me_kernel_oq(
         SUB_SAD_SEARCH;
     return return_error;
 };
-#else
-EbErrorType tf_signal_derivation_me_kernel_oq(
-    SequenceControlSet        *sequence_control_set_ptr,
-    PictureParentControlSet   *picture_control_set_ptr,
-    MotionEstimationContext_t *context_ptr) {
-    EbErrorType return_error = EB_ErrorNone;
 
-    // Set ME/HME search regions
-    tf_set_me_hme_params_oq(
-        context_ptr->me_context_ptr,
-        picture_control_set_ptr,
-        sequence_control_set_ptr,
-        sequence_control_set_ptr->input_resolution);
-
-    if (picture_control_set_ptr->sc_content_detected)
-        if (picture_control_set_ptr->enc_mode <= ENC_M1)
-            context_ptr->me_context_ptr->fractional_search_method = SSD_SEARCH;
-        else
-            context_ptr->me_context_ptr->fractional_search_method = SUB_SAD_SEARCH;
-    else
-        if (picture_control_set_ptr->enc_mode <= ENC_M6)
-            context_ptr->me_context_ptr->fractional_search_method = SSD_SEARCH;
-        else
-            context_ptr->me_context_ptr->fractional_search_method = FULL_SAD_SEARCH;
-    if (sequence_control_set_ptr->static_config.fract_search_64 == DEFAULT)
-        if (picture_control_set_ptr->sc_content_detected)
-            if (picture_control_set_ptr->enc_mode <= ENC_M1)
-                context_ptr->me_context_ptr->fractional_search64x64 = EB_TRUE;
-            else
-                context_ptr->me_context_ptr->fractional_search64x64 = EB_FALSE;
-        else
-            context_ptr->me_context_ptr->fractional_search64x64 = EB_TRUE;
-    else
-        context_ptr->me_context_ptr->fractional_search64x64 = sequence_control_set_ptr->static_config.fract_search_64;
-
-    // Set HME flags
-    context_ptr->me_context_ptr->enable_hme_flag = picture_control_set_ptr->tf_enable_hme_flag;
-    context_ptr->me_context_ptr->enable_hme_level0_flag = picture_control_set_ptr->tf_enable_hme_level0_flag;
-    context_ptr->me_context_ptr->enable_hme_level1_flag = picture_control_set_ptr->tf_enable_hme_level1_flag;
-    context_ptr->me_context_ptr->enable_hme_level2_flag = picture_control_set_ptr->tf_enable_hme_level2_flag;
-
-    if (sequence_control_set_ptr->static_config.enable_subpel == DEFAULT)
-        // Set the default settings of subpel
-        if (picture_control_set_ptr->sc_content_detected)
-            if (picture_control_set_ptr->enc_mode <= ENC_M1)
-                context_ptr->me_context_ptr->use_subpel_flag = 1;
-            else
-                context_ptr->me_context_ptr->use_subpel_flag = 0;
-        else
-            context_ptr->me_context_ptr->use_subpel_flag = 1;
-    else
-        context_ptr->me_context_ptr->use_subpel_flag = sequence_control_set_ptr->static_config.enable_subpel;
-    if (MR_MODE) {
-        context_ptr->me_context_ptr->half_pel_mode =
-            EX_HP_MODE;
-        context_ptr->me_context_ptr->quarter_pel_mode =
-            EX_QP_MODE;
-    }
-    else if (picture_control_set_ptr->enc_mode ==
-        ENC_M0) {
-        context_ptr->me_context_ptr->half_pel_mode =
-            EX_HP_MODE;
-        context_ptr->me_context_ptr->quarter_pel_mode =
-            REFINMENT_QP_MODE;
-    }
-    else {
-        context_ptr->me_context_ptr->half_pel_mode =
-            REFINMENT_HP_MODE;
-        context_ptr->me_context_ptr->quarter_pel_mode =
-            REFINMENT_QP_MODE;
-    }
-
-
-    // Set fractional search model
-    // 0: search all blocks
-    // 1: selective based on Full-Search SAD & MV.
-    // 2: off
-    if (context_ptr->me_context_ptr->use_subpel_flag == 1) {
-        if (picture_control_set_ptr->enc_mode <= ENC_M6)
-            context_ptr->me_context_ptr->fractional_search_model = 0;
-        else
-            context_ptr->me_context_ptr->fractional_search_model = 1;
-    }
-    else
-        context_ptr->me_context_ptr->fractional_search_model = 2;
-
-    // HME Search Method
-    if (picture_control_set_ptr->sc_content_detected)
-        if (picture_control_set_ptr->enc_mode <= ENC_M6)
-            context_ptr->me_context_ptr->hme_search_method = FULL_SAD_SEARCH;
-        else
-            context_ptr->me_context_ptr->hme_search_method = SUB_SAD_SEARCH;
-    else
-        context_ptr->me_context_ptr->hme_search_method = FULL_SAD_SEARCH;
-    // ME Search Method
-    if (picture_control_set_ptr->sc_content_detected)
-        if (picture_control_set_ptr->enc_mode <= ENC_M3)
-            context_ptr->me_context_ptr->me_search_method = FULL_SAD_SEARCH;
-        else
-            context_ptr->me_context_ptr->me_search_method = SUB_SAD_SEARCH;
-    else
-        context_ptr->me_context_ptr->me_search_method = (picture_control_set_ptr->enc_mode <= ENC_M1) ?
-        FULL_SAD_SEARCH :
-        SUB_SAD_SEARCH;
-    return return_error;
-};
-#endif
 void motion_estimation_context_dctor(EbPtr p)
 {
     MotionEstimationContext_t* obj = (MotionEstimationContext_t*)p;

--- a/Source/Lib/Common/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Common/Codec/EbPacketizationProcess.c
@@ -281,7 +281,6 @@ void* packetization_kernel(void *input_ptr)
         queueEntryPtr->start_time_seconds = picture_control_set_ptr->parent_pcs_ptr->start_time_seconds;
         queueEntryPtr->start_time_u_seconds = picture_control_set_ptr->parent_pcs_ptr->start_time_u_seconds;
         queueEntryPtr->is_alt_ref = picture_control_set_ptr->parent_pcs_ptr->is_alt_ref;
-#if OUT_ALLOC
         eb_get_empty_object(
             sequence_control_set_ptr->encode_context_ptr->stream_output_fifo_ptr,
             &picture_control_set_ptr->parent_pcs_ptr->output_stream_wrapper_ptr);
@@ -289,13 +288,6 @@ void* packetization_kernel(void *input_ptr)
         output_stream_ptr = (EbBufferHeaderType*)output_stream_wrapper_ptr->object_ptr;
         output_stream_ptr->p_buffer =(uint8_t*)malloc(output_stream_ptr->n_alloc_len);
         assert(output_stream_ptr->p_buffer != NULL && "bit-stream memory allocation failure");
-#else
-        //TODO: The output buffer should be big enough to avoid a deadlock here. Add an assert that make the warning
-        // Get  Output Bitstream buffer
-        output_stream_wrapper_ptr = picture_control_set_ptr->parent_pcs_ptr->output_stream_wrapper_ptr;
-        output_stream_ptr = (EbBufferHeaderType*)output_stream_wrapper_ptr->object_ptr;
-#endif
-
 
         output_stream_ptr->flags = 0;
         output_stream_ptr->flags |= (encode_context_ptr->terminating_sequence_flag_received == EB_TRUE && picture_control_set_ptr->parent_pcs_ptr->decode_order == encode_context_ptr->terminating_picture_number) ? EB_BUFFERFLAG_EOS : 0;

--- a/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Common/Codec/EbPictureAnalysisProcess.c
@@ -4299,8 +4299,6 @@ void* picture_analysis_kernel(void *input_ptr)
             picture_width_in_sb = (sequence_control_set_ptr->seq_header.max_frame_width + sequence_control_set_ptr->sb_sz - 1) / sequence_control_set_ptr->sb_sz;
             pictureHeighInLcu = (sequence_control_set_ptr->seq_header.max_frame_height + sequence_control_set_ptr->sb_sz - 1) / sequence_control_set_ptr->sb_sz;
             sb_total_count = picture_width_in_sb * pictureHeighInLcu;
-
-#if PAREF_OUT
             generate_padding(
                 input_picture_ptr->buffer_y,
                 input_picture_ptr->stride_y,
@@ -4318,7 +4316,6 @@ void* picture_analysis_kernel(void *input_ptr)
                         sizeof(uint8_t)* input_picture_ptr->width);
             }
 
-#endif
             // Set picture parameters to account for subpicture, picture scantype, and set regions by resolutions
             SetPictureParametersForStatisticsGathering(
                 sequence_control_set_ptr);

--- a/Source/Lib/Common/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.c
@@ -142,9 +142,7 @@ void picture_control_set_dctor(EbPtr p)
     EB_DELETE(obj->ep_luma_dc_sign_level_coeff_neighbor_array);
     EB_DELETE(obj->ep_cb_dc_sign_level_coeff_neighbor_array);
     EB_DELETE(obj->ep_cr_dc_sign_level_coeff_neighbor_array);
-#if RATE_ESTIMATION_UPDATE
     EB_DELETE(obj->ep_partition_context_neighbor_array);
-#endif
     EB_DELETE(obj->mode_type_neighbor_array);
     EB_DELETE(obj->partition_context_neighbor_array);
     EB_DELETE(obj->skip_flag_neighbor_array);
@@ -171,22 +169,13 @@ void picture_control_set_dctor(EbPtr p)
         EB_DELETE(obj->md_mode_type_neighbor_array[depth]);
         EB_DELETE(obj->md_leaf_depth_neighbor_array[depth]);
         EB_DELETE(obj->mdleaf_partition_neighbor_array[depth]);
-
-#if !HBD_CLEAN_UP // md_luma_recon_neighbor_array16bit md_tx_depth_1_luma_recon_neighbor_array16bit
-        if (obj->hbd_mode_decision) {
-#else
         if (obj->hbd_mode_decision > EB_8_BIT_MD){
-#endif
             EB_DELETE(obj->md_luma_recon_neighbor_array16bit[depth]);
             EB_DELETE(obj->md_tx_depth_1_luma_recon_neighbor_array16bit[depth]);
             EB_DELETE(obj->md_cb_recon_neighbor_array16bit[depth]);
             EB_DELETE(obj->md_cr_recon_neighbor_array16bit[depth]);
         }
-#if HBD_CLEAN_UP
         if (obj->hbd_mode_decision != EB_10_BIT_MD){
-#else
-         else {
-#endif
             EB_DELETE(obj->md_luma_recon_neighbor_array[depth]);
             EB_DELETE(obj->md_tx_depth_1_luma_recon_neighbor_array[depth]);
             EB_DELETE(obj->md_cb_recon_neighbor_array[depth]);
@@ -619,11 +608,7 @@ EbErrorType picture_control_set_ctor(
         return_error = create_neighbor_array_units(data, DIM(data));
         if (return_error == EB_ErrorInsufficientResources)
             return EB_ErrorInsufficientResources;
-#if HBD_CLEAN_UP //md_luma_recon_neighbor_array
         if (initDataPtr->hbd_mode_decision != EB_10_BIT_MD) {
-#else
-        if (!initDataPtr->hbd_mode_decision) {
-#endif
             InitData data[] = {
 
                 {
@@ -668,12 +653,7 @@ EbErrorType picture_control_set_ctor(
             if (return_error == EB_ErrorInsufficientResources)
                 return EB_ErrorInsufficientResources;
         }
-#if HBD_CLEAN_UP
-
         if (initDataPtr->hbd_mode_decision > EB_8_BIT_MD) {
-#else
-         else {
-#endif
             InitData data[] = {
                 {
                     &object_ptr->md_luma_recon_neighbor_array16bit[depth],
@@ -841,7 +821,6 @@ EbErrorType picture_control_set_ctor(
                 PU_NEIGHBOR_ARRAY_GRANULARITY,
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK,
             },
-#if RATE_ESTIMATION_UPDATE
             // Encode pass partition neighbor array
             {
                 &object_ptr->ep_partition_context_neighbor_array,
@@ -852,7 +831,7 @@ EbErrorType picture_control_set_ctor(
                 PU_NEIGHBOR_ARRAY_GRANULARITY,
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK,
             },
-#endif
+
             // Entropy Coding Neighbor Arrays
             {
                 &object_ptr->mode_type_neighbor_array,

--- a/Source/Lib/Common/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.h
@@ -283,14 +283,13 @@ extern "C" {
         int interval;
     } MeshPattern;
 
-#if AUTO_MAX_PARTITION
     enum {
         NOT_IN_USE,
         DIRECT_PRED,
         RELAXED_PRED,
         ADAPT_PRED
     } UENUM1BYTE(MAX_PART_PRED_MODE);
-#endif
+
 
     typedef struct SpeedFeatures
     {
@@ -310,13 +309,11 @@ extern "C" {
 
         // Pattern to be used for any exhaustive mesh searches.
         MeshPattern mesh_patterns[MAX_MESH_STEP];
-
-#if AUTO_MAX_PARTITION
         // Sets min and max square partition levels for this superblock based on
         // motion vector and prediction error distribution produced from 16x16
         // simple motion search
         MAX_PART_PRED_MODE auto_max_partition_based_on_simple_motion;
-#endif
+
     } SpeedFeatures;
 
     typedef struct PictureControlSet
@@ -452,9 +449,7 @@ extern "C" {
         NeighborArrayUnit                  *ep_luma_dc_sign_level_coeff_neighbor_array;
         NeighborArrayUnit                  *ep_cr_dc_sign_level_coeff_neighbor_array;
         NeighborArrayUnit                  *ep_cb_dc_sign_level_coeff_neighbor_array;
-#if RATE_ESTIMATION_UPDATE
         NeighborArrayUnit                  *ep_partition_context_neighbor_array;
-#endif
         // Entropy Coding Neighbor Arrays
         NeighborArrayUnit                  *mode_type_neighbor_array;
         NeighborArrayUnit                  *partition_context_neighbor_array;
@@ -508,9 +503,7 @@ extern "C" {
         struct MdRateEstimationContext *md_rate_estimation_array;
         int8_t ref_frame_side[REF_FRAMES];
         TPL_MV_REF  *tpl_mvs;
-#if FILTER_INTRA_FLAG
         uint8_t pic_filter_intra_mode;
-#endif
 #if PAL_SUP
         TOKENEXTRA *tile_tok[64][64];
 #endif
@@ -755,9 +748,7 @@ extern "C" {
 
         // MD
         EbEncMode                             enc_mode;
-#if TWO_PASS_USE_2NDP_ME_IN_1STP
         EbEncMode                             snd_pass_enc_mode;
-#endif
         EB_SB_DEPTH_MODE                     *sb_depth_mode_array;
         EbCu8x8Mode                           cu8x8_mode;
         EbBool                                use_src_ref;
@@ -934,9 +925,8 @@ extern "C" {
 #if GM_OPT
         uint8_t                                gm_level;
 #endif
-#if TX_SIZE_EARLY_EXIT
         uint8_t                                tx_size_early_exit;
-#endif
+
     } PictureParentControlSet;
 
     typedef struct PictureControlSetInitData

--- a/Source/Lib/Common/Codec/EbPredictionStructure.c
+++ b/Source/Lib/Common/Codec/EbPredictionStructure.c
@@ -185,11 +185,8 @@ PredictionStructureConfigEntry four_level_hierarchical_pred_struct[] = {
     {
         3,                      // GOP Index 1 - Temporal Layer
         3,                      // GOP Index 1 - Decode Order
-#if PRED_CHANGE
         { 1, 3, 5, 8},          // GOP Index 1 - Ref List 0
-#else
-        { 1, 3, 5, 9},          // GOP Index 1 - Ref List 0
-#endif
+
         {-1,-3,-7, 0}           // GOP Index 1 - Ref List 1
     },
     {
@@ -201,13 +198,7 @@ PredictionStructureConfigEntry four_level_hierarchical_pred_struct[] = {
     {
         3,                      // GOP Index 3 - Temporal Layer
         4,                      // GOP Index 3 - Decode Order
-#if PRED_CHANGE_MOD
         { 1, 3, 2, 5},          // GOP Index 3 - Ref List 0
-#elif PRED_CHANGE
-        { 1, 2, 3, 5},          // GOP Index 3 - Ref List 0
-#else
-        { 1, 3, 5, 7},          // GOP Index 3 - Ref List 0
-#endif
         {-1, -5, 0, 0}          // GOP Index 3 - Ref List 1
     },
     {
@@ -219,11 +210,7 @@ PredictionStructureConfigEntry four_level_hierarchical_pred_struct[] = {
     {
         3,                      // GOP Index 5 - Temporal Layer
         6,                      // GOP Index 5 - Decode Order
-#if PRED_CHANGE
         { 1, 3, 5, 4},          // GOP Index 5 - Ref List 0
-#else
-        { 1, 3, 5, 9},          // GOP Index 5 - Ref List 0
-#endif
         {-1, -3, 0, 0}          // GOP Index 5 - Ref List 1
     },
     {
@@ -235,11 +222,7 @@ PredictionStructureConfigEntry four_level_hierarchical_pred_struct[] = {
     {
         3,                      // GOP Index 7 - Temporal Layer
         7,                      // GOP Index 7 - Decode Order
-#if PRED_CHANGE
         { 1, 3, 5, 6},          // GOP Index 7 - Ref List 0
-#else
-        { 1, 3, 5, 7},          // GOP Index 7 - Ref List 0
-#endif
         {-1, 0, 0, 0}           // GOP Index 7 - Ref List 1
     }
 };
@@ -279,35 +262,19 @@ PredictionStructureConfigEntry five_level_hierarchical_pred_struct[] = {
     {
         4,                      // GOP Index 1 - Temporal Layer
         4,                      // GOP Index 1 - Decode Order
-#if PRED_CHANGE_MOD
         { 1, 9, 8, 17},          // GOP Index 1 - Ref List 0
-#elif PRED_CHANGE_5L
-        { 1, 8, 9, 17},          // GOP Index 1 - Ref List 0
-#else
-        { 1, 5, 9, 17},          // GOP Index 1 - Ref List 0
-#endif
         { -1, -3, -7, 0}         // GOP Index 1 - Ref List 1
     },
     {
         3,                      // GOP Index 2 - Temporal Layer
         3,                      // GOP Index 2 - Decode Order
-#if PRED_CHANGE_5L
         { 2, 4, 10, 18},        // GOP Index 2 - Ref List 0
-#else
-        { 2, 4, 6, 10},         // GOP Index 2 - Ref List 0
-#endif
         { -2, -6, -14, 0}       // GOP Index 2 - Ref List 1
     },
     {
         4,                      // GOP Index 3 - Temporal Layer
         5,                      // GOP Index 3 - Decode Order
-#if PRED_CHANGE_MOD
         { 1, 3, 2, 11},         // GOP Index 3 - Ref List 0
-#elif PRED_CHANGE_5L
-        { 1, 2, 3, 11},         // GOP Index 3 - Ref List 0
-#else
-        { 1, 3, 7, 11},         // GOP Index 3 - Ref List 0
-#endif
         { -1, -5, -13, 0}       // GOP Index 3 - Ref List 1
     },
     {
@@ -319,35 +286,19 @@ PredictionStructureConfigEntry five_level_hierarchical_pred_struct[] = {
     {
         4,                      // GOP Index 5 - Temporal Layer
         7,                      // GOP Index 5 - Decode Order
-#if PRED_CHANGE_MOD
         { 1, 5, 4, 13},         // GOP Index 5 - Ref List 0
-#elif PRED_CHANGE_5L
-        { 1, 4, 5, 13},         // GOP Index 5 - Ref List 0
-#else
-        { 1, 5, 9, 13},         // GOP Index 5 - Ref List 0
-#endif
         { -1, -3, -11, 0}       // GOP Index 5 - Ref List 1
     },
     {
         3,                      // GOP Index 6 - Temporal Layer
         6,                      // GOP Index 6 - Decode Order
-#if PRED_CHANGE_5L
         { 2, 4, 6, 14},         // GOP Index 6 - Ref List 0
-#else
-        { 2, 4, 6, 10},         // GOP Index 6 - Ref List 0
-#endif
         { -2, -10, 0, 0}        // GOP Index 6 - Ref List 1
     },
     {
         4,                      // GOP Index 7 - Temporal Layer
         8,                      // GOP Index 7 - Decode Order
-#if PRED_CHANGE_MOD
         { 1, 3, 6, 7},          // GOP Index 7 - Ref List 0
-#elif PRED_CHANGE_5L
-        { 1, 3, 6, 7},          // GOP Index 7 - Ref List 0
-#else
-        { 1, 3, 7, 11},         // GOP Index 7 - Ref List 0
-#endif
         { -1, -9, 0, 0}         // GOP Index 7 - Ref List 1
     },
     {
@@ -359,35 +310,19 @@ PredictionStructureConfigEntry five_level_hierarchical_pred_struct[] = {
     {
         4,                      // GOP Index 9 - Temporal Layer
         11,                     // GOP Index 9 - Decode Order
-#if PRED_CHANGE_MOD
         { 1, 9, 8, 17},         // GOP Index 9 - Ref List 0
-#elif PRED_CHANGE_5L
-        { 1, 8, 9, 17},         // GOP Index 9 - Ref List 0
-#else
-        { 1, 5, 9, 17},         // GOP Index 9 - Ref List 0
-#endif
         { -1, -3, -7, 0}        // GOP Index 9 - Ref List 1
     },
     {
         3,                      // GOP Index 10 - Temporal Layer
         10,                     // GOP Index 10 - Decode Order
-#if PRED_CHANGE_5L
         { 2, 4, 10, 18},        // GOP Index 10 - Ref List 0
-#else
-        { 2, 4, 6, 10},         // GOP Index 10 - Ref List 0
-#endif
         { -2, -6, 0, 0}         // GOP Index 10 - Ref List 1
     },
     {
         4,                      // GOP Index 11 - Temporal Layer
         12,                     // GOP Index 11 - Decode Order
-#if PRED_CHANGE_MOD
         { 1, 3, 2, 11},         // GOP Index 11 - Ref List 0
-#elif PRED_CHANGE_5L
-        { 1, 2, 3, 11},         // GOP Index 11 - Ref List 0
-#else
-        { 1, 3, 7, 11},         // GOP Index 11 - Ref List 0
-#endif
         { -1, -5, 0, 0}         // GOP Index 11 - Ref List 1
     },
     {
@@ -399,13 +334,7 @@ PredictionStructureConfigEntry five_level_hierarchical_pred_struct[] = {
     {
         4,                      // GOP Index 13 - Temporal Layer
         14,                     // GOP Index 13 - Decode Order
-#if PRED_CHANGE_MOD
         { 1, 5, 4, 13},         // GOP Index 13 - Ref List 0
-#elif PRED_CHANGE_5L
-        { 1, 4, 5, 13},         // GOP Index 13 - Ref List 0
-#else
-        { 1, 5, 9, 13},         // GOP Index 13 - Ref List 0
-#endif
         { -1, -3, 0, 0}         // GOP Index 13 - Ref List 1
     },
     {
@@ -418,13 +347,7 @@ PredictionStructureConfigEntry five_level_hierarchical_pred_struct[] = {
     {
         4,                      // GOP Index 15 - Temporal Layer
         15,                     // GOP Index 15 - Decode Order
-#if PRED_CHANGE_MOD
         { 1, 3, 6, 7},          // GOP Index 15 - Ref List 0
-#elif PRED_CHANGE_5L
-        { 1, 3, 6, 7},          // GOP Index 15 - Ref List 0
-#else
-        { 1, 3, 7, 11},         // GOP Index 15 - Ref List 0
-#endif
         { -1, 0, 0, 0}          // GOP Index 15 - Ref List 1
     }
 };

--- a/Source/Lib/Common/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Common/Codec/EbProductCodingLoop.c
@@ -29,13 +29,11 @@
 #include "EbAvcStyleMcp.h"
 #include "aom_dsp_rtcd.h"
 #include "EbCodingLoop.h"
-
-#if AUTO_MAX_PARTITION
 #include "EbMotionEstimation.h"
 #include "aom_dsp_rtcd.h"
 #include "partition_model_weights.h"
 #include "ml.h"
-#endif
+
 EbErrorType generate_md_stage_0_cand(
     SuperBlock          *sb_ptr,
     ModeDecisionContext *context_ptr,
@@ -245,7 +243,6 @@ void mode_decision_update_neighbor_arrays(
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
         }
     }
-#if ENHANCE_ATB
     uint8_t tx_size = tx_depth_to_tx_size[context_ptr->cu_ptr->tx_depth][context_ptr->blk_geom->bsize];
     uint8_t bw = tx_size_wide[tx_size];
     uint8_t bh = tx_size_high[tx_size];
@@ -267,16 +264,6 @@ void mode_decision_update_neighbor_arrays(
         bwdith,
         bheight,
         NEIGHBOR_ARRAY_UNIT_LEFT_MASK);
-#else
-    neighbor_array_unit_mode_write(
-        context_ptr->txfm_context_array,
-        &context_ptr->cu_ptr->tx_depth,
-        origin_x,
-        origin_y,
-        bwdith,
-        bheight,
-        NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
-#endif
 
     // Update the Inter Pred Type Neighbor Array
 
@@ -1584,7 +1571,6 @@ void fast_loop_core(
         context_ptr->intra_luma_top_mode);
 
 }
-#if REMOVE_MD_STAGE_1
 void set_md_stage_counts(
     PictureControlSet       *picture_control_set_ptr,
     ModeDecisionContext     *context_ptr,
@@ -1660,24 +1646,14 @@ void set_md_stage_counts(
 #if II_COMP_FLAG
     context_ptr->md_stage_1_count[CAND_CLASS_4] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 14 : 6;
 #endif
-#if OBMC_FLAG
     context_ptr->md_stage_1_count[CAND_CLASS_5] = 16;
-#endif
-#if FILTER_INTRA_FLAG
     context_ptr->md_stage_1_count[CAND_CLASS_6] = (picture_control_set_ptr->temporal_layer_index == 0) ? 10 : 5;
-#endif
-#if PAL_CLASS
     context_ptr->md_stage_1_count[CAND_CLASS_7] = 12;
-#endif
     context_ptr->md_stage_1_count[CAND_CLASS_8] = (picture_control_set_ptr->temporal_layer_index == 0) ? 5 : 4;
     if (context_ptr->combine_class12) {
         context_ptr->md_stage_1_count[CAND_CLASS_1] = context_ptr->md_stage_1_count[CAND_CLASS_1] * 2;
     }
-#if PRESETS_TUNE
     if (picture_control_set_ptr->enc_mode >= ENC_M3) {
-#else
-    if (picture_control_set_ptr->enc_mode >= ENC_M2) {
-#endif
         context_ptr->md_stage_1_count[CAND_CLASS_1] = context_ptr->md_stage_1_count[CAND_CLASS_1] / 2;
         context_ptr->md_stage_1_count[CAND_CLASS_2] = context_ptr->md_stage_1_count[CAND_CLASS_2] / 2;
         context_ptr->md_stage_1_count[CAND_CLASS_3] = context_ptr->md_stage_1_count[CAND_CLASS_3] / 2;
@@ -1685,10 +1661,7 @@ void set_md_stage_counts(
 
 
     context_ptr->md_stage_2_count[CAND_CLASS_0] = (picture_control_set_ptr->slice_type == I_SLICE) ? 10 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? ((scs->input_resolution >= INPUT_SIZE_1080i_RANGE) ? 7 : 10) : 4;
-#if FILTER_INTRA_FLAG
     context_ptr->md_stage_2_count[CAND_CLASS_6] = (picture_control_set_ptr->temporal_layer_index == 0) ? 5 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 3 : 2;
-#endif
-#if PAL_CLASS
     if (picture_control_set_ptr->parent_pcs_ptr->palette_mode == 1)
         context_ptr->md_stage_2_count[CAND_CLASS_7] =
         (picture_control_set_ptr->temporal_layer_index == 0) ? 7 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 4 : 4;
@@ -1701,17 +1674,10 @@ void set_md_stage_counts(
     else
         context_ptr->md_stage_2_count[CAND_CLASS_7] =
         (picture_control_set_ptr->temporal_layer_index == 0) ? 2 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 1 : 1;
-#endif
     context_ptr->md_stage_2_count[CAND_CLASS_8] = (picture_control_set_ptr->temporal_layer_index == 0) ? 4 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 3 : 2;
-#if REMOVE_MD_STAGE_1
     context_ptr->md_stage_2_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 6 : 3;
     context_ptr->md_stage_2_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 6 : 3;
     context_ptr->md_stage_2_count[CAND_CLASS_3] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 6 : 3;
-#else
-    context_ptr->md_stage_2_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 3 : 1;
-    context_ptr->md_stage_2_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 3 : 1;
-    context_ptr->md_stage_2_count[CAND_CLASS_3] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 3 : 1;
-#endif
 #if II_COMP_FLAG
     context_ptr->md_stage_2_count[CAND_CLASS_4] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 12 : 4;// 14 : 4;
 #endif
@@ -1730,15 +1696,9 @@ void set_md_stage_counts(
 
     if (!context_ptr->combine_class12 && picture_control_set_ptr->parent_pcs_ptr->sc_content_detected && picture_control_set_ptr->enc_mode == ENC_M0) {
         context_ptr->md_stage_2_count[CAND_CLASS_0] = (picture_control_set_ptr->slice_type == I_SLICE) ? 10 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 8 : 4;
-#if REMOVE_MD_STAGE_1
         context_ptr->md_stage_2_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 12 : 6;
         context_ptr->md_stage_2_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 12 : 6;
         context_ptr->md_stage_2_count[CAND_CLASS_3] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 12 : 6;
-#else
-        context_ptr->md_stage_2_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 8 : 4;
-        context_ptr->md_stage_2_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 8 : 4;
-        context_ptr->md_stage_2_count[CAND_CLASS_3] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 8 : 4;
-#endif
     }
 
 #if PRESETS_OPT
@@ -1828,290 +1788,6 @@ void set_md_stage_counts(
     if (context_ptr->combine_class12)
         context_ptr->md_stage_1_count[CAND_CLASS_3] = context_ptr->md_stage_2_count[CAND_CLASS_3] = 0;
 }
-#else
-void set_md_stage_counts(
-    PictureControlSet       *picture_control_set_ptr,
-    ModeDecisionContext     *context_ptr,
-    uint32_t                 fastCandidateTotalCount)
-{
-    SequenceControlSet* scs = (SequenceControlSet*)(picture_control_set_ptr->sequence_control_set_wrapper_ptr->object_ptr);
-    // Step 0: derive bypass_stage1 flags
-    if (context_ptr->md_staging_mode) {
-        context_ptr->bypass_stage1[CAND_CLASS_0] = EB_TRUE;
-#if FILTER_INTRA_FLAG
-        context_ptr->bypass_stage1[CAND_CLASS_6] = EB_TRUE;
-#endif
-#if PAL_CLASS
-        context_ptr->bypass_stage1[CAND_CLASS_7] = EB_TRUE;
-#endif
-        context_ptr->bypass_stage1[CAND_CLASS_1] = EB_FALSE;
-        context_ptr->bypass_stage1[CAND_CLASS_2] = EB_FALSE;
-        context_ptr->bypass_stage1[CAND_CLASS_3] = context_ptr->combine_class12 ? EB_TRUE : EB_FALSE;
-#if II_COMP_FLAG
-        context_ptr->bypass_stage1[CAND_CLASS_4] = EB_FALSE;
-#endif
-#if OBMC_FLAG
-        context_ptr->bypass_stage1[CAND_CLASS_5] = EB_FALSE;
-#endif
-        context_ptr->bypass_stage1[CAND_CLASS_8] = EB_FALSE;
-    }
-    else
-        memset(context_ptr->bypass_stage1, EB_TRUE, CAND_CLASS_TOTAL);
-    // Step 1: derive bypass_stage1 flags
-    if (context_ptr->md_staging_mode)
-    {
-        context_ptr->bypass_stage2[CAND_CLASS_0] = EB_FALSE;
-#if FILTER_INTRA_FLAG
-        context_ptr->bypass_stage2[CAND_CLASS_6] = EB_FALSE;
-#endif
-#if PAL_CLASS
-        context_ptr->bypass_stage2[CAND_CLASS_7] = EB_FALSE;
-#endif
-        if (context_ptr->md_staging_mode == MD_STAGING_MODE_2 || context_ptr->md_staging_mode == MD_STAGING_MODE_3) {
-            context_ptr->bypass_stage2[CAND_CLASS_1] = EB_FALSE;
-            context_ptr->bypass_stage2[CAND_CLASS_2] = EB_FALSE;
-            context_ptr->bypass_stage2[CAND_CLASS_3] = context_ptr->combine_class12 ? EB_TRUE : EB_FALSE;
-        }
-        else {
-            context_ptr->bypass_stage2[CAND_CLASS_1] = EB_TRUE;
-            context_ptr->bypass_stage2[CAND_CLASS_2] = EB_TRUE;
-            context_ptr->bypass_stage2[CAND_CLASS_3] = EB_TRUE;
-        }
-#if II_COMP_FLAG
-            context_ptr->bypass_stage2[CAND_CLASS_4] = EB_TRUE;
-#endif
-#if OBMC_FLAG
-            context_ptr->bypass_stage2[CAND_CLASS_5] = EB_TRUE;
-#endif
-        context_ptr->bypass_stage2[CAND_CLASS_8] = EB_TRUE;
-    }
-    else
-        memset(context_ptr->bypass_stage2, EB_TRUE, CAND_CLASS_TOTAL);
-    // Step 2: set md_stage count
-    context_ptr->md_stage_1_count[CAND_CLASS_0] = (picture_control_set_ptr->slice_type == I_SLICE) ? fastCandidateTotalCount : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? INTRA_NFL : (INTRA_NFL >> 1);
-#if FILTER_INTRA_FLAG
-    context_ptr->md_stage_1_count[CAND_CLASS_6] = 5;
-#endif
-#if PAL_CLASS
-    context_ptr->md_stage_1_count[CAND_CLASS_7] = 14;
-#endif
-    context_ptr->md_stage_1_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? INTER_NEW_NFL : (INTER_NEW_NFL >> 1);
-    context_ptr->md_stage_1_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? INTER_PRED_NFL : (INTER_PRED_NFL >> 1);
-
-    if (context_ptr->combine_class12) {
-        context_ptr->md_stage_1_count[CAND_CLASS_1] = context_ptr->md_stage_1_count[CAND_CLASS_1] * 2;
-    }
-    else {
-        context_ptr->md_stage_1_count[CAND_CLASS_3] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? INTER_PRED_NFL : (INTER_PRED_NFL >> 1);
-    }
-
-#if II_COMP_FLAG
-        context_ptr->md_stage_1_count[CAND_CLASS_4] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 14 :6;// INTER_PRED_NFL: (INTER_PRED_NFL >> 1);
-#endif
-#if OBMC_FLAG
-    if (picture_control_set_ptr->parent_pcs_ptr->pic_obmc_mode == 1)
-        context_ptr->md_stage_1_count[CAND_CLASS_5] = 16 ;
-    else if (picture_control_set_ptr->parent_pcs_ptr->pic_obmc_mode <= 3)
-        context_ptr->md_stage_1_count[CAND_CLASS_5] =  (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 12 : 4;
-    else
-        context_ptr->md_stage_1_count[CAND_CLASS_5] =   (picture_control_set_ptr->temporal_layer_index == 0 ) ? 12 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 8: 4;
-#endif
-    context_ptr->md_stage_1_count[CAND_CLASS_8] = (picture_control_set_ptr->temporal_layer_index == 0) ? 5 : 4;
-    if (picture_control_set_ptr->enc_mode >= ENC_M2) {
-        context_ptr->md_stage_1_count[CAND_CLASS_1] = context_ptr->md_stage_1_count[CAND_CLASS_1] / 2;
-        context_ptr->md_stage_1_count[CAND_CLASS_2] = context_ptr->md_stage_1_count[CAND_CLASS_2] / 2;
-
-        if (!context_ptr->combine_class12)
-            context_ptr->md_stage_1_count[CAND_CLASS_3] = context_ptr->md_stage_1_count[CAND_CLASS_3] / 2;
-    }
-
-    context_ptr->md_stage_2_count[CAND_CLASS_0] = (picture_control_set_ptr->slice_type == I_SLICE) ? fastCandidateTotalCount : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? INTRA_NFL : (INTRA_NFL >> 1);
-#if FILTER_INTRA_FLAG
-    context_ptr->md_stage_2_count[CAND_CLASS_6] =  5;
-#endif
-#if PAL_CLASS
-    context_ptr->md_stage_2_count[CAND_CLASS_7] = 14;// context_ptr->bypass_stage1[CAND_CLASS_7] ? context_ptr->md_stage_1_count[CAND_CLASS_7] : 14;
-#endif
-    context_ptr->md_stage_2_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 14 : 4;
-    context_ptr->md_stage_2_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 14 : 4;
-
-    if (context_ptr->combine_class12) {
-        context_ptr->md_stage_2_count[CAND_CLASS_1] = context_ptr->md_stage_2_count[CAND_CLASS_1] * 2;
-    }
-    else {
-        context_ptr->md_stage_2_count[CAND_CLASS_3] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 14 : 4;
-    }
-
-#if II_COMP_FLAG
-    context_ptr->md_stage_2_count[CAND_CLASS_4] =  (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 12: 4;// 14 : 4;
-#endif
-#if OBMC_FLAG
-    context_ptr->md_stage_2_count[CAND_CLASS_5] =  (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : 16;
-#endif
-    context_ptr->md_stage_2_count[CAND_CLASS_8] = (picture_control_set_ptr->temporal_layer_index == 0) ? 5 : 4;
-
-
-    if (picture_control_set_ptr->enc_mode >= ENC_M2) {
-        context_ptr->md_stage_2_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 12 : 3;
-        context_ptr->md_stage_2_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 4 : 2;
-        if (!context_ptr->combine_class12) {
-            context_ptr->md_stage_2_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 6 : 2;
-            context_ptr->md_stage_2_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 6 : 2;
-            context_ptr->md_stage_2_count[CAND_CLASS_3] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 4 : 2;
-        }
-    }
-
-    if (picture_control_set_ptr->enc_mode >= ENC_M1)
-        context_ptr->md_stage_3_count[CAND_CLASS_0] = (picture_control_set_ptr->slice_type == I_SLICE) ? 10 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 4 : 1;
-    else
-        context_ptr->md_stage_3_count[CAND_CLASS_0] = (picture_control_set_ptr->slice_type == I_SLICE) ? 10 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? ((scs->input_resolution >= INPUT_SIZE_1080i_RANGE) ? 7 : 10) : 4;
-#if FILTER_INTRA_FLAG
-    context_ptr->md_stage_3_count[CAND_CLASS_6] = (picture_control_set_ptr->temporal_layer_index == 0) ? 5 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 3 : 2;
-    context_ptr->md_stage_3_count[CAND_CLASS_6] = (picture_control_set_ptr->temporal_layer_index == 0) ? 5 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 3 : 2;
-#endif
-#if PAL_CLASS
-    if (picture_control_set_ptr->parent_pcs_ptr->palette_mode == 1)
-        context_ptr->md_stage_3_count[CAND_CLASS_7] =
-        (picture_control_set_ptr->temporal_layer_index == 0) ? 7 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 4 : 4;
-    else if (picture_control_set_ptr->parent_pcs_ptr->palette_mode == 2 || picture_control_set_ptr->parent_pcs_ptr->palette_mode == 3)
-        context_ptr->md_stage_3_count[CAND_CLASS_7] =
-        (picture_control_set_ptr->temporal_layer_index == 0) ? 7 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 2 : 2;
-    else if (picture_control_set_ptr->parent_pcs_ptr->palette_mode == 4 || picture_control_set_ptr->parent_pcs_ptr->palette_mode == 5)
-        context_ptr->md_stage_3_count[CAND_CLASS_7] =
-        (picture_control_set_ptr->temporal_layer_index == 0) ? 4 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 2 : 1;
-    else
-        context_ptr->md_stage_3_count[CAND_CLASS_7] =
-        (picture_control_set_ptr->temporal_layer_index == 0) ? 2 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 1 : 1;
-#endif
-
-    context_ptr->md_stage_3_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 3 : 1;
-    context_ptr->md_stage_3_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 3 : 1;
-
-    if (context_ptr->combine_class12) {
-        context_ptr->md_stage_3_count[CAND_CLASS_1] = context_ptr->md_stage_3_count[CAND_CLASS_1] * 2;
-    }
-    else {
-        context_ptr->md_stage_3_count[CAND_CLASS_3] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 3 : 1;
-    }
-
-#if II_COMP_FLAG
-    context_ptr->md_stage_3_count[CAND_CLASS_4] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 12 : 4;// 14 : 4;
-#endif
-#if OBMC_FLAG
-    if (picture_control_set_ptr->parent_pcs_ptr->pic_obmc_mode == 1)
-        context_ptr->md_stage_3_count[CAND_CLASS_5] = 16 ;
-    else if (picture_control_set_ptr->parent_pcs_ptr->pic_obmc_mode <= 3)
-        context_ptr->md_stage_3_count[CAND_CLASS_5] =  (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 12 : 4;
-    else
-        context_ptr->md_stage_3_count[CAND_CLASS_5] =   (picture_control_set_ptr->temporal_layer_index == 0 ) ? 12 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 8: 4;
-#endif
-    context_ptr->md_stage_3_count[CAND_CLASS_8] = (picture_control_set_ptr->temporal_layer_index == 0) ? 4 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 3 : 2;
-
-    if (!context_ptr->combine_class12 && picture_control_set_ptr->parent_pcs_ptr->sc_content_detected && picture_control_set_ptr->enc_mode == ENC_M0) {
-
-        context_ptr->md_stage_2_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ?  0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 16 : 8;
-        context_ptr->md_stage_2_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ?  0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 16 : 8;
-        context_ptr->md_stage_2_count[CAND_CLASS_3] = (picture_control_set_ptr->slice_type == I_SLICE) ?  0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 16 : 8;
-
-        context_ptr->md_stage_3_count[CAND_CLASS_0] = (picture_control_set_ptr->slice_type == I_SLICE) ? 10 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ?  8 : 4;
-        context_ptr->md_stage_3_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ?  0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ?  8 : 4;
-        context_ptr->md_stage_3_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ?  0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ?  8 : 4;
-        context_ptr->md_stage_3_count[CAND_CLASS_3] = (picture_control_set_ptr->slice_type == I_SLICE) ?  0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ?  8 : 4;
-    }
-
-    if (picture_control_set_ptr->enc_mode >= ENC_M2 && picture_control_set_ptr->enc_mode <= ENC_M4) {
-        context_ptr->md_stage_3_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 4 : 2;
-        context_ptr->md_stage_3_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 2 : 1;
-
-        if (!context_ptr->combine_class12) {
-            context_ptr->md_stage_3_count[CAND_CLASS_1] = context_ptr->md_stage_3_count[CAND_CLASS_1] / 2;
-            context_ptr->md_stage_3_count[CAND_CLASS_3] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 2 : 1;
-        }
-    }
-    else if (picture_control_set_ptr->enc_mode >= ENC_M5) {
-        if (context_ptr->md_staging_mode == MD_STAGING_MODE_0 && picture_control_set_ptr->enc_mode <= ENC_M6) {
-            context_ptr->md_stage_1_count[CAND_CLASS_0] = (picture_control_set_ptr->slice_type == I_SLICE) ? 8 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 3 : 1;
-
-            if (context_ptr->combine_class12) {
-                context_ptr->md_stage_1_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 5 : 3;
-                context_ptr->md_stage_1_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 1 : 1;
-
-            }
-            else {
-                context_ptr->md_stage_1_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 2 : 1;
-                context_ptr->md_stage_1_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 2 : 1;
-                context_ptr->md_stage_1_count[CAND_CLASS_3] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 1 : 1;
-            }
-
-            context_ptr->md_stage_2_count[CAND_CLASS_0] = context_ptr->md_stage_1_count[CAND_CLASS_0];
-            context_ptr->md_stage_2_count[CAND_CLASS_1] = context_ptr->md_stage_1_count[CAND_CLASS_1];
-            context_ptr->md_stage_2_count[CAND_CLASS_2] = context_ptr->md_stage_1_count[CAND_CLASS_2];
-
-            if (!context_ptr->combine_class12)
-                context_ptr->md_stage_2_count[CAND_CLASS_3] = context_ptr->md_stage_1_count[CAND_CLASS_3];
-
-            context_ptr->md_stage_3_count[CAND_CLASS_0] = context_ptr->md_stage_2_count[CAND_CLASS_0];
-            context_ptr->md_stage_3_count[CAND_CLASS_1] = context_ptr->md_stage_2_count[CAND_CLASS_1];
-            context_ptr->md_stage_3_count[CAND_CLASS_2] = context_ptr->md_stage_2_count[CAND_CLASS_2];
-            if (!context_ptr->combine_class12)
-                context_ptr->md_stage_3_count[CAND_CLASS_3] = context_ptr->md_stage_2_count[CAND_CLASS_3];
-        }
-        else {
-            context_ptr->md_stage_1_count[CAND_CLASS_0] = (picture_control_set_ptr->slice_type == I_SLICE) ? 6 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 2 : 1;
-
-            if (context_ptr->combine_class12) {
-                context_ptr->md_stage_1_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 4 : 2;
-                context_ptr->md_stage_1_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 1 : 1;
-
-            }
-            else {
-                context_ptr->md_stage_1_count[CAND_CLASS_1] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 2 : 1;
-                context_ptr->md_stage_1_count[CAND_CLASS_2] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 2 : 1;
-                context_ptr->md_stage_1_count[CAND_CLASS_3] = (picture_control_set_ptr->slice_type == I_SLICE) ? 0 : (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag) ? 1 : 1;
-
-            }
-
-            context_ptr->md_stage_2_count[CAND_CLASS_0] = context_ptr->md_stage_1_count[CAND_CLASS_0];
-            context_ptr->md_stage_2_count[CAND_CLASS_1] = context_ptr->md_stage_1_count[CAND_CLASS_1];
-            context_ptr->md_stage_2_count[CAND_CLASS_2] = context_ptr->md_stage_1_count[CAND_CLASS_2];
-
-            if (!context_ptr->combine_class12)
-                context_ptr->md_stage_2_count[CAND_CLASS_3] = context_ptr->md_stage_1_count[CAND_CLASS_3];
-
-            context_ptr->md_stage_3_count[CAND_CLASS_0] = context_ptr->md_stage_2_count[CAND_CLASS_0];
-            context_ptr->md_stage_3_count[CAND_CLASS_1] = context_ptr->md_stage_2_count[CAND_CLASS_1];
-            context_ptr->md_stage_3_count[CAND_CLASS_2] = context_ptr->md_stage_2_count[CAND_CLASS_2];
-
-            if (!context_ptr->combine_class12)
-                context_ptr->md_stage_3_count[CAND_CLASS_3] = context_ptr->md_stage_2_count[CAND_CLASS_3];
-        }
-    }
-
-    // Step 3: update count for md_stage_1 and d_stage_2 if  bypassed (no NIC setting should be done beyond this point)
-    context_ptr->md_stage_2_count[CAND_CLASS_0] = context_ptr->bypass_stage1[CAND_CLASS_0] ? context_ptr->md_stage_1_count[CAND_CLASS_0] : context_ptr->md_stage_2_count[CAND_CLASS_0];
-    context_ptr->md_stage_2_count[CAND_CLASS_1] = context_ptr->bypass_stage1[CAND_CLASS_1] ? context_ptr->md_stage_1_count[CAND_CLASS_1] : context_ptr->md_stage_2_count[CAND_CLASS_1];
-    context_ptr->md_stage_2_count[CAND_CLASS_2] = context_ptr->bypass_stage1[CAND_CLASS_2] ? context_ptr->md_stage_1_count[CAND_CLASS_2] : context_ptr->md_stage_2_count[CAND_CLASS_2];
-    context_ptr->md_stage_2_count[CAND_CLASS_3] = context_ptr->bypass_stage1[CAND_CLASS_3] ? context_ptr->md_stage_1_count[CAND_CLASS_3] : context_ptr->md_stage_2_count[CAND_CLASS_3];
-
-    context_ptr->md_stage_3_count[CAND_CLASS_0] = context_ptr->bypass_stage2[CAND_CLASS_0] ? context_ptr->md_stage_2_count[CAND_CLASS_0] : context_ptr->md_stage_3_count[CAND_CLASS_0];
-    context_ptr->md_stage_3_count[CAND_CLASS_1] = context_ptr->bypass_stage2[CAND_CLASS_1] ? context_ptr->md_stage_2_count[CAND_CLASS_1] : context_ptr->md_stage_3_count[CAND_CLASS_1];
-    context_ptr->md_stage_3_count[CAND_CLASS_2] = context_ptr->bypass_stage2[CAND_CLASS_2] ? context_ptr->md_stage_2_count[CAND_CLASS_2] : context_ptr->md_stage_3_count[CAND_CLASS_2];
-    context_ptr->md_stage_3_count[CAND_CLASS_3] = context_ptr->bypass_stage2[CAND_CLASS_3] ? context_ptr->md_stage_2_count[CAND_CLASS_3] : context_ptr->md_stage_3_count[CAND_CLASS_3];
-   //TODO: use actual number of stages on the setting section and update using the following logic.
-   // stage2_cand_count[CAND_CLASS_i] = bypass_stage2 ? stage3_cand_count[CAND_CLASS_i] : stage2_cand_count[CAND_CLASS_i];
-   // stage1_cand_count[CAND_CLASS_i] = bypass_stage1 ? stage2_cand_count[CAND_CLASS_i] : stage1_cand_count[CAND_CLASS_i];
-
-
-#if PAL_CLASS  //THIS SHOULD BE rEMOVED AFTER REBAS~~~
-    context_ptr->md_stage_2_count[CAND_CLASS_7] = context_ptr->bypass_stage1[CAND_CLASS_7] ? context_ptr->md_stage_1_count[CAND_CLASS_7] : context_ptr->md_stage_2_count[CAND_CLASS_7];
-    context_ptr->md_stage_3_count[CAND_CLASS_7] = context_ptr->bypass_stage2[CAND_CLASS_7] ? context_ptr->md_stage_2_count[CAND_CLASS_7] : context_ptr->md_stage_3_count[CAND_CLASS_7];
-#endif
-
-    // Step 4: zero-out count for CAND_CLASS_3 if CAND_CLASS_1 and CAND_CLASS_2 are merged (i.e. shift to the left)
-    if (context_ptr->combine_class12)
-        context_ptr->md_stage_1_count[CAND_CLASS_3] = context_ptr->md_stage_2_count[CAND_CLASS_3] = context_ptr->md_stage_3_count[CAND_CLASS_3] = 0;
-}
-#endif
 #if ENHANCED_M0_SETTINGS
 void sort_fast_candidates(
 #else
@@ -2124,14 +1800,7 @@ void sort_stage0_fast_candidates(
 )
 {
     ModeDecisionCandidateBuffer **buffer_ptr_array = context_ptr->candidate_buffer_ptr_array;
-#if !SPEED_OPT
-    //  fill cand_buff_indices with surviving buffer indices ; move the scratch candidates (MAX_CU_COST) to the last spots (if any)
-    uint32_t ordered_start_idx = 0;
-    uint32_t ordered_end_idx = input_buffer_count - 1;
-#endif
-
     uint32_t input_buffer_end_idx = input_buffer_start_idx + input_buffer_count - 1;
-#if SPEED_OPT
     uint32_t buffer_index, i, j;
     uint32_t k = 0;
     for (buffer_index = input_buffer_start_idx; buffer_index <= input_buffer_end_idx; buffer_index++, k++) {
@@ -2147,14 +1816,7 @@ void sort_stage0_fast_candidates(
             }
         }
     }
-#else
-    for (uint32_t buffer_index = input_buffer_start_idx; buffer_index <= input_buffer_end_idx; buffer_index++) {
-        if (*(buffer_ptr_array[buffer_index]->fast_cost_ptr) == MAX_CU_COST)
-            cand_buff_indices[ordered_end_idx--] = buffer_index;
-        else
-            cand_buff_indices[ordered_start_idx++] = buffer_index;
-    }
-#endif
+
 }
 
 static INLINE void heap_sort_stage_max_node_fast_cost_ptr(
@@ -2333,7 +1995,6 @@ static INLINE void sort_array_index_fast_cost_ptr(
     }
 }
 
-#if FIX_SORTING_METHOD
 void sort_stage1_fast_candidates(
     struct ModeDecisionContext   *context_ptr,
     uint32_t                      num_of_cand_to_sort,
@@ -2353,24 +2014,7 @@ void sort_stage1_fast_candidates(
         }
     }
 }
-#else
-void sort_stage1_fast_candidates(
-    struct ModeDecisionContext   *context_ptr,
-    uint32_t                      num_of_cand_to_sort,
-    uint32_t                     *cand_buff_indices)
-{
-    ModeDecisionCandidateBuffer **buffer_ptr_array = context_ptr->candidate_buffer_ptr_array;
-
-    //sorted best: *(buffer_ptr_array[sorted_candidate_index_array[?]]->fast_cost_ptr)
-    sort_array_index_fast_cost_ptr(buffer_ptr_array,
-        cand_buff_indices, num_of_cand_to_sort);
-}
-#endif
-#if REMOVE_MD_STAGE_1
 void sort_stage1_candidates(
-#else
-void sort_stage2_candidates(
-#endif
     struct ModeDecisionContext   *context_ptr,
     uint32_t                      num_of_cand_to_sort,
     uint32_t                     *cand_buff_indices)
@@ -2387,11 +2031,7 @@ void sort_stage2_candidates(
         }
     }
 }
-#if REMOVE_MD_STAGE_1
 void construct_best_sorted_arrays_md_stage_1(
-#else
-void construct_best_sorted_arrays_md_stage_2(
-#endif
     struct ModeDecisionContext   *context_ptr,
     ModeDecisionCandidateBuffer **buffer_ptr_array,
     uint32_t                      *best_candidate_index_array,
@@ -2402,20 +2042,11 @@ void construct_best_sorted_arrays_md_stage_2(
     //best = union from all classes
     uint32_t best_candi = 0;
     for (CAND_CLASS class_i = CAND_CLASS_0; class_i < CAND_CLASS_TOTAL; class_i++)
-#if REMOVE_MD_STAGE_1
         for (uint32_t candi = 0; candi < context_ptr->md_stage_1_count[class_i]; candi++)
-#else
-        for (uint32_t candi = 0; candi < context_ptr->md_stage_2_count[class_i]; candi++)
-#endif
             sorted_candidate_index_array[best_candi++] = context_ptr->cand_buff_indices[class_i][candi];
 
-#if REMOVE_MD_STAGE_1
     assert(best_candi == context_ptr->md_stage_1_total_count);
     uint32_t fullReconCandidateCount = context_ptr->md_stage_1_total_count;
-#else
-    assert(best_candi == context_ptr->md_stage_2_total_count);
-    uint32_t fullReconCandidateCount = context_ptr->md_stage_2_total_count;
-#endif
 
     //sort best: inter, then intra
     uint32_t i, id;
@@ -2440,11 +2071,7 @@ void construct_best_sorted_arrays_md_stage_2(
     *ref_fast_cost = *(buffer_ptr_array[sorted_candidate_index_array[0]]->fast_cost_ptr);
 }
 
-#if REMOVE_MD_STAGE_1
 void construct_best_sorted_arrays_md_stage_2(
-#else
-void construct_best_sorted_arrays_md_stage_3(
-#endif
     struct ModeDecisionContext   *context_ptr,
     ModeDecisionCandidateBuffer **buffer_ptr_array,
     uint32_t                      *best_candidate_index_array,
@@ -2454,20 +2081,11 @@ void construct_best_sorted_arrays_md_stage_3(
     //best = union from all classes
     uint32_t best_candi = 0;
     for (CAND_CLASS class_i = CAND_CLASS_0; class_i < CAND_CLASS_TOTAL; class_i++)
-#if REMOVE_MD_STAGE_1
         for (uint32_t candi = 0; candi < context_ptr->md_stage_2_count[class_i]; candi++)
-#else
-        for (uint32_t candi = 0; candi < context_ptr->md_stage_3_count[class_i]; candi++)
-#endif
             sorted_candidate_index_array[best_candi++] = context_ptr->cand_buff_indices[class_i][candi];
 
-#if REMOVE_MD_STAGE_1
     assert(best_candi == context_ptr->md_stage_2_total_count);
     uint32_t fullReconCandidateCount = context_ptr->md_stage_2_total_count;
-#else
-    assert(best_candi == context_ptr->md_stage_3_total_count);
-    uint32_t fullReconCandidateCount = context_ptr->md_stage_3_total_count;
-#endif
     //sort best: inter, then intra
     uint32_t i, id;
     uint32_t id_inter = 0;
@@ -2517,34 +2135,12 @@ void md_stage_0(
 
 
     // Set MD Staging fast_loop_core settings
-#if REMOVE_MD_STAGE_1
-#if MULTI_PASS_PD
     context_ptr->md_staging_skip_interpolation_search = (context_ptr->md_staging_mode == MD_STAGING_MODE_1) ? EB_TRUE : context_ptr->interpolation_search_level >= IT_SEARCH_FAST_LOOP_UV_BLIND ? EB_FALSE : EB_TRUE;
-#else
-    context_ptr->md_staging_skip_interpolation_search = (context_ptr->md_staging_mode == MD_STAGING_MODE_1) ? EB_TRUE : picture_control_set_ptr->parent_pcs_ptr->interpolation_search_level >= IT_SEARCH_FAST_LOOP_UV_BLIND ? EB_FALSE : EB_TRUE;
-#endif
-#else
-    context_ptr->md_staging_skip_interpolation_search = (context_ptr->md_staging_mode) ? EB_TRUE : picture_control_set_ptr->parent_pcs_ptr->interpolation_search_level >= IT_SEARCH_FAST_LOOP_UV_BLIND ? EB_FALSE : EB_TRUE;
-#endif
-#if FILTER_INTRA_FLAG
-#if REMOVE_MD_STAGE_1
-#if PAL_CLASS
+
     context_ptr->md_staging_skip_inter_chroma_pred = (context_ptr->md_staging_mode == MD_STAGING_MODE_1 &&
         context_ptr->target_class != CAND_CLASS_0 && context_ptr->target_class != CAND_CLASS_6 && context_ptr->target_class != CAND_CLASS_7) ? EB_TRUE : EB_FALSE;
-#else
-    context_ptr->md_staging_skip_inter_chroma_pred = (context_ptr->md_staging_mode == MD_STAGING_MODE_1 && context_ptr->target_class != CAND_CLASS_0 && context_ptr->target_class != CAND_CLASS_6) ? EB_TRUE : EB_FALSE;
-#endif
-#else
-    context_ptr->md_staging_skip_inter_chroma_pred = (context_ptr->md_staging_mode && context_ptr->md_stage == MD_STAGE_0 && context_ptr->target_class != CAND_CLASS_0 && context_ptr->target_class != CAND_CLASS_6) ? EB_TRUE : EB_FALSE;
-#endif
-#else
-    context_ptr->md_staging_skip_inter_chroma_pred = (context_ptr->md_staging_mode && context_ptr->md_stage == MD_STAGE_0 && context_ptr->target_class != CAND_CLASS_0) ? EB_TRUE : EB_FALSE;
-#endif
-#if REMOVE_MD_STAGE_1
+
     context_ptr->md_staging_use_bilinear = (context_ptr->md_staging_mode == MD_STAGING_MODE_1) ? EB_TRUE : EB_FALSE;
-#else
-    context_ptr->md_staging_use_bilinear = (context_ptr->md_staging_mode) ? EB_TRUE : EB_FALSE;
-#endif
     // 1st fast loop: src-to-src
     fastLoopCandidateIndex = fast_candidate_end_index;
     while (fastLoopCandidateIndex >= fast_candidate_start_index)
@@ -2658,55 +2254,6 @@ void md_stage_0(
         MAX_CU_COST :
         *(candidate_buffer_ptr_array_base[highestCostIndex]->fast_cost_ptr);
 }
-#if !REMOVE_MD_STAGE_1
-void md_stage_1(
-    PictureControlSet            *picture_control_set_ptr,
-    ModeDecisionContext          *context_ptr,
-    ModeDecisionCandidateBuffer **candidate_buffer_ptr_array_base,
-    uint32_t                      num_of_candidates,
-    EbPictureBufferDesc          *input_picture_ptr,
-    uint32_t                      inputOriginIndex,
-    uint32_t                      inputCbOriginIndex,
-    uint32_t                      inputCrOriginIndex,
-    CodingUnit                   *cu_ptr,
-    uint32_t                      cuOriginIndex,
-    uint32_t                      cuChromaOriginIndex,
-    EbBool                        use_ssd)
-{
-
-    // Set MD Staging fast_loop_core settings
-    context_ptr->md_staging_skip_interpolation_search = (context_ptr->md_staging_mode == MD_STAGING_MODE_3) ? EB_TRUE : picture_control_set_ptr->parent_pcs_ptr->interpolation_search_level >= IT_SEARCH_FAST_LOOP_UV_BLIND ? EB_FALSE : EB_TRUE;
-    context_ptr->md_staging_skip_inter_chroma_pred = EB_FALSE;
-    context_ptr->md_staging_use_bilinear = EB_FALSE;
-
-    for (uint32_t cand_idx = 0; cand_idx < num_of_candidates; ++cand_idx)
-    {
-
-        uint32_t                        candidateIndex = context_ptr->cand_buff_indices[context_ptr->target_class][cand_idx];
-        ModeDecisionCandidateBuffer    *candidate_buffer = candidate_buffer_ptr_array_base[candidateIndex];
-        ModeDecisionCandidate          *candidate_ptr = candidate_buffer->candidate_ptr;
-
-        // Initialize tx_depth
-        candidate_buffer->candidate_ptr->tx_depth = 0;
-
-        if (!candidate_ptr->distortion_ready) {
-
-            fast_loop_core(
-                candidate_buffer,
-                picture_control_set_ptr,
-                context_ptr,
-                input_picture_ptr,
-                inputOriginIndex,
-                inputCbOriginIndex,
-                inputCrOriginIndex,
-                cu_ptr,
-                cuOriginIndex,
-                cuChromaOriginIndex,
-                use_ssd);
-        }
-    }
-}
-#endif
 void predictive_me_full_pel_search(
     PictureControlSet        *picture_control_set_ptr,
     ModeDecisionContext      *context_ptr,
@@ -2726,11 +2273,7 @@ void predictive_me_full_pel_search(
     int16_t                  *best_mvy,
     uint32_t                 *best_distortion)
 {
-#if HBD2_PME
     uint8_t hbd_mode_decision = context_ptr->hbd_mode_decision == EB_DUAL_BIT_MD ? EB_8_BIT_MD: context_ptr->hbd_mode_decision ;
-#else
-    uint8_t hbd_mode_decision = context_ptr->hbd_mode_decision;
-#endif
     uint32_t  distortion;
     ModeDecisionCandidateBuffer  *candidate_buffer = &(context_ptr->candidate_buffer_ptr_array[0][0]);
     candidate_buffer->candidate_ptr = &(context_ptr->fast_candidate_array[0]);
@@ -2808,11 +2351,7 @@ void predictive_me_sub_pel_search(
     uint32_t                 *best_distortion,
     uint8_t                   search_pattern)
 {
-#if HBD2_PME
     uint8_t hbd_mode_decision = context_ptr->hbd_mode_decision == EB_DUAL_BIT_MD ? EB_8_BIT_MD: context_ptr->hbd_mode_decision ;
-#else
-    uint8_t hbd_mode_decision = context_ptr->hbd_mode_decision;
-#endif
     uint32_t  distortion;
     ModeDecisionCandidateBuffer  *candidate_buffer = &(context_ptr->candidate_buffer_ptr_array[0][0]);
     candidate_buffer->candidate_ptr = &(context_ptr->fast_candidate_array[0]);
@@ -2931,9 +2470,7 @@ uint8_t GetMaxDrlIndex(uint8_t  refmvCnt, PredictionMode   mode);
 #define FULL_PEL_REF_WINDOW_WIDTH_EXTENDED  15
 #define FULL_PEL_REF_WINDOW_HEIGHT_EXTENDED 15
 #endif
-#if EIGHT_PEL_PREDICTIVE_ME
 #define EIGHT_PEL_REF_WINDOW 3
-#endif
 #endif
 void predictive_me_search(
     PictureControlSet            *picture_control_set_ptr,
@@ -2950,15 +2487,10 @@ void predictive_me_search(
 #endif
 #endif
     EbBool use_ssd = EB_TRUE;
-#if HBD2_PME
     uint8_t hbd_mode_decision = context_ptr->hbd_mode_decision == EB_DUAL_BIT_MD ? EB_8_BIT_MD: context_ptr->hbd_mode_decision ;
     input_picture_ptr =  hbd_mode_decision  ? picture_control_set_ptr->input_frame16bit : picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
     //Update input origin
     inputOriginIndex = (context_ptr->cu_origin_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_y + (context_ptr->cu_origin_x + input_picture_ptr->origin_x);
-
-#else
-    uint8_t hbd_mode_decision = context_ptr->hbd_mode_decision;
-#endif
     // Reset valid_refined_mv
     memset(context_ptr->valid_refined_mv, 0, 8); // [2][4]
 
@@ -3304,7 +2836,6 @@ void predictive_me_search(
                             }
                         }
                     }
-#if EIGHT_PEL_PREDICTIVE_ME
                     // Step 5: perform eigh pel search around the best quarter pel position
                     if (picture_control_set_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv) {
                         uint8_t search_pattern = 0;
@@ -3336,7 +2867,6 @@ void predictive_me_search(
                             &best_search_distortion,
                             search_pattern);
                     }
-#endif
                     context_ptr->best_spatial_pred_mv[list_idx][ref_idx][0] = best_search_mvx;
                     context_ptr->best_spatial_pred_mv[list_idx][ref_idx][1] = best_search_mvy;
                     context_ptr->valid_refined_mv[list_idx][ref_idx] = 1;
@@ -3942,11 +3472,8 @@ void check_best_indepedant_cfl(
     uint64_t                      *cb_coeff_bits,
     uint64_t                      *cr_coeff_bits)
 {
-
-#if FILTER_INTRA_FLAG
     if (candidate_buffer->candidate_ptr->filter_intra_mode != FILTER_INTRA_MODES)
         assert(candidate_buffer->candidate_ptr->intra_luma_mode == DC_PRED);
-#endif
     FrameHeader *frm_hdr = &picture_control_set_ptr->parent_pcs_ptr->frm_hdr;
     // cfl cost
     uint64_t chromaRate = 0;
@@ -4132,17 +3659,9 @@ EbErrorType av1_intra_luma_prediction(
             tx_size,
             mode,                                                                           //PredictionMode mode,
             candidate_buffer_ptr->candidate_ptr->angle_delta[PLANE_TYPE_Y],
-#if PAL_SUP
             candidate_buffer_ptr->candidate_ptr->palette_info.pmi.palette_size[0]>0,
             &candidate_buffer_ptr->candidate_ptr->palette_info ,    //ATB MD
-#else
-            0,                                                                              //int32_t use_palette,
-#endif
-#if FILTER_INTRA_FLAG
             candidate_buffer_ptr->candidate_ptr->filter_intra_mode,
-#else
-            FILTER_INTRA_MODES,                                                             //CHKN FilterIntraMode filter_intra_mode,
-#endif
             topNeighArray + 1,
             leftNeighArray + 1,
             candidate_buffer_ptr->prediction_ptr,                                              //uint8_t *dst,
@@ -4179,17 +3698,9 @@ EbErrorType av1_intra_luma_prediction(
             tx_size,
             mode,
             candidate_buffer_ptr->candidate_ptr->angle_delta[PLANE_TYPE_Y],
-#if PAL_SUP
             candidate_buffer_ptr->candidate_ptr->palette_info.pmi.palette_size[0] > 0,
             &candidate_buffer_ptr->candidate_ptr->palette_info,    //ATB MD
-#else
-            0,
-#endif
-#if FILTER_INTRA_FLAG
             candidate_buffer_ptr->candidate_ptr->filter_intra_mode,
-#else
-            FILTER_INTRA_MODES,                                                             //CHKN FilterIntraMode filter_intra_mode,
-#endif
             topNeighArray + 1,
             leftNeighArray + 1,
             candidate_buffer_ptr->prediction_ptr,
@@ -4273,7 +3784,6 @@ uint8_t get_end_tx_depth(BlockSize bsize, uint8_t btype) {
     return tx_depth;
 }
 
-#if ENHANCE_ATB
 uint8_t allowed_tx_set_a[TX_SIZES_ALL][TX_TYPES];
 
 void tx_initialize_neighbor_arrays(
@@ -4283,14 +3793,12 @@ void tx_initialize_neighbor_arrays(
 
     // Set recon neighbor array to be used @ intra compensation
     if (!is_inter){
-#if ATB_HBD
         if (context_ptr->hbd_mode_decision)
             context_ptr->tx_search_luma_recon_neighbor_array16bit =
             (context_ptr->tx_depth) ?
             picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX] :
             picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX];
         else
-#endif
             context_ptr->tx_search_luma_recon_neighbor_array =
             (context_ptr->tx_depth) ?
             picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX] :
@@ -4313,11 +3821,7 @@ void tx_update_neighbor_arrays(
 
         if (!is_inter)
             tx_search_update_recon_sample_neighbor_array(
-#if ATB_HBD
                 context_ptr->hbd_mode_decision ? context_ptr->tx_search_luma_recon_neighbor_array16bit: context_ptr->tx_search_luma_recon_neighbor_array,
-#else
-                context_ptr->tx_search_luma_recon_neighbor_array,
-#endif
                 candidate_buffer->recon_ptr,
                 context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr],
@@ -4348,8 +3852,6 @@ void tx_reset_neighbor_arrays(
 
     if (end_tx_depth) {
         if (!is_inter) {
-#if ATB_HBD
-#if ATB_FIX
             if (context_ptr->hbd_mode_decision) {
                 copy_neigh_arr(
                     picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
@@ -4359,8 +3861,6 @@ void tx_reset_neighbor_arrays(
                     context_ptr->blk_geom->bwidth,
                     context_ptr->blk_geom->bheight,
                     NEIGHBOR_ARRAY_UNIT_TOPLEFT_MASK);
-
-
                 copy_neigh_arr(
                     picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
                     picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
@@ -4370,19 +3870,8 @@ void tx_reset_neighbor_arrays(
                     context_ptr->blk_geom->bheight * 2,
                     NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
             }
-#else
-                copy_neigh_arr(
-                    picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
-                    picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
-                    context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x,
-                    context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y,
-                    context_ptr->blk_geom->bwidth,
-                    context_ptr->blk_geom->bheight,
 
-#endif
         else
-#endif
-#if ATB_FIX
         {
             copy_neigh_arr(
                 picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
@@ -4403,17 +3892,7 @@ void tx_reset_neighbor_arrays(
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
             }
         }
-#else
-            copy_neigh_arr(
-                picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
-                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
-                context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x,
-                context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y,
-                context_ptr->blk_geom->bwidth,
-                context_ptr->blk_geom->bheight,
-                NEIGHBOR_ARRAY_UNIT_FULL_MASK);
 
-#endif
         copy_neigh_arr(
             picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
             picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
@@ -4432,11 +3911,7 @@ void tx_type_search(
     ModeDecisionCandidateBuffer  *candidate_buffer,
     uint32_t                      qp)
 {
-#if ATB_HBD
         EbPictureBufferDesc *input_picture_ptr = context_ptr->hbd_mode_decision ? picture_control_set_ptr->input_frame16bit : picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
-#else
-        EbPictureBufferDesc *input_picture_ptr = picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
-#endif
     int32_t seg_qp = picture_control_set_ptr->parent_pcs_ptr->frm_hdr.segmentation_params.segmentation_enabled ?
         picture_control_set_ptr->parent_pcs_ptr->frm_hdr.segmentation_params.feature_data[context_ptr->cu_ptr->segment_id][SEG_LVL_ALT_Q] : 0;
 
@@ -5043,27 +4518,20 @@ void tx_partitioning_path(
     uint64_t                     *y_coeff_bits,
     uint64_t                     *y_full_distortion)
 {
-#if ATB_HBD
     EbPictureBufferDesc *input_picture_ptr = context_ptr->hbd_mode_decision ? picture_control_set_ptr->input_frame16bit :  picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
-#else
-    EbPictureBufferDesc *input_picture_ptr = picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
-#endif
     SequenceControlSet  *sequence_control_set_ptr = (SequenceControlSet*)picture_control_set_ptr->sequence_control_set_wrapper_ptr->object_ptr;
     int32_t is_inter = (candidate_buffer->candidate_ptr->type == INTER_MODE || candidate_buffer->candidate_ptr->use_intrabc) ? EB_TRUE : EB_FALSE;
 
 
     uint8_t  best_tx_depth = 0;
     uint64_t best_cost_search = (uint64_t)~0;
-#if TX_SIZE_EARLY_EXIT
     uint8_t is_best_has_coeff = 1;
-#endif
     // Fill the scratch buffer
     memcpy(context_ptr->scratch_candidate_buffer->candidate_ptr, candidate_buffer->candidate_ptr, sizeof(ModeDecisionCandidate));
 
     if (is_inter) {
 
         uint32_t block_index = context_ptr->blk_geom->origin_x + (context_ptr->blk_geom->origin_y * MAX_SB_SIZE);
-#if ATB_HBD
         if (context_ptr->hbd_mode_decision) {
             // Copy pred
             {
@@ -5091,7 +4559,7 @@ void tx_partitioning_path(
             }
         }
         else
-#endif
+
         {
             // Copy pred
             {
@@ -5152,14 +4620,12 @@ void tx_partitioning_path(
 
     // Transform Depth Loop
     for (context_ptr->tx_depth = 0; context_ptr->tx_depth <= end_tx_depth; context_ptr->tx_depth++) {
-#if TX_SIZE_EARLY_EXIT
         if (picture_control_set_ptr->parent_pcs_ptr->tx_size_early_exit) {
             if (best_tx_depth != 1 && context_ptr->tx_depth == 2)
                 continue;
             if (!is_best_has_coeff)
                 continue;
         }
-#endif
         ModeDecisionCandidateBuffer *tx_candidate_buffer = (context_ptr->tx_depth == 0) ? candidate_buffer : context_ptr->scratch_candidate_buffer;
 
         tx_candidate_buffer->candidate_ptr->tx_depth = context_ptr->tx_depth;
@@ -5196,7 +4662,6 @@ void tx_partitioning_path(
                     tx_candidate_buffer);
 
                 // Y Residual
-#if ATB_HBD
                 residual_kernel(
                     input_picture_ptr->buffer_y,
                     input_tu_origin_index,
@@ -5211,17 +4676,7 @@ void tx_partitioning_path(
                     context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
                     context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
 
-#else
-                residual_kernel8bit(
-                    &(input_picture_ptr->buffer_y[input_tu_origin_index]),
-                    input_picture_ptr->stride_y,
-                    &(tx_candidate_buffer->prediction_ptr->buffer_y[tu_origin_index]),
-                    tx_candidate_buffer->prediction_ptr->stride_y,
-                    &(((int16_t*)tx_candidate_buffer->residual_ptr->buffer_y)[tu_origin_index]),
-                    tx_candidate_buffer->residual_ptr->stride_y,
-                    context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
-#endif
+
             }
 
             if (!tx_search_skip_flag) {
@@ -5271,9 +4726,7 @@ void tx_partitioning_path(
         if (cost < best_cost_search) {
             best_cost_search = cost;
             best_tx_depth = context_ptr->tx_depth;
-#if TX_SIZE_EARLY_EXIT
             is_best_has_coeff = block_has_coeff;
-#endif
             y_full_distortion[DIST_CALC_RESIDUAL] = tx_y_full_distortion[DIST_CALC_RESIDUAL];
             y_full_distortion[DIST_CALC_PREDICTION] = tx_y_full_distortion[DIST_CALC_PREDICTION];
             *y_coeff_bits = tx_y_coeff_bits;
@@ -5291,7 +4744,6 @@ void tx_partitioning_path(
 
         // Copy depth 1 pred
         uint32_t block_index = context_ptr->blk_geom->origin_x + (context_ptr->blk_geom->origin_y * MAX_SB_SIZE);
-#if ATB_HBD
         if (context_ptr->hbd_mode_decision) {
             // Copy pred
             // &(((int32_t*)context_ptr->trans_quant_buffers_ptr->tu_trans_coeff2_nx2_n_ptr->buffer_y)[txb_1d_offset]),
@@ -5304,7 +4756,7 @@ void tx_partitioning_path(
             }
         }
         else
-#endif
+
         {
             EbByte src = &(context_ptr->scratch_candidate_buffer->prediction_ptr->buffer_y[block_index]);
             EbByte dst = &(candidate_buffer->prediction_ptr->buffer_y[block_index]);
@@ -5321,692 +4773,6 @@ void tx_partitioning_path(
         }
 
 }
-#else
-void perform_intra_tx_partitioning(
-    ModeDecisionCandidateBuffer  *candidate_buffer,
-    ModeDecisionContext          *context_ptr,
-    PictureControlSet            *picture_control_set_ptr,
-    uint64_t                      ref_fast_cost,
-    uint8_t                       end_tx_depth,
-    uint32_t                      qp,
-    uint32_t                     *y_count_non_zero_coeffs,
-    uint64_t                     *y_coeff_bits,
-    uint64_t                     *y_full_distortion)
-{
-    EbPictureBufferDesc *input_picture_ptr = picture_control_set_ptr->hbd_mode_decision ?
-        picture_control_set_ptr->input_frame16bit : picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
-    SequenceControlSet  *sequence_control_set_ptr = (SequenceControlSet*)picture_control_set_ptr->sequence_control_set_wrapper_ptr->object_ptr;
-    uint32_t tu_origin_index;
-    uint64_t y_full_cost;
-    uint64_t y_tu_coeff_bits;
-    uint64_t tuFullDistortion[3][DIST_CALC_TOTAL];
-    uint32_t txb_1d_offset;
-
-    uint8_t  best_tx_depth = 0;
-
-    uint64_t best_cost_search = (uint64_t)~0;
-
-    TxType best_tx_type_depth_0 = DCT_DCT; // Track the best tx type @ depth 0 to be used @ the final stage (i.e. avoid redoing the tx type search).
-    uint8_t  tx_search_skip_flag;
-    if (context_ptr->md_staging_tx_search == 0)
-        tx_search_skip_flag = EB_TRUE;
-    else if (context_ptr->md_staging_tx_search == 1)
-        tx_search_skip_flag = picture_control_set_ptr->parent_pcs_ptr->tx_search_level == TX_SEARCH_FULL_LOOP ? get_skip_tx_search_flag(
-            context_ptr->blk_geom->sq_size,
-            ref_fast_cost,
-            *candidate_buffer->fast_cost_ptr,
-            picture_control_set_ptr->parent_pcs_ptr->tx_weight) : EB_TRUE;
-    else
-        tx_search_skip_flag = picture_control_set_ptr->parent_pcs_ptr->tx_search_level == TX_SEARCH_FULL_LOOP ? EB_FALSE : EB_TRUE;
-
-    // Reset depth_1 neighbor arrays
-    if (end_tx_depth) {
-        if (!picture_control_set_ptr->hbd_mode_decision) {
-            copy_neigh_arr(
-                picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
-                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
-                context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x,
-                context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y,
-                context_ptr->blk_geom->bwidth,
-                context_ptr->blk_geom->bheight,
-                NEIGHBOR_ARRAY_UNIT_FULL_MASK);
-        } else {
-            copy_neigh_arr(
-                picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
-                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
-                context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x,
-                context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y,
-                context_ptr->blk_geom->bwidth,
-                context_ptr->blk_geom->bheight,
-                NEIGHBOR_ARRAY_UNIT_FULL_MASK);
-        }
-
-        copy_neigh_arr(
-            picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
-            picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
-            context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x,
-            context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y,
-            context_ptr->blk_geom->bwidth,
-            context_ptr->blk_geom->bheight,
-            NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
-    }
-
-    // Transform Depth Loop
-    for (context_ptr->tx_depth = 0; context_ptr->tx_depth <= end_tx_depth; context_ptr->tx_depth++) {
-        // Set recon neighbor array to be used @ intra compensation
-        if (!context_ptr->hbd_mode_decision) {
-            context_ptr->tx_search_luma_recon_neighbor_array =
-                (context_ptr->tx_depth) ?
-                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX] :
-                picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
-        } else {
-            context_ptr->tx_search_luma_recon_neighbor_array16bit =
-                (context_ptr->tx_depth) ?
-                picture_control_set_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX] :
-                picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX];
-        }
-
-        // Set luma dc sign level coeff
-        context_ptr->tx_search_luma_dc_sign_level_coeff_neighbor_array =
-            (context_ptr->tx_depth) ?
-            picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX] :
-            picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
-
-        // Initialize TU Split
-        y_full_distortion[DIST_CALC_RESIDUAL] = 0;
-        y_full_distortion[DIST_CALC_PREDICTION] = 0;
-        *y_coeff_bits = 0;
-        txb_1d_offset = 0;
-        context_ptr->three_quad_energy = 0;
-        candidate_buffer->candidate_ptr->y_has_coeff = 0;
-
-        uint16_t txb_count = context_ptr->blk_geom->txb_count[context_ptr->tx_depth];
-        for (context_ptr->txb_itr = 0; context_ptr->txb_itr < txb_count; context_ptr->txb_itr++) {
-            uint16_t tx_org_x = context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr];
-            uint16_t tx_org_y = context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr];
-
-            context_ptr->luma_txb_skip_context = 0;
-            context_ptr->luma_dc_sign_context = 0;
-            get_txb_ctx(
-                sequence_control_set_ptr,
-                COMPONENT_LUMA,
-                context_ptr->tx_search_luma_dc_sign_level_coeff_neighbor_array,
-                context_ptr->sb_origin_x + tx_org_x,
-                context_ptr->sb_origin_y + tx_org_y,
-                context_ptr->blk_geom->bsize,
-                context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-                &context_ptr->luma_txb_skip_context,
-                &context_ptr->luma_dc_sign_context);
-            tu_origin_index = tx_org_x + (tx_org_y * candidate_buffer->residual_ptr->stride_y);
-
-            uint32_t input_tu_origin_index = (context_ptr->sb_origin_x + tx_org_x + input_picture_ptr->origin_x) + ((context_ptr->sb_origin_y + tx_org_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_y);
-
-            // Y Prediction
-            av1_intra_luma_prediction(
-                context_ptr,
-                picture_control_set_ptr,
-                candidate_buffer);
-
-            // Y Residual
-            residual_kernel(
-                input_picture_ptr->buffer_y,
-                input_tu_origin_index,
-                input_picture_ptr->stride_y,
-                candidate_buffer->prediction_ptr->buffer_y,
-                tu_origin_index,
-                candidate_buffer->prediction_ptr->stride_y,
-                (int16_t*)candidate_buffer->residual_ptr->buffer_y,
-                tu_origin_index,
-                candidate_buffer->residual_ptr->stride_y,
-                context_ptr->hbd_mode_decision,
-                context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
-
-            TxType best_tx_type = DCT_DCT;
-            if (!tx_search_skip_flag) {
-            TxType txk_start = DCT_DCT;
-            TxType txk_end = TX_TYPES;
-            uint64_t best_cost_tx_search = (uint64_t)~0;
-
-            const TxSetType tx_set_type = get_ext_tx_set_type(context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr], 0, 0); // assumes INTRA
-
-            for (int32_t tx_type = txk_start; tx_type < txk_end; ++tx_type) {
-                y_tu_coeff_bits = 0;
-
-                int32_t eset = get_ext_tx_set(context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr], 0, 0); // assumes INTRA
-                // eset == 0 should correspond to a set with only DCT_DCT and there
-                // is no need to send the tx_type
-                if (eset <= 0) continue;
-                else if (av1_ext_tx_used[tx_set_type][tx_type] == 0) continue;
-                else if (context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr] > 32 || context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr] > 32) continue;
-
-                int32_t seg_qp = picture_control_set_ptr->parent_pcs_ptr->frm_hdr.segmentation_params.segmentation_enabled ?
-                                 picture_control_set_ptr->parent_pcs_ptr->frm_hdr.segmentation_params.feature_data[context_ptr->cu_ptr->segment_id][SEG_LVL_ALT_Q] : 0;
-                // Y: T Q iQ
-                av1_estimate_transform(
-                    &(((int16_t*)candidate_buffer->residual_ptr->buffer_y)[tu_origin_index]),
-                    candidate_buffer->residual_ptr->stride_y,
-                    &(((int32_t*)context_ptr->trans_quant_buffers_ptr->tu_trans_coeff2_nx2_n_ptr->buffer_y)[txb_1d_offset]),
-                    NOT_USED_VALUE,
-                    context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-                    &context_ptr->three_quad_energy,
-                    context_ptr->transform_inner_array_ptr,
-                    picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
-                    tx_type,
-                    PLANE_TYPE_Y,
-                    DEFAULT_SHAPE);
-
-                av1_quantize_inv_quantize(
-                    picture_control_set_ptr,
-                    context_ptr,
-                    &(((int32_t*)context_ptr->trans_quant_buffers_ptr->tu_trans_coeff2_nx2_n_ptr->buffer_y)[txb_1d_offset]),
-                    NOT_USED_VALUE,
-                    &(((int32_t*)candidate_buffer->residual_quant_coeff_ptr->buffer_y)[txb_1d_offset]),
-                    &(((int32_t*)candidate_buffer->recon_coeff_ptr->buffer_y)[txb_1d_offset]),
-                    qp,
-                    seg_qp,
-                    context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-                    &candidate_buffer->candidate_ptr->eob[0][context_ptr->txb_itr],
-                    &(y_count_non_zero_coeffs[context_ptr->txb_itr]),
-                    COMPONENT_LUMA,
-                    picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
-                    tx_type,
-                    candidate_buffer,
-                    context_ptr->luma_txb_skip_context,
-                    context_ptr->luma_dc_sign_context,
-                    candidate_buffer->candidate_ptr->pred_mode,
-                    EB_FALSE,
-                    EB_FALSE);
-
-                candidate_buffer->candidate_ptr->quantized_dc[0][context_ptr->txb_itr] = (((int32_t*)candidate_buffer->residual_quant_coeff_ptr->buffer_y)[txb_1d_offset]);
-
-                uint32_t y_has_coeff = y_count_non_zero_coeffs[context_ptr->txb_itr] > 0;
-
-                // tx_type not equal to DCT_DCT and no coeff is not an acceptable option in AV1.
-                if (y_has_coeff == 0 && tx_type != DCT_DCT)
-                    continue;
-                if (y_has_coeff)
-                    inv_transform_recon_wrapper(
-                        candidate_buffer->prediction_ptr->buffer_y,
-                        tu_origin_index,
-                        candidate_buffer->prediction_ptr->stride_y,
-                        candidate_buffer->recon_ptr->buffer_y,
-                        tu_origin_index,
-                        candidate_buffer->recon_ptr->stride_y,
-                        (int32_t*) candidate_buffer->recon_coeff_ptr->buffer_y,
-                        txb_1d_offset,
-                        picture_control_set_ptr->hbd_mode_decision,
-                        context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-                        tx_type,
-                        PLANE_TYPE_Y,
-                        (uint16_t)candidate_buffer->candidate_ptr->eob[0][context_ptr->txb_itr]);
-                else
-                    picture_copy(
-                        candidate_buffer->prediction_ptr,
-                        tu_origin_index,
-                        0,
-                        candidate_buffer->recon_ptr,
-                        tu_origin_index,
-                        0,
-                        context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                        context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
-                        0,
-                        0,
-                        PICTURE_BUFFER_DESC_Y_FLAG,
-                        picture_control_set_ptr->hbd_mode_decision);
-
-                EbSpatialFullDistType spatial_full_dist_type_fun = context_ptr->hbd_mode_decision ?
-                        full_distortion_kernel16_bits : spatial_full_distortion_kernel;
-
-                tuFullDistortion[0][DIST_CALC_PREDICTION] = spatial_full_dist_type_fun(
-                    input_picture_ptr->buffer_y,
-                    input_tu_origin_index,
-                    input_picture_ptr->stride_y,
-                    candidate_buffer->prediction_ptr->buffer_y,
-                    tu_origin_index,
-                    candidate_buffer->prediction_ptr->stride_y,
-                    context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
-
-                tuFullDistortion[0][DIST_CALC_RESIDUAL] = spatial_full_dist_type_fun(
-                    input_picture_ptr->buffer_y,
-                    input_tu_origin_index,
-                    input_picture_ptr->stride_y,
-                    candidate_buffer->recon_ptr->buffer_y,
-                    tu_origin_index,
-                    candidate_buffer->recon_ptr->stride_y,
-                    context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
-
-                tuFullDistortion[0][DIST_CALC_PREDICTION] <<= 4;
-                tuFullDistortion[0][DIST_CALC_RESIDUAL] <<= 4;
-
-                //LUMA-ONLY
-                av1_tu_estimate_coeff_bits(
-                    context_ptr,
-                    0,   //allow_update_cdf,
-                    NULL,//FRAME_CONTEXT *ec_ctx,
-                    picture_control_set_ptr,
-                    candidate_buffer,
-                    txb_1d_offset,
-                    0,
-                    context_ptr->coeff_est_entropy_coder_ptr,
-                    candidate_buffer->residual_quant_coeff_ptr,
-                    y_count_non_zero_coeffs[context_ptr->txb_itr],
-                    0,
-                    0,
-                    &y_tu_coeff_bits,
-                    &y_tu_coeff_bits,
-                    &y_tu_coeff_bits,
-                    context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->blk_geom->txsize_uv[context_ptr->tx_depth][context_ptr->txb_itr],
-                    tx_type,
-                    candidate_buffer->candidate_ptr->transform_type_uv,
-                    COMPONENT_LUMA);
-
-                uint64_t cost = RDCOST(context_ptr->full_lambda, y_tu_coeff_bits, tuFullDistortion[0][DIST_CALC_RESIDUAL]);
-                if (cost < best_cost_tx_search) {
-                    best_cost_tx_search = cost;
-                    best_tx_type = tx_type;
-                }
-            }
-
-            // Record the best tx type @ depth 0
-            best_tx_type_depth_0 = (context_ptr->tx_depth == 0) ? best_tx_type : best_tx_type_depth_0;
-            }
-            //  Best Tx Type Pass
-            candidate_buffer->candidate_ptr->transform_type[context_ptr->txb_itr] = best_tx_type;
-
-            y_tu_coeff_bits = 0;
-
-
-            // Y: T Q iQ
-            av1_estimate_transform(
-                &(((int16_t*)candidate_buffer->residual_ptr->buffer_y)[tu_origin_index]),
-                candidate_buffer->residual_ptr->stride_y,
-                &(((int32_t*)context_ptr->trans_quant_buffers_ptr->tu_trans_coeff2_nx2_n_ptr->buffer_y)[txb_1d_offset]),
-                NOT_USED_VALUE,
-                context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-                &context_ptr->three_quad_energy,
-                context_ptr->transform_inner_array_ptr,
-                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
-                candidate_buffer->candidate_ptr->transform_type[context_ptr->txb_itr],
-                PLANE_TYPE_Y,
-                DEFAULT_SHAPE);
-
-            int32_t seg_qp = picture_control_set_ptr->parent_pcs_ptr->frm_hdr.segmentation_params.segmentation_enabled ?
-                             picture_control_set_ptr->parent_pcs_ptr->frm_hdr.segmentation_params.feature_data[context_ptr->cu_ptr->segment_id][SEG_LVL_ALT_Q] : 0;
-
-            candidate_buffer->candidate_ptr->quantized_dc[0][context_ptr->txb_itr] = av1_quantize_inv_quantize(
-                picture_control_set_ptr,
-                context_ptr,
-                &(((int32_t*)context_ptr->trans_quant_buffers_ptr->tu_trans_coeff2_nx2_n_ptr->buffer_y)[txb_1d_offset]),
-                NOT_USED_VALUE,
-                &(((int32_t*)candidate_buffer->residual_quant_coeff_ptr->buffer_y)[txb_1d_offset]),
-                &(((int32_t*)candidate_buffer->recon_coeff_ptr->buffer_y)[txb_1d_offset]),
-                qp,
-                seg_qp,
-                context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
-                context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-                &candidate_buffer->candidate_ptr->eob[0][context_ptr->txb_itr],
-                &(y_count_non_zero_coeffs[context_ptr->txb_itr]),
-                COMPONENT_LUMA,
-                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
-                candidate_buffer->candidate_ptr->transform_type[context_ptr->txb_itr],
-                candidate_buffer,
-                context_ptr->luma_txb_skip_context,
-                context_ptr->luma_dc_sign_context,
-                candidate_buffer->candidate_ptr->pred_mode,
-                EB_FALSE,
-                EB_FALSE);
-            uint32_t y_has_coeff = y_count_non_zero_coeffs[context_ptr->txb_itr] > 0;
-
-            if (y_has_coeff)
-                inv_transform_recon_wrapper(
-                    candidate_buffer->prediction_ptr->buffer_y,
-                    tu_origin_index,
-                    candidate_buffer->prediction_ptr->stride_y,
-                    candidate_buffer->recon_ptr->buffer_y,
-                    tu_origin_index,
-                    candidate_buffer->recon_ptr->stride_y,
-                    (int32_t*) candidate_buffer->recon_coeff_ptr->buffer_y,
-                    txb_1d_offset,
-                    picture_control_set_ptr->hbd_mode_decision,
-                    context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-                    candidate_buffer->candidate_ptr->transform_type[context_ptr->txb_itr],
-                    PLANE_TYPE_Y,
-                    (uint16_t)candidate_buffer->candidate_ptr->eob[0][context_ptr->txb_itr]);
-            else
-                picture_copy(
-                    candidate_buffer->prediction_ptr,
-                    tu_origin_index,
-                    0,
-                    candidate_buffer->recon_ptr,
-                    tu_origin_index,
-                    0,
-                    context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
-                    0,
-                    0,
-                    PICTURE_BUFFER_DESC_Y_FLAG,
-                    picture_control_set_ptr->hbd_mode_decision);
-
-            EbSpatialFullDistType spatial_full_dist_type_fun = context_ptr->hbd_mode_decision ?
-                full_distortion_kernel16_bits : spatial_full_distortion_kernel;
-
-            tuFullDistortion[0][DIST_CALC_PREDICTION] = spatial_full_dist_type_fun(
-                input_picture_ptr->buffer_y,
-                input_tu_origin_index,
-                input_picture_ptr->stride_y,
-                candidate_buffer->prediction_ptr->buffer_y,
-                tu_origin_index,
-                candidate_buffer->prediction_ptr->stride_y,
-                context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
-
-            tuFullDistortion[0][DIST_CALC_RESIDUAL] = spatial_full_dist_type_fun(
-                input_picture_ptr->buffer_y,
-                input_tu_origin_index,
-                input_picture_ptr->stride_y,
-                candidate_buffer->recon_ptr->buffer_y,
-                tu_origin_index,
-                candidate_buffer->recon_ptr->stride_y,
-                context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
-
-            tuFullDistortion[0][DIST_CALC_PREDICTION] <<= 4;
-            tuFullDistortion[0][DIST_CALC_RESIDUAL] <<= 4;
-
-            //LUMA-ONLY
-            av1_tu_estimate_coeff_bits(
-                context_ptr,
-                0,   //allow_update_cdf,
-                NULL,//FRAME_CONTEXT *ec_ctx,
-                picture_control_set_ptr,
-                candidate_buffer,
-                txb_1d_offset,
-                0,
-                context_ptr->coeff_est_entropy_coder_ptr,
-                candidate_buffer->residual_quant_coeff_ptr,
-                y_count_non_zero_coeffs[context_ptr->txb_itr],
-                0,
-                0,
-                &y_tu_coeff_bits,
-                &y_tu_coeff_bits,
-                &y_tu_coeff_bits,
-                context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-                context_ptr->blk_geom->txsize_uv[context_ptr->tx_depth][context_ptr->txb_itr],
-                candidate_buffer->candidate_ptr->transform_type[context_ptr->txb_itr],
-                candidate_buffer->candidate_ptr->transform_type_uv,
-                COMPONENT_LUMA);
-
-            av1_tu_calc_cost_luma(
-                context_ptr->luma_txb_skip_context,
-                candidate_buffer->candidate_ptr,
-                context_ptr->txb_itr,
-                context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-                y_count_non_zero_coeffs[context_ptr->txb_itr],
-                tuFullDistortion[0],
-                &y_tu_coeff_bits,
-                &y_full_cost,
-                context_ptr->full_lambda);
-
-            (*y_coeff_bits) += y_tu_coeff_bits;
-
-            y_full_distortion[DIST_CALC_RESIDUAL] += tuFullDistortion[0][DIST_CALC_RESIDUAL];
-            y_full_distortion[DIST_CALC_PREDICTION] += tuFullDistortion[0][DIST_CALC_PREDICTION];
-
-            txb_1d_offset += context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr] * context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr];
-
-            if (context_ptr->tx_depth)
-            {
-                NeighborArrayUnit *tx_search_luma_recon =
-                    context_ptr->hbd_mode_decision ? context_ptr->tx_search_luma_recon_neighbor_array16bit : context_ptr->tx_search_luma_recon_neighbor_array;
-
-                tx_search_update_recon_sample_neighbor_array(
-                    tx_search_luma_recon,
-                    candidate_buffer->recon_ptr,
-                    context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->sb_origin_x + context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->sb_origin_y + context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->hbd_mode_decision);
-
-                int8_t dc_sign_level_coeff = candidate_buffer->candidate_ptr->quantized_dc[0][context_ptr->txb_itr];
-                neighbor_array_unit_mode_write(
-                    picture_control_set_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
-                    (uint8_t*)&dc_sign_level_coeff,
-                    context_ptr->sb_origin_x + context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->sb_origin_y + context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
-                    NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
-            }
-        } // Transform Loop
-
-        // To do: estimate the cost of tx size = tx_size_bits
-        uint64_t cost = RDCOST(context_ptr->full_lambda, (*y_coeff_bits), y_full_distortion[DIST_CALC_RESIDUAL]);
-
-        if (cost < best_cost_search) {
-            best_cost_search = cost;
-            best_tx_depth = context_ptr->tx_depth;
-        }
-    } // Transform Depth Loop
-
-    // ATB Recon
-    context_ptr->tx_depth = candidate_buffer->candidate_ptr->tx_depth = best_tx_depth;
-
-    if (context_ptr->tx_depth == 0) {
-        // Set recon neighbor array to be used @ intra compensation
-        if (context_ptr->hbd_mode_decision)
-            context_ptr->tx_search_luma_recon_neighbor_array16bit = picture_control_set_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX];
-        else
-            context_ptr->tx_search_luma_recon_neighbor_array = picture_control_set_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
-
-        // Initialize TU Split
-        y_full_distortion[DIST_CALC_RESIDUAL] = 0;
-        y_full_distortion[DIST_CALC_PREDICTION] = 0;
-        *y_coeff_bits = 0;
-        txb_1d_offset = 0;
-        context_ptr->three_quad_energy = 0;
-        candidate_buffer->candidate_ptr->y_has_coeff = 0;
-
-        uint16_t txb_count = context_ptr->blk_geom->txb_count[context_ptr->tx_depth];
-        for (context_ptr->txb_itr = 0; context_ptr->txb_itr < txb_count; context_ptr->txb_itr++) {
-            uint16_t tx_org_x = context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr];
-            uint16_t tx_org_y = context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr];
-
-            context_ptr->luma_txb_skip_context = 0;
-            context_ptr->luma_dc_sign_context = 0;
-            get_txb_ctx(
-                sequence_control_set_ptr,
-                COMPONENT_LUMA,
-                picture_control_set_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
-                context_ptr->sb_origin_x + tx_org_x,
-                context_ptr->sb_origin_y + tx_org_y,
-                context_ptr->blk_geom->bsize,
-                context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-                &context_ptr->luma_txb_skip_context,
-                &context_ptr->luma_dc_sign_context);
-
-            tu_origin_index = tx_org_x + (tx_org_y * candidate_buffer->residual_ptr->stride_y);
-            y_tu_coeff_bits = 0;
-
-            uint32_t input_tu_origin_index = (context_ptr->sb_origin_x + tx_org_x + input_picture_ptr->origin_x) + ((context_ptr->sb_origin_y + tx_org_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_y);
-
-            // Y Prediction
-            av1_intra_luma_prediction(
-                context_ptr,
-                picture_control_set_ptr,
-                candidate_buffer);
-
-            // Y Residual
-            residual_kernel(
-                input_picture_ptr->buffer_y,
-                input_tu_origin_index,
-                input_picture_ptr->stride_y,
-                candidate_buffer->prediction_ptr->buffer_y,
-                tu_origin_index,
-                candidate_buffer->prediction_ptr->stride_y,
-                (int16_t*)candidate_buffer->residual_ptr->buffer_y,
-                tu_origin_index,
-                candidate_buffer->residual_ptr->stride_y,
-                context_ptr->hbd_mode_decision,
-                context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
-
-            // Get the depth 0 best tx type
-            candidate_buffer->candidate_ptr->transform_type[context_ptr->txb_itr] = best_tx_type_depth_0;
-
-            y_tu_coeff_bits = 0;
-
-            // Y: T Q iQ
-            av1_estimate_transform(
-                &(((int16_t*)candidate_buffer->residual_ptr->buffer_y)[tu_origin_index]),
-                candidate_buffer->residual_ptr->stride_y,
-                &(((int32_t*)context_ptr->trans_quant_buffers_ptr->tu_trans_coeff2_nx2_n_ptr->buffer_y)[txb_1d_offset]),
-                NOT_USED_VALUE,
-                context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-                &context_ptr->three_quad_energy,
-                context_ptr->transform_inner_array_ptr,
-                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
-                candidate_buffer->candidate_ptr->transform_type[context_ptr->txb_itr],
-                PLANE_TYPE_Y,
-                DEFAULT_SHAPE);
-
-            int32_t seg_qp = picture_control_set_ptr->parent_pcs_ptr->frm_hdr.segmentation_params.segmentation_enabled ?
-                             picture_control_set_ptr->parent_pcs_ptr->frm_hdr.segmentation_params.feature_data[context_ptr->cu_ptr->segment_id][SEG_LVL_ALT_Q] : 0;
-            candidate_buffer->candidate_ptr->quantized_dc[0][context_ptr->txb_itr] = av1_quantize_inv_quantize(
-                picture_control_set_ptr,
-                context_ptr,
-                &(((int32_t*)context_ptr->trans_quant_buffers_ptr->tu_trans_coeff2_nx2_n_ptr->buffer_y)[txb_1d_offset]),
-                NOT_USED_VALUE,
-                &(((int32_t*)candidate_buffer->residual_quant_coeff_ptr->buffer_y)[txb_1d_offset]),
-                &(((int32_t*)candidate_buffer->recon_coeff_ptr->buffer_y)[txb_1d_offset]),
-                qp,
-                seg_qp,
-                context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
-                context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-                &candidate_buffer->candidate_ptr->eob[0][context_ptr->txb_itr],
-                &(y_count_non_zero_coeffs[context_ptr->txb_itr]),
-                COMPONENT_LUMA,
-                picture_control_set_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
-                candidate_buffer->candidate_ptr->transform_type[context_ptr->txb_itr],
-                candidate_buffer,
-                context_ptr->luma_txb_skip_context,
-                context_ptr->luma_dc_sign_context,
-                candidate_buffer->candidate_ptr->pred_mode,
-                EB_FALSE,
-                EB_FALSE);
-            uint32_t y_has_coeff = y_count_non_zero_coeffs[context_ptr->txb_itr] > 0;
-
-            if (y_has_coeff)
-                inv_transform_recon_wrapper(
-                    candidate_buffer->prediction_ptr->buffer_y,
-                    tu_origin_index,
-                    candidate_buffer->prediction_ptr->stride_y,
-                    candidate_buffer->recon_ptr->buffer_y,
-                    tu_origin_index,
-                    candidate_buffer->recon_ptr->stride_y,
-                    (int32_t*) candidate_buffer->recon_coeff_ptr->buffer_y,
-                    txb_1d_offset,
-                    picture_control_set_ptr->hbd_mode_decision,
-                    context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-                    candidate_buffer->candidate_ptr->transform_type[context_ptr->txb_itr],
-                    PLANE_TYPE_Y,
-                    (uint16_t)candidate_buffer->candidate_ptr->eob[0][context_ptr->txb_itr]);
-
-            else
-                picture_copy(
-                    candidate_buffer->prediction_ptr,
-                    tu_origin_index,
-                    0,
-                    candidate_buffer->recon_ptr,
-                    tu_origin_index,
-                    0,
-                    context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                    context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
-                    0,
-                    0,
-                    PICTURE_BUFFER_DESC_Y_FLAG,
-                    picture_control_set_ptr->hbd_mode_decision);
-
-            EbSpatialFullDistType spatial_full_dist_type_fun = context_ptr->hbd_mode_decision ?
-                full_distortion_kernel16_bits : spatial_full_distortion_kernel;
-
-            tuFullDistortion[0][DIST_CALC_PREDICTION] = spatial_full_dist_type_fun(
-                input_picture_ptr->buffer_y,
-                input_tu_origin_index,
-                input_picture_ptr->stride_y,
-                candidate_buffer->prediction_ptr->buffer_y,
-                tu_origin_index,
-                candidate_buffer->prediction_ptr->stride_y,
-                context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
-
-            tuFullDistortion[0][DIST_CALC_RESIDUAL] = spatial_full_dist_type_fun(
-                input_picture_ptr->buffer_y,
-                input_tu_origin_index,
-                input_picture_ptr->stride_y,
-                candidate_buffer->recon_ptr->buffer_y,
-                tu_origin_index,
-                candidate_buffer->recon_ptr->stride_y,
-                context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
-                context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
-
-            tuFullDistortion[0][DIST_CALC_PREDICTION] <<= 4;
-            tuFullDistortion[0][DIST_CALC_RESIDUAL] <<= 4;
-
-            //LUMA-ONLY
-            av1_tu_estimate_coeff_bits(
-                context_ptr,
-                0,   //allow_update_cdf,
-                NULL,//FRAME_CONTEXT *ec_ctx,
-                picture_control_set_ptr,
-                candidate_buffer,
-                txb_1d_offset,
-                0,
-                context_ptr->coeff_est_entropy_coder_ptr,
-                candidate_buffer->residual_quant_coeff_ptr,
-                y_count_non_zero_coeffs[context_ptr->txb_itr],
-                0,
-                0,
-                &y_tu_coeff_bits,
-                &y_tu_coeff_bits,
-                &y_tu_coeff_bits,
-                context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-                context_ptr->blk_geom->txsize_uv[context_ptr->tx_depth][context_ptr->txb_itr],
-                candidate_buffer->candidate_ptr->transform_type[context_ptr->txb_itr],
-                candidate_buffer->candidate_ptr->transform_type_uv,
-                COMPONENT_LUMA);
-
-            av1_tu_calc_cost_luma(
-                context_ptr->luma_txb_skip_context,
-                candidate_buffer->candidate_ptr,
-                context_ptr->txb_itr,
-                context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-                y_count_non_zero_coeffs[context_ptr->txb_itr],
-                tuFullDistortion[0],
-                &y_tu_coeff_bits,
-                &y_full_cost,
-                context_ptr->full_lambda);
-
-            (*y_coeff_bits) += y_tu_coeff_bits;
-
-            y_full_distortion[DIST_CALC_RESIDUAL] += tuFullDistortion[0][DIST_CALC_RESIDUAL];
-            y_full_distortion[DIST_CALC_PREDICTION] += tuFullDistortion[0][DIST_CALC_PREDICTION];
-
-            txb_1d_offset += context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr] * context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr];
-        } // Transform Loop
-    }
-}
-#endif
 
 
 void full_loop_core(
@@ -6050,14 +4816,7 @@ void full_loop_core(
         candidate_ptr->skip_flag = EB_FALSE;
 
         if (candidate_ptr->type != INTRA_MODE) {
-#if REMOVE_MD_STAGE_1
             if (context_ptr->md_staging_skip_full_pred == EB_FALSE) {
-#else
-            if (picture_control_set_ptr->parent_pcs_ptr->interpolation_search_level > IT_SEARCH_OFF)
-                if (picture_control_set_ptr->parent_pcs_ptr->interpolation_search_level == IT_SEARCH_FULL_LOOP || context_ptr->md_staging_skip_full_pred == EB_FALSE) {
-                    context_ptr->md_staging_skip_interpolation_search = EB_FALSE;
-                    context_ptr->md_staging_skip_inter_chroma_pred = EB_FALSE;
-#endif
                     ProductPredictionFunTable[candidate_ptr->type](
                         context_ptr->hbd_mode_decision,
                         context_ptr,
@@ -6085,7 +4844,6 @@ void full_loop_core(
         else
             end_tx_depth = 0;
         // Transform partitioning path (INTRA Luma)
-#if ENHANCE_ATB
 #if MULTI_PASS_PD
         if (context_ptr->md_atb_mode && context_ptr->md_staging_skip_atb == EB_FALSE && end_tx_depth && candidate_buffer->candidate_ptr->use_intrabc == 0) {
 #else
@@ -6111,10 +4869,6 @@ void full_loop_core(
                     context_ptr->blk_geom->bheight);
 
             tx_partitioning_path(
-#else
-        if (picture_control_set_ptr->parent_pcs_ptr->atb_mode && context_ptr->md_staging_skip_atb == EB_FALSE && end_tx_depth && candidate_buffer->candidate_ptr->type == INTRA_MODE && candidate_buffer->candidate_ptr->use_intrabc == 0) {
-            perform_intra_tx_partitioning(
-#endif
                 candidate_buffer,
                 context_ptr,
                 picture_control_set_ptr,
@@ -6182,12 +4936,10 @@ void full_loop_core(
                 //re-init
                 candidate_ptr->y_has_coeff = 0;
             }
-#if ENHANCE_ATB
             context_ptr->tx_depth = candidate_buffer->candidate_ptr->tx_depth;
             context_ptr->full_loop_luma_dc_sign_level_coeff_neighbor_array = context_ptr->luma_dc_sign_level_coeff_neighbor_array;
             context_ptr->txb_1d_offset = 0;
             for (context_ptr->txb_itr = 0; context_ptr->txb_itr < context_ptr->blk_geom->txb_count[context_ptr->tx_depth]; context_ptr->txb_itr++)
-#endif
             product_full_loop(
                 candidate_buffer,
                 context_ptr,
@@ -6342,11 +5094,7 @@ void full_loop_core(
         candidate_buffer->y_coeff_bits = y_coeff_bits;
         candidate_ptr->full_distortion = (uint32_t)(y_full_distortion[0]);
 }
-#if REMOVE_MD_STAGE_1
 void md_stage_1(
-#else
-void md_stage_2(
-#endif
     PictureControlSet     *picture_control_set_ptr,
     SuperBlock            *sb_ptr,
     CodingUnit            *cu_ptr,
@@ -6367,38 +5115,19 @@ void md_stage_2(
     uint32_t candidateIndex;
 
     // Set MD Staging full_loop_core settings
-#if !REMOVE_MD_STAGE_1
-    context_ptr->md_staging_skip_full_pred = EB_TRUE;
-#endif
     context_ptr->md_staging_skip_atb = EB_TRUE;
     context_ptr->md_staging_tx_search = 0;
-#if FILTER_INTRA_FLAG
-#if REMOVE_MD_STAGE_1
     context_ptr->md_staging_skip_full_chroma = EB_TRUE;
-#else
-    context_ptr->md_staging_skip_full_chroma =  context_ptr->target_class == CAND_CLASS_0 || context_ptr->target_class == CAND_CLASS_6 || context_ptr->md_staging_mode == MD_STAGING_MODE_3;
-#endif
-#else
-    context_ptr->md_staging_skip_full_chroma = context_ptr->target_class == CAND_CLASS_0 || context_ptr->md_staging_mode == MD_STAGING_MODE_3;
-#endif
-
-#if REMOVE_MD_STAGE_1
     context_ptr->md_staging_skip_rdoq = EB_TRUE;
     for (fullLoopCandidateIndex = 0; fullLoopCandidateIndex < context_ptr->md_stage_1_count[context_ptr->target_class]; ++fullLoopCandidateIndex) {
-#else
-    context_ptr->md_staging_skip_rdoq = (context_ptr->md_staging_mode == MD_STAGING_MODE_2 || context_ptr->md_staging_mode == MD_STAGING_MODE_3);
-    for (fullLoopCandidateIndex = 0; fullLoopCandidateIndex < context_ptr->md_stage_2_count[context_ptr->target_class]; ++fullLoopCandidateIndex) {
-#endif
         candidateIndex = context_ptr->cand_buff_indices[context_ptr->target_class][fullLoopCandidateIndex];
         candidate_buffer = candidate_buffer_ptr_array[candidateIndex];
         candidate_ptr = candidate_buffer->candidate_ptr;
 
-#if REMOVE_MD_STAGE_1
         context_ptr->md_staging_skip_full_pred = EB_FALSE;
         context_ptr->md_staging_skip_interpolation_search = EB_FALSE;
         context_ptr->md_staging_skip_inter_chroma_pred = EB_TRUE;
         candidate_buffer->candidate_ptr->interp_filters = 0;
-#endif
         full_loop_core(
             picture_control_set_ptr,
             sb_ptr,
@@ -6414,11 +5143,7 @@ void md_stage_2(
             ref_fast_cost);
     }
 }
-#if REMOVE_MD_STAGE_1
 void md_stage_2(
-#else
-void md_stage_3(
-#endif
     PictureControlSet     *picture_control_set_ptr,
     SuperBlock            *sb_ptr,
     CodingUnit            *cu_ptr,
@@ -6448,41 +5173,20 @@ void md_stage_3(
         candidate_ptr = candidate_buffer->candidate_ptr;
 
         // Set MD Staging full_loop_core settings
-#if REMOVE_MD_STAGE_1
-#if MULTI_PASS_PD // Shut pred @ full loop if 1st pass
         context_ptr->md_staging_skip_full_pred = context_ptr->md_staging_mode == MD_STAGING_MODE_0;
         context_ptr->md_staging_skip_interpolation_search = context_ptr->md_staging_mode == MD_STAGING_MODE_1;
-#else
-        context_ptr->md_staging_skip_full_pred = (context_ptr->md_staging_mode == MD_STAGING_MODE_0 && picture_control_set_ptr->parent_pcs_ptr->interpolation_search_level != IT_SEARCH_FULL_LOOP);
-        context_ptr->md_staging_skip_interpolation_search = (context_ptr->md_staging_mode == MD_STAGING_MODE_1 || picture_control_set_ptr->parent_pcs_ptr->interpolation_search_level != IT_SEARCH_FULL_LOOP);
-#endif
         context_ptr->md_staging_skip_inter_chroma_pred = EB_FALSE;
-#else
-        context_ptr->md_staging_skip_full_pred = (context_ptr->md_staging_mode == MD_STAGING_MODE_3) ? EB_FALSE: EB_TRUE;
-#endif
         context_ptr->md_staging_skip_atb = context_ptr->coeff_based_skip_atb;
-#if FILTER_INTRA_FLAG
-#if PAL_CLASS
         context_ptr->md_staging_tx_search =
             (candidate_ptr->cand_class == CAND_CLASS_0 || candidate_ptr->cand_class == CAND_CLASS_6 || candidate_ptr->cand_class == CAND_CLASS_7)
             ? 2 : 1;
-#else
-        context_ptr->md_staging_tx_search = (candidate_ptr->cand_class == CAND_CLASS_0 || candidate_ptr->cand_class == CAND_CLASS_6)? 2 : 1;
-#endif
-#else
-        context_ptr->md_staging_tx_search = candidate_ptr->cand_class == CAND_CLASS_0 ? 2 : 1;
-#endif
         context_ptr->md_staging_skip_full_chroma = EB_FALSE;
 
         context_ptr->md_staging_skip_rdoq = EB_FALSE;
 
         if (picture_control_set_ptr->slice_type != I_SLICE) {
             if ((candidate_ptr->type == INTRA_MODE || context_ptr->full_loop_escape == 2) && best_inter_luma_zero_coeff == 0) {
-#if REMOVE_MD_STAGE_1
                 context_ptr->md_stage_2_total_count = fullLoopCandidateIndex;
-#else
-                context_ptr->md_stage_3_total_count = fullLoopCandidateIndex;
-#endif
                 return;
             }
         }
@@ -6643,18 +5347,13 @@ void move_cu_data(
     dst_cu->part = src_cu->part;
     dst_cu->shape = src_cu->shape;
     dst_cu->mds_idx = src_cu->mds_idx;
-#if FILTER_INTRA_FLAG
     dst_cu->filter_intra_mode = src_cu->filter_intra_mode;
-#endif
 }
 void move_cu_data_redund(
-#if PAL_SUP
     PictureControlSet     *pcs,
     ModeDecisionContext   *context_ptr,
-#endif
     CodingUnit *src_cu,
     CodingUnit *dst_cu){
-#if PAL_SUP
     dst_cu->segment_id = src_cu->segment_id;
     dst_cu->seg_id_predicted = src_cu->seg_id_predicted;
     dst_cu->ref_qp = src_cu->ref_qp;
@@ -6663,11 +5362,7 @@ void move_cu_data_redund(
     memcpy(&dst_cu->palette_info.pmi, &src_cu->palette_info.pmi, sizeof(PaletteModeInfo));
     if (svt_av1_allow_palette(pcs->parent_pcs_ptr->palette_mode, context_ptr->blk_geom->bsize))
         memcpy(dst_cu->palette_info.color_idx_map, src_cu->palette_info.color_idx_map, MAX_PALETTE_SQUARE);
-
-#endif
-#if OBMC_FLAG
     dst_cu->interp_filters = src_cu->interp_filters;
-#endif
     dst_cu->interinter_comp.type = src_cu->interinter_comp.type;
     dst_cu->interinter_comp.mask_type = src_cu->interinter_comp.mask_type;
     dst_cu->interinter_comp.wedge_index = src_cu->interinter_comp.wedge_index;
@@ -6681,9 +5376,7 @@ void move_cu_data_redund(
        dst_cu->interintra_wedge_index  = src_cu->interintra_wedge_index      ;//inter_intra wedge index
        dst_cu->ii_wedge_sign           = src_cu->ii_wedge_sign               ;//inter_intra wedge sign=-1
 #endif
-#if FILTER_INTRA_FLAG
     dst_cu->filter_intra_mode = src_cu->filter_intra_mode;
-#endif
     //CHKN TransformUnit_t             transform_unit_array[TRANSFORM_UNIT_MAX_COUNT]; // 2-bytes * 21 = 42-bytes
     memcpy(dst_cu->transform_unit_array, src_cu->transform_unit_array, TRANSFORM_UNIT_MAX_COUNT * sizeof(TransformUnit));
 
@@ -7655,7 +6348,6 @@ uint8_t check_skip_sub_blks(
     return skip_sub_blocks;
 }
 
-#if ENHANCED_M0_SETTINGS
 void search_best_independent_uv_mode(
     PictureControlSet     *picture_control_set_ptr,
     EbPictureBufferDesc   *input_picture_ptr,
@@ -7930,300 +6622,25 @@ void search_best_independent_uv_mode(
     // End uv search path
     context_ptr->uv_search_path = EB_FALSE;
 }
-#else
-// Hsan (chroma search) : av1_get_tx_type() to define as extern
-void search_best_independent_uv_mode(
-    PictureControlSet     *picture_control_set_ptr,
-    EbPictureBufferDesc   *input_picture_ptr,
-    uint32_t                 inputCbOriginIndex,
-    uint32_t                 cuChromaOriginIndex,
-    ModeDecisionContext   *context_ptr)
-{
-    FrameHeader *frm_hdr = &picture_control_set_ptr->parent_pcs_ptr->frm_hdr;
-    // Start uv search path
-    context_ptr->uv_search_path = EB_TRUE;
-#if !PAETH_HBD
-    uint8_t is_16_bit = (sequence_control_set_ptr->static_config.encoder_bit_depth > EB_8BIT);
-#endif
-    EbBool use_angle_delta = av1_use_angle_delta(context_ptr->blk_geom->bsize);
-
-    UvPredictionMode uv_mode;
-
-    int coeff_rate[UV_PAETH_PRED + 1][(MAX_ANGLE_DELTA << 1) + 1];
-    int distortion[UV_PAETH_PRED + 1][(MAX_ANGLE_DELTA << 1) + 1];
-
-    // Use the 1st spot of the candidate buffer to hold cfl settings to use same kernel as MD for coef cost estimation
-    ModeDecisionCandidateBuffer  *candidate_buffer = &(context_ptr->candidate_buffer_ptr_array[0][0]);
-    candidate_buffer->candidate_ptr = &(context_ptr->fast_candidate_array[0]);
-    candidate_buffer->candidate_ptr->type = INTRA_MODE;
-    candidate_buffer->candidate_ptr->distortion_ready = 0;
-    candidate_buffer->candidate_ptr->use_intrabc = 0;
-    candidate_buffer->candidate_ptr->angle_delta[PLANE_TYPE_UV] = 0;
-
-    uint8_t uv_mode_start = UV_DC_PRED;
-#if PAETH_HBD
-    uint8_t uv_mode_end =  UV_PAETH_PRED;
-#else
-    uint8_t uv_mode_end = is_16_bit ? UV_SMOOTH_H_PRED : UV_PAETH_PRED;
-#endif
-    for (uv_mode = uv_mode_start; uv_mode <= uv_mode_end; uv_mode++) {
-        uint8_t uv_angleDeltaCandidateCount = (use_angle_delta && av1_is_directional_mode((PredictionMode)uv_mode)) ? 7 : 1;
-        uint8_t uv_angle_delta_shift = 1;
-
-        for (uint8_t uv_angleDeltaCounter = 0; uv_angleDeltaCounter < uv_angleDeltaCandidateCount; ++uv_angleDeltaCounter) {
-            int32_t uv_angle_delta = CLIP(uv_angle_delta_shift * (uv_angleDeltaCandidateCount == 1 ? 0 : uv_angleDeltaCounter - (uv_angleDeltaCandidateCount >> 1)), -MAX_ANGLE_DELTA, MAX_ANGLE_DELTA);
-#if RDOQ_CHROMA
-            candidate_buffer->candidate_ptr->pred_mode = DC_PRED;
-#endif
-            candidate_buffer->candidate_ptr->intra_chroma_mode = uv_mode;
-            candidate_buffer->candidate_ptr->is_directional_chroma_mode_flag = (uint8_t)av1_is_directional_mode((PredictionMode)uv_mode);
-            candidate_buffer->candidate_ptr->angle_delta[PLANE_TYPE_UV] = uv_angle_delta;
-            candidate_buffer->candidate_ptr->tx_depth = 0;
-
-            candidate_buffer->candidate_ptr->transform_type_uv =
-                av1_get_tx_type(
-                    context_ptr->blk_geom->bsize,
-                    0,
-                    (PredictionMode)NULL,
-                    (UvPredictionMode)uv_mode,
-                    PLANE_TYPE_UV,
-                    0,
-                    0,
-                    0,
-                    context_ptr->blk_geom->txsize_uv[0][0],
-                    frm_hdr->reduced_tx_set);
-
-            uint16_t  cb_qp = context_ptr->qp;
-            uint16_t  cr_qp = context_ptr->qp;
-            uint64_t cb_coeff_bits = 0;
-            uint64_t cr_coeff_bits = 0;
-            uint64_t cbFullDistortion[DIST_CALC_TOTAL] = { 0, 0 };
-            uint64_t crFullDistortion[DIST_CALC_TOTAL] = { 0, 0 };
-
-            uint32_t count_non_zero_coeffs[3][MAX_NUM_OF_TU_PER_CU];
-            context_ptr->md_staging_skip_inter_chroma_pred = EB_FALSE;
-            ProductPredictionFunTable[candidate_buffer->candidate_ptr->type](
-                context_ptr->hbd_mode_decision,
-                context_ptr,
-                picture_control_set_ptr,
-                candidate_buffer);
-
-            //Cb Residual
-            residual_kernel(
-                input_picture_ptr->buffer_cb,
-                inputCbOriginIndex,
-                input_picture_ptr->stride_cb,
-                candidate_buffer->prediction_ptr->buffer_cb,
-                cuChromaOriginIndex,
-                candidate_buffer->prediction_ptr->stride_cb,
-                (int16_t*)candidate_buffer->residual_ptr->buffer_cb,
-                cuChromaOriginIndex,
-                candidate_buffer->residual_ptr->stride_cb,
-                context_ptr->hbd_mode_decision,
-                context_ptr->blk_geom->bwidth_uv,
-                context_ptr->blk_geom->bheight_uv);
-
-            //Cr Residual
-            residual_kernel(
-                input_picture_ptr->buffer_cr,
-                inputCbOriginIndex,
-                input_picture_ptr->stride_cr,
-                candidate_buffer->prediction_ptr->buffer_cr,
-                cuChromaOriginIndex,
-                candidate_buffer->prediction_ptr->stride_cr,
-                (int16_t*)candidate_buffer->residual_ptr->buffer_cr,
-                cuChromaOriginIndex,
-                candidate_buffer->residual_ptr->stride_cr,
-                context_ptr->hbd_mode_decision,
-                context_ptr->blk_geom->bwidth_uv,
-                context_ptr->blk_geom->bheight_uv);
-
-            full_loop_r(
-                context_ptr->sb_ptr,
-                candidate_buffer,
-                context_ptr,
-                input_picture_ptr,
-                picture_control_set_ptr,
-                PICTURE_BUFFER_DESC_CHROMA_MASK,
-                cb_qp,
-                cr_qp,
-                &(*count_non_zero_coeffs[1]),
-                &(*count_non_zero_coeffs[2]));
-
-            cu_full_distortion_fast_tu_mode_r(
-                context_ptr->sb_ptr,
-                candidate_buffer,
-                context_ptr,
-                candidate_buffer->candidate_ptr,
-                picture_control_set_ptr,
-                input_picture_ptr,
-                cbFullDistortion,
-                crFullDistortion,
-                count_non_zero_coeffs,
-                COMPONENT_CHROMA,
-                &cb_coeff_bits,
-                &cr_coeff_bits,
-                1);
-
-            coeff_rate[uv_mode][MAX_ANGLE_DELTA + uv_angle_delta] = (int)(cb_coeff_bits + cr_coeff_bits);
-            distortion[uv_mode][MAX_ANGLE_DELTA + uv_angle_delta] = (int)(cbFullDistortion[DIST_CALC_RESIDUAL] + crFullDistortion[DIST_CALC_RESIDUAL]);
-        }
-    }
-
-    uint8_t intra_mode_start = DC_PRED;
-#if PAETH_HBD
-    uint8_t intra_mode_end =  PAETH_PRED;
-#else
-    uint8_t intra_mode_end = is_16_bit ? SMOOTH_H_PRED : PAETH_PRED;
-#endif
-    // Loop over all intra mode, then over all uv move to derive the best uv mode for a given intra mode in term of rate
-    for (uint8_t intra_mode = intra_mode_start; intra_mode <= intra_mode_end; ++intra_mode) {
-        uint8_t angleDeltaCandidateCount = (use_angle_delta && av1_is_directional_mode((PredictionMode)intra_mode)) ? 7 : 1;
-        uint8_t angle_delta_shift = 1;
-
-        for (uint8_t angleDeltaCounter = 0; angleDeltaCounter < angleDeltaCandidateCount; ++angleDeltaCounter) {
-            int32_t angle_delta = CLIP(angle_delta_shift * (angleDeltaCandidateCount == 1 ? 0 : angleDeltaCounter - (angleDeltaCandidateCount >> 1)), -MAX_ANGLE_DELTA, MAX_ANGLE_DELTA);
-
-            candidate_buffer->candidate_ptr->type = INTRA_MODE;
-#if PAL_SUP
-            candidate_buffer->candidate_ptr->palette_info.pmi.palette_size[0] = 0;
-            candidate_buffer->candidate_ptr->palette_info.pmi.palette_size[1] = 0;
-#endif
-            candidate_buffer->candidate_ptr->intra_luma_mode = intra_mode;
-            candidate_buffer->candidate_ptr->distortion_ready = 0;
-            candidate_buffer->candidate_ptr->use_intrabc = 0;
-            candidate_buffer->candidate_ptr->is_directional_mode_flag = (uint8_t)av1_is_directional_mode((PredictionMode)intra_mode);
-            candidate_buffer->candidate_ptr->angle_delta[PLANE_TYPE_Y] = angle_delta;
-            candidate_buffer->candidate_ptr->cfl_alpha_signs = 0;
-            candidate_buffer->candidate_ptr->cfl_alpha_idx = 0;
-            // This kernel assumes no atb
-            candidate_buffer->candidate_ptr->transform_type[0] = DCT_DCT;
-            candidate_buffer->candidate_ptr->ref_frame_type = INTRA_FRAME;
-            candidate_buffer->candidate_ptr->pred_mode = (PredictionMode)intra_mode;
-            candidate_buffer->candidate_ptr->motion_mode = SIMPLE_TRANSLATION;
-
-            //int32_t  p_angle = mode_to_angle_map[(PredictionMode)openLoopIntraCandidate] + angle_delta * ANGLE_STEP;
-            //if (!disable_z2_prediction || (p_angle <= 90 || p_angle >= 180)) {
-            // uv mode loop
-            context_ptr->best_uv_cost[intra_mode][MAX_ANGLE_DELTA + angle_delta] = (uint64_t)~0;
-            for (uv_mode = uv_mode_start; uv_mode <= uv_mode_end; uv_mode++) {
-                uint8_t uv_angleDeltaCandidateCount = (use_angle_delta && av1_is_directional_mode((PredictionMode)uv_mode)) ? 7 : 1;
-                uint8_t uv_angle_delta_shift = 1;
-
-                for (uint8_t uv_angleDeltaCounter = 0; uv_angleDeltaCounter < uv_angleDeltaCandidateCount; ++uv_angleDeltaCounter) {
-                    int32_t uv_angle_delta = CLIP(uv_angle_delta_shift * (uv_angleDeltaCandidateCount == 1 ? 0 : uv_angleDeltaCounter - (uv_angleDeltaCandidateCount >> 1)), -MAX_ANGLE_DELTA, MAX_ANGLE_DELTA);
-
-                    candidate_buffer->candidate_ptr->intra_chroma_mode = uv_mode;
-                    candidate_buffer->candidate_ptr->is_directional_chroma_mode_flag = (uint8_t)av1_is_directional_mode((PredictionMode)uv_mode);
-                    candidate_buffer->candidate_ptr->angle_delta[PLANE_TYPE_UV] = uv_angle_delta;
-
-                    candidate_buffer->candidate_ptr->transform_type_uv =
-                        av1_get_tx_type(
-                            context_ptr->blk_geom->bsize,
-                            0,
-                            (PredictionMode)candidate_buffer->candidate_ptr->intra_luma_mode,
-                            (UvPredictionMode)candidate_buffer->candidate_ptr->intra_chroma_mode,
-                            PLANE_TYPE_UV,
-                            0,
-                            0,
-                            0,
-                            context_ptr->blk_geom->txsize_uv[0][0],
-                            frm_hdr->reduced_tx_set);
-
-                    // Fast Cost
-                    *(candidate_buffer->fast_cost_ptr) = Av1ProductFastCostFuncTable[candidate_buffer->candidate_ptr->type](
-                        context_ptr->cu_ptr,
-                        candidate_buffer->candidate_ptr,
-                        context_ptr->qp,
-                        0,
-                        0,
-                        0,
-                        0,
-                        picture_control_set_ptr,
-                        &(context_ptr->md_local_cu_unit[context_ptr->blk_geom->blkidx_mds].ed_ref_mv_stack[candidate_buffer->candidate_ptr->ref_frame_type][0]),
-                        context_ptr->blk_geom,
-                        context_ptr->cu_origin_y >> MI_SIZE_LOG2,
-                        context_ptr->cu_origin_x >> MI_SIZE_LOG2,
-#if MULTI_PASS_PD
-                        context_ptr->md_enable_inter_intra,
-                        context_ptr->full_cost_shut_fast_rate_flag,
-#endif
-                        1,
-                        context_ptr->intra_luma_left_mode,
-                        context_ptr->intra_luma_top_mode);
-
-                    uint64_t rate = coeff_rate[uv_mode][MAX_ANGLE_DELTA + uv_angle_delta] + candidate_buffer->candidate_ptr->fast_luma_rate + candidate_buffer->candidate_ptr->fast_chroma_rate;
-                    uint64_t uv_cost = RDCOST(context_ptr->full_lambda, rate, distortion[uv_mode][MAX_ANGLE_DELTA + uv_angle_delta]);
-
-                    if (uv_cost < context_ptr->best_uv_cost[intra_mode][MAX_ANGLE_DELTA + angle_delta]) {
-                        context_ptr->best_uv_mode[intra_mode][MAX_ANGLE_DELTA + angle_delta] = uv_mode;
-                        context_ptr->best_uv_angle[intra_mode][MAX_ANGLE_DELTA + angle_delta] = uv_angle_delta;
-
-                        context_ptr->best_uv_cost[intra_mode][MAX_ANGLE_DELTA + angle_delta] = uv_cost;
-                        context_ptr->fast_luma_rate[intra_mode][MAX_ANGLE_DELTA + angle_delta] = candidate_buffer->candidate_ptr->fast_luma_rate;
-                        context_ptr->fast_chroma_rate[intra_mode][MAX_ANGLE_DELTA + angle_delta] = candidate_buffer->candidate_ptr->fast_chroma_rate;
-                    }
-                }
-            }
-        }
-    }
-
-    // End uv search path
-    context_ptr->uv_search_path = EB_FALSE;
-}
-#endif
-#if SPEED_OPT
-#if !REMOVE_MD_STAGE_1
-void inter_class_decision_count_1(
-    struct ModeDecisionContext   *context_ptr
-)
-{
-    ModeDecisionCandidateBuffer **buffer_ptr_array = context_ptr->candidate_buffer_ptr_array;
-    // Distortion-based NIC pruning not applied to INTRA clases: CLASS_0 and CLASS
-    for (CAND_CLASS cand_class_it = CAND_CLASS_1; cand_class_it <= CAND_CLASS_3; cand_class_it++) {
-        if (context_ptr->md_stage_0_count[cand_class_it] > 0 && context_ptr->md_stage_1_count[cand_class_it] > 0) {
-            uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
-            if (*(buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr) < *(buffer_ptr_array[context_ptr->cand_buff_indices[CAND_CLASS_0][0]]->fast_cost_ptr)) {
-                uint32_t fast1_cand_count = 1;
-                while (fast1_cand_count < context_ptr->md_stage_1_count[cand_class_it] && ((((*(buffer_ptr_array[cand_buff_indices[fast1_cand_count]]->fast_cost_ptr) - *(buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr)) * 100) / (*(buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr))) < context_ptr->dist_base_md_stage_0_count_th)) {
-                    fast1_cand_count++;
-                }
-                context_ptr->md_stage_1_count[cand_class_it] = fast1_cand_count;
-            }
-        }
-    }
-}
-#endif
 extern aom_variance_fn_ptr_t mefn_ptr[BlockSizeS_ALL];
 unsigned int eb_av1_get_sby_perpixel_variance(const aom_variance_fn_ptr_t *fn_ptr, const uint8_t *src, int stride, BlockSize bs);
-#endif
-
-#if INTER_INTRA_CLASS_PRUNING
 
 void interintra_class_pruning_1(ModeDecisionContext *context_ptr, uint64_t best_md_stage_cost) {
 
     for (CAND_CLASS cand_class_it = CAND_CLASS_0; cand_class_it < CAND_CLASS_TOTAL; cand_class_it++) {
-#if MULTI_PASS_PD
         if (context_ptr->md_stage_1_cand_prune_th != (uint64_t)~0 || context_ptr->md_stage_1_class_prune_th != (uint64_t)~0)
-#endif
         if (context_ptr->md_stage_0_count[cand_class_it] > 0 && context_ptr->md_stage_1_count[cand_class_it] > 0) {
             uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
             uint64_t class_best_cost = *(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr);
 
             // inter class pruning
-#if ENHANCED_M0_SETTINGS
             if (best_md_stage_cost && class_best_cost && ((((class_best_cost - best_md_stage_cost) * 100) / best_md_stage_cost) > context_ptr->md_stage_1_class_prune_th)) {
-#else
-            if ((((class_best_cost - best_md_stage_cost) * 100) / best_md_stage_cost) > context_ptr->md_stage_1_class_prune_th){
-#endif
                 context_ptr->md_stage_1_count[cand_class_it] = 0;
                 continue;
             }
             // intra class pruning
             uint32_t cand_count = 1;
-#if ENHANCED_M0_SETTINGS
             if (class_best_cost)
-#endif
             while (cand_count < context_ptr->md_stage_1_count[cand_class_it] && ((((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[cand_count]]->fast_cost_ptr) - class_best_cost) * 100) / class_best_cost) < context_ptr->md_stage_1_cand_prune_th)) {
                 cand_count++;
             }
@@ -8267,7 +6684,7 @@ void interintra_class_pruning_2(ModeDecisionContext *context_ptr, uint64_t best_
     }
 }
 
-#endif
+
 
 void md_encode_block(
     SequenceControlSet             *sequence_control_set_ptr,
@@ -8377,12 +6794,8 @@ void md_encode_block(
 #endif
         is_nsq_table_used, picture_control_set_ptr->parent_pcs_ptr->nsq_max_shapes_md, context_ptr, is_complete_sb))
     {
-
-#if SPEED_OPT
         const aom_variance_fn_ptr_t *fn_ptr = &mefn_ptr[context_ptr->blk_geom->bsize];
         context_ptr->source_variance = eb_av1_get_sby_perpixel_variance(fn_ptr, (input_picture_ptr->buffer_y + inputOriginIndex), input_picture_ptr->stride_y, context_ptr->blk_geom->bsize);
-#endif
-
         cu_ptr->av1xd->tile.mi_col_start = context_ptr->sb_ptr->tile_info.mi_col_start;
         cu_ptr->av1xd->tile.mi_col_end = context_ptr->sb_ptr->tile_info.mi_col_end;
         cu_ptr->av1xd->tile.mi_row_start = context_ptr->sb_ptr->tile_info.mi_row_start;
@@ -8529,18 +6942,9 @@ void md_encode_block(
         uint32_t buffer_start_idx = 0;
         uint32_t buffer_count_for_curr_class;
         uint32_t buffer_total_count = 0;
-#if REMOVE_MD_STAGE_1
         context_ptr->md_stage_1_total_count = 0;
         context_ptr->md_stage_2_total_count = 0;
-#else
-        context_ptr->md_stage_2_total_count = 0;
-        context_ptr->md_stage_3_total_count = 0;
-
-        context_ptr->md_stage = MD_STAGE_0;
-#endif
-#if INTER_INTRA_CLASS_PRUNING
         uint64_t best_md_stage_cost = (uint64_t)~0;
-#endif
         for (cand_class_it = CAND_CLASS_0; cand_class_it < CAND_CLASS_TOTAL; cand_class_it++) {
 
             //number of next level candidates could not exceed number of curr level candidates
@@ -8586,90 +6990,21 @@ void md_encode_block(
                     buffer_start_idx,
                     buffer_count_for_curr_class, //how many cand buffers to sort. one of the buffers can have max cost.
                     context_ptr->cand_buff_indices[cand_class_it]);
-
-#if INTER_INTRA_CLASS_PRUNING
                 uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
                 best_md_stage_cost = MIN((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr)), best_md_stage_cost);
-#else
-#if REMOVE_MD_STAGE_1
-                // Distortion-based NIC pruning to CLASS_1, CLASS_2, CLASS_3
-                if (cand_class_it == CAND_CLASS_1 || cand_class_it == CAND_CLASS_2 || cand_class_it == CAND_CLASS_3) {
-                    uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
-                    assert(context_ptr->md_stage_0_count[CAND_CLASS_0] > 0);
-                    if (context_ptr->md_stage_0_count[CAND_CLASS_0] > 0 && *(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr) <
-                        *(context_ptr->candidate_buffer_ptr_array[context_ptr->cand_buff_indices[CAND_CLASS_0][0]]->fast_cost_ptr)) {
-                        uint32_t fast1_cand_count = 1;
-                        while (fast1_cand_count < context_ptr->md_stage_1_count[cand_class_it] && ((((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[fast1_cand_count]]->fast_cost_ptr) - *(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr)) * 100) / (*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->fast_cost_ptr))) < context_ptr->dist_base_md_stage_0_count_th)) {
-                            fast1_cand_count++;
-                        }
-                        context_ptr->md_stage_1_count[cand_class_it] = fast1_cand_count;
-                    }
-                }
-#endif
-#endif
 
                 buffer_start_idx += buffer_count_for_curr_class;//for next iteration.
 
             }
 
-#if !INTER_INTRA_CLASS_PRUNING
-#if REMOVE_MD_STAGE_1
-            context_ptr->md_stage_1_total_count += context_ptr->md_stage_1_count[cand_class_it];
-#endif
-#endif
-        }
 
-#if INTER_INTRA_CLASS_PRUNING
+        }
         interintra_class_pruning_1(context_ptr,best_md_stage_cost);
-#endif
-
-#if !REMOVE_MD_STAGE_1
-#if SPEED_OPT
-        //after completing stage0, we might shorten cand count for some classes.
-        inter_class_decision_count_1(context_ptr);
-#endif
-
-        context_ptr->md_stage = MD_STAGE_1;
-        for (cand_class_it = CAND_CLASS_0; cand_class_it < CAND_CLASS_TOTAL; cand_class_it++) {
-
-            //number of next level candidates could not exceed number of curr level candidates
-            context_ptr->md_stage_2_count[cand_class_it] = MIN(context_ptr->md_stage_1_count[cand_class_it], context_ptr->md_stage_2_count[cand_class_it]);
-            context_ptr->md_stage_2_total_count += context_ptr->md_stage_2_count[cand_class_it];
-
-            if (context_ptr->bypass_stage1[cand_class_it] == 0 && context_ptr->md_stage_1_count[cand_class_it] > 0 && context_ptr->md_stage_2_count[cand_class_it] > 0) {
-                //Input: md_stage_1_count[cand_class_it]  Output:  full_cand_count[cand_class_it]
-                context_ptr->target_class = cand_class_it;
-                md_stage_1(
-                    picture_control_set_ptr,
-                    context_ptr,
-                    candidate_buffer_ptr_array_base,
-                    context_ptr->md_stage_1_count[cand_class_it],
-                    input_picture_ptr,
-                    inputOriginIndex,
-                    inputCbOriginIndex,
-                    inputCbOriginIndex,
-                    cu_ptr,
-                    cuOriginIndex,
-                    cuChromaOriginIndex,
-                    0);
-
-                //sort the new set of candidates
-                sort_stage1_fast_candidates(
-                    context_ptr,
-                    context_ptr->md_stage_1_count[cand_class_it],
-                    context_ptr->cand_buff_indices[cand_class_it]);
-            }
-        }
-#endif
         memset(context_ptr->best_candidate_index_array, 0xFFFFFFFF, MAX_NFL_BUFF * sizeof(uint32_t));
         memset(context_ptr->sorted_candidate_index_array, 0xFFFFFFFF, MAX_NFL * sizeof(uint32_t));
 
         uint64_t ref_fast_cost = MAX_MODE_COST;
-#if REMOVE_MD_STAGE_1
         construct_best_sorted_arrays_md_stage_1(
-#else
-        construct_best_sorted_arrays_md_stage_2(
-#endif
             context_ptr,
             candidate_buffer_ptr_array,
             context_ptr->best_candidate_index_array,
@@ -8678,32 +7013,13 @@ void md_encode_block(
 
 
         // 1st Full-Loop
-#if INTER_INTRA_CLASS_PRUNING
         best_md_stage_cost = (uint64_t)~0;
-#endif
-#if REMOVE_MD_STAGE_1
         for (cand_class_it = CAND_CLASS_0; cand_class_it < CAND_CLASS_TOTAL; cand_class_it++) {
             //number of next level candidates could not exceed number of curr level candidates
             context_ptr->md_stage_2_count[cand_class_it] = MIN(context_ptr->md_stage_1_count[cand_class_it], context_ptr->md_stage_2_count[cand_class_it]);
-#if !INTER_INTRA_CLASS_PRUNING
-            context_ptr->md_stage_2_total_count += context_ptr->md_stage_2_count[cand_class_it];
-#endif
             if (context_ptr->bypass_md_stage_1[cand_class_it] == EB_FALSE && context_ptr->md_stage_1_count[cand_class_it] > 0 && context_ptr->md_stage_2_count[cand_class_it] > 0) {
-#else
-        context_ptr->md_stage = MD_STAGE_2;
-        for (cand_class_it = CAND_CLASS_0; cand_class_it < CAND_CLASS_TOTAL; cand_class_it++) {
-            //number of next level candidates could not exceed number of curr level candidates
-            context_ptr->md_stage_3_count[cand_class_it] = MIN(context_ptr->md_stage_2_count[cand_class_it], context_ptr->md_stage_3_count[cand_class_it]);
-            context_ptr->md_stage_3_total_count += context_ptr->md_stage_3_count[cand_class_it];
-
-            if (context_ptr->bypass_stage2[cand_class_it] == EB_FALSE && context_ptr->md_stage_2_count[cand_class_it] > 0 && context_ptr->md_stage_3_count[cand_class_it] > 0) {
-#endif
                 context_ptr->target_class = cand_class_it;
-#if REMOVE_MD_STAGE_1
                 md_stage_1(
-#else
-                md_stage_2(
-#endif
                     picture_control_set_ptr,
                     context_ptr->sb_ptr,
                     cu_ptr,
@@ -8718,51 +7034,26 @@ void md_encode_block(
                 // Sort the candidates of the target class based on the 1st full loop cost
 
                 //sort the new set of candidates
-#if REMOVE_MD_STAGE_1
                 if (context_ptr->md_stage_1_count[cand_class_it])
                     sort_stage1_candidates(
                         context_ptr,
                         context_ptr->md_stage_1_count[cand_class_it],
                         context_ptr->cand_buff_indices[cand_class_it]);
-#else
-                if (context_ptr->md_stage_2_count[cand_class_it])
-                    sort_stage2_candidates(
-                        context_ptr,
-                        context_ptr->md_stage_2_count[cand_class_it],
-                        context_ptr->cand_buff_indices[cand_class_it]);
-#endif
-
-#if INTER_INTRA_CLASS_PRUNING
                 uint32_t *cand_buff_indices = context_ptr->cand_buff_indices[cand_class_it];
                 best_md_stage_cost = MIN((*(context_ptr->candidate_buffer_ptr_array[cand_buff_indices[0]]->full_cost_ptr)), best_md_stage_cost);
-#endif
             }
         }
-#if INTER_INTRA_CLASS_PRUNING
         interintra_class_pruning_2(context_ptr, best_md_stage_cost);
-#endif
-
-#if REMOVE_MD_STAGE_1
         assert(context_ptr->md_stage_2_total_count <= MAX_NFL);
         assert(context_ptr->md_stage_2_total_count > 0);
         construct_best_sorted_arrays_md_stage_2(
-#else
-        assert(context_ptr->md_stage_3_total_count <= MAX_NFL);
-        assert(context_ptr->md_stage_3_total_count > 0);
-        construct_best_sorted_arrays_md_stage_3(
-#endif
             context_ptr,
             candidate_buffer_ptr_array,
             context_ptr->best_candidate_index_array,
             context_ptr->sorted_candidate_index_array);
 
         // 2nd Full-Loop
-#if REMOVE_MD_STAGE_1
         md_stage_2(
-#else
-        context_ptr->md_stage = MD_STAGE_3;
-        md_stage_3(
-#endif
             picture_control_set_ptr,
             context_ptr->sb_ptr,
             cu_ptr,
@@ -8772,11 +7063,7 @@ void md_encode_block(
             inputCbOriginIndex,
             cuOriginIndex,
             cuChromaOriginIndex,
-#if REMOVE_MD_STAGE_1
             context_ptr->md_stage_2_total_count,
-#else
-            context_ptr->md_stage_3_total_count,
-#endif
             ref_fast_cost); // fullCandidateTotalCount to number of buffers to process
 
         // Full Mode Decision (choose the best mode)
@@ -8784,11 +7071,7 @@ void md_encode_block(
             context_ptr,
             cu_ptr,
             candidate_buffer_ptr_array,
-#if REMOVE_MD_STAGE_1
             context_ptr->md_stage_2_total_count,
-#else
-            context_ptr->md_stage_3_total_count,
-#endif
             (context_ptr->full_loop_escape == 2) ? context_ptr->sorted_candidate_index_array : context_ptr->best_candidate_index_array,
             context_ptr->prune_ref_frame_for_rec_partitions,
             &best_intra_mode);
@@ -8963,7 +7246,6 @@ void md_encode_block(
     }
 }
 
-#if LESS_RECTANGULAR_CHECK_LEVEL
 void update_skip_next_nsq_for_a_b_shapes(
     ModeDecisionContext *context_ptr,
     uint64_t *sq_cost, uint64_t *h_cost,
@@ -9020,9 +7302,8 @@ void update_skip_next_nsq_for_a_b_shapes(
         break;
     }
 }
-#endif
 
-#if AUTO_MAX_PARTITION
+
 #define FLT_MAX          3.402823466e+38F        // max value
 #define FEATURE_SIZE_MAX_MIN_PART_PRED 13
 
@@ -9298,7 +7579,7 @@ BlockSize av1_predict_max_partition(
 
     return (BlockSize)((result + 2) * 3);
 }
-#endif
+
 
 EB_EXTERN EbErrorType mode_decision_sb(
     SequenceControlSet                *sequence_control_set_ptr,
@@ -9318,9 +7599,7 @@ EB_EXTERN EbErrorType mode_decision_sb(
     uint32_t                               leaf_count = mdcResultTbPtr->leaf_count;
     const EbMdcLeafData *const           leaf_data_array = mdcResultTbPtr->leaf_data_array;
     context_ptr->sb_ptr = sb_ptr;
-#if FIX_COEF_BASED_ATB_SKIP
     context_ptr->coeff_based_skip_atb = 0;
-#endif
     EbBool all_cu_init = (picture_control_set_ptr->parent_pcs_ptr->pic_depth_mode <= PIC_SQ_DEPTH_MODE);
     if (all_cu_init) {
         init_sq_nsq_block(
@@ -9409,8 +7688,6 @@ EB_EXTERN EbErrorType mode_decision_sb(
         //input_picture_ptr = context_ptr->input_sample16bit_buffer;
         input_picture_ptr = picture_control_set_ptr->input_frame16bit;
     }
-
-#if AUTO_MAX_PARTITION
     picture_control_set_ptr->sf.auto_max_partition_based_on_simple_motion = ADAPT_PRED; //DIRECT_PRED; //RELAXED_PRED;
     BlockSize max_bsize = BLOCK_128X128;
     if (context_ptr->enable_auto_max_partition == 1)
@@ -9424,16 +7701,13 @@ EB_EXTERN EbErrorType mode_decision_sb(
                 max_bsize = MIN(av1_predict_max_partition(picture_control_set_ptr, features, input_picture_ptr, sb_origin_x, sb_origin_y), max_bsize);
             }
         }
-#endif
+
 
     //CU Loop
     cuIdx = 0;  //index over mdc array
-
-#if LESS_RECTANGULAR_CHECK_LEVEL
     uint64_t sq_cost = 0;
     uint64_t h_cost;
     uint64_t v_cost;
-#endif
 
     uint32_t blk_idx_mds = 0;
     uint32_t  d1_blocks_accumlated = 0;
@@ -9576,9 +7850,7 @@ EB_EXTERN EbErrorType mode_decision_sb(
             }
         }
         else
-#if FIX_SKIP_REDUNDANT_BLOCK
         {
-#endif
             // Initialize tx_depth
             cu_ptr->tx_depth = 0;
 #if ADD_SUPPORT_TO_SKIP_PART_N
@@ -9612,11 +7884,7 @@ EB_EXTERN EbErrorType mode_decision_sb(
                 // if the total child cost is higher than the parent cost then skip the remaining  child @ the current depth
                 // when md_exit_th=0 the estimated cost for the remaining child is not taken into account and the action will be lossless compared to no exit
                 // MD_EXIT_THSL could be tuned toward a faster encoder but lossy
-#if SPEED_OPT
                 if (parent_depth_cost <= current_depth_cost + (current_depth_cost* (4 - context_ptr->blk_geom->quadi)* context_ptr->md_exit_th / context_ptr->blk_geom->quadi / 100)) {
-#else
-                if (parent_depth_cost <= current_depth_cost + (current_depth_cost* (4 - context_ptr->blk_geom->quadi)* MD_EXIT_THSL / context_ptr->blk_geom->quadi / 100)) {
-#endif
                     skip_next_sq = 1;
                     next_non_skip_blk_idx_mds = parent_depth_idx_mds + ns_depth_offset[sequence_control_set_ptr->seq_header.sb_size == BLOCK_128X128][context_ptr->blk_geom->depth - 1];
                 }
@@ -9626,14 +7894,9 @@ EB_EXTERN EbErrorType mode_decision_sb(
             // skip until we reach the next block @ the parent block depth
             if (cu_ptr->mds_idx >= next_non_skip_blk_idx_mds && skip_next_sq == 1)
                 skip_next_sq = 0;
-
-#if AUTO_MAX_PARTITION
             EbBool auto_max_partition_block_skip = (context_ptr->blk_geom->bwidth > block_size_wide[max_bsize] || context_ptr->blk_geom->bheight > block_size_high[max_bsize]) && (mdcResultTbPtr->leaf_data_array[cuIdx].split_flag == EB_TRUE);
 
             if (picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->sb_geom[lcuAddr].block_is_allowed[cu_ptr->mds_idx] && !skip_next_nsq && !skip_next_sq && !auto_max_partition_block_skip) {
-#else
-            if (picture_control_set_ptr->parent_pcs_ptr->sequence_control_set_ptr->sb_geom[lcuAddr].block_is_allowed[cu_ptr->mds_idx] && !skip_next_nsq && !skip_next_sq) {
-#endif
                 md_encode_block(
                     sequence_control_set_ptr,
                     picture_control_set_ptr,
@@ -9644,14 +7907,12 @@ EB_EXTERN EbErrorType mode_decision_sb(
                     bestcandidate_buffers);
 
             }
-#if AUTO_MAX_PARTITION
             else if (auto_max_partition_block_skip) {
                 if (context_ptr->blk_geom->shape != PART_N)
                     context_ptr->md_local_cu_unit[context_ptr->cu_ptr->mds_idx].cost = (MAX_MODE_COST >> 4);
                 else
                     context_ptr->md_local_cu_unit[context_ptr->cu_ptr->mds_idx].cost = (MAX_MODE_COST >> 10);
             }
-#endif
             else if (skip_next_sq) {
                 context_ptr->md_local_cu_unit[context_ptr->cu_ptr->mds_idx].cost = (MAX_MODE_COST >> 10);
             }
@@ -9665,9 +7926,7 @@ EB_EXTERN EbErrorType mode_decision_sb(
                 else
                     context_ptr->md_local_cu_unit[context_ptr->cu_ptr->mds_idx].cost = 0;
             }
-#if FIX_SKIP_REDUNDANT_BLOCK
         }
-#endif
         skip_next_nsq = 0;
 #if ADD_SUPPORT_TO_SKIP_PART_N
         if (blk_geom->nsi + 1 == blk_geom->totns) {
@@ -9680,11 +7939,8 @@ EB_EXTERN EbErrorType mode_decision_sb(
         }
 #elif MULTI_PASS_PD
         if (blk_geom->nsi + 1 == blk_geom->totns)
-#if MULTI_PASS_PD
             nsq_cost[context_ptr->blk_geom->shape] = d1_non_square_block_decision(context_ptr);
-#else
-            d1_non_square_block_decision(context_ptr);
-#endif
+
 #else
         if (blk_geom->nsi + 1 == blk_geom->totns)
             d1_non_square_block_decision(context_ptr);
@@ -9698,21 +7954,13 @@ EB_EXTERN EbErrorType mode_decision_sb(
             uint32_t first_blk_idx = context_ptr->cu_ptr->mds_idx - (blk_geom->nsi);//index of first block in this partition
             for (int blk_it = 0; blk_it < blk_geom->nsi + 1; blk_it++)
                 tot_cost += context_ptr->md_local_cu_unit[first_blk_idx + blk_it].cost;
-#if MULTI_PASS_PD
             nsq_cost[context_ptr->blk_geom->shape] = tot_cost;
-#endif
-#if SPEED_OPT
             if ((tot_cost + tot_cost * (blk_geom->totns - (blk_geom->nsi + 1))* context_ptr->md_exit_th / (blk_geom->nsi + 1) / 100) > context_ptr->md_local_cu_unit[context_ptr->blk_geom->sqi_mds].cost)
-#else
-            if ((tot_cost + tot_cost * (blk_geom->totns - (blk_geom->nsi + 1))* MD_EXIT_THSL / (blk_geom->nsi + 1) / 100) > context_ptr->md_local_cu_unit[context_ptr->blk_geom->sqi_mds].cost)
-#endif
                 skip_next_nsq = 1;
         }
-
-#if LESS_RECTANGULAR_CHECK_LEVEL
         if (context_ptr->sq_weight != (uint32_t)~0 && blk_geom->bsize > BLOCK_8X8)
             update_skip_next_nsq_for_a_b_shapes(context_ptr, &sq_cost, &h_cost, &v_cost, &skip_next_nsq);
-#endif
+
 
         if (blk_geom->shape != PART_N) {
             if (blk_geom->nsi + 1 < blk_geom->totns)

--- a/Source/Lib/Common/Codec/EbRateDistortionCost.h
+++ b/Source/Lib/Common/Codec/EbRateDistortionCost.h
@@ -250,14 +250,12 @@ extern "C" {
         int16_t                                   txb_skip_ctx);
 #endif
 
-#if ENHANCE_ATB
     extern uint64_t get_tx_size_bits(
         ModeDecisionCandidateBuffer          *candidateBuffer,
         ModeDecisionContext                  *context_ptr,
         PictureControlSet                    *picture_control_set_ptr,
         uint8_t                               tx_depth,
         EbBool                                block_has_coeff);
-#endif
 #ifdef __cplusplus
 }
 #endif

--- a/Source/Lib/Common/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Common/Codec/EbSequenceControlSet.c
@@ -298,10 +298,7 @@ EbErrorType copy_sequence_control_set(
     dst->use_input_stat_file = src->use_input_stat_file;
     dst->use_output_stat_file = src->use_output_stat_file;
 #endif
-
-#if SERIAL_MODE
     dst->scd_delay = src->scd_delay;
-#endif
     return EB_ErrorNone;
 }
 

--- a/Source/Lib/Common/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Common/Codec/EbSequenceControlSet.h
@@ -117,10 +117,7 @@ extern "C" {
         uint32_t                                tf_segment_column_count;
         uint32_t                                tf_segment_row_count;
         EbBool                                  enable_altrefs;
-
-#if SERIAL_MODE
         uint32_t                                scd_delay; //Number of delay frames needed to implement future window for algorithms such as SceneChange or TemporalFiltering
-#endif
         // Buffers
         uint32_t                                picture_control_set_pool_init_count;
         uint32_t                                picture_control_set_pool_init_count_child;

--- a/Source/Lib/Common/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Common/Codec/EbTemporalFiltering.c
@@ -1979,8 +1979,6 @@ static void pad_and_decimate_filtered_pic(PictureParentControlSet *picture_contr
     // reference structures (padded pictures + downsampled versions)
     EbPaReferenceObject *src_object = (EbPaReferenceObject*)picture_control_set_ptr_central->pa_reference_picture_wrapper_ptr->object_ptr;
     EbPictureBufferDesc *padded_pic_ptr = src_object->input_padded_picture_ptr;
-
-#if PAREF_OUT
     {
         EbPictureBufferDesc *input_picture_ptr =picture_control_set_ptr_central->enhanced_picture_ptr;
         uint8_t* pa = padded_pic_ptr->buffer_y + padded_pic_ptr->origin_x + padded_pic_ptr->origin_y * padded_pic_ptr->stride_y;
@@ -1998,7 +1996,6 @@ static void pad_and_decimate_filtered_pic(PictureParentControlSet *picture_contr
             input_picture_ptr->origin_x,
             input_picture_ptr->origin_y);
     }
-#endif
     generate_padding(
         &(padded_pic_ptr->buffer_y[C_Y]),
         padded_pic_ptr->stride_y,
@@ -2180,9 +2177,6 @@ EbErrorType svt_av1_init_temporal_filtering(PictureParentControlSet **list_pictu
         // Pad chroma reference samples - once only per picture
         for (int i = 0; i < (picture_control_set_ptr_central->past_altref_nframes + picture_control_set_ptr_central->future_altref_nframes + 1); i++) {
             EbPictureBufferDesc *pic_ptr_ref = list_picture_control_set_ptr[i]->enhanced_picture_ptr;
-#if FIX_ALTREF && !REVERT_ALTREF_FIX
-            if (i != picture_control_set_ptr_central->past_altref_nframes)
-#endif
                 generate_padding_pic(pic_ptr_ref,
                     ss_x,
                     ss_y,

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.c
@@ -252,25 +252,19 @@ void setup_rtcd_internal(CPU_FLAGS flags)
     if (flags & HAS_AVX2) eb_av1_selfguided_restoration = eb_av1_selfguided_restoration_avx2;
     av1_build_compound_diffwtd_mask = av1_build_compound_diffwtd_mask_c;
     if (flags & HAS_AVX2) av1_build_compound_diffwtd_mask = av1_build_compound_diffwtd_mask_avx2;
-#if COMP_HBD
      av1_build_compound_diffwtd_mask_highbd = av1_build_compound_diffwtd_mask_highbd_c;
      if (flags & HAS_AVX2) av1_build_compound_diffwtd_mask_highbd = av1_build_compound_diffwtd_mask_highbd_avx2;
-#endif
     av1_wedge_sse_from_residuals = av1_wedge_sse_from_residuals_c;
     if (flags & HAS_AVX2) av1_wedge_sse_from_residuals = av1_wedge_sse_from_residuals_avx2;
     aom_subtract_block = aom_subtract_block_c;
     if (flags & HAS_AVX2) aom_subtract_block = aom_subtract_block_avx2;
     aom_sse = aom_sse_c;
-#if COMP_HBD
     aom_highbd_subtract_block = aom_highbd_subtract_block_c;
     if (flags & HAS_AVX2) aom_highbd_subtract_block = aom_highbd_subtract_block_sse2;
-#endif
     if (flags & HAS_AVX2) aom_sse = aom_sse_avx2;
     av1_build_compound_diffwtd_mask_d16 = av1_build_compound_diffwtd_mask_d16_c;
-#if COMP_HBD
      aom_highbd_sse = aom_highbd_sse_c;
      if (flags & HAS_AVX2) aom_highbd_sse = aom_highbd_sse_avx2;
-#endif
     if (flags & HAS_AVX2) av1_build_compound_diffwtd_mask_d16 = av1_build_compound_diffwtd_mask_d16_avx2;
     aom_lowbd_blend_a64_d16_mask = aom_lowbd_blend_a64_d16_mask_c;
     if (flags & HAS_AVX2) aom_lowbd_blend_a64_d16_mask = aom_lowbd_blend_a64_d16_mask_avx2;
@@ -464,10 +458,7 @@ void setup_rtcd_internal(CPU_FLAGS flags)
     if (flags & HAS_AVX2) eb_av1_warp_affine = eb_av1_warp_affine_avx2;
 
     eb_av1_filter_intra_predictor = eb_av1_filter_intra_predictor_c;
-#if FILTER_INTRA_FLAG
     if (flags & HAS_SSE4_1) eb_av1_filter_intra_predictor = eb_av1_filter_intra_predictor_sse4_1;
-#endif
-
     eb_aom_highbd_smooth_v_predictor_16x16 = eb_aom_highbd_smooth_v_predictor_16x16_c;
     if (flags & HAS_AVX2) eb_aom_highbd_smooth_v_predictor_16x16 = eb_aom_highbd_smooth_v_predictor_16x16_avx2;
     eb_aom_highbd_smooth_v_predictor_16x32 = eb_aom_highbd_smooth_v_predictor_16x32_c;
@@ -2014,10 +2005,8 @@ void setup_rtcd_internal(CPU_FLAGS flags)
              av1_calc_indices_dim2_c,
              av1_calc_indices_dim2_avx2);
 
-#if AUTO_MAX_PARTITION
     av1_nn_predict = av1_nn_predict_c;
     if (flags & HAS_SSE3) av1_nn_predict = av1_nn_predict_sse3;
-#endif
 
 }
 

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -22,9 +22,7 @@
 #if OBMC_FLAG
 #include "EbCodingUnit.h"
 #endif
-#if AUTO_MAX_PARTITION
 # include "ml.h"
-#endif
 #ifdef RTCD_C
 #define RTCD_EXTERN                //CHKN RTCD call in effect. declare the function pointers in  encHandle.
 #else
@@ -90,12 +88,10 @@ extern "C" {
     void av1_build_compound_diffwtd_mask_c(uint8_t *mask, DIFFWTD_MASK_TYPE mask_type, const uint8_t *src0, int src0_stride, const uint8_t *src1, int src1_stride, int h, int w);
     void av1_build_compound_diffwtd_mask_avx2(uint8_t *mask, DIFFWTD_MASK_TYPE mask_type, const uint8_t *src0, int src0_stride, const uint8_t *src1, int src1_stride, int h, int w);
     RTCD_EXTERN void (*av1_build_compound_diffwtd_mask)(uint8_t *mask, DIFFWTD_MASK_TYPE mask_type, const uint8_t *src0, int src0_stride, const uint8_t *src1, int src1_stride, int h, int w);
-#if COMP_HBD
     void av1_build_compound_diffwtd_mask_highbd_c(uint8_t *mask, DIFFWTD_MASK_TYPE mask_type, const uint8_t *src0, int src0_stride, const uint8_t *src1, int src1_stride, int h, int w, int bd);
     void av1_build_compound_diffwtd_mask_highbd_ssse3(uint8_t *mask, DIFFWTD_MASK_TYPE mask_type, const uint8_t *src0, int src0_stride, const uint8_t *src1, int src1_stride, int h, int w, int bd);
     void av1_build_compound_diffwtd_mask_highbd_avx2(uint8_t *mask, DIFFWTD_MASK_TYPE mask_type, const uint8_t *src0, int src0_stride, const uint8_t *src1, int src1_stride, int h, int w, int bd);
     RTCD_EXTERN void (*av1_build_compound_diffwtd_mask_highbd)(uint8_t *mask, DIFFWTD_MASK_TYPE mask_type, const uint8_t *src0, int src0_stride, const uint8_t *src1, int src1_stride, int h, int w, int bd);
-#endif
     uint64_t av1_wedge_sse_from_residuals_c(const int16_t *r1, const int16_t *d, const uint8_t *m, int N);
     uint64_t av1_wedge_sse_from_residuals_avx2(const int16_t *r1, const int16_t *d, const uint8_t *m, int N);
     RTCD_EXTERN uint64_t (*av1_wedge_sse_from_residuals)(const int16_t *r1, const int16_t *d, const uint8_t *m, int N);
@@ -105,20 +101,16 @@ extern "C" {
     void eb_aom_subtract_block_sse2(int rows, int cols, int16_t *diff_ptr, ptrdiff_t diff_stride, const uint8_t *src_ptr, ptrdiff_t src_stride, const uint8_t *pred_ptr, ptrdiff_t pred_stride);
     void aom_subtract_block_avx2(int rows, int cols, int16_t *diff_ptr, ptrdiff_t diff_stride, const uint8_t *src_ptr, ptrdiff_t src_stride, const uint8_t *pred_ptr, ptrdiff_t pred_stride);
     RTCD_EXTERN void (*aom_subtract_block)(int rows, int cols, int16_t *diff_ptr, ptrdiff_t diff_stride, const uint8_t *src_ptr, ptrdiff_t src_stride, const uint8_t *pred_ptr, ptrdiff_t pred_stride);
-#if COMP_HBD
     void aom_highbd_subtract_block_c(int rows, int cols, int16_t *diff_ptr, ptrdiff_t diff_stride, const uint8_t *src_ptr, ptrdiff_t src_stride, const uint8_t *pred_ptr, ptrdiff_t pred_stride, int bd);
     void aom_highbd_subtract_block_sse2(int rows, int cols, int16_t *diff_ptr, ptrdiff_t diff_stride, const uint8_t *src_ptr, ptrdiff_t src_stride, const uint8_t *pred_ptr, ptrdiff_t pred_stride, int bd);
     RTCD_EXTERN void (*aom_highbd_subtract_block) (int rows, int cols, int16_t *diff_ptr, ptrdiff_t diff_stride, const uint8_t *src_ptr, ptrdiff_t src_stride, const uint8_t *pred_ptr, ptrdiff_t pred_stride, int bd);
-#endif
 
     int64_t aom_sse_c(const uint8_t *a, int a_stride, const uint8_t *b,int b_stride, int width, int height);
     int64_t aom_sse_avx2(const uint8_t *a, int a_stride, const uint8_t *b,int b_stride, int width, int height);
     RTCD_EXTERN int64_t (*aom_sse)(const uint8_t *a, int a_stride, const uint8_t *b,int b_stride, int width, int height);
-#if COMP_HBD
     int64_t aom_highbd_sse_c(const uint8_t *a8, int a_stride, const uint8_t *b8,int b_stride, int width, int height);
     int64_t aom_highbd_sse_avx2(const uint8_t *a8, int a_stride, const uint8_t *b8,int b_stride, int width, int height);
     RTCD_EXTERN int64_t (*aom_highbd_sse)(const uint8_t *a8, int a_stride, const uint8_t *b8,int b_stride, int width, int height);
-#endif
     void av1_build_compound_diffwtd_mask_d16_c(uint8_t *mask, DIFFWTD_MASK_TYPE mask_type, const CONV_BUF_TYPE *src0, int src0_stride, const CONV_BUF_TYPE *src1, int src1_stride, int h, int w, ConvolveParams *conv_params, int bd);
     void av1_build_compound_diffwtd_mask_d16_avx2(uint8_t *mask, DIFFWTD_MASK_TYPE mask_type, const CONV_BUF_TYPE *src0, int src0_stride, const CONV_BUF_TYPE *src1, int src1_stride, int h, int w, ConvolveParams *conv_params, int bd);
     RTCD_EXTERN void (*av1_build_compound_diffwtd_mask_d16)(uint8_t *mask, DIFFWTD_MASK_TYPE mask_type, const CONV_BUF_TYPE *src0, int src0_stride, const CONV_BUF_TYPE *src1, int src1_stride, int h, int w, ConvolveParams *conv_params, int bd);
@@ -2848,11 +2840,8 @@ extern "C" {
     void eb_av1_highbd_dr_prediction_z3_c(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
     void eb_av1_highbd_dr_prediction_z3_avx2(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
     RTCD_EXTERN void(*eb_av1_highbd_dr_prediction_z3)(uint16_t *dst, ptrdiff_t stride, int32_t bw, int32_t bh, const uint16_t *above, const uint16_t *left, int32_t upsample_left, int32_t dx, int32_t dy, int32_t bd);
-
     void eb_av1_filter_intra_predictor_c(uint8_t *dst, ptrdiff_t stride, TxSize tx_size, const uint8_t *above, const uint8_t *left, int32_t mode);
-#if FILTER_INTRA_FLAG
     void eb_av1_filter_intra_predictor_sse4_1(uint8_t *dst, ptrdiff_t stride, TxSize tx_size, const uint8_t *above, const uint8_t *left, int mode);
-#endif
     RTCD_EXTERN void (*eb_av1_filter_intra_predictor) (uint8_t *dst, ptrdiff_t stride, TxSize tx_size, const uint8_t *above, const uint8_t *left, int32_t mode);
 
     void eb_av1_get_nz_map_contexts_c(const uint8_t *const levels, const int16_t *const scan, const uint16_t eob, const TxSize tx_size, const TxClass tx_class, int8_t *const coeff_contexts);
@@ -2979,12 +2968,9 @@ extern "C" {
     RTCD_EXTERN void(*compute_interm_var_four8x8)(uint8_t *input_samples, uint16_t input_stride, uint64_t *mean_of8x8_blocks, uint64_t *mean_of_squared8x8_blocks);
     RTCD_EXTERN uint32_t(*sad_16b_kernel)(uint16_t *src, uint32_t src_stride, uint16_t *ref, uint32_t ref_stride, uint32_t height, uint32_t width);
     RTCD_EXTERN void(*residual_kernel16bit)(uint16_t *input, uint32_t input_stride, uint16_t *pred, uint32_t pred_stride, int16_t *residual, uint32_t residual_stride, uint32_t area_width, uint32_t area_height);
-
-#if AUTO_MAX_PARTITION
     void av1_nn_predict_c(const float *input_nodes, const NN_CONFIG *const nn_config, int reduce_prec, float *const output);
     void av1_nn_predict_sse3(const float *input_nodes, const NN_CONFIG *const nn_config, int reduce_prec, float *const output);
     RTCD_EXTERN void(*av1_nn_predict)(const float *input_nodes, const NN_CONFIG *const nn_config, int reduce_prec, float *const output);
-#endif
 
     /* Moved to aom_dsp_rtcd.c file:
     static void setup_rtcd_internal(EbAsm asm_type)

--- a/Source/Lib/Decoder/Codec/EbDecInterPrediction.c
+++ b/Source/Lib/Decoder/Codec/EbDecInterPrediction.c
@@ -31,10 +31,8 @@
 #include "EbDecObmc.h"
 
 #include "aom_dsp_rtcd.h"
-#if COMP_INTERINTRA
 #include "EbDecProcessFrame.h"
 #include "EbDecIntraPrediction.h"
-#endif //comd_interintra
 
 static INLINE void dec_clamp_mv(MV *mv, int32_t min_col, int32_t max_col,
     int32_t min_row, int32_t max_row)
@@ -237,7 +235,6 @@ void svt_make_masked_inter_predictor(PartitionInfo_t *part_info, int32_t ref,
 
 }
 
-#if COMP_INTERINTRA
 void av1_combine_interintra(PartitionInfo_t *part_info, BlockSize bsize,
     int plane, uint8_t *inter_pred, int inter_stride,
     uint8_t *intra_pred, int intra_stride, EbBitDepthEnum bit_depth)
@@ -327,7 +324,6 @@ void av1_build_interintra_predictors(DecModCtxt *dec_mod_ctxt,
     }
 }
 
-#endif //comp_interintra
 
 
 void svtav1_predict_inter_block_plane(DecModCtxt *dec_mod_ctx,
@@ -502,14 +498,12 @@ void svtav1_predict_inter_block(DecModCtxt *dec_mod_ctxt,
             0/*OBMC_FLAG*/, mi_col*MI_SIZE, mi_row*MI_SIZE, blk_recon_buf,
             recon_stride, some_use_intra, recon_picture_buf->bit_depth);
 
-#if COMP_INTERINTRA
         if (is_interintra_pred(part_info->mi)) {
 /*Inter prd is done in above function, In the below function Intra prd happens follwed by interintra blending */
             av1_build_interintra_predictors(dec_mod_ctxt, part_info, blk_recon_buf,
                 recon_stride, plane, bsize, recon_picture_buf->bit_depth);
         }
 
-#endif //comp_interitra
     }
     if (part_info->mi->motion_mode == OBMC_CAUSAL) {
         dec_build_obmc_inter_predictors_sb((void *)dec_mod_ctxt,

--- a/Source/Lib/Decoder/Codec/EbDecIntraPrediction.h
+++ b/Source/Lib/Decoder/Codec/EbDecIntraPrediction.h
@@ -20,7 +20,6 @@ void svt_av1_predict_intra(DecModCtxt *dec_mod_ctxt, PartitionInfo_t *part_info,
     void *pv_blk_recon_buf, int32_t recon_stride,
     EbBitDepthEnum bit_depth, int32_t blk_mi_col_off, int32_t blk_mi_row_off);
 
-#if COMP_INTERINTRA
 
 void svtav1_predict_intra_block(PartitionInfo_t *xd, int32_t plane,
     TxSize tx_size, TileInfo *td, void *pv_pred_buf, int32_t pred_stride,
@@ -28,7 +27,6 @@ void svtav1_predict_intra_block(PartitionInfo_t *xd, int32_t plane,
     SeqHeader *seq_header, const PredictionMode mode, int32_t blk_mi_col_off,
     int32_t blk_mi_row_off, EbBitDepthEnum bit_depth);
 
-#endif //comp_interintra
 
 void cfl_store_tx(PartitionInfo_t *xd, CflCtx *cfl_ctx, int row, int col, TxSize tx_size,
     BlockSize  bsize, EbColorConfig *cc, uint8_t *dst_buff,

--- a/Source/Lib/Decoder/Codec/EbDecParseBlock.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseBlock.c
@@ -1479,11 +1479,7 @@ void read_var_tx_size(ParseCtxt *parse_ctx, PartitionInfo_t *pi,
 
     if (blk_row >= max_blocks_high || blk_col >= max_blocks_wide) return;
 
-#if ENHANCE_ATB
     if (tx_size == TX_4X4 || depth == MAX_VARTX_DEPTH)
-#else
-    if (tx_size == TX_4X4 || depth == MAX_VARTX_DEPTH + 1)
-#endif
         txfm_split = 0;
     else {
         int ctx = get_txfm_split_ctx(pi, parse_ctx, tx_size, blk_row, blk_col);

--- a/Source/Lib/Decoder/Codec/EbDecUtils.h
+++ b/Source/Lib/Decoder/Codec/EbDecUtils.h
@@ -57,12 +57,10 @@ static INLINE int is_interintra_allowed(const BlockModeInfo *mbmi) {
         is_interintra_allowed_ref(mbmi->ref_frame);
 }
 
-#if COMP_INTERINTRA
 static INLINE int is_interintra_pred(const BlockModeInfo *mbmi) {
     return mbmi->ref_frame[0] > INTRA_FRAME &&
         mbmi->ref_frame[1] == INTRA_FRAME && is_interintra_allowed(mbmi);
 }
-#endif //comp_interintra
 
 static INLINE int has_second_ref(const BlockModeInfo *mbmi) {
     return mbmi->ref_frame[1] > INTRA_FRAME;

--- a/Source/Lib/Encoder/Codec/EbCdefProcess.c
+++ b/Source/Lib/Encoder/Codec/EbCdefProcess.c
@@ -42,9 +42,6 @@ int32_t eb_sb_compute_cdef_list(PictureControlSet   *picture_control_set_ptr, co
     cdef_list *dlist, BlockSize bs);
 void finish_cdef_search(
     EncDecContext                *context_ptr,
-#if !UPDATE_CDEF
-    SequenceControlSet           *sequence_control_set_ptr,
-#endif
     PictureControlSet            *picture_control_set_ptr,
     int32_t                      selected_strength_cnt[64]);
 void av1_cdef_frame16bit(
@@ -476,9 +473,6 @@ void* cdef_kernel(void *input_ptr)
         if (sequence_control_set_ptr->seq_header.enable_cdef && picture_control_set_ptr->parent_pcs_ptr->cdef_filter_mode) {
                 finish_cdef_search(
                     0,
-#if !UPDATE_CDEF
-                    sequence_control_set_ptr,
-#endif
                     picture_control_set_ptr,
                     selected_strength_cnt);
 

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -1113,9 +1113,6 @@ void* initial_rate_control_kernel(void *input_ptr)
 
     // Segments
     uint32_t                              segment_index;
-#if ! OUT_ALLOC
-    EbObjectWrapper                *output_stream_wrapper_ptr;
-#endif
     for (;;) {
         // Get Input Full Object
         eb_get_full_object(
@@ -1309,14 +1306,6 @@ void* initial_rate_control_kernel(void *input_ptr)
                         picture_control_set_ptr->stat_struct_first_pass_ptr = picture_control_set_ptr->is_used_as_reference_flag ? &((EbReferenceObject*)picture_control_set_ptr->reference_picture_wrapper_ptr->object_ptr)->stat_struct : &picture_control_set_ptr->stat_struct;
                         if (sequence_control_set_ptr->use_output_stat_file)
                             memset(picture_control_set_ptr->stat_struct_first_pass_ptr, 0, sizeof(stat_struct_t));
-#endif
-#if ! OUT_ALLOC
-                        //OPTION 1:  get the output stream buffer in ressource coordination
-                        eb_get_empty_object(
-                            sequence_control_set_ptr->encode_context_ptr->stream_output_fifo_ptr,
-                            &output_stream_wrapper_ptr);
-
-                        picture_control_set_ptr->output_stream_wrapper_ptr = output_stream_wrapper_ptr;
 #endif
                         // Get Empty Results Object
                         eb_get_empty_object(


### PR DESCRIPTION
## Description
Cleanup the following macros : 
WARP_UPDATE
EIGTH_PEL_MV and UPDATE_CDEF
EIGHT_PEL_PREDICTIVE_ME
EIGHT_PEL_FIX
COMP_INTERINTRA
RDOQ_CHROMA
ENHANCE_ATB
REMOVE_MD_STAGE_1
NON_KF_INTRA_TF_FIX
TX_SIZE_EARLY_EXIT
SINGLE_CORE_ENCODE
SERIAL_MODE
OUT_ALLOC
PAREF_OUT
NO_THREAD_PIN
RATE_ESTIMATION_UPDATE
HBD_CLEAN_UP
HBD2_COMP
HBD2_PME
HBD2_OBMC
IFS_8BIT_MD
COMP_HBD
INTERINTRA_HBD
ATB_HBD
ATB_FIX
REVERT_ALTREF_FIX
FIX_ALTREF
FIX_NEAREST_NEW
FIX_ESTIMATE_INTRA
FIX_SKIP_REDUNDANT_BLOCK
FIX_COEF_BASED_ATB_SKIP
FIX_WM_SETTINGS
FIX_ENABLE_CDF_UPDATE
FIX_SORTING_METHOD
FIX_SETTINGS_RESET
FIX_COMPOUND
PRED_CHANGE
PRED_CHANGE_5L
PRED_CHANGE_MOD
AUTO_MAX_PARTITION
LESS_RECTANGULAR_CHECK_LEVEL
INTER_INTRA_CLASS_PRUNING
INJECT_NEW_NEAR_NEAR_NEW
FILTER_INTRA_FLAG
PAETH_HBD
INTER_INTER_HBD
INTER_INTRA_HBD
ATB_10_BIT
SPEED_OPT
TWO_PASS_USE_2NDP_ME_IN_1STP
TWO_PASS_IMPROVEMENT

## Performance 
No impact