### PR TITLE
[RFC] consistent namespacing for public API functions

### DIFF
--- a/Source/API/EbSvtAv1Dec.h
+++ b/Source/API/EbSvtAv1Dec.h
@@ -132,7 +132,7 @@ typedef struct EbSvtAv1DecConfiguration {
      * @ *p_app_data     Callback data.
      * @ *config_ptr     Pointer passed back to the client during callbacks, it will be
      *                   loaded with default parameters from the library. */
-EB_API EbErrorType eb_dec_init_handle(EbComponentType **p_handle, void *p_app_data,
+EB_API EbErrorType svt_av1_dec_init_handle(EbComponentType **p_handle, void *p_app_data,
                                       EbSvtAv1DecConfiguration *config_ptr);
 
 /* STEP 2: Set configuration parameters.
@@ -140,7 +140,7 @@ EB_API EbErrorType eb_dec_init_handle(EbComponentType **p_handle, void *p_app_da
      * Parameter:
      * @ *svt_dec_component             Decoder handle.
      * @ *pComponentParameterStructure  Decoder and buffer configurations will be copied to the library. */
-EB_API EbErrorType eb_svt_dec_set_parameter(
+EB_API EbErrorType svt_av1_dec_set_parameter(
     EbComponentType *svt_dec_component,
     EbSvtAv1DecConfiguration *
         pComponentParameterStructure); // pComponentParameterStructure contents will be copied to the library
@@ -149,7 +149,7 @@ EB_API EbErrorType eb_svt_dec_set_parameter(
      *
      * Parameter:
      * @ *svt_dec_component  Decoder handle. */
-EB_API EbErrorType eb_init_decoder(EbComponentType *svt_dec_component);
+EB_API EbErrorType svt_av1_dec_init(EbComponentType *svt_dec_component);
 
 /*!\brief STEP 4: Decodes a frame with associated data. The data in *data
      * should belong to one frame, possibly with sequence header and metadata.
@@ -160,13 +160,13 @@ EB_API EbErrorType eb_init_decoder(EbComponentType *svt_dec_component);
      * @ data_size              Data size in bytes
      *
      *  Returns EB_ErrorNone if the coded data has been processed successfully. */
-EB_API EbErrorType eb_svt_decode_frame(EbComponentType *svt_dec_component, const uint8_t *data,
+EB_API EbErrorType svt_av1_dec_frame(EbComponentType *svt_dec_component, const uint8_t *data,
                                        const size_t data_size, uint32_t is_annexb);
 
 /* STEP 5: Get the next decoded picture. When several output pictures
      * have been generated, calling this function multiple times will
      * iterate over the decoded pictures. The previous output picture becomes
-     * unavailable after the eb_svt_dec_get_picture() or one of the decoding
+     * unavailable after the svt_av1_dec_get_picture() or one of the decoding
      * functions is called. The pictures are returned in their display order.
      *
      * Parameter:
@@ -178,7 +178,7 @@ EB_API EbErrorType eb_svt_decode_frame(EbComponentType *svt_dec_component, const
      *  Returns EB_ErrorNone if the picture has been returned successfully.
      *  Returns EB_DecNoOutputPicture if the next output picture has not
      *  been generated yet. Calling a decoding function is needed to generate more pictures. */
-EB_API EbErrorType eb_svt_dec_get_picture(EbComponentType *   svt_dec_component,
+EB_API EbErrorType svt_av1_dec_get_picture(EbComponentType *   svt_dec_component,
                                           EbBufferHeaderType *p_buffer,
                                           EbAV1StreamInfo *stream_info, EbAV1FrameInfo *frame_info);
 
@@ -186,13 +186,13 @@ EB_API EbErrorType eb_svt_dec_get_picture(EbComponentType *   svt_dec_component,
      *
      * Parameter:
      * @ *svt_dec_component     Decoder handle */
-EB_API EbErrorType eb_deinit_decoder(EbComponentType *svt_dec_component);
+EB_API EbErrorType svt_av1_dec_deinit(EbComponentType *svt_dec_component);
 
 /* STEP 7: Deconstruct decoder handler.
      *
      * Parameter:
      * @ *svt_dec_component     Decoder handle */
-EB_API EbErrorType eb_dec_deinit_handle(EbComponentType *svt_dec_component);
+EB_API EbErrorType svt_av1_dec_deinit_handle(EbComponentType *svt_dec_component);
 
 #ifdef __cplusplus
 }

--- a/Source/API/EbSvtAv1Dec.h
+++ b/Source/API/EbSvtAv1Dec.h
@@ -135,24 +135,7 @@ typedef struct EbSvtAv1DecConfiguration {
 EB_API EbErrorType eb_dec_init_handle(EbComponentType **p_handle, void *p_app_data,
                                       EbSvtAv1DecConfiguration *config_ptr);
 
-/* STEP 2: Peek into sequence header.
-     *
-     * The function is used to find the sequence header
-     * before the decoder is initialized. The decoder needs
-     * to read the sequence header again when starting decoding.
-     * The function can be called multiple times before it returns
-     * the EB_ErrorNone, which means the the sequence header is found.
-     * When the OBU is not a valid sequence header, EB_DecUnsupportedBitstream
-     * is returned.
-     *
-     * Parameter:
-     * @ *header            Sequence header info.
-     * @ *data              Input buffer pointer.
-     * @ data_size          Input data size in bytes */
-EB_API EbErrorType eb_peek_sequence_header(EbAV1StreamInfo *header, const uint8_t *data,
-                                           const uint32_t data_size);
-
-/* STEP 3: Set configuration parameters.
+/* STEP 2: Set configuration parameters.
      *
      * Parameter:
      * @ *svt_dec_component             Decoder handle.
@@ -162,25 +145,13 @@ EB_API EbErrorType eb_svt_dec_set_parameter(
     EbSvtAv1DecConfiguration *
         pComponentParameterStructure); // pComponentParameterStructure contents will be copied to the library
 
-/* STEP 4: Initialize decoder and allocate memory to necessary buffers.
+/* STEP 3: Initialize decoder and allocate memory to necessary buffers.
      *
      * Parameter:
      * @ *svt_dec_component  Decoder handle. */
 EB_API EbErrorType eb_init_decoder(EbComponentType *svt_dec_component);
 
-/*!\brief STEP 5: Decodes one OBU.
-     *
-     * Parameter:
-     * @ *svt_dec_component     Decoder handle
-     * @ *data                  Buffer with data
-     * @ data_size              Data size in bytes
-     * @ *user_priv             pointer to the private user data
-     *
-     *  Returns EB_ErrorNone if the coded data has been processed successfully. */
-EB_API EbErrorType eb_svt_decode_obu(EbComponentType *svt_dec_component, const uint8_t *data,
-                                     const uint32_t data_size);
-
-/*!\brief STEP 5-alt-1: Decodes a frame with associated data. The data in *data
+/*!\brief STEP 4: Decodes a frame with associated data. The data in *data
      * should belong to one frame, possibly with sequence header and metadata.
      *
      * Parameter:
@@ -192,23 +163,7 @@ EB_API EbErrorType eb_svt_decode_obu(EbComponentType *svt_dec_component, const u
 EB_API EbErrorType eb_svt_decode_frame(EbComponentType *svt_dec_component, const uint8_t *data,
                                        const size_t data_size, uint32_t is_annexb);
 
-/*!\brief STEP 5-alt-2: Decodes a temporal unit (TU). Decoding a TU
-     * may result in several output pictures generated if output_all_layers
-     * was set to 1 in the  EbSvtAv1DecConfiguration.
-     * In this case, calling eb_svt_dec_get_picture() multiple times
-     * would output pictures that belong to the corresponding quality layers
-     * in the increasing order.
-     *
-     * Parameter:
-     * @ *svt_dec_component     Decoder handle
-     * @ *data                  Buffer with data
-     * @ data_size              Data size in bytes
-     *
-     *  Returns EB_ErrorNone if the coded data has been processed successfully. */
-EB_API EbErrorType eb_svt_decode_tu(EbComponentType *svt_dec_component, const uint8_t *data,
-                                    const uint32_t data_size);
-
-/* STEP 6: Get the next decoded picture. When several output pictures
+/* STEP 5: Get the next decoded picture. When several output pictures
      * have been generated, calling this function multiple times will
      * iterate over the decoded pictures. The previous output picture becomes
      * unavailable after the eb_svt_dec_get_picture() or one of the decoding
@@ -227,39 +182,17 @@ EB_API EbErrorType eb_svt_dec_get_picture(EbComponentType *   svt_dec_component,
                                           EbBufferHeaderType *p_buffer,
                                           EbAV1StreamInfo *stream_info, EbAV1FrameInfo *frame_info);
 
-/* STEP 7: Deinitialize decoder library.
+/* STEP 6: Deinitialize decoder library.
      *
      * Parameter:
      * @ *svt_dec_component     Decoder handle */
 EB_API EbErrorType eb_deinit_decoder(EbComponentType *svt_dec_component);
 
-/* STEP 8: Deconstruct decoder handler.
+/* STEP 7: Deconstruct decoder handler.
      *
      * Parameter:
      * @ *svt_dec_component     Decoder handle */
 EB_API EbErrorType eb_dec_deinit_handle(EbComponentType *svt_dec_component);
-
-/*  Flush a decoder
-     *
-     *  Clears the decoder frame buffers.
-     *  The decoder is ready to parse a new sequence header.
-     *
-     *  Parameter:
-     *  @ *svt_dec_component     Decoder handle
-     *
-     *  Returns EB_ErrorNone if the decode buffer has been flushed successfully.
-     */
-EB_API EbErrorType eb_dec_flush(EbComponentType *svt_dec_component);
-
-/* Returns information about the bitstream and
-     * the last decoded frame.
-     *
-     * Parameter:
-     * @ *svt_dec_component     Decoder handle.
-     * @ *stream_info           Sequence header info
-     * @ *frame_info            Last decoded frame info */
-EB_API EbErrorType eb_get_stream_info(EbComponentType *svt_dec_component,
-                                      EbAV1StreamInfo *stream_info, EbAV1FrameInfo *frame_info);
 
 #ifdef __cplusplus
 }

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -661,7 +661,7 @@ typedef struct EbSvtAv1EncConfiguration {
      * @ *config_ptr     Pointer passed back to the client during callbacks, it will be
      *                  loaded with default params from the library. */
 EB_API EbErrorType
-eb_init_handle(EbComponentType **p_handle, void *p_app_data,
+svt_av1_enc_init_handle(EbComponentType **p_handle, void *p_app_data,
                EbSvtAv1EncConfiguration
                    *config_ptr); // config_ptr will be loaded with default params from the library
 
@@ -670,7 +670,7 @@ eb_init_handle(EbComponentType **p_handle, void *p_app_data,
      * Parameter:
      * @ *svt_enc_component              Encoder handler.
      * @ *pComponentParameterStructure  Encoder and buffer configurations will be copied to the library. */
-EB_API EbErrorType eb_svt_enc_set_parameter(
+EB_API EbErrorType svt_av1_enc_set_parameter(
     EbComponentType *svt_enc_component,
     EbSvtAv1EncConfiguration *
         pComponentParameterStructure); // pComponentParameterStructure contents will be copied to the library
@@ -679,21 +679,21 @@ EB_API EbErrorType eb_svt_enc_set_parameter(
      *
      * Parameter:
      * @ *svt_enc_component  Encoder handler. */
-EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component);
+EB_API EbErrorType svt_av1_enc_init(EbComponentType *svt_enc_component);
 
 /* OPTIONAL: Get stream headers at init time.
      *
      * Parameter:
      * @ *svt_enc_component   Encoder handler.
      * @ **output_stream_ptr  Output buffer. */
-EB_API EbErrorType eb_svt_enc_stream_header(EbComponentType *    svt_enc_component,
+EB_API EbErrorType svt_av1_enc_stream_header(EbComponentType *    svt_enc_component,
                                             EbBufferHeaderType **output_stream_ptr);
 
 /* OPTIONAL: Release stream headers at init time.
      *
      * Parameter:
      * @ *stream_header_ptr  stream header buffer. */
-EB_API EbErrorType eb_svt_release_enc_stream_header(EbBufferHeaderType *stream_header_ptr);
+EB_API EbErrorType svt_av1_enc_stream_header_release(EbBufferHeaderType *stream_header_ptr);
 
 
 /* OPTIONAL: Get the end of sequence Network Abstraction Layer.
@@ -701,7 +701,7 @@ EB_API EbErrorType eb_svt_release_enc_stream_header(EbBufferHeaderType *stream_h
      * Parameter:
      * @ *svt_enc_component  Encoder handler.
      * @ **output_stream_ptr  Output stream. */
-EB_API EbErrorType eb_svt_enc_eos_nal(EbComponentType *    svt_enc_component,
+EB_API EbErrorType svt_av1_enc_eos_nal(EbComponentType *    svt_enc_component,
                                       EbBufferHeaderType **output_stream_ptr);
 
 /* STEP 4: Send the picture.
@@ -709,7 +709,7 @@ EB_API EbErrorType eb_svt_enc_eos_nal(EbComponentType *    svt_enc_component,
      * Parameter:
      * @ *svt_enc_component  Encoder handler.
      * @ *p_buffer           Header pointer, picture buffer. */
-EB_API EbErrorType eb_svt_enc_send_picture(EbComponentType *   svt_enc_component,
+EB_API EbErrorType svt_av1_enc_send_picture(EbComponentType *   svt_enc_component,
                                            EbBufferHeaderType *p_buffer);
 
 /* STEP 5: Receive packet.
@@ -718,34 +718,34 @@ EB_API EbErrorType eb_svt_enc_send_picture(EbComponentType *   svt_enc_component
      * @ **p_buffer          Header pointer to return packet with.
      * @ pic_send_done       Flag to signal that all input pictures have been sent, this call becomes locking one this signal is 1.
      * Non-locking call, returns EB_ErrorMax for an encode error, EB_NoErrorEmptyQueue when the library does not have any available packets.*/
-EB_API EbErrorType eb_svt_get_packet(EbComponentType *    svt_enc_component,
+EB_API EbErrorType svt_av1_enc_get_packet(EbComponentType *    svt_enc_component,
                                      EbBufferHeaderType **p_buffer, uint8_t pic_send_done);
 
 /* STEP 5-1: Release output buffer back into the pool.
      *
      * Parameter:
      * @ **p_buffer          Header pointer that contains the output packet to be released. */
-EB_API void eb_svt_release_out_buffer(EbBufferHeaderType **p_buffer);
+EB_API void svt_av1_enc_release_out_buffer(EbBufferHeaderType **p_buffer);
 
 /* OPTIONAL: Fill buffer with reconstructed picture.
      *
      * Parameter:
      * @ *svt_enc_component  Encoder handler.
      * @ *p_buffer           Output buffer. */
-EB_API EbErrorType eb_svt_get_recon(EbComponentType *   svt_enc_component,
+EB_API EbErrorType svt_av1_get_recon(EbComponentType *   svt_enc_component,
                                     EbBufferHeaderType *p_buffer);
 
 /* STEP 6: Deinitialize encoder library.
      *
      * Parameter:
      * @ *svt_enc_component  Encoder handler. */
-EB_API EbErrorType eb_deinit_encoder(EbComponentType *svt_enc_component);
+EB_API EbErrorType svt_av1_enc_deinit(EbComponentType *svt_enc_component);
 
 /* STEP 7: Deconstruct encoder handler.
      *
      * Parameter:
      * @ *svt_enc_component  Encoder handler. */
-EB_API EbErrorType eb_deinit_handle(EbComponentType *svt_enc_component);
+EB_API EbErrorType svt_av1_enc_deinit_handle(EbComponentType *svt_enc_component);
 
 #ifdef __cplusplus
 }

--- a/Source/App/DecApp/EbDecAppMain.c
+++ b/Source/App/DecApp/EbDecAppMain.c
@@ -169,14 +169,14 @@ int32_t main(int32_t argc, char *argv[]) {
     EbComponentType *p_handle;
     void *           p_app_data = NULL;
 
-    return_error |= eb_dec_init_handle(&p_handle, p_app_data, config_ptr);
+    return_error |= svt_av1_dec_init_handle(&p_handle, p_app_data, config_ptr);
     if (return_error != EB_ErrorNone) goto fail;
 
     if (read_command_line(argc, argv, config_ptr, &cli, &obu_ctx) == 0 &&
-        !eb_svt_dec_set_parameter(p_handle, config_ptr)) {
-        return_error = eb_init_decoder(p_handle);
+        !svt_av1_dec_set_parameter(p_handle, config_ptr)) {
+        return_error = svt_av1_dec_init(p_handle);
         if (return_error != EB_ErrorNone) {
-            return_error |= eb_dec_deinit_handle(p_handle);
+            return_error |= svt_av1_dec_deinit_handle(p_handle);
             goto fail;
         }
 
@@ -222,14 +222,14 @@ int32_t main(int32_t argc, char *argv[]) {
                     dec_timer_start(&timer);
 
                     return_error |=
-                        eb_svt_decode_frame(p_handle, buf, bytes_in_buffer, obu_ctx.is_annexb);
+                        svt_av1_dec_frame(p_handle, buf, bytes_in_buffer, obu_ctx.is_annexb);
 
                     dec_timer_mark(&timer);
                     dx_time += dec_timer_elapsed(&timer);
 
                     in_frame++;
 
-                    if (eb_svt_dec_get_picture(p_handle, recon_buffer, stream_info, frame_info) !=
+                    if (svt_av1_dec_get_picture(p_handle, recon_buffer, stream_info, frame_info) !=
                         EB_DecNoOutputPicture) {
                         if (fps_frm) show_progress(in_frame, dx_time);
 
@@ -249,7 +249,7 @@ int32_t main(int32_t argc, char *argv[]) {
                 print_md5(md5_digest);
             }
 
-            return_error |= eb_deinit_decoder(p_handle);
+            return_error |= svt_av1_dec_deinit(p_handle);
 
             free(frame_info);
             free(stream_info);
@@ -264,7 +264,7 @@ int32_t main(int32_t argc, char *argv[]) {
         free(buf);
     } else
         fprintf(stderr, "Error in configuration. \n");
-    return_error |= eb_dec_deinit_handle(p_handle);
+    return_error |= svt_av1_dec_deinit_handle(p_handle);
 
 fail:
     if (cli.in_file) fclose(cli.in_file);

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -472,7 +472,7 @@ EbErrorType init_encoder(EbConfig *config, EbAppContext *callback_data, uint32_t
 
     ///************************* LIBRARY INIT [START] *********************///
     // STEP 1: Call the library to construct a Component Handle
-    return_error = eb_init_handle(
+    return_error = svt_av1_enc_init_handle(
         &callback_data->svt_encoder_handle, callback_data, &callback_data->eb_enc_parameters);
 
     if (return_error != EB_ErrorNone) return return_error;
@@ -482,12 +482,12 @@ EbErrorType init_encoder(EbConfig *config, EbAppContext *callback_data, uint32_t
     if (return_error != EB_ErrorNone) return return_error;
     // STEP 4: Send over all configuration parameters
     // Set the Parameters
-    return_error = eb_svt_enc_set_parameter(callback_data->svt_encoder_handle,
+    return_error = svt_av1_enc_set_parameter(callback_data->svt_encoder_handle,
                                             &callback_data->eb_enc_parameters);
 
     if (return_error != EB_ErrorNone) return return_error;
     // STEP 5: Init Encoder
-    return_error = eb_init_encoder(callback_data->svt_encoder_handle);
+    return_error = svt_av1_enc_init(callback_data->svt_encoder_handle);
     if (return_error != EB_ErrorNone) { return return_error; }
 
     ///************************* LIBRARY INIT [END] *********************///
@@ -527,7 +527,7 @@ EbErrorType de_init_encoder(EbAppContext *callback_data_ptr, uint32_t instance_i
     EbMemoryMapEntry *memory_entry = (EbMemoryMapEntry *)0;
 
     if (((EbComponentType *)(callback_data_ptr->svt_encoder_handle)) != NULL)
-        return_error = eb_deinit_encoder(callback_data_ptr->svt_encoder_handle);
+        return_error = svt_av1_enc_deinit(callback_data_ptr->svt_encoder_handle);
     // Destruct the buffer memory pool
     if (return_error != EB_ErrorNone) return return_error;
     // Loop through the ptr table and free all malloc'd pointers per channel
@@ -542,7 +542,7 @@ EbErrorType de_init_encoder(EbAppContext *callback_data_ptr, uint32_t instance_i
     free(app_memory_map_all_channels[instance_index]);
 
     // Destruct the component
-    eb_deinit_handle(callback_data_ptr->svt_encoder_handle);
+    svt_av1_enc_deinit_handle(callback_data_ptr->svt_encoder_handle);
 
     return return_error;
 }

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -949,7 +949,7 @@ AppExitConditionType process_input_buffer(EbConfig *config, EbAppContext *app_ca
             header_ptr->flags    = 0;
 
             // Send the picture
-            eb_svt_enc_send_picture(component_handle, header_ptr);
+            svt_av1_enc_send_picture(component_handle, header_ptr);
         }
 
         if ((config->processed_frame_count == (uint64_t)config->frames_to_be_encoded) ||
@@ -962,7 +962,7 @@ AppExitConditionType process_input_buffer(EbConfig *config, EbAppContext *app_ca
             header_ptr->p_buffer      = NULL;
             header_ptr->pic_type      = EB_AV1_INVALID_PICTURE;
 
-            eb_svt_enc_send_picture(component_handle, header_ptr);
+            svt_av1_enc_send_picture(component_handle, header_ptr);
         }
 
         return_value =
@@ -1133,7 +1133,7 @@ AppExitConditionType process_output_stream_buffer(EbConfig *config, EbAppContext
     while (is_alt_ref) {
         is_alt_ref = 0;
         // non-blocking call until all input frames are sent
-        stream_status = eb_svt_get_packet(component_handle, &header_ptr, pic_send_done);
+        stream_status = svt_av1_enc_get_packet(component_handle, &header_ptr, pic_send_done);
 
         if (stream_status == EB_ErrorMax) {
             fprintf(stderr, "\n");
@@ -1184,7 +1184,7 @@ AppExitConditionType process_output_stream_buffer(EbConfig *config, EbAppContext
                                                                    : APP_ExitConditionNone;
 
             // Release the output buffer
-            eb_svt_release_out_buffer(&header_ptr);
+            svt_av1_enc_release_out_buffer(&header_ptr);
 
 #if DEADLOCK_DEBUG
             ++frame_count;
@@ -1227,7 +1227,7 @@ AppExitConditionType process_output_recon_buffer(EbConfig *config, EbAppContext 
     EbErrorType          recon_status     = EB_ErrorNone;
     int32_t              fseek_return_val;
     // non-blocking call until all input frames are sent
-    recon_status = eb_svt_get_recon(component_handle, header_ptr);
+    recon_status = svt_av1_get_recon(component_handle, header_ptr);
 
     if (recon_status == EB_ErrorMax) {
         fprintf(stderr, "\n");

--- a/Source/Lib/Decoder/Codec/EbDecHandle.c
+++ b/Source/Lib/Decoder/Codec/EbDecHandle.c
@@ -485,7 +485,7 @@ static EbErrorType init_svt_av1_decoder_handle(EbComponentType *hComponent) {
 __attribute__((visibility("default")))
 #endif
 EB_API EbErrorType
-eb_dec_init_handle(EbComponentType **p_handle, void *p_app_data,
+svt_av1_dec_init_handle(EbComponentType **p_handle, void *p_app_data,
                    EbSvtAv1DecConfiguration *config_ptr) {
     EbErrorType return_error = EB_ErrorNone;
 
@@ -503,7 +503,7 @@ eb_dec_init_handle(EbComponentType **p_handle, void *p_app_data,
         if (return_error == EB_ErrorNone)
             ((EbComponentType *)(*p_handle))->p_application_private = p_app_data;
         else if (return_error == EB_ErrorInsufficientResources) {
-            eb_deinit_decoder((EbComponentType *)NULL);
+            svt_av1_dec_deinit((EbComponentType *)NULL);
             *p_handle = (EbComponentType *)NULL;
         } else
             return_error = EB_ErrorInvalidComponent;
@@ -521,7 +521,7 @@ eb_dec_init_handle(EbComponentType **p_handle, void *p_app_data,
 __attribute__((visibility("default")))
 #endif
 EB_API EbErrorType
-eb_svt_dec_set_parameter(EbComponentType *         svt_dec_component,
+svt_av1_dec_set_parameter(EbComponentType *         svt_dec_component,
                          EbSvtAv1DecConfiguration *config_struct) {
     if (svt_dec_component == NULL || config_struct == NULL) return EB_ErrorBadParameter;
 
@@ -537,7 +537,7 @@ eb_svt_dec_set_parameter(EbComponentType *         svt_dec_component,
 __attribute__((visibility("default")))
 #endif
 EB_API EbErrorType
-eb_init_decoder(EbComponentType *svt_dec_component) {
+svt_av1_dec_init(EbComponentType *svt_dec_component) {
     EbErrorType return_error = EB_ErrorNone;
     if (svt_dec_component == NULL) return EB_ErrorBadParameter;
 
@@ -582,7 +582,7 @@ eb_init_decoder(EbComponentType *svt_dec_component) {
 __attribute__((visibility("default")))
 #endif
 EB_API EbErrorType
-eb_svt_decode_frame(EbComponentType *svt_dec_component, const uint8_t *data, const size_t data_size,
+svt_av1_dec_frame(EbComponentType *svt_dec_component, const uint8_t *data, const size_t data_size,
                     uint32_t is_annexb) {
     EbErrorType return_error = EB_ErrorNone;
     if (svt_dec_component == NULL) return EB_ErrorBadParameter;
@@ -628,7 +628,7 @@ eb_svt_decode_frame(EbComponentType *svt_dec_component, const uint8_t *data, con
 __attribute__((visibility("default")))
 #endif
 EB_API EbErrorType
-eb_svt_dec_get_picture(EbComponentType *svt_dec_component, EbBufferHeaderType *p_buffer,
+svt_av1_dec_get_picture(EbComponentType *svt_dec_component, EbBufferHeaderType *p_buffer,
                        EbAV1StreamInfo *stream_info, EbAV1FrameInfo *frame_info) {
     (void)stream_info;
     (void)frame_info;
@@ -646,7 +646,7 @@ eb_svt_dec_get_picture(EbComponentType *svt_dec_component, EbBufferHeaderType *p
 __attribute__((visibility("default")))
 #endif
 EB_API EbErrorType
-eb_deinit_decoder(EbComponentType *svt_dec_component) {
+svt_av1_dec_deinit(EbComponentType *svt_dec_component) {
     if (svt_dec_component == NULL) return EB_ErrorBadParameter;
     EbDecHandle *dec_handle_ptr = (EbDecHandle *)svt_dec_component->p_component_private;
     EbErrorType  return_error   = EB_ErrorNone;
@@ -701,7 +701,7 @@ EbErrorType eb_dec_component_de_init(EbComponentType *svt_dec_component) {
 __attribute__((visibility("default")))
 #endif
 EB_API EbErrorType
-eb_dec_deinit_handle(EbComponentType *svt_dec_component) {
+svt_av1_dec_deinit_handle(EbComponentType *svt_dec_component) {
     EbErrorType return_error = EB_ErrorNone;
 
     if (svt_dec_component) {

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -938,7 +938,7 @@ void av1_init_wedge_masks(void);
 #ifdef __GNUC__
 __attribute__((visibility("default")))
 #endif
-EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
+EB_API EbErrorType svt_av1_enc_init(EbComponentType *svt_enc_component)
 {
     if(svt_enc_component == NULL)
         return EB_ErrorBadParameter;
@@ -1735,7 +1735,7 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
 #ifdef __GNUC__
 __attribute__((visibility("default")))
 #endif
-EB_API EbErrorType eb_deinit_encoder(EbComponentType *svt_enc_component){
+EB_API EbErrorType svt_av1_enc_deinit(EbComponentType *svt_enc_component){
     if(svt_enc_component == NULL)
         return EB_ErrorBadParameter;
 
@@ -1772,7 +1772,7 @@ EbErrorType init_svt_av1_encoder_handle(
 #ifdef __GNUC__
 __attribute__((visibility("default")))
 #endif
-EB_API EbErrorType eb_init_handle(
+EB_API EbErrorType svt_av1_enc_init_handle(
     EbComponentType** p_handle,               // Function to be called in the future for manipulating the component
     void*              p_app_data,
     EbSvtAv1EncConfiguration  *config_ptr)              // pointer passed back to the client during callbacks
@@ -1803,7 +1803,7 @@ EB_API EbErrorType eb_init_handle(
         return_error = eb_svt_enc_init_parameter(config_ptr);
     }
     if (return_error != EB_ErrorNone) {
-        eb_deinit_encoder(*p_handle);
+        svt_av1_enc_deinit(*p_handle);
         free(*p_handle);
         *p_handle = NULL;
         return return_error;
@@ -1830,12 +1830,12 @@ EbErrorType eb_av1_enc_component_de_init(EbComponentType  *svt_enc_component)
 }
 
 /**********************************
-* eb_deinit_handle
+* svt_av1_enc_deinit_handle
 **********************************/
 #ifdef __GNUC__
 __attribute__((visibility("default")))
 #endif
-EB_API EbErrorType eb_deinit_handle(
+EB_API EbErrorType svt_av1_enc_deinit_handle(
     EbComponentType  *svt_enc_component)
 {
     EbErrorType return_error = EB_ErrorNone;
@@ -3141,7 +3141,7 @@ static void print_lib_params(
 #ifdef __GNUC__
 __attribute__((visibility("default")))
 #endif
-EB_API EbErrorType eb_svt_enc_set_parameter(
+EB_API EbErrorType svt_av1_enc_set_parameter(
     EbComponentType              *svt_enc_component,
     EbSvtAv1EncConfiguration     *config_struct)
 {
@@ -3201,7 +3201,7 @@ EB_API EbErrorType eb_svt_enc_set_parameter(
 #ifdef __GNUC__
 __attribute__((visibility("default")))
 #endif
-EB_API EbErrorType eb_svt_enc_stream_header(
+EB_API EbErrorType svt_av1_enc_stream_header(
     EbComponentType           *svt_enc_component,
     EbBufferHeaderType        **output_stream_ptr)
 {
@@ -3253,7 +3253,7 @@ EB_API EbErrorType eb_svt_enc_stream_header(
 #ifdef __GNUC__
 __attribute__((visibility("default")))
 #endif
-EB_API EbErrorType eb_svt_release_enc_stream_header(
+EB_API EbErrorType svt_av1_enc_stream_header_release(
     EbBufferHeaderType        *stream_header_ptr)
 {
     EbErrorType           return_error = EB_ErrorNone;
@@ -3271,7 +3271,7 @@ EB_API EbErrorType eb_svt_release_enc_stream_header(
 #ifdef __GNUC__
 __attribute__((visibility("default")))
 #endif
-EB_API EbErrorType eb_svt_enc_eos_nal(
+EB_API EbErrorType svt_av1_enc_eos_nal(
     EbComponentType           *svt_enc_component,
     EbBufferHeaderType       **output_stream_ptr
 )
@@ -3465,7 +3465,7 @@ static void copy_input_buffer(
 #ifdef __GNUC__
 __attribute__((visibility("default")))
 #endif
-EB_API EbErrorType eb_svt_enc_send_picture(
+EB_API EbErrorType svt_av1_enc_send_picture(
     EbComponentType      *svt_enc_component,
     EbBufferHeaderType   *p_buffer)
 {
@@ -3510,12 +3510,12 @@ static void copy_output_recon_buffer(
 }
 
 /**********************************
-* eb_svt_get_packet sends out packet
+* svt_av1_enc_get_packet sends out packet
 **********************************/
 #ifdef __GNUC__
 __attribute__((visibility("default")))
 #endif
-EB_API EbErrorType eb_svt_get_packet(
+EB_API EbErrorType svt_av1_enc_get_packet(
     EbComponentType      *svt_enc_component,
     EbBufferHeaderType  **p_buffer,
     unsigned char          pic_send_done)
@@ -3551,7 +3551,7 @@ EB_API EbErrorType eb_svt_get_packet(
 #ifdef __GNUC__
 __attribute__((visibility("default")))
 #endif
-EB_API void eb_svt_release_out_buffer(
+EB_API void svt_av1_enc_release_out_buffer(
     EbBufferHeaderType  **p_buffer)
 {
     if (p_buffer && (*p_buffer)->wrapper_ptr)
@@ -3570,7 +3570,7 @@ EB_API void eb_svt_release_out_buffer(
 #ifdef __GNUC__
 __attribute__((visibility("default")))
 #endif
-EB_API EbErrorType eb_svt_get_recon(
+EB_API EbErrorType svt_av1_get_recon(
     EbComponentType      *svt_enc_component,
     EbBufferHeaderType   *p_buffer)
 {

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
@@ -49,7 +49,7 @@ index d654be5d72..7aa44c3d10 100755
  enabled libspeex          && require_pkg_config libspeex speex speex/speex.h speex_decoder_init
  enabled libsrt            && require_pkg_config libsrt "srt >= 1.3.0" srt/srt.h srt_socket
  enabled libsvthevc        && require_pkg_config libsvthevc SvtHevcEnc EbApi.h EbInitHandle
-+enabled libsvtav1         && require_pkg_config libsvtav1 SvtAv1Enc EbSvtAv1Enc.h eb_init_handle
++enabled libsvtav1         && require_pkg_config libsvtav1 SvtAv1Enc EbSvtAv1Enc.h svt_av1_enc_init_handle
  enabled libtensorflow     && require libtensorflow tensorflow/c/c_api.h TF_Version -ltensorflow
  enabled libtesseract      && require_pkg_config libtesseract tesseract tesseract/capi.h TessBaseAPICreate
  enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -ltheoraenc -ltheoradec -logg
@@ -349,7 +349,7 @@ index 0000000000..4984816830
 +
 +    svt_enc->eos_flag = EOS_NOT_REACHED;
 +
-+    svt_ret = eb_init_handle(&svt_enc->svt_handle, svt_enc, &svt_enc->enc_params);
++    svt_ret = svt_av1_enc_init_handle(&svt_enc->svt_handle, svt_enc, &svt_enc->enc_params);
 +    if (svt_ret != EB_ErrorNone) {
 +        return svt_print_error(avctx, svt_ret, "Error init encoder handle");
 +    }
@@ -360,14 +360,14 @@ index 0000000000..4984816830
 +        return ret;
 +    }
 +
-+    svt_ret = eb_svt_enc_set_parameter(svt_enc->svt_handle, &svt_enc->enc_params);
++    svt_ret = svt_av1_enc_set_parameter(svt_enc->svt_handle, &svt_enc->enc_params);
 +    if (svt_ret != EB_ErrorNone) {
 +        return svt_print_error(avctx, svt_ret, "Error setting encoder parameters");
 +    }
 +
-+    svt_ret = eb_init_encoder(svt_enc->svt_handle);
++    svt_ret = svt_av1_enc_init(svt_enc->svt_handle);
 +    if (svt_ret != EB_ErrorNone) {
-+        eb_deinit_handle(svt_enc->svt_handle);
++        svt_av1_enc_deinit_handle(svt_enc->svt_handle);
 +        svt_enc->svt_handle = NULL;
 +        return svt_print_error(avctx, svt_ret, "Error init encoder");
 +    }
@@ -375,7 +375,7 @@ index 0000000000..4984816830
 +    if (avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER) {
 +        EbBufferHeaderType *headerPtr = NULL;
 +
-+        svt_ret = eb_svt_enc_stream_header(svt_enc->svt_handle, &headerPtr);
++        svt_ret = svt_av1_enc_stream_header(svt_enc->svt_handle, &headerPtr);
 +        if (svt_ret != EB_ErrorNone) {
 +            return svt_print_error(avctx, svt_ret, "Error when build stream header");
 +        }
@@ -390,7 +390,7 @@ index 0000000000..4984816830
 +
 +        memcpy(avctx->extradata, headerPtr->p_buffer, avctx->extradata_size);
 +
-+        svt_ret = eb_svt_release_enc_stream_header(headerPtr);
++        svt_ret = svt_av1_enc_stream_header_release(headerPtr);
 +        if (svt_ret != EB_ErrorNone) {
 +            return svt_print_error(avctx, svt_ret, "Error when destroy stream header");
 +        }
@@ -417,7 +417,7 @@ index 0000000000..4984816830
 +        headerPtrLast.p_buffer     = NULL;
 +        headerPtrLast.flags      = EB_BUFFERFLAG_EOS;
 +
-+        eb_svt_enc_send_picture(svt_enc->svt_handle, &headerPtrLast);
++        svt_av1_enc_send_picture(svt_enc->svt_handle, &headerPtrLast);
 +        svt_enc->eos_flag = EOS_SENT;
 +        av_log(avctx, AV_LOG_DEBUG, "Finish sending frames!!!\n");
 +        return 0;
@@ -429,7 +429,7 @@ index 0000000000..4984816830
 +    headerPtr->p_app_private  = NULL;
 +    headerPtr->pts          = frame->pts;
 +
-+    eb_svt_enc_send_picture(svt_enc->svt_handle, headerPtr);
++    svt_av1_enc_send_picture(svt_enc->svt_handle, headerPtr);
 +
 +    return 0;
 +}
@@ -445,14 +445,14 @@ index 0000000000..4984816830
 +    if (svt_enc->eos_flag == EOS_RECEIVED)
 +        return AVERROR_EOF;
 +
-+    svt_ret = eb_svt_get_packet(svt_enc->svt_handle, &headerPtr, svt_enc->eos_flag);
++    svt_ret = svt_av1_enc_get_packet(svt_enc->svt_handle, &headerPtr, svt_enc->eos_flag);
 +    if (svt_ret == EB_NoErrorEmptyQueue)
 +        return AVERROR(EAGAIN);
 +
 +    ref = av_buffer_pool_get(svt_enc->pool);
 +    if (!ref) {
 +        av_log(avctx, AV_LOG_ERROR, "Failed to allocate output packet.\n");
-+        eb_svt_release_out_buffer(&headerPtr);
++        svt_av1_enc_release_out_buffer(&headerPtr);
 +        return AVERROR(ENOMEM);
 +    }
 +    pkt->buf = ref;
@@ -480,7 +480,7 @@ index 0000000000..4984816830
 +
 +    ff_side_data_set_encoder_stats(pkt, headerPtr->qp * FF_QP2LAMBDA, NULL, 0, pict_type);
 +
-+    eb_svt_release_out_buffer(&headerPtr);
++    svt_av1_enc_release_out_buffer(&headerPtr);
 +
 +    return ret;
 +}
@@ -491,8 +491,8 @@ index 0000000000..4984816830
 +
 +    if (svt_enc) {
 +        if (svt_enc->svt_handle) {
-+            eb_deinit_encoder(svt_enc->svt_handle);
-+            eb_deinit_handle(svt_enc->svt_handle);
++            svt_av1_enc_deinit(svt_enc->svt_handle);
++            svt_av1_enc_deinit_handle(svt_enc->svt_handle);
 +        }
 +
 +        free_buffer(svt_enc);

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -49,7 +49,7 @@ index 8f4f2884cf..d2ffecc9f6 100755
  enabled libssh            && require_pkg_config libssh libssh libssh/sftp.h sftp_init
  enabled libspeex          && require_pkg_config libspeex speex speex/speex.h speex_decoder_init
  enabled libsrt            && require_pkg_config libsrt "srt >= 1.3.0" srt/srt.h srt_socket
-+enabled libsvtav1         && require_pkg_config libsvtav1 SvtAv1Enc EbSvtAv1Enc.h eb_init_handle
++enabled libsvtav1         && require_pkg_config libsvtav1 SvtAv1Enc EbSvtAv1Enc.h svt_av1_enc_init_handle
  enabled libtensorflow     && require libtensorflow tensorflow/c/c_api.h TF_Version -ltensorflow
  enabled libtesseract      && require_pkg_config libtesseract tesseract tesseract/capi.h TessBaseAPICreate
  enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -ltheoraenc -ltheoradec -logg
@@ -349,7 +349,7 @@ index 0000000000..4984816830
 +
 +    svt_enc->eos_flag = EOS_NOT_REACHED;
 +
-+    svt_ret = eb_init_handle(&svt_enc->svt_handle, svt_enc, &svt_enc->enc_params);
++    svt_ret = svt_av1_enc_init_handle(&svt_enc->svt_handle, svt_enc, &svt_enc->enc_params);
 +    if (svt_ret != EB_ErrorNone) {
 +        return svt_print_error(avctx, svt_ret, "Error init encoder handle");
 +    }
@@ -360,14 +360,14 @@ index 0000000000..4984816830
 +        return ret;
 +    }
 +
-+    svt_ret = eb_svt_enc_set_parameter(svt_enc->svt_handle, &svt_enc->enc_params);
++    svt_ret = svt_av1_enc_set_parameter(svt_enc->svt_handle, &svt_enc->enc_params);
 +    if (svt_ret != EB_ErrorNone) {
 +        return svt_print_error(avctx, svt_ret, "Error setting encoder parameters");
 +    }
 +
-+    svt_ret = eb_init_encoder(svt_enc->svt_handle);
++    svt_ret = svt_av1_enc_init(svt_enc->svt_handle);
 +    if (svt_ret != EB_ErrorNone) {
-+        eb_deinit_handle(svt_enc->svt_handle);
++        svt_av1_enc_deinit_handle(svt_enc->svt_handle);
 +        svt_enc->svt_handle = NULL;
 +        return svt_print_error(avctx, svt_ret, "Error init encoder");
 +    }
@@ -375,7 +375,7 @@ index 0000000000..4984816830
 +    if (avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER) {
 +        EbBufferHeaderType *headerPtr = NULL;
 +
-+        svt_ret = eb_svt_enc_stream_header(svt_enc->svt_handle, &headerPtr);
++        svt_ret = svt_av1_enc_stream_header(svt_enc->svt_handle, &headerPtr);
 +        if (svt_ret != EB_ErrorNone) {
 +            return svt_print_error(avctx, svt_ret, "Error when build stream header");
 +        }
@@ -390,7 +390,7 @@ index 0000000000..4984816830
 +
 +        memcpy(avctx->extradata, headerPtr->p_buffer, avctx->extradata_size);
 +
-+        svt_ret = eb_svt_release_enc_stream_header(headerPtr);
++        svt_ret = svt_av1_enc_stream_header_release(headerPtr);
 +        if (svt_ret != EB_ErrorNone) {
 +            return svt_print_error(avctx, svt_ret, "Error when destroy stream header");
 +        }
@@ -417,7 +417,7 @@ index 0000000000..4984816830
 +        headerPtrLast.p_buffer     = NULL;
 +        headerPtrLast.flags      = EB_BUFFERFLAG_EOS;
 +
-+        eb_svt_enc_send_picture(svt_enc->svt_handle, &headerPtrLast);
++        svt_av1_enc_send_picture(svt_enc->svt_handle, &headerPtrLast);
 +        svt_enc->eos_flag = EOS_SENT;
 +        av_log(avctx, AV_LOG_DEBUG, "Finish sending frames!!!\n");
 +        return 0;
@@ -429,7 +429,7 @@ index 0000000000..4984816830
 +    headerPtr->p_app_private  = NULL;
 +    headerPtr->pts          = frame->pts;
 +
-+    eb_svt_enc_send_picture(svt_enc->svt_handle, headerPtr);
++    svt_av1_enc_send_picture(svt_enc->svt_handle, headerPtr);
 +
 +    return 0;
 +}
@@ -445,14 +445,14 @@ index 0000000000..4984816830
 +    if (svt_enc->eos_flag == EOS_RECEIVED)
 +        return AVERROR_EOF;
 +
-+    svt_ret = eb_svt_get_packet(svt_enc->svt_handle, &headerPtr, svt_enc->eos_flag);
++    svt_ret = svt_av1_enc_get_packet(svt_enc->svt_handle, &headerPtr, svt_enc->eos_flag);
 +    if (svt_ret == EB_NoErrorEmptyQueue)
 +        return AVERROR(EAGAIN);
 +
 +    ref = av_buffer_pool_get(svt_enc->pool);
 +    if (!ref) {
 +        av_log(avctx, AV_LOG_ERROR, "Failed to allocate output packet.\n");
-+        eb_svt_release_out_buffer(&headerPtr);
++        svt_av1_enc_release_out_buffer(&headerPtr);
 +        return AVERROR(ENOMEM);
 +    }
 +    pkt->buf = ref;
@@ -480,7 +480,7 @@ index 0000000000..4984816830
 +
 +    ff_side_data_set_encoder_stats(pkt, headerPtr->qp * FF_QP2LAMBDA, NULL, 0, pict_type);
 +
-+    eb_svt_release_out_buffer(&headerPtr);
++    svt_av1_enc_release_out_buffer(&headerPtr);
 +
 +    return ret;
 +}
@@ -491,8 +491,8 @@ index 0000000000..4984816830
 +
 +    if (svt_enc) {
 +        if (svt_enc->svt_handle) {
-+            eb_deinit_encoder(svt_enc->svt_handle);
-+            eb_deinit_handle(svt_enc->svt_handle);
++            svt_av1_enc_deinit(svt_enc->svt_handle);
++            svt_av1_enc_deinit_handle(svt_enc->svt_handle);
 +        }
 +
 +        free_buffer(svt_enc);

--- a/test/api_test/SvtAv1EncApiTest.cc
+++ b/test/api_test/SvtAv1EncApiTest.cc
@@ -25,13 +25,13 @@ namespace {
  *
  * Test strategy: <br>
  * Report a death caused by set a null pointer to function
- * eb_svt_enc_set_parameter, which should not happen <br>
+ * svt_av1_enc_set_parameter, which should not happen <br>
  *
  * Expected result: <br>
- * Capture a signal of death in function eb_svt_enc_set_parameter <br>
+ * Capture a signal of death in function svt_av1_enc_set_parameter <br>
  *
  * Test coverage:
- * eb_svt_enc_set_parameter.
+ * svt_av1_enc_set_parameter.
  */
 TEST(EncApiDeathTest, set_parameter_null_pointer) {
     // death tests: TODO: alert, fix me! fix me!! fix me!!!
@@ -41,12 +41,12 @@ TEST(EncApiDeathTest, set_parameter_null_pointer) {
 
     // initialize encoder and get handle
     EXPECT_EQ(EB_ErrorBadParameter,
-              eb_init_handle(&context.enc_handle, nullptr, nullptr));
+              svt_av1_enc_init_handle(&context.enc_handle, nullptr, nullptr));
     // watch out, function down
     EXPECT_EQ(EB_ErrorBadParameter,
-              eb_svt_enc_set_parameter(context.enc_handle, nullptr));
+              svt_av1_enc_set_parameter(context.enc_handle, nullptr));
     // destory encoder handle
-    EXPECT_EQ(EB_ErrorInvalidComponent, eb_deinit_handle(nullptr));
+    EXPECT_EQ(EB_ErrorInvalidComponent, svt_av1_enc_deinit_handle(nullptr));
     SUCCEED();
 }
 
@@ -69,34 +69,34 @@ TEST(EncApiTest, check_null_pointer) {
     memset(&context, 0, sizeof(context));
 
     // initialize encoder and with all null pointer
-    EXPECT_EQ(EB_ErrorBadParameter, eb_init_handle(nullptr, nullptr, nullptr));
+    EXPECT_EQ(EB_ErrorBadParameter, svt_av1_enc_init_handle(nullptr, nullptr, nullptr));
     // initialize encoder and with all null pointer and get handle
     EXPECT_EQ(EB_ErrorBadParameter,
-              eb_init_handle(&context.enc_handle, nullptr, nullptr));
+              svt_av1_enc_init_handle(&context.enc_handle, nullptr, nullptr));
     // setup encoder parameters with null pointer
-    EXPECT_EQ(EB_ErrorBadParameter, eb_svt_enc_set_parameter(nullptr, nullptr));
+    EXPECT_EQ(EB_ErrorBadParameter, svt_av1_enc_set_parameter(nullptr, nullptr));
     // TODO: Some function will crash with nullptr input,
     // and it will block test on linux platform. please refer to
     // EncApiDeathTest-->check_null_pointer
     // EXPECT_EQ(EB_ErrorBadParameter,
-    //          eb_svt_enc_set_parameter(context.enc_handle,
+    //          svt_av1_enc_set_parameter(context.enc_handle,
     //          nullptr));
     // open encoder with null pointer
-    EXPECT_EQ(EB_ErrorBadParameter, eb_init_encoder(nullptr));
+    EXPECT_EQ(EB_ErrorBadParameter, svt_av1_enc_init(nullptr));
     // get stream header with null pointer
-    EXPECT_EQ(EB_ErrorBadParameter, eb_svt_enc_stream_header(nullptr, nullptr));
+    EXPECT_EQ(EB_ErrorBadParameter, svt_av1_enc_stream_header(nullptr, nullptr));
     // get end of sequence NAL with null pointer
-    //EXPECT_EQ(EB_ErrorBadParameter, eb_svt_enc_eos_nal(nullptr, nullptr));
-    // EXPECT_EQ(EB_ErrorBadParameter, eb_svt_enc_send_picture(nullptr,
-    // nullptr)); EXPECT_EQ(EB_ErrorBadParameter, eb_svt_get_packet(nullptr,
-    // nullptr, 0)); EXPECT_EQ(EB_ErrorBadParameter, eb_svt_get_recon(nullptr,
+    //EXPECT_EQ(EB_ErrorBadParameter, svt_av1_enc_eos_nal(nullptr, nullptr));
+    // EXPECT_EQ(EB_ErrorBadParameter, svt_av1_enc_send_picture(nullptr,
+    // nullptr)); EXPECT_EQ(EB_ErrorBadParameter, svt_av1_enc_get_packet(nullptr,
+    // nullptr, 0)); EXPECT_EQ(EB_ErrorBadParameter, svt_av1_get_recon(nullptr,
     // nullptr)); No return value, just feed nullptr as parameter.
     // release output buffer with null pointer
-    eb_svt_release_out_buffer(nullptr);
+    svt_av1_enc_release_out_buffer(nullptr);
     // close encoder with null pointer
-    EXPECT_EQ(EB_ErrorBadParameter, eb_deinit_encoder(nullptr));
+    EXPECT_EQ(EB_ErrorBadParameter, svt_av1_enc_deinit(nullptr));
     // destory encoder handle with null pointer
-    EXPECT_EQ(EB_ErrorInvalidComponent, eb_deinit_handle(nullptr));
+    EXPECT_EQ(EB_ErrorInvalidComponent, svt_av1_enc_deinit_handle(nullptr));
     SUCCEED();
 }
 
@@ -127,24 +127,24 @@ TEST(EncApiTest, DISABLED_check_normal_setup) {
     // initialize encoder and get handle
     EXPECT_EQ(
         EB_ErrorNone,
-        eb_init_handle(&context.enc_handle, &context, &context.enc_params))
-        << "eb_init_handle failed";
+        svt_av1_enc_init_handle(&context.enc_handle, &context, &context.enc_params))
+        << "svt_av1_enc_init_handle failed";
     // setup source width/height with default value
     context.enc_params.source_width = width;
     context.enc_params.source_height = height;
     // setup encoder parameters with all default
     EXPECT_EQ(EB_ErrorNone,
-              eb_svt_enc_set_parameter(context.enc_handle, &context.enc_params))
-        << "eb_svt_enc_set_parameter failed";
+              svt_av1_enc_set_parameter(context.enc_handle, &context.enc_params))
+        << "svt_av1_enc_set_parameter failed";
     // open encoder
-    EXPECT_EQ(EB_ErrorNone, eb_init_encoder(context.enc_handle))
-        << "eb_init_encoder failed";
+    EXPECT_EQ(EB_ErrorNone, svt_av1_enc_init(context.enc_handle))
+        << "svt_av1_enc_init failed";
     // close encoder
-    EXPECT_EQ(EB_ErrorNone, eb_deinit_encoder(context.enc_handle))
-        << "eb_deinit_encoder failed";
+    EXPECT_EQ(EB_ErrorNone, svt_av1_enc_deinit(context.enc_handle))
+        << "svt_av1_enc_deinit failed";
     // destory encoder
-    EXPECT_EQ(EB_ErrorNone, eb_deinit_handle(context.enc_handle))
-        << "eb_deinit_handle failed";
+    EXPECT_EQ(EB_ErrorNone, svt_av1_enc_deinit_handle(context.enc_handle))
+        << "svt_av1_enc_deinit_handle failed";
 }
 
 /** @brief repeat_normal_setup is a api test case
@@ -175,23 +175,23 @@ TEST(EncApiTest, DISABLED_repeat_normal_setup) {
         // initialize encoder and get handle
         ASSERT_EQ(
             EB_ErrorNone,
-            eb_init_handle(&context.enc_handle, &context, &context.enc_params))
-            << "eb_init_handle failed at " << i << " times";
+            svt_av1_enc_init_handle(&context.enc_handle, &context, &context.enc_params))
+            << "svt_av1_enc_init_handle failed at " << i << " times";
         // setup source width/height with default value
         context.enc_params.source_width = width;
         context.enc_params.source_height = height;
         // setup encoder parameters with all default
         ASSERT_EQ(
             EB_ErrorNone,
-            eb_svt_enc_set_parameter(context.enc_handle, &context.enc_params))
-            << "eb_svt_enc_set_parameter failed at " << i << " times";
-        // TODO:if not calls eb_deinit_encoder, there is huge memory leak, fix
+            svt_av1_enc_set_parameter(context.enc_handle, &context.enc_params))
+            << "svt_av1_enc_set_parameter failed at " << i << " times";
+        // TODO:if not calls svt_av1_enc_deinit, there is huge memory leak, fix
         // me
-        // ASSERT_EQ(EB_ErrorNone, eb_deinit_encoder(context.enc_handle))
-        //    << "eb_deinit_encoder failed";
+        // ASSERT_EQ(EB_ErrorNone, svt_av1_enc_deinit(context.enc_handle))
+        //    << "svt_av1_enc_deinit failed";
         // destory encoder
-        ASSERT_EQ(EB_ErrorNone, eb_deinit_handle(context.enc_handle))
-            << "eb_deinit_handle failed at " << i << " times";
+        ASSERT_EQ(EB_ErrorNone, svt_av1_enc_deinit_handle(context.enc_handle))
+            << "svt_av1_enc_deinit_handle failed at " << i << " times";
     }
 }
 

--- a/test/api_test/SvtAv1EncParamsTest.cc
+++ b/test/api_test/SvtAv1EncParamsTest.cc
@@ -69,8 +69,8 @@ class EncParamTestBase : public ::testing::Test {
     virtual void SetUp() override {
         // initialize encoder and get handle
         ASSERT_EQ(EB_ErrorNone,
-                  eb_init_handle(&ctxt_.enc_handle, &ctxt_, &ctxt_.enc_params))
-            << "eb_init_handle failed";
+                  svt_av1_enc_init_handle(&ctxt_.enc_handle, &ctxt_, &ctxt_.enc_params))
+            << "svt_av1_enc_init_handle failed";
         // setup encoder parameters with all default
         ASSERT_NE(nullptr, ctxt_.enc_handle) << "enc_handle is invalid";
         // setup source width/height with default if not in test source_width or
@@ -87,15 +87,15 @@ class EncParamTestBase : public ::testing::Test {
 
     // Tears down the test fixture.
     virtual void TearDown() override {
-        // TODO: eb_deinit_encoder should not be called here, for this test does
-        // not call eb_init_encoder, but there is huge memory leak if only calls
-        // eb_deinit_handle. please remmove it after we pass
+        // TODO: svt_av1_enc_deinit should not be called here, for this test does
+        // not call svt_av1_enc_init, but there is huge memory leak if only calls
+        // svt_av1_enc_deinit_handle. please remmove it after we pass
         // EncApiTest-->repeat_normal_setup
-        ASSERT_EQ(EB_ErrorNone, eb_deinit_encoder(ctxt_.enc_handle))
-            << "eb_deinit_encoder failed";
+        ASSERT_EQ(EB_ErrorNone, svt_av1_enc_deinit(ctxt_.enc_handle))
+            << "svt_av1_enc_deinit failed";
         // destory encoder
-        ASSERT_EQ(EB_ErrorNone, eb_deinit_handle(ctxt_.enc_handle))
-            << "eb_deinit_handle failed";
+        ASSERT_EQ(EB_ErrorNone, svt_av1_enc_deinit_handle(ctxt_.enc_handle))
+            << "svt_av1_enc_deinit_handle failed";
     }
 
     /** setup some of the params with related params modified before set
@@ -138,11 +138,11 @@ class EncParamTestBase : public ::testing::Test {
 
 /** Marcro defininition of printing parameter name when in failed */
 #define PRINT_PARAM_FATAL(p) \
-    << "eb_svt_enc_set_parameter " << #p << ": " << (int)(p) << " failed"
+    << "svt_av1_enc_set_parameter " << #p << ": " << (int)(p) << " failed"
 
 /** Marcro defininition of printing 2 parameters name when in failed */
 #define PRINT_2PARAM_FATAL(p1, p2)                                             \
-    << "eb_svt_enc_set_parameter " << #p1 << ": " << (int)(p1) << " + " << #p2 \
+    << "svt_av1_enc_set_parameter " << #p1 << ": " << (int)(p1) << " + " << #p2 \
     << ": " << (int)(p2) << " failed"
 
 /** Marcro defininition of batch processing check for default, valid, invalid
@@ -175,7 +175,7 @@ class EncParamTestBase : public ::testing::Test {
                 ctxt_.enc_params.param_name = GET_VALID_PARAM(param_name, i); \
                 config_enc_param();                                           \
                 EXPECT_EQ(EB_ErrorNone,                                       \
-                          eb_svt_enc_set_parameter(ctxt_.enc_handle,          \
+                          svt_av1_enc_set_parameter(ctxt_.enc_handle,          \
                                                    &ctxt_.enc_params))        \
                 PRINT_PARAM_FATAL(ctxt_.enc_params.param_name);               \
                 EncParamTestBase::TearDown();                                 \
@@ -188,7 +188,7 @@ class EncParamTestBase : public ::testing::Test {
                     GET_INVALID_PARAM(param_name, i);                         \
                 config_enc_param();                                           \
                 EXPECT_EQ(EB_ErrorBadParameter,                               \
-                          eb_svt_enc_set_parameter(ctxt_.enc_handle,          \
+                          svt_av1_enc_set_parameter(ctxt_.enc_handle,          \
                                                    &ctxt_.enc_params))        \
                 PRINT_PARAM_FATAL(ctxt_.enc_params.param_name);               \
                 EncParamTestBase::TearDown();                                 \

--- a/test/e2e_test/ConfigEncoder.cc
+++ b/test/e2e_test/ConfigEncoder.cc
@@ -31,7 +31,7 @@ int copy_enc_param(EbSvtAv1EncConfiguration *dst_enc_config, void *config_ptr) {
     EbAppContext app_ctx;
     EbConfig *config = (EbConfig *)config_ptr;
     // Initial app_ctx.eb_enc_parameters by copying from dst_enc_config,
-    // which should be initialed in eb_init_handle
+    // which should be initialed in svt_av1_enc_init_handle
     memcpy(&app_ctx.eb_enc_parameters,
            dst_enc_config,
            sizeof(EbSvtAv1EncConfiguration));

--- a/test/e2e_test/SvtAv1E2EFramework.cc
+++ b/test/e2e_test/SvtAv1E2EFramework.cc
@@ -167,12 +167,12 @@ void SvtAv1E2ETestFramework::init_test(TestVideoVector &test_vector) {
     //
     // Init handle
     //
-    return_error = eb_init_handle(
+    return_error = svt_av1_enc_init_handle(
         &av1enc_ctx_.enc_handle, &av1enc_ctx_, &av1enc_ctx_.enc_params);
     ASSERT_EQ(return_error, EB_ErrorNone)
-        << "eb_init_handle return error:" << return_error;
+        << "svt_av1_enc_init_handle return error:" << return_error;
     ASSERT_NE(av1enc_ctx_.enc_handle, nullptr)
-        << "eb_init_handle return null handle.";
+        << "svt_av1_enc_init_handle return null handle.";
     setup_src_param(video_src_, av1enc_ctx_.enc_params);
     av1enc_ctx_.enc_params.recon_enabled = 0;
 
@@ -219,23 +219,23 @@ void SvtAv1E2ETestFramework::init_test(TestVideoVector &test_vector) {
     }
 
     // set the parameter to encoder
-    return_error = eb_svt_enc_set_parameter(av1enc_ctx_.enc_handle,
+    return_error = svt_av1_enc_set_parameter(av1enc_ctx_.enc_handle,
                                             &av1enc_ctx_.enc_params);
     ASSERT_EQ(return_error, EB_ErrorNone)
-        << "eb_svt_enc_set_parameter return error:" << return_error;
+        << "svt_av1_enc_set_parameter return error:" << return_error;
 
     // initial encoder
-    return_error = eb_init_encoder(av1enc_ctx_.enc_handle);
+    return_error = svt_av1_enc_init(av1enc_ctx_.enc_handle);
     ASSERT_EQ(return_error, EB_ErrorNone)
-        << "eb_init_encoder return error:" << return_error;
+        << "svt_av1_enc_init return error:" << return_error;
 
     // Get ivf header
-    return_error = eb_svt_enc_stream_header(av1enc_ctx_.enc_handle,
+    return_error = svt_av1_enc_stream_header(av1enc_ctx_.enc_handle,
                                             &av1enc_ctx_.output_stream_buffer);
     ASSERT_EQ(return_error, EB_ErrorNone)
-        << "eb_svt_enc_stream_header return error:" << return_error;
+        << "svt_av1_enc_stream_header return error:" << return_error;
     ASSERT_NE(av1enc_ctx_.output_stream_buffer, nullptr)
-        << "eb_svt_enc_stream_header return null output buffer."
+        << "svt_av1_enc_stream_header return null output buffer."
         << return_error;
 
 #if TILES_PARALLEL
@@ -267,14 +267,14 @@ void SvtAv1E2ETestFramework::init_test(TestVideoVector &test_vector) {
 }
 
 void SvtAv1E2ETestFramework::deinit_test() {
-    EbErrorType return_error = eb_deinit_encoder(av1enc_ctx_.enc_handle);
+    EbErrorType return_error = svt_av1_enc_deinit(av1enc_ctx_.enc_handle);
     ASSERT_EQ(return_error, EB_ErrorNone)
-        << "eb_deinit_encoder return error:" << return_error;
+        << "svt_av1_enc_deinit return error:" << return_error;
 
     // Destruct the component
-    return_error = eb_deinit_handle(av1enc_ctx_.enc_handle);
+    return_error = svt_av1_enc_deinit_handle(av1enc_ctx_.enc_handle);
     ASSERT_EQ(return_error, EB_ErrorNone)
-        << "eb_deinit_handle return error:" << return_error;
+        << "svt_av1_enc_deinit_handle return error:" << return_error;
     av1enc_ctx_.enc_handle = nullptr;
 
     // Clear the intput and output buffer
@@ -402,10 +402,10 @@ void SvtAv1E2ETestFramework::run_encode_process() {
                         video_src_->get_frame_qp(video_src_->get_frame_index());
                     // Send the picture
                     EXPECT_EQ(EB_ErrorNone,
-                              return_error = eb_svt_enc_send_picture(
+                              return_error = svt_av1_enc_send_picture(
                                   av1enc_ctx_.enc_handle,
                                   av1enc_ctx_.input_picture_buffer))
-                        << "eb_svt_enc_send_picture error at: "
+                        << "svt_av1_enc_send_picture error at: "
                         << av1enc_ctx_.input_picture_buffer->pts;
                 }
 
@@ -422,9 +422,9 @@ void SvtAv1E2ETestFramework::run_encode_process() {
                     headerPtrLast.pic_type = EB_AV1_INVALID_PICTURE;
                     av1enc_ctx_.input_picture_buffer->flags = EB_BUFFERFLAG_EOS;
                     EXPECT_EQ(EB_ErrorNone,
-                              return_error = eb_svt_enc_send_picture(
+                              return_error = svt_av1_enc_send_picture(
                                   av1enc_ctx_.enc_handle, &headerPtrLast))
-                        << "eb_svt_enc_send_picture EOS error";
+                        << "svt_av1_enc_send_picture EOS error";
                 }
             }
         }
@@ -446,7 +446,7 @@ void SvtAv1E2ETestFramework::run_encode_process() {
                     TimeAutoCount counter(ENCODING, collect_);
                     uint8_t pic_send_done =
                         (src_file_eos && rec_file_eos) ? 1 : 0;
-                    return_error = eb_svt_get_packet(
+                    return_error = svt_av1_enc_get_packet(
                         av1enc_ctx_.enc_handle, &enc_out, pic_send_done);
                     ASSERT_NE(return_error, EB_ErrorMax)
                         << "Error while encoding, code:" << enc_out->flags;
@@ -477,7 +477,7 @@ void SvtAv1E2ETestFramework::run_encode_process() {
 
                 // Release the output buffer
                 if (enc_out != nullptr)
-                    eb_svt_release_out_buffer(&enc_out);
+                    svt_av1_enc_release_out_buffer(&enc_out);
             } while (src_file_eos);
         }  // if (!enc_file_eos)
     } while (!rec_file_eos || !src_file_eos || !enc_file_eos);
@@ -696,7 +696,7 @@ void SvtAv1E2ETestFramework::get_recon_frame(const SvtAv1Context &ctxt,
         recon_frame.p_app_private = nullptr;
         // non-blocking call until all input frames are sent
         EbErrorType recon_status =
-            eb_svt_get_recon(ctxt.enc_handle, &recon_frame);
+            svt_av1_get_recon(ctxt.enc_handle, &recon_frame);
         ASSERT_NE(recon_status, EB_ErrorMax)
             << "Error while outputing recon, code:" << recon_frame.flags;
         if (recon_status == EB_NoErrorEmptyQueue) {


### PR DESCRIPTION
sending this PR primarily for gathering feedback on API namespacing, I do not
actually expect it to be merged in its current form.

SVT-AV1 currently uses `eb_` as the prefix for public functions, but I see
multiple problems with it:
-    it is used across several separate projects, causing symbol conflicts
-    it is used for both public and private functions, making it harder to
     distinguish between them
-    as far as I can tell, it's used mainly for historical reasons and it does
     not carry much meaning for the API users

Since the library API is not stable yet, these problems can still be addressed
without breaking compatibility. It thus seems reasonable to pick a prefix that
would be
-    meaningful for the end-users
-    unique for SVT-AV1
-    used for public functions only (it would also be good to pick a consistent
     prefix to be used for non-static private functions, to avoid conflicts with
     static linking, but that's a separate question)
-    ideally short, so it's easy to write
and officially document it as the reserved namespace for this library.

I am proposing `svt_av1_` in this PR. It satisfies all the points above, except
possibly the last one. `svtav1_` is also possible, but starts looking like
character soup, which is IMO not worth it for saving one character.

Thoughts? Opinions? Bikeshed colorscheme preferenes? Do you even see this as
a worthwhile issue to address?