### PR TITLE
Ois memory reduction

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -32,6 +32,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define OIS_MEM              1 //reduce memory consumption due to ois struct
+
+
 #define MC_DYNAMIC_PAD              1
 #define GLOBAL_WARPED_MOTION 1 // Global warped motion detection and insertion
 #ifndef NON_AVX512_SUPPORT

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.c
@@ -1938,16 +1938,25 @@ EbErrorType picture_parent_control_set_ctor(PictureParentControlSet *object_ptr,
         }
     }
 
-    EB_MALLOC_2D(object_ptr->ois_sb_results, object_ptr->sb_total_count, 1);
-    EB_MALLOC_2D(
-        object_ptr->ois_candicate, object_ptr->sb_total_count, MAX_OIS_CANDIDATES * CU_MAX_COUNT);
+#if OIS_MEM
+    if (init_data_ptr->allocate_ois_struct) {
+#endif
+        EB_MALLOC_2D(object_ptr->ois_sb_results, object_ptr->sb_total_count, 1);
+        EB_MALLOC_2D(
+            object_ptr->ois_candicate, object_ptr->sb_total_count, MAX_OIS_CANDIDATES * CU_MAX_COUNT);
 
-    for (sb_index = 0; sb_index < object_ptr->sb_total_count; ++sb_index) {
-        uint32_t cu_idx;
-        for (cu_idx = 0; cu_idx < CU_MAX_COUNT; ++cu_idx)
-            object_ptr->ois_sb_results[sb_index]->ois_candidate_array[cu_idx] =
+        for (sb_index = 0; sb_index < object_ptr->sb_total_count; ++sb_index) {
+            uint32_t cu_idx;
+            for (cu_idx = 0; cu_idx < CU_MAX_COUNT; ++cu_idx)
+                object_ptr->ois_sb_results[sb_index]->ois_candidate_array[cu_idx] =
                 &object_ptr->ois_candicate[sb_index][cu_idx * MAX_OIS_CANDIDATES];
+        }
+#if OIS_MEM
     }
+    else {
+        object_ptr->ois_sb_results = NULL;
+    }
+#endif
 
     object_ptr->max_number_of_candidates_per_block =
         (init_data_ptr->mrp_mode == 0)

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -1005,6 +1005,9 @@ typedef struct PictureControlSetInitData {
     uint8_t log2_tile_cols;
     uint8_t log2_sb_sz; //in mi unit
 #endif
+#if OIS_MEM
+    uint8_t allocate_ois_struct; //allocate ois results
+#endif
 } PictureControlSetInitData;
 
 typedef struct Av1Comp {

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -1000,6 +1000,9 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         input_data.log2_tile_cols = enc_handle_ptr->scs_instance_array[instance_index]->scs_ptr->static_config.tile_columns;
         input_data.log2_sb_sz = (scs_init.sb_size == 128) ? 5 : 4;
 #endif
+#if OIS_MEM
+        input_data.allocate_ois_struct = 0;
+#endif
         EB_NEW(
             enc_handle_ptr->picture_parent_control_set_pool_ptr_array[instance_index],
             eb_system_resource_ctor,


### PR DESCRIPTION
## Description

make OIS: open Loop intra search results allocation in parent pcs structure based on config demand.



## Type of Change

Memory Footprint Reduction

## Author

@chkngit 


## Performance

Memory footprint reduction of an M0 1080 p encode (-lad 0, -lp 1) from ~2GB to ~1.5GB