### PR TITLE
EbAppConfig: Don't call fclose on error_log_file if it's equal to stderr

### DIFF
--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -717,7 +717,7 @@ void eb_config_dtor(EbConfig *config_ptr)
         config_ptr->recon_file = (FILE *)NULL;
     }
 
-    if (config_ptr->error_log_file) {
+    if (config_ptr->error_log_file && config_ptr->error_log_file != stderr) {
         fclose(config_ptr->error_log_file);
         config_ptr->error_log_file = (FILE *) NULL;
     }


### PR DESCRIPTION
Calling `fprintf` on `stderr` after we close it is causing MSVC to raise an assert failure, fixes the issue in https://github.com/OpenVisualCloud/SVT-AV1/pull/919#issuecomment-568906796