### PR TITLE
Fix memory leak on EbModeDecisionProcess.c:L115

### DIFF
--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.c
@@ -14,12 +14,14 @@ static void mode_decision_context_dctor(EbPtr p) {
     for (int cd = 0; cd < MAX_PAL_CAND; cd++)
         if (obj->palette_cand_array[cd].color_idx_map)
             EB_FREE_ARRAY(obj->palette_cand_array[cd].color_idx_map);
-    for (uint32_t cand_index = 0; cand_index < MODE_DECISION_CANDIDATE_MAX_COUNT; ++cand_index)
+    for (uint32_t cand_index = 0; cand_index < MODE_DECISION_CANDIDATE_MAX_COUNT; ++cand_index) {
         if (obj->fast_candidate_ptr_array[cand_index]->palette_info.color_idx_map)
             for (uint32_t coded_leaf_index = 0; coded_leaf_index < BLOCK_MAX_COUNT_SB_128;
                  ++coded_leaf_index)
                 if (obj->md_blk_arr_nsq[coded_leaf_index].palette_info.color_idx_map)
                     EB_FREE_ARRAY(obj->md_blk_arr_nsq[coded_leaf_index].palette_info.color_idx_map);
+        EB_FREE_ARRAY(obj->fast_candidate_ptr_array[cand_index]->palette_info.color_idx_map);
+    }
     EB_FREE_ARRAY(obj->ref_best_ref_sq_table);
     EB_FREE_ARRAY(obj->ref_best_cost_sq_table);
     EB_FREE_ARRAY(obj->above_txfm_context);


### PR DESCRIPTION
Signed-off-by: Luis Garcia <luigi311.lg@gmail.com>

Building debug and running it causes a memory leak as reported by SvtMalloc.

Command used:
sudo ./SvtAv1EncApp -i ../../../Chim*.y4m -enc-mode 8 -b test.mkv

Message:
SvtMalloc[error]: malloced memory leaked at /home/luis/Desktop/SVT-AV1/Source/Lib/Encoder/Codec/EbModeDecisionProcess.c:L115

This will add a EB_FREE_ARRAY for the palette_info in the fast_candidate_ptr_array pointer due to just doing the EB_FREE_ARRAY on the entire pointer still leaves the memory leak