### PR TITLE
Tx Path Unification and Enhancements

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -58,6 +58,12 @@ extern "C" {
 #define FASTER_RDOQ 1 // Perform a fast RDOQ stage to reduce non-zero coeffs before the main/complex RDOQ stage for inter and chroma blocks
 #define FP_QUANT_BOTH_INTRA_INTER 1 // Add quantize_fp for INTER blocks
 
+#define LOSSLESS_TX_SIZE_OPT 1
+#define LOSSLESS_TX_TYPE_OPT 1
+#define TX_SEARCH_REDUCED 1
+#define REMOVE_COEFF_BASED_SKIP_ATB 1
+#define TX_ORG_INTERINTRA 1
+
 #define HIGH_PRECISION_MV_QTHRESH 150
 // Actions in the second pass: Frame and SB QP assignment and temporal filtering strenght change
 //FOR DEBUGGING - Do not remove

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -63,6 +63,7 @@ extern "C" {
 #define TX_SEARCH_REDUCED 1
 #define REMOVE_COEFF_BASED_SKIP_ATB 1
 #define TX_ORG_INTERINTRA 1
+#define FREQUENCY_SPATIAL_DOMAIN 1
 
 #define HIGH_PRECISION_MV_QTHRESH 150
 // Actions in the second pass: Frame and SB QP assignment and temporal filtering strenght change

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -58,13 +58,6 @@ extern "C" {
 #define FASTER_RDOQ 1 // Perform a fast RDOQ stage to reduce non-zero coeffs before the main/complex RDOQ stage for inter and chroma blocks
 #define FP_QUANT_BOTH_INTRA_INTER 1 // Add quantize_fp for INTER blocks
 
-#define LOSSLESS_TX_SIZE_OPT 1
-#define LOSSLESS_TX_TYPE_OPT 1
-#define TX_SEARCH_REDUCED 1
-#define REMOVE_COEFF_BASED_SKIP_ATB 1
-#define TX_ORG_INTERINTRA 1
-#define FREQUENCY_SPATIAL_DOMAIN 1
-
 #define HIGH_PRECISION_MV_QTHRESH 150
 // Actions in the second pass: Frame and SB QP assignment and temporal filtering strenght change
 //FOR DEBUGGING - Do not remove

--- a/Source/Lib/Common/Codec/EbUtility.c
+++ b/Source/Lib/Common/Codec/EbUtility.c
@@ -506,7 +506,6 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                 blk_geom_mds[*idx_mds].txsize_uv[tx_depth][txb_itr] =
                     av1_get_tx_size(blk_geom_mds[*idx_mds].bsize, 1);
                 if (blk_geom_mds[*idx_mds].bsize == BLOCK_128X128) {
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             (txb_itr == 0 || txb_itr == 2) ? blk_geom_mds[*idx_mds].origin_x
@@ -515,16 +514,7 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             (txb_itr == 0 || txb_itr == 1) ? blk_geom_mds[*idx_mds].origin_y
                                                            : blk_geom_mds[*idx_mds].origin_y + 64;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        (txb_itr == 0 || txb_itr == 2) ? blk_geom_mds[*idx_mds].origin_x
-                                                       : blk_geom_mds[*idx_mds].origin_x + 64;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        (txb_itr == 0 || txb_itr == 1) ? blk_geom_mds[*idx_mds].origin_y
-                                                       : blk_geom_mds[*idx_mds].origin_y + 64;
-#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_128X64) {
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             (txb_itr == 0) ? blk_geom_mds[*idx_mds].origin_x
@@ -532,15 +522,7 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        (txb_itr == 0) ? blk_geom_mds[*idx_mds].origin_x
-                                       : blk_geom_mds[*idx_mds].origin_x + 64;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y;
-#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_64X128) {
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x;
@@ -548,38 +530,16 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             (txb_itr == 0) ? blk_geom_mds[*idx_mds].origin_y
                                            : blk_geom_mds[*idx_mds].origin_y + 64;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        (txb_itr == 0) ? blk_geom_mds[*idx_mds].origin_y
-                                       : blk_geom_mds[*idx_mds].origin_y + 64;
-#endif
                 } else {
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y;
-#endif
                 }
                 /*if (blk_geom_mds[*idx_mds].bsize == BLOCK_16X8)
                     SVT_LOG("");*/
-#if !TX_ORG_INTERINTRA
-                blk_geom_mds[*idx_mds].tx_boff_x[tx_depth][txb_itr] =
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] -
-                    blk_geom_mds[*idx_mds].origin_x;
-                blk_geom_mds[*idx_mds].tx_boff_y[tx_depth][txb_itr] =
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] -
-                    blk_geom_mds[*idx_mds].origin_y;
-#endif
                 blk_geom_mds[*idx_mds].tx_width[tx_depth][txb_itr] =
                     tx_size_wide[blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr]];
                 blk_geom_mds[*idx_mds].tx_height[tx_depth][txb_itr] =
@@ -635,19 +595,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y + tby;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x + tbx;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y + tby;
-#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_64X32) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_32X32, 0);
@@ -659,19 +612,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y + tby;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x + tbx;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y + tby;
-#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_32X64) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_32X32, 0);
@@ -683,19 +629,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y + tby;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x + tbx;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y + tby;
-#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_32X32) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_16X16, 0);
@@ -708,19 +647,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y + tby;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x + tbx;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y + tby;
-#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_32X16) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_16X16, 0);
@@ -732,19 +664,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y + tby;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x + tbx;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y + tby;
-#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_16X32) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_16X16, 0);
@@ -756,19 +681,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y + tby;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x + tbx;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y + tby;
-#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_16X16) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_8X8, 0);
@@ -781,19 +699,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y + tby;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x + tbx;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y + tby;
-#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_16X8) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_8X8, 0);
@@ -805,20 +716,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y + tby;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x + tbx;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y + tby;
-#endif
-                    //SVT_LOG("");
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_8X16) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_8X8, 0);
@@ -830,19 +733,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y + tby;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x + tbx;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y + tby;
-#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_8X8) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_4X4, 0);
@@ -855,19 +751,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y + tby;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x + tbx;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y + tby;
-#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_64X16) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_16X16, 0);
@@ -879,19 +768,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx        = offsetx[txb_itr];
                     uint8_t tby        = offsety[txb_itr];
 
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y + tby;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x + tbx;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y + tby;
-#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_16X64) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_16X16, 0);
@@ -903,19 +785,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx        = offsetx[txb_itr];
                     uint8_t tby        = offsety[txb_itr];
 
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y + tby;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x + tbx;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y + tby;
-#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_32X8) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_8X8, 0);
@@ -927,19 +802,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx        = offsetx[txb_itr];
                     uint8_t tby        = offsety[txb_itr];
 
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y + tby;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x + tbx;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y + tby;
-#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_8X32) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_8X8, 0);
@@ -951,19 +819,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx        = offsetx[txb_itr];
                     uint8_t tby        = offsety[txb_itr];
 
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y + tby;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x + tbx;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y + tby;
-#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_16X4) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_4X4, 0);
@@ -975,19 +836,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx        = offsetx[txb_itr];
                     uint8_t tby        = offsety[txb_itr];
 
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y + tby;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x + tbx;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y + tby;
-#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_4X16) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_4X4, 0);
@@ -999,19 +853,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx        = offsetx[txb_itr];
                     uint8_t tby        = offsety[txb_itr];
 
-#if TX_ORG_INTERINTRA
                     blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y + tby;
-#else
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_x + tbx;
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                        blk_geom_mds[*idx_mds].origin_y + tby;
-#endif
                 } else {
                     if (blk_geom_mds[*idx_mds].bsize == BLOCK_128X128) {
                         blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
@@ -1019,7 +866,6 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                         blk_geom_mds[*idx_mds].txsize_uv[tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].txsize_uv[0][0];
 
-#if TX_ORG_INTERINTRA
                         blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                                 (txb_itr == 0 || txb_itr == 2)
@@ -1030,21 +876,12 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                                 (txb_itr == 0 || txb_itr == 1)
                                     ? blk_geom_mds[*idx_mds].origin_y
                                     : blk_geom_mds[*idx_mds].origin_y + 64;
-#else
-                        blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                            (txb_itr == 0 || txb_itr == 2) ? blk_geom_mds[*idx_mds].origin_x
-                                                           : blk_geom_mds[*idx_mds].origin_x + 64;
-                        blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                            (txb_itr == 0 || txb_itr == 1) ? blk_geom_mds[*idx_mds].origin_y
-                                                           : blk_geom_mds[*idx_mds].origin_y + 64;
-#endif
                     } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_128X64) {
                         blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                             av1_get_tx_size(blk_geom_mds[*idx_mds].bsize, 0);
                         blk_geom_mds[*idx_mds].txsize_uv[tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].txsize_uv[0][0];
 
-#if TX_ORG_INTERINTRA
                         blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                                 (txb_itr == 0) ? blk_geom_mds[*idx_mds].origin_x
@@ -1052,19 +889,11 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                         blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                                 blk_geom_mds[*idx_mds].origin_y;
-#else
-                        blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                            (txb_itr == 0) ? blk_geom_mds[*idx_mds].origin_x
-                                           : blk_geom_mds[*idx_mds].origin_x + 64;
-                        blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                            blk_geom_mds[*idx_mds].origin_y;
-#endif
                     } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_64X128) {
                         blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                             av1_get_tx_size(blk_geom_mds[*idx_mds].bsize, 0);
                         blk_geom_mds[*idx_mds].txsize_uv[tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].txsize_uv[0][0];
-#if TX_ORG_INTERINTRA
                         blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                                 blk_geom_mds[*idx_mds].origin_x;
@@ -1072,41 +901,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                             blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                                 (txb_itr == 0) ? blk_geom_mds[*idx_mds].origin_y
                                                : blk_geom_mds[*idx_mds].origin_y + 64;
-#else
-                        blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                            blk_geom_mds[*idx_mds].origin_x;
-                        blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                            (txb_itr == 0) ? blk_geom_mds[*idx_mds].origin_y
-                                           : blk_geom_mds[*idx_mds].origin_y + 64;
-#endif
                     } else {
                         blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                             av1_get_tx_size(blk_geom_mds[*idx_mds].bsize, 0);
                         blk_geom_mds[*idx_mds].txsize_uv[tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].txsize_uv[0][0];
-#if TX_ORG_INTERINTRA
                         blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
                                 blk_geom_mds[*idx_mds].origin_x;
                         blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
                                 blk_geom_mds[*idx_mds].origin_y;
-#else
-                        blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
-                            blk_geom_mds[*idx_mds].origin_x;
-                        blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
-                            blk_geom_mds[*idx_mds].origin_y;
-#endif
                     }
                 }
-#if !TX_ORG_INTERINTRA
-                blk_geom_mds[*idx_mds].tx_boff_x[tx_depth][txb_itr] =
-                    blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] -
-                    blk_geom_mds[*idx_mds].origin_x;
-                blk_geom_mds[*idx_mds].tx_boff_y[tx_depth][txb_itr] =
-                    blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] -
-                    blk_geom_mds[*idx_mds].origin_y;
-#endif
                 blk_geom_mds[*idx_mds].tx_width[tx_depth][txb_itr] =
                     tx_size_wide[blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr]];
                 blk_geom_mds[*idx_mds].tx_height[tx_depth][txb_itr] =

--- a/Source/Lib/Common/Codec/EbUtility.c
+++ b/Source/Lib/Common/Codec/EbUtility.c
@@ -506,38 +506,80 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                 blk_geom_mds[*idx_mds].txsize_uv[tx_depth][txb_itr] =
                     av1_get_tx_size(blk_geom_mds[*idx_mds].bsize, 1);
                 if (blk_geom_mds[*idx_mds].bsize == BLOCK_128X128) {
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            (txb_itr == 0 || txb_itr == 2) ? blk_geom_mds[*idx_mds].origin_x
+                                                           : blk_geom_mds[*idx_mds].origin_x + 64;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            (txb_itr == 0 || txb_itr == 1) ? blk_geom_mds[*idx_mds].origin_y
+                                                           : blk_geom_mds[*idx_mds].origin_y + 64;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         (txb_itr == 0 || txb_itr == 2) ? blk_geom_mds[*idx_mds].origin_x
                                                        : blk_geom_mds[*idx_mds].origin_x + 64;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         (txb_itr == 0 || txb_itr == 1) ? blk_geom_mds[*idx_mds].origin_y
                                                        : blk_geom_mds[*idx_mds].origin_y + 64;
+#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_128X64) {
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            (txb_itr == 0) ? blk_geom_mds[*idx_mds].origin_x
+                                           : blk_geom_mds[*idx_mds].origin_x + 64;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         (txb_itr == 0) ? blk_geom_mds[*idx_mds].origin_x
                                        : blk_geom_mds[*idx_mds].origin_x + 64;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y;
+#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_64X128) {
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            (txb_itr == 0) ? blk_geom_mds[*idx_mds].origin_y
+                                           : blk_geom_mds[*idx_mds].origin_y + 64;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         (txb_itr == 0) ? blk_geom_mds[*idx_mds].origin_y
                                        : blk_geom_mds[*idx_mds].origin_y + 64;
+#endif
                 } else {
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y;
+#endif
                 }
                 /*if (blk_geom_mds[*idx_mds].bsize == BLOCK_16X8)
                     SVT_LOG("");*/
+#if !TX_ORG_INTERINTRA
                 blk_geom_mds[*idx_mds].tx_boff_x[tx_depth][txb_itr] =
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] -
                     blk_geom_mds[*idx_mds].origin_x;
                 blk_geom_mds[*idx_mds].tx_boff_y[tx_depth][txb_itr] =
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] -
                     blk_geom_mds[*idx_mds].origin_y;
+#endif
                 blk_geom_mds[*idx_mds].tx_width[tx_depth][txb_itr] =
                     tx_size_wide[blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr]];
                 blk_geom_mds[*idx_mds].tx_height[tx_depth][txb_itr] =
@@ -593,10 +635,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x + tbx;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y + tby;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y + tby;
+#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_64X32) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_32X32, 0);
@@ -608,10 +659,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x + tbx;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y + tby;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y + tby;
+#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_32X64) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_32X32, 0);
@@ -623,10 +683,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x + tbx;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y + tby;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y + tby;
+#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_32X32) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_16X16, 0);
@@ -639,10 +708,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x + tbx;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y + tby;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y + tby;
+#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_32X16) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_16X16, 0);
@@ -654,10 +732,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x + tbx;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y + tby;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y + tby;
+#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_16X32) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_16X16, 0);
@@ -669,10 +756,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x + tbx;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y + tby;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y + tby;
+#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_16X16) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_8X8, 0);
@@ -685,10 +781,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x + tbx;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y + tby;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y + tby;
+#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_16X8) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_8X8, 0);
@@ -700,10 +805,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x + tbx;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y + tby;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y + tby;
+#endif
                     //SVT_LOG("");
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_8X16) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
@@ -716,10 +830,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x + tbx;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y + tby;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y + tby;
+#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_8X8) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_4X4, 0);
@@ -732,10 +855,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx = offsetx[txb_itr];
                     uint8_t tby = offsety[txb_itr];
 
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x + tbx;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y + tby;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y + tby;
+#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_64X16) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_16X16, 0);
@@ -747,10 +879,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx        = offsetx[txb_itr];
                     uint8_t tby        = offsety[txb_itr];
 
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x + tbx;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y + tby;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y + tby;
+#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_16X64) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_16X16, 0);
@@ -762,10 +903,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx        = offsetx[txb_itr];
                     uint8_t tby        = offsety[txb_itr];
 
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x + tbx;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y + tby;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y + tby;
+#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_32X8) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_8X8, 0);
@@ -777,10 +927,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx        = offsetx[txb_itr];
                     uint8_t tby        = offsety[txb_itr];
 
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x + tbx;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y + tby;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y + tby;
+#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_8X32) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_8X8, 0);
@@ -792,10 +951,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx        = offsetx[txb_itr];
                     uint8_t tby        = offsety[txb_itr];
 
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x + tbx;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y + tby;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y + tby;
+#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_16X4) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_4X4, 0);
@@ -807,10 +975,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx        = offsetx[txb_itr];
                     uint8_t tby        = offsety[txb_itr];
 
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x + tbx;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y + tby;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y + tby;
+#endif
                 } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_4X16) {
                     blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                         av1_get_tx_size(BLOCK_4X4, 0);
@@ -822,10 +999,19 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                     uint8_t tbx        = offsetx[txb_itr];
                     uint8_t tby        = offsety[txb_itr];
 
+#if TX_ORG_INTERINTRA
+                    blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_x + tbx;
+                    blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                        blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].origin_y + tby;
+#else
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_x + tbx;
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                         blk_geom_mds[*idx_mds].origin_y + tby;
+#endif
                 } else {
                     if (blk_geom_mds[*idx_mds].bsize == BLOCK_128X128) {
                         blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
@@ -833,50 +1019,94 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
                         blk_geom_mds[*idx_mds].txsize_uv[tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].txsize_uv[0][0];
 
+#if TX_ORG_INTERINTRA
+                        blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                                (txb_itr == 0 || txb_itr == 2)
+                                    ? blk_geom_mds[*idx_mds].origin_x
+                                    : blk_geom_mds[*idx_mds].origin_x + 64;
+                        blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                                (txb_itr == 0 || txb_itr == 1)
+                                    ? blk_geom_mds[*idx_mds].origin_y
+                                    : blk_geom_mds[*idx_mds].origin_y + 64;
+#else
                         blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                             (txb_itr == 0 || txb_itr == 2) ? blk_geom_mds[*idx_mds].origin_x
                                                            : blk_geom_mds[*idx_mds].origin_x + 64;
                         blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                             (txb_itr == 0 || txb_itr == 1) ? blk_geom_mds[*idx_mds].origin_y
                                                            : blk_geom_mds[*idx_mds].origin_y + 64;
+#endif
                     } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_128X64) {
                         blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                             av1_get_tx_size(blk_geom_mds[*idx_mds].bsize, 0);
                         blk_geom_mds[*idx_mds].txsize_uv[tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].txsize_uv[0][0];
 
+#if TX_ORG_INTERINTRA
+                        blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                                (txb_itr == 0) ? blk_geom_mds[*idx_mds].origin_x
+                                               : blk_geom_mds[*idx_mds].origin_x + 64;
+                        blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                                blk_geom_mds[*idx_mds].origin_y;
+#else
                         blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                             (txb_itr == 0) ? blk_geom_mds[*idx_mds].origin_x
                                            : blk_geom_mds[*idx_mds].origin_x + 64;
                         blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y;
+#endif
                     } else if (blk_geom_mds[*idx_mds].bsize == BLOCK_64X128) {
                         blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                             av1_get_tx_size(blk_geom_mds[*idx_mds].bsize, 0);
                         blk_geom_mds[*idx_mds].txsize_uv[tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].txsize_uv[0][0];
+#if TX_ORG_INTERINTRA
+                        blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                                blk_geom_mds[*idx_mds].origin_x;
+                        blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                                (txb_itr == 0) ? blk_geom_mds[*idx_mds].origin_y
+                                               : blk_geom_mds[*idx_mds].origin_y + 64;
+#else
                         blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x;
                         blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                             (txb_itr == 0) ? blk_geom_mds[*idx_mds].origin_y
                                            : blk_geom_mds[*idx_mds].origin_y + 64;
+#endif
                     } else {
                         blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr] =
                             av1_get_tx_size(blk_geom_mds[*idx_mds].bsize, 0);
                         blk_geom_mds[*idx_mds].txsize_uv[tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].txsize_uv[0][0];
+#if TX_ORG_INTERINTRA
+                        blk_geom_mds[*idx_mds].tx_org_x[0][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].tx_org_x[1][tx_depth][txb_itr] =
+                                blk_geom_mds[*idx_mds].origin_x;
+                        blk_geom_mds[*idx_mds].tx_org_y[0][tx_depth][txb_itr] =
+                            blk_geom_mds[*idx_mds].tx_org_y[1][tx_depth][txb_itr] =
+                                blk_geom_mds[*idx_mds].origin_y;
+#else
                         blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_x;
                         blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] =
                             blk_geom_mds[*idx_mds].origin_y;
+#endif
                     }
                 }
+#if !TX_ORG_INTERINTRA
                 blk_geom_mds[*idx_mds].tx_boff_x[tx_depth][txb_itr] =
                     blk_geom_mds[*idx_mds].tx_org_x[tx_depth][txb_itr] -
                     blk_geom_mds[*idx_mds].origin_x;
                 blk_geom_mds[*idx_mds].tx_boff_y[tx_depth][txb_itr] =
                     blk_geom_mds[*idx_mds].tx_org_y[tx_depth][txb_itr] -
                     blk_geom_mds[*idx_mds].origin_y;
+#endif
                 blk_geom_mds[*idx_mds].tx_width[tx_depth][txb_itr] =
                     tx_size_wide[blk_geom_mds[*idx_mds].txsize[tx_depth][txb_itr]];
                 blk_geom_mds[*idx_mds].tx_height[tx_depth][txb_itr] =

--- a/Source/Lib/Common/Codec/EbUtility.h
+++ b/Source/Lib/Common/Codec/EbUtility.h
@@ -49,10 +49,16 @@ typedef struct BlockGeom {
     uint16_t  txb_count[MAX_VARTX_DEPTH + 1]; //4-2-1
     TxSize    txsize[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT];
     TxSize    txsize_uv[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT];
-    uint16_t  tx_org_x[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //orgin is SB
-    uint16_t  tx_org_y[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //origin is SB
-    uint16_t  tx_boff_x[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //block offset , origin is block
-    uint16_t  tx_boff_y[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //block offset , origin is block
+#if TX_ORG_INTERINTRA
+    uint16_t tx_org_x[2][MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //origin is SB - separate tables for INTRA (idx 0) and INTER (idx 1)
+    uint16_t tx_org_y[2][MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //origin is SB - separate tables for INTRA (idx 0) and INTER (idx 1)
+#else
+    uint16_t tx_org_x[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //orgin is SB
+    uint16_t tx_org_y[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //origin is SB
+
+    uint16_t tx_boff_x[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //block offset , origin is block
+    uint16_t tx_boff_y[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //block offset , origin is block
+#endif
     uint8_t   tx_width[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //tx_size_wide
     uint8_t   tx_height[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //tx_size_wide
     uint8_t   tx_width_uv[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //tx_size_wide

--- a/Source/Lib/Common/Codec/EbUtility.h
+++ b/Source/Lib/Common/Codec/EbUtility.h
@@ -49,16 +49,8 @@ typedef struct BlockGeom {
     uint16_t  txb_count[MAX_VARTX_DEPTH + 1]; //4-2-1
     TxSize    txsize[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT];
     TxSize    txsize_uv[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT];
-#if TX_ORG_INTERINTRA
     uint16_t tx_org_x[2][MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //origin is SB - separate tables for INTRA (idx 0) and INTER (idx 1)
     uint16_t tx_org_y[2][MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //origin is SB - separate tables for INTRA (idx 0) and INTER (idx 1)
-#else
-    uint16_t tx_org_x[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //orgin is SB
-    uint16_t tx_org_y[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //origin is SB
-
-    uint16_t tx_boff_x[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //block offset , origin is block
-    uint16_t tx_boff_y[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //block offset , origin is block
-#endif
     uint8_t   tx_width[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //tx_size_wide
     uint8_t   tx_height[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //tx_size_wide
     uint8_t   tx_width_uv[MAX_VARTX_DEPTH + 1][MAX_TXB_COUNT]; //tx_size_wide

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -1444,7 +1444,7 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                                BlkStruct *blk_ptr, PredictionUnit *pu_ptr,
                                EncDecContext *context_ptr) {
     EbBool is_16bit = context_ptr->is_16bit;
-
+    uint8_t is_inter = 0; // set to 0 b/c this is the intra path
     EbPictureBufferDesc *recon_buffer =
         is_16bit ? pcs_ptr->recon_picture16bit_ptr : pcs_ptr->recon_picture_ptr;
     EbPictureBufferDesc *coeff_buffer_sb = sb_ptr->quantized_coeff;
@@ -1502,11 +1502,11 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
     for (context_ptr->txb_itr = 0; context_ptr->txb_itr < tot_tu; context_ptr->txb_itr++) {
         uint16_t txb_origin_x =
             context_ptr->blk_origin_x +
-            context_ptr->blk_geom->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+            context_ptr->blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] -
             context_ptr->blk_geom->origin_x;
         uint16_t txb_origin_y =
             context_ptr->blk_origin_y +
-            context_ptr->blk_geom->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+            context_ptr->blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] -
             context_ptr->blk_geom->origin_y;
         context_ptr->md_context->luma_txb_skip_context = 0;
         context_ptr->md_context->luma_dc_sign_context  = 0;
@@ -1563,10 +1563,10 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                 top_neigh_array + 1,
                 left_neigh_array + 1,
                 recon_buffer,
-                (context_ptr->blk_geom->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                (context_ptr->blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] -
                  context_ptr->blk_geom->origin_x) >>
                     2,
-                (context_ptr->blk_geom->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                (context_ptr->blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] -
                  context_ptr->blk_geom->origin_y) >>
                     2,
                 0,
@@ -1621,10 +1621,10 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                 top_neigh_array + 1,
                 left_neigh_array + 1,
                 recon_buffer,
-                (context_ptr->blk_geom->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                (context_ptr->blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] -
                  context_ptr->blk_geom->origin_x) >>
                     2,
-                (context_ptr->blk_geom->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                (context_ptr->blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] -
                  context_ptr->blk_geom->origin_y) >>
                     2,
                 0,
@@ -1752,11 +1752,11 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
         context_ptr->txb_itr = 0;
         uint16_t txb_origin_x =
             context_ptr->blk_origin_x +
-            context_ptr->blk_geom->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+            context_ptr->blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] -
             context_ptr->blk_geom->origin_x;
         uint16_t txb_origin_y =
             context_ptr->blk_origin_y +
-            context_ptr->blk_geom->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+            context_ptr->blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] -
             context_ptr->blk_geom->origin_y;
         uint32_t blk_originx_uv = (context_ptr->blk_origin_x >> 3 << 3) >> 1;
         uint32_t blk_originy_uv = (context_ptr->blk_origin_y >> 3 << 3) >> 1;
@@ -1856,12 +1856,12 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                     recon_buffer,
                     plane ? 0
                           : (context_ptr->blk_geom
-                                 ->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                                 ->tx_org_x[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] -
                              context_ptr->blk_geom->origin_x) >>
                                 2,
                     plane ? 0
                           : (context_ptr->blk_geom
-                                 ->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                                 ->tx_org_y[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] -
                              context_ptr->blk_geom->origin_y) >>
                                 2,
                     plane,
@@ -1945,12 +1945,12 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                     recon_buffer,
                     plane ? 0
                           : (context_ptr->blk_geom
-                                 ->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                                 ->tx_org_x[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] -
                              context_ptr->blk_geom->origin_x) >>
                                 2,
                     plane ? 0
                           : (context_ptr->blk_geom
-                                 ->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                                 ->tx_org_y[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] -
                              context_ptr->blk_geom->origin_y) >>
                                 2,
                     plane,
@@ -2899,7 +2899,7 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
 
                 // Inter
                 else if (blk_ptr->prediction_mode_flag == INTER_MODE) {
-                    context_ptr->is_inter = 1;
+                    uint8_t is_inter = context_ptr->is_inter = 1;
                     int8_t ref_idx_l0 = (&blk_ptr->prediction_unit_array[0])->ref_frame_index_l0;
                     int8_t ref_idx_l1 = (&blk_ptr->prediction_unit_array[0])->ref_frame_index_l1;
                     MvReferenceFrame rf[2];
@@ -3113,11 +3113,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 blk_ptr->tx_depth && tu_it ? 0 : 1; //NM: 128x128 exeption
                             txb_origin_x =
                                 context_ptr->blk_origin_x +
-                                context_ptr->blk_geom->tx_org_x[1][blk_ptr->tx_depth][tu_it] -
+                                context_ptr->blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][tu_it] -
                                 context_ptr->blk_geom->origin_x;
                             txb_origin_y =
                                 context_ptr->blk_origin_y +
-                                context_ptr->blk_geom->tx_org_y[1][blk_ptr->tx_depth][tu_it] -
+                                context_ptr->blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][tu_it] -
                                 context_ptr->blk_geom->origin_y;
 
                             context_ptr->md_context->luma_txb_skip_context = 0;
@@ -3475,11 +3475,11 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                         context_ptr->txb_itr = tu_it;
                         txb_origin_x = context_ptr->blk_origin_x +
                                        (context_ptr->blk_geom
-                                            ->tx_org_x[1][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                                            ->tx_org_x[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] -
                                         context_ptr->blk_geom->origin_x);
                         txb_origin_y = context_ptr->blk_origin_y +
                                        (context_ptr->blk_geom
-                                            ->tx_org_y[1][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                                            ->tx_org_y[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] -
                                         context_ptr->blk_geom->origin_y);
                         context_ptr->md_context->luma_txb_skip_context = 0;
                         context_ptr->md_context->luma_dc_sign_context  = 0;

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -402,7 +402,29 @@ static void av1_encode_loop(PictureControlSet *pcs_ptr, EncDecContext *context_p
     const uint32_t pred_cr_offset =
         (((pred_samples->origin_y + round_origin_y) >> 1) * pred_samples->stride_cr) +
         ((pred_samples->origin_x + round_origin_x) >> 1);
-
+#if TX_ORG_INTERINTRA
+    int32_t is_inter = (blk_ptr->prediction_mode_flag == INTER_MODE || blk_ptr->av1xd->use_intrabc)
+                           ? EB_TRUE
+                           : EB_FALSE;
+    const uint32_t scratch_luma_offset =
+        context_ptr->blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] +
+        context_ptr->blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] *
+            SB_STRIDE_Y;
+    const uint32_t scratch_cb_offset =
+        ROUND_UV(
+            context_ptr->blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr]) /
+            2 +
+        ROUND_UV(
+            context_ptr->blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr]) /
+            2 * SB_STRIDE_UV;
+    const uint32_t scratch_cr_offset =
+        ROUND_UV(
+            context_ptr->blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr]) /
+            2 +
+        ROUND_UV(
+            context_ptr->blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr]) /
+            2 * SB_STRIDE_UV;
+#else
     const uint32_t scratch_luma_offset =
         context_ptr->blk_geom->tx_org_x[blk_ptr->tx_depth][context_ptr->txb_itr] +
         context_ptr->blk_geom->tx_org_y[blk_ptr->tx_depth][context_ptr->txb_itr] * SB_STRIDE_Y;
@@ -414,7 +436,7 @@ static void av1_encode_loop(PictureControlSet *pcs_ptr, EncDecContext *context_p
         ROUND_UV(context_ptr->blk_geom->tx_org_x[blk_ptr->tx_depth][context_ptr->txb_itr]) / 2 +
         ROUND_UV(context_ptr->blk_geom->tx_org_y[blk_ptr->tx_depth][context_ptr->txb_itr]) / 2 *
             SB_STRIDE_UV;
-
+#endif
     const uint32_t coeff1d_offset = context_ptr->coded_area_sb;
 
     const uint32_t coeff1d_offset_chroma = context_ptr->coded_area_sb_uv;
@@ -815,7 +837,30 @@ static void av1_encode_loop_16bit(PictureControlSet *pcs_ptr, EncDecContext *con
     EbPictureBufferDesc *pred_samples16bit  = pred_samples;
     uint32_t             round_origin_x = (origin_x >> 3) << 3; // for Chroma blocks with size of 4
     uint32_t             round_origin_y = (origin_y >> 3) << 3; // for Chroma blocks with size of 4
-    const uint32_t       input_luma_offset =
+#if TX_ORG_INTERINTRA
+    int32_t is_inter = (blk_ptr->prediction_mode_flag == INTER_MODE || blk_ptr->av1xd->use_intrabc)
+                           ? EB_TRUE
+                           : EB_FALSE;
+    const uint32_t input_luma_offset =
+        context_ptr->blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] +
+        context_ptr->blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] *
+            SB_STRIDE_Y;
+    const uint32_t input_cb_offset =
+        ROUND_UV(
+            context_ptr->blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr]) /
+            2 +
+        ROUND_UV(
+            context_ptr->blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr]) /
+            2 * SB_STRIDE_UV;
+    const uint32_t input_cr_offset =
+        ROUND_UV(
+            context_ptr->blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr]) /
+            2 +
+        ROUND_UV(
+            context_ptr->blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr]) /
+            2 * SB_STRIDE_UV;
+#else
+    const uint32_t input_luma_offset =
         context_ptr->blk_geom->tx_org_x[blk_ptr->tx_depth][context_ptr->txb_itr] +
         context_ptr->blk_geom->tx_org_y[blk_ptr->tx_depth][context_ptr->txb_itr] * SB_STRIDE_Y;
     const uint32_t input_cb_offset =
@@ -826,6 +871,7 @@ static void av1_encode_loop_16bit(PictureControlSet *pcs_ptr, EncDecContext *con
         ROUND_UV(context_ptr->blk_geom->tx_org_x[blk_ptr->tx_depth][context_ptr->txb_itr]) / 2 +
         ROUND_UV(context_ptr->blk_geom->tx_org_y[blk_ptr->tx_depth][context_ptr->txb_itr]) / 2 *
             SB_STRIDE_UV;
+#endif
     const uint32_t pred_luma_offset =
         ((pred_samples16bit->origin_y + origin_y) * pred_samples16bit->stride_y) +
         (pred_samples16bit->origin_x + origin_x);
@@ -1482,13 +1528,23 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
 
     // Luma path
     for (context_ptr->txb_itr = 0; context_ptr->txb_itr < tot_tu; context_ptr->txb_itr++) {
+#if TX_ORG_INTERINTRA
+        uint16_t txb_origin_x =
+            context_ptr->blk_origin_x +
+            context_ptr->blk_geom->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+            context_ptr->blk_geom->origin_x;
+        uint16_t txb_origin_y =
+            context_ptr->blk_origin_y +
+            context_ptr->blk_geom->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+            context_ptr->blk_geom->origin_y;
+#else
         uint16_t txb_origin_x =
             context_ptr->blk_origin_x +
             context_ptr->blk_geom->tx_boff_x[blk_ptr->tx_depth][context_ptr->txb_itr];
         uint16_t txb_origin_y =
             context_ptr->blk_origin_y +
             context_ptr->blk_geom->tx_boff_y[blk_ptr->tx_depth][context_ptr->txb_itr];
-
+#endif
         context_ptr->md_context->luma_txb_skip_context = 0;
         context_ptr->md_context->luma_dc_sign_context  = 0;
         get_txb_ctx(pcs_ptr,
@@ -1544,8 +1600,17 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                 top_neigh_array + 1,
                 left_neigh_array + 1,
                 recon_buffer,
+#if TX_ORG_INTERINTRA
+                (context_ptr->blk_geom->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                 context_ptr->blk_geom->origin_x) >>
+                    2,
+                (context_ptr->blk_geom->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                 context_ptr->blk_geom->origin_y) >>
+                    2,
+#else
                 context_ptr->blk_geom->tx_boff_x[blk_ptr->tx_depth][context_ptr->txb_itr] >> 2,
                 context_ptr->blk_geom->tx_boff_y[blk_ptr->tx_depth][context_ptr->txb_itr] >> 2,
+#endif
                 0,
                 context_ptr->blk_geom->bsize,
                 txb_origin_x,
@@ -1598,8 +1663,17 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                 top_neigh_array + 1,
                 left_neigh_array + 1,
                 recon_buffer,
+#if TX_ORG_INTERINTRA
+                (context_ptr->blk_geom->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                 context_ptr->blk_geom->origin_x) >>
+                    2,
+                (context_ptr->blk_geom->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                 context_ptr->blk_geom->origin_y) >>
+                    2,
+#else
                 context_ptr->blk_geom->tx_boff_x[blk_ptr->tx_depth][context_ptr->txb_itr] >> 2,
                 context_ptr->blk_geom->tx_boff_y[blk_ptr->tx_depth][context_ptr->txb_itr] >> 2,
+#endif
                 0,
                 context_ptr->blk_geom->bsize,
                 txb_origin_x,
@@ -1723,13 +1797,23 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
 
     if (context_ptr->blk_geom->has_uv) {
         context_ptr->txb_itr = 0;
+#if TX_ORG_INTERINTRA
+        uint16_t txb_origin_x =
+            context_ptr->blk_origin_x +
+            context_ptr->blk_geom->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+            context_ptr->blk_geom->origin_x;
+        uint16_t txb_origin_y =
+            context_ptr->blk_origin_y +
+            context_ptr->blk_geom->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+            context_ptr->blk_geom->origin_y;
+#else
         uint16_t txb_origin_x =
             context_ptr->blk_origin_x +
             context_ptr->blk_geom->tx_boff_x[blk_ptr->tx_depth][context_ptr->txb_itr];
         uint16_t txb_origin_y =
             context_ptr->blk_origin_y +
             context_ptr->blk_geom->tx_boff_y[blk_ptr->tx_depth][context_ptr->txb_itr];
-
+#endif
         uint32_t blk_originx_uv = (context_ptr->blk_origin_x >> 3 << 3) >> 1;
         uint32_t blk_originy_uv = (context_ptr->blk_origin_y >> 3 << 3) >> 1;
 
@@ -1826,6 +1910,18 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                     top_neigh_array + 1,
                     left_neigh_array + 1,
                     recon_buffer,
+#if TX_ORG_INTERINTRA
+                    plane ? 0
+                          : (context_ptr->blk_geom
+                                 ->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                             context_ptr->blk_geom->origin_x) >>
+                                2,
+                    plane ? 0
+                          : (context_ptr->blk_geom
+                                 ->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                             context_ptr->blk_geom->origin_y) >>
+                                2,
+#else
                     plane ? 0
                           : context_ptr->blk_geom
                                     ->tx_boff_x[blk_ptr->tx_depth][context_ptr->txb_itr] >>
@@ -1834,6 +1930,7 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                           : context_ptr->blk_geom
                                     ->tx_boff_y[blk_ptr->tx_depth][context_ptr->txb_itr] >>
                                 2,
+#endif
                     plane,
                     context_ptr->blk_geom->bsize,
                     txb_origin_x,
@@ -1913,6 +2010,18 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                     top_neigh_array + 1,
                     left_neigh_array + 1,
                     recon_buffer,
+#if TX_ORG_INTERINTRA
+                    plane ? 0
+                          : (context_ptr->blk_geom
+                                 ->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                             context_ptr->blk_geom->origin_x) >>
+                                2,
+                    plane ? 0
+                          : (context_ptr->blk_geom
+                                 ->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                             context_ptr->blk_geom->origin_y) >>
+                                2,
+#else
                     plane ? 0
                           : context_ptr->blk_geom
                                     ->tx_boff_x[blk_ptr->tx_depth][context_ptr->txb_itr] >>
@@ -1921,6 +2030,7 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                           : context_ptr->blk_geom
                                     ->tx_boff_y[blk_ptr->tx_depth][context_ptr->txb_itr] >>
                                 2,
+#endif
                     plane,
                     context_ptr->blk_geom->bsize,
                     txb_origin_x,
@@ -3079,12 +3189,23 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                             context_ptr->txb_itr = tu_it;
                             uint8_t uv_pass =
                                 blk_ptr->tx_depth && tu_it ? 0 : 1; //NM: 128x128 exeption
+#if TX_ORG_INTERINTRA
+                            txb_origin_x =
+                                context_ptr->blk_origin_x +
+                                context_ptr->blk_geom->tx_org_x[1][blk_ptr->tx_depth][tu_it] -
+                                context_ptr->blk_geom->origin_x;
+                            txb_origin_y =
+                                context_ptr->blk_origin_y +
+                                context_ptr->blk_geom->tx_org_y[1][blk_ptr->tx_depth][tu_it] -
+                                context_ptr->blk_geom->origin_y;
+#else
                             txb_origin_x =
                                 context_ptr->blk_origin_x +
                                 context_ptr->blk_geom->tx_boff_x[blk_ptr->tx_depth][tu_it];
                             txb_origin_y =
                                 context_ptr->blk_origin_y +
                                 context_ptr->blk_geom->tx_boff_y[blk_ptr->tx_depth][tu_it];
+#endif
 
                             context_ptr->md_context->luma_txb_skip_context = 0;
                             context_ptr->md_context->luma_dc_sign_context  = 0;
@@ -3439,11 +3560,21 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                     for (tu_it = 0; tu_it < tot_tu; tu_it++) {
                         uint8_t uv_pass = blk_ptr->tx_depth && tu_it ? 0 : 1; //NM: 128x128 exeption
                         context_ptr->txb_itr = tu_it;
-                        txb_origin_x         = context_ptr->blk_origin_x +
+#if TX_ORG_INTERINTRA
+                        txb_origin_x = context_ptr->blk_origin_x +
+                                       (context_ptr->blk_geom
+                                            ->tx_org_x[1][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                                        context_ptr->blk_geom->origin_x);
+                        txb_origin_y = context_ptr->blk_origin_y +
+                                       (context_ptr->blk_geom
+                                            ->tx_org_y[1][blk_ptr->tx_depth][context_ptr->txb_itr] -
+                                        context_ptr->blk_geom->origin_y);
+#else
+                        txb_origin_x = context_ptr->blk_origin_x +
                                        context_ptr->blk_geom->tx_boff_x[blk_ptr->tx_depth][tu_it];
                         txb_origin_y = context_ptr->blk_origin_y +
                                        context_ptr->blk_geom->tx_boff_y[blk_ptr->tx_depth][tu_it];
-
+#endif
                         context_ptr->md_context->luma_txb_skip_context = 0;
                         context_ptr->md_context->luma_dc_sign_context  = 0;
                         get_txb_ctx(

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -402,7 +402,6 @@ static void av1_encode_loop(PictureControlSet *pcs_ptr, EncDecContext *context_p
     const uint32_t pred_cr_offset =
         (((pred_samples->origin_y + round_origin_y) >> 1) * pred_samples->stride_cr) +
         ((pred_samples->origin_x + round_origin_x) >> 1);
-#if TX_ORG_INTERINTRA
     int32_t is_inter = (blk_ptr->prediction_mode_flag == INTER_MODE || blk_ptr->av1xd->use_intrabc)
                            ? EB_TRUE
                            : EB_FALSE;
@@ -424,19 +423,6 @@ static void av1_encode_loop(PictureControlSet *pcs_ptr, EncDecContext *context_p
         ROUND_UV(
             context_ptr->blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr]) /
             2 * SB_STRIDE_UV;
-#else
-    const uint32_t scratch_luma_offset =
-        context_ptr->blk_geom->tx_org_x[blk_ptr->tx_depth][context_ptr->txb_itr] +
-        context_ptr->blk_geom->tx_org_y[blk_ptr->tx_depth][context_ptr->txb_itr] * SB_STRIDE_Y;
-    const uint32_t scratch_cb_offset =
-        ROUND_UV(context_ptr->blk_geom->tx_org_x[blk_ptr->tx_depth][context_ptr->txb_itr]) / 2 +
-        ROUND_UV(context_ptr->blk_geom->tx_org_y[blk_ptr->tx_depth][context_ptr->txb_itr]) / 2 *
-            SB_STRIDE_UV;
-    const uint32_t scratch_cr_offset =
-        ROUND_UV(context_ptr->blk_geom->tx_org_x[blk_ptr->tx_depth][context_ptr->txb_itr]) / 2 +
-        ROUND_UV(context_ptr->blk_geom->tx_org_y[blk_ptr->tx_depth][context_ptr->txb_itr]) / 2 *
-            SB_STRIDE_UV;
-#endif
     const uint32_t coeff1d_offset = context_ptr->coded_area_sb;
 
     const uint32_t coeff1d_offset_chroma = context_ptr->coded_area_sb_uv;
@@ -837,7 +823,6 @@ static void av1_encode_loop_16bit(PictureControlSet *pcs_ptr, EncDecContext *con
     EbPictureBufferDesc *pred_samples16bit  = pred_samples;
     uint32_t             round_origin_x = (origin_x >> 3) << 3; // for Chroma blocks with size of 4
     uint32_t             round_origin_y = (origin_y >> 3) << 3; // for Chroma blocks with size of 4
-#if TX_ORG_INTERINTRA
     int32_t is_inter = (blk_ptr->prediction_mode_flag == INTER_MODE || blk_ptr->av1xd->use_intrabc)
                            ? EB_TRUE
                            : EB_FALSE;
@@ -859,19 +844,6 @@ static void av1_encode_loop_16bit(PictureControlSet *pcs_ptr, EncDecContext *con
         ROUND_UV(
             context_ptr->blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr]) /
             2 * SB_STRIDE_UV;
-#else
-    const uint32_t input_luma_offset =
-        context_ptr->blk_geom->tx_org_x[blk_ptr->tx_depth][context_ptr->txb_itr] +
-        context_ptr->blk_geom->tx_org_y[blk_ptr->tx_depth][context_ptr->txb_itr] * SB_STRIDE_Y;
-    const uint32_t input_cb_offset =
-        ROUND_UV(context_ptr->blk_geom->tx_org_x[blk_ptr->tx_depth][context_ptr->txb_itr]) / 2 +
-        ROUND_UV(context_ptr->blk_geom->tx_org_y[blk_ptr->tx_depth][context_ptr->txb_itr]) / 2 *
-            SB_STRIDE_UV;
-    const uint32_t input_cr_offset =
-        ROUND_UV(context_ptr->blk_geom->tx_org_x[blk_ptr->tx_depth][context_ptr->txb_itr]) / 2 +
-        ROUND_UV(context_ptr->blk_geom->tx_org_y[blk_ptr->tx_depth][context_ptr->txb_itr]) / 2 *
-            SB_STRIDE_UV;
-#endif
     const uint32_t pred_luma_offset =
         ((pred_samples16bit->origin_y + origin_y) * pred_samples16bit->stride_y) +
         (pred_samples16bit->origin_x + origin_x);
@@ -1528,7 +1500,6 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
 
     // Luma path
     for (context_ptr->txb_itr = 0; context_ptr->txb_itr < tot_tu; context_ptr->txb_itr++) {
-#if TX_ORG_INTERINTRA
         uint16_t txb_origin_x =
             context_ptr->blk_origin_x +
             context_ptr->blk_geom->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
@@ -1537,14 +1508,6 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
             context_ptr->blk_origin_y +
             context_ptr->blk_geom->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
             context_ptr->blk_geom->origin_y;
-#else
-        uint16_t txb_origin_x =
-            context_ptr->blk_origin_x +
-            context_ptr->blk_geom->tx_boff_x[blk_ptr->tx_depth][context_ptr->txb_itr];
-        uint16_t txb_origin_y =
-            context_ptr->blk_origin_y +
-            context_ptr->blk_geom->tx_boff_y[blk_ptr->tx_depth][context_ptr->txb_itr];
-#endif
         context_ptr->md_context->luma_txb_skip_context = 0;
         context_ptr->md_context->luma_dc_sign_context  = 0;
         get_txb_ctx(pcs_ptr,
@@ -1600,17 +1563,12 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                 top_neigh_array + 1,
                 left_neigh_array + 1,
                 recon_buffer,
-#if TX_ORG_INTERINTRA
                 (context_ptr->blk_geom->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
                  context_ptr->blk_geom->origin_x) >>
                     2,
                 (context_ptr->blk_geom->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
                  context_ptr->blk_geom->origin_y) >>
                     2,
-#else
-                context_ptr->blk_geom->tx_boff_x[blk_ptr->tx_depth][context_ptr->txb_itr] >> 2,
-                context_ptr->blk_geom->tx_boff_y[blk_ptr->tx_depth][context_ptr->txb_itr] >> 2,
-#endif
                 0,
                 context_ptr->blk_geom->bsize,
                 txb_origin_x,
@@ -1663,17 +1621,12 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                 top_neigh_array + 1,
                 left_neigh_array + 1,
                 recon_buffer,
-#if TX_ORG_INTERINTRA
                 (context_ptr->blk_geom->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
                  context_ptr->blk_geom->origin_x) >>
                     2,
                 (context_ptr->blk_geom->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
                  context_ptr->blk_geom->origin_y) >>
                     2,
-#else
-                context_ptr->blk_geom->tx_boff_x[blk_ptr->tx_depth][context_ptr->txb_itr] >> 2,
-                context_ptr->blk_geom->tx_boff_y[blk_ptr->tx_depth][context_ptr->txb_itr] >> 2,
-#endif
                 0,
                 context_ptr->blk_geom->bsize,
                 txb_origin_x,
@@ -1797,7 +1750,6 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
 
     if (context_ptr->blk_geom->has_uv) {
         context_ptr->txb_itr = 0;
-#if TX_ORG_INTERINTRA
         uint16_t txb_origin_x =
             context_ptr->blk_origin_x +
             context_ptr->blk_geom->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
@@ -1806,14 +1758,6 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
             context_ptr->blk_origin_y +
             context_ptr->blk_geom->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
             context_ptr->blk_geom->origin_y;
-#else
-        uint16_t txb_origin_x =
-            context_ptr->blk_origin_x +
-            context_ptr->blk_geom->tx_boff_x[blk_ptr->tx_depth][context_ptr->txb_itr];
-        uint16_t txb_origin_y =
-            context_ptr->blk_origin_y +
-            context_ptr->blk_geom->tx_boff_y[blk_ptr->tx_depth][context_ptr->txb_itr];
-#endif
         uint32_t blk_originx_uv = (context_ptr->blk_origin_x >> 3 << 3) >> 1;
         uint32_t blk_originy_uv = (context_ptr->blk_origin_y >> 3 << 3) >> 1;
 
@@ -1910,7 +1854,6 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                     top_neigh_array + 1,
                     left_neigh_array + 1,
                     recon_buffer,
-#if TX_ORG_INTERINTRA
                     plane ? 0
                           : (context_ptr->blk_geom
                                  ->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
@@ -1921,16 +1864,6 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                                  ->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
                              context_ptr->blk_geom->origin_y) >>
                                 2,
-#else
-                    plane ? 0
-                          : context_ptr->blk_geom
-                                    ->tx_boff_x[blk_ptr->tx_depth][context_ptr->txb_itr] >>
-                                2,
-                    plane ? 0
-                          : context_ptr->blk_geom
-                                    ->tx_boff_y[blk_ptr->tx_depth][context_ptr->txb_itr] >>
-                                2,
-#endif
                     plane,
                     context_ptr->blk_geom->bsize,
                     txb_origin_x,
@@ -2010,7 +1943,6 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                     top_neigh_array + 1,
                     left_neigh_array + 1,
                     recon_buffer,
-#if TX_ORG_INTERINTRA
                     plane ? 0
                           : (context_ptr->blk_geom
                                  ->tx_org_x[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
@@ -2021,16 +1953,6 @@ void perform_intra_coding_loop(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, u
                                  ->tx_org_y[0][blk_ptr->tx_depth][context_ptr->txb_itr] -
                              context_ptr->blk_geom->origin_y) >>
                                 2,
-#else
-                    plane ? 0
-                          : context_ptr->blk_geom
-                                    ->tx_boff_x[blk_ptr->tx_depth][context_ptr->txb_itr] >>
-                                2,
-                    plane ? 0
-                          : context_ptr->blk_geom
-                                    ->tx_boff_y[blk_ptr->tx_depth][context_ptr->txb_itr] >>
-                                2,
-#endif
                     plane,
                     context_ptr->blk_geom->bsize,
                     txb_origin_x,
@@ -3189,7 +3111,6 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                             context_ptr->txb_itr = tu_it;
                             uint8_t uv_pass =
                                 blk_ptr->tx_depth && tu_it ? 0 : 1; //NM: 128x128 exeption
-#if TX_ORG_INTERINTRA
                             txb_origin_x =
                                 context_ptr->blk_origin_x +
                                 context_ptr->blk_geom->tx_org_x[1][blk_ptr->tx_depth][tu_it] -
@@ -3198,14 +3119,6 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 context_ptr->blk_origin_y +
                                 context_ptr->blk_geom->tx_org_y[1][blk_ptr->tx_depth][tu_it] -
                                 context_ptr->blk_geom->origin_y;
-#else
-                            txb_origin_x =
-                                context_ptr->blk_origin_x +
-                                context_ptr->blk_geom->tx_boff_x[blk_ptr->tx_depth][tu_it];
-                            txb_origin_y =
-                                context_ptr->blk_origin_y +
-                                context_ptr->blk_geom->tx_boff_y[blk_ptr->tx_depth][tu_it];
-#endif
 
                             context_ptr->md_context->luma_txb_skip_context = 0;
                             context_ptr->md_context->luma_dc_sign_context  = 0;
@@ -3560,7 +3473,6 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                     for (tu_it = 0; tu_it < tot_tu; tu_it++) {
                         uint8_t uv_pass = blk_ptr->tx_depth && tu_it ? 0 : 1; //NM: 128x128 exeption
                         context_ptr->txb_itr = tu_it;
-#if TX_ORG_INTERINTRA
                         txb_origin_x = context_ptr->blk_origin_x +
                                        (context_ptr->blk_geom
                                             ->tx_org_x[1][blk_ptr->tx_depth][context_ptr->txb_itr] -
@@ -3569,12 +3481,6 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                        (context_ptr->blk_geom
                                             ->tx_org_y[1][blk_ptr->tx_depth][context_ptr->txb_itr] -
                                         context_ptr->blk_geom->origin_y);
-#else
-                        txb_origin_x = context_ptr->blk_origin_x +
-                                       context_ptr->blk_geom->tx_boff_x[blk_ptr->tx_depth][tu_it];
-                        txb_origin_y = context_ptr->blk_origin_y +
-                                       context_ptr->blk_geom->tx_boff_y[blk_ptr->tx_depth][tu_it];
-#endif
                         context_ptr->md_context->luma_txb_skip_context = 0;
                         context_ptr->md_context->luma_dc_sign_context  = 0;
                         get_txb_ctx(

--- a/Source/Lib/Encoder/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Encoder/Codec/EbEntropyCoding.c
@@ -724,7 +724,11 @@ static EbErrorType av1_encode_tx_coef_y(
     uint32_t intraLumaDir, BlockSize plane_bsize, EbPictureBufferDesc *coeff_ptr,
     NeighborArrayUnit *luma_dc_sign_level_coeff_neighbor_array) {
     EbErrorType return_error = EB_ErrorNone;
-
+#if TX_ORG_INTERINTRA
+    int32_t is_inter = (blk_ptr->prediction_mode_flag == INTER_MODE || blk_ptr->av1xd->use_intrabc)
+                           ? EB_TRUE
+                           : EB_FALSE;
+#endif
     const BlockGeom *blk_geom    = get_blk_geom_mds(blk_ptr->mds_idx);
     int32_t          cul_level_y = 0;
 
@@ -751,8 +755,13 @@ static EbErrorType av1_encode_tx_coef_y(
             get_txb_ctx(pcs_ptr,
                         COMPONENT_LUMA,
                         luma_dc_sign_level_coeff_neighbor_array,
+#if TX_ORG_INTERINTRA
+                        blk_origin_x + blk_geom->tx_org_x[is_inter][tx_depth][txb_itr] - blk_geom->origin_x,
+                        blk_origin_y + blk_geom->tx_org_y[is_inter][tx_depth][txb_itr] - blk_geom->origin_y,
+#else
                         blk_origin_x + blk_geom->tx_org_x[tx_depth][txb_itr] - blk_geom->origin_x,
                         blk_origin_y + blk_geom->tx_org_y[tx_depth][txb_itr] - blk_geom->origin_y,
+#endif
                         plane_bsize,
                         tx_size,
                         &txb_skip_ctx,
@@ -781,8 +790,13 @@ static EbErrorType av1_encode_tx_coef_y(
             neighbor_array_unit_mode_write(
                 luma_dc_sign_level_coeff_neighbor_array,
                 (uint8_t *)&dc_sign_level_coeff,
+#if TX_ORG_INTERINTRA
+                blk_origin_x + blk_geom->tx_org_x[is_inter][tx_depth][txb_itr] - blk_geom->origin_x,
+                blk_origin_y + blk_geom->tx_org_y[is_inter][tx_depth][txb_itr] - blk_geom->origin_y,
+#else
                 blk_origin_x + blk_geom->tx_org_x[tx_depth][txb_itr] - blk_geom->origin_x,
                 blk_origin_y + blk_geom->tx_org_y[tx_depth][txb_itr] - blk_geom->origin_y,
+#endif
                 blk_geom->tx_width[tx_depth][txb_itr],
                 blk_geom->tx_height[tx_depth][txb_itr],
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
@@ -803,7 +817,11 @@ static EbErrorType av1_encode_tx_coef_uv(PictureControlSet *   pcs_ptr,
                                          NeighborArrayUnit *  cr_dc_sign_level_coeff_neighbor_array,
                                          NeighborArrayUnit *cb_dc_sign_level_coeff_neighbor_array) {
     EbErrorType return_error = EB_ErrorNone;
-
+#if TX_ORG_INTERINTRA
+    int32_t is_inter = (blk_ptr->prediction_mode_flag == INTER_MODE || blk_ptr->av1xd->use_intrabc)
+                           ? EB_TRUE
+                           : EB_FALSE;
+#endif
     const BlockGeom *blk_geom = get_blk_geom_mds(blk_ptr->mds_idx);
 
     if (!blk_geom->has_uv) return return_error;
@@ -837,12 +855,21 @@ static EbErrorType av1_encode_tx_coef_uv(PictureControlSet *   pcs_ptr,
                 get_txb_ctx(pcs_ptr,
                             COMPONENT_CHROMA,
                             cb_dc_sign_level_coeff_neighbor_array,
+#if TX_ORG_INTERINTRA
+                            ROUND_UV(blk_origin_x + blk_geom->tx_org_x[is_inter][tx_depth][txb_itr] -
+                                     blk_geom->origin_x) >>
+                                1,
+                            ROUND_UV(blk_origin_y + blk_geom->tx_org_y[is_inter][tx_depth][txb_itr] -
+                                     blk_geom->origin_y) >>
+                                1,
+#else
                             ROUND_UV(blk_origin_x + blk_geom->tx_org_x[tx_depth][txb_itr] -
                                      blk_geom->origin_x) >>
                                 1,
                             ROUND_UV(blk_origin_y + blk_geom->tx_org_y[tx_depth][txb_itr] -
                                      blk_geom->origin_y) >>
                                 1,
+#endif
                             blk_geom->bsize_uv,
                             chroma_tx_size,
                             &txb_skip_ctx,
@@ -874,12 +901,21 @@ static EbErrorType av1_encode_tx_coef_uv(PictureControlSet *   pcs_ptr,
                 get_txb_ctx(pcs_ptr,
                             COMPONENT_CHROMA,
                             cr_dc_sign_level_coeff_neighbor_array,
+#if TX_ORG_INTERINTRA
+                            ROUND_UV(blk_origin_x + blk_geom->tx_org_x[is_inter][tx_depth][txb_itr] -
+                                     blk_geom->origin_x) >>
+                                1,
+                            ROUND_UV(blk_origin_y + blk_geom->tx_org_y[is_inter][tx_depth][txb_itr] -
+                                     blk_geom->origin_y) >>
+                                1,
+#else
                             ROUND_UV(blk_origin_x + blk_geom->tx_org_x[tx_depth][txb_itr] -
                                      blk_geom->origin_x) >>
                                 1,
                             ROUND_UV(blk_origin_y + blk_geom->tx_org_y[tx_depth][txb_itr] -
                                      blk_geom->origin_y) >>
                                 1,
+#endif
                             blk_geom->bsize_uv,
                             chroma_tx_size,
                             &txb_skip_ctx,
@@ -910,12 +946,21 @@ static EbErrorType av1_encode_tx_coef_uv(PictureControlSet *   pcs_ptr,
             neighbor_array_unit_mode_write(
                 cb_dc_sign_level_coeff_neighbor_array,
                 (uint8_t *)&dc_sign_level_coeff,
+#if TX_ORG_INTERINTRA
+                ROUND_UV(blk_origin_x + blk_geom->tx_org_x[is_inter][tx_depth][txb_itr] -
+                         blk_geom->origin_x) >>
+                    1,
+                ROUND_UV(blk_origin_y + blk_geom->tx_org_y[is_inter][tx_depth][txb_itr] -
+                         blk_geom->origin_y) >>
+                    1,
+#else
                 ROUND_UV(blk_origin_x + blk_geom->tx_org_x[tx_depth][txb_itr] -
                          blk_geom->origin_x) >>
                     1,
                 ROUND_UV(blk_origin_y + blk_geom->tx_org_y[tx_depth][txb_itr] -
                          blk_geom->origin_y) >>
                     1,
+#endif
                 blk_geom->tx_width_uv[tx_depth][txb_itr],
                 blk_geom->tx_height_uv[tx_depth][txb_itr],
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
@@ -928,12 +973,21 @@ static EbErrorType av1_encode_tx_coef_uv(PictureControlSet *   pcs_ptr,
             neighbor_array_unit_mode_write(
                 cr_dc_sign_level_coeff_neighbor_array,
                 (uint8_t *)&dc_sign_level_coeff,
+#if TX_ORG_INTERINTRA
+                ROUND_UV(blk_origin_x + blk_geom->tx_org_x[is_inter][tx_depth][txb_itr] -
+                         blk_geom->origin_x) >>
+                    1,
+                ROUND_UV(blk_origin_y + blk_geom->tx_org_y[is_inter][tx_depth][txb_itr] -
+                         blk_geom->origin_y) >>
+                    1,
+#else
                 ROUND_UV(blk_origin_x + blk_geom->tx_org_x[tx_depth][txb_itr] -
                          blk_geom->origin_x) >>
                     1,
                 ROUND_UV(blk_origin_y + blk_geom->tx_org_y[tx_depth][txb_itr] -
                          blk_geom->origin_y) >>
                     1,
+#endif
                 blk_geom->tx_width_uv[tx_depth][txb_itr],
                 blk_geom->tx_height_uv[tx_depth][txb_itr],
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
@@ -958,6 +1012,11 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                                        NeighborArrayUnit *cr_dc_sign_level_coeff_neighbor_array,
                                        NeighborArrayUnit *cb_dc_sign_level_coeff_neighbor_array) {
     EbErrorType return_error = EB_ErrorNone;
+#if TX_ORG_INTERINTRA
+    int32_t is_inter = (blk_ptr->prediction_mode_flag == INTER_MODE || blk_ptr->av1xd->use_intrabc)
+                           ? EB_TRUE
+                           : EB_FALSE;
+#endif
     if (blk_ptr->tx_depth) {
         av1_encode_tx_coef_y(pcs_ptr,
                              context_ptr,
@@ -1006,10 +1065,17 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                 get_txb_ctx(pcs_ptr,
                             COMPONENT_LUMA,
                             luma_dc_sign_level_coeff_neighbor_array,
+#if TX_ORG_INTERINTRA
+                            blk_origin_x + blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][txb_itr] -
+                                blk_geom->origin_x,
+                            blk_origin_y + blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][txb_itr] -
+                                blk_geom->origin_y,
+#else
                             blk_origin_x + blk_geom->tx_org_x[blk_ptr->tx_depth][txb_itr] -
                                 blk_geom->origin_x,
                             blk_origin_y + blk_geom->tx_org_y[blk_ptr->tx_depth][txb_itr] -
                                 blk_geom->origin_y,
+#endif
                             plane_bsize,
                             tx_size,
                             &txb_skip_ctx,
@@ -1042,12 +1108,25 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                         pcs_ptr,
                         COMPONENT_CHROMA,
                         cb_dc_sign_level_coeff_neighbor_array,
-                        ROUND_UV(blk_origin_x + blk_geom->tx_org_x[blk_ptr->tx_depth][txb_itr] -
-                                 blk_geom->origin_x) >>
+#if TX_ORG_INTERINTRA
+                        ROUND_UV(blk_origin_x +
+                                    blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][txb_itr] -
+                                    blk_geom->origin_x) >>
                             1,
-                        ROUND_UV(blk_origin_y + blk_geom->tx_org_y[blk_ptr->tx_depth][txb_itr] -
-                                 blk_geom->origin_y) >>
+                        ROUND_UV(blk_origin_y +
+                                    blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][txb_itr] -
+                                    blk_geom->origin_y) >>
                             1,
+#else
+                        ROUND_UV(blk_origin_x +
+                                    blk_geom->tx_org_x[blk_ptr->tx_depth][txb_itr] -
+                                    blk_geom->origin_x) >>
+                            1,
+                        ROUND_UV(blk_origin_y +
+                                    blk_geom->tx_org_y[blk_ptr->tx_depth][txb_itr] -
+                                    blk_geom->origin_y) >>
+                            1,
+#endif
                         blk_geom->bsize_uv,
                         chroma_tx_size,
                         &txb_skip_ctx,
@@ -1080,12 +1159,25 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                         pcs_ptr,
                         COMPONENT_CHROMA,
                         cr_dc_sign_level_coeff_neighbor_array,
-                        ROUND_UV(blk_origin_x + blk_geom->tx_org_x[blk_ptr->tx_depth][txb_itr] -
-                                 blk_geom->origin_x) >>
+#if TX_ORG_INTERINTRA
+                        ROUND_UV(blk_origin_x +
+                                    blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][txb_itr] -
+                                    blk_geom->origin_x) >>
                             1,
-                        ROUND_UV(blk_origin_y + blk_geom->tx_org_y[blk_ptr->tx_depth][txb_itr] -
-                                 blk_geom->origin_y) >>
+                        ROUND_UV(blk_origin_y +
+                                    blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][txb_itr] -
+                                    blk_geom->origin_y) >>
                             1,
+#else
+                        ROUND_UV(blk_origin_x +
+                                    blk_geom->tx_org_x[blk_ptr->tx_depth][txb_itr] -
+                                    blk_geom->origin_x) >>
+                            1,
+                        ROUND_UV(blk_origin_y +
+                                    blk_geom->tx_org_y[blk_ptr->tx_depth][txb_itr] -
+                                    blk_geom->origin_y) >>
+                            1,
+#endif
                         blk_geom->bsize_uv,
                         chroma_tx_size,
                         &txb_skip_ctx,
@@ -1117,10 +1209,17 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                 neighbor_array_unit_mode_write(
                     luma_dc_sign_level_coeff_neighbor_array,
                     (uint8_t *)&dc_sign_level_coeff,
+#if TX_ORG_INTERINTRA
+                    blk_origin_x + blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][txb_itr] -
+                        blk_geom->origin_x,
+                    blk_origin_y + blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][txb_itr] -
+                        blk_geom->origin_y,
+#else
                     blk_origin_x + blk_geom->tx_org_x[blk_ptr->tx_depth][txb_itr] -
                         blk_geom->origin_x,
                     blk_origin_y + blk_geom->tx_org_y[blk_ptr->tx_depth][txb_itr] -
                         blk_geom->origin_y,
+#endif
                     blk_geom->tx_width[blk_ptr->tx_depth][txb_itr],
                     blk_geom->tx_height[blk_ptr->tx_depth][txb_itr],
                     NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
@@ -1133,12 +1232,23 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                 neighbor_array_unit_mode_write(
                     cb_dc_sign_level_coeff_neighbor_array,
                     (uint8_t *)&dc_sign_level_coeff,
+#if TX_ORG_INTERINTRA
+                    ROUND_UV(blk_origin_x +
+                             blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][txb_itr] -
+                             blk_geom->origin_x) >>
+                        1,
+                    ROUND_UV(blk_origin_y +
+                             blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][txb_itr] -
+                             blk_geom->origin_y) >>
+                        1,
+#else
                     ROUND_UV(blk_origin_x + blk_geom->tx_org_x[blk_ptr->tx_depth][txb_itr] -
                              blk_geom->origin_x) >>
                         1,
                     ROUND_UV(blk_origin_y + blk_geom->tx_org_y[blk_ptr->tx_depth][txb_itr] -
                              blk_geom->origin_y) >>
                         1,
+#endif
                     blk_geom->tx_width_uv[blk_ptr->tx_depth][txb_itr],
                     blk_geom->tx_height_uv[blk_ptr->tx_depth][txb_itr],
                     NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
@@ -1151,12 +1261,23 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                 neighbor_array_unit_mode_write(
                     cr_dc_sign_level_coeff_neighbor_array,
                     (uint8_t *)&dc_sign_level_coeff,
+#if TX_ORG_INTERINTRA
+                    ROUND_UV(blk_origin_x +
+                             blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][txb_itr] -
+                             blk_geom->origin_x) >>
+                        1,
+                    ROUND_UV(blk_origin_y +
+                             blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][txb_itr] -
+                             blk_geom->origin_y) >>
+                        1,
+#else
                     ROUND_UV(blk_origin_x + blk_geom->tx_org_x[blk_ptr->tx_depth][txb_itr] -
                              blk_geom->origin_x) >>
                         1,
                     ROUND_UV(blk_origin_y + blk_geom->tx_org_y[blk_ptr->tx_depth][txb_itr] -
                              blk_geom->origin_y) >>
                         1,
+#endif
                     blk_geom->tx_width_uv[blk_ptr->tx_depth][txb_itr],
                     blk_geom->tx_height_uv[blk_ptr->tx_depth][txb_itr],
                     NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);

--- a/Source/Lib/Encoder/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Encoder/Codec/EbEntropyCoding.c
@@ -724,11 +724,9 @@ static EbErrorType av1_encode_tx_coef_y(
     uint32_t intraLumaDir, BlockSize plane_bsize, EbPictureBufferDesc *coeff_ptr,
     NeighborArrayUnit *luma_dc_sign_level_coeff_neighbor_array) {
     EbErrorType return_error = EB_ErrorNone;
-#if TX_ORG_INTERINTRA
     int32_t is_inter = (blk_ptr->prediction_mode_flag == INTER_MODE || blk_ptr->av1xd->use_intrabc)
                            ? EB_TRUE
                            : EB_FALSE;
-#endif
     const BlockGeom *blk_geom    = get_blk_geom_mds(blk_ptr->mds_idx);
     int32_t          cul_level_y = 0;
 
@@ -755,13 +753,8 @@ static EbErrorType av1_encode_tx_coef_y(
             get_txb_ctx(pcs_ptr,
                         COMPONENT_LUMA,
                         luma_dc_sign_level_coeff_neighbor_array,
-#if TX_ORG_INTERINTRA
                         blk_origin_x + blk_geom->tx_org_x[is_inter][tx_depth][txb_itr] - blk_geom->origin_x,
                         blk_origin_y + blk_geom->tx_org_y[is_inter][tx_depth][txb_itr] - blk_geom->origin_y,
-#else
-                        blk_origin_x + blk_geom->tx_org_x[tx_depth][txb_itr] - blk_geom->origin_x,
-                        blk_origin_y + blk_geom->tx_org_y[tx_depth][txb_itr] - blk_geom->origin_y,
-#endif
                         plane_bsize,
                         tx_size,
                         &txb_skip_ctx,
@@ -790,13 +783,8 @@ static EbErrorType av1_encode_tx_coef_y(
             neighbor_array_unit_mode_write(
                 luma_dc_sign_level_coeff_neighbor_array,
                 (uint8_t *)&dc_sign_level_coeff,
-#if TX_ORG_INTERINTRA
                 blk_origin_x + blk_geom->tx_org_x[is_inter][tx_depth][txb_itr] - blk_geom->origin_x,
                 blk_origin_y + blk_geom->tx_org_y[is_inter][tx_depth][txb_itr] - blk_geom->origin_y,
-#else
-                blk_origin_x + blk_geom->tx_org_x[tx_depth][txb_itr] - blk_geom->origin_x,
-                blk_origin_y + blk_geom->tx_org_y[tx_depth][txb_itr] - blk_geom->origin_y,
-#endif
                 blk_geom->tx_width[tx_depth][txb_itr],
                 blk_geom->tx_height[tx_depth][txb_itr],
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
@@ -817,11 +805,9 @@ static EbErrorType av1_encode_tx_coef_uv(PictureControlSet *   pcs_ptr,
                                          NeighborArrayUnit *  cr_dc_sign_level_coeff_neighbor_array,
                                          NeighborArrayUnit *cb_dc_sign_level_coeff_neighbor_array) {
     EbErrorType return_error = EB_ErrorNone;
-#if TX_ORG_INTERINTRA
     int32_t is_inter = (blk_ptr->prediction_mode_flag == INTER_MODE || blk_ptr->av1xd->use_intrabc)
                            ? EB_TRUE
                            : EB_FALSE;
-#endif
     const BlockGeom *blk_geom = get_blk_geom_mds(blk_ptr->mds_idx);
 
     if (!blk_geom->has_uv) return return_error;
@@ -855,21 +841,12 @@ static EbErrorType av1_encode_tx_coef_uv(PictureControlSet *   pcs_ptr,
                 get_txb_ctx(pcs_ptr,
                             COMPONENT_CHROMA,
                             cb_dc_sign_level_coeff_neighbor_array,
-#if TX_ORG_INTERINTRA
                             ROUND_UV(blk_origin_x + blk_geom->tx_org_x[is_inter][tx_depth][txb_itr] -
                                      blk_geom->origin_x) >>
                                 1,
                             ROUND_UV(blk_origin_y + blk_geom->tx_org_y[is_inter][tx_depth][txb_itr] -
                                      blk_geom->origin_y) >>
                                 1,
-#else
-                            ROUND_UV(blk_origin_x + blk_geom->tx_org_x[tx_depth][txb_itr] -
-                                     blk_geom->origin_x) >>
-                                1,
-                            ROUND_UV(blk_origin_y + blk_geom->tx_org_y[tx_depth][txb_itr] -
-                                     blk_geom->origin_y) >>
-                                1,
-#endif
                             blk_geom->bsize_uv,
                             chroma_tx_size,
                             &txb_skip_ctx,
@@ -901,21 +878,12 @@ static EbErrorType av1_encode_tx_coef_uv(PictureControlSet *   pcs_ptr,
                 get_txb_ctx(pcs_ptr,
                             COMPONENT_CHROMA,
                             cr_dc_sign_level_coeff_neighbor_array,
-#if TX_ORG_INTERINTRA
                             ROUND_UV(blk_origin_x + blk_geom->tx_org_x[is_inter][tx_depth][txb_itr] -
                                      blk_geom->origin_x) >>
                                 1,
                             ROUND_UV(blk_origin_y + blk_geom->tx_org_y[is_inter][tx_depth][txb_itr] -
                                      blk_geom->origin_y) >>
                                 1,
-#else
-                            ROUND_UV(blk_origin_x + blk_geom->tx_org_x[tx_depth][txb_itr] -
-                                     blk_geom->origin_x) >>
-                                1,
-                            ROUND_UV(blk_origin_y + blk_geom->tx_org_y[tx_depth][txb_itr] -
-                                     blk_geom->origin_y) >>
-                                1,
-#endif
                             blk_geom->bsize_uv,
                             chroma_tx_size,
                             &txb_skip_ctx,
@@ -946,21 +914,12 @@ static EbErrorType av1_encode_tx_coef_uv(PictureControlSet *   pcs_ptr,
             neighbor_array_unit_mode_write(
                 cb_dc_sign_level_coeff_neighbor_array,
                 (uint8_t *)&dc_sign_level_coeff,
-#if TX_ORG_INTERINTRA
                 ROUND_UV(blk_origin_x + blk_geom->tx_org_x[is_inter][tx_depth][txb_itr] -
                          blk_geom->origin_x) >>
                     1,
                 ROUND_UV(blk_origin_y + blk_geom->tx_org_y[is_inter][tx_depth][txb_itr] -
                          blk_geom->origin_y) >>
                     1,
-#else
-                ROUND_UV(blk_origin_x + blk_geom->tx_org_x[tx_depth][txb_itr] -
-                         blk_geom->origin_x) >>
-                    1,
-                ROUND_UV(blk_origin_y + blk_geom->tx_org_y[tx_depth][txb_itr] -
-                         blk_geom->origin_y) >>
-                    1,
-#endif
                 blk_geom->tx_width_uv[tx_depth][txb_itr],
                 blk_geom->tx_height_uv[tx_depth][txb_itr],
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
@@ -973,21 +932,12 @@ static EbErrorType av1_encode_tx_coef_uv(PictureControlSet *   pcs_ptr,
             neighbor_array_unit_mode_write(
                 cr_dc_sign_level_coeff_neighbor_array,
                 (uint8_t *)&dc_sign_level_coeff,
-#if TX_ORG_INTERINTRA
                 ROUND_UV(blk_origin_x + blk_geom->tx_org_x[is_inter][tx_depth][txb_itr] -
                          blk_geom->origin_x) >>
                     1,
                 ROUND_UV(blk_origin_y + blk_geom->tx_org_y[is_inter][tx_depth][txb_itr] -
                          blk_geom->origin_y) >>
                     1,
-#else
-                ROUND_UV(blk_origin_x + blk_geom->tx_org_x[tx_depth][txb_itr] -
-                         blk_geom->origin_x) >>
-                    1,
-                ROUND_UV(blk_origin_y + blk_geom->tx_org_y[tx_depth][txb_itr] -
-                         blk_geom->origin_y) >>
-                    1,
-#endif
                 blk_geom->tx_width_uv[tx_depth][txb_itr],
                 blk_geom->tx_height_uv[tx_depth][txb_itr],
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
@@ -1012,11 +962,9 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                                        NeighborArrayUnit *cr_dc_sign_level_coeff_neighbor_array,
                                        NeighborArrayUnit *cb_dc_sign_level_coeff_neighbor_array) {
     EbErrorType return_error = EB_ErrorNone;
-#if TX_ORG_INTERINTRA
     int32_t is_inter = (blk_ptr->prediction_mode_flag == INTER_MODE || blk_ptr->av1xd->use_intrabc)
                            ? EB_TRUE
                            : EB_FALSE;
-#endif
     if (blk_ptr->tx_depth) {
         av1_encode_tx_coef_y(pcs_ptr,
                              context_ptr,
@@ -1065,17 +1013,10 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                 get_txb_ctx(pcs_ptr,
                             COMPONENT_LUMA,
                             luma_dc_sign_level_coeff_neighbor_array,
-#if TX_ORG_INTERINTRA
                             blk_origin_x + blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][txb_itr] -
                                 blk_geom->origin_x,
                             blk_origin_y + blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][txb_itr] -
                                 blk_geom->origin_y,
-#else
-                            blk_origin_x + blk_geom->tx_org_x[blk_ptr->tx_depth][txb_itr] -
-                                blk_geom->origin_x,
-                            blk_origin_y + blk_geom->tx_org_y[blk_ptr->tx_depth][txb_itr] -
-                                blk_geom->origin_y,
-#endif
                             plane_bsize,
                             tx_size,
                             &txb_skip_ctx,
@@ -1108,7 +1049,6 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                         pcs_ptr,
                         COMPONENT_CHROMA,
                         cb_dc_sign_level_coeff_neighbor_array,
-#if TX_ORG_INTERINTRA
                         ROUND_UV(blk_origin_x +
                                     blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][txb_itr] -
                                     blk_geom->origin_x) >>
@@ -1117,16 +1057,6 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                                     blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][txb_itr] -
                                     blk_geom->origin_y) >>
                             1,
-#else
-                        ROUND_UV(blk_origin_x +
-                                    blk_geom->tx_org_x[blk_ptr->tx_depth][txb_itr] -
-                                    blk_geom->origin_x) >>
-                            1,
-                        ROUND_UV(blk_origin_y +
-                                    blk_geom->tx_org_y[blk_ptr->tx_depth][txb_itr] -
-                                    blk_geom->origin_y) >>
-                            1,
-#endif
                         blk_geom->bsize_uv,
                         chroma_tx_size,
                         &txb_skip_ctx,
@@ -1159,7 +1089,6 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                         pcs_ptr,
                         COMPONENT_CHROMA,
                         cr_dc_sign_level_coeff_neighbor_array,
-#if TX_ORG_INTERINTRA
                         ROUND_UV(blk_origin_x +
                                     blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][txb_itr] -
                                     blk_geom->origin_x) >>
@@ -1168,16 +1097,6 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                                     blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][txb_itr] -
                                     blk_geom->origin_y) >>
                             1,
-#else
-                        ROUND_UV(blk_origin_x +
-                                    blk_geom->tx_org_x[blk_ptr->tx_depth][txb_itr] -
-                                    blk_geom->origin_x) >>
-                            1,
-                        ROUND_UV(blk_origin_y +
-                                    blk_geom->tx_org_y[blk_ptr->tx_depth][txb_itr] -
-                                    blk_geom->origin_y) >>
-                            1,
-#endif
                         blk_geom->bsize_uv,
                         chroma_tx_size,
                         &txb_skip_ctx,
@@ -1209,17 +1128,10 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                 neighbor_array_unit_mode_write(
                     luma_dc_sign_level_coeff_neighbor_array,
                     (uint8_t *)&dc_sign_level_coeff,
-#if TX_ORG_INTERINTRA
                     blk_origin_x + blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][txb_itr] -
                         blk_geom->origin_x,
                     blk_origin_y + blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][txb_itr] -
                         blk_geom->origin_y,
-#else
-                    blk_origin_x + blk_geom->tx_org_x[blk_ptr->tx_depth][txb_itr] -
-                        blk_geom->origin_x,
-                    blk_origin_y + blk_geom->tx_org_y[blk_ptr->tx_depth][txb_itr] -
-                        blk_geom->origin_y,
-#endif
                     blk_geom->tx_width[blk_ptr->tx_depth][txb_itr],
                     blk_geom->tx_height[blk_ptr->tx_depth][txb_itr],
                     NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
@@ -1232,7 +1144,6 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                 neighbor_array_unit_mode_write(
                     cb_dc_sign_level_coeff_neighbor_array,
                     (uint8_t *)&dc_sign_level_coeff,
-#if TX_ORG_INTERINTRA
                     ROUND_UV(blk_origin_x +
                              blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][txb_itr] -
                              blk_geom->origin_x) >>
@@ -1241,14 +1152,6 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                              blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][txb_itr] -
                              blk_geom->origin_y) >>
                         1,
-#else
-                    ROUND_UV(blk_origin_x + blk_geom->tx_org_x[blk_ptr->tx_depth][txb_itr] -
-                             blk_geom->origin_x) >>
-                        1,
-                    ROUND_UV(blk_origin_y + blk_geom->tx_org_y[blk_ptr->tx_depth][txb_itr] -
-                             blk_geom->origin_y) >>
-                        1,
-#endif
                     blk_geom->tx_width_uv[blk_ptr->tx_depth][txb_itr],
                     blk_geom->tx_height_uv[blk_ptr->tx_depth][txb_itr],
                     NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
@@ -1261,7 +1164,6 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                 neighbor_array_unit_mode_write(
                     cr_dc_sign_level_coeff_neighbor_array,
                     (uint8_t *)&dc_sign_level_coeff,
-#if TX_ORG_INTERINTRA
                     ROUND_UV(blk_origin_x +
                              blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][txb_itr] -
                              blk_geom->origin_x) >>
@@ -1270,14 +1172,6 @@ static EbErrorType av1_encode_coeff_1d(PictureControlSet *   pcs_ptr,
                              blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][txb_itr] -
                              blk_geom->origin_y) >>
                         1,
-#else
-                    ROUND_UV(blk_origin_x + blk_geom->tx_org_x[blk_ptr->tx_depth][txb_itr] -
-                             blk_geom->origin_x) >>
-                        1,
-                    ROUND_UV(blk_origin_y + blk_geom->tx_org_y[blk_ptr->tx_depth][txb_itr] -
-                             blk_geom->origin_y) >>
-                        1,
-#endif
                     blk_geom->tx_width_uv[blk_ptr->tx_depth][txb_itr],
                     blk_geom->tx_height_uv[blk_ptr->tx_depth][txb_itr],
                     NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);

--- a/Source/Lib/Encoder/Codec/EbFullLoop.c
+++ b/Source/Lib/Encoder/Codec/EbFullLoop.c
@@ -2155,8 +2155,8 @@ void encode_pass_tx_search(PictureControlSet *pcs_ptr, EncDecContext *context_pt
     TxType                tx_type;
     TxSize         tx_size = context_ptr->blk_geom->txsize[blk_ptr->tx_depth][context_ptr->txb_itr];
     const uint32_t scratch_luma_offset =
-        context_ptr->blk_geom->tx_org_x[1][blk_ptr->tx_depth][context_ptr->txb_itr] +
-        context_ptr->blk_geom->tx_org_y[1][blk_ptr->tx_depth][context_ptr->txb_itr] * SB_STRIDE_Y;
+        context_ptr->blk_geom->tx_org_x[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] +
+        context_ptr->blk_geom->tx_org_y[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] * SB_STRIDE_Y;
     assert(tx_size < TX_SIZES_ALL);
     const TxSetType tx_set_type =
         get_ext_tx_set_type(tx_size, is_inter, pcs_ptr->parent_pcs_ptr->frm_hdr.reduced_tx_set);

--- a/Source/Lib/Encoder/Codec/EbFullLoop.c
+++ b/Source/Lib/Encoder/Codec/EbFullLoop.c
@@ -1879,17 +1879,12 @@ void product_full_loop(ModeDecisionCandidateBuffer *candidate_buffer,
     uint8_t  tx_depth              = context_ptr->tx_depth;
     uint32_t txb_itr               = context_ptr->txb_itr;
     uint32_t txb_1d_offset         = context_ptr->txb_1d_offset;
-#if TX_ORG_INTERINTRA
     int32_t is_inter = (candidate_buffer->candidate_ptr->type == INTER_MODE ||
                         candidate_buffer->candidate_ptr->use_intrabc)
                            ? EB_TRUE
                            : EB_FALSE;
     uint16_t tx_org_x = context_ptr->blk_geom->tx_org_x[is_inter][tx_depth][txb_itr];
     uint16_t tx_org_y = context_ptr->blk_geom->tx_org_y[is_inter][tx_depth][txb_itr];
-#else
-    uint16_t       tx_org_x = context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr];
-    uint16_t       tx_org_y = context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr];
-#endif
     int32_t cropped_tx_width =
         MIN(context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
             pcs_ptr->parent_pcs_ptr->aligned_width - (context_ptr->sb_origin_x + tx_org_x));
@@ -1955,11 +1950,7 @@ void product_full_loop(ModeDecisionCandidateBuffer *candidate_buffer,
         candidate_buffer->candidate_ptr->use_intrabc,
         EB_FALSE);
 
-#if FREQUENCY_SPATIAL_DOMAIN
     if (context_ptr->md_staging_spatial_sse_full_loop) {
-#else
-    if (context_ptr->spatial_sse_full_loop) {
-#endif
         uint32_t input_txb_origin_index =
             (context_ptr->sb_origin_x + tx_org_x + input_picture_ptr->origin_x) +
             ((context_ptr->sb_origin_y + tx_org_y + input_picture_ptr->origin_y) *
@@ -2134,294 +2125,7 @@ uint8_t allowed_tx_set_b[TX_SIZES_ALL][TX_TYPES] = {
     {1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0},
     {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
     {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
-#if !LOSSLESS_TX_TYPE_OPT
-void product_full_loop_tx_search(ModeDecisionCandidateBuffer *candidate_buffer,
-                                 ModeDecisionContext *context_ptr, PictureControlSet *pcs_ptr) {
-    uint32_t              txb_origin_index;
-    uint64_t              y_txb_coeff_bits;
-    EB_ALIGN(16) uint64_t txb_full_distortion[3][DIST_CALC_TOTAL];
-    int32_t               plane    = 0;
-    const int32_t         is_inter = (candidate_buffer->candidate_ptr->type == INTER_MODE ||
-                              candidate_buffer->candidate_ptr->use_intrabc)
-                                 ? EB_TRUE
-                                 : EB_FALSE;
-    uint64_t best_full_cost = UINT64_MAX;
-    uint64_t y_full_cost    = MAX_CU_COST;
-    uint32_t y_count_non_zero_coeffs_temp;
-    TxType   txk_start = DCT_DCT;
-    TxType   txk_end   = TX_TYPES;
-    TxType   tx_type;
-    int32_t  txb_itr  = 0;
-    uint8_t  tx_depth = candidate_buffer->candidate_ptr->tx_depth;
-    TxSize   tx_size  = context_ptr->blk_geom->txsize[tx_depth][txb_itr];
-    assert(tx_size < TX_SIZES_ALL);
-    const TxSetType tx_set_type =
-        get_ext_tx_set_type(tx_size, is_inter, pcs_ptr->parent_pcs_ptr->frm_hdr.reduced_tx_set);
 
-    int32_t allowed_tx_mask[TX_TYPES] = {0}; // 1: allow; 0: skip.
-    int32_t allowed_tx_num            = 0;
-    TxType  uv_tx_type                = DCT_DCT;
-    if (context_ptr->tx_search_reduced_set == 2) txk_end = 2;
-    for (int32_t tx_type_index = txk_start; tx_type_index < txk_end; ++tx_type_index) {
-        if (context_ptr->tx_search_reduced_set == 2)
-            tx_type_index = (tx_type_index == 1) ? IDTX : tx_type_index;
-        tx_type                  = (TxType)tx_type_index;
-        allowed_tx_mask[tx_type] = 1;
-        if (plane == 0) {
-            if (allowed_tx_mask[tx_type]) {
-                const TxType ref_tx_type = ((!av1_ext_tx_used[tx_set_type][tx_type]) ||
-                                            txsize_sqr_up_map[tx_size] > TX_32X32)
-                                               ? DCT_DCT
-                                               : tx_type;
-                if (tx_type != ref_tx_type) allowed_tx_mask[tx_type] = 0;
-            }
-        }
-
-        allowed_tx_num += allowed_tx_mask[tx_type];
-    }
-    // Need to have at least one transform type allowed.
-    if (allowed_tx_num == 0) allowed_tx_mask[plane ? uv_tx_type : DCT_DCT] = 1;
-    TxType best_tx_type = DCT_DCT;
-    for (int32_t tx_type_index = txk_start; tx_type_index < txk_end; ++tx_type_index) {
-        if (context_ptr->tx_search_reduced_set == 2)
-            tx_type_index = (tx_type_index == 1) ? IDTX : tx_type_index;
-        tx_type = (TxType)tx_type_index;
-        if (!allowed_tx_mask[tx_type]) continue;
-        if (context_ptr->tx_search_reduced_set)
-            if (!allowed_tx_set_a[tx_size][tx_type]) continue;
-        context_ptr->three_quad_energy = 0;
-        uint32_t txb_itr               = 0;
-        uint16_t txb_count             = context_ptr->blk_geom->txb_count[tx_depth];
-        for (txb_itr = 0; txb_itr < txb_count; txb_itr++) {
-#if TX_ORG_INTERINTRA
-            uint8_t txb_origin_x =
-                (uint8_t)context_ptr->blk_geom->tx_org_x[is_inter][tx_depth][txb_itr];
-            uint8_t txb_origin_y =
-                (uint8_t)context_ptr->blk_geom->tx_org_y[is_inter][tx_depth][txb_itr];
-#else
-            uint8_t txb_origin_x = (uint8_t)context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr];
-            uint8_t txb_origin_y = (uint8_t)context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr];
-#endif
-            txb_origin_index =
-                txb_origin_x + (txb_origin_y * candidate_buffer->residual_ptr->stride_y);
-            y_txb_coeff_bits = 0;
-
-            candidate_buffer->candidate_ptr->transform_type[txb_itr] = tx_type;
-
-            context_ptr->luma_txb_skip_context = 0;
-            context_ptr->luma_dc_sign_context  = 0;
-            get_txb_ctx(pcs_ptr,
-                        COMPONENT_LUMA,
-                        context_ptr->luma_dc_sign_level_coeff_neighbor_array,
-                        context_ptr->sb_origin_x + txb_origin_x,
-                        context_ptr->sb_origin_y + txb_origin_y,
-                        //txb_origin_x,// context_ptr->blk_origin_x,
-                        //txb_origin_y,// context_ptr->blk_origin_y,
-                        context_ptr->blk_geom->bsize,
-                        context_ptr->blk_geom->txsize[tx_depth][txb_itr], //[0][0],
-                        &context_ptr->luma_txb_skip_context,
-                        &context_ptr->luma_dc_sign_context);
-
-            // Y: T Q i_q
-            av1_estimate_transform(
-                &(((int16_t *)candidate_buffer->residual_ptr->buffer_y)[txb_origin_index]),
-                candidate_buffer->residual_ptr->stride_y,
-                &(((int32_t *)context_ptr->trans_quant_buffers_ptr->txb_trans_coeff2_nx2_n_ptr
-                       ->buffer_y)[txb_origin_index]),
-                NOT_USED_VALUE,
-                context_ptr->blk_geom->txsize[tx_depth][txb_itr],
-                &context_ptr->three_quad_energy,
-                context_ptr->transform_inner_array_ptr,
-                context_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
-                tx_type,
-                PLANE_TYPE_Y,
-                context_ptr->pf_md_mode);
-
-            int32_t seg_qp =
-                pcs_ptr->parent_pcs_ptr->frm_hdr.segmentation_params.segmentation_enabled
-                    ? pcs_ptr->parent_pcs_ptr->frm_hdr.segmentation_params
-                          .feature_data[context_ptr->blk_ptr->segment_id][SEG_LVL_ALT_Q]
-                    : 0;
-
-            av1_quantize_inv_quantize(
-                pcs_ptr,
-                context_ptr,
-                &(((int32_t *)context_ptr->trans_quant_buffers_ptr->txb_trans_coeff2_nx2_n_ptr
-                       ->buffer_y)[txb_origin_index]),
-                NOT_USED_VALUE,
-                &(((int32_t *)
-                       candidate_buffer->residual_quant_coeff_ptr->buffer_y)[txb_origin_index]),
-                &(((int32_t *)candidate_buffer->recon_coeff_ptr->buffer_y)[txb_origin_index]),
-                context_ptr->blk_ptr->qp,
-                seg_qp,
-                context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
-                context_ptr->blk_geom->tx_height[tx_depth][txb_itr],
-                context_ptr->blk_geom->txsize[tx_depth][txb_itr],
-                &candidate_buffer->candidate_ptr->eob[0][txb_itr],
-                &y_count_non_zero_coeffs_temp,
-                COMPONENT_LUMA,
-                context_ptr->hbd_mode_decision ? BIT_INCREMENT_10BIT : BIT_INCREMENT_8BIT,
-                tx_type,
-                candidate_buffer,
-                context_ptr->luma_txb_skip_context,
-                context_ptr->luma_dc_sign_context,
-                candidate_buffer->candidate_ptr->pred_mode,
-                candidate_buffer->candidate_ptr->use_intrabc,
-                EB_FALSE);
-
-            //tx_type not equal to DCT_DCT and no coeff is not an acceptable option in AV1.
-            if (y_count_non_zero_coeffs_temp == 0 && tx_type != DCT_DCT) continue;
-
-            if (context_ptr->spatial_sse_full_loop) {
-                if (y_count_non_zero_coeffs_temp)
-                    inv_transform_recon_wrapper(
-                        candidate_buffer->prediction_ptr->buffer_y,
-                        txb_origin_index,
-                        candidate_buffer->prediction_ptr->stride_y,
-                        candidate_buffer->recon_ptr->buffer_y,
-                        txb_origin_index,
-                        candidate_buffer->recon_ptr->stride_y,
-                        (int32_t *)candidate_buffer->recon_coeff_ptr->buffer_y,
-                        txb_origin_index,
-                        context_ptr->hbd_mode_decision,
-                        context_ptr->blk_geom->txsize[tx_depth][txb_itr],
-                        tx_type,
-                        PLANE_TYPE_Y,
-                        (uint16_t)candidate_buffer->candidate_ptr->eob[0][txb_itr]);
-                else
-                    picture_copy(candidate_buffer->prediction_ptr,
-                                 txb_origin_index,
-                                 0,
-                                 candidate_buffer->recon_ptr,
-                                 txb_origin_index,
-                                 0,
-                                 context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
-                                 context_ptr->blk_geom->tx_height[tx_depth][txb_itr],
-                                 0,
-                                 0,
-                                 PICTURE_BUFFER_DESC_Y_FLAG,
-                                 context_ptr->hbd_mode_decision);
-
-                EbPictureBufferDesc *input_picture_ptr =
-                    context_ptr->hbd_mode_decision ? pcs_ptr->input_frame16bit
-                                                   : pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
-                uint32_t input_txb_origin_index =
-                    (context_ptr->sb_origin_x + txb_origin_x + input_picture_ptr->origin_x) +
-                    ((context_ptr->sb_origin_y + txb_origin_y + input_picture_ptr->origin_y) *
-                     input_picture_ptr->stride_y);
-
-                EbSpatialFullDistType spatial_full_dist_type_fun =
-                    context_ptr->hbd_mode_decision ? full_distortion_kernel16_bits
-                                                   : spatial_full_distortion_kernel;
-
-                txb_full_distortion[0][DIST_CALC_PREDICTION] =
-                    spatial_full_dist_type_fun(input_picture_ptr->buffer_y,
-                                               input_txb_origin_index,
-                                               input_picture_ptr->stride_y,
-                                               candidate_buffer->prediction_ptr->buffer_y,
-                                               txb_origin_index,
-                                               candidate_buffer->prediction_ptr->stride_y,
-                                               context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
-                                               context_ptr->blk_geom->tx_height[tx_depth][txb_itr]);
-
-                txb_full_distortion[0][DIST_CALC_RESIDUAL] =
-                    spatial_full_dist_type_fun(input_picture_ptr->buffer_y,
-                                               input_txb_origin_index,
-                                               input_picture_ptr->stride_y,
-                                               candidate_buffer->recon_ptr->buffer_y,
-                                               txb_origin_index,
-                                               candidate_buffer->recon_ptr->stride_y,
-                                               context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
-                                               context_ptr->blk_geom->tx_height[tx_depth][txb_itr]);
-
-                txb_full_distortion[0][DIST_CALC_PREDICTION] <<= 4;
-                txb_full_distortion[0][DIST_CALC_RESIDUAL] <<= 4;
-            } else {
-                // LUMA DISTORTION
-                picture_full_distortion32_bits(
-                    context_ptr->trans_quant_buffers_ptr->txb_trans_coeff2_nx2_n_ptr,
-                    txb_origin_index,
-                    0,
-                    candidate_buffer->recon_coeff_ptr,
-                    txb_origin_index,
-                    0,
-                    context_ptr->blk_geom->bwidth,
-                    context_ptr->blk_geom->bheight,
-                    context_ptr->blk_geom->bwidth_uv,
-                    context_ptr->blk_geom->bheight_uv,
-                    txb_full_distortion[0],
-                    txb_full_distortion[0],
-                    txb_full_distortion[0],
-                    y_count_non_zero_coeffs_temp,
-                    0,
-                    0,
-                    COMPONENT_LUMA);
-
-                txb_full_distortion[0][DIST_CALC_RESIDUAL] += context_ptr->three_quad_energy;
-                txb_full_distortion[0][DIST_CALC_PREDICTION] += context_ptr->three_quad_energy;
-
-                int32_t shift = (MAX_TX_SCALE - av1_get_tx_scale(tx_size)) * 2;
-                txb_full_distortion[0][DIST_CALC_RESIDUAL] =
-                    RIGHT_SIGNED_SHIFT(txb_full_distortion[0][DIST_CALC_RESIDUAL], shift);
-                txb_full_distortion[0][DIST_CALC_PREDICTION] =
-                    RIGHT_SIGNED_SHIFT(txb_full_distortion[0][DIST_CALC_PREDICTION], shift);
-            }
-            //LUMA-ONLY
-            av1_txb_estimate_coeff_bits(context_ptr,
-                                        0, //allow_update_cdf,
-                                        NULL, //FRAME_CONTEXT *ec_ctx,
-                                        pcs_ptr,
-                                        candidate_buffer,
-                                        txb_origin_index,
-                                        0,
-                                        context_ptr->coeff_est_entropy_coder_ptr,
-                                        candidate_buffer->residual_quant_coeff_ptr,
-                                        y_count_non_zero_coeffs_temp,
-                                        0,
-                                        0,
-                                        &y_txb_coeff_bits,
-                                        &y_txb_coeff_bits,
-                                        &y_txb_coeff_bits,
-                                        context_ptr->blk_geom->txsize[tx_depth][txb_itr],
-                                        context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr],
-                                        candidate_buffer->candidate_ptr->transform_type[txb_itr],
-                                        candidate_buffer->candidate_ptr->transform_type_uv,
-                                        COMPONENT_LUMA);
-
-            av1_txb_calc_cost_luma(context_ptr->luma_txb_skip_context,
-                                   candidate_buffer->candidate_ptr,
-                                   txb_itr,
-                                   context_ptr->blk_geom->txsize[tx_depth][txb_itr],
-                                   y_count_non_zero_coeffs_temp,
-                                   txb_full_distortion[0],
-                                   &y_txb_coeff_bits,
-                                   &y_full_cost,
-                                   context_ptr->full_lambda);
-        }
-
-        if (y_full_cost < best_full_cost) {
-            best_full_cost = y_full_cost;
-            best_tx_type   = tx_type;
-        }
-
-        //if (cpi->sf.adaptive_txb_search_level) {
-        //    if ((best_rd - (best_rd >> cpi->sf.adaptive_txb_search_level)) >
-        //        ref_best_rd) {
-        //        break;
-        //    }
-        //}
-        //// Skip transform type search when we found the block has been quantized to
-        //// all zero and at the same time, it has better rdcost than doing transform.
-        //if (cpi->sf.tx_type_search.skip_tx_search && !best_eob) break;
-    }
-    // this kernel assumes no atb
-    candidate_buffer->candidate_ptr->transform_type[0] = best_tx_type;
-    // For Inter blocks, transform type of chroma follows luma transfrom type
-    if (is_inter)
-        candidate_buffer->candidate_ptr->transform_type_uv =
-            candidate_buffer->candidate_ptr->transform_type[0];
-}
-#endif
 void encode_pass_tx_search(PictureControlSet *pcs_ptr, EncDecContext *context_ptr,
                            SuperBlock *sb_ptr, uint32_t cb_qp,
                            EbPictureBufferDesc *coeff_samples_sb,
@@ -2450,15 +2154,9 @@ void encode_pass_tx_search(PictureControlSet *pcs_ptr, EncDecContext *context_pt
     TxType                txk_end   = TX_TYPES;
     TxType                tx_type;
     TxSize         tx_size = context_ptr->blk_geom->txsize[blk_ptr->tx_depth][context_ptr->txb_itr];
-#if TX_ORG_INTERINTRA
     const uint32_t scratch_luma_offset =
         context_ptr->blk_geom->tx_org_x[1][blk_ptr->tx_depth][context_ptr->txb_itr] +
         context_ptr->blk_geom->tx_org_y[1][blk_ptr->tx_depth][context_ptr->txb_itr] * SB_STRIDE_Y;
-#else
-    const uint32_t scratch_luma_offset =
-        context_ptr->blk_geom->tx_org_x[blk_ptr->tx_depth][context_ptr->txb_itr] +
-        context_ptr->blk_geom->tx_org_y[blk_ptr->tx_depth][context_ptr->txb_itr] * SB_STRIDE_Y;
-#endif
     assert(tx_size < TX_SIZES_ALL);
     const TxSetType tx_set_type =
         get_ext_tx_set_type(tx_size, is_inter, pcs_ptr->parent_pcs_ptr->frm_hdr.reduced_tx_set);
@@ -2856,25 +2554,19 @@ void full_loop_r(SuperBlock *sb_ptr, ModeDecisionCandidateBuffer *candidate_buff
     context_ptr->three_quad_energy = 0;
 
     uint8_t tx_depth = candidate_buffer->candidate_ptr->tx_depth;
-#if TX_ORG_INTERINTRA
     int32_t is_inter = (candidate_buffer->candidate_ptr->type == INTER_MODE ||
                         candidate_buffer->candidate_ptr->use_intrabc)
                            ? EB_TRUE
                            : EB_FALSE;
-#endif
+
     tu_count = context_ptr->blk_geom->txb_count[candidate_buffer->candidate_ptr->tx_depth];
     uint32_t txb_1d_offset = 0;
     tu_count               = tx_depth ? 1 : tu_count; //NM: 128x128 exeption
 
     txb_itr = 0;
     do {
-#if TX_ORG_INTERINTRA
         txb_origin_x = context_ptr->blk_geom->tx_org_x[is_inter][tx_depth][txb_itr];
         txb_origin_y = context_ptr->blk_geom->tx_org_y[is_inter][tx_depth][txb_itr];
-#else
-        txb_origin_x = context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr];
-        txb_origin_y = context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr];
-#endif
 
         context_ptr->cb_txb_skip_context = 0;
         context_ptr->cb_dc_sign_context  = 0;
@@ -2968,11 +2660,7 @@ void full_loop_r(SuperBlock *sb_ptr, ModeDecisionCandidateBuffer *candidate_buff
                 candidate_buffer->candidate_ptr->use_intrabc,
                 EB_FALSE);
 
-#if FREQUENCY_SPATIAL_DOMAIN
             if (context_ptr->md_staging_spatial_sse_full_loop) {
-#else
-            if (context_ptr->spatial_sse_full_loop) {
-#endif
                 uint32_t cb_has_coeff = cb_count_non_zero_coeffs[txb_itr] > 0;
 
                 if (cb_has_coeff)
@@ -3059,11 +2747,7 @@ void full_loop_r(SuperBlock *sb_ptr, ModeDecisionCandidateBuffer *candidate_buff
                 candidate_buffer->candidate_ptr->use_intrabc,
                 EB_FALSE);
 
-#if FREQUENCY_SPATIAL_DOMAIN
             if (context_ptr->md_staging_spatial_sse_full_loop) {
-#else
-            if (context_ptr->spatial_sse_full_loop) {
-#endif
                 uint32_t cr_has_coeff = cr_count_non_zero_coeffs[txb_itr] > 0;
 
                 if (cr_has_coeff)
@@ -3134,25 +2818,19 @@ void cu_full_distortion_fast_txb_mode_r(
     current_txb_index              = 0;
     transform_buffer = context_ptr->trans_quant_buffers_ptr->txb_trans_coeff2_nx2_n_ptr;
 
-#if TX_ORG_INTERINTRA
     int32_t is_inter = (candidate_buffer->candidate_ptr->type == INTER_MODE ||
                         candidate_buffer->candidate_ptr->use_intrabc)
                            ? EB_TRUE
                            : EB_FALSE;
-#endif
 
     uint32_t txb_1d_offset     = 0;
     candidate_ptr->u_has_coeff = 0;
     candidate_ptr->v_has_coeff = 0;
     tu_total_count             = tx_depth ? 1 : tu_total_count; //NM: 128x128 exeption
     do {
-#if TX_ORG_INTERINTRA
         txb_origin_x = context_ptr->blk_geom->tx_org_x[is_inter][tx_depth][txb_itr];
         txb_origin_y = context_ptr->blk_geom->tx_org_y[is_inter][tx_depth][txb_itr];
-#else
-        txb_origin_x = context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr];
-        txb_origin_y = context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr];
-#endif
+
         int32_t cropped_tx_width_uv =
             MIN(context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
                 pcs_ptr->parent_pcs_ptr->aligned_width / 2 -
@@ -3176,11 +2854,7 @@ void cu_full_distortion_fast_txb_mode_r(
             count_nonzero_coeffs_all[1] = count_non_zero_coeffs[1][current_txb_index];
             count_nonzero_coeffs_all[2] = count_non_zero_coeffs[2][current_txb_index];
 
-#if FREQUENCY_SPATIAL_DOMAIN
             if (is_full_loop && context_ptr->md_staging_spatial_sse_full_loop) {
-#else
-            if (is_full_loop && context_ptr->spatial_sse_full_loop) {
-#endif
                 uint32_t input_chroma_txb_origin_index =
                     (((context_ptr->sb_origin_y + ((txb_origin_y >> 3) << 3)) >> 1) +
                      (input_picture_ptr->origin_y >> 1)) *

--- a/Source/Lib/Encoder/Codec/EbFullLoop.c
+++ b/Source/Lib/Encoder/Codec/EbFullLoop.c
@@ -1955,7 +1955,11 @@ void product_full_loop(ModeDecisionCandidateBuffer *candidate_buffer,
         candidate_buffer->candidate_ptr->use_intrabc,
         EB_FALSE);
 
+#if FREQUENCY_SPATIAL_DOMAIN
+    if (context_ptr->md_staging_spatial_sse_full_loop) {
+#else
     if (context_ptr->spatial_sse_full_loop) {
+#endif
         uint32_t input_txb_origin_index =
             (context_ptr->sb_origin_x + tx_org_x + input_picture_ptr->origin_x) +
             ((context_ptr->sb_origin_y + tx_org_y + input_picture_ptr->origin_y) *
@@ -2964,7 +2968,11 @@ void full_loop_r(SuperBlock *sb_ptr, ModeDecisionCandidateBuffer *candidate_buff
                 candidate_buffer->candidate_ptr->use_intrabc,
                 EB_FALSE);
 
+#if FREQUENCY_SPATIAL_DOMAIN
+            if (context_ptr->md_staging_spatial_sse_full_loop) {
+#else
             if (context_ptr->spatial_sse_full_loop) {
+#endif
                 uint32_t cb_has_coeff = cb_count_non_zero_coeffs[txb_itr] > 0;
 
                 if (cb_has_coeff)
@@ -3051,7 +3059,11 @@ void full_loop_r(SuperBlock *sb_ptr, ModeDecisionCandidateBuffer *candidate_buff
                 candidate_buffer->candidate_ptr->use_intrabc,
                 EB_FALSE);
 
+#if FREQUENCY_SPATIAL_DOMAIN
+            if (context_ptr->md_staging_spatial_sse_full_loop) {
+#else
             if (context_ptr->spatial_sse_full_loop) {
+#endif
                 uint32_t cr_has_coeff = cr_count_non_zero_coeffs[txb_itr] > 0;
 
                 if (cr_has_coeff)
@@ -3164,7 +3176,11 @@ void cu_full_distortion_fast_txb_mode_r(
             count_nonzero_coeffs_all[1] = count_non_zero_coeffs[1][current_txb_index];
             count_nonzero_coeffs_all[2] = count_non_zero_coeffs[2][current_txb_index];
 
+#if FREQUENCY_SPATIAL_DOMAIN
+            if (is_full_loop && context_ptr->md_staging_spatial_sse_full_loop) {
+#else
             if (is_full_loop && context_ptr->spatial_sse_full_loop) {
+#endif
                 uint32_t input_chroma_txb_origin_index =
                     (((context_ptr->sb_origin_y + ((txb_origin_y >> 3) << 3)) >> 1) +
                      (input_picture_ptr->origin_y >> 1)) *

--- a/Source/Lib/Encoder/Codec/EbFullLoop.c
+++ b/Source/Lib/Encoder/Codec/EbFullLoop.c
@@ -1879,9 +1879,18 @@ void product_full_loop(ModeDecisionCandidateBuffer *candidate_buffer,
     uint8_t  tx_depth              = context_ptr->tx_depth;
     uint32_t txb_itr               = context_ptr->txb_itr;
     uint32_t txb_1d_offset         = context_ptr->txb_1d_offset;
-    uint16_t tx_org_x              = context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr];
-    uint16_t tx_org_y              = context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr];
-    int32_t  cropped_tx_width =
+#if TX_ORG_INTERINTRA
+    int32_t is_inter = (candidate_buffer->candidate_ptr->type == INTER_MODE ||
+                        candidate_buffer->candidate_ptr->use_intrabc)
+                           ? EB_TRUE
+                           : EB_FALSE;
+    uint16_t tx_org_x = context_ptr->blk_geom->tx_org_x[is_inter][tx_depth][txb_itr];
+    uint16_t tx_org_y = context_ptr->blk_geom->tx_org_y[is_inter][tx_depth][txb_itr];
+#else
+    uint16_t       tx_org_x = context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr];
+    uint16_t       tx_org_y = context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr];
+#endif
+    int32_t cropped_tx_width =
         MIN(context_ptr->blk_geom->tx_width[tx_depth][txb_itr],
             pcs_ptr->parent_pcs_ptr->aligned_width - (context_ptr->sb_origin_x + tx_org_x));
     int32_t cropped_tx_height =
@@ -2121,7 +2130,7 @@ uint8_t allowed_tx_set_b[TX_SIZES_ALL][TX_TYPES] = {
     {1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0},
     {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
     {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}};
-
+#if !LOSSLESS_TX_TYPE_OPT
 void product_full_loop_tx_search(ModeDecisionCandidateBuffer *candidate_buffer,
                                  ModeDecisionContext *context_ptr, PictureControlSet *pcs_ptr) {
     uint32_t              txb_origin_index;
@@ -2180,8 +2189,15 @@ void product_full_loop_tx_search(ModeDecisionCandidateBuffer *candidate_buffer,
         uint32_t txb_itr               = 0;
         uint16_t txb_count             = context_ptr->blk_geom->txb_count[tx_depth];
         for (txb_itr = 0; txb_itr < txb_count; txb_itr++) {
+#if TX_ORG_INTERINTRA
+            uint8_t txb_origin_x =
+                (uint8_t)context_ptr->blk_geom->tx_org_x[is_inter][tx_depth][txb_itr];
+            uint8_t txb_origin_y =
+                (uint8_t)context_ptr->blk_geom->tx_org_y[is_inter][tx_depth][txb_itr];
+#else
             uint8_t txb_origin_x = (uint8_t)context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr];
             uint8_t txb_origin_y = (uint8_t)context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr];
+#endif
             txb_origin_index =
                 txb_origin_x + (txb_origin_y * candidate_buffer->residual_ptr->stride_y);
             y_txb_coeff_bits = 0;
@@ -2401,7 +2417,7 @@ void product_full_loop_tx_search(ModeDecisionCandidateBuffer *candidate_buffer,
         candidate_buffer->candidate_ptr->transform_type_uv =
             candidate_buffer->candidate_ptr->transform_type[0];
 }
-
+#endif
 void encode_pass_tx_search(PictureControlSet *pcs_ptr, EncDecContext *context_ptr,
                            SuperBlock *sb_ptr, uint32_t cb_qp,
                            EbPictureBufferDesc *coeff_samples_sb,
@@ -2430,9 +2446,15 @@ void encode_pass_tx_search(PictureControlSet *pcs_ptr, EncDecContext *context_pt
     TxType                txk_end   = TX_TYPES;
     TxType                tx_type;
     TxSize         tx_size = context_ptr->blk_geom->txsize[blk_ptr->tx_depth][context_ptr->txb_itr];
+#if TX_ORG_INTERINTRA
+    const uint32_t scratch_luma_offset =
+        context_ptr->blk_geom->tx_org_x[1][blk_ptr->tx_depth][context_ptr->txb_itr] +
+        context_ptr->blk_geom->tx_org_y[1][blk_ptr->tx_depth][context_ptr->txb_itr] * SB_STRIDE_Y;
+#else
     const uint32_t scratch_luma_offset =
         context_ptr->blk_geom->tx_org_x[blk_ptr->tx_depth][context_ptr->txb_itr] +
         context_ptr->blk_geom->tx_org_y[blk_ptr->tx_depth][context_ptr->txb_itr] * SB_STRIDE_Y;
+#endif
     assert(tx_size < TX_SIZES_ALL);
     const TxSetType tx_set_type =
         get_ext_tx_set_type(tx_size, is_inter, pcs_ptr->parent_pcs_ptr->frm_hdr.reduced_tx_set);
@@ -2830,14 +2852,25 @@ void full_loop_r(SuperBlock *sb_ptr, ModeDecisionCandidateBuffer *candidate_buff
     context_ptr->three_quad_energy = 0;
 
     uint8_t tx_depth = candidate_buffer->candidate_ptr->tx_depth;
-    tu_count         = context_ptr->blk_geom->txb_count[candidate_buffer->candidate_ptr->tx_depth];
+#if TX_ORG_INTERINTRA
+    int32_t is_inter = (candidate_buffer->candidate_ptr->type == INTER_MODE ||
+                        candidate_buffer->candidate_ptr->use_intrabc)
+                           ? EB_TRUE
+                           : EB_FALSE;
+#endif
+    tu_count = context_ptr->blk_geom->txb_count[candidate_buffer->candidate_ptr->tx_depth];
     uint32_t txb_1d_offset = 0;
     tu_count               = tx_depth ? 1 : tu_count; //NM: 128x128 exeption
 
     txb_itr = 0;
     do {
+#if TX_ORG_INTERINTRA
+        txb_origin_x = context_ptr->blk_geom->tx_org_x[is_inter][tx_depth][txb_itr];
+        txb_origin_y = context_ptr->blk_geom->tx_org_y[is_inter][tx_depth][txb_itr];
+#else
         txb_origin_x = context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr];
         txb_origin_y = context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr];
+#endif
 
         context_ptr->cb_txb_skip_context = 0;
         context_ptr->cb_dc_sign_context  = 0;
@@ -3089,13 +3122,25 @@ void cu_full_distortion_fast_txb_mode_r(
     current_txb_index              = 0;
     transform_buffer = context_ptr->trans_quant_buffers_ptr->txb_trans_coeff2_nx2_n_ptr;
 
+#if TX_ORG_INTERINTRA
+    int32_t is_inter = (candidate_buffer->candidate_ptr->type == INTER_MODE ||
+                        candidate_buffer->candidate_ptr->use_intrabc)
+                           ? EB_TRUE
+                           : EB_FALSE;
+#endif
+
     uint32_t txb_1d_offset     = 0;
     candidate_ptr->u_has_coeff = 0;
     candidate_ptr->v_has_coeff = 0;
     tu_total_count             = tx_depth ? 1 : tu_total_count; //NM: 128x128 exeption
     do {
+#if TX_ORG_INTERINTRA
+        txb_origin_x = context_ptr->blk_geom->tx_org_x[is_inter][tx_depth][txb_itr];
+        txb_origin_y = context_ptr->blk_geom->tx_org_y[is_inter][tx_depth][txb_itr];
+#else
         txb_origin_x = context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr];
         txb_origin_y = context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr];
+#endif
         int32_t cropped_tx_width_uv =
             MIN(context_ptr->blk_geom->tx_width_uv[tx_depth][txb_itr],
                 pcs_ptr->parent_pcs_ptr->aligned_width / 2 -

--- a/Source/Lib/Encoder/Codec/EbFullLoop.h
+++ b/Source/Lib/Encoder/Codec/EbFullLoop.h
@@ -34,10 +34,7 @@ void product_full_loop(ModeDecisionCandidateBuffer *candidate_buffer,
                        EbPictureBufferDesc *input_picture_ptr, uint32_t qp,
                        uint32_t *y_count_non_zero_coeffs, uint64_t *y_coeff_bits,
                        uint64_t *y_full_distortion);
-#if !LOSSLESS_TX_TYPE_OPT
-void product_full_loop_tx_search(ModeDecisionCandidateBuffer *candidate_buffer,
-                                 ModeDecisionContext *context_ptr, PictureControlSet *pcs_ptr);
-#endif
+
 void inv_transform_recon_wrapper(uint8_t *pred_buffer, uint32_t pred_offset, uint32_t pred_stride,
                                  uint8_t *rec_buffer, uint32_t rec_offset, uint32_t rec_stride,
                                  int32_t *rec_coeff_buffer, uint32_t coeff_offset, EbBool hbd,

--- a/Source/Lib/Encoder/Codec/EbFullLoop.h
+++ b/Source/Lib/Encoder/Codec/EbFullLoop.h
@@ -34,9 +34,10 @@ void product_full_loop(ModeDecisionCandidateBuffer *candidate_buffer,
                        EbPictureBufferDesc *input_picture_ptr, uint32_t qp,
                        uint32_t *y_count_non_zero_coeffs, uint64_t *y_coeff_bits,
                        uint64_t *y_full_distortion);
+#if !LOSSLESS_TX_TYPE_OPT
 void product_full_loop_tx_search(ModeDecisionCandidateBuffer *candidate_buffer,
                                  ModeDecisionContext *context_ptr, PictureControlSet *pcs_ptr);
-
+#endif
 void inv_transform_recon_wrapper(uint8_t *pred_buffer, uint32_t pred_offset, uint32_t pred_stride,
                                  uint8_t *rec_buffer, uint32_t rec_offset, uint32_t rec_stride,
                                  int32_t *rec_coeff_buffer, uint32_t coeff_offset, EbBool hbd,

--- a/Source/Lib/Encoder/Codec/EbIntraPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbIntraPrediction.c
@@ -3684,8 +3684,13 @@ EbErrorType  intra_luma_prediction_for_interintra(
             top_neigh_array + 1,
             left_neigh_array + 1,
             prediction_ptr,                                         //uint8_t *dst,
+#if TX_ORG_INTERINTRA
+            (md_context_ptr->blk_geom->tx_org_x[0][0][0] - md_context_ptr->blk_geom->origin_x) >> 2,
+            (md_context_ptr->blk_geom->tx_org_y[0][0][0] - md_context_ptr->blk_geom->origin_y) >> 2,
+#else
             md_context_ptr->blk_geom->tx_boff_x[0][0] >> 2,         //int32_t col_off,
             md_context_ptr->blk_geom->tx_boff_y[0][0] >> 2,         //int32_t row_off,
+#endif
             PLANE_TYPE_Y,                                           //int32_t plane,
             md_context_ptr->blk_geom->bsize,                        //uint32_t puSize,
             md_context_ptr->blk_origin_x,
@@ -3722,8 +3727,13 @@ EbErrorType  intra_luma_prediction_for_interintra(
             top_neigh_array + 1,
             left_neigh_array + 1,
             prediction_ptr,                                         //uint8_t *dst,
+#if TX_ORG_INTERINTRA
+            (md_context_ptr->blk_geom->tx_org_x[0][0][0] - md_context_ptr->blk_geom->origin_x) >> 2,
+            (md_context_ptr->blk_geom->tx_org_y[0][0][0] - md_context_ptr->blk_geom->origin_y) >> 2,
+#else
             md_context_ptr->blk_geom->tx_boff_x[0][0] >> 2,         //int32_t col_off,
             md_context_ptr->blk_geom->tx_boff_y[0][0] >> 2,         //int32_t row_off,
+#endif
             PLANE_TYPE_Y,                                           //int32_t plane,
             md_context_ptr->blk_geom->bsize,                        //uint32_t puSize,
             md_context_ptr->blk_origin_x,

--- a/Source/Lib/Encoder/Codec/EbIntraPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbIntraPrediction.c
@@ -3632,6 +3632,7 @@ EbErrorType  intra_luma_prediction_for_interintra(
     EbPictureBufferDesc         *prediction_ptr)
 {
     EbErrorType return_error = EB_ErrorNone;
+    uint8_t is_inter = 0; // set to 0 b/c this is an intra path
 
     uint32_t mode_type_left_neighbor_index = get_neighbor_array_unit_left_index(
         md_context_ptr->mode_type_neighbor_array,
@@ -3684,8 +3685,8 @@ EbErrorType  intra_luma_prediction_for_interintra(
             top_neigh_array + 1,
             left_neigh_array + 1,
             prediction_ptr,                                         //uint8_t *dst,
-            (md_context_ptr->blk_geom->tx_org_x[0][0][0] - md_context_ptr->blk_geom->origin_x) >> 2,
-            (md_context_ptr->blk_geom->tx_org_y[0][0][0] - md_context_ptr->blk_geom->origin_y) >> 2,
+            (md_context_ptr->blk_geom->tx_org_x[is_inter][0][0] - md_context_ptr->blk_geom->origin_x) >> 2,
+            (md_context_ptr->blk_geom->tx_org_y[is_inter][0][0] - md_context_ptr->blk_geom->origin_y) >> 2,
             PLANE_TYPE_Y,                                           //int32_t plane,
             md_context_ptr->blk_geom->bsize,                        //uint32_t puSize,
             md_context_ptr->blk_origin_x,
@@ -3722,8 +3723,8 @@ EbErrorType  intra_luma_prediction_for_interintra(
             top_neigh_array + 1,
             left_neigh_array + 1,
             prediction_ptr,                                         //uint8_t *dst,
-            (md_context_ptr->blk_geom->tx_org_x[0][0][0] - md_context_ptr->blk_geom->origin_x) >> 2,
-            (md_context_ptr->blk_geom->tx_org_y[0][0][0] - md_context_ptr->blk_geom->origin_y) >> 2,
+            (md_context_ptr->blk_geom->tx_org_x[is_inter][0][0] - md_context_ptr->blk_geom->origin_x) >> 2,
+            (md_context_ptr->blk_geom->tx_org_y[is_inter][0][0] - md_context_ptr->blk_geom->origin_y) >> 2,
             PLANE_TYPE_Y,                                           //int32_t plane,
             md_context_ptr->blk_geom->bsize,                        //uint32_t puSize,
             md_context_ptr->blk_origin_x,

--- a/Source/Lib/Encoder/Codec/EbIntraPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbIntraPrediction.c
@@ -3684,13 +3684,8 @@ EbErrorType  intra_luma_prediction_for_interintra(
             top_neigh_array + 1,
             left_neigh_array + 1,
             prediction_ptr,                                         //uint8_t *dst,
-#if TX_ORG_INTERINTRA
             (md_context_ptr->blk_geom->tx_org_x[0][0][0] - md_context_ptr->blk_geom->origin_x) >> 2,
             (md_context_ptr->blk_geom->tx_org_y[0][0][0] - md_context_ptr->blk_geom->origin_y) >> 2,
-#else
-            md_context_ptr->blk_geom->tx_boff_x[0][0] >> 2,         //int32_t col_off,
-            md_context_ptr->blk_geom->tx_boff_y[0][0] >> 2,         //int32_t row_off,
-#endif
             PLANE_TYPE_Y,                                           //int32_t plane,
             md_context_ptr->blk_geom->bsize,                        //uint32_t puSize,
             md_context_ptr->blk_origin_x,
@@ -3727,13 +3722,8 @@ EbErrorType  intra_luma_prediction_for_interintra(
             top_neigh_array + 1,
             left_neigh_array + 1,
             prediction_ptr,                                         //uint8_t *dst,
-#if TX_ORG_INTERINTRA
             (md_context_ptr->blk_geom->tx_org_x[0][0][0] - md_context_ptr->blk_geom->origin_x) >> 2,
             (md_context_ptr->blk_geom->tx_org_y[0][0][0] - md_context_ptr->blk_geom->origin_y) >> 2,
-#else
-            md_context_ptr->blk_geom->tx_boff_x[0][0] >> 2,         //int32_t col_off,
-            md_context_ptr->blk_geom->tx_boff_y[0][0] >> 2,         //int32_t row_off,
-#endif
             PLANE_TYPE_Y,                                           //int32_t plane,
             md_context_ptr->blk_geom->bsize,                        //uint32_t puSize,
             md_context_ptr->blk_origin_x,

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
@@ -298,26 +298,17 @@ typedef struct ModeDecisionContext {
     // full_loop_core signals
     EbBool
            md_staging_skip_full_pred; // 0: perform luma & chroma prediction + interpolation search, 2: nothing (use information from previous stages)
-#if LOSSLESS_TX_TYPE_OPT
     EbBool md_staging_tx_size_mode; // 0: Tx Size recon only, 1:Tx Size search and recon
-#else
-    EbBool md_staging_skip_atb;
-#endif
     EbBool md_staging_tx_search; // 0: skip, 1: use ref cost, 2: no shortcuts
     EbBool md_staging_skip_full_chroma;
     EbBool md_staging_skip_rdoq;
-#if FREQUENCY_SPATIAL_DOMAIN
     EbBool md_staging_spatial_sse_full_loop;
-#endif
     DECLARE_ALIGNED(
         16, uint8_t,
         intrapred_buf[INTERINTRA_MODES][2 * 32 * 32]); //MAX block size for inter intra is 32x32
     uint64_t *   ref_best_cost_sq_table;
     uint32_t *   ref_best_ref_sq_table;
     uint8_t      edge_based_skip_angle_intra;
-#if !REMOVE_COEFF_BASED_SKIP_ATB
-    EbBool       coeff_based_skip_atb;
-#endif
     uint8_t      prune_ref_frame_for_rec_partitions;
     unsigned int source_variance; // input block variance
     unsigned int inter_inter_wedge_variance_th;

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
@@ -306,6 +306,9 @@ typedef struct ModeDecisionContext {
     EbBool md_staging_tx_search; // 0: skip, 1: use ref cost, 2: no shortcuts
     EbBool md_staging_skip_full_chroma;
     EbBool md_staging_skip_rdoq;
+#if FREQUENCY_SPATIAL_DOMAIN
+    EbBool md_staging_spatial_sse_full_loop;
+#endif
     DECLARE_ALIGNED(
         16, uint8_t,
         intrapred_buf[INTERINTRA_MODES][2 * 32 * 32]); //MAX block size for inter intra is 32x32

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
@@ -312,7 +312,9 @@ typedef struct ModeDecisionContext {
     uint64_t *   ref_best_cost_sq_table;
     uint32_t *   ref_best_ref_sq_table;
     uint8_t      edge_based_skip_angle_intra;
+#if !REMOVE_COEFF_BASED_SKIP_ATB
     EbBool       coeff_based_skip_atb;
+#endif
     uint8_t      prune_ref_frame_for_rec_partitions;
     unsigned int source_variance; // input block variance
     unsigned int inter_inter_wedge_variance_th;

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -931,9 +931,6 @@ typedef struct PictureParentControlSet {
     FrameHeader       frm_hdr;
     uint8_t           compound_mode;
     uint8_t           prune_unipred_at_me;
-#if !REMOVE_COEFF_BASED_SKIP_ATB
-    uint8_t           coeff_based_skip_atb;
-#endif
     uint16_t *        altref_buffer_highbd[3];
     uint8_t           enable_inter_intra;
     uint8_t           pic_obmc_mode;

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -931,7 +931,9 @@ typedef struct PictureParentControlSet {
     FrameHeader       frm_hdr;
     uint8_t           compound_mode;
     uint8_t           prune_unipred_at_me;
+#if !REMOVE_COEFF_BASED_SKIP_ATB
     uint8_t           coeff_based_skip_atb;
+#endif
     uint16_t *        altref_buffer_highbd[3];
     uint8_t           enable_inter_intra;
     uint8_t           pic_obmc_mode;

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -1114,10 +1114,12 @@ EbErrorType signal_derivation_multi_processes_oq(
         // 0                                     OFF
         // 1                                     ON
         // Phoenix: Active only when atb compound is on
+        #if !REMOVE_COEFF_BASED_SKIP_ATB
         if (pcs_ptr->enc_mode <= ENC_M7)
             pcs_ptr->coeff_based_skip_atb = 0;
         else
             pcs_ptr->coeff_based_skip_atb = 1;
+        #endif
         // Set Wedge mode      Settings
         // 0                 FULL: Full search
         // 1                 Fast: If two predictors are very similar, skip wedge compound mode search

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -1110,16 +1110,6 @@ EbErrorType signal_derivation_multi_processes_oq(
         else
             pcs_ptr->tx_size_search_mode = 0;
 
-        // Set skip atb                          Settings
-        // 0                                     OFF
-        // 1                                     ON
-        // Phoenix: Active only when atb compound is on
-        #if !REMOVE_COEFF_BASED_SKIP_ATB
-        if (pcs_ptr->enc_mode <= ENC_M7)
-            pcs_ptr->coeff_based_skip_atb = 0;
-        else
-            pcs_ptr->coeff_based_skip_atb = 1;
-        #endif
         // Set Wedge mode      Settings
         // 0                 FULL: Full search
         // 1                 Fast: If two predictors are very similar, skip wedge compound mode search

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -4410,7 +4410,7 @@ void perform_tx_partitioning(ModeDecisionCandidateBuffer *candidate_buffer,
         memcpy(context_ptr->scratch_candidate_buffer->candidate_ptr,
                candidate_buffer->candidate_ptr,
                sizeof(ModeDecisionCandidate));
-    }
+    
 
     if (is_inter) {
         uint32_t block_index =
@@ -4472,6 +4472,7 @@ void perform_tx_partitioning(ModeDecisionCandidateBuffer *candidate_buffer,
                 }
             }
         }
+    }
     }
 
     uint8_t tx_search_skip_flag;

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -4391,9 +4391,10 @@ uint64_t get_tx_size_bits(ModeDecisionCandidateBuffer *candidateBuffer,
 
 void perform_tx_partitioning(ModeDecisionCandidateBuffer *candidate_buffer,
                              ModeDecisionContext *context_ptr, PictureControlSet *pcs_ptr,
-                             uint64_t ref_fast_cost, uint8_t end_tx_depth, uint32_t qp,
-                             uint32_t *y_count_non_zero_coeffs, uint64_t *y_coeff_bits,
+                             uint64_t ref_fast_cost, uint8_t start_tx_depth, uint8_t end_tx_depth,
+                             uint32_t qp, uint32_t *y_count_non_zero_coeffs, uint64_t *y_coeff_bits,
                              uint64_t *y_full_distortion) {
+    UNUSED(start_tx_depth); // TODO: start_tx_depth will be used for future features; this commit is adding the infrastructure for that
     EbPictureBufferDesc *input_picture_ptr = context_ptr->hbd_mode_decision
                                                  ? pcs_ptr->input_frame16bit
                                                  : pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
@@ -4761,6 +4762,7 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
                                 context_ptr,
                                 pcs_ptr,
                                 ref_fast_cost,
+                                start_tx_depth,
                                 end_tx_depth,
                                 context_ptr->blk_ptr->qp,
                                 &(*count_non_zero_coeffs[0]),
@@ -4969,8 +4971,7 @@ void md_stage_2(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *blk_p
         candidate_buffer = candidate_buffer_ptr_array[candidateIndex];
         candidate_ptr    = candidate_buffer->candidate_ptr;
 
-        // TODO: change to context_ptr->md_staging_tx_size_mode = 0;
-        context_ptr->md_staging_skip_atb = context_ptr->coeff_based_skip_atb;
+        context_ptr->md_staging_tx_size_mode = 0;
 
         context_ptr->md_staging_tx_search =
             (candidate_ptr->cand_class == CAND_CLASS_0 ||
@@ -4983,8 +4984,7 @@ void md_stage_2(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *blk_p
         context_ptr->md_staging_skip_interpolation_search = EB_TRUE;
         context_ptr->md_staging_skip_inter_chroma_pred    = EB_TRUE;
 
-        // TODO: add this line when supporting spatial/freq distortion calc per md stage
-        // context_ptr->md_staging_spatial_sse_full_loop = context_ptr->spatial_sse_full_loop;
+        context_ptr->md_staging_spatial_sse_full_loop = context_ptr->spatial_sse_full_loop;
 
         full_loop_core(pcs_ptr,
                        sb_ptr,

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -103,6 +103,12 @@ void mode_decision_update_neighbor_arrays(PictureControlSet *  pcs_ptr,
     uint8_t inter_pred_direction_index =
         (uint8_t)context_ptr->blk_ptr->prediction_unit_array->inter_pred_direction_index;
     uint8_t ref_frame_type = (uint8_t)context_ptr->blk_ptr->prediction_unit_array[0].ref_frame_type;
+#if TX_ORG_INTERINTRA
+    int32_t is_inter = (context_ptr->blk_ptr->prediction_mode_flag == INTER_MODE ||
+                        context_ptr->blk_ptr->av1xd->use_intrabc)
+                           ? EB_TRUE
+                           : EB_FALSE;
+#endif
 
 #if TILES_PARALLEL
     uint16_t tile_idx = context_ptr->tile_index;
@@ -154,10 +160,19 @@ void mode_decision_update_neighbor_arrays(PictureControlSet *  pcs_ptr,
             neighbor_array_unit_mode_write(
                 context_ptr->luma_dc_sign_level_coeff_neighbor_array,
                 (uint8_t *)&dc_sign_level_coeff,
+#if TX_ORG_INTERINTRA
+                context_ptr->sb_origin_x +
+                    context_ptr->blk_geom
+                        ->tx_org_x[is_inter][context_ptr->blk_ptr->tx_depth][txb_itr],
+                context_ptr->sb_origin_y +
+                    context_ptr->blk_geom
+                        ->tx_org_y[is_inter][context_ptr->blk_ptr->tx_depth][txb_itr],
+#else
                 context_ptr->sb_origin_x +
                     context_ptr->blk_geom->tx_org_x[context_ptr->blk_ptr->tx_depth][txb_itr],
                 context_ptr->sb_origin_y +
                     context_ptr->blk_geom->tx_org_y[context_ptr->blk_ptr->tx_depth][txb_itr],
+#endif
                 context_ptr->blk_geom->tx_width[context_ptr->blk_ptr->tx_depth][txb_itr],
                 context_ptr->blk_geom->tx_height[context_ptr->blk_ptr->tx_depth][txb_itr],
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
@@ -170,10 +185,19 @@ void mode_decision_update_neighbor_arrays(PictureControlSet *  pcs_ptr,
                     [MD_NEIGHBOR_ARRAY_INDEX],
 #endif
                 (uint8_t *)&dc_sign_level_coeff,
+#if TX_ORG_INTERINTRA
+                context_ptr->sb_origin_x +
+                    context_ptr->blk_geom
+                        ->tx_org_x[is_inter][context_ptr->blk_ptr->tx_depth][txb_itr],
+                context_ptr->sb_origin_y +
+                    context_ptr->blk_geom
+                        ->tx_org_y[is_inter][context_ptr->blk_ptr->tx_depth][txb_itr],
+#else
                 context_ptr->sb_origin_x +
                     context_ptr->blk_geom->tx_org_x[context_ptr->blk_ptr->tx_depth][txb_itr],
                 context_ptr->sb_origin_y +
                     context_ptr->blk_geom->tx_org_y[context_ptr->blk_ptr->tx_depth][txb_itr],
+#endif
                 context_ptr->blk_geom->tx_width[context_ptr->blk_ptr->tx_depth][txb_itr],
                 context_ptr->blk_geom->tx_height[context_ptr->blk_ptr->tx_depth][txb_itr],
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
@@ -871,11 +895,22 @@ void av1_perform_inverse_transform_recon_luma(PictureControlSet *          pcs_p
         tu_total_count         = context_ptr->blk_geom->txb_count[tx_depth];
         txb_itr                = 0;
         uint32_t txb_1d_offset = 0;
+#if TX_ORG_INTERINTRA
+        int32_t is_inter = (candidate_buffer->candidate_ptr->type == INTER_MODE ||
+                            candidate_buffer->candidate_ptr->use_intrabc)
+                               ? EB_TRUE
+                               : EB_FALSE;
+#endif
         do {
+#if TX_ORG_INTERINTRA
+            txb_origin_x = context_ptr->blk_geom->tx_org_x[is_inter][tx_depth][txb_itr];
+            txb_origin_y = context_ptr->blk_geom->tx_org_y[is_inter][tx_depth][txb_itr];
+#else
             txb_origin_x = context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr];
             txb_origin_y = context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr];
-            txb_width    = context_ptr->blk_geom->tx_width[tx_depth][txb_itr];
-            txb_height   = context_ptr->blk_geom->tx_height[tx_depth][txb_itr];
+#endif
+            txb_width  = context_ptr->blk_geom->tx_width[tx_depth][txb_itr];
+            txb_height = context_ptr->blk_geom->tx_height[tx_depth][txb_itr];
             txb_origin_index =
                 txb_origin_x + txb_origin_y * candidate_buffer->prediction_ptr->stride_y;
             uint32_t rec_luma_offset =
@@ -948,13 +983,35 @@ void av1_perform_inverse_transform_recon(PictureControlSet *          pcs_ptr,
         txb_itr                = 0;
         uint32_t txb_1d_offset = 0, txb_1d_offset_uv = 0;
         uint32_t rec_luma_offset, rec_cb_offset, rec_cr_offset;
+#if TX_ORG_INTERINTRA
+        int32_t is_inter = (candidate_buffer->candidate_ptr->type == INTER_MODE ||
+                            candidate_buffer->candidate_ptr->use_intrabc)
+                               ? EB_TRUE
+                               : EB_FALSE;
+#endif
 
         do {
-            txb_origin_x    = context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr];
-            txb_origin_y    = context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr];
-            txb_width       = context_ptr->blk_geom->tx_width[tx_depth][txb_itr];
-            txb_height      = context_ptr->blk_geom->tx_height[tx_depth][txb_itr];
-            txb_ptr         = &blk_ptr->txb_array[txb_index];
+#if TX_ORG_INTERINTRA
+            txb_origin_x = context_ptr->blk_geom->tx_org_x[is_inter][tx_depth][txb_itr];
+            txb_origin_y = context_ptr->blk_geom->tx_org_y[is_inter][tx_depth][txb_itr];
+#else
+            txb_origin_x = context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr];
+            txb_origin_y = context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr];
+#endif
+            txb_width  = context_ptr->blk_geom->tx_width[tx_depth][txb_itr];
+            txb_height = context_ptr->blk_geom->tx_height[tx_depth][txb_itr];
+            txb_ptr    = &blk_ptr->txb_array[txb_index];
+#if TX_ORG_INTERINTRA
+            rec_luma_offset = txb_origin_x + txb_origin_y * candidate_buffer->recon_ptr->stride_y;
+            rec_cb_offset =
+                ((((txb_origin_x >> 3) << 3) +
+                  ((txb_origin_y >> 3) << 3) * candidate_buffer->recon_ptr->stride_cb) >>
+                 1);
+            rec_cr_offset =
+                ((((txb_origin_x >> 3) << 3) +
+                  ((txb_origin_y >> 3) << 3) * candidate_buffer->recon_ptr->stride_cr) >>
+                 1);
+#else
             rec_luma_offset = context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr] +
                               context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr] *
                                   candidate_buffer->recon_ptr->stride_y;
@@ -966,6 +1023,7 @@ void av1_perform_inverse_transform_recon(PictureControlSet *          pcs_ptr,
                               ((context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr] >> 3) << 3) *
                                   candidate_buffer->recon_ptr->stride_cr) >>
                              1);
+#endif
             txb_origin_index =
                 txb_origin_x + txb_origin_y * candidate_buffer->prediction_ptr->stride_y;
             if (txb_ptr->y_has_coeff)
@@ -3392,13 +3450,23 @@ EbErrorType av1_intra_luma_prediction(ModeDecisionContext *        md_context_pt
                                       ModeDecisionCandidateBuffer *candidate_buffer_ptr) {
     EbErrorType return_error = EB_ErrorNone;
 
+#if TX_ORG_INTERINTRA
+    uint16_t txb_origin_x =
+        md_context_ptr->blk_origin_x +
+        md_context_ptr->blk_geom->tx_org_x[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
+        md_context_ptr->blk_geom->origin_x;
+    uint16_t txb_origin_y =
+        md_context_ptr->blk_origin_y +
+        md_context_ptr->blk_geom->tx_org_y[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
+        md_context_ptr->blk_geom->origin_y;
+#else
     uint16_t txb_origin_x =
         md_context_ptr->blk_origin_x +
         md_context_ptr->blk_geom->tx_boff_x[md_context_ptr->tx_depth][md_context_ptr->txb_itr];
     uint16_t txb_origin_y =
         md_context_ptr->blk_origin_y +
         md_context_ptr->blk_geom->tx_boff_y[md_context_ptr->tx_depth][md_context_ptr->txb_itr];
-
+#endif
     uint8_t tx_width =
         md_context_ptr->blk_geom->tx_width[md_context_ptr->tx_depth][md_context_ptr->txb_itr];
     uint8_t tx_height =
@@ -3465,24 +3533,44 @@ EbErrorType av1_intra_luma_prediction(ModeDecisionContext *        md_context_pt
             top_neigh_array + 1,
             left_neigh_array + 1,
             candidate_buffer_ptr->prediction_ptr, //uint8_t *dst,
+#if TX_ORG_INTERINTRA
+            (md_context_ptr->blk_geom
+                 ->tx_org_x[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
+             md_context_ptr->blk_geom->origin_x) >>
+                2,
+            (md_context_ptr->blk_geom
+                 ->tx_org_y[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
+             md_context_ptr->blk_geom->origin_y) >>
+                2,
+#else
             md_context_ptr->blk_geom
                     ->tx_boff_x[md_context_ptr->tx_depth][md_context_ptr->txb_itr] >>
                 2, //int32_t col_off,
             md_context_ptr->blk_geom
                     ->tx_boff_y[md_context_ptr->tx_depth][md_context_ptr->txb_itr] >>
                 2, //int32_t row_off,
+#endif
             PLANE_TYPE_Y, //int32_t plane,
             md_context_ptr->blk_geom->bsize,
             md_context_ptr->blk_origin_x,
             md_context_ptr->blk_origin_y,
             md_context_ptr->blk_origin_x,
             md_context_ptr->blk_origin_y,
+#if TX_ORG_INTERINTRA
+            md_context_ptr->blk_geom
+                ->tx_org_x[0][md_context_ptr->tx_depth]
+                          [md_context_ptr->txb_itr], //uint32_t cuOrgX used only for prediction Ptr
+            md_context_ptr->blk_geom
+                ->tx_org_y[0][md_context_ptr->tx_depth]
+                          [md_context_ptr->txb_itr] //uint32_t cuOrgY used only for prediction Ptr
+#else
             md_context_ptr->blk_geom
                 ->tx_org_x[md_context_ptr->tx_depth]
                           [md_context_ptr->txb_itr], //uint32_t cuOrgX used only for prediction Ptr
             md_context_ptr->blk_geom
                 ->tx_org_y[md_context_ptr->tx_depth]
                           [md_context_ptr->txb_itr] //uint32_t cuOrgY used only for prediction Ptr
+#endif
         );
     } else {
         uint16_t top_neigh_array[64 * 2 + 1];
@@ -3523,24 +3611,44 @@ EbErrorType av1_intra_luma_prediction(ModeDecisionContext *        md_context_pt
             top_neigh_array + 1,
             left_neigh_array + 1,
             candidate_buffer_ptr->prediction_ptr,
+#if TX_ORG_INTERINTRA
+            (md_context_ptr->blk_geom
+                 ->tx_org_x[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
+             md_context_ptr->blk_geom->origin_x) >>
+                2,
+            (md_context_ptr->blk_geom
+                 ->tx_org_y[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
+             md_context_ptr->blk_geom->origin_y) >>
+                2,
+#else
             md_context_ptr->blk_geom
                     ->tx_boff_x[md_context_ptr->tx_depth][md_context_ptr->txb_itr] >>
                 2,
             md_context_ptr->blk_geom
                     ->tx_boff_y[md_context_ptr->tx_depth][md_context_ptr->txb_itr] >>
                 2, //int32_t row_off,
+#endif
             PLANE_TYPE_Y,
             md_context_ptr->blk_geom->bsize,
             md_context_ptr->blk_origin_x,
             md_context_ptr->blk_origin_y,
             md_context_ptr->blk_origin_x,
             md_context_ptr->blk_origin_y,
+#if TX_ORG_INTERINTRA
+            md_context_ptr->blk_geom
+                ->tx_org_x[0][md_context_ptr->tx_depth]
+                          [md_context_ptr->txb_itr], //uint32_t cuOrgX used only for prediction Ptr
+            md_context_ptr->blk_geom
+                ->tx_org_y[0][md_context_ptr->tx_depth]
+                          [md_context_ptr->txb_itr] //uint32_t cuOrgY used only for prediction Ptr
+#else
             md_context_ptr->blk_geom
                 ->tx_org_x[md_context_ptr->tx_depth]
                           [md_context_ptr->txb_itr], //uint32_t cuOrgX used only for prediction Ptr
             md_context_ptr->blk_geom
                 ->tx_org_y[md_context_ptr->tx_depth]
                           [md_context_ptr->txb_itr] //uint32_t cuOrgY used only for prediction Ptr
+#endif
         );
     }
 
@@ -3648,12 +3756,25 @@ void tx_update_neighbor_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *
                     ? context_ptr->tx_search_luma_recon_neighbor_array16bit
                     : context_ptr->tx_search_luma_recon_neighbor_array,
                 candidate_buffer->recon_ptr,
+#if TX_ORG_INTERINTRA
+                context_ptr->blk_geom
+                    ->tx_org_x[is_inter][context_ptr->tx_depth][context_ptr->txb_itr],
+                context_ptr->blk_geom
+                    ->tx_org_y[is_inter][context_ptr->tx_depth][context_ptr->txb_itr],
+                context_ptr->sb_origin_x +
+                    context_ptr->blk_geom
+                        ->tx_org_x[is_inter][context_ptr->tx_depth][context_ptr->txb_itr],
+                context_ptr->sb_origin_y +
+                    context_ptr->blk_geom
+                        ->tx_org_y[is_inter][context_ptr->tx_depth][context_ptr->txb_itr],
+#else
                 context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->sb_origin_x +
                     context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->sb_origin_y +
                     context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr],
+#endif
                 context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->hbd_mode_decision);
@@ -3667,10 +3788,19 @@ void tx_update_neighbor_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *
             pcs_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
 #endif
             (uint8_t *)&dc_sign_level_coeff,
+#if TX_ORG_INTERINTRA
+            context_ptr->sb_origin_x +
+                context_ptr->blk_geom
+                    ->tx_org_x[is_inter][context_ptr->tx_depth][context_ptr->txb_itr],
+            context_ptr->sb_origin_y +
+                context_ptr->blk_geom
+                    ->tx_org_y[is_inter][context_ptr->tx_depth][context_ptr->txb_itr],
+#else
             context_ptr->sb_origin_x +
                 context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr],
             context_ptr->sb_origin_y +
                 context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr],
+#endif
             context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
             context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
             NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
@@ -3782,10 +3912,20 @@ void tx_type_search(PictureControlSet *pcs_ptr,
                            : EB_FALSE;
     const TxSetType tx_set_type =
         get_ext_tx_set_type(tx_size, is_inter, context_ptr->tx_search_reduced_set);
+
+#if TX_ORG_INTERINTRA
+    uint8_t txb_origin_x =
+        (uint8_t)
+            context_ptr->blk_geom->tx_org_x[is_inter][context_ptr->tx_depth][context_ptr->txb_itr];
+    uint8_t txb_origin_y =
+        (uint8_t)
+            context_ptr->blk_geom->tx_org_y[is_inter][context_ptr->tx_depth][context_ptr->txb_itr];
+#else
     uint8_t txb_origin_x =
         (uint8_t)context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr];
     uint8_t txb_origin_y =
         (uint8_t)context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr];
+#endif
     uint32_t txb_origin_index =
         txb_origin_x + (txb_origin_y * candidate_buffer->residual_ptr->stride_y);
     uint32_t input_txb_origin_index =
@@ -3805,18 +3945,65 @@ void tx_type_search(PictureControlSet *pcs_ptr,
                 &context_ptr->luma_txb_skip_context,
                 &context_ptr->luma_dc_sign_context);
     if (context_ptr->tx_search_reduced_set == 2) txk_end = 2;
+#if TX_SEARCH_REDUCED
+    // part of 2
+    int32_t allowed_tx_mask[TX_TYPES] = {0}; // 1: allow; 0: skip.
+    int32_t allowed_tx_num            = 0;
+    int32_t plane                     = 0;
+    TxType  uv_tx_type                = DCT_DCT;
+    for (int32_t tx_type_index = txk_start; tx_type_index < txk_end; ++tx_type_index) {
+        if (context_ptr->tx_search_reduced_set == 2)
+            tx_type_index = (tx_type_index == 1) ? IDTX : tx_type_index;
+        tx_type                  = (TxType)tx_type_index;
+        allowed_tx_mask[tx_type] = 1;
+        if (plane == 0) {
+            if (allowed_tx_mask[tx_type]) {
+                const TxType ref_tx_type = ((!av1_ext_tx_used[tx_set_type][tx_type]) ||
+                                            txsize_sqr_up_map[tx_size] > TX_32X32)
+                                               ? DCT_DCT
+                                               : tx_type;
+                if (tx_type != ref_tx_type) allowed_tx_mask[tx_type] = 0;
+            }
+        }
 
+        allowed_tx_num += allowed_tx_mask[tx_type];
+    }
+    // Need to have at least one transform type allowed.
+    if (allowed_tx_num == 0) allowed_tx_mask[plane ? uv_tx_type : DCT_DCT] = 1;
+    //if (allowed_tx_mask[tx_type] &&
+    //    !(context_ptr->tx_search_reduced_set && !allowed_tx_set_a[tx_size][tx_type])) {
+    //    context_ptr->luma_txb_skip_context = 0;
+    //    context_ptr->luma_dc_sign_context  = 0;
+    //    get_txb_ctx(scs_ptr,
+    //                COMPONENT_LUMA,
+    //                context_ptr->full_loop_luma_dc_sign_level_coeff_neighbor_array,
+    //                context_ptr->sb_origin_x + txb_origin_x,
+    //                context_ptr->sb_origin_y + txb_origin_y,
+    //                context_ptr->blk_geom->bsize,
+    //                context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
+    //                &context_ptr->luma_txb_skip_context,
+    //                &context_ptr->luma_dc_sign_context);
+    //    context_ptr->three_quad_energy = 0;
+    //}
+#endif
     TxType best_tx_type = DCT_DCT;
     for (tx_type = txk_start; tx_type < txk_end; ++tx_type) {
         uint64_t txb_full_distortion[3][DIST_CALC_TOTAL];
         uint64_t y_txb_coeff_bits = 0;
         uint32_t y_count_non_zero_coeffs;
 
+#if TX_SEARCH_REDUCED
+        if (context_ptr->tx_search_reduced_set == 2) tx_type = (tx_type == 1) ? IDTX : tx_type;
+        // below is part of 2
+        if (!allowed_tx_mask[tx_type]) continue;
+        //if (context_ptr->tx_search_reduced_set) // done below
+        //    if (!allowed_tx_set_a[tx_size][tx_type]) continue;
+#endif
         //context_ptr->three_quad_energy = 0;
         if (tx_type != DCT_DCT) {
             if (is_inter) {
                 TxSize          max_tx_size = context_ptr->blk_geom->txsize[0][0];
-                const TxSetType tx_set_type =
+                const TxSetType tx_set_type_inter =
                     get_ext_tx_set_type(max_tx_size, is_inter, context_ptr->tx_search_reduced_set);
                 int32_t eset =
                     get_ext_tx_set(max_tx_size, is_inter, context_ptr->tx_search_reduced_set);
@@ -3824,7 +4011,7 @@ void tx_type_search(PictureControlSet *pcs_ptr,
                 // is no need to send the tx_type
                 if (eset <= 0)
                     continue;
-                else if (av1_ext_tx_used[tx_set_type][tx_type] == 0)
+                else if (av1_ext_tx_used[tx_set_type_inter][tx_type] == 0)
                     continue;
                 else if (context_ptr->blk_geom
                                  ->tx_height[context_ptr->tx_depth][context_ptr->txb_itr] > 32 ||
@@ -3898,7 +4085,11 @@ void tx_type_search(PictureControlSet *pcs_ptr,
             context_ptr->luma_txb_skip_context,
             context_ptr->luma_dc_sign_context,
             candidate_buffer->candidate_ptr->pred_mode,
+#if LOSSLESS_TX_TYPE_OPT
+            candidate_buffer->candidate_ptr->use_intrabc,
+#else
             EB_FALSE,
+#endif
             EB_FALSE);
 
         candidate_buffer->candidate_ptr->quantized_dc[0][context_ptr->txb_itr] =
@@ -4327,12 +4518,15 @@ uint64_t get_tx_size_bits(ModeDecisionCandidateBuffer *candidateBuffer,
 
     return tx_size_bits;
 }
-
+#if LOSSLESS_TX_TYPE_OPT
+void perform_tx_partitioning(ModeDecisionCandidateBuffer *candidate_buffer,
+#else
 void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
-                          ModeDecisionContext *context_ptr, PictureControlSet *pcs_ptr,
-                          uint64_t ref_fast_cost, uint8_t end_tx_depth, uint32_t qp,
-                          uint32_t *y_count_non_zero_coeffs, uint64_t *y_coeff_bits,
-                          uint64_t *y_full_distortion) {
+#endif
+                             ModeDecisionContext *context_ptr, PictureControlSet *pcs_ptr,
+                             uint64_t ref_fast_cost, uint8_t end_tx_depth, uint32_t qp,
+                             uint32_t *y_count_non_zero_coeffs, uint64_t *y_coeff_bits,
+                             uint64_t *y_full_distortion) {
     EbPictureBufferDesc *input_picture_ptr = context_ptr->hbd_mode_decision
                                                  ? pcs_ptr->input_frame16bit
                                                  : pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
@@ -4345,10 +4539,15 @@ void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
     uint64_t best_cost_search  = (uint64_t)~0;
     uint8_t  is_best_has_coeff = 1;
     // Fill the scratch buffer
-    memcpy(context_ptr->scratch_candidate_buffer->candidate_ptr,
-           candidate_buffer->candidate_ptr,
-           sizeof(ModeDecisionCandidate));
-
+#if LOSSLESS_TX_TYPE_OPT
+    if (end_tx_depth) {
+#endif
+        memcpy(context_ptr->scratch_candidate_buffer->candidate_ptr,
+               candidate_buffer->candidate_ptr,
+               sizeof(ModeDecisionCandidate));
+#if LOSSLESS_TX_TYPE_OPT
+    }
+#endif
     if (is_inter) {
         uint32_t block_index =
             context_ptr->blk_geom->origin_x + (context_ptr->blk_geom->origin_y * MAX_SB_SIZE);
@@ -4445,6 +4644,11 @@ void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
         uint64_t tx_y_coeff_bits                       = 0;
         uint64_t tx_y_full_distortion[DIST_CALC_TOTAL] = {0};
 
+#if LOSSLESS_TX_SIZE_OPT
+        // Current tx_cost while performing tx loop
+        uint64_t current_tx_cost = 0;
+#endif
+
         context_ptr->txb_1d_offset                      = 0;
         context_ptr->three_quad_energy                  = 0;
         tx_candidate_buffer->candidate_ptr->y_has_coeff = 0;
@@ -4453,10 +4657,19 @@ void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
 
         uint32_t block_has_coeff = EB_FALSE;
         for (context_ptr->txb_itr = 0; context_ptr->txb_itr < txb_count; context_ptr->txb_itr++) {
+#if TX_ORG_INTERINTRA
+            uint16_t tx_org_x =
+                context_ptr->blk_geom
+                    ->tx_org_x[is_inter][context_ptr->tx_depth][context_ptr->txb_itr];
+            uint16_t tx_org_y =
+                context_ptr->blk_geom
+                    ->tx_org_y[is_inter][context_ptr->tx_depth][context_ptr->txb_itr];
+#else
             uint16_t tx_org_x =
                 context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr];
             uint16_t tx_org_y =
                 context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr];
+#endif
             uint32_t txb_origin_index =
                 tx_org_x + (tx_org_y * tx_candidate_buffer->residual_ptr->stride_y);
             uint32_t input_txb_origin_index =
@@ -4467,7 +4680,10 @@ void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
             // Y Prediction
 
             if (!is_inter) {
-                av1_intra_luma_prediction(context_ptr, pcs_ptr, tx_candidate_buffer);
+#if LOSSLESS_TX_TYPE_OPT
+                if (context_ptr->tx_depth)
+#endif
+                    av1_intra_luma_prediction(context_ptr, pcs_ptr, tx_candidate_buffer);
 
                 // Y Residual
                 residual_kernel(
@@ -4485,9 +4701,14 @@ void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
                     context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
             }
 
-            if (!tx_search_skip_flag) {
-                tx_type_search(pcs_ptr, context_ptr, tx_candidate_buffer, qp);
-            }
+#if LOSSLESS_TX_TYPE_OPT
+            if (context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr] <=
+                    32 &&
+                context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr] <= 32)
+#endif
+                if (!tx_search_skip_flag) {
+                    tx_type_search(pcs_ptr, context_ptr, tx_candidate_buffer, qp);
+                }
 
             product_full_loop(tx_candidate_buffer,
                               context_ptr,
@@ -4504,21 +4725,46 @@ void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
 
             if (y_has_coeff) block_has_coeff = EB_TRUE;
 
+#if LOSSLESS_TX_SIZE_OPT
+            current_tx_cost = RDCOST(context_ptr->full_lambda,
+                                     tx_y_coeff_bits,
+                                     tx_y_full_distortion[DIST_CALC_RESIDUAL]);
+            if (current_tx_cost > best_cost_search) break;
+#endif
+
         } // Transform Loop
 
-        uint64_t tx_size_bits = 0;
-        if (pcs_ptr->parent_pcs_ptr->frm_hdr.tx_mode == TX_MODE_SELECT)
-            tx_size_bits = get_tx_size_bits(
-                tx_candidate_buffer, context_ptr, pcs_ptr, context_ptr->tx_depth, block_has_coeff);
+#if LOSSLESS_TX_TYPE_OPT
+        if (end_tx_depth) {
+#endif
+            uint64_t tx_size_bits = 0;
+            if (pcs_ptr->parent_pcs_ptr->frm_hdr.tx_mode == TX_MODE_SELECT)
+                tx_size_bits = get_tx_size_bits(tx_candidate_buffer,
+                                                context_ptr,
+                                                pcs_ptr,
+                                                context_ptr->tx_depth,
+                                                block_has_coeff);
 
         uint64_t cost = RDCOST(context_ptr->full_lambda,
                                (tx_y_coeff_bits + tx_size_bits),
                                tx_y_full_distortion[DIST_CALC_RESIDUAL]);
 
-        if (cost < best_cost_search) {
-            best_cost_search                        = cost;
-            best_tx_depth                           = context_ptr->tx_depth;
-            is_best_has_coeff                       = block_has_coeff;
+            if (cost < best_cost_search) {
+                best_cost_search                      = cost;
+                best_tx_depth                         = context_ptr->tx_depth;
+                is_best_has_coeff                     = block_has_coeff;
+                y_full_distortion[DIST_CALC_RESIDUAL] = tx_y_full_distortion[DIST_CALC_RESIDUAL];
+                y_full_distortion[DIST_CALC_PREDICTION] =
+                    tx_y_full_distortion[DIST_CALC_PREDICTION];
+                *y_coeff_bits = tx_y_coeff_bits;
+                for (context_ptr->txb_itr = 0; context_ptr->txb_itr < txb_count;
+                     context_ptr->txb_itr++) {
+                    y_count_non_zero_coeffs[context_ptr->txb_itr] =
+                        tx_y_count_non_zero_coeffs[context_ptr->txb_itr];
+                }
+            }
+#if LOSSLESS_TX_TYPE_OPT
+        } else {
             y_full_distortion[DIST_CALC_RESIDUAL]   = tx_y_full_distortion[DIST_CALC_RESIDUAL];
             y_full_distortion[DIST_CALC_PREDICTION] = tx_y_full_distortion[DIST_CALC_PREDICTION];
             *y_coeff_bits                           = tx_y_coeff_bits;
@@ -4528,6 +4774,7 @@ void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
                     tx_y_count_non_zero_coeffs[context_ptr->txb_itr];
             }
         }
+#endif
     } // Transform Depth Loop
 
     // ATB Recon
@@ -4622,22 +4869,37 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
     candidate_ptr->transform_type[2] = DCT_DCT;
     candidate_ptr->transform_type[3] = DCT_DCT;
 
+#if LOSSLESS_TX_TYPE_OPT
+    uint8_t start_tx_depth = 0;
+#endif
     uint8_t end_tx_depth = 0;
-    // end_tx_depth set to zero for blocks which go beyond the picture boundaries
-    if ((context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x +
-                 context_ptr->blk_geom->bwidth <
-             pcs_ptr->parent_pcs_ptr->aligned_width &&
-         context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y +
-                 context_ptr->blk_geom->bheight <
-                 pcs_ptr->parent_pcs_ptr->aligned_height))
-        end_tx_depth =
-            get_end_tx_depth(context_ptr->blk_geom->bsize, candidate_buffer->candidate_ptr->type);
-    else
-        end_tx_depth = 0;
+
+#if LOSSLESS_TX_TYPE_OPT
+    if (context_ptr->md_tx_size_search_mode == 0 || candidate_buffer->candidate_ptr->use_intrabc) {
+        start_tx_depth = end_tx_depth = 0;
+    } else if (context_ptr->md_staging_tx_size_mode == 0) {
+        start_tx_depth = end_tx_depth = candidate_buffer->candidate_ptr->tx_depth;
+    } else {
+#endif
+        // end_tx_depth set to zero for blocks which go beyond the picture boundaries
+        if ((context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x +
+                     context_ptr->blk_geom->bwidth <
+                 pcs_ptr->parent_pcs_ptr->scs_ptr->seq_header.max_frame_width &&
+             context_ptr->sb_origin_y + context_ptr->blk_geom->origin_y +
+                     context_ptr->blk_geom->bheight <
+                 pcs_ptr->parent_pcs_ptr->scs_ptr->seq_header.max_frame_height))
+            end_tx_depth = get_end_tx_depth(context_ptr->blk_geom->bsize,
+                                            candidate_buffer->candidate_ptr->type);
+        else
+            end_tx_depth = 0;
+#if LOSSLESS_TX_TYPE_OPT
+    }
+#endif
     // Transform partitioning path (INTRA Luma)
+#if !LOSSLESS_TX_TYPE_OPT
     if (context_ptr->md_tx_size_search_mode && context_ptr->md_staging_skip_atb == EB_FALSE &&
-        end_tx_depth &&
-        candidate_buffer->candidate_ptr->use_intrabc == 0) {
+        end_tx_depth && candidate_buffer->candidate_ptr->use_intrabc == 0) {
+#endif
         int32_t is_inter = (candidate_buffer->candidate_ptr->type == INTER_MODE ||
                             candidate_buffer->candidate_ptr->use_intrabc)
                                ? EB_TRUE
@@ -4659,15 +4921,20 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
                             context_ptr->blk_geom->bwidth,
                             context_ptr->blk_geom->bheight);
 
-        tx_partitioning_path(candidate_buffer,
-                             context_ptr,
-                             pcs_ptr,
-                             ref_fast_cost,
-                             end_tx_depth,
-                             context_ptr->blk_ptr->qp,
-                             &(*count_non_zero_coeffs[0]),
-                             &y_coeff_bits,
-                             &y_full_distortion[0]);
+#if LOSSLESS_TX_TYPE_OPT
+        perform_tx_partitioning(candidate_buffer,
+#else
+    tx_partitioning_path(candidate_buffer,
+#endif
+                                context_ptr,
+                                pcs_ptr,
+                                ref_fast_cost,
+                                end_tx_depth,
+                                context_ptr->blk_ptr->qp,
+                                &(*count_non_zero_coeffs[0]),
+                                &y_coeff_bits,
+                                &y_full_distortion[0]);
+#if !LOSSLESS_TX_TYPE_OPT
     } else {
         // Transform partitioning free patch (except the 128x128 case)
 
@@ -4701,7 +4968,6 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
                 context_ptr->tx_search_level == TX_SEARCH_FULL_LOOP ? EB_FALSE : EB_TRUE;
         if (!tx_search_skip_flag) {
             product_full_loop_tx_search(candidate_buffer, context_ptr, pcs_ptr);
-
             candidate_ptr->full_distortion = 0;
 
             memset(candidate_ptr->eob[0], 0, sizeof(uint16_t));
@@ -4725,6 +4991,7 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
                               &y_coeff_bits,
                               &y_full_distortion[0]);
     }
+#endif
 
     candidate_ptr->chroma_distortion_inter_depth = 0;
     candidate_ptr->chroma_distortion             = 0;
@@ -4871,7 +5138,11 @@ void md_stage_1(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *blk_p
     uint32_t cand_index;
 
     // Set MD Staging full_loop_core settings
-    context_ptr->md_staging_skip_atb         = EB_TRUE;
+#if LOSSLESS_TX_TYPE_OPT
+    context_ptr->md_staging_tx_size_mode = 0;
+#else
+    context_ptr->md_staging_skip_atb = EB_TRUE;
+#endif
     context_ptr->md_staging_tx_search        = 0;
     context_ptr->md_staging_skip_full_chroma = EB_TRUE;
     context_ptr->md_staging_skip_rdoq        = EB_TRUE;
@@ -4989,7 +5260,19 @@ void md_stage_3(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *blk_p
             (context_ptr->md_staging_mode == MD_STAGING_MODE_1 ||
              context_ptr->md_staging_mode == MD_STAGING_MODE_2);
         context_ptr->md_staging_skip_inter_chroma_pred = EB_FALSE;
-        context_ptr->md_staging_skip_atb               = context_ptr->coeff_based_skip_atb;
+#if LOSSLESS_TX_TYPE_OPT
+#if REMOVE_COEFF_BASED_SKIP_ATB
+        context_ptr->md_staging_tx_size_mode = EB_TRUE;
+#else
+        context_ptr->md_staging_tx_size_mode = !context_ptr->coeff_based_skip_atb;
+#endif
+#else
+#if REMOVE_COEFF_BASED_SKIP_ATB
+        context_ptr->md_staging_skip_atb = 0;
+#else
+        context_ptr->md_staging_skip_atb = context_ptr->coeff_based_skip_atb;
+#endif
+#endif
         context_ptr->md_staging_tx_search =
             (candidate_ptr->cand_class == CAND_CLASS_0 ||
              candidate_ptr->cand_class == CAND_CLASS_6 || candidate_ptr->cand_class == CAND_CLASS_7)
@@ -6831,7 +7114,10 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
     const uint16_t tile_idx = context_ptr->tile_index;
 #endif
     context_ptr->sb_ptr                        = sb_ptr;
+
+#if !REMOVE_COEFF_BASED_SKIP_ATB
     context_ptr->coeff_based_skip_atb = 0;
+#endif
     EbBool all_blk_init = (pcs_ptr->parent_pcs_ptr->pic_depth_mode <= PIC_SQ_DEPTH_MODE);
     init_sq_nsq_block(scs_ptr, context_ptr);
 
@@ -7306,12 +7592,14 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
                                               pcs_ptr);
             d1_block_itr   = 0;
             d1_first_block = 1;
+#if !REMOVE_COEFF_BASED_SKIP_ATB
             context_ptr->coeff_based_skip_atb =
                 pcs_ptr->parent_pcs_ptr->coeff_based_skip_atb &&
                         context_ptr->md_local_blk_unit[last_blk_index_mds].avail_blk_flag &&
                         context_ptr->md_blk_arr_nsq[last_blk_index_mds].block_has_coeff == 0
                     ? 1
                     : 0;
+#endif
             if (context_ptr->md_blk_arr_nsq[last_blk_index_mds].split_flag == EB_FALSE) {
                 md_update_all_neighbour_arrays_multiple(
                     pcs_ptr,

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -103,12 +103,10 @@ void mode_decision_update_neighbor_arrays(PictureControlSet *  pcs_ptr,
     uint8_t inter_pred_direction_index =
         (uint8_t)context_ptr->blk_ptr->prediction_unit_array->inter_pred_direction_index;
     uint8_t ref_frame_type = (uint8_t)context_ptr->blk_ptr->prediction_unit_array[0].ref_frame_type;
-#if TX_ORG_INTERINTRA
     int32_t is_inter = (context_ptr->blk_ptr->prediction_mode_flag == INTER_MODE ||
                         context_ptr->blk_ptr->av1xd->use_intrabc)
                            ? EB_TRUE
                            : EB_FALSE;
-#endif
 
 #if TILES_PARALLEL
     uint16_t tile_idx = context_ptr->tile_index;
@@ -160,19 +158,12 @@ void mode_decision_update_neighbor_arrays(PictureControlSet *  pcs_ptr,
             neighbor_array_unit_mode_write(
                 context_ptr->luma_dc_sign_level_coeff_neighbor_array,
                 (uint8_t *)&dc_sign_level_coeff,
-#if TX_ORG_INTERINTRA
                 context_ptr->sb_origin_x +
                     context_ptr->blk_geom
                         ->tx_org_x[is_inter][context_ptr->blk_ptr->tx_depth][txb_itr],
                 context_ptr->sb_origin_y +
                     context_ptr->blk_geom
                         ->tx_org_y[is_inter][context_ptr->blk_ptr->tx_depth][txb_itr],
-#else
-                context_ptr->sb_origin_x +
-                    context_ptr->blk_geom->tx_org_x[context_ptr->blk_ptr->tx_depth][txb_itr],
-                context_ptr->sb_origin_y +
-                    context_ptr->blk_geom->tx_org_y[context_ptr->blk_ptr->tx_depth][txb_itr],
-#endif
                 context_ptr->blk_geom->tx_width[context_ptr->blk_ptr->tx_depth][txb_itr],
                 context_ptr->blk_geom->tx_height[context_ptr->blk_ptr->tx_depth][txb_itr],
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
@@ -185,19 +176,12 @@ void mode_decision_update_neighbor_arrays(PictureControlSet *  pcs_ptr,
                     [MD_NEIGHBOR_ARRAY_INDEX],
 #endif
                 (uint8_t *)&dc_sign_level_coeff,
-#if TX_ORG_INTERINTRA
                 context_ptr->sb_origin_x +
                     context_ptr->blk_geom
                         ->tx_org_x[is_inter][context_ptr->blk_ptr->tx_depth][txb_itr],
                 context_ptr->sb_origin_y +
                     context_ptr->blk_geom
                         ->tx_org_y[is_inter][context_ptr->blk_ptr->tx_depth][txb_itr],
-#else
-                context_ptr->sb_origin_x +
-                    context_ptr->blk_geom->tx_org_x[context_ptr->blk_ptr->tx_depth][txb_itr],
-                context_ptr->sb_origin_y +
-                    context_ptr->blk_geom->tx_org_y[context_ptr->blk_ptr->tx_depth][txb_itr],
-#endif
                 context_ptr->blk_geom->tx_width[context_ptr->blk_ptr->tx_depth][txb_itr],
                 context_ptr->blk_geom->tx_height[context_ptr->blk_ptr->tx_depth][txb_itr],
                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
@@ -895,20 +879,13 @@ void av1_perform_inverse_transform_recon_luma(PictureControlSet *          pcs_p
         tu_total_count         = context_ptr->blk_geom->txb_count[tx_depth];
         txb_itr                = 0;
         uint32_t txb_1d_offset = 0;
-#if TX_ORG_INTERINTRA
         int32_t is_inter = (candidate_buffer->candidate_ptr->type == INTER_MODE ||
                             candidate_buffer->candidate_ptr->use_intrabc)
                                ? EB_TRUE
                                : EB_FALSE;
-#endif
         do {
-#if TX_ORG_INTERINTRA
             txb_origin_x = context_ptr->blk_geom->tx_org_x[is_inter][tx_depth][txb_itr];
             txb_origin_y = context_ptr->blk_geom->tx_org_y[is_inter][tx_depth][txb_itr];
-#else
-            txb_origin_x = context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr];
-            txb_origin_y = context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr];
-#endif
             txb_width  = context_ptr->blk_geom->tx_width[tx_depth][txb_itr];
             txb_height = context_ptr->blk_geom->tx_height[tx_depth][txb_itr];
             txb_origin_index =
@@ -983,25 +960,17 @@ void av1_perform_inverse_transform_recon(PictureControlSet *          pcs_ptr,
         txb_itr                = 0;
         uint32_t txb_1d_offset = 0, txb_1d_offset_uv = 0;
         uint32_t rec_luma_offset, rec_cb_offset, rec_cr_offset;
-#if TX_ORG_INTERINTRA
         int32_t is_inter = (candidate_buffer->candidate_ptr->type == INTER_MODE ||
                             candidate_buffer->candidate_ptr->use_intrabc)
                                ? EB_TRUE
                                : EB_FALSE;
-#endif
 
         do {
-#if TX_ORG_INTERINTRA
             txb_origin_x = context_ptr->blk_geom->tx_org_x[is_inter][tx_depth][txb_itr];
             txb_origin_y = context_ptr->blk_geom->tx_org_y[is_inter][tx_depth][txb_itr];
-#else
-            txb_origin_x = context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr];
-            txb_origin_y = context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr];
-#endif
             txb_width  = context_ptr->blk_geom->tx_width[tx_depth][txb_itr];
             txb_height = context_ptr->blk_geom->tx_height[tx_depth][txb_itr];
             txb_ptr    = &blk_ptr->txb_array[txb_index];
-#if TX_ORG_INTERINTRA
             rec_luma_offset = txb_origin_x + txb_origin_y * candidate_buffer->recon_ptr->stride_y;
             rec_cb_offset =
                 ((((txb_origin_x >> 3) << 3) +
@@ -1011,19 +980,6 @@ void av1_perform_inverse_transform_recon(PictureControlSet *          pcs_ptr,
                 ((((txb_origin_x >> 3) << 3) +
                   ((txb_origin_y >> 3) << 3) * candidate_buffer->recon_ptr->stride_cr) >>
                  1);
-#else
-            rec_luma_offset = context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr] +
-                              context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr] *
-                                  candidate_buffer->recon_ptr->stride_y;
-            rec_cb_offset = ((((context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr] >> 3) << 3) +
-                              ((context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr] >> 3) << 3) *
-                                  candidate_buffer->recon_ptr->stride_cb) >>
-                             1);
-            rec_cr_offset = ((((context_ptr->blk_geom->tx_org_x[tx_depth][txb_itr] >> 3) << 3) +
-                              ((context_ptr->blk_geom->tx_org_y[tx_depth][txb_itr] >> 3) << 3) *
-                                  candidate_buffer->recon_ptr->stride_cr) >>
-                             1);
-#endif
             txb_origin_index =
                 txb_origin_x + txb_origin_y * candidate_buffer->prediction_ptr->stride_y;
             if (txb_ptr->y_has_coeff)
@@ -3450,7 +3406,6 @@ EbErrorType av1_intra_luma_prediction(ModeDecisionContext *        md_context_pt
                                       ModeDecisionCandidateBuffer *candidate_buffer_ptr) {
     EbErrorType return_error = EB_ErrorNone;
 
-#if TX_ORG_INTERINTRA
     uint16_t txb_origin_x =
         md_context_ptr->blk_origin_x +
         md_context_ptr->blk_geom->tx_org_x[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
@@ -3459,14 +3414,6 @@ EbErrorType av1_intra_luma_prediction(ModeDecisionContext *        md_context_pt
         md_context_ptr->blk_origin_y +
         md_context_ptr->blk_geom->tx_org_y[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
         md_context_ptr->blk_geom->origin_y;
-#else
-    uint16_t txb_origin_x =
-        md_context_ptr->blk_origin_x +
-        md_context_ptr->blk_geom->tx_boff_x[md_context_ptr->tx_depth][md_context_ptr->txb_itr];
-    uint16_t txb_origin_y =
-        md_context_ptr->blk_origin_y +
-        md_context_ptr->blk_geom->tx_boff_y[md_context_ptr->tx_depth][md_context_ptr->txb_itr];
-#endif
     uint8_t tx_width =
         md_context_ptr->blk_geom->tx_width[md_context_ptr->tx_depth][md_context_ptr->txb_itr];
     uint8_t tx_height =
@@ -3533,7 +3480,6 @@ EbErrorType av1_intra_luma_prediction(ModeDecisionContext *        md_context_pt
             top_neigh_array + 1,
             left_neigh_array + 1,
             candidate_buffer_ptr->prediction_ptr, //uint8_t *dst,
-#if TX_ORG_INTERINTRA
             (md_context_ptr->blk_geom
                  ->tx_org_x[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
              md_context_ptr->blk_geom->origin_x) >>
@@ -3542,35 +3488,18 @@ EbErrorType av1_intra_luma_prediction(ModeDecisionContext *        md_context_pt
                  ->tx_org_y[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
              md_context_ptr->blk_geom->origin_y) >>
                 2,
-#else
-            md_context_ptr->blk_geom
-                    ->tx_boff_x[md_context_ptr->tx_depth][md_context_ptr->txb_itr] >>
-                2, //int32_t col_off,
-            md_context_ptr->blk_geom
-                    ->tx_boff_y[md_context_ptr->tx_depth][md_context_ptr->txb_itr] >>
-                2, //int32_t row_off,
-#endif
             PLANE_TYPE_Y, //int32_t plane,
             md_context_ptr->blk_geom->bsize,
             md_context_ptr->blk_origin_x,
             md_context_ptr->blk_origin_y,
             md_context_ptr->blk_origin_x,
             md_context_ptr->blk_origin_y,
-#if TX_ORG_INTERINTRA
             md_context_ptr->blk_geom
                 ->tx_org_x[0][md_context_ptr->tx_depth]
                           [md_context_ptr->txb_itr], //uint32_t cuOrgX used only for prediction Ptr
             md_context_ptr->blk_geom
                 ->tx_org_y[0][md_context_ptr->tx_depth]
                           [md_context_ptr->txb_itr] //uint32_t cuOrgY used only for prediction Ptr
-#else
-            md_context_ptr->blk_geom
-                ->tx_org_x[md_context_ptr->tx_depth]
-                          [md_context_ptr->txb_itr], //uint32_t cuOrgX used only for prediction Ptr
-            md_context_ptr->blk_geom
-                ->tx_org_y[md_context_ptr->tx_depth]
-                          [md_context_ptr->txb_itr] //uint32_t cuOrgY used only for prediction Ptr
-#endif
         );
     } else {
         uint16_t top_neigh_array[64 * 2 + 1];
@@ -3611,7 +3540,6 @@ EbErrorType av1_intra_luma_prediction(ModeDecisionContext *        md_context_pt
             top_neigh_array + 1,
             left_neigh_array + 1,
             candidate_buffer_ptr->prediction_ptr,
-#if TX_ORG_INTERINTRA
             (md_context_ptr->blk_geom
                  ->tx_org_x[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
              md_context_ptr->blk_geom->origin_x) >>
@@ -3620,35 +3548,18 @@ EbErrorType av1_intra_luma_prediction(ModeDecisionContext *        md_context_pt
                  ->tx_org_y[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
              md_context_ptr->blk_geom->origin_y) >>
                 2,
-#else
-            md_context_ptr->blk_geom
-                    ->tx_boff_x[md_context_ptr->tx_depth][md_context_ptr->txb_itr] >>
-                2,
-            md_context_ptr->blk_geom
-                    ->tx_boff_y[md_context_ptr->tx_depth][md_context_ptr->txb_itr] >>
-                2, //int32_t row_off,
-#endif
             PLANE_TYPE_Y,
             md_context_ptr->blk_geom->bsize,
             md_context_ptr->blk_origin_x,
             md_context_ptr->blk_origin_y,
             md_context_ptr->blk_origin_x,
             md_context_ptr->blk_origin_y,
-#if TX_ORG_INTERINTRA
             md_context_ptr->blk_geom
                 ->tx_org_x[0][md_context_ptr->tx_depth]
                           [md_context_ptr->txb_itr], //uint32_t cuOrgX used only for prediction Ptr
             md_context_ptr->blk_geom
                 ->tx_org_y[0][md_context_ptr->tx_depth]
                           [md_context_ptr->txb_itr] //uint32_t cuOrgY used only for prediction Ptr
-#else
-            md_context_ptr->blk_geom
-                ->tx_org_x[md_context_ptr->tx_depth]
-                          [md_context_ptr->txb_itr], //uint32_t cuOrgX used only for prediction Ptr
-            md_context_ptr->blk_geom
-                ->tx_org_y[md_context_ptr->tx_depth]
-                          [md_context_ptr->txb_itr] //uint32_t cuOrgY used only for prediction Ptr
-#endif
         );
     }
 
@@ -3756,7 +3667,6 @@ void tx_update_neighbor_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *
                     ? context_ptr->tx_search_luma_recon_neighbor_array16bit
                     : context_ptr->tx_search_luma_recon_neighbor_array,
                 candidate_buffer->recon_ptr,
-#if TX_ORG_INTERINTRA
                 context_ptr->blk_geom
                     ->tx_org_x[is_inter][context_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom
@@ -3767,14 +3677,6 @@ void tx_update_neighbor_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *
                 context_ptr->sb_origin_y +
                     context_ptr->blk_geom
                         ->tx_org_y[is_inter][context_ptr->tx_depth][context_ptr->txb_itr],
-#else
-                context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr],
-                context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr],
-                context_ptr->sb_origin_x +
-                    context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr],
-                context_ptr->sb_origin_y +
-                    context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr],
-#endif
                 context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->hbd_mode_decision);
@@ -3788,19 +3690,12 @@ void tx_update_neighbor_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *
             pcs_ptr->md_tx_depth_1_luma_dc_sign_level_coeff_neighbor_array[MD_NEIGHBOR_ARRAY_INDEX],
 #endif
             (uint8_t *)&dc_sign_level_coeff,
-#if TX_ORG_INTERINTRA
             context_ptr->sb_origin_x +
                 context_ptr->blk_geom
                     ->tx_org_x[is_inter][context_ptr->tx_depth][context_ptr->txb_itr],
             context_ptr->sb_origin_y +
                 context_ptr->blk_geom
                     ->tx_org_y[is_inter][context_ptr->tx_depth][context_ptr->txb_itr],
-#else
-            context_ptr->sb_origin_x +
-                context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr],
-            context_ptr->sb_origin_y +
-                context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr],
-#endif
             context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
             context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
             NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
@@ -3911,24 +3806,13 @@ void tx_type_search(PictureControlSet *pcs_ptr,
                            ? EB_TRUE
                            : EB_FALSE;
     const TxSetType tx_set_type =
-#if TX_SEARCH_REDUCED
         get_ext_tx_set_type(tx_size, is_inter, pcs_ptr->parent_pcs_ptr->frm_hdr.reduced_tx_set);
-#else
-        get_ext_tx_set_type(tx_size, is_inter, context_ptr->tx_search_reduced_set);
-#endif
-#if TX_ORG_INTERINTRA
     uint8_t txb_origin_x =
         (uint8_t)
             context_ptr->blk_geom->tx_org_x[is_inter][context_ptr->tx_depth][context_ptr->txb_itr];
     uint8_t txb_origin_y =
         (uint8_t)
             context_ptr->blk_geom->tx_org_y[is_inter][context_ptr->tx_depth][context_ptr->txb_itr];
-#else
-    uint8_t txb_origin_x =
-        (uint8_t)context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr];
-    uint8_t txb_origin_y =
-        (uint8_t)context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr];
-#endif
     uint32_t txb_origin_index =
         txb_origin_x + (txb_origin_y * candidate_buffer->residual_ptr->stride_y);
     uint32_t input_txb_origin_index =
@@ -3948,80 +3832,22 @@ void tx_type_search(PictureControlSet *pcs_ptr,
                 &context_ptr->luma_txb_skip_context,
                 &context_ptr->luma_dc_sign_context);
     if (context_ptr->tx_search_reduced_set == 2) txk_end = 2;
-#if TX_SEARCH_REDUCED
-    // part of 2
-    int32_t allowed_tx_mask[TX_TYPES] = {0}; // 1: allow; 0: skip.
-    int32_t allowed_tx_num            = 0;
-    int32_t plane                     = 0;
-    TxType  uv_tx_type                = DCT_DCT;
-    for (int32_t tx_type_index = txk_start; tx_type_index < txk_end; ++tx_type_index) {
-        if (context_ptr->tx_search_reduced_set == 2)
-            tx_type_index = (tx_type_index == 1) ? IDTX : tx_type_index;
-        tx_type                  = (TxType)tx_type_index;
-        allowed_tx_mask[tx_type] = 1;
-        if (plane == 0) {
-            if (allowed_tx_mask[tx_type]) {
-                const TxType ref_tx_type = ((!av1_ext_tx_used[tx_set_type][tx_type]) ||
-                                            txsize_sqr_up_map[tx_size] > TX_32X32)
-                                               ? DCT_DCT
-                                               : tx_type;
-                if (tx_type != ref_tx_type) allowed_tx_mask[tx_type] = 0;
-            }
-        }
-
-        allowed_tx_num += allowed_tx_mask[tx_type];
-    }
-    // Need to have at least one transform type allowed.
-    if (allowed_tx_num == 0) allowed_tx_mask[plane ? uv_tx_type : DCT_DCT] = 1;
-    //if (allowed_tx_mask[tx_type] &&
-    //    !(context_ptr->tx_search_reduced_set && !allowed_tx_set_a[tx_size][tx_type])) {
-    //    context_ptr->luma_txb_skip_context = 0;
-    //    context_ptr->luma_dc_sign_context  = 0;
-    //    get_txb_ctx(scs_ptr,
-    //                COMPONENT_LUMA,
-    //                context_ptr->full_loop_luma_dc_sign_level_coeff_neighbor_array,
-    //                context_ptr->sb_origin_x + txb_origin_x,
-    //                context_ptr->sb_origin_y + txb_origin_y,
-    //                context_ptr->blk_geom->bsize,
-    //                context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr],
-    //                &context_ptr->luma_txb_skip_context,
-    //                &context_ptr->luma_dc_sign_context);
-    //    context_ptr->three_quad_energy = 0;
-    //}
-#endif
     TxType best_tx_type = DCT_DCT;
     for (tx_type = txk_start; tx_type < txk_end; ++tx_type) {
         uint64_t txb_full_distortion[3][DIST_CALC_TOTAL];
         uint64_t y_txb_coeff_bits = 0;
         uint32_t y_count_non_zero_coeffs;
 
-#if TX_SEARCH_REDUCED
         if (context_ptr->tx_search_reduced_set == 2) tx_type = (tx_type == 1) ? IDTX : tx_type;
-        // below is part of 2
-        if (!allowed_tx_mask[tx_type]) continue;
-        //if (context_ptr->tx_search_reduced_set) // done below
-        //    if (!allowed_tx_set_a[tx_size][tx_type]) continue;
-#endif
-#if FREQUENCY_SPATIAL_DOMAIN
+
         context_ptr->three_quad_energy = 0;
-#else
-        //context_ptr->three_quad_energy = 0;
-#endif
         if (tx_type != DCT_DCT) {
             if (is_inter) {
                 TxSize          max_tx_size = context_ptr->blk_geom->txsize[0][0];
                 const TxSetType tx_set_type_inter =
-#if TX_SEARCH_REDUCED
                     get_ext_tx_set_type(max_tx_size, is_inter, pcs_ptr->parent_pcs_ptr->frm_hdr.reduced_tx_set);
-#else
-                    get_ext_tx_set_type(max_tx_size, is_inter, context_ptr->tx_search_reduced_set);
-#endif
                 int32_t eset =
-#if TX_SEARCH_REDUCED
                     get_ext_tx_set(max_tx_size, is_inter, pcs_ptr->parent_pcs_ptr->frm_hdr.reduced_tx_set);
-#else
-                    get_ext_tx_set(max_tx_size, is_inter, context_ptr->tx_search_reduced_set);
-#endif
                 // eset == 0 should correspond to a set with only DCT_DCT and there
                 // is no need to send the tx_type
                 if (eset <= 0)
@@ -4100,11 +3926,7 @@ void tx_type_search(PictureControlSet *pcs_ptr,
             context_ptr->luma_txb_skip_context,
             context_ptr->luma_dc_sign_context,
             candidate_buffer->candidate_ptr->pred_mode,
-#if LOSSLESS_TX_TYPE_OPT
             candidate_buffer->candidate_ptr->use_intrabc,
-#else
-            EB_FALSE,
-#endif
             EB_FALSE);
 
         candidate_buffer->candidate_ptr->quantized_dc[0][context_ptr->txb_itr] =
@@ -4114,9 +3936,8 @@ void tx_type_search(PictureControlSet *pcs_ptr,
 
         // tx_type not equal to DCT_DCT and no coeff is not an acceptable option in AV1.
         if (y_has_coeff == 0 && tx_type != DCT_DCT) continue;
-#if FREQUENCY_SPATIAL_DOMAIN
+
         if (context_ptr->md_staging_spatial_sse_full_loop) {
-#endif
         if (y_has_coeff)
             inv_transform_recon_wrapper(
                 candidate_buffer->prediction_ptr->buffer_y,
@@ -4173,7 +3994,6 @@ void tx_type_search(PictureControlSet *pcs_ptr,
 
         txb_full_distortion[0][DIST_CALC_PREDICTION] <<= 4;
         txb_full_distortion[0][DIST_CALC_RESIDUAL] <<= 4;
-#if FREQUENCY_SPATIAL_DOMAIN
         } else {
             // LUMA DISTORTION
             picture_full_distortion32_bits(
@@ -4206,7 +4026,7 @@ void tx_type_search(PictureControlSet *pcs_ptr,
             txb_full_distortion[0][DIST_CALC_PREDICTION] =
                 RIGHT_SIGNED_SHIFT(txb_full_distortion[0][DIST_CALC_PREDICTION], shift);
         }
-#endif
+
         //LUMA-ONLY
         av1_txb_estimate_coeff_bits(
             context_ptr,
@@ -4568,11 +4388,8 @@ uint64_t get_tx_size_bits(ModeDecisionCandidateBuffer *candidateBuffer,
 
     return tx_size_bits;
 }
-#if LOSSLESS_TX_TYPE_OPT
+
 void perform_tx_partitioning(ModeDecisionCandidateBuffer *candidate_buffer,
-#else
-void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
-#endif
                              ModeDecisionContext *context_ptr, PictureControlSet *pcs_ptr,
                              uint64_t ref_fast_cost, uint8_t end_tx_depth, uint32_t qp,
                              uint32_t *y_count_non_zero_coeffs, uint64_t *y_coeff_bits,
@@ -4589,15 +4406,12 @@ void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
     uint64_t best_cost_search  = (uint64_t)~0;
     uint8_t  is_best_has_coeff = 1;
     // Fill the scratch buffer
-#if LOSSLESS_TX_TYPE_OPT
     if (end_tx_depth) {
-#endif
         memcpy(context_ptr->scratch_candidate_buffer->candidate_ptr,
                candidate_buffer->candidate_ptr,
                sizeof(ModeDecisionCandidate));
-#if LOSSLESS_TX_TYPE_OPT
     }
-#endif
+
     if (is_inter) {
         uint32_t block_index =
             context_ptr->blk_geom->origin_x + (context_ptr->blk_geom->origin_y * MAX_SB_SIZE);
@@ -4694,10 +4508,8 @@ void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
         uint64_t tx_y_coeff_bits                       = 0;
         uint64_t tx_y_full_distortion[DIST_CALC_TOTAL] = {0};
 
-#if LOSSLESS_TX_SIZE_OPT
         // Current tx_cost while performing tx loop
         uint64_t current_tx_cost = 0;
-#endif
 
         context_ptr->txb_1d_offset                      = 0;
         context_ptr->three_quad_energy                  = 0;
@@ -4707,19 +4519,12 @@ void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
 
         uint32_t block_has_coeff = EB_FALSE;
         for (context_ptr->txb_itr = 0; context_ptr->txb_itr < txb_count; context_ptr->txb_itr++) {
-#if TX_ORG_INTERINTRA
             uint16_t tx_org_x =
                 context_ptr->blk_geom
                     ->tx_org_x[is_inter][context_ptr->tx_depth][context_ptr->txb_itr];
             uint16_t tx_org_y =
                 context_ptr->blk_geom
                     ->tx_org_y[is_inter][context_ptr->tx_depth][context_ptr->txb_itr];
-#else
-            uint16_t tx_org_x =
-                context_ptr->blk_geom->tx_org_x[context_ptr->tx_depth][context_ptr->txb_itr];
-            uint16_t tx_org_y =
-                context_ptr->blk_geom->tx_org_y[context_ptr->tx_depth][context_ptr->txb_itr];
-#endif
             uint32_t txb_origin_index =
                 tx_org_x + (tx_org_y * tx_candidate_buffer->residual_ptr->stride_y);
             uint32_t input_txb_origin_index =
@@ -4730,9 +4535,7 @@ void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
             // Y Prediction
 
             if (!is_inter) {
-#if LOSSLESS_TX_TYPE_OPT
                 if (context_ptr->tx_depth)
-#endif
                     av1_intra_luma_prediction(context_ptr, pcs_ptr, tx_candidate_buffer);
 
                 // Y Residual
@@ -4751,11 +4554,9 @@ void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
                     context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
             }
 
-#if LOSSLESS_TX_TYPE_OPT
             if (context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr] <=
                     32 &&
                 context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr] <= 32)
-#endif
                 if (!tx_search_skip_flag) {
                     tx_type_search(pcs_ptr, context_ptr, tx_candidate_buffer, qp);
                 }
@@ -4775,18 +4576,14 @@ void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
 
             if (y_has_coeff) block_has_coeff = EB_TRUE;
 
-#if LOSSLESS_TX_SIZE_OPT
             current_tx_cost = RDCOST(context_ptr->full_lambda,
                                      tx_y_coeff_bits,
                                      tx_y_full_distortion[DIST_CALC_RESIDUAL]);
             if (current_tx_cost > best_cost_search) break;
-#endif
 
         } // Transform Loop
 
-#if LOSSLESS_TX_TYPE_OPT
         if (end_tx_depth) {
-#endif
             uint64_t tx_size_bits = 0;
             if (pcs_ptr->parent_pcs_ptr->frm_hdr.tx_mode == TX_MODE_SELECT)
                 tx_size_bits = get_tx_size_bits(tx_candidate_buffer,
@@ -4813,7 +4610,6 @@ void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
                         tx_y_count_non_zero_coeffs[context_ptr->txb_itr];
                 }
             }
-#if LOSSLESS_TX_TYPE_OPT
         } else {
             y_full_distortion[DIST_CALC_RESIDUAL]   = tx_y_full_distortion[DIST_CALC_RESIDUAL];
             y_full_distortion[DIST_CALC_PREDICTION] = tx_y_full_distortion[DIST_CALC_PREDICTION];
@@ -4824,7 +4620,6 @@ void tx_partitioning_path(ModeDecisionCandidateBuffer *candidate_buffer,
                     tx_y_count_non_zero_coeffs[context_ptr->txb_itr];
             }
         }
-#endif
     } // Transform Depth Loop
 
     // ATB Recon
@@ -4919,18 +4714,14 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
     candidate_ptr->transform_type[2] = DCT_DCT;
     candidate_ptr->transform_type[3] = DCT_DCT;
 
-#if LOSSLESS_TX_TYPE_OPT
     uint8_t start_tx_depth = 0;
-#endif
     uint8_t end_tx_depth = 0;
 
-#if LOSSLESS_TX_TYPE_OPT
     if (context_ptr->md_tx_size_search_mode == 0 || candidate_buffer->candidate_ptr->use_intrabc) {
         start_tx_depth = end_tx_depth = 0;
     } else if (context_ptr->md_staging_tx_size_mode == 0) {
         start_tx_depth = end_tx_depth = candidate_buffer->candidate_ptr->tx_depth;
     } else {
-#endif
         // end_tx_depth set to zero for blocks which go beyond the picture boundaries
         if ((context_ptr->sb_origin_x + context_ptr->blk_geom->origin_x +
                      context_ptr->blk_geom->bwidth <
@@ -4942,14 +4733,8 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
                                             candidate_buffer->candidate_ptr->type);
         else
             end_tx_depth = 0;
-#if LOSSLESS_TX_TYPE_OPT
     }
-#endif
     // Transform partitioning path (INTRA Luma)
-#if !LOSSLESS_TX_TYPE_OPT
-    if (context_ptr->md_tx_size_search_mode && context_ptr->md_staging_skip_atb == EB_FALSE &&
-        end_tx_depth && candidate_buffer->candidate_ptr->use_intrabc == 0) {
-#endif
         int32_t is_inter = (candidate_buffer->candidate_ptr->type == INTER_MODE ||
                             candidate_buffer->candidate_ptr->use_intrabc)
                                ? EB_TRUE
@@ -4971,11 +4756,7 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
                             context_ptr->blk_geom->bwidth,
                             context_ptr->blk_geom->bheight);
 
-#if LOSSLESS_TX_TYPE_OPT
         perform_tx_partitioning(candidate_buffer,
-#else
-    tx_partitioning_path(candidate_buffer,
-#endif
                                 context_ptr,
                                 pcs_ptr,
                                 ref_fast_cost,
@@ -4984,64 +4765,6 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
                                 &(*count_non_zero_coeffs[0]),
                                 &y_coeff_bits,
                                 &y_full_distortion[0]);
-#if !LOSSLESS_TX_TYPE_OPT
-    } else {
-        // Transform partitioning free patch (except the 128x128 case)
-
-        //Y Residual
-        residual_kernel(input_picture_ptr->buffer_y,
-                        input_origin_index,
-                        input_picture_ptr->stride_y,
-                        candidate_buffer->prediction_ptr->buffer_y,
-                        blk_origin_index,
-                        candidate_buffer->prediction_ptr->stride_y,
-                        (int16_t *)candidate_buffer->residual_ptr->buffer_y,
-                        blk_origin_index,
-                        candidate_buffer->residual_ptr->stride_y,
-                        context_ptr->hbd_mode_decision,
-                        context_ptr->blk_geom->bwidth,
-                        context_ptr->blk_geom->bheight);
-
-        // Transform partitioning free path
-        uint8_t tx_search_skip_flag;
-        if (context_ptr->md_staging_tx_search == 0)
-            tx_search_skip_flag = EB_TRUE;
-        else if (context_ptr->md_staging_tx_search == 1)
-            tx_search_skip_flag = context_ptr->tx_search_level == TX_SEARCH_FULL_LOOP
-                                      ? get_skip_tx_search_flag(context_ptr->blk_geom->sq_size,
-                                                                ref_fast_cost,
-                                                                *candidate_buffer->fast_cost_ptr,
-                                                                context_ptr->tx_weight)
-                                      : EB_TRUE;
-        else
-            tx_search_skip_flag =
-                context_ptr->tx_search_level == TX_SEARCH_FULL_LOOP ? EB_FALSE : EB_TRUE;
-        if (!tx_search_skip_flag) {
-            product_full_loop_tx_search(candidate_buffer, context_ptr, pcs_ptr);
-            candidate_ptr->full_distortion = 0;
-
-            memset(candidate_ptr->eob[0], 0, sizeof(uint16_t));
-
-            //re-init
-            candidate_ptr->y_has_coeff = 0;
-        }
-        context_ptr->tx_depth = candidate_buffer->candidate_ptr->tx_depth;
-        context_ptr->full_loop_luma_dc_sign_level_coeff_neighbor_array =
-            context_ptr->luma_dc_sign_level_coeff_neighbor_array;
-        context_ptr->txb_1d_offset = 0;
-        for (context_ptr->txb_itr = 0;
-             context_ptr->txb_itr < context_ptr->blk_geom->txb_count[context_ptr->tx_depth];
-             context_ptr->txb_itr++)
-            product_full_loop(candidate_buffer,
-                              context_ptr,
-                              pcs_ptr,
-                              input_picture_ptr,
-                              context_ptr->blk_ptr->qp,
-                              &(*count_non_zero_coeffs[0]),
-                              &y_coeff_bits,
-                              &y_full_distortion[0]);
-    }
-#endif
 
     candidate_ptr->chroma_distortion_inter_depth = 0;
     candidate_ptr->chroma_distortion             = 0;
@@ -5188,17 +4911,12 @@ void md_stage_1(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *blk_p
     uint32_t cand_index;
 
     // Set MD Staging full_loop_core settings
-#if LOSSLESS_TX_TYPE_OPT
     context_ptr->md_staging_tx_size_mode = 0;
-#else
-    context_ptr->md_staging_skip_atb = EB_TRUE;
-#endif
     context_ptr->md_staging_tx_search        = 0;
     context_ptr->md_staging_skip_full_chroma = EB_TRUE;
     context_ptr->md_staging_skip_rdoq        = EB_TRUE;
-#if FREQUENCY_SPATIAL_DOMAIN
     context_ptr->md_staging_spatial_sse_full_loop = context_ptr->spatial_sse_full_loop;
-#endif
+
     for (full_loop_candidate_index = 0;
          full_loop_candidate_index < context_ptr->md_stage_1_count[context_ptr->target_class];
          ++full_loop_candidate_index) {
@@ -5313,19 +5031,7 @@ void md_stage_3(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *blk_p
             (context_ptr->md_staging_mode == MD_STAGING_MODE_1 ||
              context_ptr->md_staging_mode == MD_STAGING_MODE_2);
         context_ptr->md_staging_skip_inter_chroma_pred = EB_FALSE;
-#if LOSSLESS_TX_TYPE_OPT
-#if REMOVE_COEFF_BASED_SKIP_ATB
         context_ptr->md_staging_tx_size_mode = EB_TRUE;
-#else
-        context_ptr->md_staging_tx_size_mode = !context_ptr->coeff_based_skip_atb;
-#endif
-#else
-#if REMOVE_COEFF_BASED_SKIP_ATB
-        context_ptr->md_staging_skip_atb = 0;
-#else
-        context_ptr->md_staging_skip_atb = context_ptr->coeff_based_skip_atb;
-#endif
-#endif
         context_ptr->md_staging_tx_search =
             (candidate_ptr->cand_class == CAND_CLASS_0 ||
              candidate_ptr->cand_class == CAND_CLASS_6 || candidate_ptr->cand_class == CAND_CLASS_7)
@@ -5334,9 +5040,7 @@ void md_stage_3(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *blk_p
         context_ptr->md_staging_skip_full_chroma = EB_FALSE;
 
         context_ptr->md_staging_skip_rdoq = EB_FALSE;
-#if FREQUENCY_SPATIAL_DOMAIN
         context_ptr->md_staging_spatial_sse_full_loop = context_ptr->spatial_sse_full_loop;
-#endif
 
         if (pcs_ptr->slice_type != I_SLICE) {
             if ((candidate_ptr->type == INTRA_MODE || context_ptr->full_loop_escape == 2) &&
@@ -7171,9 +6875,6 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
 #endif
     context_ptr->sb_ptr                        = sb_ptr;
 
-#if !REMOVE_COEFF_BASED_SKIP_ATB
-    context_ptr->coeff_based_skip_atb = 0;
-#endif
     EbBool all_blk_init = (pcs_ptr->parent_pcs_ptr->pic_depth_mode <= PIC_SQ_DEPTH_MODE);
     init_sq_nsq_block(scs_ptr, context_ptr);
 
@@ -7648,14 +7349,6 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
                                               pcs_ptr);
             d1_block_itr   = 0;
             d1_first_block = 1;
-#if !REMOVE_COEFF_BASED_SKIP_ATB
-            context_ptr->coeff_based_skip_atb =
-                pcs_ptr->parent_pcs_ptr->coeff_based_skip_atb &&
-                        context_ptr->md_local_blk_unit[last_blk_index_mds].avail_blk_flag &&
-                        context_ptr->md_blk_arr_nsq[last_blk_index_mds].block_has_coeff == 0
-                    ? 1
-                    : 0;
-#endif
             if (context_ptr->md_blk_arr_nsq[last_blk_index_mds].split_flag == EB_FALSE) {
                 md_update_all_neighbour_arrays_multiple(
                     pcs_ptr,

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -3405,14 +3405,15 @@ EbErrorType av1_intra_luma_prediction(ModeDecisionContext *        md_context_pt
                                       PictureControlSet *          pcs_ptr,
                                       ModeDecisionCandidateBuffer *candidate_buffer_ptr) {
     EbErrorType return_error = EB_ErrorNone;
+    uint8_t     is_inter     = 0; // set to 0 b/c this is an intra path
 
     uint16_t txb_origin_x =
         md_context_ptr->blk_origin_x +
-        md_context_ptr->blk_geom->tx_org_x[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
+        md_context_ptr->blk_geom->tx_org_x[is_inter][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
         md_context_ptr->blk_geom->origin_x;
     uint16_t txb_origin_y =
         md_context_ptr->blk_origin_y +
-        md_context_ptr->blk_geom->tx_org_y[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
+        md_context_ptr->blk_geom->tx_org_y[is_inter][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
         md_context_ptr->blk_geom->origin_y;
     uint8_t tx_width =
         md_context_ptr->blk_geom->tx_width[md_context_ptr->tx_depth][md_context_ptr->txb_itr];
@@ -3481,11 +3482,11 @@ EbErrorType av1_intra_luma_prediction(ModeDecisionContext *        md_context_pt
             left_neigh_array + 1,
             candidate_buffer_ptr->prediction_ptr, //uint8_t *dst,
             (md_context_ptr->blk_geom
-                 ->tx_org_x[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
+                 ->tx_org_x[is_inter][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
              md_context_ptr->blk_geom->origin_x) >>
                 2,
             (md_context_ptr->blk_geom
-                 ->tx_org_y[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
+                 ->tx_org_y[is_inter][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
              md_context_ptr->blk_geom->origin_y) >>
                 2,
             PLANE_TYPE_Y, //int32_t plane,
@@ -3495,10 +3496,10 @@ EbErrorType av1_intra_luma_prediction(ModeDecisionContext *        md_context_pt
             md_context_ptr->blk_origin_x,
             md_context_ptr->blk_origin_y,
             md_context_ptr->blk_geom
-                ->tx_org_x[0][md_context_ptr->tx_depth]
+                ->tx_org_x[is_inter][md_context_ptr->tx_depth]
                           [md_context_ptr->txb_itr], //uint32_t cuOrgX used only for prediction Ptr
             md_context_ptr->blk_geom
-                ->tx_org_y[0][md_context_ptr->tx_depth]
+                ->tx_org_y[is_inter][md_context_ptr->tx_depth]
                           [md_context_ptr->txb_itr] //uint32_t cuOrgY used only for prediction Ptr
         );
     } else {
@@ -3541,11 +3542,11 @@ EbErrorType av1_intra_luma_prediction(ModeDecisionContext *        md_context_pt
             left_neigh_array + 1,
             candidate_buffer_ptr->prediction_ptr,
             (md_context_ptr->blk_geom
-                 ->tx_org_x[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
+                 ->tx_org_x[is_inter][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
              md_context_ptr->blk_geom->origin_x) >>
                 2,
             (md_context_ptr->blk_geom
-                 ->tx_org_y[0][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
+                 ->tx_org_y[is_inter][md_context_ptr->tx_depth][md_context_ptr->txb_itr] -
              md_context_ptr->blk_geom->origin_y) >>
                 2,
             PLANE_TYPE_Y,
@@ -3555,10 +3556,10 @@ EbErrorType av1_intra_luma_prediction(ModeDecisionContext *        md_context_pt
             md_context_ptr->blk_origin_x,
             md_context_ptr->blk_origin_y,
             md_context_ptr->blk_geom
-                ->tx_org_x[0][md_context_ptr->tx_depth]
+                ->tx_org_x[is_inter][md_context_ptr->tx_depth]
                           [md_context_ptr->txb_itr], //uint32_t cuOrgX used only for prediction Ptr
             md_context_ptr->blk_geom
-                ->tx_org_y[0][md_context_ptr->tx_depth]
+                ->tx_org_y[is_inter][md_context_ptr->tx_depth]
                           [md_context_ptr->txb_itr] //uint32_t cuOrgY used only for prediction Ptr
         );
     }
@@ -4411,7 +4412,6 @@ void perform_tx_partitioning(ModeDecisionCandidateBuffer *candidate_buffer,
         memcpy(context_ptr->scratch_candidate_buffer->candidate_ptr,
                candidate_buffer->candidate_ptr,
                sizeof(ModeDecisionCandidate));
-    
 
     if (is_inter) {
         uint32_t block_index =

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -4011,9 +4011,17 @@ void tx_type_search(PictureControlSet *pcs_ptr,
             if (is_inter) {
                 TxSize          max_tx_size = context_ptr->blk_geom->txsize[0][0];
                 const TxSetType tx_set_type_inter =
+#if TX_SEARCH_REDUCED
+                    get_ext_tx_set_type(max_tx_size, is_inter, pcs_ptr->parent_pcs_ptr->frm_hdr.reduced_tx_set);
+#else
                     get_ext_tx_set_type(max_tx_size, is_inter, context_ptr->tx_search_reduced_set);
+#endif
                 int32_t eset =
+#if TX_SEARCH_REDUCED
+                    get_ext_tx_set(max_tx_size, is_inter, pcs_ptr->parent_pcs_ptr->frm_hdr.reduced_tx_set);
+#else
                     get_ext_tx_set(max_tx_size, is_inter, context_ptr->tx_search_reduced_set);
+#endif
                 // eset == 0 should correspond to a set with only DCT_DCT and there
                 // is no need to send the tx_type
                 if (eset <= 0)

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -3999,7 +3999,11 @@ void tx_type_search(PictureControlSet *pcs_ptr,
         //if (context_ptr->tx_search_reduced_set) // done below
         //    if (!allowed_tx_set_a[tx_size][tx_type]) continue;
 #endif
+#if FREQUENCY_SPATIAL_DOMAIN
+        context_ptr->three_quad_energy = 0;
+#else
         //context_ptr->three_quad_energy = 0;
+#endif
         if (tx_type != DCT_DCT) {
             if (is_inter) {
                 TxSize          max_tx_size = context_ptr->blk_geom->txsize[0][0];
@@ -4099,7 +4103,9 @@ void tx_type_search(PictureControlSet *pcs_ptr,
 
         // tx_type not equal to DCT_DCT and no coeff is not an acceptable option in AV1.
         if (y_has_coeff == 0 && tx_type != DCT_DCT) continue;
-
+#if FREQUENCY_SPATIAL_DOMAIN
+        if (context_ptr->md_staging_spatial_sse_full_loop) {
+#endif
         if (y_has_coeff)
             inv_transform_recon_wrapper(
                 candidate_buffer->prediction_ptr->buffer_y,
@@ -4156,7 +4162,40 @@ void tx_type_search(PictureControlSet *pcs_ptr,
 
         txb_full_distortion[0][DIST_CALC_PREDICTION] <<= 4;
         txb_full_distortion[0][DIST_CALC_RESIDUAL] <<= 4;
+#if FREQUENCY_SPATIAL_DOMAIN
+        } else {
+            // LUMA DISTORTION
+            picture_full_distortion32_bits(
+                context_ptr->trans_quant_buffers_ptr->txb_trans_coeff2_nx2_n_ptr,
+                context_ptr->txb_1d_offset,
+                0,
+                candidate_buffer->recon_coeff_ptr,
+                context_ptr->txb_1d_offset,
+                0,
+                context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
+                context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr],
+                NOT_USED_VALUE,
+                NOT_USED_VALUE,
+                txb_full_distortion[0],
+                NOT_USED_VALUE,
+                NOT_USED_VALUE,
+                y_count_non_zero_coeffs,
+                0,
+                0,
+                COMPONENT_LUMA);
 
+            txb_full_distortion[0][DIST_CALC_RESIDUAL] += context_ptr->three_quad_energy;
+            txb_full_distortion[0][DIST_CALC_PREDICTION] += context_ptr->three_quad_energy;
+            //assert(context_ptr->three_quad_energy == 0 && context_ptr->cu_stats->size < 64);
+            TxSize tx_size =
+                context_ptr->blk_geom->txsize[context_ptr->tx_depth][context_ptr->txb_itr];
+            int32_t shift = (MAX_TX_SCALE - av1_get_tx_scale(tx_size)) * 2;
+            txb_full_distortion[0][DIST_CALC_RESIDUAL] =
+                RIGHT_SIGNED_SHIFT(txb_full_distortion[0][DIST_CALC_RESIDUAL], shift);
+            txb_full_distortion[0][DIST_CALC_PREDICTION] =
+                RIGHT_SIGNED_SHIFT(txb_full_distortion[0][DIST_CALC_PREDICTION], shift);
+        }
+#endif
         //LUMA-ONLY
         av1_txb_estimate_coeff_bits(
             context_ptr,
@@ -5146,6 +5185,9 @@ void md_stage_1(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *blk_p
     context_ptr->md_staging_tx_search        = 0;
     context_ptr->md_staging_skip_full_chroma = EB_TRUE;
     context_ptr->md_staging_skip_rdoq        = EB_TRUE;
+#if FREQUENCY_SPATIAL_DOMAIN
+    context_ptr->md_staging_spatial_sse_full_loop = context_ptr->spatial_sse_full_loop;
+#endif
     for (full_loop_candidate_index = 0;
          full_loop_candidate_index < context_ptr->md_stage_1_count[context_ptr->target_class];
          ++full_loop_candidate_index) {
@@ -5281,6 +5323,9 @@ void md_stage_3(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *blk_p
         context_ptr->md_staging_skip_full_chroma = EB_FALSE;
 
         context_ptr->md_staging_skip_rdoq = EB_FALSE;
+#if FREQUENCY_SPATIAL_DOMAIN
+        context_ptr->md_staging_spatial_sse_full_loop = context_ptr->spatial_sse_full_loop;
+#endif
 
         if (pcs_ptr->slice_type != I_SLICE) {
             if ((candidate_ptr->type == INTRA_MODE || context_ptr->full_loop_escape == 2) &&

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -3911,8 +3911,11 @@ void tx_type_search(PictureControlSet *pcs_ptr,
                            ? EB_TRUE
                            : EB_FALSE;
     const TxSetType tx_set_type =
+#if TX_SEARCH_REDUCED
+        get_ext_tx_set_type(tx_size, is_inter, pcs_ptr->parent_pcs_ptr->frm_hdr.reduced_tx_set);
+#else
         get_ext_tx_set_type(tx_size, is_inter, context_ptr->tx_search_reduced_set);
-
+#endif
 #if TX_ORG_INTERINTRA
     uint8_t txb_origin_x =
         (uint8_t)


### PR DESCRIPTION
## Description

- Unified the tx partitioning path (txs/txt search) and the default path (txt search only) @ full_loop_core() into 1 unique path (i.e. product_full_loop_tx_search() is removed, and only tx_type_search() is now called). This will make future development(s) easier (1 spot to modify instead of 2).
- Added txs early exit (if cost of performed child tx(s) is higher than the cost of the Parent tx then exit current Tx depth) .
- Bypassed txt search for Tx(s) where only DCT is allowed (if tx width > 32 or tx high > 32).
- Bypassed INTRA compensation for Tx depth 0 as previous stage predicted samples could be re-used.
 - Added the ability to specify whether frequency or spatial domain @ distortion calculation per PD/MD stage.
- Removed useless tx signal(s).  
- Updated tx block geometry.

## Type of Change

Enhancement

## Authors

@hguermaz 
@PhoenixWorthVCD 

## Testing and Performance

The changes are lossless. No speed or memory overhead.