### PR TITLE
Fix assertion failed in transform unit tests

### DIFF
--- a/test/ref/TxfmRef.cc
+++ b/test/ref/TxfmRef.cc
@@ -146,6 +146,7 @@ void reference_idtx_1d(const double *in, double *out, int size) {
     case 8: scale = 2; break;
     case 16: scale = 2 * Sqrt2; break;
     case 32: scale = 4; break;
+    case 64: scale = 4 * Sqrt2; break;
     default: assert(0); break;
     }
 


### PR DESCRIPTION
1. Txfm unit test triggers assertion failed after 64x64 TxSize added into tests:
~~~
18:03:40 SvtAv1UnitTests: /home/av1-slave1/workspace/SVTAV1-Coverage/test/ref/TxfmRef.cc:149: void svt_av1_test_reference::reference_idtx_1d(const double*, double*, int): Assertion `0' failed.
18:03:40 xargs: env: terminated by signal 6
~~~
this commit fixes it in TxfmRef.cc