### PR TITLE
EbPictureManagerProcess: do not take an I_SLICE as global motion reference

### DIFF
--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -1123,10 +1123,16 @@ void *picture_manager_kernel(void *input_ptr) {
                                                 LAST_FRAME;
                                             for (int frame = LAST_FRAME; frame <= ALTREF_FRAME;
                                                  ++frame)
+                                            {
+                                                EbReferenceObject *ref =
+                                                    (EbReferenceObject *)reference_entry_ptr
+                                                     ->reference_object_ptr->object_ptr;
+
                                                 child_pcs_ptr->ref_global_motion[frame] =
-                                                    ((EbReferenceObject *)reference_entry_ptr
-                                                         ->reference_object_ptr->object_ptr)
-                                                        ->global_motion[frame];
+                                                        ref->slice_type != I_SLICE ?
+                                                        ref->global_motion[frame] :
+                                                        default_warp_params;
+                                            }
                                         }
                                     }
                                     // Set the Reference Object
@@ -1202,10 +1208,16 @@ void *picture_manager_kernel(void *input_ptr) {
                                                 LAST_FRAME;
                                             for (int frame = LAST_FRAME; frame <= ALTREF_FRAME;
                                                  ++frame)
+                                            {
+                                                EbReferenceObject *ref =
+                                                    (EbReferenceObject *)reference_entry_ptr
+                                                     ->reference_object_ptr->object_ptr;
+
                                                 child_pcs_ptr->ref_global_motion[frame] =
-                                                    ((EbReferenceObject *)reference_entry_ptr
-                                                         ->reference_object_ptr->object_ptr)
-                                                        ->global_motion[frame];
+                                                        ref->slice_type != I_SLICE ?
+                                                        ref->global_motion[frame] :
+                                                        default_warp_params;
+                                            }
                                         }
                                     }
                                     // Set the Reference Object


### PR DESCRIPTION
Since it is an I_SLICE, no global motion has been computed. We must
fallback to default_warp_params for entropy coding.

This should fix #986.