### PR TITLE
Improve Warp motion

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -48,8 +48,8 @@ extern "C" {
 #define MAX_TILE_CNTS 128 // Annex A.3
 #endif
 #define ALTREF_IMPROVEMENT     1 // Enable TF for layer 1 in 1 pass encoding. Adjust the filter strength
-
 #define MD_RATE_EST_ENH 1 // MD rate estimation enhancement. Active for LP =1 for now
+#define WARP_IMPROVEMENT       1 // Improve Warp motion by adding all the candidates in list0 and list 1
 #define MR_MODE 0
 
 #define ALT_REF_QP_THRESH 20

--- a/Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.c
@@ -2032,9 +2032,13 @@ EbBool warped_motion_parameters(PictureControlSet *pcs_ptr, BlkStruct *blk_ptr, 
     if (nsamples == 0) return apply_wm;
 
     MV mv;
+#if WARP_IMPROVEMENT
+    mv.col = mv_unit->mv[mv_unit->pred_direction].x;
+    mv.row = mv_unit->mv[mv_unit->pred_direction].y;
+#else
     mv.col = mv_unit->mv[REF_LIST_0].x;
     mv.row = mv_unit->mv[REF_LIST_0].y;
-
+#endif
     if (nsamples > 1) nsamples = select_samples(&mv, pts, pts_inref, nsamples, bsize);
     *num_samples = nsamples;
 

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -2973,6 +2973,22 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
 
                         // Inter Prediction
                         if (do_mc && pu_ptr->motion_mode == WARPED_CAUSAL) {
+#if WARP_IMPROVEMENT
+                            EbPictureBufferDesc             *ref_pic_list0;
+                            EbPictureBufferDesc             *ref_pic_list1;
+                            if (!is_16bit) {
+                                ref_pic_list0 = blk_ptr->prediction_unit_array->ref_frame_index_l0 >= 0 ?
+                                    ref_obj_0->reference_picture : (EbPictureBufferDesc*)EB_NULL;
+                                ref_pic_list1 = blk_ptr->prediction_unit_array->ref_frame_index_l1 >= 0 ?
+                                    ref_obj_1->reference_picture : (EbPictureBufferDesc*)EB_NULL;
+                            }
+                            else {
+                                ref_pic_list0 = blk_ptr->prediction_unit_array->ref_frame_index_l0 >= 0 ?
+                                    ref_obj_0->reference_picture16bit : (EbPictureBufferDesc*)EB_NULL;
+                                ref_pic_list1 = blk_ptr->prediction_unit_array->ref_frame_index_l1 >= 0 ?
+                                    ref_obj_1->reference_picture16bit : (EbPictureBufferDesc*)EB_NULL;
+                            }
+#endif
                             warped_motion_prediction(
                                 pcs_ptr,
                                 &context_ptr->mv_unit,
@@ -2983,11 +2999,16 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 context_ptr->blk_origin_y,
                                 blk_ptr,
                                 blk_geom,
+#if WARP_IMPROVEMENT
+                                ref_pic_list0,
+                                ref_pic_list1,
+#else
                                 is_16bit ? ref_obj_0->reference_picture16bit
                                          : ref_obj_0->reference_picture,
                                 ref_idx_l1 >= 0 ? is_16bit ? ref_obj_1->reference_picture16bit
                                                            : ref_obj_1->reference_picture
                                                 : NULL,
+#endif
                                 recon_buffer,
                                 context_ptr->blk_origin_x,
                                 context_ptr->blk_origin_y,

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -1516,6 +1516,18 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
     // Level                Settings
     // 0                    OFF
     // 1                    On
+#if WARP_IMPROVEMENT
+    FrameHeader *frm_hdr = &pcs_ptr->parent_pcs_ptr->frm_hdr;
+    if(frm_hdr->allow_warped_motion)
+        if (context_ptr->pd_pass == PD_PASS_0)
+            context_ptr->warped_motion_injection = 0;
+        else if (context_ptr->pd_pass == PD_PASS_1)
+            context_ptr->warped_motion_injection = 1;
+        else
+            context_ptr->warped_motion_injection = 1;
+    else
+        context_ptr->warped_motion_injection = 0;
+#else
     if (context_ptr->pd_pass == PD_PASS_0) {
         context_ptr->warped_motion_injection = 0;
     } else if (context_ptr->pd_pass == PD_PASS_1) {
@@ -1524,7 +1536,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
         context_ptr->warped_motion_injection = 0;
     else
         context_ptr->warped_motion_injection = 1;
-
+#endif
     // Set unipred3x3 injection
     // Level                Settings
     // 0                    OFF

--- a/Source/Lib/Encoder/Codec/EbInterPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbInterPrediction.c
@@ -6155,8 +6155,13 @@ static void chroma_plane_warped_motion_prediction_sub8x8(
     InterpFilterParams filter_params_x, filter_params_y;
 
     MV mv_l0;
+#if WARP_IMPROVEMENT
+    mv_l0.col = mv_unit->mv[mv_unit->pred_direction].x;
+    mv_l0.row = mv_unit->mv[mv_unit->pred_direction].y;
+#else
     mv_l0.col = mv_unit->mv[REF_LIST_0].x;
     mv_l0.row = mv_unit->mv[REF_LIST_0].y;
+#endif
 
     MV mv_q4 = clamp_mv_to_umv_border_sb(
         blk_ptr->av1xd, &mv_l0, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
@@ -6393,6 +6398,27 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
 
     uint8_t *src_ptr_l0, *src_ptr_l1;
     uint8_t *dst_ptr;
+#if WARP_IMPROVEMENT
+    if (mv_unit->pred_direction == UNI_PRED_LIST_0 || mv_unit->pred_direction == BI_PRED) {
+        // Y
+        src_ptr_l0 = ref_pic_list0->buffer_y + (is16bit ? 2 : 1)
+            * (ref_pic_list0->origin_x + ref_pic_list0->origin_y * ref_pic_list0->stride_y);
+        src_ptr_l1 = is_compound ? ref_pic_list1->buffer_y + (is16bit ? 2 : 1)
+            * (ref_pic_list1->origin_x + ref_pic_list1->origin_y * ref_pic_list1->stride_y)
+            : NULL;
+        src_stride = ref_pic_list0->stride_y;
+        buf_width = ref_pic_list0->width;
+        buf_height = ref_pic_list0->height;
+    }
+    else{ //UNI_PRED_LIST_1
+        src_ptr_l0 = ref_pic_list1->buffer_y + (is16bit ? 2 : 1)
+            * (ref_pic_list1->origin_x + ref_pic_list1->origin_y * ref_pic_list1->stride_y);
+        src_ptr_l1 = NULL;
+        src_stride = ref_pic_list1->stride_y;
+        buf_width = ref_pic_list1->width;
+        buf_height = ref_pic_list1->height;
+    }
+#else
     assert(ref_pic_list0 != NULL);
 
     // Y
@@ -6407,7 +6433,7 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
     src_stride = ref_pic_list0->stride_y;
     buf_width  = ref_pic_list0->width;
     buf_height = ref_pic_list0->height;
-
+#endif
     dst_ptr =
         prediction_ptr->buffer_y +
         (is16bit ? 2 : 1) * (prediction_ptr->origin_x + dst_origin_x +
@@ -6444,6 +6470,25 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
     if (perform_chroma) {
         if (blk_geom->bwidth >= 16 && blk_geom->bheight >= 16) {
             // Cb
+#if WARP_IMPROVEMENT
+            if (mv_unit->pred_direction == UNI_PRED_LIST_0 || mv_unit->pred_direction == BI_PRED) {
+                src_ptr_l0 = ref_pic_list0->buffer_cb + (is16bit ? 2 : 1)
+                    * (ref_pic_list0->origin_x / 2
+                        + (ref_pic_list0->origin_y / 2) * ref_pic_list0->stride_cb);
+                src_ptr_l1 = is_compound ? ref_pic_list1->buffer_cb + (is16bit ? 2 : 1)
+                    * (ref_pic_list1->origin_x / 2
+                        + (ref_pic_list1->origin_y / 2) * ref_pic_list1->stride_cb)
+                    : NULL;
+                src_stride = ref_pic_list0->stride_cb;
+            }
+            else { //UNI_PRED_LIST_1
+                src_ptr_l0 = ref_pic_list1->buffer_cb + (is16bit ? 2 : 1)
+                    * (ref_pic_list1->origin_x / 2
+                        + (ref_pic_list1->origin_y / 2) * ref_pic_list1->stride_cb);
+                src_ptr_l1 = NULL;
+                src_stride = ref_pic_list1->stride_cb;
+            }
+#else
             src_ptr_l0 =
                 ref_pic_list0->buffer_cb +
                 (is16bit ? 2 : 1) * (ref_pic_list0->origin_x / 2 +
@@ -6454,7 +6499,7 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
                                                                     ref_pic_list1->stride_cb)
                                      : NULL;
             src_stride = ref_pic_list0->stride_cb;
-
+#endif
             dst_ptr =
                 prediction_ptr->buffer_cb +
                 (is16bit ? 2 : 1) * ((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
@@ -6487,6 +6532,25 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
                                            rf);
 
             // Cr
+#if WARP_IMPROVEMENT
+            if (mv_unit->pred_direction == UNI_PRED_LIST_0 || mv_unit->pred_direction == BI_PRED) {
+                src_ptr_l0 = ref_pic_list0->buffer_cr + (is16bit ? 2 : 1)
+                    * (ref_pic_list0->origin_x / 2
+                        + (ref_pic_list0->origin_y / 2) * ref_pic_list0->stride_cr);
+                src_ptr_l1 = is_compound ? ref_pic_list1->buffer_cr + (is16bit ? 2 : 1)
+                    * (ref_pic_list1->origin_x / 2
+                        + (ref_pic_list1->origin_y / 2) * ref_pic_list1->stride_cr)
+                    : NULL;
+                src_stride = ref_pic_list0->stride_cr;
+            }
+            else { //UNI_PRED_LIST_1
+                src_ptr_l0 = ref_pic_list1->buffer_cr + (is16bit ? 2 : 1)
+                    * (ref_pic_list1->origin_x / 2
+                        + (ref_pic_list1->origin_y / 2) * ref_pic_list1->stride_cr);
+                src_ptr_l1 = NULL;
+                src_stride = ref_pic_list1->stride_cr;
+            }
+#else
             src_ptr_l0 =
                 ref_pic_list0->buffer_cr +
                 (is16bit ? 2 : 1) * (ref_pic_list0->origin_x / 2 +
@@ -6497,7 +6561,7 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
                                                                     ref_pic_list1->stride_cr)
                                      : NULL;
             src_stride = ref_pic_list0->stride_cr;
-
+#endif
             dst_ptr =
                 prediction_ptr->buffer_cr +
                 (is16bit ? 2 : 1) * ((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
@@ -6532,6 +6596,25 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
         } else { // Translation prediction when chroma block is smaller than 8x8
 
             // Cb
+#if WARP_IMPROVEMENT
+            if (mv_unit->pred_direction == UNI_PRED_LIST_0 || mv_unit->pred_direction == BI_PRED) {
+                src_ptr_l0 = ref_pic_list0->buffer_cb + (is16bit ? 2 : 1)
+                    * ((ref_pic_list0->origin_x + ((pu_origin_x >> 3) << 3)) / 2
+                        + (ref_pic_list0->origin_y + ((pu_origin_y >> 3) << 3)) / 2 * ref_pic_list0->stride_cb);
+                src_ptr_l1 = is_compound ? ref_pic_list1->buffer_cb + (is16bit ? 2 : 1)
+                    * ((ref_pic_list1->origin_x + ((pu_origin_x >> 3) << 3)) / 2
+                        + (ref_pic_list1->origin_y + ((pu_origin_y >> 3) << 3)) / 2 * ref_pic_list1->stride_cb)
+                    : NULL;
+                src_stride = ref_pic_list0->stride_cb;
+            }
+            else { //UNI_PRED_LIST_1
+                src_ptr_l0 = ref_pic_list1->buffer_cb + (is16bit ? 2 : 1)
+                    * ((ref_pic_list1->origin_x + ((pu_origin_x >> 3) << 3)) / 2
+                        + (ref_pic_list1->origin_y + ((pu_origin_y >> 3) << 3)) / 2 * ref_pic_list1->stride_cb);
+                src_ptr_l1 = NULL;
+                src_stride = ref_pic_list1->stride_cb;
+            }
+#else
             src_ptr_l0 =
                 ref_pic_list0->buffer_cb +
                 (is16bit ? 2 : 1) * ((ref_pic_list0->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
@@ -6544,12 +6627,13 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
                                         (ref_pic_list1->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
                                             ref_pic_list1->stride_cb)
                              : NULL;
+            src_stride = ref_pic_list0->stride_cb;
+#endif
             dst_ptr =
                 prediction_ptr->buffer_cb +
                 (is16bit ? 2 : 1) * ((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
                                      (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
                                          prediction_ptr->stride_cb);
-            src_stride = ref_pic_list0->stride_cb;
             dst_stride = prediction_ptr->stride_cb;
 
             chroma_plane_warped_motion_prediction_sub8x8(picture_control_set_ptr,
@@ -6569,6 +6653,25 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
                                                          mv_unit);
 
             // Cr
+#if WARP_IMPROVEMENT
+            if (mv_unit->pred_direction == UNI_PRED_LIST_0 || mv_unit->pred_direction == BI_PRED) {
+                src_ptr_l0 = ref_pic_list0->buffer_cr + (is16bit ? 2 : 1)
+                    * ((ref_pic_list0->origin_x + ((pu_origin_x >> 3) << 3)) / 2
+                        + (ref_pic_list0->origin_y + ((pu_origin_y >> 3) << 3)) / 2 * ref_pic_list0->stride_cr);
+                src_ptr_l1 = is_compound ? ref_pic_list1->buffer_cr + (is16bit ? 2 : 1)
+                    * ((ref_pic_list1->origin_x + ((pu_origin_x >> 3) << 3)) / 2
+                        + (ref_pic_list1->origin_y + ((pu_origin_y >> 3) << 3)) / 2 * ref_pic_list1->stride_cr)
+                    : NULL;
+                src_stride = ref_pic_list0->stride_cr;
+            }
+            else { //UNI_PRED_LIST_1
+                src_ptr_l0 = ref_pic_list1->buffer_cr + (is16bit ? 2 : 1)
+                    * ((ref_pic_list1->origin_x + ((pu_origin_x >> 3) << 3)) / 2
+                        + (ref_pic_list1->origin_y + ((pu_origin_y >> 3) << 3)) / 2 * ref_pic_list1->stride_cr);
+                src_ptr_l1 = NULL;
+                src_stride = ref_pic_list1->stride_cr;
+            }
+#else
             src_ptr_l0 =
                 ref_pic_list0->buffer_cr +
                 (is16bit ? 2 : 1) * ((ref_pic_list0->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
@@ -6581,12 +6684,13 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
                                         (ref_pic_list1->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
                                             ref_pic_list1->stride_cr)
                              : NULL;
+            src_stride = ref_pic_list0->stride_cr;
+#endif
             dst_ptr =
                 prediction_ptr->buffer_cr +
                 (is16bit ? 2 : 1) * ((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
                                      (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
                                          prediction_ptr->stride_cb);
-            src_stride = ref_pic_list0->stride_cr;
             dst_stride = prediction_ptr->stride_cr;
 
             chroma_plane_warped_motion_prediction_sub8x8(picture_control_set_ptr,
@@ -7306,8 +7410,9 @@ EbErrorType inter_pu_prediction_av1(uint8_t hbd_mode_decision, ModeDecisionConte
         bit_depth = scs_ptr->static_config.encoder_bit_depth;
 
     if (candidate_ptr->motion_mode == WARPED_CAUSAL) {
+#if !WARP_IMPROVEMENT
         assert(ref_pic_list0 != NULL);
-
+#endif
         warped_motion_prediction(picture_control_set_ptr,
                                  &mv_unit,
                                  candidate_ptr->ref_frame_type,

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -2538,7 +2538,370 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
     //update tot Candidate count
     *candTotCnt = cand_idx;
 }
+#if WARP_IMPROVEMENT
+void inject_warped_motion_candidates(
+    PictureControlSet              *pcs_ptr,
+    struct ModeDecisionContext     *context_ptr,
+    BlkStruct                      *blk_ptr,
+    uint32_t                       *cand_tot_cnt,
+    MeSbResults                    *me_results) {
+    uint32_t can_idx = *cand_tot_cnt;
+    ModeDecisionCandidate *cand_array = context_ptr->fast_candidate_array;
+    MacroBlockD  *xd = blk_ptr->av1xd;
+    uint8_t drli, max_drl_index;
+    IntMv nearest_mv[2], near_mv[2], ref_mv[2];
 
+    int inside_tile = 1;
+    SequenceControlSet *scs_ptr =
+        (SequenceControlSet *)pcs_ptr->parent_pcs_ptr->scs_wrapper_ptr->object_ptr;
+    int umv0_tile = (scs_ptr->static_config.unrestricted_motion_vector == 0);
+    uint32_t mi_row = context_ptr->blk_origin_y >> MI_SIZE_LOG2;
+    uint32_t mi_col = context_ptr->blk_origin_x >> MI_SIZE_LOG2;
+    uint32_t ref_it;
+    MvReferenceFrame rf[2];
+    Mv mv_0;
+    MvUnit mv_unit;
+    int16_t to_inject_mv_x, to_inject_mv_y;
+    //all of ref pairs: (1)single-ref List0  (2)single-ref List1
+    for (ref_it = 0; ref_it < pcs_ptr->parent_pcs_ptr->tot_ref_frame_types; ++ref_it) {
+        MvReferenceFrame ref_frame_pair = pcs_ptr->parent_pcs_ptr->ref_frame_type_arr[ref_it];
+        av1_set_ref_frame(rf, ref_frame_pair);
+
+        //single ref/list
+        if (rf[1] == NONE_FRAME)
+        {
+            MvReferenceFrame frame_type = rf[0];
+            uint8_t list_idx = get_list_idx(rf[0]);
+            uint8_t ref_idx = get_ref_frame_idx(rf[0]);
+            if (ref_idx > context_ptr->md_max_ref_count - 1)
+                continue;
+            //NEAREST
+            to_inject_mv_x = context_ptr->blk_ptr->ref_mvs[frame_type][0].as_mv.col;
+            to_inject_mv_y = context_ptr->blk_ptr->ref_mvs[frame_type][0].as_mv.row;
+
+            if (umv0_tile)
+                inside_tile = is_inside_tile_boundary(&(xd->tile), to_inject_mv_x, to_inject_mv_y, mi_col, mi_row, context_ptr->blk_geom->bsize);
+            if (inside_tile)
+            {
+                cand_array[can_idx].type = INTER_MODE;
+                cand_array[can_idx].inter_mode = NEARESTMV;
+                cand_array[can_idx].pred_mode = NEARESTMV;
+                cand_array[can_idx].motion_mode = WARPED_CAUSAL;
+                cand_array[can_idx].wm_params_l0.wmtype = AFFINE;
+                cand_array[can_idx].is_compound = 0;
+                cand_array[can_idx].is_interintra_used = 0;
+                cand_array[can_idx].distortion_ready = 0;
+                cand_array[can_idx].use_intrabc = 0;
+                cand_array[can_idx].merge_flag = EB_FALSE;
+                cand_array[can_idx].prediction_direction[0] = list_idx;
+                cand_array[can_idx].is_new_mv = 0;
+                cand_array[can_idx].is_zero_mv = 0;
+                if (list_idx == 0) {
+                    cand_array[can_idx].motion_vector_xl0 = to_inject_mv_x;
+                    cand_array[can_idx].motion_vector_yl0 = to_inject_mv_y;
+                }
+                else {
+                    cand_array[can_idx].motion_vector_xl1 = to_inject_mv_x;
+                    cand_array[can_idx].motion_vector_yl1 = to_inject_mv_y;
+                }
+                cand_array[can_idx].drl_index = 0;
+                cand_array[can_idx].ref_mv_index = 0;
+                cand_array[can_idx].pred_mv_weight = 0;
+                cand_array[can_idx].ref_frame_type = frame_type;
+                cand_array[can_idx].ref_frame_index_l0 = (list_idx == 0) ? ref_idx : -1;
+                cand_array[can_idx].ref_frame_index_l1 = (list_idx == 1) ? ref_idx : -1;
+                cand_array[can_idx].transform_type[0] = DCT_DCT;
+                cand_array[can_idx].transform_type_uv = DCT_DCT;
+                mv_0.x = to_inject_mv_x;
+                mv_0.y = to_inject_mv_y;
+                mv_unit.mv[list_idx] = mv_0;
+                mv_unit.pred_direction = cand_array[can_idx].prediction_direction[0];
+                cand_array[can_idx].local_warp_valid = warped_motion_parameters(
+                    pcs_ptr,
+                    context_ptr->blk_ptr,
+                    &mv_unit,
+                    context_ptr->blk_geom,
+                    context_ptr->blk_origin_x,
+                    context_ptr->blk_origin_y,
+                    cand_array[can_idx].ref_frame_type,
+                    &cand_array[can_idx].wm_params_l0,
+                    &cand_array[can_idx].num_proj_ref);
+
+                if (cand_array[can_idx].local_warp_valid)
+                    INCRMENT_CAND_TOTAL_COUNT(can_idx);
+            }
+            //NEAR
+            max_drl_index = get_max_drl_index(xd->ref_mv_count[frame_type], NEARMV);
+            for (drli = 0; drli < max_drl_index; drli++) {
+                get_av1_mv_pred_drl(
+                    context_ptr,
+                    blk_ptr,
+                    frame_type,
+                    0,
+                    NEARMV,
+                    drli,
+                    nearest_mv,
+                    near_mv,
+                    ref_mv);
+
+                to_inject_mv_x = near_mv[0].as_mv.col;
+                to_inject_mv_y = near_mv[0].as_mv.row;
+
+                if (umv0_tile)
+                    inside_tile = is_inside_tile_boundary(&(xd->tile), to_inject_mv_x, to_inject_mv_y, mi_col, mi_row, context_ptr->blk_geom->bsize);
+                if (inside_tile)
+                {
+                    cand_array[can_idx].type = INTER_MODE;
+                    cand_array[can_idx].inter_mode = NEARMV;
+                    cand_array[can_idx].pred_mode = NEARMV;
+                    cand_array[can_idx].motion_mode = WARPED_CAUSAL;
+                    cand_array[can_idx].wm_params_l0.wmtype = AFFINE;
+                    cand_array[can_idx].is_compound = 0;
+                    cand_array[can_idx].is_interintra_used = 0;
+                    cand_array[can_idx].distortion_ready = 0;
+                    cand_array[can_idx].use_intrabc = 0;
+                    cand_array[can_idx].merge_flag = EB_FALSE;
+                    cand_array[can_idx].prediction_direction[0] = list_idx;
+                    cand_array[can_idx].is_new_mv = 0;
+                    cand_array[can_idx].is_zero_mv = 0;
+                    if (list_idx == 0) {
+                        cand_array[can_idx].motion_vector_xl0 = to_inject_mv_x;
+                        cand_array[can_idx].motion_vector_yl0 = to_inject_mv_y;
+                    }
+                    else {
+                        cand_array[can_idx].motion_vector_xl1 = to_inject_mv_x;
+                        cand_array[can_idx].motion_vector_yl1 = to_inject_mv_y;
+                    }
+                    cand_array[can_idx].drl_index = drli;
+                    cand_array[can_idx].ref_mv_index = 0;
+                    cand_array[can_idx].pred_mv_weight = 0;
+                    cand_array[can_idx].ref_frame_type = frame_type;
+                    cand_array[can_idx].ref_frame_index_l0 = (list_idx == 0) ? ref_idx : -1;
+                    cand_array[can_idx].ref_frame_index_l1 = (list_idx == 1) ? ref_idx : -1;
+                    cand_array[can_idx].transform_type[0] = DCT_DCT;
+                    cand_array[can_idx].transform_type_uv = DCT_DCT;
+                    mv_0.x = to_inject_mv_x;
+                    mv_0.y = to_inject_mv_y;
+                    mv_unit.mv[list_idx] = mv_0;
+                    mv_unit.pred_direction = cand_array[can_idx].prediction_direction[0];
+
+                    cand_array[can_idx].local_warp_valid = warped_motion_parameters(
+                        pcs_ptr,
+                        context_ptr->blk_ptr,
+                        &mv_unit,
+                        context_ptr->blk_geom,
+                        context_ptr->blk_origin_x,
+                        context_ptr->blk_origin_y,
+                        cand_array[can_idx].ref_frame_type,
+                        &cand_array[can_idx].wm_params_l0,
+                        &cand_array[can_idx].num_proj_ref);
+
+                    if (cand_array[can_idx].local_warp_valid)
+                        INCRMENT_CAND_TOTAL_COUNT(can_idx);
+                }
+            }
+        }
+    }
+    // NEWMV L0
+    const MV neighbors[9] = {
+        {0, 0}, {0, -1}, {1, 0}, {0, 1}, {-1, 0}, {0, -2}, {2, 0}, {0, 2}, {-2, 0} };
+    IntMv  best_pred_mv[2] = { {0}, {0} };
+
+    uint8_t total_me_cnt = me_results->total_me_candidate_index[context_ptr->me_block_offset];
+    const MeCandidate *me_block_results = me_results->me_candidate[context_ptr->me_block_offset];
+
+    for (uint8_t me_candidate_index = 0; me_candidate_index < total_me_cnt; ++me_candidate_index)
+    {
+        const MeCandidate *me_block_results_ptr = &me_block_results[me_candidate_index];
+        const uint8_t inter_direction = me_block_results_ptr->direction;
+        const uint8_t list0_ref_index = me_block_results_ptr->ref_idx_l0;
+        const uint8_t list1_ref_index = me_block_results_ptr->ref_idx_l1;
+
+        /**************
+            NEWMV L0
+        ************* */
+        if (inter_direction == 0) {
+            if (list0_ref_index > context_ptr->md_max_ref_count - 1)
+                continue;
+            to_inject_mv_x = me_results->me_mv_array[context_ptr->me_block_offset][list0_ref_index].x_mv << 1;
+            to_inject_mv_y = me_results->me_mv_array[context_ptr->me_block_offset][list0_ref_index].y_mv << 1;
+            uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_0, list0_ref_index);
+            uint8_t skip_cand = check_ref_beackout(
+                context_ptr,
+                to_inject_ref_type,
+                context_ptr->blk_geom->shape);
+
+            if (!skip_cand) {
+                for (int i = 0; i < 9; i++) {
+
+                    cand_array[can_idx].type = INTER_MODE;
+                    cand_array[can_idx].distortion_ready = 0;
+                    cand_array[can_idx].use_intrabc = 0;
+                    cand_array[can_idx].merge_flag = EB_FALSE;
+                    cand_array[can_idx].prediction_direction[0] = (EbPredDirection)0;
+                    cand_array[can_idx].inter_mode = NEWMV;
+                    cand_array[can_idx].pred_mode = NEWMV;
+                    cand_array[can_idx].motion_mode = WARPED_CAUSAL;
+                    cand_array[can_idx].wm_params_l0.wmtype = AFFINE;
+                    cand_array[can_idx].is_compound = 0;
+                    cand_array[can_idx].is_interintra_used = 0;
+                    cand_array[can_idx].is_new_mv = 1;
+                    cand_array[can_idx].is_zero_mv = 0;
+                    cand_array[can_idx].drl_index = 0;
+
+                    if (pcs_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv) {
+                        cand_array[can_idx].motion_vector_xl0 = to_inject_mv_x + neighbors[i].col;
+                        cand_array[can_idx].motion_vector_yl0 = to_inject_mv_y + neighbors[i].row;
+                    }
+                    else {
+                        cand_array[can_idx].motion_vector_xl0 = to_inject_mv_x + (neighbors[i].col << 1);
+                        cand_array[can_idx].motion_vector_yl0 = to_inject_mv_y + (neighbors[i].row << 1);
+                    }
+                    cand_array[can_idx].ref_mv_index = 0;
+                    cand_array[can_idx].pred_mv_weight = 0;
+                    cand_array[can_idx].ref_frame_type = svt_get_ref_frame_type(REF_LIST_0, list0_ref_index);
+                    cand_array[can_idx].ref_frame_index_l0 = list0_ref_index;
+                    cand_array[can_idx].ref_frame_index_l1 = -1;
+                    cand_array[can_idx].transform_type[0] = DCT_DCT;
+                    cand_array[can_idx].transform_type_uv = DCT_DCT;
+
+                    choose_best_av1_mv_pred(
+                        context_ptr,
+                        cand_array[can_idx].md_rate_estimation_ptr,
+                        context_ptr->blk_ptr,
+                        cand_array[can_idx].ref_frame_type,
+                        cand_array[can_idx].is_compound,
+                        cand_array[can_idx].pred_mode,
+                        cand_array[can_idx].motion_vector_xl0,
+                        cand_array[can_idx].motion_vector_yl0,
+                        0, 0,
+                        &cand_array[can_idx].drl_index,
+                        best_pred_mv);
+
+                    cand_array[can_idx].motion_vector_pred_x[REF_LIST_0] = best_pred_mv[0].as_mv.col;
+                    cand_array[can_idx].motion_vector_pred_y[REF_LIST_0] = best_pred_mv[0].as_mv.row;
+                    mv_0.x = cand_array[can_idx].motion_vector_xl0;
+                    mv_0.y = cand_array[can_idx].motion_vector_yl0;
+                    mv_unit.mv[0] = mv_0;
+                    mv_unit.pred_direction = cand_array[can_idx].prediction_direction[0];
+                    if (umv0_tile)
+                        inside_tile = is_inside_tile_boundary(&(xd->tile), mv_0.x, mv_0.y, mi_col, mi_row, context_ptr->blk_geom->bsize);
+                    if (inside_tile)
+                    {
+                        cand_array[can_idx].local_warp_valid = warped_motion_parameters(
+                            pcs_ptr,
+                            context_ptr->blk_ptr,
+                            &mv_unit,
+                            context_ptr->blk_geom,
+                            context_ptr->blk_origin_x,
+                            context_ptr->blk_origin_y,
+                            cand_array[can_idx].ref_frame_type,
+                            &cand_array[can_idx].wm_params_l0,
+                            &cand_array[can_idx].num_proj_ref);
+
+                        if (cand_array[can_idx].local_warp_valid)
+                            INCRMENT_CAND_TOTAL_COUNT(can_idx);
+                    }
+                }
+            }
+        }
+        /**************
+           NEWMV L1
+       ************* */
+        if (inter_direction == 1) {
+            if (list1_ref_index > context_ptr->md_max_ref_count - 1)
+                continue;
+            to_inject_mv_x = me_results->me_mv_array[context_ptr->me_block_offset][((scs_ptr->mrp_mode == 0) ? 4 : 2) + list1_ref_index].x_mv << 1;
+            to_inject_mv_y = me_results->me_mv_array[context_ptr->me_block_offset][((scs_ptr->mrp_mode == 0) ? 4 : 2) + list1_ref_index].y_mv << 1;
+            uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_1, list1_ref_index);
+            uint8_t skip_cand = check_ref_beackout(
+                context_ptr,
+                to_inject_ref_type,
+                context_ptr->blk_geom->shape);
+            if (!skip_cand) {
+                for (int i = 0; i < 9; i++) {
+
+                    cand_array[can_idx].type = INTER_MODE;
+                    cand_array[can_idx].distortion_ready = 0;
+                    cand_array[can_idx].use_intrabc = 0;
+                    cand_array[can_idx].merge_flag = EB_FALSE;
+                    cand_array[can_idx].prediction_direction[0] = (EbPredDirection)1;
+                    cand_array[can_idx].inter_mode = NEWMV;
+                    cand_array[can_idx].pred_mode = NEWMV;
+                    cand_array[can_idx].motion_mode = WARPED_CAUSAL;
+                    cand_array[can_idx].wm_params_l0.wmtype = AFFINE;
+
+                    cand_array[can_idx].is_compound = 0;
+                    cand_array[can_idx].is_interintra_used = 0;
+                    cand_array[can_idx].is_new_mv = 1;
+                    cand_array[can_idx].is_zero_mv = 0;
+
+                    cand_array[can_idx].drl_index = 0;
+
+                    if (pcs_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv) {
+                        cand_array[can_idx].motion_vector_xl1 = to_inject_mv_x + neighbors[i].col;
+                        cand_array[can_idx].motion_vector_yl1 = to_inject_mv_y + neighbors[i].row;
+                    }
+                    else {
+                        cand_array[can_idx].motion_vector_xl1 = to_inject_mv_x + (neighbors[i].col << 1);
+                        cand_array[can_idx].motion_vector_yl1 = to_inject_mv_y + (neighbors[i].row << 1);
+                    }
+                    cand_array[can_idx].ref_mv_index = 0;
+                    cand_array[can_idx].pred_mv_weight = 0;
+                    cand_array[can_idx].ref_frame_type = svt_get_ref_frame_type(REF_LIST_1, list1_ref_index);
+                    cand_array[can_idx].ref_frame_index_l0 = -1;
+                    cand_array[can_idx].ref_frame_index_l1 = list1_ref_index;
+
+                    cand_array[can_idx].transform_type[0] = DCT_DCT;
+                    cand_array[can_idx].transform_type_uv = DCT_DCT;
+
+                    choose_best_av1_mv_pred(
+                        context_ptr,
+                        cand_array[can_idx].md_rate_estimation_ptr,
+                        context_ptr->blk_ptr,
+                        cand_array[can_idx].ref_frame_type,
+                        cand_array[can_idx].is_compound,
+                        cand_array[can_idx].pred_mode,
+                        cand_array[can_idx].motion_vector_xl1,
+                        cand_array[can_idx].motion_vector_yl1,
+                        0,
+                        0,
+                        &cand_array[can_idx].drl_index,
+                        best_pred_mv);
+
+                    cand_array[can_idx].motion_vector_pred_x[REF_LIST_1] = best_pred_mv[0].as_mv.col;
+                    cand_array[can_idx].motion_vector_pred_y[REF_LIST_1] = best_pred_mv[0].as_mv.row;
+
+                    mv_0.x = cand_array[can_idx].motion_vector_xl1;
+                    mv_0.y = cand_array[can_idx].motion_vector_yl1;
+                    mv_unit.mv[1] = mv_0;
+                    mv_unit.pred_direction = cand_array[can_idx].prediction_direction[0];
+                    if (umv0_tile)
+                        inside_tile = is_inside_tile_boundary(&(xd->tile), mv_0.x, mv_0.y, mi_col, mi_row, context_ptr->blk_geom->bsize);
+                    if (inside_tile)
+                    {
+                        cand_array[can_idx].local_warp_valid = warped_motion_parameters(
+                            pcs_ptr,
+                            context_ptr->blk_ptr,
+                            &mv_unit,
+                            context_ptr->blk_geom,
+                            context_ptr->blk_origin_x,
+                            context_ptr->blk_origin_y,
+                            cand_array[can_idx].ref_frame_type,
+                            &cand_array[can_idx].wm_params_l0,
+                            &cand_array[can_idx].num_proj_ref);
+
+                        if (cand_array[can_idx].local_warp_valid)
+                            INCRMENT_CAND_TOTAL_COUNT(can_idx);
+                    }
+                }
+            }
+        }
+    }
+
+    *cand_tot_cnt = can_idx;
+}
+#else
 void inject_warped_motion_candidates(PictureControlSet *         pcs_ptr,
                                      struct ModeDecisionContext *context_ptr, BlkStruct *blk_ptr,
                                      uint32_t *candTotCnt, MeSbResults *meResult) {
@@ -2757,7 +3120,7 @@ void inject_warped_motion_candidates(PictureControlSet *         pcs_ptr,
 
     *candTotCnt = cand_idx;
 }
-
+#endif
 static INLINE void setup_pred_plane(struct Buf2D *dst, BlockSize bsize, uint8_t *src, int width,
                                     int height, int stride, int mi_row, int mi_col,
                                     int subsampling_x, int subsampling_y) {

--- a/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
@@ -1271,7 +1271,11 @@ EbErrorType signal_derivation_mode_decision_config_kernel_oq(
     if (pcs_ptr->parent_pcs_ptr->sc_content_detected)
         enable_wm = EB_FALSE;
     else
+#if WARP_IMPROVEMENT
+        enable_wm = (pcs_ptr->parent_pcs_ptr->enc_mode <= ENC_M2 ||
+#else
         enable_wm = (pcs_ptr->parent_pcs_ptr->enc_mode == ENC_M0 ||
+#endif
                      (pcs_ptr->parent_pcs_ptr->enc_mode <= ENC_M5 &&
                       pcs_ptr->parent_pcs_ptr->temporal_layer_index == 0))
                         ? EB_TRUE


### PR DESCRIPTION
**Description:**
Improve warp motion by enabling warp motion for all references in list 0 and list 1

**Authors**
@anaghdin

**Type of change**
Enhancement

**Tests and performance**
Expected Average PSNR-SSIM BD-rate gain in the range of -0.2% for 1 pass encoding over the fast objective list, using 5 QP values: {20, 32, 43, 55 and 63}.
Speed impact in context of M0 ~1%