### PR TITLE
Resolve library errors for binary identical test in Github Actions

### DIFF
--- a/.github/workflows/svt-av1.yml
+++ b/.github/workflows/svt-av1.yml
@@ -43,17 +43,17 @@ jobs:
         fetch-depth: 1
     - name: Compile SVT-AV1
       run: |
-        ./Build/linux/build.sh release
+        ./Build/linux/build.sh static
         ./Bin/Release/SvtAv1EncApp -help
     - name: Compress SVT-AV1 binaries
       if: matrix.compiler == 'gcc-9'
-      run: tar czf ./svtav1.tar.gz ./Bin/Release/*
-    - name: Upload SVT-AV1 binaries
+      run: tar czf ./svtav1-current.tar.gz ./Bin/Release/*
+    - name: Upload artifact SVT-AV1 (current)
       if: matrix.compiler == 'gcc-9'
       uses: actions/upload-artifact@v1
       with:
-        name: svtav1
-        path: ./svtav1.tar.gz
+        name: svtav1-current
+        path: ./svtav1-current.tar.gz
 
   binary-identical-test:
     runs-on: ubuntu-18.04
@@ -63,39 +63,41 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y gcc-9 g++-9 nasm yasm cmake
-    - uses: actions/checkout@v2
-      with:
-        ref: master
-    - name: Setup SVT-AV1 (master)
-      run: |
-        ./Build/linux/build.sh release
-        mkdir $HOME/master
-        mv -t $HOME/master/ ./Bin/Release/*
-    - name: Download SVT-AV1 binaries
-      uses: actions/download-artifact@v1
-      with:
-        name: svtav1
-    - name: Setup SVT-AV1 (current)
-      run: tar xf svtav1/svtav1.tar.gz
     - name: Download videos
       run: |
         wget -nc https://raw.githubusercontent.com/OpenVisualCloud/SVT-AV1-Resources/master/video.tar.gz || wget -nc http://randomderp.com/video.tar.gz
         tar xf video.tar.gz
-    - name: Encode videos (current)
-      run: |
         mv -t $HOME akiyo_cif.y4m
         mv -t $HOME Chimera-Aerial_480x264_2997fps_10bit_420_150frames.y4m
-        ./Bin/Release/SvtAv1EncApp -enc-mode 8 -i $HOME/akiyo_cif.y4m -n 120 -b $HOME/test-pr-8bit-m8.ivf
-        ./Bin/Release/SvtAv1EncApp -enc-mode 0 -i $HOME/akiyo_cif.y4m -n 3 -b $HOME/test-pr-8bit-m0.ivf
-        ./Bin/Release/SvtAv1EncApp -enc-mode 8 -i $HOME/Chimera-Aerial_480x264_2997fps_10bit_420_150frames.y4m -n 120 -b $HOME/test-pr-10bit-m8.ivf
-        ./Bin/Release/SvtAv1EncApp -enc-mode 0 -i $HOME/Chimera-Aerial_480x264_2997fps_10bit_420_150frames.y4m -n 3 -b $HOME/test-pr-10bit-m0.ivf
+    - name: Checkout SVT-AV1 (master)
+      uses: actions/checkout@v2
+      with:
+        ref: master
+    - name: Build SVT-AV1 (master)
+      run: |
+        mkdir $HOME/master
+        mv * $HOME/master
+        $HOME/master/Build/linux/build.sh static
     - name: Encode videos (master)
       run: |
-        cd $HOME
-        ./master/SvtAv1EncApp -enc-mode 8 -i akiyo_cif.y4m -n 120 -b $HOME/test-master-8bit-m8.ivf
-        ./master/SvtAv1EncApp -enc-mode 0 -i akiyo_cif.y4m -n 3 -b $HOME/test-master-8bit-m0.ivf
-        ./master/SvtAv1EncApp -enc-mode 8 -i Chimera-Aerial_480x264_2997fps_10bit_420_150frames.y4m -n 120 -b $HOME/test-master-10bit-m8.ivf
-        ./master/SvtAv1EncApp -enc-mode 0 -i Chimera-Aerial_480x264_2997fps_10bit_420_150frames.y4m -n 3 -b $HOME/test-master-10bit-m0.ivf
+        $HOME/master/Bin/Release/SvtAv1EncApp -enc-mode 8 -i $HOME/akiyo_cif.y4m -n 120 -b $HOME/test-master-8bit-m8.ivf
+        $HOME/master/Bin/Release/SvtAv1EncApp -enc-mode 0 -i $HOME/akiyo_cif.y4m -n 3 -b $HOME/test-master-8bit-m0.ivf
+        $HOME/master/Bin/Release/SvtAv1EncApp -enc-mode 8 -i $HOME/Chimera-Aerial_480x264_2997fps_10bit_420_150frames.y4m -n 120 -b $HOME/test-master-10bit-m8.ivf
+        $HOME/master/Bin/Release/SvtAv1EncApp -enc-mode 0 -i $HOME/Chimera-Aerial_480x264_2997fps_10bit_420_150frames.y4m -n 3 -b $HOME/test-master-10bit-m0.ivf
+    - name: Download artifact SVT-AV1 (current)
+      uses: actions/download-artifact@v1
+      with:
+        name: svtav1-current
+    - name: Extract artifact SVT-AV1 (current)
+      run: |
+        mkdir $HOME/current
+        tar xf svtav1-current/svtav1-current.tar.gz -C $HOME/current
+    - name: Encode videos (current)
+      run: |
+        $HOME/current/Bin/Release/SvtAv1EncApp -enc-mode 8 -i $HOME/akiyo_cif.y4m -n 120 -b $HOME/test-pr-8bit-m8.ivf
+        $HOME/current/Bin/Release/SvtAv1EncApp -enc-mode 0 -i $HOME/akiyo_cif.y4m -n 3 -b $HOME/test-pr-8bit-m0.ivf
+        $HOME/current/Bin/Release/SvtAv1EncApp -enc-mode 8 -i $HOME/Chimera-Aerial_480x264_2997fps_10bit_420_150frames.y4m -n 120 -b $HOME/test-pr-10bit-m8.ivf
+        $HOME/current/Bin/Release/SvtAv1EncApp -enc-mode 0 -i $HOME/Chimera-Aerial_480x264_2997fps_10bit_420_150frames.y4m -n 3 -b $HOME/test-pr-10bit-m0.ivf
     - name: Binary compare
       run: |
         echo Comparing 8-bit M8: akiyo_cif.y4m
@@ -106,3 +108,12 @@ jobs:
         diff $HOME/test-pr-10bit-m8.ivf $HOME/test-master-10bit-m8.ivf
         echo Comparing 10-bit M0: Chimera-Aerial_480x264_2997fps_10bit_420_150frames.y4m
         diff $HOME/test-pr-10bit-m0.ivf $HOME/test-master-10bit-m0.ivf
+    - name: On fail, compress SVT-AV1 (master)
+      if: failure()
+      run: tar czf ./svtav1-master.tar.gz $HOME/master/Bin/Release/*
+    - name: On fail, upload artifact SVT-AV1 (master)
+      if: failure()
+      uses: actions/upload-artifact@v1
+      with:
+        name: svtav1-master
+        path: ./svtav1-master.tar.gz


### PR DESCRIPTION
There was an issue reported by @mafonsoN and @luigi311 where the the libraries were not being correctly linked when running the branch and master executables in the binary identical test.

See:
- https://github.com/OpenVisualCloud/SVT-AV1/pull/963/checks?check_run_id=413615745
- https://github.com/OpenVisualCloud/SVT-AV1/runs/414096956

I reordered the steps, changed the build from dynamically linked to statically linked, and changed where executables are called for clarity. 

Additionally, if the binary identical test fails on mismatch, we upload both files as artifacts so that they can be inspected for debugging.

Problem discussed in #873 
