### PR TITLE
Fix valgrind issues

### DIFF
--- a/Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.h
+++ b/Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.h
@@ -55,7 +55,7 @@ void enc_pass_av1_mv_pred(TileInfo *tile, struct ModeDecisionContext *md_context
 
 void update_mi_map(struct ModeDecisionContext *context_ptr, BlkStruct *blk_ptr,
                    uint32_t blk_origin_x, uint32_t blk_origin_y, const BlockGeom *blk_geom,
-                   PictureControlSet *pcs_ptr);
+                   uint8_t avail_blk_flag, PictureControlSet *pcs_ptr);
 
 uint16_t wm_find_samples(BlkStruct *blk_ptr, const BlockGeom *blk_geom, uint16_t blk_origin_x,
                          uint16_t blk_origin_y, MvReferenceFrame rf0, PictureControlSet *pcs_ptr,

--- a/Source/Lib/Encoder/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Encoder/Codec/EbEntropyCoding.c
@@ -1519,9 +1519,9 @@ MotionMode motion_mode_allowed(const PictureControlSet *pcs_ptr, const BlkStruct
         if (!has_overlappable_candidates(blk_ptr)) // check_num_overlappable_neighbors
             return SIMPLE_TRANSLATION;
 
-        if (blk_ptr->prediction_unit_array[0].num_proj_ref >= 1 &&
-            (frm_hdr
-                 ->allow_warped_motion)) // TODO(JS): when scale is added, put: && !av1_is_scaled(&(xd->block_refs[0]->sf))
+        if (frm_hdr->allow_warped_motion &&
+            /* TODO(JS): when scale is added, put: !av1_is_scaled(&(xd->block_refs[0]->sf)) && */
+            blk_ptr->prediction_unit_array[0].num_proj_ref >= 1)
         {
             if (frm_hdr->force_integer_mv) return OBMC_CAUSAL;
             return WARPED_CAUSAL;

--- a/Source/Lib/Encoder/Codec/EbFullLoop.c
+++ b/Source/Lib/Encoder/Codec/EbFullLoop.c
@@ -3240,11 +3240,13 @@ EbBool merge_1d_inter_block(ModeDecisionContext *context_ptr, uint32_t sq_idx, u
     int parent_diriction  = parent_blk_ptr->prediction_unit_array[0].inter_pred_direction_index;
     int parent_mv_l0      = parent_blk_ptr->prediction_unit_array[0].mv[REF_LIST_0].mv_union;
     int parent_mv_l1      = parent_blk_ptr->prediction_unit_array[0].mv[REF_LIST_1].mv_union;
+    int child_avail_flag  = context_ptr->md_local_blk_unit[nsq_idx].avail_blk_flag;
     int child_0_diriction = child_blk_ptr->prediction_unit_array[0].inter_pred_direction_index;
     int child_0_mv_l0     = child_blk_ptr->prediction_unit_array[0].mv[REF_LIST_0].mv_union;
     int child_0_mv_l1     = child_blk_ptr->prediction_unit_array[0].mv[REF_LIST_1].mv_union;
     int child_eob         = child_blk_ptr->block_has_coeff;
-    if (parent_diriction == child_0_diriction && child_eob == 0) {
+
+    if (child_avail_flag && parent_diriction == child_0_diriction && child_eob == 0) {
         switch (parent_diriction) {
         case UNI_PRED_LIST_0:
             if (parent_mv_l0 == child_0_mv_l0) merge_blocks = EB_TRUE;

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -697,6 +697,7 @@ void md_update_all_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionCont
     context_ptr->round_origin_y = ((context_ptr->blk_origin_y >> 3) << 3);
 
     context_ptr->blk_ptr = &context_ptr->md_blk_arr_nsq[last_blk_index_mds];
+    uint8_t avail_blk_flag = context_ptr->md_local_blk_unit[last_blk_index_mds].avail_blk_flag;
 
     mode_decision_update_neighbor_arrays(
         pcs_ptr, context_ptr, last_blk_index_mds, pcs_ptr->intra_md_open_loop_flag, EB_FALSE);
@@ -706,6 +707,7 @@ void md_update_all_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionCont
                   context_ptr->blk_origin_x,
                   context_ptr->blk_origin_y,
                   context_ptr->blk_geom,
+                  avail_blk_flag,
                   pcs_ptr);
 }
 
@@ -6273,7 +6275,6 @@ void md_encode_block(SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
         context_ptr->md_local_blk_unit[blk_ptr->mds_idx].avail_blk_flag = EB_TRUE;
     } else {
         context_ptr->md_local_blk_unit[blk_ptr->mds_idx].cost = MAX_MODE_COST;
-        blk_ptr->prediction_unit_array->ref_frame_type        = 0;
     }
 }
 


### PR DESCRIPTION
This PR should fix the following valgrind issues and should not modify the bitstream:

```
Conditional jump or move depends on uninitialised value(s)
   at 0x4AA1DBA: merge_1d_inter_block (Source/Lib/Encoder/Codec/EbFullLoop.c:3247)
   by 0x4AA1F5E: d1_non_square_block_decision (Source/Lib/Encoder/Codec/EbFullLoop.c:3278)
   by 0x4B89D60: mode_decision_sb (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:7032)
   by 0x4A6FC57: enc_dec_kernel (Source/Lib/Encoder/Codec/EbEncDecProcess.c:2800)
   by 0xF3BD668: start_thread (pthread_create.c:479)
   by 0xF648322: clone (clone.S:95)

Conditional jump or move depends on uninitialised value(s)
   at 0x4AA1DFB: merge_1d_inter_block (Source/Lib/Encoder/Codec/EbFullLoop.c:3250)
   by 0x4AA1F5E: d1_non_square_block_decision (Source/Lib/Encoder/Codec/EbFullLoop.c:3278)
   by 0x4B89D60: mode_decision_sb (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:7032)
   by 0x4A6FC57: enc_dec_kernel (Source/Lib/Encoder/Codec/EbEncDecProcess.c:2800)
   by 0xF3BD668: start_thread (pthread_create.c:479)
   by 0xF648322: clone (clone.S:95)

Conditional jump or move depends on uninitialised value(s)
   at 0x4A3C543: av1_set_ref_frame (Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.c:147)
   by 0x4A423C0: update_mi_map (Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.c:1587)
   by 0x4B735D9: md_update_all_neighbour_arrays (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:704)
   by 0x4B89F03: mode_decision_sb (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:7049)
   by 0x4A6FDD7: enc_dec_kernel (Source/Lib/Encoder/Codec/EbEncDecProcess.c:2879)
   by 0xF3BB668: start_thread (pthread_create.c:479)
   by 0xF646322: clone (clone.S:95)

Conditional jump or move depends on uninitialised value(s)
   at 0x4A42467: update_mi_map (Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.c:1597)
   by 0x4B735D9: md_update_all_neighbour_arrays (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:704)
   by 0x4B89F03: mode_decision_sb (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:7049)
   by 0x4A6FDD7: enc_dec_kernel (Source/Lib/Encoder/Codec/EbEncDecProcess.c:2879)
   by 0xF3BB668: start_thread (pthread_create.c:479)
   by 0xF646322: clone (clone.S:95)

Conditional jump or move depends on uninitialised value(s)
   at 0x4A425FA: update_mi_map (Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.c:1614)
   by 0x4B735D9: md_update_all_neighbour_arrays (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:704)
   by 0x4B89F03: mode_decision_sb (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:7049)
   by 0x4A6FDD7: enc_dec_kernel (Source/Lib/Encoder/Codec/EbEncDecProcess.c:2879)
   by 0xF3BB668: start_thread (pthread_create.c:479)
   by 0xF646322: clone (clone.S:95)

Conditional jump or move depends on uninitialised value(s)
   at 0x4A42650: update_mi_map (Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.c:1615)
   by 0x4B735D9: md_update_all_neighbour_arrays (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:704)
   by 0x4B89F03: mode_decision_sb (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:7049)
   by 0x4A6FDD7: enc_dec_kernel (Source/Lib/Encoder/Codec/EbEncDecProcess.c:2879)
   by 0xF3BB668: start_thread (pthread_create.c:479)
   by 0xF646322: clone (clone.S:95)

Conditional jump or move depends on uninitialised value(s)
   at 0x4A42856: update_mi_map (Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.c:1642)
   by 0x4B735D9: md_update_all_neighbour_arrays (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:704)
   by 0x4B89F03: mode_decision_sb (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:7049)
   by 0x4A6FDD7: enc_dec_kernel (Source/Lib/Encoder/Codec/EbEncDecProcess.c:2879)
   by 0xF3BB668: start_thread (pthread_create.c:479)
   by 0xF646322: clone (clone.S:95)

Conditional jump or move depends on uninitialised value(s)
   at 0x4A42879: update_mi_map (Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.c:1643)
   by 0x4B735D9: md_update_all_neighbour_arrays (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:704)
   by 0x4B89F03: mode_decision_sb (Source/Lib/Encoder/Codec/EbProductCodingLoop.c:7049)
   by 0x4A6FDD7: enc_dec_kernel (Source/Lib/Encoder/Codec/EbEncDecProcess.c:2879)
   by 0xF3BB668: start_thread (pthread_create.c:479)
   by 0xF646322: clone (clone.S:95)

Conditional jump or move depends on uninitialised value(s)
   at 0x4A7BA4D: motion_mode_allowed (Source/Lib/Encoder/Codec/EbEntropyCoding.c:1522)
   by 0x4A88476: write_motion_mode (Source/Lib/Encoder/Codec/EbEntropyCoding.c:1544)
   by 0x4A8543D: write_modes_b (Source/Lib/Encoder/Codec/EbEntropyCoding.c:6156)
   by 0x4A88C3F: write_sb (Source/Lib/Encoder/Codec/EbEntropyCoding.c:6448)
   by 0x4A907EF: entropy_coding_kernel (Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c:621)
   by 0xF3BB668: start_thread (pthread_create.c:479)
   by 0xF646322: clone (clone.S:95)
```