### PR TITLE
EbFullLoop: fix valgrind errors in merge_1d_inter_block

### DIFF
--- a/Source/Lib/Encoder/Codec/EbFullLoop.c
+++ b/Source/Lib/Encoder/Codec/EbFullLoop.c
@@ -3240,11 +3240,13 @@ EbBool merge_1d_inter_block(ModeDecisionContext *context_ptr, uint32_t sq_idx, u
     int parent_diriction  = parent_blk_ptr->prediction_unit_array[0].inter_pred_direction_index;
     int parent_mv_l0      = parent_blk_ptr->prediction_unit_array[0].mv[REF_LIST_0].mv_union;
     int parent_mv_l1      = parent_blk_ptr->prediction_unit_array[0].mv[REF_LIST_1].mv_union;
+    int child_avail_flag  = context_ptr->md_local_blk_unit[nsq_idx].avail_blk_flag;
     int child_0_diriction = child_blk_ptr->prediction_unit_array[0].inter_pred_direction_index;
     int child_0_mv_l0     = child_blk_ptr->prediction_unit_array[0].mv[REF_LIST_0].mv_union;
     int child_0_mv_l1     = child_blk_ptr->prediction_unit_array[0].mv[REF_LIST_1].mv_union;
     int child_eob         = child_blk_ptr->block_has_coeff;
-    if (parent_diriction == child_0_diriction && child_eob == 0) {
+
+    if (child_avail_flag && parent_diriction == child_0_diriction && child_eob == 0) {
         switch (parent_diriction) {
         case UNI_PRED_LIST_0:
             if (parent_mv_l0 == child_0_mv_l0) merge_blocks = EB_TRUE;


### PR DESCRIPTION
This should fix the following valgrind errors without modifying the
bitstream:

Conditional jump or move depends on uninitialised value(s)
   at 0x4AA1DBA: merge_1d_inter_block (Source/Lib/Encoder/Codec/EbFullLoop.c:3247)
   by 0x4AA1F5E: d1_non_square_block_decision (Source/Lib/Encoder/Codec/EbFullLoop.c:3278)
   by 0x4B89D60: mode_decision_sb (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:7032)
   by 0x4A6FC57: enc_dec_kernel (Source/Lib/Encoder/Codec/EbEncDecProcess.c:2800)
   by 0xF3BD668: start_thread (pthread_create.c:479)
   by 0xF648322: clone (clone.S:95)

Conditional jump or move depends on uninitialised value(s)
   at 0x4AA1DFB: merge_1d_inter_block (Source/Lib/Encoder/Codec/EbFullLoop.c:3250)
   by 0x4AA1F5E: d1_non_square_block_decision (Source/Lib/Encoder/Codec/EbFullLoop.c:3278)
   by 0x4B89D60: mode_decision_sb (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:7032)
   by 0x4A6FC57: enc_dec_kernel (Source/Lib/Encoder/Codec/EbEncDecProcess.c:2800)
   by 0xF3BD668: start_thread (pthread_create.c:479)
   by 0xF648322: clone (clone.S:95)