### PR TITLE
Default -scm to 0

### DIFF
--- a/Config/Sample.cfg
+++ b/Config/Sample.cfg
@@ -96,7 +96,7 @@ NumberHmeSearchRegionInWidth    : 2                         # Set hierarchical m
 NumberHmeSearchRegionInHeight   : 2                         # Set Hme search region in height
 HmeLevel0TotalSearchAreaWidth   : 64                        # Set hierarchical motion estimation level0 total search area in Width
 HmeLevel0TotalSearchAreaHeight  : 25                        # Set Hme level0 total search area in height
-ScreenContentMode               : 2                         # Set screen content detection level
+ScreenContentMode               : 0                         # Set screen content detection level
 HighBitDepthModeDecision        : 1                         # Enable high bit depth mode decision(0: OFF, 1: ON partially[default],2: fully ON)
 PaletteMode                     : -1                        # Set palette prediction mode(-1: default or [0-6])
 UnrestrictedMotionVector        : ?                         # Allow motion vectors to reach outside of the picture boundary

--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -216,7 +216,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **NumberHmeSearchRegionInHeight** | -num-hme-h | [1 - 2] | Depends on input resolution | Search Regions in Height |
 | **HmeLevel0TotalSearchAreaWidth** | -hme-tot-l0-w | [1 - 256] | Depends on input resolution | Total HME Level 0 Search Area in Width |
 | **HmeLevel0TotalSearchAreaHeight** | -hme-tot-l0-h | [1 - 256] | Depends on input resolution | Total HME Level 1 Search Area in Width |
-| **ScreenContentMode** | -scm | [0 - 2] | 2 | Enable Screen Content Optimization mode (0: OFF, 1: ON, 2: Content Based Detection) |
+| **ScreenContentMode** | -scm | [0 - 2] | 0 | Enable Screen Content Optimization mode (0: OFF, 1: ON, 2: Content Based Detection) |
 | **HighBitDepthModeDecision** | -hbd-md | [0-2, 1 for default] | 1 | Enable high bit depth mode decision(0: OFF, 1: ON partially[default],2: fully ON) |
 | **PaletteMode** | -palette | [0 - 6] | -1 | Enable Palette mode (-1: DEFAULT (ON at level6 when SC is detected), 0: OFF 1: ON Level 1, ...6: ON Level6 ) |
 | **UnrestrictedMotionVector** | -umv | [0-1] | 1 | Enables or disables unrestriced motion vectors, 0 = OFF(motion vectors are constrained within tile boundary), 1 = ON. For MCTS support, set -umv 0 |

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -433,7 +433,7 @@ typedef struct EbSvtAv1EncConfiguration {
 
     /* Flag to signal the content being a screen sharing content type
     *
-    * Default is 2. */
+    * Default is 0. */
     uint32_t screen_content_mode;
 
     /* Enable adaptive quantization within a frame using segmentation.

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -1285,7 +1285,7 @@ void eb_config_ctor(EbConfig *config_ptr) {
     config_ptr->hme_level2_search_area_in_width_array[1]  = 1;
     config_ptr->hme_level2_search_area_in_height_array[0] = 1;
     config_ptr->hme_level2_search_area_in_height_array[1] = 1;
-    config_ptr->screen_content_mode                       = 2;
+    config_ptr->screen_content_mode                       = 0;
     config_ptr->enable_hbd_mode_decision                  = 2;
     config_ptr->enable_palette                            = -1;
     config_ptr->olpd_refinement                           = -1;

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2943,7 +2943,7 @@ EbErrorType eb_svt_enc_init_parameter(
     config_ptr->unrestricted_motion_vector = EB_TRUE;
 
     config_ptr->high_dynamic_range_input = 0;
-    config_ptr->screen_content_mode = 2;
+    config_ptr->screen_content_mode = 0;
 
     // Annex A parameters
     config_ptr->profile = 0;


### PR DESCRIPTION
## Description:

The screen content detector is having a lot of misdetections e.g. niklas clip. Also the detection takes place at the picture decision process and some features would need to be turned on / off (such as MRP, the max block size) at init time and switching them would cause major stability issues if done at run-time
This PR sets the detection to be off by default until further work is done there to solve all of these problems.

## Impact:

Screen content clips would have to be encoded using -scm 1