### PR TITLE
Enhanced RDOQ

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -55,8 +55,8 @@ extern "C" {
 
 #define ALT_REF_QP_THRESH 20
 
-#define FASTER_RDOQ 1
-#define FP_QUANT_BOTH_INTRA_INTER 1
+#define FASTER_RDOQ 1 // Perform a fast RDOQ stage to reduce non-zero coeffs before the main/complex RDOQ stage for inter and chroma blocks
+#define FP_QUANT_BOTH_INTRA_INTER 1 // Add quantize_fp for INTER blocks
 
 #define HIGH_PRECISION_MV_QTHRESH 150
 // Actions in the second pass: Frame and SB QP assignment and temporal filtering strenght change

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -54,6 +54,10 @@ extern "C" {
 #define MR_MODE 0
 
 #define ALT_REF_QP_THRESH 20
+
+#define FASTER_RDOQ 1
+#define FP_QUANT_BOTH_INTRA_INTER 1
+
 #define HIGH_PRECISION_MV_QTHRESH 150
 // Actions in the second pass: Frame and SB QP assignment and temporal filtering strenght change
 //FOR DEBUGGING - Do not remove

--- a/Source/Lib/Encoder/Codec/EbFullLoop.c
+++ b/Source/Lib/Encoder/Codec/EbFullLoop.c
@@ -1414,6 +1414,11 @@ static const int plane_rd_mult[REF_TYPES][PLANE_TYPES] = {
 };
 
 #if FASTER_RDOQ
+/*
+ * Reduce the number of non-zero quantized coefficients before getting to the main/complex RDOQ stage
+ * (it performs an early check of whether to zero out each of the non-zero quantized coefficients,
+ * and updates the quantized coeffs if it is determined it can be zeroed out).
+ */
 static INLINE void update_coeff_eob_fast(uint16_t *eob, int shift, const int16_t *dequant_ptr,
                                          const int16_t *scan, const TranLow *coeff_ptr,
                                          TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr) {
@@ -1455,7 +1460,8 @@ void eb_av1_optimize_b(ModeDecisionContext *md_context, int16_t txb_skip_context
     // Hsan (Trellis): hardcoded as not supported:
     int                    sharpness       = 0; // No Sharpness
 #if FASTER_RDOQ
-    int                    fast_mode       = (is_inter && plane); // TBD
+    // Perform a fast RDOQ stage for inter and chroma blocks
+    int                    fast_mode       = (is_inter && plane);
 #else
     int                    fast_mode       = 0; // TBD
 #endif

--- a/Source/Lib/Encoder/Codec/EbFullLoop.c
+++ b/Source/Lib/Encoder/Codec/EbFullLoop.c
@@ -1413,6 +1413,31 @@ static const int plane_rd_mult[REF_TYPES][PLANE_TYPES] = {
     {16, 10},
 };
 
+#if FASTER_RDOQ
+static INLINE void update_coeff_eob_fast(uint16_t *eob, int shift, const int16_t *dequant_ptr,
+                                         const int16_t *scan, const TranLow *coeff_ptr,
+                                         TranLow *qcoeff_ptr, TranLow *dqcoeff_ptr) {
+    int eob_out = *eob;
+    int zbin[2] = {dequant_ptr[0] + ROUND_POWER_OF_TWO(dequant_ptr[0] * 70, 7),
+                   dequant_ptr[1] + ROUND_POWER_OF_TWO(dequant_ptr[1] * 70, 7)};
+    for (int i = *eob - 1; i >= 0; i--) {
+        const int rc         = scan[i];
+        const int qcoeff     = qcoeff_ptr[rc];
+        const int coeff      = coeff_ptr[rc];
+        const int coeff_sign = (coeff >> 31);
+        int64_t   abs_coeff  = (coeff ^ coeff_sign) - coeff_sign;
+        if (((abs_coeff << (1 + shift)) < zbin[rc != 0]) || (qcoeff == 0)) {
+            eob_out--;
+            qcoeff_ptr[rc]  = 0;
+            dqcoeff_ptr[rc] = 0;
+        } else {
+            break;
+        }
+    }
+    *eob = eob_out;
+}
+#endif
+
 void eb_av1_optimize_b(ModeDecisionContext *md_context, int16_t txb_skip_context,
                        int16_t dc_sign_context, const TranLow *coeff_ptr, int32_t stride,
                        intptr_t n_coeffs, const MacroblockPlane *p, TranLow *qcoeff_ptr,
@@ -1429,7 +1454,11 @@ void eb_av1_optimize_b(ModeDecisionContext *md_context, int16_t txb_skip_context
 
     // Hsan (Trellis): hardcoded as not supported:
     int                    sharpness       = 0; // No Sharpness
+#if FASTER_RDOQ
+    int                    fast_mode       = (is_inter && plane); // TBD
+#else
     int                    fast_mode       = 0; // TBD
+#endif
     AQ_MODE                aq_mode         = NO_AQ;
     DELTAQ_MODE            deltaq_mode     = NO_DELTA_Q;
     int8_t                 segment_id      = 0;
@@ -1450,6 +1479,12 @@ void eb_av1_optimize_b(ModeDecisionContext *md_context, int16_t txb_skip_context
     const int           eob_multi_size = txsize_log2_minus4[tx_size];
     const LvMapEobCost *txb_eob_costs =
         &md_context->md_rate_estimation_ptr->eob_frac_bits[eob_multi_size][plane_type];
+#if FASTER_RDOQ
+    if (fast_mode) {
+        update_coeff_eob_fast(eob, shift, p->dequant_qtx, scan, coeff_ptr, qcoeff_ptr, dqcoeff_ptr);
+        if (*eob == 0) return;
+    }
+#endif
     const int rshift =
         (sharpness + (aq_mode == VARIANCE_AQ && segment_id < 4 ? 7 - segment_id : 2) +
          (aq_mode != VARIANCE_AQ && deltaq_mode > NO_DELTA_Q && sb_energy_level < 0
@@ -1731,7 +1766,11 @@ int32_t av1_quantize_inv_quantize(
             perform_rdoq = EB_FALSE;
     } else
         perform_rdoq = (EbBool)scs_ptr->static_config.enable_rdoq;
+#if FP_QUANT_BOTH_INTRA_INTER
+    if (perform_rdoq && md_context->rdoq_quantize_fp) {
+#else
     if (perform_rdoq && md_context->rdoq_quantize_fp && !is_inter) {
+#endif
         if (bit_increment) {
             eb_av1_highbd_quantize_fp_facade((TranLow *)coeff,
                                              n_coeffs,


### PR DESCRIPTION
## Description

quantize_fp is now added for INTER blocks @ RDOQ (previously added for INTRA blocks only). quantize_b is still called when RDOQ is not used (quantize_b and quantize_fp are both libaom kernels).
Also added the support for Fast_RDOQ (libaom technique). The idea consists of reducing the number of non-zero quantized coefficients before getting to the main/complex RDOQ stage (it performs an early check whether to zero out or not each of the non-zero quantized coefficients, and early exit if all are zeroed-out).

closes #1001 

## Type of Change

Enhancement

## Author

@hguermaz 
@PhoenixWorthVCD 

## Performance

Testing was performed on the objective-1-fast dataset (8 bit) in context of CORE.  A BD-rate gain of -0.27% was found for M0, with no speed deviation.

For 10 bit testing, fourteen 720p true 10bit clips were used.  In context of CORE, a BD-rate gain of -0.25% was found for M0, with no speed deviation.

