### PR TITLE
Fix encoding for non multiple of 8 pictures

### DIFF
--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -2721,10 +2721,8 @@ EbErrorType read_command_line(int32_t argc, char *const argv[], EbConfig **confi
 
                 // Assuming no errors, add padding to width and height
                 if (return_errors[index] == EB_ErrorNone) {
-                    configs[index]->input_padded_width =
-                        configs[index]->source_width + configs[index]->source_width % 8;
-                    configs[index]->input_padded_height =
-                        configs[index]->source_height + configs[index]->source_width % 8;
+                    configs[index]->input_padded_width = configs[index]->source_width;
+                    configs[index]->input_padded_height = configs[index]->source_height;
                 }
 
                 // Assuming no errors, set the frames to be encoded to the number of frames in the input yuv

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -44,6 +44,7 @@ extern "C" {
 #define MR_MODE 0
 #define ALT_REF_QP_THRESH 20
 #define HIGH_PRECISION_MV_QTHRESH 150
+#define NON8_FIX_REST 1
 
 #define ENHANCED_MULTI_PASS_PD_MD_STAGING_SETTINGS 1 // Updated Multi-Pass-PD and MD-Staging Settings
 #define IFS_MD_STAGE_3 1

--- a/Source/Lib/Common/Codec/EbPictureBufferDesc.c
+++ b/Source/Lib/Common/Codec/EbPictureBufferDesc.c
@@ -229,9 +229,8 @@ void link_eb_to_aom_buffer_desc_8bit(EbPictureBufferDesc *picBuffDsc,
     }
 }
 
-void link_eb_to_aom_buffer_desc(EbPictureBufferDesc *picBuffDsc, Yv12BufferConfig *aomBuffDsc
-    , EbBool is_16bit
-) {
+void link_eb_to_aom_buffer_desc(EbPictureBufferDesc *picBuffDsc, Yv12BufferConfig *aomBuffDsc, uint16_t pad_right, uint16_t pad_bottom, EbBool is_16bit)
+{
     //NOTe:  Not all fileds are connected. add more connections as needed.
     if (!is_16bit) {
         aomBuffDsc->y_buffer = picBuffDsc->buffer_y + picBuffDsc->origin_x +
@@ -255,10 +254,10 @@ void link_eb_to_aom_buffer_desc(EbPictureBufferDesc *picBuffDsc, Yv12BufferConfi
         aomBuffDsc->subsampling_x = 1;
         aomBuffDsc->subsampling_y = 1;
 
-        aomBuffDsc->y_crop_width   = aomBuffDsc->y_width;
-        aomBuffDsc->uv_crop_width  = aomBuffDsc->uv_width;
-        aomBuffDsc->y_crop_height  = aomBuffDsc->y_height;
-        aomBuffDsc->uv_crop_height = aomBuffDsc->uv_height;
+        aomBuffDsc->y_crop_width   = aomBuffDsc->y_width - pad_right;
+        aomBuffDsc->uv_crop_width  = aomBuffDsc->y_crop_width / 2;
+        aomBuffDsc->y_crop_height  = aomBuffDsc->y_height - pad_bottom;
+        aomBuffDsc->uv_crop_height = aomBuffDsc->y_crop_height / 2;
 
         aomBuffDsc->flags = 0;
     } else {
@@ -313,10 +312,10 @@ void link_eb_to_aom_buffer_desc(EbPictureBufferDesc *picBuffDsc, Yv12BufferConfi
         aomBuffDsc->subsampling_x = 1;
         aomBuffDsc->subsampling_y = 1;
 
-        aomBuffDsc->y_crop_width   = aomBuffDsc->y_width;
-        aomBuffDsc->uv_crop_width  = aomBuffDsc->uv_width;
-        aomBuffDsc->y_crop_height  = aomBuffDsc->y_height;
-        aomBuffDsc->uv_crop_height = aomBuffDsc->uv_height;
+        aomBuffDsc->y_crop_width   = aomBuffDsc->y_width - pad_right;
+        aomBuffDsc->uv_crop_width  = aomBuffDsc->y_crop_width / 2;
+        aomBuffDsc->y_crop_height  = aomBuffDsc->y_height - pad_bottom;
+        aomBuffDsc->uv_crop_height = aomBuffDsc->y_crop_height / 2;
         aomBuffDsc->flags          = YV12_FLAG_HIGHBITDEPTH;
     }
 }

--- a/Source/Lib/Common/Codec/EbPictureBufferDesc.h
+++ b/Source/Lib/Common/Codec/EbPictureBufferDesc.h
@@ -230,7 +230,7 @@ typedef struct Yv12BufferConfig {
     int32_t flags;
 } Yv12BufferConfig;
 
-void link_eb_to_aom_buffer_desc(EbPictureBufferDesc *picBuffDsc, Yv12BufferConfig *aomBuffDsc
+void link_eb_to_aom_buffer_desc(EbPictureBufferDesc *picBuffDsc, Yv12BufferConfig *aomBuffDsc, uint16_t pad_right, uint16_t pad_bottom
     ,EbBool is_16bit
 );
 

--- a/Source/Lib/Encoder/Codec/EbDlfProcess.c
+++ b/Source/Lib/Encoder/Codec/EbDlfProcess.c
@@ -262,7 +262,7 @@ void *dlf_kernel(void *input_ptr) {
                 }
                 cm->use_highbitdepth = 1;
             }
-            link_eb_to_aom_buffer_desc(recon_picture_ptr, cm->frame_to_show, is_16bit || scs_ptr->static_config.encoder_16bit_pipeline);
+            link_eb_to_aom_buffer_desc(recon_picture_ptr, cm->frame_to_show, scs_ptr->max_input_pad_right, scs_ptr->max_input_pad_bottom, is_16bit || scs_ptr->static_config.encoder_16bit_pipeline);
             if (scs_ptr->seq_header.enable_restoration)
                 eb_av1_loop_restoration_save_boundary_lines(cm->frame_to_show, cm, 0);
             if (scs_ptr->seq_header.enable_cdef && pcs_ptr->parent_pcs_ptr->cdef_filter_mode) {

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -656,9 +656,9 @@ void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) 
 
         residual_distortion = 0;
 
-        while (row_index < input_picture_ptr->height) {
+        while (row_index < (uint32_t)(input_picture_ptr->height - scs_ptr->max_input_pad_bottom)) {
             column_index = 0;
-            while (column_index < input_picture_ptr->width) {
+            while (column_index < (uint32_t)(input_picture_ptr->width - scs_ptr->max_input_pad_right)) {
                 residual_distortion += (int64_t)SQR((int64_t)(input_buffer[column_index]) -
                                                     (recon_coeff_buffer[column_index]));
                 ++column_index;
@@ -679,9 +679,9 @@ void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) 
 
         residual_distortion = 0;
         row_index           = 0;
-        while (row_index < (uint32_t)(input_picture_ptr->height >> ss_y)) {
+        while (row_index < (uint32_t)((input_picture_ptr->height - scs_ptr->max_input_pad_bottom) >> ss_y)) {
             column_index = 0;
-            while (column_index < (uint32_t)(input_picture_ptr->width >> ss_x)) {
+            while (column_index < (uint32_t)((input_picture_ptr->width - scs_ptr->max_input_pad_bottom) >> ss_x)) {
                 residual_distortion += (int64_t)SQR((int64_t)(input_buffer[column_index]) -
                                                     (recon_coeff_buffer[column_index]));
                 ++column_index;
@@ -702,9 +702,9 @@ void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) 
         residual_distortion = 0;
         row_index           = 0;
 
-        while (row_index < (uint32_t)(input_picture_ptr->height >> ss_y)) {
+        while (row_index < (uint32_t)((input_picture_ptr->height - scs_ptr->max_input_pad_bottom) >> ss_y)) {
             column_index = 0;
-            while (column_index < (uint32_t)(input_picture_ptr->width >> ss_x)) {
+            while (column_index < (uint32_t)((input_picture_ptr->width - scs_ptr->max_input_pad_bottom) >> ss_x)) {
                 residual_distortion += (int64_t)SQR((int64_t)(input_buffer[column_index]) -
                                                     (recon_coeff_buffer[column_index]));
                 ++column_index;
@@ -746,13 +746,13 @@ void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) 
         uint16_t *recon_coeff_buffer;
 
         if (scs_ptr->static_config.ten_bit_format == 1) {
-            const uint32_t luma_width        = input_picture_ptr->width;
-            const uint32_t luma_height       = input_picture_ptr->height;
-            const uint32_t chroma_width      = input_picture_ptr->width >> ss_x;
+            const uint32_t luma_width        = input_picture_ptr->width - scs_ptr->max_input_pad_right;
+            const uint32_t luma_height       = input_picture_ptr->height - scs_ptr->max_input_pad_bottom;
+            const uint32_t chroma_width      = luma_width >> ss_x;
             const uint32_t pic_width_in_sb   = (luma_width + 64 - 1) / 64;
             const uint32_t pic_height_in_sb  = (luma_height + 64 - 1) / 64;
             const uint32_t luma_2bit_width   = luma_width / 4;
-            const uint32_t chroma_height     = input_picture_ptr->height >> ss_y;
+            const uint32_t chroma_height     = luma_height >> ss_y;
             const uint32_t chroma_2bit_width = chroma_width / 4;
             uint32_t       sb_num_in_height, sb_num_in_width;
 
@@ -997,9 +997,9 @@ void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) 
 
             residual_distortion = 0;
 
-            while (row_index < input_picture_ptr->height) {
+            while (row_index < (uint32_t)(input_picture_ptr->height - scs_ptr->max_input_pad_bottom)) {
                 column_index = 0;
-                while (column_index < input_picture_ptr->width) {
+                while (column_index < (uint32_t)(input_picture_ptr->width - scs_ptr->max_input_pad_right)) {
                     residual_distortion +=
                         (int64_t)SQR((int64_t)((((input_buffer[column_index]) << 2) |
                                                 ((input_buffer_bit_inc[column_index] >> 6) & 3))) -
@@ -1029,9 +1029,9 @@ void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) 
 
             residual_distortion = 0;
             row_index           = 0;
-            while (row_index < (uint32_t)(input_picture_ptr->height >> ss_y)) {
+            while (row_index < (uint32_t)((input_picture_ptr->height - scs_ptr->max_input_pad_bottom) >> ss_y)) {
                 column_index = 0;
-                while (column_index < (uint32_t)(input_picture_ptr->width >> ss_x)) {
+                while (column_index < (uint32_t)((input_picture_ptr->width - scs_ptr->max_input_pad_right) >> ss_x)) {
                     residual_distortion +=
                         (int64_t)SQR((int64_t)((((input_buffer[column_index]) << 2) |
                                                 ((input_buffer_bit_inc[column_index] >> 6) & 3))) -
@@ -1061,9 +1061,9 @@ void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) 
             residual_distortion = 0;
             row_index           = 0;
 
-            while (row_index < (uint32_t)(input_picture_ptr->height >> ss_y)) {
+            while (row_index < (uint32_t)((input_picture_ptr->height - scs_ptr->max_input_pad_bottom) >> ss_y)) {
                 column_index = 0;
-                while (column_index < (uint32_t)(input_picture_ptr->width >> ss_x)) {
+                while (column_index < (uint32_t)((input_picture_ptr->width - scs_ptr->max_input_pad_right) >> ss_x)) {
                     residual_distortion +=
                         (int64_t)SQR((int64_t)((((input_buffer[column_index]) << 2) |
                                                 ((input_buffer_bit_inc[column_index] >> 6) & 3))) -
@@ -1107,24 +1107,24 @@ void pad_ref_and_set_flags(PictureControlSet *pcs_ptr, SequenceControlSet *scs_p
         // Y samples
         generate_padding(ref_pic_ptr->buffer_y,
                          ref_pic_ptr->stride_y,
-                         ref_pic_ptr->width,
-                         ref_pic_ptr->height,
+                         ref_pic_ptr->width - scs_ptr->max_input_pad_right,
+                         ref_pic_ptr->height - scs_ptr->max_input_pad_bottom,
                          ref_pic_ptr->origin_x,
                          ref_pic_ptr->origin_y);
 
         // Cb samples
         generate_padding(ref_pic_ptr->buffer_cb,
                          ref_pic_ptr->stride_cb,
-                         ref_pic_ptr->width >> 1,
-                         ref_pic_ptr->height >> 1,
+                         (ref_pic_ptr->width - scs_ptr->max_input_pad_right) >> 1,
+                         (ref_pic_ptr->height - scs_ptr->max_input_pad_bottom) >> 1,
                          ref_pic_ptr->origin_x >> 1,
                          ref_pic_ptr->origin_y >> 1);
 
         // Cr samples
         generate_padding(ref_pic_ptr->buffer_cr,
                          ref_pic_ptr->stride_cr,
-                         ref_pic_ptr->width >> 1,
-                         ref_pic_ptr->height >> 1,
+                         (ref_pic_ptr->width - scs_ptr->max_input_pad_right) >> 1,
+                         (ref_pic_ptr->height - scs_ptr->max_input_pad_bottom) >> 1,
                          ref_pic_ptr->origin_x >> 1,
                          ref_pic_ptr->origin_y >> 1);
     }
@@ -1187,24 +1187,24 @@ void pad_ref_and_set_flags(PictureControlSet *pcs_ptr, SequenceControlSet *scs_p
         // Y samples
         generate_padding16_bit(ref_pic_16bit_ptr->buffer_y,
                                ref_pic_16bit_ptr->stride_y << 1,
-                               ref_pic_16bit_ptr->width << 1,
-                               ref_pic_16bit_ptr->height,
+                               (ref_pic_16bit_ptr->width - scs_ptr->max_input_pad_right) << 1,
+                               ref_pic_16bit_ptr->height - scs_ptr->max_input_pad_bottom,
                                ref_pic_16bit_ptr->origin_x << 1,
                                ref_pic_16bit_ptr->origin_y);
 
         // Cb samples
         generate_padding16_bit(ref_pic_16bit_ptr->buffer_cb,
                                ref_pic_16bit_ptr->stride_cb << 1,
-                               ref_pic_16bit_ptr->width,
-                               ref_pic_16bit_ptr->height >> 1,
+                               (ref_pic_16bit_ptr->width - scs_ptr->max_input_pad_right),
+                               (ref_pic_16bit_ptr->height - scs_ptr->max_input_pad_bottom) >> 1,
                                ref_pic_16bit_ptr->origin_x,
                                ref_pic_16bit_ptr->origin_y >> 1);
 
         // Cr samples
         generate_padding16_bit(ref_pic_16bit_ptr->buffer_cr,
                                ref_pic_16bit_ptr->stride_cr << 1,
-                               ref_pic_16bit_ptr->width,
-                               ref_pic_16bit_ptr->height >> 1,
+                               (ref_pic_16bit_ptr->width - scs_ptr->max_input_pad_right),
+                               (ref_pic_16bit_ptr->height - scs_ptr->max_input_pad_bottom) >> 1,
                                ref_pic_16bit_ptr->origin_x,
                                ref_pic_16bit_ptr->origin_y >> 1);
 

--- a/Source/Lib/Encoder/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Encoder/Codec/EbEntropyCoding.c
@@ -16,6 +16,7 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <math.h>
 
 #include "EbEntropyCoding.h"
 #include "EbEntropyCodingUtil.h"
@@ -3274,18 +3275,18 @@ static void write_tile_info(const PictureParentControlSet *const pcs_ptr,
     }
 }
 
-static void write_render_size(struct AomWriteBitBuffer *wb, SequenceControlSet *scs) {
-    uint16_t width                           = scs->max_input_luma_width;
-    uint16_t render_width                    = width - scs->max_input_pad_right;
-    uint16_t height                          = scs->max_input_luma_height;
-    uint16_t render_height                   = height - scs->max_input_pad_bottom;
-    int      render_and_frame_size_different = (width != render_width) || (height != render_height);
+static void write_render_size(struct AomWriteBitBuffer *wb, SequenceControlSet *scs)
+{
+    (void) scs;
+    int render_and_frame_size_different = 0;
     eb_aom_wb_write_bit(wb, render_and_frame_size_different);
+    /*
     if (!render_and_frame_size_different) return;
     uint32_t render_width_minus_1  = render_width - 1;
     uint32_t render_height_minus_1 = render_height - 1;
     eb_aom_wb_write_literal(wb, render_width_minus_1, 16);
     eb_aom_wb_write_literal(wb, render_height_minus_1, 16);
+    */
 }
 
 static AOM_INLINE void write_superres_scale(struct AomWriteBitBuffer *wb,
@@ -3424,27 +3425,18 @@ static void write_color_config(SequenceControlSet *      scs_ptr /*Av1Common *co
     //eb_aom_wb_write_bit(wb, cm->separate_uv_delta_q);
 }
 
-void write_sequence_header(SequenceControlSet *      scs_ptr /*Av1Comp *cpi*/,
-                           struct AomWriteBitBuffer *wb) {
-    //    Av1Common *const cm = &cpi->common;
-    //    SequenceHeader *seq_params = &cm->seq_params;
-    //
-
-    int32_t max_frame_width = scs_ptr->seq_header.max_frame_width;
-    /*        cpi->oxcf.forced_max_frame_width
-    ? cpi->oxcf.forced_max_frame_width
-    : cpi->oxcf.width;*/
-    int32_t max_frame_height = scs_ptr->seq_header.max_frame_height;
-    /*cpi->oxcf.forced_max_frame_height
-    ? cpi->oxcf.forced_max_frame_height
-    : cpi->oxcf.height;*/
-
-    eb_aom_wb_write_literal(wb, scs_ptr->seq_header.frame_width_bits - 1, 4);
-    eb_aom_wb_write_literal(wb, scs_ptr->seq_header.frame_height_bits - 1, 4);
-    eb_aom_wb_write_literal(wb, max_frame_width - 1, scs_ptr->seq_header.frame_width_bits);
-    eb_aom_wb_write_literal(wb, max_frame_height - 1, scs_ptr->seq_header.frame_height_bits);
-    //
-    /* Placeholder for actually writing to the Bitstream */
+void write_sequence_header(SequenceControlSet *scs_ptr, struct AomWriteBitBuffer *wb)
+{
+    const int32_t max_frame_width =
+        scs_ptr->seq_header.max_frame_width - scs_ptr->max_input_pad_right;
+    const int32_t max_frame_height =
+        scs_ptr->seq_header.max_frame_height - scs_ptr->max_input_pad_bottom;
+    const unsigned frame_width_bits = (unsigned) ceil(log2(max_frame_width));
+    const unsigned frame_height_bits = (unsigned) ceil(log2(max_frame_height));
+    eb_aom_wb_write_literal(wb, frame_width_bits - 1, 4);
+    eb_aom_wb_write_literal(wb, frame_height_bits - 1, 4);
+    eb_aom_wb_write_literal(wb, max_frame_width - 1, frame_width_bits);
+    eb_aom_wb_write_literal(wb, max_frame_height - 1, frame_height_bits);
 
     if (!scs_ptr->seq_header.reduced_still_picture_header) {
         //scs_ptr->frame_id_numbers_present_flag = 0;

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.c
@@ -1351,7 +1351,7 @@ EbErrorType picture_parent_control_set_ctor(PictureParentControlSet *object_ptr,
     object_ptr->av1_cm->color_format                      = init_data_ptr->color_format;
     object_ptr->av1_cm->subsampling_x                     = subsampling_x;
     object_ptr->av1_cm->subsampling_y                     = subsampling_y;
-#if NON8_FIX_REST   
+#if NON8_FIX_REST
     object_ptr->av1_cm->frm_size.frame_width = init_data_ptr->picture_width- init_data_ptr->non_m8_pad_w;
     object_ptr->av1_cm->frm_size.frame_height = init_data_ptr->picture_height- init_data_ptr->non_m8_pad_h;
     object_ptr->av1_cm->frm_size.superres_upscaled_width = init_data_ptr->picture_width - init_data_ptr->non_m8_pad_w;;

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.c
@@ -1351,10 +1351,18 @@ EbErrorType picture_parent_control_set_ctor(PictureParentControlSet *object_ptr,
     object_ptr->av1_cm->color_format                      = init_data_ptr->color_format;
     object_ptr->av1_cm->subsampling_x                     = subsampling_x;
     object_ptr->av1_cm->subsampling_y                     = subsampling_y;
+#if NON8_FIX_REST   
+    object_ptr->av1_cm->frm_size.frame_width = init_data_ptr->picture_width- init_data_ptr->non_m8_pad_w;
+    object_ptr->av1_cm->frm_size.frame_height = init_data_ptr->picture_height- init_data_ptr->non_m8_pad_h;
+    object_ptr->av1_cm->frm_size.superres_upscaled_width = init_data_ptr->picture_width - init_data_ptr->non_m8_pad_w;;
+    object_ptr->av1_cm->frm_size.superres_upscaled_height = init_data_ptr->picture_height - init_data_ptr->non_m8_pad_h;
+
+#else
     object_ptr->av1_cm->frm_size.frame_width              = init_data_ptr->picture_width;
     object_ptr->av1_cm->frm_size.frame_height             = init_data_ptr->picture_height;
     object_ptr->av1_cm->frm_size.superres_upscaled_width  = init_data_ptr->picture_width;
     object_ptr->av1_cm->frm_size.superres_upscaled_height = init_data_ptr->picture_height;
+#endif
     object_ptr->av1_cm->frm_size.superres_denominator     = SCALE_NUMERATOR;
 
     object_ptr->av1_cm->mi_cols = init_data_ptr->picture_width >> MI_SIZE_LOG2;

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -793,6 +793,12 @@ typedef struct PictureControlSetInitData {
     uint8_t log2_sb_sz; //in mi unit
     uint8_t allocate_ois_struct; //allocate ois results
     EbBool is_16bit_pipeline;
+
+#if NON8_FIX_REST
+    uint16_t  non_m8_pad_w;
+    uint16_t  non_m8_pad_h;
+#endif
+
 } PictureControlSetInitData;
 
 typedef struct Av1Comp {

--- a/Source/Lib/Encoder/Codec/EbRestProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRestProcess.c
@@ -526,17 +526,21 @@ void *rest_kernel(void *input_ptr) {
             link_eb_to_aom_buffer_desc(scs_ptr->static_config.encoder_16bit_pipeline || is_16bit
                                        ? pcs_ptr->input_frame16bit
                                        : pcs_ptr->parent_pcs_ptr->enhanced_unscaled_picture_ptr,
-                                       &cpi_source
-                , scs_ptr->static_config.encoder_16bit_pipeline || is_16bit
-            );
+                                       &cpi_source,
+                                       scs_ptr->max_input_pad_right,
+                                       scs_ptr->max_input_pad_bottom,
+                                       scs_ptr->static_config.encoder_16bit_pipeline || is_16bit);
 
             Yv12BufferConfig trial_frame_rst;
-            link_eb_to_aom_buffer_desc(context_ptr->trial_frame_rst, &trial_frame_rst
-                , scs_ptr->static_config.encoder_16bit_pipeline || is_16bit
-            );
+            link_eb_to_aom_buffer_desc(context_ptr->trial_frame_rst, &trial_frame_rst,
+                                       scs_ptr->max_input_pad_right,
+                                       scs_ptr->max_input_pad_bottom,
+                                       scs_ptr->static_config.encoder_16bit_pipeline || is_16bit);
 
             Yv12BufferConfig org_fts;
-            link_eb_to_aom_buffer_desc(context_ptr->org_rec_frame, &org_fts
+            link_eb_to_aom_buffer_desc(context_ptr->org_rec_frame, &org_fts,
+                                       scs_ptr->max_input_pad_right,
+                                       scs_ptr->max_input_pad_bottom
 
                 , scs_ptr->static_config.encoder_16bit_pipeline || is_16bit
             );

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
@@ -70,6 +70,11 @@
     } while (0)
 #endif
 
+void setup_rtcd_non8(CPU_FLAGS flags) {
+    (void) flags;
+    eb_av1_compute_stats = eb_av1_compute_stats_c;
+    eb_av1_compute_stats_highbd = eb_av1_compute_stats_highbd_c;
+}
 void setup_rtcd_internal(CPU_FLAGS flags) {
     /** Should be done during library initialization,
         but for safe limiting cpu flags again. */

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
@@ -55,6 +55,8 @@ extern "C" {
 //    CPU_FLAGS get_cpu_flags_to_use();
     void setup_rtcd_internal(CPU_FLAGS flags);
 
+    void setup_rtcd_non8(CPU_FLAGS flags);
+
     //to not include convolve.h, just forward declare what's needed.
     struct ConvolveParams;
     struct InterpFilterParams;

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -479,8 +479,13 @@ EbErrorType load_default_buffer_configuration_settings(
     uint32_t unit_size                                  = 256;
     uint32_t rest_seg_w                                 = MAX((scs_ptr->max_input_luma_width /2 + (unit_size >> 1)) / unit_size, 1);
     uint32_t rest_seg_h                                 = MAX((scs_ptr->max_input_luma_height/2 + (unit_size >> 1)) / unit_size, 1);
-    scs_ptr->rest_segment_column_count = MIN(rest_seg_w,6);
-    scs_ptr->rest_segment_row_count    = MIN(rest_seg_h,4);
+#if NON8_FIX_REST
+    scs_ptr->rest_segment_column_count =  MIN(rest_seg_w, 6);
+    scs_ptr->rest_segment_row_count =  MIN(rest_seg_h, 4);
+#else
+    scs_ptr->rest_segment_column_count = 1;
+    scs_ptr->rest_segment_row_count = 1;
+#endif
 
     scs_ptr->tf_segment_column_count = me_seg_w;//1;//
     scs_ptr->tf_segment_row_count =  me_seg_h;//1;//
@@ -935,6 +940,13 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
 
     setup_common_rtcd_internal(enc_handle_ptr->scs_instance_array[0]->scs_ptr->static_config.use_cpu_flags);
     setup_rtcd_internal(enc_handle_ptr->scs_instance_array[0]->scs_ptr->static_config.use_cpu_flags);
+
+#if NON8_FIX_REST
+    if(enc_handle_ptr->scs_instance_array[0]->scs_ptr->max_input_pad_right>0 || 
+       enc_handle_ptr->scs_instance_array[0]->scs_ptr->max_input_pad_bottom>0)    
+        setup_rtcd_non8(enc_handle_ptr->scs_instance_array[0]->scs_ptr->static_config.use_cpu_flags);
+#endif
+
     asm_set_convolve_asm_table();
 
     init_intra_dc_predictors_c_internal();
@@ -996,6 +1008,12 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
         input_data.log2_sb_sz = (scs_init.sb_size == 128) ? 5 : 4;
         input_data.allocate_ois_struct = 0;
         input_data.is_16bit_pipeline = enc_handle_ptr->scs_instance_array[instance_index]->scs_ptr->static_config.encoder_16bit_pipeline;
+
+#if NON8_FIX_REST
+        input_data.non_m8_pad_w = enc_handle_ptr->scs_instance_array[instance_index]->scs_ptr->max_input_pad_right;
+        input_data.non_m8_pad_h = enc_handle_ptr->scs_instance_array[instance_index]->scs_ptr->max_input_pad_bottom;
+#endif
+
         EB_NEW(
             enc_handle_ptr->picture_parent_control_set_pool_ptr_array[instance_index],
             eb_system_resource_ctor,
@@ -3261,36 +3279,41 @@ static EbErrorType copy_frame_buffer(
         uint32_t     chroma_buffer_offset = (input_picture_ptr->stride_cr*(scs_ptr->top_padding >> 1) + (scs_ptr->left_padding >> 1)) << is_16bit_input;
         uint16_t     luma_stride = input_picture_ptr->stride_y << is_16bit_input;
         uint16_t     chroma_stride = input_picture_ptr->stride_cb << is_16bit_input;
-        uint16_t     luma_width = (uint16_t)(input_picture_ptr->width - scs_ptr->max_input_pad_right) << is_16bit_input;
-        uint16_t     chroma_width = (luma_width >> 1) << is_16bit_input;
         uint16_t     luma_height = (uint16_t)(input_picture_ptr->height - scs_ptr->max_input_pad_bottom);
 
         uint16_t     source_luma_stride = (uint16_t)(input_ptr->y_stride);
         uint16_t     source_cr_stride = (uint16_t)(input_ptr->cr_stride);
         uint16_t     source_cb_stride = (uint16_t)(input_ptr->cb_stride);
+        uint16_t source_chroma_height =
+            (luma_height >> (input_picture_ptr->color_format == EB_YUV420));
 
-        //uint16_t     luma_height  = input_picture_ptr->max_height;
-        // Y
-        for (input_row_index = 0; input_row_index < luma_height; input_row_index++) {
-            EB_MEMCPY((input_picture_ptr->buffer_y + luma_buffer_offset + luma_stride * input_row_index),
-                (input_ptr->luma + source_luma_stride * input_row_index),
-                luma_width);
+        uint8_t *src, *dst;
+
+        src = input_ptr->luma;
+        dst = input_picture_ptr->buffer_y + luma_buffer_offset;
+        for (unsigned i = 0; i < luma_height; i++) {
+            EB_MEMCPY(dst, src, source_luma_stride);
+            src += source_luma_stride;
+            dst += luma_stride;
         }
 
-        // U
-        for (input_row_index = 0; input_row_index < luma_height >> 1; input_row_index++) {
-            EB_MEMCPY((input_picture_ptr->buffer_cb + chroma_buffer_offset + chroma_stride * input_row_index),
-                (input_ptr->cb + (source_cb_stride*input_row_index)),
-                chroma_width);
+        src = input_ptr->cb;
+        dst = input_picture_ptr->buffer_cb + chroma_buffer_offset;
+        for (unsigned i = 0; i < source_chroma_height; i++) {
+            EB_MEMCPY(dst, src, source_cb_stride);
+            src += source_cb_stride;
+            dst += chroma_stride;
         }
 
-        // V
-        for (input_row_index = 0; input_row_index < luma_height >> 1; input_row_index++) {
-            EB_MEMCPY((input_picture_ptr->buffer_cr + chroma_buffer_offset + chroma_stride * input_row_index),
-                (input_ptr->cr + (source_cr_stride*input_row_index)),
-                chroma_width);
+        src = input_ptr->cr;
+        dst = input_picture_ptr->buffer_cr + chroma_buffer_offset;
+        for (unsigned i = 0; i < source_chroma_height; i++) {
+            EB_MEMCPY(dst, src, source_cr_stride);
+            src += source_cr_stride;
+            dst += chroma_stride;
         }
     }
+
     else if (is_16bit_input && config->compressed_ten_bit_format == 1)
     {
         {
@@ -3298,35 +3321,39 @@ static EbErrorType copy_frame_buffer(
             uint32_t  chroma_buffer_offset = (input_picture_ptr->stride_cr*(scs_ptr->top_padding >> 1) + (scs_ptr->left_padding >> 1));
             uint16_t  luma_stride = input_picture_ptr->stride_y;
             uint16_t  chroma_stride = input_picture_ptr->stride_cb;
-            uint16_t  luma_width = (uint16_t)(input_picture_ptr->width - scs_ptr->max_input_pad_right);
-            uint16_t  chroma_width = (luma_width >> 1);
             uint16_t  luma_height = (uint16_t)(input_picture_ptr->height - scs_ptr->max_input_pad_bottom);
 
             uint16_t  source_luma_stride = (uint16_t)(input_ptr->y_stride);
             uint16_t  source_cr_stride = (uint16_t)(input_ptr->cr_stride);
             uint16_t  source_cb_stride = (uint16_t)(input_ptr->cb_stride);
+            uint16_t source_chroma_height =
+                (luma_height >> (input_picture_ptr->color_format == EB_YUV420));
 
-            // Y 8bit
-            for (input_row_index = 0; input_row_index < luma_height; input_row_index++) {
-                EB_MEMCPY((input_picture_ptr->buffer_y + luma_buffer_offset + luma_stride * input_row_index),
-                    (input_ptr->luma + source_luma_stride * input_row_index),
-                    luma_width);
+            uint8_t *src, *dst;
+
+            src = input_ptr->luma;
+            dst = input_picture_ptr->buffer_y + luma_buffer_offset;
+            for (unsigned i = 0; i < luma_height; i++) {
+                EB_MEMCPY(dst, src, source_luma_stride);
+                src += source_luma_stride;
+                dst += luma_stride;
             }
 
-            // U 8bit
-            for (input_row_index = 0; input_row_index < luma_height >> 1; input_row_index++) {
-                EB_MEMCPY((input_picture_ptr->buffer_cb + chroma_buffer_offset + chroma_stride * input_row_index),
-                    (input_ptr->cb + (source_cb_stride*input_row_index)),
-                    chroma_width);
+            src = input_ptr->cb;
+            dst = input_picture_ptr->buffer_cb + chroma_buffer_offset;
+            for (unsigned i = 0; i < source_chroma_height; i++) {
+                EB_MEMCPY(dst, src, source_cb_stride);
+                src += source_cb_stride;
+                dst += chroma_stride;
             }
 
-            // V 8bit
-            for (input_row_index = 0; input_row_index < luma_height >> 1; input_row_index++) {
-                EB_MEMCPY((input_picture_ptr->buffer_cr + chroma_buffer_offset + chroma_stride * input_row_index),
-                    (input_ptr->cr + (source_cr_stride*input_row_index)),
-                    chroma_width);
+            src = input_ptr->cr;
+            dst = input_picture_ptr->buffer_cr + chroma_buffer_offset;
+            for (unsigned i = 0; i < source_chroma_height; i++) {
+                EB_MEMCPY(dst, src, source_cr_stride);
+                src += source_cr_stride;
+                dst += chroma_stride;
             }
-
             //efficient copy - final
             //compressed 2Bit in 1D format
             {
@@ -3621,6 +3648,7 @@ EbErrorType init_svt_av1_encoder_handle(
 
     return return_error;
 }
+
 static EbErrorType allocate_frame_buffer(
     SequenceControlSet       *scs_ptr,
     EbBufferHeaderType        *input_buffer)
@@ -3629,9 +3657,17 @@ static EbErrorType allocate_frame_buffer(
     EbPictureBufferDescInitData input_pic_buf_desc_init_data;
     EbSvtAv1EncConfiguration   * config = &scs_ptr->static_config;
     uint8_t is_16bit = config->encoder_bit_depth > 8 ? 1 : 0;
-    // Init Picture Init data
-    input_pic_buf_desc_init_data.max_width = (uint16_t)scs_ptr->max_input_luma_width;
-    input_pic_buf_desc_init_data.max_height = (uint16_t)scs_ptr->max_input_luma_height;
+
+    input_pic_buf_desc_init_data.max_width =
+        !scs_ptr->max_input_luma_width % 8 ?
+        scs_ptr->max_input_luma_width :
+        scs_ptr->max_input_luma_width + (scs_ptr->max_input_luma_width % 8);
+
+    input_pic_buf_desc_init_data.max_height =
+        !scs_ptr->max_input_luma_height % 8 ?
+        scs_ptr->max_input_luma_height :
+        scs_ptr->max_input_luma_height + (scs_ptr->max_input_luma_height % 8);
+
     input_pic_buf_desc_init_data.bit_depth = (EbBitDepthEnum)config->encoder_bit_depth;
     input_pic_buf_desc_init_data.color_format = (EbColorFormat)config->encoder_color_format;
 
@@ -3640,6 +3676,7 @@ static EbErrorType allocate_frame_buffer(
     else
         input_pic_buf_desc_init_data.buffer_enable_mask = is_16bit ?
              PICTURE_BUFFER_DESC_FULL_MASK : 0;
+
     input_pic_buf_desc_init_data.left_padding = scs_ptr->left_padding;
     input_pic_buf_desc_init_data.right_padding = scs_ptr->right_padding;
     input_pic_buf_desc_init_data.top_padding = scs_ptr->top_padding;
@@ -3661,6 +3698,7 @@ static EbErrorType allocate_frame_buffer(
             eb_picture_buffer_desc_ctor,
             (EbPtr)&input_pic_buf_desc_init_data);
         input_buffer->p_buffer = (uint8_t*)buf;
+
         if (is_16bit && config->compressed_ten_bit_format == 1) {
             //pack 4 2bit pixels into 1Byte
             EB_MALLOC_ALIGNED_ARRAY(buf->buffer_bit_inc_y,

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -942,8 +942,8 @@ EB_API EbErrorType eb_init_encoder(EbComponentType *svt_enc_component)
     setup_rtcd_internal(enc_handle_ptr->scs_instance_array[0]->scs_ptr->static_config.use_cpu_flags);
 
 #if NON8_FIX_REST
-    if(enc_handle_ptr->scs_instance_array[0]->scs_ptr->max_input_pad_right>0 || 
-       enc_handle_ptr->scs_instance_array[0]->scs_ptr->max_input_pad_bottom>0)    
+    if(enc_handle_ptr->scs_instance_array[0]->scs_ptr->max_input_pad_right>0 ||
+       enc_handle_ptr->scs_instance_array[0]->scs_ptr->max_input_pad_bottom>0)
         setup_rtcd_non8(enc_handle_ptr->scs_instance_array[0]->scs_ptr->static_config.use_cpu_flags);
 #endif
 


### PR DESCRIPTION
Fixes encoding for pictures with a non multiple of 8 dimensions. Bonus: also saves a few bits for each sequence header, since `frame_width_bits_minus_1` and `frame_height_bits_minus_1` are now derived instead of always set to 16 - 1.