### PR TITLE
ALT REF Filtering Improvement

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -42,9 +42,11 @@ extern "C" {
 #if TILES_PARALLEL
 #define MAX_TILE_CNTS 128 // Annex A.3
 #endif
+#define ALTREF_IMPROVEMENT     1 // Enable TF for layer 1 in 1 pass encoding. Adjust the filter strength
 
 #define MR_MODE 0
 
+#define ALT_REF_QP_THRESH 20
 #define HIGH_PRECISION_MV_QTHRESH 150
 // Actions in the second pass: Frame and SB QP assignment and temporal filtering strenght change
 //FOR DEBUGGING - Do not remove

--- a/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
@@ -1954,9 +1954,13 @@ static void adjust_filter_strength(PictureParentControlSet *picture_control_set_
     // unsuccessful and therefore keep the strength as it was set
     if (noise_level > 0) {
         int noiselevel_adj;
+#if ALTREF_IMPROVEMENT
+        if (noise_level < 1.2)
+#else
         if (noise_level < 0.75)
             noiselevel_adj = -2;
         else if (noise_level < 1.75)
+#endif
             noiselevel_adj = -1;
         else if (noise_level < 4.0)
             noiselevel_adj = 0;
@@ -1982,7 +1986,12 @@ static void adjust_filter_strength(PictureParentControlSet *picture_control_set_
         strength = adj_strength;
     else
         strength = 0;
-
+#if ALTREF_IMPROVEMENT
+    // Decrease the filter strength for low QPs
+    if (picture_control_set_ptr_central->scs_ptr->static_config.qp <= ALT_REF_QP_THRESH){
+        strength = strength - 1;
+    }
+#endif
     // if highbd, adjust filter strength strength = strength + 2*(bit depth - 8)
     if (is_highbd) strength = strength + 2 * (encoder_bit_depth - 8);
 


### PR DESCRIPTION
**Description:**
ALT REF filtering improvement:
- Enable TF for layer 1 in 1 pass encoding (already active in 2 pass) 
- Adjust the filter strength

**Authors**
@anaghdin

**Type of change**
Enhancement

**Tests and performance**
Expected Average PSNR-SSIM BD-rate gain in the range of -0.5% (~-0.2% for TF in layer 1 and -0.3% for strength update) for 1 pass encoding over the fast objective list, using 5 QP values: {20, 32, 43, 55 and 63}.
Speed impact in context of M0 ~1%