### PR TITLE
EbProductCodingLoop: fix valgrind errors

### DIFF
--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -613,6 +613,8 @@ void init_sq_nsq_block(SequenceControlSet *scs_ptr, ModeDecisionContext *context
     do {
         const BlockGeom *blk_geom                              = get_blk_geom_mds(blk_idx);
         context_ptr->md_local_blk_unit[blk_idx].avail_blk_flag = EB_FALSE;
+        context_ptr->md_local_blk_unit[blk_idx].left_neighbor_partition = INVALID_NEIGHBOR_DATA;
+        context_ptr->md_local_blk_unit[blk_idx].above_neighbor_partition = INVALID_NEIGHBOR_DATA;
         if (blk_geom->shape == PART_N) {
             context_ptr->md_blk_arr_nsq[blk_idx].split_flag         = EB_TRUE;
             context_ptr->md_blk_arr_nsq[blk_idx].part               = PARTITION_SPLIT;
@@ -628,6 +630,8 @@ void init_sq_non4_block(SequenceControlSet *scs_ptr, ModeDecisionContext *contex
     }
     for (uint32_t blk_idx = 0; blk_idx < scs_ptr->max_block_cnt; ++blk_idx) {
         context_ptr->md_local_blk_unit[blk_idx].avail_blk_flag = EB_FALSE;
+        context_ptr->md_local_blk_unit[blk_idx].left_neighbor_partition = INVALID_NEIGHBOR_DATA;
+        context_ptr->md_local_blk_unit[blk_idx].above_neighbor_partition = INVALID_NEIGHBOR_DATA;
     }
 }
 static INLINE TranHigh check_range(TranHigh input, int32_t bd) {


### PR DESCRIPTION
==21579== Conditional jump or move depends on uninitialised value(s)
==21579==    at 0x4A4BFEC: av1_split_flag_rate (Source/Lib/Encoder/Codec/EbRateDistortionCost.c:2554)
==21579==    by 0x4947D02: d1_non_square_block_decision (Source/Lib/Encoder/Codec/EbFullLoop.c:3284)
==21579==    by 0x4A2D9AB: mode_decision_sb (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:6787)
==21579==    by 0x4916459: enc_dec_kernel (Source/Lib/Encoder/Codec/EbEncDecProcess.c:2766)
==21579==    by 0xF3AC668: start_thread (pthread_create.c:479)
==21579==    by 0xF637322: clone (clone.S:95)

==21579== Conditional jump or move depends on uninitialised value(s)
==21579==    at 0x4A4C057: av1_split_flag_rate (Source/Lib/Encoder/Codec/EbRateDistortionCost.c:2559)
==21579==    by 0x4947D02: d1_non_square_block_decision (Source/Lib/Encoder/Codec/EbFullLoop.c:3284)
==21579==    by 0x4A2D9AB: mode_decision_sb (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:6787)
==21579==    by 0x4916459: enc_dec_kernel (Source/Lib/Encoder/Codec/EbEncDecProcess.c:2766)
==21579==    by 0xF3AC668: start_thread (pthread_create.c:479)
==21579==    by 0xF637322: clone (clone.S:95)
