### PR TITLE
Enable tile parallelism

### DIFF
--- a/Source/Lib/Common/Codec/EbBlockStructures.h
+++ b/Source/Lib/Common/Codec/EbBlockStructures.h
@@ -40,6 +40,9 @@ typedef struct TileInfo {
     int32_t tg_horz_boundary;
     int32_t tile_row;
     int32_t tile_col;
+#if TILES_PARALLEL
+    int32_t tile_rs_index; //tile index in raster order
+#endif
 } TileInfo;
 
 #define INTER_TX_SIZE_BUF_LEN 16

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -37,6 +37,12 @@ extern "C" {
 #define NON_AVX512_SUPPORT
 #endif
 
+#define TILES_PARALLEL 1
+
+#if TILES_PARALLEL
+#define MAX_TILE_CNTS 128 // Annex A.3
+#endif
+
 #define MR_MODE 0
 
 #define HIGH_PRECISION_MV_QTHRESH 150
@@ -177,6 +183,7 @@ enum {
 // Maximum number of tile rows and tile columns
 #define MAX_TILE_ROWS 64
 #define MAX_TILE_COLS 64
+
 #define MAX_VARTX_DEPTH 2
 #define MI_SIZE_64X64 (64 >> MI_SIZE_LOG2)
 #define MI_SIZE_128X128 (128 >> MI_SIZE_LOG2)
@@ -353,6 +360,16 @@ static __inline void mem_put_le16(void *vmem, MEM_VALUE_T val) {
     mem[0] = (MAU_T)((val >> 0) & 0xff);
     mem[1] = (MAU_T)((val >> 8) & 0xff);
 }
+
+#if TILES_PARALLEL
+static __inline void mem_put_le24(void *vmem, MEM_VALUE_T val) {
+    MAU_T *mem = (MAU_T *)vmem;
+
+    mem[0] = (MAU_T)((val >>  0) & 0xff);
+    mem[1] = (MAU_T)((val >>  8) & 0xff);
+    mem[2] = (MAU_T)((val >> 16) & 0xff);
+}
+#endif
 
 static __inline void mem_put_le32(void *vmem, MEM_VALUE_T val) {
     MAU_T *mem = (MAU_T *)vmem;

--- a/Source/Lib/Common/Codec/EbPictureBufferDesc.c
+++ b/Source/Lib/Common/Codec/EbPictureBufferDesc.c
@@ -229,8 +229,6 @@ void link_eb_to_aom_buffer_desc_8bit(EbPictureBufferDesc *picBuffDsc,
     }
 }
 
-//Jing: TODO
-//Change here later
 void link_eb_to_aom_buffer_desc(EbPictureBufferDesc *picBuffDsc, Yv12BufferConfig *aomBuffDsc) {
     //NOTe:  Not all fileds are connected. add more connections as needed.
     if (picBuffDsc->bit_depth == EB_8BIT) {

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -1434,6 +1434,18 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
         is_16bit ? pcs_ptr->recon_picture16bit_ptr : pcs_ptr->recon_picture_ptr;
     EbPictureBufferDesc *coeff_buffer_sb = sb_ptr->quantized_coeff;
 
+#if TILES_PARALLEL
+    uint16_t tile_idx = context_ptr->tile_index;
+    NeighborArrayUnit *ep_luma_recon_neighbor_array =
+        is_16bit ? pcs_ptr->ep_luma_recon_neighbor_array16bit[tile_idx]
+                 : pcs_ptr->ep_luma_recon_neighbor_array[tile_idx];
+    NeighborArrayUnit *ep_cb_recon_neighbor_array =
+        is_16bit ? pcs_ptr->ep_cb_recon_neighbor_array16bit[tile_idx]
+                 : pcs_ptr->ep_cb_recon_neighbor_array[tile_idx];
+    NeighborArrayUnit *ep_cr_recon_neighbor_array =
+        is_16bit ? pcs_ptr->ep_cr_recon_neighbor_array16bit[tile_idx]
+                 : pcs_ptr->ep_cr_recon_neighbor_array[tile_idx];
+#else
     NeighborArrayUnit *ep_luma_recon_neighbor_array =
         is_16bit ? pcs_ptr->ep_luma_recon_neighbor_array16bit
                  : pcs_ptr->ep_luma_recon_neighbor_array;
@@ -1441,6 +1453,7 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
         is_16bit ? pcs_ptr->ep_cb_recon_neighbor_array16bit : pcs_ptr->ep_cb_recon_neighbor_array;
     NeighborArrayUnit *ep_cr_recon_neighbor_array =
         is_16bit ? pcs_ptr->ep_cr_recon_neighbor_array16bit : pcs_ptr->ep_cr_recon_neighbor_array;
+#endif
 
     EbPictureBufferDesc *residual_buffer           = context_ptr->residual_buffer;
     EbPictureBufferDesc *transform_buffer          = context_ptr->transform_buffer;
@@ -1483,7 +1496,11 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
         context_ptr->md_context->luma_dc_sign_context  = 0;
         get_txb_ctx(pcs_ptr->parent_pcs_ptr->scs_ptr,
                     COMPONENT_LUMA,
+#if TILES_PARALLEL
+                    pcs_ptr->ep_luma_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                     pcs_ptr->ep_luma_dc_sign_level_coeff_neighbor_array,
+#endif
                     txb_origin_x,
                     txb_origin_y,
                     context_ptr->blk_geom->bsize,
@@ -1690,7 +1707,11 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
             uint8_t dc_sign_level_coeff = (uint8_t)blk_ptr->quantized_dc[0][context_ptr->txb_itr];
 
             neighbor_array_unit_mode_write(
+#if TILES_PARALLEL
+                pcs_ptr->ep_luma_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                 pcs_ptr->ep_luma_dc_sign_level_coeff_neighbor_array,
+#endif
                 (uint8_t *)&dc_sign_level_coeff,
                 txb_origin_x,
                 txb_origin_y,
@@ -1719,7 +1740,11 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
         context_ptr->md_context->cb_dc_sign_context  = 0;
         get_txb_ctx(pcs_ptr->parent_pcs_ptr->scs_ptr,
                     COMPONENT_CHROMA,
+#if TILES_PARALLEL
+                    pcs_ptr->ep_cb_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                     pcs_ptr->ep_cb_dc_sign_level_coeff_neighbor_array,
+#endif
                     blk_originx_uv,
                     blk_originy_uv,
                     context_ptr->blk_geom->bsize_uv,
@@ -1732,7 +1757,11 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
         get_txb_ctx(
             pcs_ptr->parent_pcs_ptr->scs_ptr,
             COMPONENT_CHROMA,
+#if TILES_PARALLEL
+            pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
             pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array,
+#endif
             blk_originx_uv,
             blk_originy_uv,
             context_ptr->blk_geom->bsize_uv,
@@ -2001,7 +2030,11 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
         {
             uint8_t dc_sign_level_coeff = (uint8_t)blk_ptr->quantized_dc[1][context_ptr->txb_itr];
             neighbor_array_unit_mode_write(
+#if TILES_PARALLEL
+                pcs_ptr->ep_cb_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                 pcs_ptr->ep_cb_dc_sign_level_coeff_neighbor_array,
+#endif
                 (uint8_t *)&dc_sign_level_coeff,
                 ROUND_UV(txb_origin_x) >> 1,
                 ROUND_UV(txb_origin_y) >> 1,
@@ -2014,7 +2047,11 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
         {
             uint8_t dc_sign_level_coeff = (uint8_t)blk_ptr->quantized_dc[2][context_ptr->txb_itr];
             neighbor_array_unit_mode_write(
+#if TILES_PARALLEL
+                pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                 pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array,
+#endif
                 (uint8_t *)&dc_sign_level_coeff,
                 ROUND_UV(txb_origin_x) >> 1,
                 ROUND_UV(txb_origin_y) >> 1,
@@ -2131,6 +2168,27 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
     uint64_t              cr_txb_coeff_bits;
     EncodeContext *       encode_context_ptr;
     // Dereferencing early
+#if TILES_PARALLEL
+    uint16_t tile_idx = context_ptr->tile_index;
+    uint16_t total_tile_cnt = pcs_ptr->parent_pcs_ptr->av1_cm->tiles_info.tile_cols *
+        pcs_ptr->parent_pcs_ptr->av1_cm->tiles_info.tile_rows;
+    NeighborArrayUnit *ep_mode_type_neighbor_array = pcs_ptr->ep_mode_type_neighbor_array[tile_idx];
+    NeighborArrayUnit *ep_intra_luma_mode_neighbor_array =
+        pcs_ptr->ep_intra_luma_mode_neighbor_array[tile_idx];
+    NeighborArrayUnit *ep_intra_chroma_mode_neighbor_array =
+        pcs_ptr->ep_intra_chroma_mode_neighbor_array[tile_idx];
+    NeighborArrayUnit *ep_mv_neighbor_array = pcs_ptr->ep_mv_neighbor_array[tile_idx];
+    NeighborArrayUnit *ep_luma_recon_neighbor_array =
+        is_16bit ? pcs_ptr->ep_luma_recon_neighbor_array16bit[tile_idx]
+                 : pcs_ptr->ep_luma_recon_neighbor_array[tile_idx];
+    NeighborArrayUnit *ep_cb_recon_neighbor_array =
+        is_16bit ? pcs_ptr->ep_cb_recon_neighbor_array16bit[tile_idx]
+                 : pcs_ptr->ep_cb_recon_neighbor_array[tile_idx];
+    NeighborArrayUnit *ep_cr_recon_neighbor_array =
+        is_16bit ? pcs_ptr->ep_cr_recon_neighbor_array16bit[tile_idx]
+                 : pcs_ptr->ep_cr_recon_neighbor_array[tile_idx];
+    NeighborArrayUnit *ep_skip_flag_neighbor_array = pcs_ptr->ep_skip_flag_neighbor_array[tile_idx];
+#else
     NeighborArrayUnit *ep_mode_type_neighbor_array = pcs_ptr->ep_mode_type_neighbor_array;
     NeighborArrayUnit *ep_intra_luma_mode_neighbor_array =
         pcs_ptr->ep_intra_luma_mode_neighbor_array;
@@ -2145,6 +2203,7 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
     NeighborArrayUnit *ep_cr_recon_neighbor_array =
         is_16bit ? pcs_ptr->ep_cr_recon_neighbor_array16bit : pcs_ptr->ep_cr_recon_neighbor_array;
     NeighborArrayUnit *ep_skip_flag_neighbor_array = pcs_ptr->ep_skip_flag_neighbor_array;
+#endif
 
     EbBool       dlf_enable_flag = (EbBool)pcs_ptr->parent_pcs_ptr->loop_filter_mode;
     const EbBool is_intra_sb     = pcs_ptr->limit_intra ? EB_FALSE : EB_TRUE;
@@ -2301,7 +2360,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
     context_ptr->coded_area_sb                = 0;
     context_ptr->coded_area_sb_uv             = 0;
 
+#if TILES_PARALLEL
+    if (dlf_enable_flag && pcs_ptr->parent_pcs_ptr->loop_filter_mode == 1 && total_tile_cnt == 1) {
+#else
     if (dlf_enable_flag && pcs_ptr->parent_pcs_ptr->loop_filter_mode == 1) {
+#endif
         if (sb_addr == 0) {
             eb_av1_loop_filter_init(pcs_ptr);
 
@@ -2333,6 +2396,9 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
             // Update the partition stats
             update_part_stats(pcs_ptr,
                               blk_ptr,
+#if TILES_PARALLEL
+                              tile_idx,
+#endif
                               (sb_origin_y + blk_geom->origin_y) >> MI_SIZE_LOG2,
                               (sb_origin_x + blk_geom->origin_x) >> MI_SIZE_LOG2);
         }
@@ -2468,7 +2534,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                             context_ptr->md_context->luma_dc_sign_context  = 0;
                             get_txb_ctx(pcs_ptr->parent_pcs_ptr->scs_ptr,
                                         COMPONENT_LUMA,
+#if TILES_PARALLEL
+                                        pcs_ptr->ep_luma_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                         pcs_ptr->ep_luma_dc_sign_level_coeff_neighbor_array,
+#endif
                                         context_ptr->blk_origin_x,
                                         context_ptr->blk_origin_y,
                                         context_ptr->blk_geom->bsize,
@@ -2481,7 +2551,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 context_ptr->md_context->cb_dc_sign_context  = 0;
                                 get_txb_ctx(pcs_ptr->parent_pcs_ptr->scs_ptr,
                                             COMPONENT_CHROMA,
+#if TILES_PARALLEL
+                                            pcs_ptr->ep_cb_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                             pcs_ptr->ep_cb_dc_sign_level_coeff_neighbor_array,
+#endif
                                             blk_originx_uv,
                                             blk_originy_uv,
                                             context_ptr->blk_geom->bsize_uv,
@@ -2493,7 +2567,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 context_ptr->md_context->cr_dc_sign_context  = 0;
                                 get_txb_ctx(pcs_ptr->parent_pcs_ptr->scs_ptr,
                                             COMPONENT_CHROMA,
+#if TILES_PARALLEL
+                                            pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                             pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array,
+#endif
                                             blk_originx_uv,
                                             blk_originy_uv,
                                             context_ptr->blk_geom->bsize_uv,
@@ -2718,7 +2796,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 uint8_t dc_sign_level_coeff =
                                     (uint8_t)blk_ptr->quantized_dc[0][context_ptr->txb_itr];
                                 neighbor_array_unit_mode_write(
+#if TILES_PARALLEL
+                                    pcs_ptr->ep_luma_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                     pcs_ptr->ep_luma_dc_sign_level_coeff_neighbor_array,
+#endif
                                     (uint8_t *)&dc_sign_level_coeff,
                                     context_ptr->blk_origin_x,
                                     context_ptr->blk_origin_y,
@@ -2732,7 +2814,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 uint8_t dc_sign_level_coeff =
                                     (uint8_t)blk_ptr->quantized_dc[1][context_ptr->txb_itr];
                                 neighbor_array_unit_mode_write(
+#if TILES_PARALLEL
+                                    pcs_ptr->ep_cb_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                     pcs_ptr->ep_cb_dc_sign_level_coeff_neighbor_array,
+#endif
                                     (uint8_t *)&dc_sign_level_coeff,
                                     ROUND_UV(context_ptr->blk_origin_x) >> 1,
                                     ROUND_UV(context_ptr->blk_origin_y) >> 1,
@@ -2746,7 +2832,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 uint8_t dc_sign_level_coeff =
                                     (uint8_t)blk_ptr->quantized_dc[2][context_ptr->txb_itr];
                                 neighbor_array_unit_mode_write(
+#if TILES_PARALLEL
+                                    pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                     pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array,
+#endif
                                     (uint8_t *)&dc_sign_level_coeff,
                                     ROUND_UV(context_ptr->blk_origin_x) >> 1,
                                     ROUND_UV(context_ptr->blk_origin_y) >> 1,
@@ -3004,7 +3094,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                             context_ptr->md_context->luma_dc_sign_context  = 0;
                             get_txb_ctx(pcs_ptr->parent_pcs_ptr->scs_ptr,
                                         COMPONENT_LUMA,
+#if TILES_PARALLEL
+                                        pcs_ptr->ep_luma_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                         pcs_ptr->ep_luma_dc_sign_level_coeff_neighbor_array,
+#endif
                                         txb_origin_x,
                                         txb_origin_y,
                                         context_ptr->blk_geom->bsize,
@@ -3019,7 +3113,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 get_txb_ctx(
                                     pcs_ptr->parent_pcs_ptr->scs_ptr,
                                     COMPONENT_CHROMA,
+#if TILES_PARALLEL
+                                    pcs_ptr->ep_cb_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                     pcs_ptr->ep_cb_dc_sign_level_coeff_neighbor_array,
+#endif
                                     ROUND_UV(txb_origin_x) >> 1,
                                     ROUND_UV(txb_origin_y) >> 1,
                                     context_ptr->blk_geom->bsize_uv,
@@ -3032,7 +3130,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 context_ptr->md_context->cr_dc_sign_context  = 0;
                                 get_txb_ctx(pcs_ptr->parent_pcs_ptr->scs_ptr,
                                             COMPONENT_CHROMA,
+#if TILES_PARALLEL
+                                            pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                             pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array,
+#endif
                                             ROUND_UV(txb_origin_x) >> 1,
                                             ROUND_UV(txb_origin_y) >> 1,
                                             context_ptr->blk_geom->bsize_uv,
@@ -3260,7 +3362,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                     (uint8_t)blk_ptr->quantized_dc[0][context_ptr->txb_itr];
 
                                 neighbor_array_unit_mode_write(
+#if TILES_PARALLEL
+                                    pcs_ptr->ep_luma_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                     pcs_ptr->ep_luma_dc_sign_level_coeff_neighbor_array,
+#endif
                                     (uint8_t *)&dc_sign_level_coeff,
                                     txb_origin_x,
                                     txb_origin_y,
@@ -3276,7 +3382,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 uint8_t dc_sign_level_coeff =
                                     (uint8_t)blk_ptr->quantized_dc[1][context_ptr->txb_itr];
                                 neighbor_array_unit_mode_write(
+#if TILES_PARALLEL
+                                    pcs_ptr->ep_cb_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                     pcs_ptr->ep_cb_dc_sign_level_coeff_neighbor_array,
+#endif
                                     (uint8_t *)&dc_sign_level_coeff,
                                     ROUND_UV(txb_origin_x) >> 1,
                                     ROUND_UV(txb_origin_y) >> 1,
@@ -3292,7 +3402,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 uint8_t dc_sign_level_coeff =
                                     (uint8_t)blk_ptr->quantized_dc[2][context_ptr->txb_itr];
                                 neighbor_array_unit_mode_write(
+#if TILES_PARALLEL
+                                    pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                     pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array,
+#endif
                                     (uint8_t *)&dc_sign_level_coeff,
                                     ROUND_UV(txb_origin_x) >> 1,
                                     ROUND_UV(txb_origin_y) >> 1,
@@ -3339,7 +3453,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                         get_txb_ctx(
                             pcs_ptr->parent_pcs_ptr->scs_ptr,
                             COMPONENT_LUMA,
+#if TILES_PARALLEL
+                            pcs_ptr->ep_luma_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                             pcs_ptr->ep_luma_dc_sign_level_coeff_neighbor_array,
+#endif
                             txb_origin_x,
                             txb_origin_y,
                             context_ptr->blk_geom->bsize,
@@ -3353,7 +3471,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                             get_txb_ctx(
                                 pcs_ptr->parent_pcs_ptr->scs_ptr,
                                 COMPONENT_CHROMA,
+#if TILES_PARALLEL
+                                pcs_ptr->ep_cb_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                 pcs_ptr->ep_cb_dc_sign_level_coeff_neighbor_array,
+#endif
                                 ROUND_UV(txb_origin_x) >> 1,
                                 ROUND_UV(txb_origin_y) >> 1,
                                 context_ptr->blk_geom->bsize_uv,
@@ -3366,7 +3488,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                             context_ptr->md_context->cr_dc_sign_context  = 0;
                             get_txb_ctx(pcs_ptr->parent_pcs_ptr->scs_ptr,
                                         COMPONENT_CHROMA,
+#if TILES_PARALLEL
+                                        pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                         pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array,
+#endif
                                         ROUND_UV(txb_origin_x) >> 1,
                                         ROUND_UV(txb_origin_y) >> 1,
                                         context_ptr->blk_geom->bsize_uv,
@@ -3498,7 +3624,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 (uint8_t)blk_ptr->quantized_dc[0][context_ptr->txb_itr];
 
                             neighbor_array_unit_mode_write(
+#if TILES_PARALLEL
+                                pcs_ptr->ep_luma_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                 pcs_ptr->ep_luma_dc_sign_level_coeff_neighbor_array,
+#endif
                                 (uint8_t *)&dc_sign_level_coeff,
                                 txb_origin_x,
                                 txb_origin_y,
@@ -3514,7 +3644,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                             uint8_t dc_sign_level_coeff =
                                 (uint8_t)blk_ptr->quantized_dc[1][context_ptr->txb_itr];
                             neighbor_array_unit_mode_write(
+#if TILES_PARALLEL
+                                pcs_ptr->ep_cb_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                 pcs_ptr->ep_cb_dc_sign_level_coeff_neighbor_array,
+#endif
                                 (uint8_t *)&dc_sign_level_coeff,
                                 ROUND_UV(txb_origin_x) >> 1,
                                 ROUND_UV(txb_origin_y) >> 1,
@@ -3530,7 +3664,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                             uint8_t dc_sign_level_coeff =
                                 (uint8_t)blk_ptr->quantized_dc[2][context_ptr->txb_itr];
                             neighbor_array_unit_mode_write(
+#if TILES_PARALLEL
+                                pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array[tile_idx],
+#else
                                 pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array,
+#endif
                                 (uint8_t *)&dc_sign_level_coeff,
                                 ROUND_UV(txb_origin_x) >> 1,
                                 ROUND_UV(txb_origin_y) >> 1,
@@ -3814,7 +3952,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                     partition.above = partition_context_lookup[blk_geom->bsize].above;
                     partition.left  = partition_context_lookup[blk_geom->bsize].left;
 
+#if TILES_PARALLEL
+                    neighbor_array_unit_mode_write(pcs_ptr->ep_partition_context_neighbor_array[tile_idx],
+#else
                     neighbor_array_unit_mode_write(pcs_ptr->ep_partition_context_neighbor_array,
+#endif
                                                    (uint8_t *)&partition,
                                                    context_ptr->blk_origin_x,
                                                    context_ptr->blk_origin_y,
@@ -3853,9 +3995,9 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
             int32_t            mi_col    = context_ptr->blk_origin_x >> MI_SIZE_LOG2;
             const int32_t      offset    = mi_row * mi_stride + mi_col;
             ModeInfo *         mi_ptr    = *(pcs_ptr->mi_grid_base + offset);
-            const int          x_mis     = AOMMIN(context_ptr->blk_geom->bwidth,
+            const int          x_mis     = AOMMIN(context_ptr->blk_geom->bwidth >> MI_SIZE_LOG2,
                                      pcs_ptr->parent_pcs_ptr->av1_cm->mi_cols - mi_col);
-            const int          y_mis     = AOMMIN(context_ptr->blk_geom->bheight,
+            const int          y_mis     = AOMMIN(context_ptr->blk_geom->bheight >> MI_SIZE_LOG2,
                                      pcs_ptr->parent_pcs_ptr->av1_cm->mi_rows - mi_row);
             EbReferenceObject *obj_l0 =
                 (EbReferenceObject *)
@@ -3878,7 +4020,12 @@ else blk_it +=
     d1_depth_offset[scs_ptr->seq_header.sb_size == BLOCK_128X128][context_ptr->blk_geom->depth];
 } // CU Loop
 // First Pass Deblocking
+#if TILES_PARALLEL
+    if (dlf_enable_flag && pcs_ptr->parent_pcs_ptr->loop_filter_mode == 1 && total_tile_cnt == 1) {
+        //Jing: Don't work for tile_parallel since the SB of bottom tile comes early than the bottom SB of top tile
+#else
 if (dlf_enable_flag && pcs_ptr->parent_pcs_ptr->loop_filter_mode == 1) {
+#endif
     if (pcs_ptr->parent_pcs_ptr->frm_hdr.loop_filter_params.filter_level[0] ||
         pcs_ptr->parent_pcs_ptr->frm_hdr.loop_filter_params.filter_level[1]) {
         uint8_t last_col =

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.h
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.h
@@ -87,6 +87,12 @@ typedef struct EncDecContext {
     EbBool
             evaluate_cfl_ep; // 0: CFL is evaluated @ mode decision, 1: CFL is evaluated @ encode pass
     uint8_t md_skip_blk;
+
+#if TILES_PARALLEL
+    uint16_t tile_group_index;
+    uint16_t tile_index;
+    uint32_t coded_sb_count;
+#endif
 } EncDecContext;
 
 /**************************************

--- a/Source/Lib/Encoder/Codec/EbEncDecResults.h
+++ b/Source/Lib/Encoder/Codec/EbEncDecResults.h
@@ -39,6 +39,9 @@ typedef struct RestResults {
     EbObjectWrapper *pcs_wrapper_ptr;
     uint32_t         completed_sb_row_index_start;
     uint32_t         completed_sb_row_count;
+#if TILES_PARALLEL
+    uint16_t         tile_index;
+#endif
 } RestResults;
 
 typedef struct EncDecResultsInitData {

--- a/Source/Lib/Encoder/Codec/EbEncDecSegments.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecSegments.c
@@ -62,6 +62,13 @@ void enc_dec_segments_init(EncDecSegments *segments_ptr, uint32_t segColCount, u
                            uint32_t pic_width_sb, uint32_t pic_height_sb) {
     unsigned x, y, y_last;
     unsigned row_index, band_index, segment_index;
+#if TILES_PARALLEL
+    segColCount = (segColCount < pic_width_sb) ? segColCount : pic_width_sb;
+    segRowCount = (segRowCount < pic_height_sb) ? segRowCount : pic_height_sb;
+    segRowCount = (segRowCount < segments_ptr->segment_max_row_count)
+                      ? segRowCount
+                      : segments_ptr->segment_max_row_count;
+#endif
 
     segments_ptr->sb_row_count       = pic_height_sb;
     segments_ptr->sb_band_count      = BAND_TOTAL_COUNT(pic_height_sb, pic_width_sb);

--- a/Source/Lib/Encoder/Codec/EbEncDecTasks.h
+++ b/Source/Lib/Encoder/Codec/EbEncDecTasks.h
@@ -24,6 +24,9 @@ typedef struct EncDecTasks {
     EbObjectWrapper *pcs_wrapper_ptr;
     uint32_t         input_type;
     int16_t          enc_dec_segment_row;
+#if TILES_PARALLEL
+    uint16_t         tile_group_index;
+#endif
 } EncDecTasks;
 
 typedef struct EncDecTasksInitData {

--- a/Source/Lib/Encoder/Codec/EbEntropyCoding.h
+++ b/Source/Lib/Encoder/Codec/EbEntropyCoding.h
@@ -45,9 +45,16 @@ extern "C" {
      * Extern Function Declarations
      **************************************/
 struct EntropyCodingContext;
+#if TILES_PARALLEL
+extern EbErrorType write_sb(struct EntropyCodingContext *context_ptr, SuperBlock *tb_ptr,
+                            PictureControlSet *pcs_ptr, uint16_t tile_idx,
+                            EntropyCoder *entropy_coder_ptr,
+                            EbPictureBufferDesc *coeff_ptr);
+#else
 extern EbErrorType write_sb(struct EntropyCodingContext *context_ptr, SuperBlock *tb_ptr,
                             PictureControlSet *pcs_ptr, EntropyCoder *entropy_coder_ptr,
                             EbPictureBufferDesc *coeff_ptr);
+#endif
 
 extern EbErrorType encode_slice_finish(EntropyCoder *entropy_coder_ptr);
 

--- a/Source/Lib/Encoder/Codec/EbEntropyCodingObject.h
+++ b/Source/Lib/Encoder/Codec/EbEntropyCodingObject.h
@@ -27,6 +27,25 @@ typedef struct EntropyCoder {
     uint64_t       ec_frame_size;
 } EntropyCoder;
 
+#if TILES_PARALLEL
+typedef struct EntropyTileInfo
+{
+    EbDctor           dctor;
+    EntropyCoder     *entropy_coder_ptr;
+    int8_t            entropy_coding_current_available_row;
+    EbBool            entropy_coding_row_array[MAX_SB_ROWS];
+    int8_t            entropy_coding_current_row;
+    int8_t            entropy_coding_row_count;
+    EbHandle          entropy_coding_mutex;
+    EbBool            entropy_coding_in_progress;
+    EbBool            entropy_coding_tile_done;
+} EntropyTileInfo;
+
+extern EbErrorType entropy_tile_info_ctor(
+        EntropyTileInfo *entropy_tile_info_ptr,
+        uint32_t buf_size);
+#endif
+
 extern EbErrorType bitstream_ctor(Bitstream *bitstream_ptr, uint32_t buffer_size);
 
 extern EbErrorType entropy_coder_ctor(EntropyCoder *entropy_coder_ptr, uint32_t buffer_size);

--- a/Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c
@@ -24,7 +24,11 @@
 #include "EbCabacContextModel.h"
 #include "EbLog.h"
 #define AV1_MIN_TILE_SIZE_BYTES 1
-void eb_av1_reset_loop_restoration(PictureControlSet *piCSetPtr);
+#if TILES_PARALLEL
+void eb_av1_reset_loop_restoration(PictureControlSet *piCSetPtr, uint16_t tile_idx);
+#else
+void        eb_av1_reset_loop_restoration(PictureControlSet *piCSetPtr);
+#endif
 
 static void rest_context_dctor(EbPtr p) {
     EbThreadContext *     thread_context_ptr = (EbThreadContext *)p;
@@ -61,6 +65,28 @@ EbErrorType entropy_coding_context_ctor(EbThreadContext *  thread_context_ptr,
 /***********************************************
  * Entropy Coding Reset Neighbor Arrays
  ***********************************************/
+#if TILES_PARALLEL
+static void entropy_coding_reset_neighbor_arrays(PictureControlSet *pcs_ptr, uint16_t tile_idx) {
+    neighbor_array_unit_reset(pcs_ptr->mode_type_neighbor_array[tile_idx]);
+
+    neighbor_array_unit_reset(pcs_ptr->partition_context_neighbor_array[tile_idx]);
+
+    neighbor_array_unit_reset(pcs_ptr->skip_flag_neighbor_array[tile_idx]);
+
+    neighbor_array_unit_reset(pcs_ptr->skip_coeff_neighbor_array[tile_idx]);
+    neighbor_array_unit_reset(pcs_ptr->luma_dc_sign_level_coeff_neighbor_array[tile_idx]);
+    neighbor_array_unit_reset(pcs_ptr->cb_dc_sign_level_coeff_neighbor_array[tile_idx]);
+    neighbor_array_unit_reset(pcs_ptr->cr_dc_sign_level_coeff_neighbor_array[tile_idx]);
+    neighbor_array_unit_reset(pcs_ptr->inter_pred_dir_neighbor_array[tile_idx]);
+    neighbor_array_unit_reset(pcs_ptr->ref_frame_type_neighbor_array[tile_idx]);
+
+    neighbor_array_unit_reset(pcs_ptr->intra_luma_mode_neighbor_array[tile_idx]);
+    neighbor_array_unit_reset32(pcs_ptr->interpolation_type_neighbor_array[tile_idx]);
+    neighbor_array_unit_reset(pcs_ptr->txfm_context_array[tile_idx]);
+    neighbor_array_unit_reset(pcs_ptr->segmentation_id_pred_array[tile_idx]);
+    return;
+}
+#else
 static void entropy_coding_reset_neighbor_arrays(PictureControlSet *pcs_ptr) {
     neighbor_array_unit_reset(pcs_ptr->mode_type_neighbor_array);
 
@@ -81,6 +107,7 @@ static void entropy_coding_reset_neighbor_arrays(PictureControlSet *pcs_ptr) {
     neighbor_array_unit_reset(pcs_ptr->segmentation_id_pred_array);
     return;
 }
+#endif
 
 void av1_get_syntax_rate_from_cdf(int32_t *costs, const AomCdfProb *cdf, const int32_t *inv_map);
 
@@ -166,6 +193,70 @@ void eb_av1_build_nmv_cost_table(int32_t *mvjoint, int32_t *mvcost[2], const Nmv
 /**************************************************
  * Reset Entropy Coding Picture
  **************************************************/
+#if TILES_PARALLEL
+static void reset_entropy_coding_picture(EntropyCodingContext *context_ptr,
+                                         PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) {
+    uint16_t tile_cnt = pcs_ptr->parent_pcs_ptr->av1_cm->tiles_info.tile_rows *
+                        pcs_ptr->parent_pcs_ptr->av1_cm->tiles_info.tile_cols;
+    uint16_t tile_idx = 0;
+    for (tile_idx = 0; tile_idx < tile_cnt; tile_idx++) {
+        reset_bitstream(entropy_coder_get_bitstream_ptr(
+            pcs_ptr->entropy_coding_info[tile_idx]->entropy_coder_ptr));
+    }
+
+    uint32_t entropy_coding_qp;
+
+    context_ptr->is_16bit = (EbBool)(scs_ptr->static_config.encoder_bit_depth > EB_8BIT);
+    FrameHeader *frm_hdr  = &pcs_ptr->parent_pcs_ptr->frm_hdr;
+    // Asuming cb and cr offset to be the same for chroma QP in both slice and pps for lambda computation
+    entropy_coding_qp = pcs_ptr->parent_pcs_ptr->frm_hdr.quantization_params.base_q_idx;
+
+    for (tile_idx = 0; tile_idx < tile_cnt; tile_idx++) {
+        pcs_ptr->parent_pcs_ptr->prev_qindex[tile_idx] =
+            pcs_ptr->parent_pcs_ptr->frm_hdr.quantization_params.base_q_idx;
+    }
+    if (pcs_ptr->parent_pcs_ptr->frm_hdr.allow_intrabc)
+        assert(pcs_ptr->parent_pcs_ptr->frm_hdr.delta_lf_params.delta_lf_present == 0);
+    if (pcs_ptr->parent_pcs_ptr->frm_hdr.delta_lf_params.delta_lf_present) {
+        pcs_ptr->parent_pcs_ptr->prev_delta_lf_from_base = 0;
+        const int32_t frame_lf_count =
+            pcs_ptr->parent_pcs_ptr->monochrome == 0 ? FRAME_LF_COUNT : FRAME_LF_COUNT - 2;
+        for (int32_t lf_id = 0; lf_id < frame_lf_count; ++lf_id)
+            pcs_ptr->parent_pcs_ptr->prev_delta_lf[lf_id] = 0;
+    }
+
+    // pass the ent
+    for (tile_idx = 0; tile_idx < tile_cnt; tile_idx++) {
+        OutputBitstreamUnit *output_bitstream_ptr =
+            (OutputBitstreamUnit *)(pcs_ptr->entropy_coding_info[tile_idx]
+                                        ->entropy_coder_ptr->ec_output_bitstream_ptr);
+        //****************************************************************//
+        uint8_t *data = output_bitstream_ptr->buffer_av1;
+        pcs_ptr->entropy_coding_info[tile_idx]->entropy_coder_ptr->ec_writer.allow_update_cdf =
+            !pcs_ptr->parent_pcs_ptr->large_scale_tile;
+        pcs_ptr->entropy_coding_info[tile_idx]->entropy_coder_ptr->ec_writer.allow_update_cdf =
+            pcs_ptr->entropy_coding_info[tile_idx]->entropy_coder_ptr->ec_writer.allow_update_cdf &&
+            !frm_hdr->disable_cdf_update;
+
+        aom_start_encode(&pcs_ptr->entropy_coding_info[tile_idx]->entropy_coder_ptr->ec_writer,
+                         data);
+
+        // ADD Reset here
+        if (pcs_ptr->parent_pcs_ptr->frm_hdr.primary_ref_frame != PRIMARY_REF_NONE)
+            memcpy(pcs_ptr->entropy_coding_info[tile_idx]->entropy_coder_ptr->fc,
+                   &pcs_ptr->ref_frame_context[pcs_ptr->parent_pcs_ptr->frm_hdr.primary_ref_frame],
+                   sizeof(FRAME_CONTEXT));
+        else
+            reset_entropy_coder(scs_ptr->encode_context_ptr,
+                                pcs_ptr->entropy_coding_info[tile_idx]->entropy_coder_ptr,
+                                entropy_coding_qp,
+                                pcs_ptr->slice_type);
+
+        entropy_coding_reset_neighbor_arrays(pcs_ptr, tile_idx);
+    }
+    return;
+}
+#else
 static void reset_entropy_coding_picture(EntropyCodingContext *context_ptr,
                                          PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) {
     reset_bitstream(entropy_coder_get_bitstream_ptr(pcs_ptr->entropy_coder_ptr));
@@ -214,7 +305,9 @@ static void reset_entropy_coding_picture(EntropyCodingContext *context_ptr,
 
     return;
 }
+#endif
 
+#if !TILES_PARALLEL
 static void reset_ec_tile(uint32_t total_size, uint32_t is_last_tile_in_tg,
                           EntropyCodingContext *context_ptr, PictureControlSet *pcs_ptr,
                           SequenceControlSet *scs_ptr) {
@@ -265,6 +358,7 @@ static void reset_ec_tile(uint32_t total_size, uint32_t is_last_tile_in_tg,
 
     return;
 }
+#endif
 
 /******************************************************
  * Update Entropy Coding Rows
@@ -304,6 +398,53 @@ static void reset_ec_tile(uint32_t total_size, uint32_t is_last_tile_in_tg,
  *   of the segment-row (b) as this would block other
  *   threads from performing an update (A).
  ******************************************************/
+#if TILES_PARALLEL
+static EbBool update_entropy_coding_rows(PictureControlSet *pcs_ptr, uint32_t *row_index,
+                                         uint32_t row_count, uint16_t tile_idx,
+                                         EbBool *initial_process_call) {
+    EbBool process_next_row = EB_FALSE;
+
+    EntropyTileInfo *ec_ptr = pcs_ptr->entropy_coding_info[tile_idx];
+
+    // Note, any writes & reads to status variables (e.g. in_progress) in MD-CTRL must be thread-safe
+    eb_block_on_mutex(ec_ptr->entropy_coding_mutex);
+
+    // Update availability mask
+    if (*initial_process_call == EB_TRUE) {
+        unsigned i;
+
+        for (i = *row_index; i < *row_index + row_count; ++i)
+            ec_ptr->entropy_coding_row_array[i] = EB_TRUE;
+
+        while (ec_ptr->entropy_coding_row_array[ec_ptr->entropy_coding_current_available_row] ==
+                   EB_TRUE &&
+               ec_ptr->entropy_coding_current_available_row < ec_ptr->entropy_coding_row_count) {
+            ++ec_ptr->entropy_coding_current_available_row;
+        }
+    }
+
+    // Release in_progress token
+    if (*initial_process_call == EB_FALSE && ec_ptr->entropy_coding_in_progress == EB_TRUE)
+        ec_ptr->entropy_coding_in_progress = EB_FALSE;
+    // Test if the picture is not already complete AND not currently being worked on by another ENCDEC process
+    if (ec_ptr->entropy_coding_current_row < ec_ptr->entropy_coding_row_count &&
+        ec_ptr->entropy_coding_row_array[ec_ptr->entropy_coding_current_row] == EB_TRUE &&
+        ec_ptr->entropy_coding_in_progress == EB_FALSE) {
+        // Test if the next SB-row is ready to go
+        if (ec_ptr->entropy_coding_current_row <= ec_ptr->entropy_coding_current_available_row) {
+            ec_ptr->entropy_coding_in_progress = EB_TRUE;
+            *row_index                         = ec_ptr->entropy_coding_current_row++;
+            process_next_row                   = EB_TRUE;
+        }
+    }
+
+    *initial_process_call = EB_FALSE;
+
+    eb_release_mutex(ec_ptr->entropy_coding_mutex);
+
+    return process_next_row;
+}
+#else
 static EbBool update_entropy_coding_rows(PictureControlSet *pcs_ptr, uint32_t *row_index,
                                          uint32_t row_count, EbBool *initial_process_call) {
     EbBool process_next_row = EB_FALSE;
@@ -345,6 +486,7 @@ static EbBool update_entropy_coding_rows(PictureControlSet *pcs_ptr, uint32_t *r
 
     return process_next_row;
 }
+#endif
 /******************************************************
  * Write Stat to File
  * write stat_struct per frame in the first pass
@@ -369,8 +511,13 @@ void *entropy_coding_kernel(void *input_ptr) {
     SequenceControlSet *  scs_ptr;
 
     // Input
+#if TILES_PARALLEL
+    EbObjectWrapper *rest_results_wrapper_ptr;
+    RestResults *    rest_results_ptr;
+#else
     EbObjectWrapper *enc_dec_results_wrapper_ptr;
     EncDecResults *  enc_dec_results_ptr;
+#endif
 
     // Output
     EbObjectWrapper *     entropy_coding_results_wrapper_ptr;
@@ -390,10 +537,16 @@ void *entropy_coding_kernel(void *input_ptr) {
     EbBool initial_process_call;
     for (;;) {
         // Get Mode Decision Results
+#if TILES_PARALLEL
+        eb_get_full_object(context_ptr->enc_dec_input_fifo_ptr, &rest_results_wrapper_ptr);
+        rest_results_ptr = (RestResults *)rest_results_wrapper_ptr->object_ptr;
+        pcs_ptr          = (PictureControlSet *)rest_results_ptr->pcs_wrapper_ptr->object_ptr;
+#else
         eb_get_full_object(context_ptr->enc_dec_input_fifo_ptr, &enc_dec_results_wrapper_ptr);
         enc_dec_results_ptr = (EncDecResults *)enc_dec_results_wrapper_ptr->object_ptr;
-        pcs_ptr             = (PictureControlSet *)enc_dec_results_ptr->pcs_wrapper_ptr->object_ptr;
-        scs_ptr             = (SequenceControlSet *)pcs_ptr->scs_wrapper_ptr->object_ptr;
+        pcs_ptr = (PictureControlSet *)enc_dec_results_ptr->pcs_wrapper_ptr->object_ptr;
+#endif
+        scs_ptr = (SequenceControlSet *)pcs_ptr->scs_wrapper_ptr->object_ptr;
         // SB Constants
 
         sb_sz = (uint8_t)scs_ptr->sb_size_pix;
@@ -401,6 +554,194 @@ void *entropy_coding_kernel(void *input_ptr) {
         sb_size_log2       = (uint8_t)Log2f(sb_sz);
         context_ptr->sb_sz = sb_sz;
         pic_width_in_sb    = (scs_ptr->seq_header.max_frame_width + sb_sz - 1) >> sb_size_log2;
+#if TILES_PARALLEL
+        uint16_t         tile_idx = rest_results_ptr->tile_index;
+        Av1Common *const cm       = pcs_ptr->parent_pcs_ptr->av1_cm;
+        const uint16_t   tile_cnt = cm->tiles_info.tile_rows * cm->tiles_info.tile_cols;
+        const uint16_t   tile_col = tile_idx % cm->tiles_info.tile_cols;
+        const uint16_t   tile_row = tile_idx / cm->tiles_info.tile_cols;
+        const uint16_t   tile_sb_start_x =
+            cm->tiles_info.tile_col_start_mi[tile_col] >> scs_ptr->seq_header.sb_size_log2;
+        const uint16_t tile_sb_start_y =
+            cm->tiles_info.tile_row_start_mi[tile_row] >> scs_ptr->seq_header.sb_size_log2;
+        uint16_t tile_width_in_sb = (cm->tiles_info.tile_col_start_mi[tile_col + 1] -
+                                     cm->tiles_info.tile_col_start_mi[tile_col]) >>
+                                    scs_ptr->seq_header.sb_size_log2;
+
+        {
+            initial_process_call = EB_TRUE;
+            y_sb_index           = rest_results_ptr->completed_sb_row_index_start;
+
+            // SB-loops
+            while (update_entropy_coding_rows(pcs_ptr,
+                                              &y_sb_index,
+                                              rest_results_ptr->completed_sb_row_count,
+                                              tile_idx,
+                                              &initial_process_call) == EB_TRUE) {
+                uint32_t row_total_bits = 0;
+
+                if (y_sb_index == 0) {
+                    eb_block_on_mutex(pcs_ptr->entropy_coding_pic_mutex);
+                    if (pcs_ptr->entropy_coding_pic_reset_flag) {
+                        pcs_ptr->entropy_coding_pic_reset_flag = EB_FALSE;
+
+                        reset_entropy_coding_picture(context_ptr, pcs_ptr, scs_ptr);
+                    }
+                    eb_release_mutex(pcs_ptr->entropy_coding_pic_mutex);
+                    pcs_ptr->entropy_coding_info[tile_idx]->entropy_coding_tile_done = EB_FALSE;
+                }
+
+                for (x_sb_index = 0; x_sb_index < tile_width_in_sb; ++x_sb_index) {
+                    sb_index = (uint16_t)((x_sb_index + tile_sb_start_x) +
+                                          (y_sb_index + tile_sb_start_y) * pic_width_in_sb);
+                    sb_ptr   = pcs_ptr->sb_ptr_array[sb_index];
+
+                    sb_origin_x = x_sb_index << sb_size_log2;
+                    sb_origin_y = y_sb_index << sb_size_log2;
+
+                    sb_origin_x = (x_sb_index + tile_sb_start_x) << sb_size_log2;
+                    sb_origin_y = (y_sb_index + tile_sb_start_y) << sb_size_log2;
+
+                    context_ptr->sb_origin_x = sb_origin_x;
+                    context_ptr->sb_origin_y = sb_origin_y;
+                    if (x_sb_index == 0 && y_sb_index == 0)
+                        eb_av1_reset_loop_restoration(pcs_ptr, tile_idx);
+
+                    if (x_sb_index == 0 && y_sb_index == 0) {
+                        context_ptr->tok = pcs_ptr->tile_tok[tile_row][tile_col];
+                    }
+                    sb_ptr->total_bits = 0;
+                    uint32_t prev_pos =
+                        (x_sb_index == 0 && y_sb_index == 0)
+                            ? 0
+                            : pcs_ptr->entropy_coding_info[tile_idx]
+                                  ->entropy_coder_ptr->ec_writer.ec.offs; //residual_bc.pos
+
+                    EbPictureBufferDesc *coeff_picture_ptr = sb_ptr->quantized_coeff;
+                    write_sb(context_ptr,
+                             sb_ptr,
+                             pcs_ptr,
+                             tile_idx,
+                             pcs_ptr->entropy_coding_info[tile_idx]->entropy_coder_ptr,
+                             coeff_picture_ptr);
+                    sb_ptr->total_bits = (pcs_ptr->entropy_coding_info[tile_idx]
+                                              ->entropy_coder_ptr->ec_writer.ec.offs -
+                                          prev_pos)
+                                         << 3;
+
+                    pcs_ptr->parent_pcs_ptr->quantized_coeff_num_bits += sb_ptr->total_bits;
+                    row_total_bits += sb_ptr->total_bits;
+                }
+
+                // At the end of each SB-row, send the updated bit-count to Entropy Coding
+                {
+                    EbObjectWrapper * rate_control_task_wrapper_ptr;
+                    RateControlTasks *rate_control_task_ptr;
+
+                    // Get Empty EncDec Results
+                    eb_get_empty_object(context_ptr->rate_control_output_fifo_ptr,
+                                        &rate_control_task_wrapper_ptr);
+                    rate_control_task_ptr =
+                        (RateControlTasks *)rate_control_task_wrapper_ptr->object_ptr;
+                    rate_control_task_ptr->task_type      = RC_ENTROPY_CODING_ROW_FEEDBACK_RESULT;
+                    rate_control_task_ptr->picture_number = pcs_ptr->picture_number;
+                    rate_control_task_ptr->row_number     = y_sb_index;
+                    rate_control_task_ptr->bit_count      = row_total_bits;
+
+                    rate_control_task_ptr->pcs_wrapper_ptr = 0;
+                    rate_control_task_ptr->segment_index   = ~0u;
+
+                    // Post EncDec Results
+                    eb_post_full_object(rate_control_task_wrapper_ptr);
+                }
+
+                eb_block_on_mutex(pcs_ptr->entropy_coding_info[tile_idx]->entropy_coding_mutex);
+                if (pcs_ptr->entropy_coding_info[tile_idx]->entropy_coding_tile_done == EB_FALSE) {
+                    // If the picture is complete, terminate the slice
+                    if (pcs_ptr->entropy_coding_info[tile_idx]->entropy_coding_current_row ==
+                        pcs_ptr->entropy_coding_info[tile_idx]->entropy_coding_row_count) {
+                        uint32_t ref_idx;
+
+                        EbBool pic_ready = EB_TRUE;
+
+                        // Current tile ready
+                        encode_slice_finish(
+                            pcs_ptr->entropy_coding_info[tile_idx]->entropy_coder_ptr);
+
+                        eb_block_on_mutex(pcs_ptr->entropy_coding_pic_mutex);
+                        pcs_ptr->entropy_coding_info[tile_idx]->entropy_coding_tile_done = EB_TRUE;
+                        for (uint16_t i = 0; i < tile_cnt; i++) {
+                            if (pcs_ptr->entropy_coding_info[i]->entropy_coding_tile_done ==
+                                EB_FALSE) {
+                                pic_ready = EB_FALSE;
+                                break;
+                            }
+                        }
+                        eb_release_mutex(pcs_ptr->entropy_coding_pic_mutex);
+
+                        //Jing, two pass doesn't work with multi-tile right now
+                        // for Non Reference frames
+                        if (scs_ptr->use_output_stat_file && tile_cnt == 1 &&
+                            !pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag)
+                            write_stat_to_file(scs_ptr,
+                                               *pcs_ptr->parent_pcs_ptr->stat_struct_first_pass_ptr,
+                                               pcs_ptr->parent_pcs_ptr->picture_number);
+                        if (pic_ready) {
+                            // Release the List 0 Reference Pictures
+                            for (ref_idx = 0; ref_idx < pcs_ptr->parent_pcs_ptr->ref_list0_count;
+                                 ++ref_idx) {
+                                if (scs_ptr->use_output_stat_file && tile_cnt == 1 &&
+                                    pcs_ptr->ref_pic_ptr_array[0][ref_idx] != EB_NULL &&
+                                    pcs_ptr->ref_pic_ptr_array[0][ref_idx]->live_count == 1)
+                                    write_stat_to_file(
+                                        scs_ptr,
+                                        ((EbReferenceObject *)pcs_ptr->ref_pic_ptr_array[0][ref_idx]
+                                             ->object_ptr)
+                                            ->stat_struct,
+                                        ((EbReferenceObject *)pcs_ptr->ref_pic_ptr_array[0][ref_idx]
+                                             ->object_ptr)
+                                            ->ref_poc);
+                                if (pcs_ptr->ref_pic_ptr_array[0][ref_idx] != EB_NULL) {
+                                    eb_release_object(pcs_ptr->ref_pic_ptr_array[0][ref_idx]);
+                                }
+                            }
+
+                            // Release the List 1 Reference Pictures
+                            for (ref_idx = 0; ref_idx < pcs_ptr->parent_pcs_ptr->ref_list1_count;
+                                 ++ref_idx) {
+                                if (scs_ptr->use_output_stat_file && tile_cnt == 1 &&
+                                    pcs_ptr->ref_pic_ptr_array[1][ref_idx] != EB_NULL &&
+                                    pcs_ptr->ref_pic_ptr_array[1][ref_idx]->live_count == 1)
+                                    write_stat_to_file(
+                                        scs_ptr,
+                                        ((EbReferenceObject *)pcs_ptr->ref_pic_ptr_array[1][ref_idx]
+                                             ->object_ptr)
+                                            ->stat_struct,
+                                        ((EbReferenceObject *)pcs_ptr->ref_pic_ptr_array[1][ref_idx]
+                                             ->object_ptr)
+                                            ->ref_poc);
+                                if (pcs_ptr->ref_pic_ptr_array[1][ref_idx] != EB_NULL)
+                                    eb_release_object(pcs_ptr->ref_pic_ptr_array[1][ref_idx]);
+                            }
+
+                            // Get Empty Entropy Coding Results
+                            eb_get_empty_object(context_ptr->entropy_coding_output_fifo_ptr,
+                                                &entropy_coding_results_wrapper_ptr);
+                            entropy_coding_results_ptr =
+                                (EntropyCodingResults *)
+                                    entropy_coding_results_wrapper_ptr->object_ptr;
+                            entropy_coding_results_ptr->pcs_wrapper_ptr =
+                                rest_results_ptr->pcs_wrapper_ptr;
+
+                            // Post EntropyCoding Results
+                            eb_post_full_object(entropy_coding_results_wrapper_ptr);
+                        }
+                    } // End if(PictureCompleteFlag)
+                }
+                eb_release_mutex(pcs_ptr->entropy_coding_info[tile_idx]->entropy_coding_mutex);
+            }
+        }
+#else
         if (pcs_ptr->parent_pcs_ptr->av1_cm->tiles_info.tile_cols *
                 pcs_ptr->parent_pcs_ptr->av1_cm->tiles_info.tile_rows ==
             1)
@@ -638,9 +979,13 @@ void *entropy_coding_kernel(void *input_ptr) {
                 eb_post_full_object(entropy_coding_results_wrapper_ptr);
             }
         }
-
+#endif
         // Release Mode Decision Results
+#if TILES_PARALLEL
+        eb_release_object(rest_results_wrapper_ptr);
+#else
         eb_release_object(enc_dec_results_wrapper_ptr);
+#endif
     }
 
     return EB_NULL;

--- a/Source/Lib/Encoder/Codec/EbMdRateEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMdRateEstimation.c
@@ -1069,7 +1069,12 @@ void update_stats(PictureControlSet *pcs_ptr, BlkStruct *blk_ptr, int mi_row, in
 /*******************************************************************************
  * Updates the partition stats/CDF for the current block
  ******************************************************************************/
+#if TILES_PARALLEL
+void update_part_stats(PictureControlSet *pcs_ptr, BlkStruct *blk_ptr,
+                       uint16_t tile_idx, int mi_row, int mi_col) {
+#else
 void update_part_stats(PictureControlSet *pcs_ptr, BlkStruct *blk_ptr, int mi_row, int mi_col) {
+#endif
     const AV1_COMMON *const cm       = pcs_ptr->parent_pcs_ptr->av1_cm;
     MacroBlockD *           xd       = blk_ptr->av1xd;
     const BlockGeom *       blk_geom = get_blk_geom_mds(blk_ptr->mds_idx);
@@ -1084,7 +1089,11 @@ void update_part_stats(PictureControlSet *pcs_ptr, BlkStruct *blk_ptr, int mi_ro
         int                 ctx;
 
         NeighborArrayUnit *partition_context_neighbor_array =
+#if TILES_PARALLEL
+            pcs_ptr->ep_partition_context_neighbor_array[tile_idx];
+#else
             pcs_ptr->ep_partition_context_neighbor_array;
+#endif
         uint32_t partition_context_left_neighbor_index = get_neighbor_array_unit_left_index(
             partition_context_neighbor_array, (mi_row << MI_SIZE_LOG2));
         uint32_t partition_context_top_neighbor_index = get_neighbor_array_unit_top_index(

--- a/Source/Lib/Encoder/Codec/EbMdRateEstimation.h
+++ b/Source/Lib/Encoder/Codec/EbMdRateEstimation.h
@@ -514,6 +514,9 @@ void update_stats(
 void update_part_stats(
     struct PictureControlSet   *pcs_ptr,
     struct BlkStruct          *blk_ptr,
+#if TILES_PARALLEL
+    uint16_t                    tile_idx,
+#endif
     int                         mi_row,
     int                         mi_col);
 

--- a/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
@@ -1961,6 +1961,23 @@ void *mode_decision_configuration_kernel(void *input_ptr) {
             pcs_ptr);
 
         // Post the results to the MD processes
+#if TILES_PARALLEL
+
+        uint16_t tg_count =
+            pcs_ptr->parent_pcs_ptr->tile_group_cols * pcs_ptr->parent_pcs_ptr->tile_group_rows;
+        for (uint16_t tile_group_idx = 0; tile_group_idx < tg_count; tile_group_idx++) {
+            eb_get_empty_object(context_ptr->mode_decision_configuration_output_fifo_ptr,
+                                &enc_dec_tasks_wrapper_ptr);
+
+            enc_dec_tasks_ptr = (EncDecTasks *)enc_dec_tasks_wrapper_ptr->object_ptr;
+            enc_dec_tasks_ptr->pcs_wrapper_ptr  = rate_control_results_ptr->pcs_wrapper_ptr;
+            enc_dec_tasks_ptr->input_type       = ENCDEC_TASKS_MDC_INPUT;
+            enc_dec_tasks_ptr->tile_group_index = tile_group_idx;
+
+            // Post the Full Results Object
+            eb_post_full_object(enc_dec_tasks_wrapper_ptr);
+        }
+#else
         eb_get_empty_object(context_ptr->mode_decision_configuration_output_fifo_ptr,
                             &enc_dec_tasks_wrapper_ptr);
 
@@ -1970,6 +1987,7 @@ void *mode_decision_configuration_kernel(void *input_ptr) {
 
         // Post the Full Results Object
         eb_post_full_object(enc_dec_tasks_wrapper_ptr);
+#endif
 
         // Release Rate Control Results
         eb_release_object(rate_control_results_wrapper_ptr);

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
@@ -263,6 +263,9 @@ typedef struct ModeDecisionContext {
     int16_t              best_spatial_pred_mv[2][4][2];
     int8_t               valid_refined_mv[2][4];
     EbPictureBufferDesc *input_sample16bit_buffer;
+#if TILES_PARALLEL
+    uint16_t             tile_index;
+#endif
     DECLARE_ALIGNED(16, uint8_t, pred0[2 * MAX_SB_SQUARE]);
     DECLARE_ALIGNED(16, uint8_t, pred1[2 * MAX_SB_SQUARE]);
     DECLARE_ALIGNED(32, int16_t, residual1[MAX_SB_SQUARE]);
@@ -371,7 +374,9 @@ extern EbErrorType mode_decision_context_ctor(ModeDecisionContext *context_ptr,
                                               uint8_t enable_hbd_mode_decision,
                                               uint8_t cfg_palette);
 
+#if !TILES_PARALLEL
 extern void reset_mode_decision_neighbor_arrays(PictureControlSet *pcs_ptr);
+#endif
 
 extern void lambda_assign_low_delay(uint32_t *fast_lambda, uint32_t *full_lambda,
                                     uint32_t *fast_chroma_lambda, uint32_t *full_chroma_lambda,
@@ -396,8 +401,13 @@ static const uint8_t quantizer_to_qindex[] = {
     128, 132, 136, 140, 144, 148, 152, 156, 160, 164, 168, 172, 176, 180, 184, 188,
     192, 196, 200, 204, 208, 212, 216, 220, 224, 228, 232, 236, 240, 244, 249, 255};
 
+#if TILES_PARALLEL
+extern void reset_mode_decision(SequenceControlSet *scs_ptr, ModeDecisionContext *context_ptr,
+                                PictureControlSet *pcs_ptr, uint16_t tile_row_idx, uint32_t segment_index);
+#else
 extern void reset_mode_decision(SequenceControlSet *scs_ptr, ModeDecisionContext *context_ptr,
                                 PictureControlSet *pcs_ptr, uint32_t segment_index);
+#endif
 
 extern void mode_decision_configure_sb(ModeDecisionContext *context_ptr, PictureControlSet *pcs_ptr,
                                        uint8_t sb_qp);

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -29,7 +29,23 @@ typedef struct PictureManagerContext {
     EbFifo *picture_control_set_fifo_ptr;
 } PictureManagerContext;
 
-void                    set_tile_info(PictureParentControlSet *pcs_ptr);
+#if TILES_PARALLEL
+// Token buffer is only used for palette tokens.
+static INLINE unsigned int get_token_alloc(int mb_rows, int mb_cols, int sb_size_log2,
+                                           const int num_planes) {
+    // Calculate the maximum number of max superblocks in the image.
+    const int shift          = sb_size_log2 - 4;
+    const int sb_size        = 1 << sb_size_log2;
+    const int sb_size_square = sb_size * sb_size;
+    const int sb_rows        = ALIGN_POWER_OF_TWO(mb_rows, shift) >> shift;
+    const int sb_cols        = ALIGN_POWER_OF_TWO(mb_cols, shift) >> shift;
+
+    // One palette token for each pixel. There can be palettes on two planes.
+    const int sb_palette_toks = AOMMIN(2, num_planes) * sb_size_square;
+
+    return sb_rows * sb_cols * sb_palette_toks;
+}
+#endif
 extern MvReferenceFrame svt_get_ref_frame_type(uint8_t list, uint8_t ref_idx);
 /************************************************
  * Defines
@@ -803,6 +819,9 @@ void *picture_manager_kernel(void *input_ptr) {
                         child_pcs_ptr->parent_pcs_ptr->sad_me         = 0;
                         child_pcs_ptr->parent_pcs_ptr->quantized_coeff_num_bits = 0;
                         child_pcs_ptr->enc_mode = entry_pcs_ptr->enc_mode;
+#if TILES_PARALLEL
+                        child_pcs_ptr->enc_dec_coded_sb_count = 0;
+#endif
 
                         //3.make all  init for ChildPCS
                         pic_width_in_sb = (uint8_t)((entry_scs_ptr->seq_header.max_frame_width +
@@ -812,7 +831,132 @@ void *picture_manager_kernel(void *input_ptr) {
                             (uint8_t)((entry_scs_ptr->seq_header.max_frame_height +
                                        entry_scs_ptr->sb_size_pix - 1) /
                                       entry_scs_ptr->sb_size_pix);
+#if TILES_PARALLEL
+                        int      sb_size_log2    = entry_scs_ptr->seq_header.sb_size_log2;
+                        uint32_t encDecSegColCnt = entry_scs_ptr->enc_dec_segment_col_count_array
+                                                       [entry_pcs_ptr->temporal_layer_index];
+                        uint32_t encDecSegRowCnt = entry_scs_ptr->enc_dec_segment_row_count_array
+                                                       [entry_pcs_ptr->temporal_layer_index];
 
+                        struct PictureParentControlSet *ppcs_ptr = child_pcs_ptr->parent_pcs_ptr;
+                        Av1Common *const                cm       = ppcs_ptr->av1_cm;
+                        uint16_t                        tile_row, tile_col;
+                        uint32_t                        x_sb_index, y_sb_index;
+                        const int tile_cols = ppcs_ptr->av1_cm->tiles_info.tile_cols;
+                        const int tile_rows = ppcs_ptr->av1_cm->tiles_info.tile_rows;
+                        TileInfo  tile_info;
+                        uint8_t   tile_group_cols = MIN(
+                            tile_cols,
+                            entry_scs_ptr
+                                ->tile_group_col_count_array[entry_pcs_ptr->temporal_layer_index]);
+                        uint8_t tile_group_rows = MIN(
+                            tile_rows,
+                            entry_scs_ptr
+                                ->tile_group_row_count_array[entry_pcs_ptr->temporal_layer_index]);
+
+                        if (tile_group_cols * tile_group_rows > 1) {
+                            encDecSegColCnt = pic_width_in_sb / tile_group_cols;
+                            encDecSegRowCnt = picture_height_in_sb / tile_group_rows;
+                        }
+
+                        ppcs_ptr->tile_group_cols = tile_group_cols;
+                        ppcs_ptr->tile_group_rows = tile_group_rows;
+
+                        uint8_t tile_group_col_start_tile_idx[1024];
+                        uint8_t tile_group_row_start_tile_idx[1024];
+
+                        // Get the tile start index for tile group
+                        for (uint8_t c = 0; c <= tile_group_cols; c++) {
+                            tile_group_col_start_tile_idx[c] = c * tile_cols / tile_group_cols;
+                        }
+                        for (uint8_t r = 0; r <= tile_group_rows; r++) {
+                            tile_group_row_start_tile_idx[r] = r * tile_rows / tile_group_rows;
+                        }
+
+                        for (uint8_t r = 0; r < tile_group_rows; r++) {
+                            for (uint8_t c = 0; c < tile_group_cols; c++) {
+                                uint16_t tile_group_idx        = r * tile_group_cols + c;
+                                uint16_t top_left_tile_col_idx = tile_group_col_start_tile_idx[c];
+                                uint16_t top_left_tile_row_idx = tile_group_row_start_tile_idx[r];
+                                uint16_t bottom_right_tile_col_idx =
+                                    tile_group_col_start_tile_idx[c + 1];
+                                uint16_t bottom_right_tile_row_idx =
+                                    tile_group_row_start_tile_idx[r + 1];
+
+                                TileGroupInfo *tg_info_ptr =
+                                    &ppcs_ptr->tile_group_info[tile_group_idx];
+
+                                tg_info_ptr->tile_group_tile_start_x = top_left_tile_col_idx;
+                                tg_info_ptr->tile_group_tile_end_x   = bottom_right_tile_col_idx;
+
+                                tg_info_ptr->tile_group_tile_start_y = top_left_tile_row_idx;
+                                tg_info_ptr->tile_group_tile_end_y   = bottom_right_tile_row_idx;
+
+                                tg_info_ptr->tile_group_sb_start_x =
+                                    cm->tiles_info.tile_col_start_mi[top_left_tile_col_idx] >>
+                                    sb_size_log2;
+                                tg_info_ptr->tile_group_sb_start_y =
+                                    cm->tiles_info.tile_row_start_mi[top_left_tile_row_idx] >>
+                                    sb_size_log2;
+
+                                // Get the SB end of the bottom right tile
+                                tg_info_ptr->tile_group_sb_end_x =
+                                    (cm->tiles_info.tile_col_start_mi[bottom_right_tile_col_idx] >>
+                                     sb_size_log2);
+                                tg_info_ptr->tile_group_sb_end_y =
+                                    (cm->tiles_info.tile_row_start_mi[bottom_right_tile_row_idx] >>
+                                     sb_size_log2);
+
+                                // Get the width/height of tile group in SB
+                                tg_info_ptr->tile_group_height_in_sb =
+                                    tg_info_ptr->tile_group_sb_end_y -
+                                    tg_info_ptr->tile_group_sb_start_y;
+                                tg_info_ptr->tile_group_width_in_sb =
+                                    tg_info_ptr->tile_group_sb_end_x -
+                                    tg_info_ptr->tile_group_sb_start_x;
+
+                                // Init segments within the tile group
+                                enc_dec_segments_init(
+                                    child_pcs_ptr->enc_dec_segment_ctrl[tile_group_idx],
+                                    encDecSegColCnt,
+                                    encDecSegRowCnt,
+                                    tg_info_ptr->tile_group_width_in_sb,
+                                    tg_info_ptr->tile_group_height_in_sb);
+
+                                // Enable tile parallelism in Entropy Coding stage
+                                for (uint16_t r = top_left_tile_row_idx;
+                                     r < bottom_right_tile_row_idx;
+                                     r++) {
+                                    for (uint16_t c = top_left_tile_col_idx;
+                                         c < bottom_right_tile_col_idx;
+                                         c++) {
+                                        uint16_t tileIdx = r * tile_cols + c;
+                                        child_pcs_ptr->entropy_coding_info[tileIdx]
+                                            ->entropy_coding_current_row = 0;
+                                        child_pcs_ptr->entropy_coding_info[tileIdx]
+                                            ->entropy_coding_current_available_row = 0;
+                                        child_pcs_ptr->entropy_coding_info[tileIdx]
+                                            ->entropy_coding_row_count =
+                                            (cm->tiles_info.tile_row_start_mi[r + 1] -
+                                             cm->tiles_info.tile_row_start_mi[r]) >>
+                                            sb_size_log2;
+                                        child_pcs_ptr->entropy_coding_info[tileIdx]
+                                            ->entropy_coding_in_progress = EB_FALSE;
+                                        child_pcs_ptr->entropy_coding_info[tileIdx]
+                                            ->entropy_coding_tile_done = EB_FALSE;
+
+                                        for (unsigned rowIndex = 0; rowIndex < MAX_SB_ROWS;
+                                             ++rowIndex) {
+                                            child_pcs_ptr->entropy_coding_info[tileIdx]
+                                                ->entropy_coding_row_array[rowIndex] = EB_FALSE;
+                                        }
+                                    }
+                                }
+                                child_pcs_ptr->entropy_coding_pic_reset_flag = EB_TRUE;
+                            }
+                        }
+
+#else
                         // EncDec Segments
                         enc_dec_segments_init(child_pcs_ptr->enc_dec_segment_ctrl,
                                               entry_scs_ptr->enc_dec_segment_col_count_array
@@ -834,9 +978,10 @@ void *picture_manager_kernel(void *input_ptr) {
                             for (row_index = 0; row_index < MAX_SB_ROWS; ++row_index)
                                 child_pcs_ptr->entropy_coding_row_array[row_index] = EB_FALSE;
                         }
+#endif
 
                         child_pcs_ptr->parent_pcs_ptr->av1_cm->pcs_ptr = child_pcs_ptr;
-
+#if !TILES_PARALLEL
                         struct PictureParentControlSet *ppcs_ptr = child_pcs_ptr->parent_pcs_ptr;
                         Av1Common *const                cm       = ppcs_ptr->av1_cm;
                         int                             tile_row, tile_col;
@@ -845,6 +990,12 @@ void *picture_manager_kernel(void *input_ptr) {
                         const int tile_rows = ppcs_ptr->av1_cm->tiles_info.tile_rows;
                         TileInfo  tile_info;
                         int       sb_size_log2 = scs_ptr->seq_header.sb_size_log2;
+#endif
+#if TILES_PARALLEL
+                        // Palette
+                        TOKENEXTRA * pre_tok  = child_pcs_ptr->tile_tok[0][0];
+                        unsigned int tile_tok = 0;
+#endif
                         //Tile Loop
                         for (tile_row = 0; tile_row < tile_rows; tile_row++) {
                             eb_av1_tile_set_row(&tile_info, &cm->tiles_info, cm->mi_rows, tile_row);
@@ -852,7 +1003,22 @@ void *picture_manager_kernel(void *input_ptr) {
                             for (tile_col = 0; tile_col < tile_cols; tile_col++) {
                                 eb_av1_tile_set_col(
                                     &tile_info, &cm->tiles_info, cm->mi_cols, tile_col);
+#if TILES_PARALLEL
+                                tile_info.tile_rs_index = tile_col + tile_row * tile_cols;
 
+                                // Palette
+                                if (child_pcs_ptr->tile_tok[0][0]) {
+                                    child_pcs_ptr->tile_tok[tile_row][tile_col] =
+                                        pre_tok + tile_tok;
+                                    pre_tok = child_pcs_ptr->tile_tok[tile_row][tile_col];
+                                    int tile_mb_rows =
+                                        (tile_info.mi_row_end - tile_info.mi_row_start + 2) >> 2;
+                                    int tile_mb_cols =
+                                        (tile_info.mi_col_end - tile_info.mi_col_start + 2) >> 2;
+                                    tile_tok = get_token_alloc(
+                                        tile_mb_rows, tile_mb_cols, (sb_size_log2 + 2), 2);
+                                }
+#endif
                                 for ((y_sb_index = cm->tiles_info.tile_row_start_mi[tile_row] >>
                                                    sb_size_log2);
                                      (y_sb_index <

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -103,6 +103,11 @@ void mode_decision_update_neighbor_arrays(PictureControlSet *  pcs_ptr,
     uint8_t inter_pred_direction_index =
         (uint8_t)context_ptr->blk_ptr->prediction_unit_array->inter_pred_direction_index;
     uint8_t ref_frame_type = (uint8_t)context_ptr->blk_ptr->prediction_unit_array[0].ref_frame_type;
+
+#if TILES_PARALLEL
+    uint16_t tile_idx = context_ptr->tile_index;
+#endif
+
     if (context_ptr->interpolation_search_level != IT_SEARCH_OFF)
         neighbor_array_unit_mode_write32(context_ptr->interpolation_type_neighbor_array,
                                          context_ptr->blk_ptr->interp_filters,
@@ -159,7 +164,11 @@ void mode_decision_update_neighbor_arrays(PictureControlSet *  pcs_ptr,
 
             neighbor_array_unit_mode_write(
                 pcs_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array
+#if TILES_PARALLEL
+                    [MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
                     [MD_NEIGHBOR_ARRAY_INDEX],
+#endif
                 (uint8_t *)&dc_sign_level_coeff,
                 context_ptr->sb_origin_x +
                     context_ptr->blk_geom->tx_org_x[context_ptr->blk_ptr->tx_depth][txb_itr],
@@ -267,7 +276,11 @@ void mode_decision_update_neighbor_arrays(PictureControlSet *  pcs_ptr,
                                         context_ptr->blk_geom->bheight);
             if (context_ptr->md_tx_size_search_mode) {
                 update_recon_neighbor_array(
+#if TILES_PARALLEL
+                    pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
                     pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
+#endif
                     context_ptr->blk_ptr->neigh_top_recon[0],
                     context_ptr->blk_ptr->neigh_left_recon[0],
                     origin_x,
@@ -306,7 +319,11 @@ void mode_decision_update_neighbor_arrays(PictureControlSet *  pcs_ptr,
                                              context_ptr->blk_geom->bheight);
         if (context_ptr->md_tx_size_search_mode) {
             update_recon_neighbor_array16bit(
+#if TILES_PARALLEL
+                pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
                 pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
+#endif
                 context_ptr->blk_ptr->neigh_top_recon_16bit[0],
                 context_ptr->blk_ptr->neigh_left_recon_16bit[0],
                 origin_x,
@@ -340,7 +357,11 @@ void mode_decision_update_neighbor_arrays(PictureControlSet *  pcs_ptr,
 void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
                            uint32_t src_idx, uint32_t dst_idx, uint32_t blk_mds, uint32_t sb_org_x,
                            uint32_t sb_org_y) {
+#if TILES_PARALLEL
+    uint16_t tile_idx = context_ptr->tile_index;
+#else
     (void)*context_ptr;
+#endif
 
     const BlockGeom *blk_geom = get_blk_geom_mds(blk_mds);
 
@@ -351,8 +372,13 @@ void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *cont
     uint32_t bwidth_uv    = blk_geom->bwidth_uv;
     uint32_t bheight_uv   = blk_geom->bheight_uv;
 
+#if TILES_PARALLEL
+    copy_neigh_arr(pcs_ptr->md_intra_luma_mode_neighbor_array[src_idx][tile_idx],
+                   pcs_ptr->md_intra_luma_mode_neighbor_array[dst_idx][tile_idx],
+#else
     copy_neigh_arr(pcs_ptr->md_intra_luma_mode_neighbor_array[src_idx],
                    pcs_ptr->md_intra_luma_mode_neighbor_array[dst_idx],
+#endif
                    blk_org_x,
                    blk_org_y,
                    blk_geom->bwidth,
@@ -360,8 +386,13 @@ void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *cont
                    NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
 
     //neighbor_array_unit_reset(pcs_ptr->md_intra_chroma_mode_neighbor_array[depth]);
+#if TILES_PARALLEL
+    copy_neigh_arr(pcs_ptr->md_intra_chroma_mode_neighbor_array[src_idx][tile_idx],
+                   pcs_ptr->md_intra_chroma_mode_neighbor_array[dst_idx][tile_idx],
+#else
     copy_neigh_arr(pcs_ptr->md_intra_chroma_mode_neighbor_array[src_idx],
                    pcs_ptr->md_intra_chroma_mode_neighbor_array[dst_idx],
+#endif
                    blk_org_x_uv,
                    blk_org_y_uv,
                    bwidth_uv,
@@ -369,8 +400,13 @@ void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *cont
                    NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
 
     //neighbor_array_unit_reset(pcs_ptr->md_skip_flag_neighbor_array[depth]);
+#if TILES_PARALLEL
+    copy_neigh_arr(pcs_ptr->md_skip_flag_neighbor_array[src_idx][tile_idx],
+                   pcs_ptr->md_skip_flag_neighbor_array[dst_idx][tile_idx],
+#else
     copy_neigh_arr(pcs_ptr->md_skip_flag_neighbor_array[src_idx],
                    pcs_ptr->md_skip_flag_neighbor_array[dst_idx],
+#endif
                    blk_org_x,
                    blk_org_y,
                    blk_geom->bwidth,
@@ -378,8 +414,13 @@ void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *cont
                    NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
 
     //neighbor_array_unit_reset(pcs_ptr->md_mode_type_neighbor_array[depth]);
+#if TILES_PARALLEL
+    copy_neigh_arr(pcs_ptr->md_mode_type_neighbor_array[src_idx][tile_idx],
+                   pcs_ptr->md_mode_type_neighbor_array[dst_idx][tile_idx],
+#else
     copy_neigh_arr(pcs_ptr->md_mode_type_neighbor_array[src_idx],
                    pcs_ptr->md_mode_type_neighbor_array[dst_idx],
+#endif
                    blk_org_x,
                    blk_org_y,
                    blk_geom->bwidth,
@@ -387,15 +428,25 @@ void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *cont
                    NEIGHBOR_ARRAY_UNIT_FULL_MASK);
 
     //neighbor_array_unit_reset(pcs_ptr->md_leaf_depth_neighbor_array[depth]);
+#if TILES_PARALLEL
+    copy_neigh_arr(pcs_ptr->md_leaf_depth_neighbor_array[src_idx][tile_idx],
+                   pcs_ptr->md_leaf_depth_neighbor_array[dst_idx][tile_idx],
+#else
     copy_neigh_arr(pcs_ptr->md_leaf_depth_neighbor_array[src_idx],
                    pcs_ptr->md_leaf_depth_neighbor_array[dst_idx],
+#endif
                    blk_org_x,
                    blk_org_y,
                    blk_geom->bwidth,
                    blk_geom->bheight,
                    NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
+#if TILES_PARALLEL
+    copy_neigh_arr(pcs_ptr->mdleaf_partition_neighbor_array[src_idx][tile_idx],
+                   pcs_ptr->mdleaf_partition_neighbor_array[dst_idx][tile_idx],
+#else
     copy_neigh_arr(pcs_ptr->mdleaf_partition_neighbor_array[src_idx],
                    pcs_ptr->mdleaf_partition_neighbor_array[dst_idx],
+#endif
                    blk_org_x,
                    blk_org_y,
                    blk_geom->bwidth,
@@ -403,16 +454,26 @@ void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *cont
                    NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
 
     if (!context_ptr->hbd_mode_decision) {
+#if TILES_PARALLEL
+        copy_neigh_arr(pcs_ptr->md_luma_recon_neighbor_array[src_idx][tile_idx],
+                       pcs_ptr->md_luma_recon_neighbor_array[dst_idx][tile_idx],
+#else
         copy_neigh_arr(pcs_ptr->md_luma_recon_neighbor_array[src_idx],
                        pcs_ptr->md_luma_recon_neighbor_array[dst_idx],
+#endif
                        blk_org_x,
                        blk_org_y,
                        blk_geom->bwidth,
                        blk_geom->bheight,
                        NEIGHBOR_ARRAY_UNIT_FULL_MASK);
         if (context_ptr->md_tx_size_search_mode) {
+#if TILES_PARALLEL
+            copy_neigh_arr(pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array[src_idx][tile_idx],
+                           pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array[dst_idx][tile_idx],
+#else
             copy_neigh_arr(pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array[src_idx],
                            pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array[dst_idx],
+#endif
                            blk_org_x,
                            blk_org_y,
                            blk_geom->bwidth,
@@ -420,16 +481,26 @@ void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *cont
                            NEIGHBOR_ARRAY_UNIT_FULL_MASK);
         }
         if (blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+#if TILES_PARALLEL
+            copy_neigh_arr(pcs_ptr->md_cb_recon_neighbor_array[src_idx][tile_idx],
+                           pcs_ptr->md_cb_recon_neighbor_array[dst_idx][tile_idx],
+#else
             copy_neigh_arr(pcs_ptr->md_cb_recon_neighbor_array[src_idx],
                            pcs_ptr->md_cb_recon_neighbor_array[dst_idx],
+#endif
                            blk_org_x_uv,
                            blk_org_y_uv,
                            bwidth_uv,
                            bheight_uv,
                            NEIGHBOR_ARRAY_UNIT_FULL_MASK);
 
+#if TILES_PARALLEL
+            copy_neigh_arr(pcs_ptr->md_cr_recon_neighbor_array[src_idx][tile_idx],
+                           pcs_ptr->md_cr_recon_neighbor_array[dst_idx][tile_idx],
+#else
             copy_neigh_arr(pcs_ptr->md_cr_recon_neighbor_array[src_idx],
                            pcs_ptr->md_cr_recon_neighbor_array[dst_idx],
+#endif
                            blk_org_x_uv,
                            blk_org_y_uv,
                            bwidth_uv,
@@ -437,16 +508,26 @@ void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *cont
                            NEIGHBOR_ARRAY_UNIT_FULL_MASK);
         }
     } else {
+#if TILES_PARALLEL
+        copy_neigh_arr(pcs_ptr->md_luma_recon_neighbor_array16bit[src_idx][tile_idx],
+                       pcs_ptr->md_luma_recon_neighbor_array16bit[dst_idx][tile_idx],
+#else
         copy_neigh_arr(pcs_ptr->md_luma_recon_neighbor_array16bit[src_idx],
                        pcs_ptr->md_luma_recon_neighbor_array16bit[dst_idx],
+#endif
                        blk_org_x,
                        blk_org_y,
                        blk_geom->bwidth,
                        blk_geom->bheight,
                        NEIGHBOR_ARRAY_UNIT_FULL_MASK);
         if (context_ptr->md_tx_size_search_mode) {
+#if TILES_PARALLEL
+            copy_neigh_arr(pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[src_idx][tile_idx],
+                           pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[dst_idx][tile_idx],
+#else
             copy_neigh_arr(pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[src_idx],
                            pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[dst_idx],
+#endif
                            blk_org_x,
                            blk_org_y,
                            blk_geom->bwidth,
@@ -455,16 +536,26 @@ void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *cont
         }
 
         if (blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+#if TILES_PARALLEL
+            copy_neigh_arr(pcs_ptr->md_cb_recon_neighbor_array16bit[src_idx][tile_idx],
+                           pcs_ptr->md_cb_recon_neighbor_array16bit[dst_idx][tile_idx],
+#else
             copy_neigh_arr(pcs_ptr->md_cb_recon_neighbor_array16bit[src_idx],
                            pcs_ptr->md_cb_recon_neighbor_array16bit[dst_idx],
+#endif
                            blk_org_x_uv,
                            blk_org_y_uv,
                            bwidth_uv,
                            bheight_uv,
                            NEIGHBOR_ARRAY_UNIT_FULL_MASK);
 
+#if TILES_PARALLEL
+            copy_neigh_arr(pcs_ptr->md_cr_recon_neighbor_array16bit[src_idx][tile_idx],
+                           pcs_ptr->md_cr_recon_neighbor_array16bit[dst_idx][tile_idx],
+#else
             copy_neigh_arr(pcs_ptr->md_cr_recon_neighbor_array16bit[src_idx],
                            pcs_ptr->md_cr_recon_neighbor_array16bit[dst_idx],
+#endif
                            blk_org_x_uv,
                            blk_org_y_uv,
                            bwidth_uv,
@@ -474,24 +565,39 @@ void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *cont
     }
 
     //neighbor_array_unit_reset(pcs_ptr->md_skip_coeff_neighbor_array[depth]);
+#if TILES_PARALLEL
+    copy_neigh_arr(pcs_ptr->md_skip_coeff_neighbor_array[src_idx][tile_idx],
+                   pcs_ptr->md_skip_coeff_neighbor_array[dst_idx][tile_idx],
+#else
     copy_neigh_arr(pcs_ptr->md_skip_coeff_neighbor_array[src_idx],
                    pcs_ptr->md_skip_coeff_neighbor_array[dst_idx],
+#endif
                    blk_org_x,
                    blk_org_y,
                    blk_geom->bwidth,
                    blk_geom->bheight,
                    NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
     //neighbor_array_unit_reset(pcs_ptr->md_luma_dc_sign_level_coeff_neighbor_array[depth]);
+#if TILES_PARALLEL
+    copy_neigh_arr(pcs_ptr->md_luma_dc_sign_level_coeff_neighbor_array[src_idx][tile_idx],
+                   pcs_ptr->md_luma_dc_sign_level_coeff_neighbor_array[dst_idx][tile_idx],
+#else
     copy_neigh_arr(pcs_ptr->md_luma_dc_sign_level_coeff_neighbor_array[src_idx],
                    pcs_ptr->md_luma_dc_sign_level_coeff_neighbor_array[dst_idx],
+#endif
                    blk_org_x,
                    blk_org_y,
                    blk_geom->bwidth,
                    blk_geom->bheight,
                    NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
 
+#if TILES_PARALLEL
+    copy_neigh_arr(pcs_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[src_idx][tile_idx],
+                   pcs_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[dst_idx][tile_idx],
+#else
     copy_neigh_arr(pcs_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[src_idx],
                    pcs_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[dst_idx],
+#endif
                    blk_org_x,
                    blk_org_y,
                    blk_geom->bwidth,
@@ -499,8 +605,13 @@ void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *cont
                    NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
 
     if (blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+#if TILES_PARALLEL
+        copy_neigh_arr(pcs_ptr->md_cb_dc_sign_level_coeff_neighbor_array[src_idx][tile_idx],
+                       pcs_ptr->md_cb_dc_sign_level_coeff_neighbor_array[dst_idx][tile_idx],
+#else
         copy_neigh_arr(pcs_ptr->md_cb_dc_sign_level_coeff_neighbor_array[src_idx],
                        pcs_ptr->md_cb_dc_sign_level_coeff_neighbor_array[dst_idx],
+#endif
                        blk_org_x_uv,
                        blk_org_y_uv,
                        bwidth_uv,
@@ -508,8 +619,13 @@ void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *cont
                        NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
         //neighbor_array_unit_reset(pcs_ptr->md_cr_dc_sign_level_coeff_neighbor_array[depth]);
 
+#if TILES_PARALLEL
+        copy_neigh_arr(pcs_ptr->md_cr_dc_sign_level_coeff_neighbor_array[src_idx][tile_idx],
+                       pcs_ptr->md_cr_dc_sign_level_coeff_neighbor_array[dst_idx][tile_idx],
+#else
         copy_neigh_arr(pcs_ptr->md_cr_dc_sign_level_coeff_neighbor_array[src_idx],
                        pcs_ptr->md_cr_dc_sign_level_coeff_neighbor_array[dst_idx],
+#endif
                        blk_org_x_uv,
                        blk_org_y_uv,
                        bwidth_uv,
@@ -518,32 +634,52 @@ void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *cont
     }
 
     //neighbor_array_unit_reset(pcs_ptr->md_txfm_context_array[depth]);
+#if TILES_PARALLEL
+    copy_neigh_arr(pcs_ptr->md_txfm_context_array[src_idx][tile_idx],
+                   pcs_ptr->md_txfm_context_array[dst_idx][tile_idx],
+#else
     copy_neigh_arr(pcs_ptr->md_txfm_context_array[src_idx],
                    pcs_ptr->md_txfm_context_array[dst_idx],
+#endif
                    blk_org_x,
                    blk_org_y,
                    blk_geom->bwidth,
                    blk_geom->bheight,
                    NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
     //neighbor_array_unit_reset(pcs_ptr->md_inter_pred_dir_neighbor_array[depth]);
+#if TILES_PARALLEL
+    copy_neigh_arr(pcs_ptr->md_inter_pred_dir_neighbor_array[src_idx][tile_idx],
+                   pcs_ptr->md_inter_pred_dir_neighbor_array[dst_idx][tile_idx],
+#else
     copy_neigh_arr(pcs_ptr->md_inter_pred_dir_neighbor_array[src_idx],
                    pcs_ptr->md_inter_pred_dir_neighbor_array[dst_idx],
+#endif
                    blk_org_x,
                    blk_org_y,
                    blk_geom->bwidth,
                    blk_geom->bheight,
                    NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
     //neighbor_array_unit_reset(pcs_ptr->md_ref_frame_type_neighbor_array[depth]);
+#if TILES_PARALLEL
+    copy_neigh_arr(pcs_ptr->md_ref_frame_type_neighbor_array[src_idx][tile_idx],
+                   pcs_ptr->md_ref_frame_type_neighbor_array[dst_idx][tile_idx],
+#else
     copy_neigh_arr(pcs_ptr->md_ref_frame_type_neighbor_array[src_idx],
                    pcs_ptr->md_ref_frame_type_neighbor_array[dst_idx],
+#endif
                    blk_org_x,
                    blk_org_y,
                    blk_geom->bwidth,
                    blk_geom->bheight,
                    NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
 
+#if TILES_PARALLEL
+    copy_neigh_arr_32(pcs_ptr->md_interpolation_type_neighbor_array[src_idx][tile_idx],
+                      pcs_ptr->md_interpolation_type_neighbor_array[dst_idx][tile_idx],
+#else
     copy_neigh_arr_32(pcs_ptr->md_interpolation_type_neighbor_array[src_idx],
                       pcs_ptr->md_interpolation_type_neighbor_array[dst_idx],
+#endif
                       blk_org_x,
                       blk_org_y,
                       blk_geom->bwidth,
@@ -3386,29 +3522,51 @@ uint8_t allowed_tx_set_a[TX_SIZES_ALL][TX_TYPES];
 
 void tx_initialize_neighbor_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
                                    EbBool is_inter) {
+#if TILES_PARALLEL
+    uint16_t tile_idx = context_ptr->tile_index;
+#endif
     // Set recon neighbor array to be used @ intra compensation
     if (!is_inter) {
         if (context_ptr->hbd_mode_decision)
             context_ptr->tx_search_luma_recon_neighbor_array16bit =
                 (context_ptr->tx_depth)
+#if TILES_PARALLEL
+                    ? pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx]
+                    : pcs_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+#else
                     ? pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX]
                     : pcs_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX];
+#endif
         else
             context_ptr->tx_search_luma_recon_neighbor_array =
                 (context_ptr->tx_depth)
+#if TILES_PARALLEL
+                    ? pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx]
+                    : pcs_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+#else
                     ? pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX]
                     : pcs_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
+#endif
     }
     // Set luma dc sign level coeff
     context_ptr->full_loop_luma_dc_sign_level_coeff_neighbor_array =
         (context_ptr->tx_depth == 1)
+#if TILES_PARALLEL
+            ? pcs_ptr
+                  ->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx]
+            : pcs_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+#else
             ? pcs_ptr
                   ->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX]
             : pcs_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
+#endif
 }
 
 void tx_update_neighbor_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
                                ModeDecisionCandidateBuffer *candidate_buffer, EbBool is_inter) {
+#if TILES_PARALLEL
+    uint16_t tile_idx = context_ptr->tile_index;
+#endif
     if (context_ptr->tx_depth) {
         if (!is_inter)
             tx_search_update_recon_sample_neighbor_array(
@@ -3429,7 +3587,11 @@ void tx_update_neighbor_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *
         int8_t dc_sign_level_coeff =
             candidate_buffer->candidate_ptr->quantized_dc[0][context_ptr->txb_itr];
         neighbor_array_unit_mode_write(
+#if TILES_PARALLEL
+            pcs_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
             pcs_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
+#endif
             (uint8_t *)&dc_sign_level_coeff,
             context_ptr->sb_origin_x +
                 context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr],
@@ -3443,20 +3605,33 @@ void tx_update_neighbor_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *
 
 void tx_reset_neighbor_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
                               EbBool is_inter, uint8_t end_tx_depth) {
+#if TILES_PARALLEL
+    uint16_t tile_idx = context_ptr->tile_index;
+#endif
     if (end_tx_depth) {
         if (!is_inter) {
             if (context_ptr->hbd_mode_decision) {
                 copy_neigh_arr(
+#if TILES_PARALLEL
+                    pcs_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+                    pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
                     pcs_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
                     pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
+#endif
                     context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x,
                     context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y,
                     context_ptr->blk_geom->bwidth,
                     context_ptr->blk_geom->bheight,
                     NEIGHBOR_ARRAY_UNIT_TOPLEFT_MASK);
                 copy_neigh_arr(
+#if TILES_PARALLEL
+                    pcs_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+                    pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
                     pcs_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
                     pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX],
+#endif
                     context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x,
                     context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y,
                     context_ptr->blk_geom->bwidth * 2,
@@ -3466,8 +3641,13 @@ void tx_reset_neighbor_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *c
 
             else {
                 copy_neigh_arr(
+#if TILES_PARALLEL
+                    pcs_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+                    pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
                     pcs_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
                     pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
+#endif
                     context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x,
                     context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y,
                     context_ptr->blk_geom->bwidth,
@@ -3475,8 +3655,13 @@ void tx_reset_neighbor_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *c
                     NEIGHBOR_ARRAY_UNIT_TOPLEFT_MASK);
 
                 copy_neigh_arr(
+#if TILES_PARALLEL
+                    pcs_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+                    pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
                     pcs_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
                     pcs_ptr->md_tx_depth_1_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
+#endif
                     context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x,
                     context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y,
                     context_ptr->blk_geom->bwidth * 2,
@@ -3486,8 +3671,13 @@ void tx_reset_neighbor_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *c
         }
 
         copy_neigh_arr(
+#if TILES_PARALLEL
+            pcs_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+            pcs_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx],
+#else
             pcs_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
             pcs_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
+#endif
             context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x,
             context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y,
             context_ptr->blk_geom->bwidth,
@@ -6421,6 +6611,9 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
     // Pre Intra Search
     uint32_t                   leaf_count      = mdcResultTbPtr->leaf_count;
     const EbMdcLeafData *const leaf_data_array = mdcResultTbPtr->leaf_data_array;
+#if TILES_PARALLEL
+    const uint16_t tile_idx = context_ptr->tile_index;
+#endif
     context_ptr->sb_ptr                        = sb_ptr;
     context_ptr->coeff_based_skip_atb          = 0;
     EbBool all_blk_init = (pcs_ptr->parent_pcs_ptr->pic_depth_mode <= PIC_SQ_DEPTH_MODE);
@@ -6430,6 +6623,52 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
         init_sq_non4_block(scs_ptr, context_ptr);
     }
     // Mode Decision Neighbor Arrays
+#if TILES_PARALLEL
+    context_ptr->intra_luma_mode_neighbor_array =
+        pcs_ptr->md_intra_luma_mode_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->intra_chroma_mode_neighbor_array =
+        pcs_ptr->md_intra_chroma_mode_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->mv_neighbor_array = pcs_ptr->md_mv_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->skip_flag_neighbor_array =
+        pcs_ptr->md_skip_flag_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->mode_type_neighbor_array =
+        pcs_ptr->md_mode_type_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->leaf_depth_neighbor_array =
+        pcs_ptr->md_leaf_depth_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->leaf_partition_neighbor_array =
+        pcs_ptr->mdleaf_partition_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+
+    if (!context_ptr->hbd_mode_decision) {
+        context_ptr->luma_recon_neighbor_array =
+            pcs_ptr->md_luma_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+        context_ptr->cb_recon_neighbor_array =
+            pcs_ptr->md_cb_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+        context_ptr->cr_recon_neighbor_array =
+            pcs_ptr->md_cr_recon_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    } else {
+        context_ptr->luma_recon_neighbor_array16bit =
+            pcs_ptr->md_luma_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+        context_ptr->cb_recon_neighbor_array16bit =
+            pcs_ptr->md_cb_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+        context_ptr->cr_recon_neighbor_array16bit =
+            pcs_ptr->md_cr_recon_neighbor_array16bit[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    }
+    context_ptr->skip_coeff_neighbor_array =
+        pcs_ptr->md_skip_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->luma_dc_sign_level_coeff_neighbor_array =
+        pcs_ptr->md_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->cb_dc_sign_level_coeff_neighbor_array =
+        pcs_ptr->md_cb_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->cr_dc_sign_level_coeff_neighbor_array =
+        pcs_ptr->md_cr_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->txfm_context_array = pcs_ptr->md_txfm_context_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->inter_pred_dir_neighbor_array =
+        pcs_ptr->md_inter_pred_dir_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->ref_frame_type_neighbor_array =
+        pcs_ptr->md_ref_frame_type_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+    context_ptr->interpolation_type_neighbor_array =
+        pcs_ptr->md_interpolation_type_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX][tile_idx];
+#else
     context_ptr->intra_luma_mode_neighbor_array =
         pcs_ptr->md_intra_luma_mode_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
     context_ptr->intra_chroma_mode_neighbor_array =
@@ -6474,6 +6713,7 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
         pcs_ptr->md_ref_frame_type_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
     context_ptr->interpolation_type_neighbor_array =
         pcs_ptr->md_interpolation_type_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX];
+#endif
     uint32_t             d1_block_itr      = 0;
     uint32_t             d1_first_block    = 1;
     EbPictureBufferDesc *input_picture_ptr = pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -57,7 +57,11 @@ typedef struct ResourceCoordinationContext {
     EbBool   start_flag;
 } ResourceCoordinationContext;
 
+#if !TILES_PARALLEL
+//Jing: move to EncHandle, since we need to know the tile count to alloc resources in child pcs
 void set_tile_info(PictureParentControlSet *pcs_ptr);
+#endif
+
 static void resource_coordination_context_dctor(EbPtr p) {
     EbThreadContext *thread_contxt_ptr = (EbThreadContext *)p;
     if (thread_contxt_ptr->priv) {
@@ -997,8 +1001,9 @@ void *resource_coordination_kernel(void *input_ptr) {
                 eb_object_inc_live_count(pcs_ptr->pa_reference_picture_wrapper_ptr, 1);
             else
                 eb_object_inc_live_count(pcs_ptr->pa_reference_picture_wrapper_ptr, 2);
-
+#if !TILES_PARALLEL
             set_tile_info(pcs_ptr);
+#endif
             if (scs_ptr->static_config.unrestricted_motion_vector == 0) {
                 struct PictureParentControlSet *ppcs_ptr = pcs_ptr;
                 Av1Common *const                cm       = ppcs_ptr->av1_cm;

--- a/Source/Lib/Encoder/Codec/EbRestProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRestProcess.c
@@ -41,9 +41,9 @@ typedef struct RestContext {
 
     EbPictureBufferDesc *
         org_rec_frame; // while doing the filtering recon gets updated uisng setup/restore processing_stripe_bounadaries
-        // many threads doing the above will result in race condition.
-        // each thread will hence have his own copy of recon to work on.
-        // later we can have a search version that does not need the exact right recon
+    // many threads doing the above will result in race condition.
+    // each thread will hence have his own copy of recon to work on.
+    // later we can have a search version that does not need the exact right recon
     int32_t *rst_tmpbuf;
 } RestContext;
 
@@ -260,9 +260,11 @@ void *rest_kernel(void *input_ptr) {
         pcs_ptr          = (PictureControlSet *)cdef_results_ptr->pcs_wrapper_ptr->object_ptr;
         scs_ptr          = (SequenceControlSet *)pcs_ptr->scs_wrapper_ptr->object_ptr;
         frm_hdr          = &pcs_ptr->parent_pcs_ptr->frm_hdr;
-        uint8_t    sb_size_log2 = (uint8_t)Log2f(scs_ptr->sb_size_pix);
-        EbBool     is_16bit     = (EbBool)(scs_ptr->static_config.encoder_bit_depth > EB_8BIT);
-        Av1Common *cm           = pcs_ptr->parent_pcs_ptr->av1_cm;
+#if !TILES_PARALLEL
+        uint8_t sb_size_log2 = (uint8_t)Log2f(scs_ptr->sb_size_pix);
+#endif
+        EbBool     is_16bit = (EbBool)(scs_ptr->static_config.encoder_bit_depth > EB_8BIT);
+        Av1Common *cm       = pcs_ptr->parent_pcs_ptr->av1_cm;
 
         if (scs_ptr->seq_header.enable_restoration && frm_hdr->allow_intrabc == 0) {
             get_own_recon(scs_ptr, pcs_ptr, context_ptr, is_16bit);
@@ -344,6 +346,36 @@ void *rest_kernel(void *input_ptr) {
                 // Post Reference Picture
                 eb_post_full_object(picture_demux_results_wrapper_ptr);
             }
+#if TILES_PARALLEL
+            //Jing: TODO
+            //Consider to add parallelism here, sending line by line, not waiting for a full frame
+            int sb_size_log2 = scs_ptr->seq_header.sb_size_log2;
+            for (int tile_row_idx = 0;
+                 tile_row_idx < pcs_ptr->parent_pcs_ptr->av1_cm->tiles_info.tile_rows;
+                 tile_row_idx++) {
+                uint16_t tile_height_in_sb =
+                    (cm->tiles_info.tile_row_start_mi[tile_row_idx + 1] -
+                     cm->tiles_info.tile_row_start_mi[tile_row_idx] + (1 << sb_size_log2) - 1)
+                     >> sb_size_log2;
+                for (int tile_col_idx = 0;
+                     tile_col_idx < pcs_ptr->parent_pcs_ptr->av1_cm->tiles_info.tile_cols;
+                     tile_col_idx++) {
+                    const int tile_idx =
+                        tile_row_idx * pcs_ptr->parent_pcs_ptr->av1_cm->tiles_info.tile_cols +
+                        tile_col_idx;
+                    eb_get_empty_object(context_ptr->rest_output_fifo_ptr,
+                                        &rest_results_wrapper_ptr);
+                    rest_results_ptr = (struct RestResults *)rest_results_wrapper_ptr->object_ptr;
+                    rest_results_ptr->pcs_wrapper_ptr = cdef_results_ptr->pcs_wrapper_ptr;
+                    rest_results_ptr->completed_sb_row_index_start = 0;
+                    // Set to tile rows
+                    rest_results_ptr->completed_sb_row_count = tile_height_in_sb;
+                    rest_results_ptr->tile_index             = tile_idx;
+                    // Post Rest Results
+                    eb_post_full_object(rest_results_wrapper_ptr);
+                }
+            }
+#else
 
             // Get Empty rest Results to EC
             eb_get_empty_object(context_ptr->rest_output_fifo_ptr, &rest_results_wrapper_ptr);
@@ -354,6 +386,7 @@ void *rest_kernel(void *input_ptr) {
                 ((scs_ptr->seq_header.max_frame_height + scs_ptr->sb_size_pix - 1) >> sb_size_log2);
             // Post Rest Results
             eb_post_full_object(rest_results_wrapper_ptr);
+#endif
         }
         eb_release_mutex(pcs_ptr->rest_search_mutex);
 

--- a/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
@@ -351,6 +351,10 @@ EbErrorType copy_sequence_control_set(SequenceControlSet *dst, SequenceControlSe
         dst->me_segment_row_count_array[i]      = src->me_segment_row_count_array[i];
         dst->enc_dec_segment_col_count_array[i] = src->enc_dec_segment_col_count_array[i];
         dst->enc_dec_segment_row_count_array[i] = src->enc_dec_segment_row_count_array[i];
+#if TILES_PARALLEL
+        dst->tile_group_col_count_array[i] = src->tile_group_col_count_array[i];
+        dst->tile_group_row_count_array[i] = src->tile_group_row_count_array[i];
+#endif
     }
 
     dst->cdef_segment_column_count = src->cdef_segment_column_count;

--- a/Source/Lib/Encoder/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbSequenceControlSet.h
@@ -100,6 +100,12 @@ typedef struct SequenceControlSet {
     uint32_t picture_analysis_number_of_regions_per_width;
     uint32_t picture_analysis_number_of_regions_per_height;
 
+#if TILES_PARALLEL
+    // Tile Group
+    uint8_t tile_group_col_count_array[MAX_TEMPORAL_LAYERS];
+    uint8_t tile_group_row_count_array[MAX_TEMPORAL_LAYERS];
+#endif
+
     // Segments
     uint32_t me_segment_column_count_array[MAX_TEMPORAL_LAYERS];
     uint32_t me_segment_row_count_array[MAX_TEMPORAL_LAYERS];


### PR DESCRIPTION
## Description

-Enabled tile group parallelism at encDec kernel, now set tile group the same as tile row
-Enabled tile parallelism at enctropy kernel
-Fixed a bug during saving the mvs
-Enabled palette for tile parallelism at entropy kernel
-Improved the tile_size_bytes_minus_1 field

Signed-off-by: Jing Li <jing.b.li@intel.com>