### PR TITLE
Fix all tests from SvtAv1E2ETests

### DIFF
--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2580,6 +2580,11 @@ static EbErrorType verify_settings(
         return_error = EB_ErrorBadParameter;
     }
 
+    if (config->encoder_color_format != EB_YUV420) {
+        SVT_LOG("Error instance %u: Only support 420 now \n", channel_number + 1);
+        return_error = EB_ErrorBadParameter;
+    }
+
     if (config->profile == 0 && config->encoder_color_format > EB_YUV420) {
         SVT_LOG("Error instance %u: Non 420 color format requires profile 1 or 2\n", channel_number + 1);
         return_error = EB_ErrorBadParameter;

--- a/test/api_test/SvtAv1EncParamsTest.cc
+++ b/test/api_test/SvtAv1EncParamsTest.cc
@@ -354,9 +354,9 @@ DEFINE_PARAM_TEST_CLASS(EncParamHighDynamicRangeInputTest,
                         high_dynamic_range_input);
 PARAM_TEST(EncParamHighDynamicRangeInputTest);
 
-/** Test case for profile*/
-DEFINE_PARAM_TEST_CLASS(EncParamProfileTest, profile);
-PARAM_TEST(EncParamProfileTest);
+/** Test case for profile, requiure YUV 422 or 444 which is unsupported now */
+//DEFINE_PARAM_TEST_CLASS(EncParamProfileTest, profile);
+//PARAM_TEST(EncParamProfileTest);
 
 /** Test case for tier*/
 DEFINE_PARAM_TEST_CLASS(EncParamTierTest, tier);

--- a/test/e2e_test/SvtAv1E2EFramework.cc
+++ b/test/e2e_test/SvtAv1E2EFramework.cc
@@ -238,7 +238,7 @@ void SvtAv1E2ETestFramework::init_test(TestVideoVector &test_vector) {
         << "eb_svt_enc_stream_header return null output buffer."
         << return_error;
 
-#if TILES
+#if TILES_PARALLEL
     EbBool has_tiles = (EbBool)(av1enc_ctx_.enc_params.tile_columns ||
                                 av1enc_ctx_.enc_params.tile_rows);
 #else

--- a/test/e2e_test/SvtAv1E2EParamsTest.cc
+++ b/test/e2e_test/SvtAv1E2EParamsTest.cc
@@ -98,13 +98,13 @@ static const std::vector<EncTestSetting> default_enc_settings = {
      {{"RateControlMode", "2"}, {"TargetBitRate", "500000"}},
      res_480p_test_vectors},
     {"RcTest4",
-     {{"RateControlMode", "3"}, {"TargetBitRate", "1000000"}},
+     {{"RateControlMode", "1"}, {"TargetBitRate", "1000000"}},
      res_480p_test_vectors},
     {"RcTest5",
-     {{"RateControlMode", "3"}, {"TargetBitRate", "750000"}},
+     {{"RateControlMode", "1"}, {"TargetBitRate", "750000"}},
      res_480p_test_vectors},
     {"RcTest6",
-     {{"RateControlMode", "3"}, {"TargetBitRate", "500000"}},
+     {{"RateControlMode", "1"}, {"TargetBitRate", "500000"}},
      res_480p_test_vectors},
 
     // test high bitrate with big min_qp, or low bitrate with small max_qp
@@ -118,13 +118,13 @@ static const std::vector<EncTestSetting> default_enc_settings = {
      {{"RateControlMode", "2"}, {"TargetBitRate", "750000"}, {"MaxQpAllowed", "50"}, {"MinQpAllowed", "20"}},
      res_480p_test_vectors},
     {"RcQpTest4",
-     {{"RateControlMode", "3"}, {"TargetBitRate", "1000000"}, {"MinQpAllowed", "20"}},
+     {{"RateControlMode", "1"}, {"TargetBitRate", "1000000"}, {"MinQpAllowed", "20"}},
      res_480p_test_vectors},
     {"RcQpTest5",
-     {{"RateControlMode", "3"}, {"TargetBitRate", "500000"}, {"MaxQpAllowed", "50"}},
+     {{"RateControlMode", "1"}, {"TargetBitRate", "500000"}, {"MaxQpAllowed", "50"}},
      res_480p_test_vectors},
     {"RcQpTest6",
-     {{"RateControlMode", "3"}, {"TargetBitRate", "750000"}, {"MaxQpAllowed", "50"}, {"MinQpAllowed", "20"}},
+     {{"RateControlMode", "1"}, {"TargetBitRate", "750000"}, {"MaxQpAllowed", "50"}, {"MinQpAllowed", "20"}},
      res_480p_test_vectors},
 };
 /* clang-format on */

--- a/test/e2e_test/SvtAv1E2ETest.cc
+++ b/test/e2e_test/SvtAv1E2ETest.cc
@@ -137,9 +137,9 @@ static const std::vector<EncTestSetting> default_enc_settings = {
     // test constrained intra, default is 0
     {"ConstrainIntraTest1", {{"ConstrainedIntra", "1"}}, default_test_vectors},
 
-    // test rate control modes, default is 0, 1 is not supported
+    // test rate control modes, default is 0, 1 and 2 is supported
     {"RateControlTest1", {{"RateControlMode", "2"}}, default_test_vectors},
-    {"RateControlTest2", {{"RateControlMode", "3"}}, default_test_vectors},
+    {"RateControlTest2", {{"RateControlMode", "1"}}, default_test_vectors},
 
     // test scene change detection, default is 1
     {"SCDTest1", {{"SceneChangeDetection", "0"}}, default_test_vectors},
@@ -202,8 +202,10 @@ static const std::vector<EncTestSetting> default_enc_settings = {
 
     // test by using a dummy source of color bar
     {"DummySrcTest1", {{"EncoderMode", "8"}}, dummy_test_vectors},
-    {"DummySrcTest2", {{"EncoderMode", "8"}, {"Profile", "2"}}, dummy_422_test_vectors},
-    {"DummySrcTest3", {{"EncoderMode", "8"}, {"Profile", "1"}}, dummy_444_test_vectors},
+
+    // only 420 input is supported
+    //{"DummySrcTest2", {{"EncoderMode", "8"}, {"Profile", "2"}}, dummy_422_test_vectors},
+    //{"DummySrcTest3", {{"EncoderMode", "8"}, {"Profile", "1"}}, dummy_444_test_vectors},
 };
 
 /* clang-format on */


### PR DESCRIPTION
Fix for unsupported RateControlMode format in tests
Fix for tile rows/cols tests
Added additional validiation for encode_color_format, only 420 is supported