### PR TITLE
MD rate estimation enhancement

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -43,6 +43,7 @@ extern "C" {
 #define MAX_TILE_CNTS 128 // Annex A.3
 #endif
 
+#define MD_RATE_EST_ENH 1 // MD rate estimation enhancement. Active for LP =1 for now
 #define MR_MODE 0
 
 #define HIGH_PRECISION_MV_QTHRESH 150

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -2719,6 +2719,38 @@ void *enc_dec_kernel(void *input_ptr) {
 
                     if (pcs_ptr->update_cdf) {
                         pcs_ptr->rate_est_array[sb_index] = *pcs_ptr->md_rate_estimation_array;
+#if MD_RATE_EST_ENH
+                        if (scs_ptr->enc_dec_segment_row_count_array[pcs_ptr->temporal_layer_index] == 1 &&
+                            scs_ptr->enc_dec_segment_col_count_array[pcs_ptr->temporal_layer_index] == 1) {
+                            if (sb_index == 0)
+                                pcs_ptr->ec_ctx_array[sb_index] = *pcs_ptr->coeff_est_entropy_coder_ptr->fc;
+                            else
+                                pcs_ptr->ec_ctx_array[sb_index] = pcs_ptr->ec_ctx_array[sb_index - 1];
+                        }
+                        else {
+                            // Use the latest available CDF for the current SB
+                            // Use the weighted average of left (3x) and top (1x) if available.
+                            int8_t up_available = ((int32_t)(sb_origin_y >> MI_SIZE_LOG2) >
+                                sb_ptr->tile_info.mi_row_start);
+                            int8_t left_available = ((int32_t)(sb_origin_x >> MI_SIZE_LOG2) >
+                                sb_ptr->tile_info.mi_col_start);
+                            if (!left_available && !up_available)
+                                pcs_ptr->ec_ctx_array[sb_index] =
+                                *pcs_ptr->coeff_est_entropy_coder_ptr->fc;
+                            else if (!left_available)
+                                pcs_ptr->ec_ctx_array[sb_index] =
+                                pcs_ptr->ec_ctx_array[sb_index - pic_width_in_sb];
+                            else if (!up_available)
+                                pcs_ptr->ec_ctx_array[sb_index] = pcs_ptr->ec_ctx_array[sb_index - 1];
+                            else {
+                                pcs_ptr->ec_ctx_array[sb_index] = pcs_ptr->ec_ctx_array[sb_index - 1];
+                                avg_cdf_symbols(&pcs_ptr->ec_ctx_array[sb_index],
+                                    &pcs_ptr->ec_ctx_array[sb_index - pic_width_in_sb],
+                                    AVG_CDF_WEIGHT_LEFT,
+                                    AVG_CDF_WEIGHT_TOP);
+                            }
+                        }
+#else
                         // Use the latest available CDF for the current SB
                         // Use the weighted average of left (3x) and top (1x) if available.
                         int8_t up_available   = ((int32_t)(sb_origin_y >> MI_SIZE_LOG2) >
@@ -2740,6 +2772,7 @@ void *enc_dec_kernel(void *input_ptr) {
                                             AVG_CDF_WEIGHT_LEFT,
                                             AVG_CDF_WEIGHT_TOP);
                         }
+#endif
 
                         // Initial Rate Estimation of the syntax elements
                         av1_estimate_syntax_rate(&pcs_ptr->rate_est_array[sb_index],

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -377,6 +377,7 @@ int32_t set_parent_pcs(EbSvtAv1EncConfiguration*   config, uint32_t core_count, 
 EbErrorType load_default_buffer_configuration_settings(
     SequenceControlSet       *scs_ptr){
     EbErrorType           return_error = EB_ErrorNone;
+#if !MD_RATE_EST_ENH
     uint32_t enc_dec_seg_h = (scs_ptr->static_config.super_block_size == 128) ?
         ((scs_ptr->max_input_luma_height + 64) / 128) :
         ((scs_ptr->max_input_luma_height + 32) / 64);
@@ -385,7 +386,7 @@ EbErrorType load_default_buffer_configuration_settings(
         ((scs_ptr->max_input_luma_width + 32) / 64);
     uint32_t me_seg_h     = (((scs_ptr->max_input_luma_height + 32) / BLOCK_SIZE_64) < 6) ? 1 : 6;
     uint32_t me_seg_w     = (((scs_ptr->max_input_luma_width + 32) / BLOCK_SIZE_64) < 10) ? 1 : 10;
-
+#endif
     unsigned int lp_count   = get_num_processors();
     unsigned int core_count = lp_count;
 #if defined(_WIN32) || defined(__linux__)
@@ -417,7 +418,20 @@ EbErrorType load_default_buffer_configuration_settings(
     scs_ptr->input_buffer_fifo_init_count = input_pic + SCD_LAD + scs_ptr->static_config.look_ahead_distance;
     scs_ptr->output_stream_buffer_fifo_init_count =
         scs_ptr->input_buffer_fifo_init_count + 4;
-
+#if MD_RATE_EST_ENH
+    uint32_t enc_dec_seg_h = (core_count == SINGLE_CORE_COUNT) ? 1 :
+        (scs_ptr->static_config.super_block_size == 128) ?
+        ((scs_ptr->max_input_luma_height + 64) / 128) :
+        ((scs_ptr->max_input_luma_height + 32) / 64);
+    uint32_t enc_dec_seg_w = (core_count == SINGLE_CORE_COUNT) ? 1 :
+        (scs_ptr->static_config.super_block_size == 128) ?
+        ((scs_ptr->max_input_luma_width + 64) / 128) :
+        ((scs_ptr->max_input_luma_width + 32) / 64);
+    uint32_t me_seg_h = (core_count == SINGLE_CORE_COUNT) ? 1 :
+        (((scs_ptr->max_input_luma_height + 32) / BLOCK_SIZE_64) < 6) ? 1 : 6;
+    uint32_t me_seg_w = (core_count == SINGLE_CORE_COUNT) ? 1 :
+        (((scs_ptr->max_input_luma_width + 32) / BLOCK_SIZE_64) < 10) ? 1 : 10;
+#endif
     // ME segments
     scs_ptr->me_segment_row_count_array[0] = me_seg_h;
     scs_ptr->me_segment_row_count_array[1] = me_seg_h;


### PR DESCRIPTION
**Description:**
MD rate estimation enhancement (MD_RATE_EST_ENH). Use the CDFs from the previous SB. Active for LP =1 for now

**Authors**
@anaghdin

**Type of change**
Enhancement

**Tests and performance**
Expected Average PSNR-SSIM BD-rate gain in the range of -0.4% (8 bit and 10 bit) over the fast objective list, using 5 QP values: {20, 32, 43, 55 and 63}.
Speed impact is negligible (<1%)

**To Do**
To make it work with multi-segments