### PR TITLE
Fix the tmvp issue

### DIFF
--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -3853,9 +3853,9 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
             int32_t            mi_col    = context_ptr->blk_origin_x >> MI_SIZE_LOG2;
             const int32_t      offset    = mi_row * mi_stride + mi_col;
             ModeInfo *         mi_ptr    = *(pcs_ptr->mi_grid_base + offset);
-            const int          x_mis     = AOMMIN(context_ptr->blk_geom->bwidth,
+            const int          x_mis     = AOMMIN(context_ptr->blk_geom->bwidth >> MI_SIZE_LOG2,
                                      pcs_ptr->parent_pcs_ptr->av1_cm->mi_cols - mi_col);
-            const int          y_mis     = AOMMIN(context_ptr->blk_geom->bheight,
+            const int          y_mis     = AOMMIN(context_ptr->blk_geom->bheight >> MI_SIZE_LOG2,
                                      pcs_ptr->parent_pcs_ptr->av1_cm->mi_rows - mi_row);
             EbReferenceObject *obj_l0 =
                 (EbReferenceObject *)


### PR DESCRIPTION
## Description

this function is meant to save the current mv set and will be used as tmvp for following frames.
However, it overwritten the data, and it will cause some mistakes in some rare cases.
For example, if sb size is 64x64. if we process (0,256) first, and (576, 0) later. the mv of block starting at (0,256) may be overwritten by the mv from (576, 0).
It will affect the mode decision a bit.
For multi-tile case, it is more easy to trigger, and may also affect the entropy part(when building the tmvp stack), and cause corrupt bitstreams


Signed-off-by: Jing Li <jing.b.li@intel.com>