### PR TITLE
Support manual prediction structure

### DIFF
--- a/Config/PredStruct_level0.cfg
+++ b/Config/PredStruct_level0.cfg
@@ -1,0 +1,7 @@
+#
+# Copyright(c) 2020 Tencent Corporation
+# SPDX - License - Identifier: BSD - 2 - Clause - Patent
+#
+
+#keyword           display_order decode_order temporal_layer num_ref_list0 num_ref_list1 diff_poc_ref_list0 diff_poc_ref_list1
+PredStructEntry :  0             0            0              2             2             1 2                1 2

--- a/Config/PredStruct_level1.cfg
+++ b/Config/PredStruct_level1.cfg
@@ -1,0 +1,8 @@
+#
+# Copyright(c) 2020 Tencent Corporation
+# SPDX - License - Identifier: BSD - 2 - Clause - Patent
+#
+
+#keyword           display_order decode_order temporal_layer num_ref_list0 num_ref_list1 diff_poc_ref_list0 diff_poc_ref_list1
+PredStructEntry :  0             1            1              2             1             1 3                -1
+PredStructEntry :  1             0            0              2             2             2 4                2 4

--- a/Config/PredStruct_level2.cfg
+++ b/Config/PredStruct_level2.cfg
@@ -1,0 +1,10 @@
+#
+# Copyright(c) 2020 Tencent Corporation
+# SPDX - License - Identifier: BSD - 2 - Clause - Patent
+#
+
+#keyword           display_order decode_order temporal_layer num_ref_list0 num_ref_list1 diff_poc_ref_list0 diff_poc_ref_list1
+PredStructEntry :  0             2            2              3             2             1 3 5              -1 -3
+PredStructEntry :  1             1            1              3             1             2 4 6              -2
+PredStructEntry :  2             3            2              3             1             1 3 2              -1
+PredStructEntry :  3             0            0              2             2             4 8                4 8

--- a/Config/PredStruct_level3.cfg
+++ b/Config/PredStruct_level3.cfg
@@ -1,0 +1,14 @@
+#
+# Copyright(c) 2020 Tencent Corporation
+# SPDX - License - Identifier: BSD - 2 - Clause - Patent
+#
+
+#keyword           display_order decode_order temporal_layer num_ref_list0 num_ref_list1 diff_poc_ref_list0 diff_poc_ref_list1
+PredStructEntry :  0             3            3              4             3             1 3 5 8            -1 -3 -7
+PredStructEntry :  1             2            2              4             2             2 4 6 10           -2 -6
+PredStructEntry :  2             4            3              4             2             1 3 2 5            -1 -5
+PredStructEntry :  3             1            1              3             1             4 8 12             -4
+PredStructEntry :  4             6            3              4             2             1 3 5 4            -1 -3
+PredStructEntry :  5             5            2              4             1             2 4 6 10           -2
+PredStructEntry :  6             7            3              4             1             1 3 5 6            -1
+PredStructEntry :  7             0            0              1             1             8                   8

--- a/Config/PredStruct_level4.cfg
+++ b/Config/PredStruct_level4.cfg
@@ -1,0 +1,22 @@
+#
+# Copyright(c) 2020 Tencent Corporation
+# SPDX - License - Identifier: BSD - 2 - Clause - Patent
+#
+
+#keyword           display_order decode_order temporal_layer num_ref_list0 num_ref_list1 diff_poc_ref_list0 diff_poc_ref_list1
+PredStructEntry :  0             4            4              4             3             1 9 8 17           -1 -3 -7
+PredStructEntry :  1             3            3              4             3             2 4 10 18          -2 -6 -14
+PredStructEntry :  2             5            4              4             3             1 3 2 11           -1 -5 -13
+PredStructEntry :  3             2            2              4             2             4 8 12 20          -4 -12
+PredStructEntry :  4             7            4              4             3             1 5 4 13           -1 -3 -11
+PredStructEntry :  5             6            3              4             2             2 4 6 14           -2 -10
+PredStructEntry :  6             8            4              4             2             1 3 6 7            -1 -9
+PredStructEntry :  7             1            1              3             1             8 16 24            -8
+PredStructEntry :  8             11           4              4             3             1 9 8 17           -1 -3 -7
+PredStructEntry :  9             10           3              4             2             2 4 10 18          -2 -6
+PredStructEntry :  10            12           4              4             2             1 3 2 11           -1 -5
+PredStructEntry :  11            9            2              3             1             4 8 12             -4
+PredStructEntry :  12            14           4              4             2             1 5 4 13           -1 -3
+PredStructEntry :  13            13           3              4             1             2 4 6 14           -2
+PredStructEntry :  14            15           4              4             1             1 3 6 7            -1
+PredStructEntry :  15            0            0              2             2             16 48              16 32

--- a/Config/PredStruct_level5.cfg
+++ b/Config/PredStruct_level5.cfg
@@ -1,0 +1,38 @@
+#
+# Copyright(c) 2020 Tencent Corporation
+# SPDX - License - Identifier: BSD - 2 - Clause - Patent
+#
+
+#keyword           display_order decode_order temporal_layer num_ref_list0 num_ref_list1 diff_poc_ref_list0 diff_poc_ref_list1
+PredStructEntry :  0             5            5              1             1             1                  -1
+PredStructEntry :  1             4            4              1             1             2                  -2
+PredStructEntry :  2             6            5              1             1             1                  -1
+PredStructEntry :  3             3            3              1             1             4                  -4
+PredStructEntry :  4             8            5              1             1             1                  -1
+PredStructEntry :  5             7            4              1             1             2                  -2
+PredStructEntry :  6             9            5              1             1             1                  -1
+PredStructEntry :  7             2            2              1             1             8                  -8
+PredStructEntry :  8             12           5              1             1             1                  -1
+PredStructEntry :  9             11           4              1             1             2                  -2
+PredStructEntry :  10            13           5              1             1             1                  -1
+PredStructEntry :  11            10           3              1             1             4                  -4
+PredStructEntry :  12            15           5              1             1             1                  -1
+PredStructEntry :  13            14           4              1             1             2                  -2
+PredStructEntry :  14            16           5              1             1             1                  -1
+PredStructEntry :  15            1            1              1             1             16                 -16
+PredStructEntry :  16            20           5              1             1             1                  -1
+PredStructEntry :  17            19           4              1             1             2                  -2
+PredStructEntry :  18            21           5              1             1             1                  -1
+PredStructEntry :  19            18           3              1             1             4                  -4
+PredStructEntry :  20            23           5              1             1             1                  -1
+PredStructEntry :  21            22           4              1             1             2                  -2
+PredStructEntry :  22            24           5              1             1             1                  -1
+PredStructEntry :  23            17           2              1             1             8                  -8
+PredStructEntry :  24            27           5              1             1             1                  -1
+PredStructEntry :  25            26           4              1             1             2                  -2
+PredStructEntry :  26            28           5              1             1             1                  -1
+PredStructEntry :  27            25           3              1             1             4                  -4
+PredStructEntry :  28            30           5              1             1             1                  -1
+PredStructEntry :  29            29           4              1             1             2                  -2
+PredStructEntry :  30            31           5              1             1             1                  -1
+PredStructEntry :  31            0            0              1             1             32                 -32

--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -129,6 +129,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **EncoderMode2p** | -enc-mode-2p | [0 - 8] | 8 | Encoder Preset [0,1,2,3,4,5,6,7,8] 0 = highest quality, 8 = highest speed. Passed to encoder's first pass to use the ME settings of the second pass to achieve better bdRate|
 | **InputStatFile** | -input-stat-file | any string | Null | Input stat file for second pass|
 | **OutputStatFile** | -output-stat-file | any string | Null | Output stat file for first pass|
+| **PredStructFile** | -pred-struct-file | any string | Null | Manual prediction structure file path,refer to the comments in the Config/PredStruct_level0~5.cfg for specific details|
 | **EncoderMode** | -enc-mode | [0 - 8] | 8 | Encoder Preset [0,1,2,3,4,5,6,7,8] 0 = highest quality, 8 = highest speed |
 | **EncoderBitDepth** | -bit-depth | [8 , 10] | 8 | specifies the bit depth of the input video |
 | **CompressedTenBitFormat** | -compressed-ten-bit-format | [0 - 1] | 0 | Offline packing of the 2bits: requires two bits packed input (0: OFF, 1: ON) |

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -17,6 +17,8 @@ extern "C" {
 //***HME***
 #define EB_HME_SEARCH_AREA_COLUMN_MAX_COUNT 2
 #define EB_HME_SEARCH_AREA_ROW_MAX_COUNT 2
+#define MAX_HIERARCHICAL_LEVEL 6
+#define REF_LIST_MAX_DEPTH 4
 
 #define MAX_ENC_PRESET 8
 
@@ -29,6 +31,19 @@ extern "C" {
 #define EB_BUFFERFLAG_IS_ALT_REF 0x00000008 // signals that the packet contains an ALT_REF frame
 #define EB_BUFFERFLAG_ERROR_MASK \
     0xFFFFFFF0 // mask for signalling error assuming top flags fit in 4 bits. To be changed, if more flags are added.
+
+/************************************************
+ * Prediction Structure Config Entry
+ *   Contains the basic reference lists and
+ *   configurations for each Prediction Structure
+ *   Config Entry.
+ ************************************************/
+typedef struct PredictionStructureConfigEntry {
+  uint32_t temporal_layer_index;
+  uint32_t decode_order;
+  int32_t ref_list0[REF_LIST_MAX_DEPTH];
+  int32_t ref_list1[REF_LIST_MAX_DEPTH];
+} PredictionStructureConfigEntry;
 
 // super-res modes
 typedef enum {
@@ -595,6 +610,17 @@ typedef struct EbSvtAv1EncConfiguration {
     // signal for automax_partition; on by default
     uint8_t enable_auto_max_partition;
 
+  /* Prediction Structure user defined
+   */
+  PredictionStructureConfigEntry pred_struct[1 << (MAX_HIERARCHICAL_LEVEL - 1)];
+  /* Flag to enable use prediction structure user defined
+   *
+   * Default is false. */
+  EbBool enable_manual_pred_struct;
+  /* The minigop size of prediction structure user defined
+   *
+   * Default is 0. */
+  int32_t manual_pred_struct_entry_num;
 } EbSvtAv1EncConfiguration;
 
 /* STEP 1: Call the library to construct a Component Handle.

--- a/Source/API/EbSvtAv1ErrorCodes.h
+++ b/Source/API/EbSvtAv1ErrorCodes.h
@@ -222,6 +222,7 @@ typedef enum ENCODER_ERROR_CODES {
     EB_ENC_PD_ERROR6 = 0x2105,
     EB_ENC_PD_ERROR7 = 0x2106,
     EB_ENC_PD_ERROR8 = 0x2107,
+    EB_ENC_PD_ERROR9 = 0x2108,
 } ENCODER_ERROR_CODES;
 
 #ifdef __cplusplus

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -159,6 +159,7 @@ typedef struct EbConfig {
     FILE *        qp_file;
     FILE *        input_stat_file;
     FILE *        output_stat_file;
+    FILE *        input_pred_struct_file;
     EbBool        use_input_stat_file;
     EbBool        use_output_stat_file;
     EbBool        y4m_input;
@@ -464,6 +465,10 @@ typedef struct EbConfig {
     // signal for enabling shortcut to skip search depths
     uint8_t enable_auto_max_partition;
 
+    // prediction structure
+    PredictionStructureConfigEntry pred_struct[1 << (MAX_HIERARCHICAL_LEVEL - 1)];
+    EbBool enable_manual_pred_struct;
+    int32_t manual_pred_struct_entry_num;
 } EbConfig;
 
 extern void eb_config_ctor(EbConfig *config_ptr);

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -8,6 +8,7 @@
  ***************************************/
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "EbAppContext.h"
 #include "EbAppConfig.h"
@@ -229,6 +230,13 @@ EbErrorType copy_configuration_parameters(EbConfig *config, EbAppContext *callba
     callback_data->eb_enc_parameters.md_stage_1_class_prune_th = config->md_stage_1_class_prune_th;
     callback_data->eb_enc_parameters.md_stage_2_cand_prune_th  = config->md_stage_2_cand_prune_th;
     callback_data->eb_enc_parameters.md_stage_2_class_prune_th = config->md_stage_2_class_prune_th;
+
+    // Prediction Structure
+    callback_data->eb_enc_parameters.enable_manual_pred_struct    = config->enable_manual_pred_struct;
+    if (callback_data->eb_enc_parameters.enable_manual_pred_struct) {
+        callback_data->eb_enc_parameters.manual_pred_struct_entry_num = config->manual_pred_struct_entry_num;
+        memcpy(&callback_data->eb_enc_parameters.pred_struct[0], &config->pred_struct[0],config->manual_pred_struct_entry_num*sizeof(PredictionStructureConfigEntry));
+    }
 
     return return_error;
 }

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <stddef.h>
 #include "EbSvtAv1.h"
+#include "EbSvtAv1Enc.h"
 #ifdef _WIN32
 #define inline __inline
 #elif __GNUC__
@@ -2397,9 +2398,7 @@ void(*error_handler)(
 #define MAX_SUPERRES_DENOM                          16
 
 //***Prediction Structure***
-#define REF_LIST_MAX_DEPTH                          4 // NM - To be specified
 #define MAX_TEMPORAL_LAYERS                         6
-#define MAX_HIERARCHICAL_LEVEL                      6
 #define MAX_REF_IDX                                 4
 #define INVALID_POC                                 (((uint32_t) (~0)) - (((uint32_t) (~0)) >> 1))
 #define MAX_ELAPSED_IDR_COUNT                       1024

--- a/Source/Lib/Encoder/Codec/EbEncodeContext.h
+++ b/Source/Lib/Encoder/Codec/EbEncodeContext.h
@@ -40,6 +40,24 @@
 #define RC_GROUP_IN_GOP_MAX_NUMBER 512
 #define PICTURE_IN_RC_GROUP_MAX_NUMBER 64
 
+typedef struct DpbDependentList
+{
+    int32_t                              list[1 << MAX_TEMPORAL_LAYERS];
+    uint32_t                             list_count;
+} DpbDependentList;
+
+typedef struct DPBInfo {
+    uint64_t picture_number;
+    int32_t dep_count;
+    int32_t dep_list0_count;
+    int32_t dep_list1_count;
+    uint8_t temporal_layer_index;
+    EbBool  is_displayed;
+    EbBool  is_used;
+    EbBool  is_alt_ref;
+    DpbDependentList dep_list0;
+    DpbDependentList dep_list1;
+} DPBInfo;
 typedef struct EncodeContext {
     EbDctor dctor;
     // Callback Functions
@@ -143,6 +161,10 @@ typedef struct EncodeContext {
     EbHandle         shared_reference_mutex;
     uint64_t picture_number_alt; // The picture number overlay includes all the overlay frames
     EbHandle stat_file_mutex;
+    //DPB list management
+    DPBInfo dpb_list[REF_FRAMES];
+    uint64_t display_picture_number;
+    EbBool  is_mini_gop_changed;
 } EncodeContext;
 
 typedef struct EncodeContextInitData {

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -634,7 +634,7 @@ EbErrorType update_base_layer_reference_queue_dependent_count(
     pcs_ptr->hierarchical_layers_diff = (uint8_t)(encode_context_ptr->previous_mini_gop_hierarchical_levels - pcs_ptr->hierarchical_levels);
 
     // Set init_pred_struct_position_flag to TRUE if mini GOP switch
-    pcs_ptr->init_pred_struct_position_flag = (pcs_ptr->hierarchical_layers_diff != 0) ?
+    pcs_ptr->init_pred_struct_position_flag = encode_context_ptr->is_mini_gop_changed = (pcs_ptr->hierarchical_layers_diff != 0) ?
         EB_TRUE :
         EB_FALSE;
 
@@ -2495,6 +2495,423 @@ static void  av1_generate_rps_info(
     }
 }
 
+static EbErrorType av1_generate_rps_info_from_user_config(
+    PictureParentControlSet       *picture_control_set_ptr,
+    EncodeContext                 *encode_context_ptr
+)
+{
+    Av1RpsNode *av1_rps = &picture_control_set_ptr->av1_ref_signal;
+    FrameHeader *frm_hdr = &picture_control_set_ptr->frm_hdr;
+    PredictionStructureEntry *pred_position_ptr = picture_control_set_ptr->pred_struct_ptr->pred_struct_entry_ptr_array[picture_control_set_ptr->pred_struct_index];
+    DPBInfo *dpb_list_ptr = &encode_context_ptr->dpb_list[0];
+    int32_t dpb_list_idx = 0;
+    uint64_t ref_poc = 0;
+    uint32_t dep_idx = 0;
+    uint8_t  ref_idx = 0;
+
+    if (frm_hdr->frame_type == KEY_FRAME) {
+        frm_hdr->show_frame = EB_TRUE;
+        picture_control_set_ptr->has_show_existing = EB_FALSE;
+        EB_MEMSET(dpb_list_ptr, 0, sizeof(DPBInfo)*REF_FRAMES);
+        encode_context_ptr->display_picture_number = picture_control_set_ptr->picture_number;
+        dpb_list_ptr[dpb_list_idx].is_used = EB_TRUE;
+        dpb_list_ptr[dpb_list_idx].picture_number = picture_control_set_ptr->picture_number;
+        dpb_list_ptr[dpb_list_idx].is_displayed = EB_TRUE;
+        dpb_list_ptr[dpb_list_idx].temporal_layer_index = picture_control_set_ptr->temporal_layer_index;
+
+        // Construct dependent lists
+        dpb_list_ptr[dpb_list_idx].dep_list0.list_count = 0;
+        for (dep_idx = 0; dep_idx < pred_position_ptr->dep_list0.list_count; ++dep_idx) {
+            if (pred_position_ptr->dep_list0.list[dep_idx] >= 0){
+                dpb_list_ptr[dpb_list_idx].dep_list0.list[dpb_list_ptr[dpb_list_idx].dep_list0.list_count++] = pred_position_ptr->dep_list0.list[dep_idx];
+            }
+        }
+        dpb_list_ptr[dpb_list_idx].dep_list1.list_count = pred_position_ptr->dep_list1.list_count;
+        for (dep_idx = 0; dep_idx < pred_position_ptr->dep_list1.list_count; ++dep_idx) {
+            dpb_list_ptr[dpb_list_idx].dep_list1.list[dep_idx] = pred_position_ptr->dep_list1.list[dep_idx];
+        }
+        dpb_list_ptr[dpb_list_idx].dep_list0_count = dpb_list_ptr[dpb_list_idx].dep_list0.list_count;
+        dpb_list_ptr[dpb_list_idx].dep_list1_count = dpb_list_ptr[dpb_list_idx].dep_list1.list_count;
+        dpb_list_ptr[dpb_list_idx].dep_count = dpb_list_ptr[dpb_list_idx].dep_list0_count + dpb_list_ptr[dpb_list_idx].dep_list1_count;
+        return EB_ErrorNone;
+    }
+
+    // If there was an I-frame or Scene Change, then cleanup the Reference Queue's Dependent Counts
+    if (picture_control_set_ptr->slice_type == I_SLICE)
+    {
+        dpb_list_idx = 0;
+        while (dpb_list_idx < REF_FRAMES) {
+            DPBInfo *referenceEntryPtr = &dpb_list_ptr[dpb_list_idx];
+
+            // Modify Dependent List0
+            for (dep_idx = 0; dep_idx < referenceEntryPtr->dep_list0.list_count; ++dep_idx) {
+                uint64_t depPoc = POC_CIRCULAR_ADD(
+                referenceEntryPtr->picture_number,
+                referenceEntryPtr->dep_list0.list[dep_idx]);
+
+                if (depPoc >= picture_control_set_ptr->picture_number && referenceEntryPtr->dep_list0.list[dep_idx]) {
+                    referenceEntryPtr->dep_list0.list[dep_idx] = 0;
+                    --referenceEntryPtr->dep_count;
+                    if (referenceEntryPtr->dep_count < 0) {
+                        return EB_Corrupt_Frame;
+                    }
+                }
+            }
+
+            // Modify Dependent List1
+            for (dep_idx = 0; dep_idx < referenceEntryPtr->dep_list1.list_count; ++dep_idx) {
+                uint64_t depPoc = POC_CIRCULAR_ADD(
+                referenceEntryPtr->picture_number,
+                referenceEntryPtr->dep_list1.list[dep_idx]);
+
+                if (((depPoc >= picture_control_set_ptr->picture_number)
+                || (((picture_control_set_ptr->pre_assignment_buffer_count != picture_control_set_ptr->pred_struct_ptr->pred_struct_period)
+                || (picture_control_set_ptr->idr_flag == EB_TRUE))
+                && (depPoc > (picture_control_set_ptr->picture_number - picture_control_set_ptr->pre_assignment_buffer_count))))
+                && referenceEntryPtr->dep_list1.list[dep_idx]) {
+                    referenceEntryPtr->dep_list1.list[dep_idx] = 0;
+                    --referenceEntryPtr->dep_count;
+                    if (referenceEntryPtr->dep_count < 0) {
+                        return EB_Corrupt_Frame;
+                    }
+                }
+            }
+            ++dpb_list_idx;
+        }
+    }
+
+    // Construct dpb index mapping for ref list0
+    if ((picture_control_set_ptr->slice_type == P_SLICE) || (picture_control_set_ptr->slice_type == B_SLICE)) {
+        for (ref_idx = LAST; ref_idx < LAST + picture_control_set_ptr->ref_list0_count; ++ref_idx) {
+            if (picture_control_set_ptr->is_overlay) {
+                ref_poc = picture_control_set_ptr->picture_number;
+            }
+            else {
+                ref_poc = picture_control_set_ptr->picture_number - pred_position_ptr->ref_list0.reference_list[ref_idx-LAST];
+            }
+            dpb_list_idx = 0;
+            do {
+                if (dpb_list_ptr[dpb_list_idx].is_used == EB_TRUE && dpb_list_ptr[dpb_list_idx].picture_number == ref_poc) {
+                    if (dpb_list_ptr[dpb_list_idx].temporal_layer_index > picture_control_set_ptr->temporal_layer_index) {
+                        return EB_Corrupt_Frame;
+                    }
+                    else {
+                        break;
+                    }
+                }
+            } while (++dpb_list_idx < REF_FRAMES);
+            if (dpb_list_idx < REF_FRAMES) {
+                av1_rps->ref_dpb_index[ref_idx] = dpb_list_idx;
+                --dpb_list_ptr[dpb_list_idx].dep_count;
+                if(dpb_list_ptr[dpb_list_idx].dep_count < 0){
+                    SVT_LOG("Error: dep_count error in dpb list0\n");
+                    return EB_Corrupt_Frame;
+                }
+            }
+            else {
+                SVT_LOG("Error: can't find ref frame in dpb list0\n");
+                return EB_Corrupt_Frame;
+            }
+        }
+        for (; ref_idx <= GOLD; ++ref_idx) {
+            av1_rps->ref_dpb_index[ref_idx] = av1_rps->ref_dpb_index[LAST];
+        }
+
+        // Construct dpb index mapping for ref list1
+        if (picture_control_set_ptr->slice_type == B_SLICE) {
+            for (ref_idx = BWD; ref_idx < BWD + picture_control_set_ptr->ref_list1_count; ++ref_idx) {
+                ref_poc = picture_control_set_ptr->picture_number - pred_position_ptr->ref_list1.reference_list[ref_idx-BWD];
+                dpb_list_idx = 0;
+                do {
+                    if (dpb_list_ptr[dpb_list_idx].is_used == EB_TRUE && dpb_list_ptr[dpb_list_idx].picture_number == ref_poc) {
+                        if (dpb_list_ptr[dpb_list_idx].temporal_layer_index > picture_control_set_ptr->temporal_layer_index) {
+                            return EB_Corrupt_Frame;
+                        }
+                        else {
+                            break;
+                        }
+                    }
+                } while (++dpb_list_idx < REF_FRAMES);
+
+                if (dpb_list_idx < REF_FRAMES) {
+                    av1_rps->ref_dpb_index[ref_idx] = dpb_list_idx;
+                    --dpb_list_ptr[dpb_list_idx].dep_count;
+                    if(dpb_list_ptr[dpb_list_idx].dep_count < 0){
+                        SVT_LOG("Error: dep_count error in dpb list1\n");
+                        return EB_Corrupt_Frame;
+                    }
+                }
+                else {
+                    SVT_LOG("Error: can't find ref frame in dpb list1\n");
+                    return EB_Corrupt_Frame;
+                }
+            }
+            for (; ref_idx <= ALT; ++ref_idx) {
+                av1_rps->ref_dpb_index[ref_idx] = av1_rps->ref_dpb_index[BWD];
+            }
+        }
+        else{
+            av1_rps->ref_dpb_index[BWD] = av1_rps->ref_dpb_index[ALT2] = av1_rps->ref_dpb_index[ALT] = av1_rps->ref_dpb_index[LAST];
+        }
+    }
+
+    // Release unused positions in dpb list
+    dpb_list_idx = 0;
+    do {
+        if (dpb_list_ptr[dpb_list_idx].is_used == EB_TRUE
+        && dpb_list_ptr[dpb_list_idx].is_displayed == EB_TRUE
+        && dpb_list_ptr[dpb_list_idx].dep_count == 0) {
+            dpb_list_ptr[dpb_list_idx].is_used = EB_FALSE;
+            dpb_list_ptr[dpb_list_idx].is_displayed = EB_FALSE;
+        }
+    } while (++dpb_list_idx < REF_FRAMES);
+
+    // Insert current frame into dpb list
+    if (picture_control_set_ptr->picture_number == encode_context_ptr->display_picture_number + 1
+    && picture_control_set_ptr->is_used_as_reference_flag == 0 ) {
+        frm_hdr->show_frame = EB_TRUE;
+        ++encode_context_ptr->display_picture_number;
+        av1_rps->refresh_frame_mask = 0;
+    }
+    else {
+        frm_hdr->show_frame = EB_FALSE;
+        dpb_list_idx = 0;
+        do {
+            if (dpb_list_ptr[dpb_list_idx].is_used == EB_FALSE) {
+                break;
+            }
+        } while (++dpb_list_idx < REF_FRAMES);
+        if (dpb_list_idx < REF_FRAMES) {
+            av1_rps->refresh_frame_mask = 1 << dpb_list_idx;
+            dpb_list_ptr[dpb_list_idx].is_used = EB_TRUE;
+            dpb_list_ptr[dpb_list_idx].picture_number = picture_control_set_ptr->picture_number;
+            dpb_list_ptr[dpb_list_idx].is_alt_ref = picture_control_set_ptr->is_alt_ref;
+            dpb_list_ptr[dpb_list_idx].temporal_layer_index = picture_control_set_ptr->temporal_layer_index;
+            if (picture_control_set_ptr->is_alt_ref) {
+                dpb_list_ptr[dpb_list_idx].is_displayed = EB_TRUE;
+            }
+            // Construct dependent lists
+            dpb_list_ptr[dpb_list_idx].dep_list0.list_count = 0;
+            for (dep_idx = 0; dep_idx < pred_position_ptr->dep_list0.list_count; ++dep_idx) {
+                if (pred_position_ptr->dep_list0.list[dep_idx] >= 0){
+                    dpb_list_ptr[dpb_list_idx].dep_list0.list[dpb_list_ptr[dpb_list_idx].dep_list0.list_count++] = pred_position_ptr->dep_list0.list[dep_idx];
+                }
+            }
+            dpb_list_ptr[dpb_list_idx].dep_list1.list_count = pred_position_ptr->dep_list1.list_count;
+            for (dep_idx = 0; dep_idx < pred_position_ptr->dep_list1.list_count; ++dep_idx) {
+                dpb_list_ptr[dpb_list_idx].dep_list1.list[dep_idx] = pred_position_ptr->dep_list1.list[dep_idx];
+            }
+            dpb_list_ptr[dpb_list_idx].dep_list0_count = (picture_control_set_ptr->is_alt_ref) ? dpb_list_ptr[dpb_list_idx].dep_list0.list_count + 1 : dpb_list_ptr[dpb_list_idx].dep_list0.list_count;
+            dpb_list_ptr[dpb_list_idx].dep_list1_count = dpb_list_ptr[dpb_list_idx].dep_list1.list_count;
+            dpb_list_ptr[dpb_list_idx].dep_count = dpb_list_ptr[dpb_list_idx].dep_list0_count + dpb_list_ptr[dpb_list_idx].dep_list1_count;
+        }
+        else {
+            SVT_LOG("Error: can't find unused dpb to hold current frame\n");
+            return EB_Corrupt_Frame;
+        }
+    }
+
+    // Calculate output flag
+    picture_control_set_ptr->has_show_existing = EB_FALSE;
+    do {
+        dpb_list_idx = 0;
+        do {
+            if (dpb_list_ptr[dpb_list_idx].is_used == EB_TRUE
+            && dpb_list_ptr[dpb_list_idx].is_displayed == EB_FALSE
+            && dpb_list_ptr[dpb_list_idx].picture_number == encode_context_ptr->display_picture_number + 1) {
+                break;
+            }
+        } while (++dpb_list_idx < REF_FRAMES);
+        if (dpb_list_idx < REF_FRAMES) {
+            dpb_list_ptr[dpb_list_idx].is_displayed = EB_TRUE;
+            ++encode_context_ptr->display_picture_number;
+            if (encode_context_ptr->display_picture_number == picture_control_set_ptr->picture_number) {
+                frm_hdr->show_frame = EB_TRUE;
+            }
+            else {
+                picture_control_set_ptr->has_show_existing = EB_TRUE;
+                frm_hdr->show_existing_frame = dpb_list_idx;
+                break;
+            }
+        }
+        else {
+            break;
+        }
+    } while (1);
+
+    return EB_ErrorNone;
+}
+
+static EbErrorType av1_generate_minigop_rps_info_from_user_config(
+    PictureParentControlSet       *picture_control_set_ptr,
+    EncodeContext                 *encode_context_ptr,
+    PictureDecisionContext        *context_ptr,
+    uint32_t                       mini_gop_index
+)
+{
+    if (encode_context_ptr->is_mini_gop_changed) {
+        PredictionStructure          *next_pred_struct_ptr;
+        PredictionStructureEntry     *next_base_layer_pred_position_ptr;
+        uint32_t                      dependant_list_removed_entries, dep_idx = 0;
+        int32_t                       dpb_list_idx = 0;
+        DPBInfo                      *dpb_list_ptr = &encode_context_ptr->dpb_list[0];
+
+        picture_control_set_ptr = (PictureParentControlSet*)encode_context_ptr->pre_assignment_buffer[0]->object_ptr;
+        while (dpb_list_idx < REF_FRAMES) {
+            DPBInfo *referenceEntryPtr = &dpb_list_ptr[dpb_list_idx];
+
+            if (referenceEntryPtr->picture_number == (picture_control_set_ptr->picture_number - 1)) {
+
+                next_pred_struct_ptr = picture_control_set_ptr->pred_struct_ptr;
+
+                next_base_layer_pred_position_ptr = next_pred_struct_ptr->pred_struct_entry_ptr_array[next_pred_struct_ptr->pred_struct_entry_count - 1];
+
+                // Remove all positive entries from the dependant lists
+                int32_t dependant_list_positive_entries = 0;
+                for (dep_idx = 0; dep_idx < referenceEntryPtr->dep_list0.list_count; ++dep_idx) {
+                    if (referenceEntryPtr->dep_list0.list[dep_idx] >= 0) {
+                        dependant_list_positive_entries++;
+                    }
+                }
+                referenceEntryPtr->dep_list0.list_count = referenceEntryPtr->dep_list0.list_count - dependant_list_positive_entries;
+
+                dependant_list_positive_entries = 0;
+                for (dep_idx = 0; dep_idx < referenceEntryPtr->dep_list1.list_count; ++dep_idx) {
+                    if (referenceEntryPtr->dep_list1.list[dep_idx] >= 0) {
+                        dependant_list_positive_entries++;
+                    }
+                }
+                referenceEntryPtr->dep_list1.list_count = referenceEntryPtr->dep_list1.list_count - dependant_list_positive_entries;
+
+                for (dep_idx = 0; dep_idx < next_base_layer_pred_position_ptr->dep_list0.list_count; ++dep_idx) {
+                    if (next_base_layer_pred_position_ptr->dep_list0.list[dep_idx] >= 0) {
+                        referenceEntryPtr->dep_list0.list[referenceEntryPtr->dep_list0.list_count++] = next_base_layer_pred_position_ptr->dep_list0.list[dep_idx];
+                    }
+                }
+
+                for (dep_idx = 0; dep_idx < next_base_layer_pred_position_ptr->dep_list1.list_count; ++dep_idx) {
+                    if (next_base_layer_pred_position_ptr->dep_list1.list[dep_idx] >= 0) {
+                        referenceEntryPtr->dep_list1.list[referenceEntryPtr->dep_list1.list_count++] = next_base_layer_pred_position_ptr->dep_list1.list[dep_idx];
+                    }
+                }
+
+                // Update the dependant count update
+                dependant_list_removed_entries = referenceEntryPtr->dep_list0_count + referenceEntryPtr->dep_list1_count - referenceEntryPtr->dep_count;
+                referenceEntryPtr->dep_list0_count = (referenceEntryPtr->is_alt_ref) ? referenceEntryPtr->dep_list0.list_count + 1 : referenceEntryPtr->dep_list0.list_count;
+                referenceEntryPtr->dep_list1_count = referenceEntryPtr->dep_list1.list_count;
+                referenceEntryPtr->dep_count = referenceEntryPtr->dep_list0_count + referenceEntryPtr->dep_list1_count - dependant_list_removed_entries;
+            }
+            else {
+                // Modify Dependent List0
+                for (dep_idx = 0; dep_idx < referenceEntryPtr->dep_list0.list_count; ++dep_idx) {
+                    uint64_t depPoc = POC_CIRCULAR_ADD(
+                    referenceEntryPtr->picture_number,
+                    referenceEntryPtr->dep_list0.list[dep_idx]);
+
+                    if (depPoc >= picture_control_set_ptr->picture_number && referenceEntryPtr->dep_list0.list[dep_idx]) {
+                        referenceEntryPtr->dep_list0.list[dep_idx] = 0;
+
+                        --referenceEntryPtr->dep_count;
+
+                        if (referenceEntryPtr->dep_count < 0) {
+                            return EB_Corrupt_Frame;
+                        }
+                    }
+                }
+
+                // Modify Dependent List1
+                for (dep_idx = 0; dep_idx < referenceEntryPtr->dep_list1.list_count; ++dep_idx) {
+                    uint64_t depPoc = POC_CIRCULAR_ADD(
+                    referenceEntryPtr->picture_number,
+                    referenceEntryPtr->dep_list1.list[dep_idx]);
+
+                    if ((depPoc >= picture_control_set_ptr->picture_number) && referenceEntryPtr->dep_list1.list[dep_idx]) {
+                        referenceEntryPtr->dep_list1.list[dep_idx] = 0;
+
+                        --referenceEntryPtr->dep_count;
+
+                        if (referenceEntryPtr->dep_count < 0) {
+                            return EB_Corrupt_Frame;
+                        }
+                    }
+                }
+            }
+            ++dpb_list_idx;
+        }
+    }
+
+    // Add 1 to the loop for the overlay picture. If the last picture is alt ref, increase the loop by 1 to add the overlay picture
+    uint32_t has_overlay = ((PictureParentControlSet*)encode_context_ptr->pre_assignment_buffer[context_ptr->mini_gop_end_index[mini_gop_index]]->object_ptr)->is_alt_ref ? 1 : 0;
+    for (uint32_t decode_order = 0,pictureIndex = context_ptr->mini_gop_start_index[mini_gop_index]; pictureIndex <= context_ptr->mini_gop_end_index[mini_gop_index]+has_overlay; ++pictureIndex, ++decode_order) {
+        if (has_overlay && pictureIndex == context_ptr->mini_gop_end_index[mini_gop_index] + has_overlay) {
+            picture_control_set_ptr = ((PictureParentControlSet*)encode_context_ptr->pre_assignment_buffer[context_ptr->mini_gop_end_index[mini_gop_index]]->object_ptr)->overlay_ppcs_ptr;
+        }
+        else if (context_ptr->mini_gop_length[mini_gop_index] == picture_control_set_ptr->pred_struct_ptr->pred_struct_period) {
+            uint32_t pic_idx = context_ptr->mini_gop_start_index[mini_gop_index];
+            do {
+                picture_control_set_ptr = (PictureParentControlSet*)encode_context_ptr->pre_assignment_buffer[pic_idx]->object_ptr;
+                if (decode_order == picture_control_set_ptr->pred_struct_ptr->pred_struct_entry_ptr_array[picture_control_set_ptr->pred_struct_index]->decode_order) {
+                    break;
+                }
+            } while (++pic_idx <= context_ptr->mini_gop_end_index[mini_gop_index]);
+            if (pic_idx > context_ptr->mini_gop_end_index[mini_gop_index]) {
+                return EB_Corrupt_Frame;
+            }
+        }
+        else {
+            picture_control_set_ptr = (PictureParentControlSet*)encode_context_ptr->pre_assignment_buffer[pictureIndex]->object_ptr;
+        }
+        EbErrorType ret = av1_generate_rps_info_from_user_config(picture_control_set_ptr, encode_context_ptr);
+        if (ret != EB_ErrorNone) {
+            return EB_Corrupt_Frame;
+        }
+    }
+    return EB_ErrorNone;
+}
+
+static void av1_generate_rps_ref_poc_from_user_config(PictureParentControlSet *picture_control_set_ptr)
+{
+    Av1RpsNode *av1_rps = &picture_control_set_ptr->av1_ref_signal;
+    FrameHeader *frm_hdr = &picture_control_set_ptr->frm_hdr;
+    PredictionStructureEntry *pred_position_ptr = picture_control_set_ptr->pred_struct_ptr->pred_struct_entry_ptr_array[picture_control_set_ptr->pred_struct_index];
+    uint32_t ref_idx = 0;
+
+    if (picture_control_set_ptr->slice_type == I_SLICE)
+        frm_hdr->frame_type = picture_control_set_ptr->idr_flag ? KEY_FRAME : INTRA_ONLY_FRAME;
+    else
+        frm_hdr->frame_type = INTER_FRAME;
+
+    picture_control_set_ptr->intra_only = picture_control_set_ptr->slice_type == I_SLICE ? 1 : 0;
+
+    if (picture_control_set_ptr->is_overlay) {
+        for (ref_idx = LAST; ref_idx <= ALT; ++ref_idx) {
+            av1_rps->ref_poc_array[ref_idx] = picture_control_set_ptr->picture_number;
+        }
+    }
+    else {
+        if ((picture_control_set_ptr->slice_type == P_SLICE) || (picture_control_set_ptr->slice_type == B_SLICE)) {
+            for (ref_idx = LAST; ref_idx < LAST + pred_position_ptr->ref_list0.reference_list_count; ++ref_idx) {
+                av1_rps->ref_poc_array[ref_idx] = picture_control_set_ptr->picture_number - pred_position_ptr->ref_list0.reference_list[ref_idx-LAST];
+            }
+            for (; ref_idx <= GOLD; ++ref_idx) {
+                av1_rps->ref_poc_array[ref_idx] = av1_rps->ref_poc_array[LAST];
+            }
+            if (picture_control_set_ptr->slice_type == B_SLICE) {
+                for (ref_idx = BWD; ref_idx < BWD + pred_position_ptr->ref_list1.reference_list_count; ++ref_idx) {
+                  av1_rps->ref_poc_array[ref_idx] = picture_control_set_ptr->picture_number - pred_position_ptr->ref_list1.reference_list[ref_idx-BWD];
+                }
+                for (; ref_idx <= ALT; ++ref_idx) {
+                  av1_rps->ref_poc_array[ref_idx] = av1_rps->ref_poc_array[BWD];
+                }
+            }
+            else {
+                av1_rps->ref_poc_array[BWD] = av1_rps->ref_poc_array[ALT2] = av1_rps->ref_poc_array[ALT] = av1_rps->ref_poc_array[LAST];
+            }
+        }
+    }
+    return;
+}
+
 /***************************************************************************************************
 // Perform Required Picture Analysis Processing for the Overlay frame
 ***************************************************************************************************/
@@ -2978,6 +3395,7 @@ void* picture_decision_kernel(void *input_ptr)
 
                     for (mini_gop_index = 0; mini_gop_index < context_ptr->total_number_of_mini_gops; ++mini_gop_index) {
                         pre_assignment_buffer_first_pass_flag = EB_TRUE;
+                        encode_context_ptr->is_mini_gop_changed = EB_FALSE;
                         {
                             update_base_layer_reference_queue_dependent_count(
                                 context_ptr,
@@ -3211,13 +3629,17 @@ void* picture_decision_kernel(void *input_ptr)
                                             (uint32_t)((pcs_ptr->picture_number - 1) % pcs_ptr->pred_struct_ptr->pred_struct_period);
                                     }
                                 }
-
-                                av1_generate_rps_info(
-                                    pcs_ptr,
-                                    encode_context_ptr,
-                                    context_ptr,
-                                    pic_index,
-                                    mini_gop_index);
+                                if(scs_ptr->static_config.enable_manual_pred_struct){
+                                    av1_generate_rps_ref_poc_from_user_config(pcs_ptr);
+                                }
+                                else{
+                                    av1_generate_rps_info(
+                                        pcs_ptr,
+                                        encode_context_ptr,
+                                        context_ptr,
+                                        pic_index,
+                                        mini_gop_index);
+                                }
                                 pcs_ptr->allow_comp_inter_inter = 0;
                                 pcs_ptr->is_skip_mode_allowed = 0;
 
@@ -3569,7 +3991,14 @@ void* picture_decision_kernel(void *input_ptr)
                                 pcs_ptr->temporal_filtering_on = EB_FALSE; // set temporal filtering flag OFF for current picture
 
                         }
-
+                        if(scs_ptr->static_config.enable_manual_pred_struct){
+                            EbErrorType ret = av1_generate_minigop_rps_info_from_user_config(pcs_ptr,encode_context_ptr,context_ptr,mini_gop_index);
+                            if (ret != EB_ErrorNone) {
+                                CHECK_REPORT_ERROR_NC(
+                                    encode_context_ptr->app_callback_ptr,
+                                    EB_ENC_PD_ERROR9);
+                            }
+                        }
                         // Add 1 to the loop for the overlay picture. If the last picture is alt ref, increase the loop by 1 to add the overlay picture
                         uint32_t has_overlay = ((PictureParentControlSet*)encode_context_ptr->pre_assignment_buffer[context_ptr->mini_gop_end_index[mini_gop_index]]->object_ptr)->is_alt_ref ? 1 : 0;
                         for (out_stride_diff64 = context_ptr->mini_gop_start_index[mini_gop_index]; out_stride_diff64 <= context_ptr->mini_gop_end_index[mini_gop_index] + has_overlay; ++out_stride_diff64) {

--- a/Source/Lib/Encoder/Codec/EbPredictionStructure.h
+++ b/Source/Lib/Encoder/Codec/EbPredictionStructure.h
@@ -60,19 +60,6 @@ typedef struct DependentList {
 } DependentList;
 
 /************************************************
-     * Prediction Structure Config Entry
-     *   Contains the basic reference lists and
-     *   configurations for each Prediction Structure
-     *   Config Entry.
-     ************************************************/
-typedef struct PredictionStructureConfigEntry {
-    uint32_t temporal_layer_index;
-    uint32_t decode_order;
-    int32_t  ref_list0[REF_LIST_MAX_DEPTH];
-    int32_t  ref_list1[REF_LIST_MAX_DEPTH];
-} PredictionStructureConfigEntry;
-
-/************************************************
      * Prediction Structure Config
      *   Contains a collection of basic control data
      *   for the basic prediction structure.
@@ -192,7 +179,8 @@ typedef struct PredictionStructureGroup {
      ************************************************/
 extern EbErrorType prediction_structure_group_ctor(PredictionStructureGroup *pred_struct_group_ptr,
                                                    uint8_t                   enc_mode,
-                                                   uint32_t base_layer_switch_mode);
+                                                   uint32_t base_layer_switch_mode,
+                                                   EbSvtAv1EncConfiguration *config);
 
 extern PredictionStructure *get_prediction_structure(
     PredictionStructureGroup *prediction_structure_group_ptr, EbPred pred_structure,

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2241,6 +2241,36 @@ void copy_api_from_app(
     scs_ptr->static_config.md_stage_2_cand_prune_th = config_struct->md_stage_2_cand_prune_th;
     scs_ptr->static_config.md_stage_2_class_prune_th = config_struct->md_stage_2_class_prune_th;
 
+    // Prediction Structure
+    scs_ptr->static_config.enable_manual_pred_struct    = config_struct->enable_manual_pred_struct;
+    if(scs_ptr->static_config.enable_manual_pred_struct){
+        scs_ptr->static_config.manual_pred_struct_entry_num = config_struct->manual_pred_struct_entry_num;
+        memcpy(&scs_ptr->static_config.pred_struct[0], &config_struct->pred_struct[0],config_struct->manual_pred_struct_entry_num*sizeof(PredictionStructureConfigEntry));
+        switch (scs_ptr->static_config.manual_pred_struct_entry_num) {
+            case 1:
+                scs_ptr->static_config.hierarchical_levels =  0;
+                break;
+            case 2:
+                scs_ptr->static_config.hierarchical_levels =  1;
+                break;
+            case 4:
+                scs_ptr->static_config.hierarchical_levels =  2;
+                break;
+            case 8:
+                scs_ptr->static_config.hierarchical_levels =  3;
+                break;
+            case 16:
+                scs_ptr->static_config.hierarchical_levels =  4;
+                break;
+            case 32:
+                scs_ptr->static_config.hierarchical_levels =  5;
+                break;
+            default:
+                scs_ptr->static_config.hierarchical_levels =  0;
+                break;
+        }
+    }
+
     return;
 }
 
@@ -2739,6 +2769,48 @@ static EbErrorType verify_settings(
         SVT_LOG("Error instance %u: Invalid OLPD Refinement mode for M%d [0], your input: %i\n", channel_number + 1, config->enc_mode, config->olpd_refinement);
         return_error = EB_ErrorBadParameter;
     }
+    // prediction structure
+    if(config->enable_manual_pred_struct) {
+        if(config->manual_pred_struct_entry_num > (1<<(MAX_HIERARCHICAL_LEVEL-1))){
+            SVT_LOG("Error instance %u: Invalid manual prediction structure entry number [1 - 32], your input: %d\n", channel_number + 1, config->manual_pred_struct_entry_num);
+            return_error = EB_ErrorBadParameter;
+        }
+        else {
+            for(int32_t i = 0; i < config->manual_pred_struct_entry_num; i++) {
+                config->pred_struct[i].ref_list1[REF_LIST_MAX_DEPTH-1] = 0;
+                if(config->pred_struct[i].decode_order >= (1<<(MAX_HIERARCHICAL_LEVEL-1))){
+                    SVT_LOG("Error instance %u: Invalid decode order for manual prediction structure [0 - 31], your input: %d\n", channel_number + 1, config->pred_struct[i].decode_order);
+                    return_error = EB_ErrorBadParameter;
+                }
+                if(config->pred_struct[i].temporal_layer_index >= (1<<(MAX_HIERARCHICAL_LEVEL-1))){
+                    SVT_LOG("Error instance %u: Invalid temporal layer index for manual prediction structure [0 - 31], your input: %d\n", channel_number + 1, config->pred_struct[i].temporal_layer_index);
+                    return_error = EB_ErrorBadParameter;
+                }
+                EbBool have_ref_frame_within_minigop_in_list0 = EB_FALSE;
+                int32_t entry_idx = i + 1;
+                for(int32_t j = 0; j < REF_LIST_MAX_DEPTH; j++) {
+                    if((entry_idx - config->pred_struct[i].ref_list1[j] > config->manual_pred_struct_entry_num)) {
+                        SVT_LOG("Error instance %u: Invalid ref frame %d in list1 entry%d for manual prediction structure, all ref frames in list1 should not exceed minigop end\n",
+                        channel_number + 1, config->pred_struct[i].ref_list1[j], i);
+                        return_error = EB_ErrorBadParameter;
+                    }
+                    if(config->pred_struct[i].ref_list0[j] < 0) {
+                        SVT_LOG("Error instance %u: Invalid ref frame %d in list0 entry%d for manual prediction structure, only forward frames can be in list0\n",
+                        channel_number + 1, config->pred_struct[i].ref_list0[j], i);
+                        return_error = EB_ErrorBadParameter;
+                    }
+                    if(!have_ref_frame_within_minigop_in_list0 && config->pred_struct[i].ref_list0[j] && entry_idx - config->pred_struct[i].ref_list0[j] >= 0 ) {
+                        have_ref_frame_within_minigop_in_list0 = EB_TRUE;
+                    }
+                }
+                if(!have_ref_frame_within_minigop_in_list0) {
+                    SVT_LOG("Error instance %u: Invalid ref frame in list0 entry%d for manual prediction structure,there should be at least one frame within minigop \n",
+                    channel_number + 1, i);
+                    return_error = EB_ErrorBadParameter;
+                }
+            }
+        }
+    }
 
     if (config->superres_mode > 2) {
         SVT_LOG("Error instance %u: invalid superres-mode %d, should be in the range [%d - %d], "
@@ -3047,7 +3119,8 @@ EB_API EbErrorType eb_svt_enc_set_parameter(
         enc_handle->scs_instance_array[instance_index]->encode_context_ptr->prediction_structure_group_ptr,
         prediction_structure_group_ctor,
         enc_handle->scs_instance_array[instance_index]->scs_ptr->static_config.enc_mode,
-        enc_handle->scs_instance_array[instance_index]->scs_ptr->static_config.base_layer_switch_mode);
+        enc_handle->scs_instance_array[instance_index]->scs_ptr->static_config.base_layer_switch_mode,
+        &(enc_handle->scs_instance_array[instance_index]->scs_ptr->static_config));
     if (!enc_handle->scs_instance_array[instance_index]->encode_context_ptr->prediction_structure_group_ptr) {
         eb_release_mutex(enc_handle->scs_instance_array[instance_index]->config_mutex);
         return EB_ErrorInsufficientResources;


### PR DESCRIPTION
This PR implements manual prediction structure, user can specify the prediction structure via the configuration file with command line "-pred-struct-file xx/PredStruct_level0.cfg".

Some example prediction structure configuration files are placed at SVT-AV1\Config\PredStruct_level0.cfg~PredStruct_level5.cfg, which match the fixed prediction structure in current code. 

When prediction structure configration file is used, hierarchical_levels value in command line is ignored, and will be set the actual size automatically accoring to the prediction structure configuration file.

There are still some restrictions on this manual prediction structure due to the current SVT_AV1 framework:
1. Only hierarchical prediction structure is supported
2. The maximum levels supported is 5 (minigop 32)
3. Some other parameters with specific layers not related to the prediction structure (e.g. lambda/qp...) are not added yet
4. In current SVT_AV1, only hierarchical_levels 3 and 4 are allowed to be used in verify_settings(), don't know why levels 0/1/2 can't be used with the internal code being ready(#973 ), and level 5 PR(#921 ) hasn't been merged, so manual prediction structure is also affected by this restriction for now until the above issues are fixed.

