### PR TITLE
Fix issues in manual prediction structure scheme

### DIFF
--- a/Config/PredStruct_level5.cfg
+++ b/Config/PredStruct_level5.cfg
@@ -35,4 +35,4 @@ PredStructEntry :  27            25           3              1             1    
 PredStructEntry :  28            30           5              1             1             1                  -1
 PredStructEntry :  29            29           4              1             1             2                  -2
 PredStructEntry :  30            31           5              1             1             1                  -1
-PredStructEntry :  31            0            0              1             1             32                 -32
+PredStructEntry :  31            0            0              1             1             32                 32

--- a/Source/Lib/Encoder/Codec/EbEncodeContext.h
+++ b/Source/Lib/Encoder/Codec/EbEncodeContext.h
@@ -165,6 +165,8 @@ typedef struct EncodeContext {
     DPBInfo dpb_list[REF_FRAMES];
     uint64_t display_picture_number;
     EbBool  is_mini_gop_changed;
+    EbBool  is_i_slice_in_last_mini_gop;
+    uint64_t i_slice_picture_number_in_last_mini_gop;
 } EncodeContext;
 
 typedef struct EncodeContextInitData {

--- a/Source/Lib/Encoder/Codec/EbPredictionStructure.c
+++ b/Source/Lib/Encoder/Codec/EbPredictionStructure.c
@@ -2008,8 +2008,8 @@ EbErrorType prediction_structure_group_ctor(PredictionStructureGroup *pred_struc
     if (ref_count_used > 0 && ref_count_used < MAX_REF_IDX) {
         for (int gop_i = 1; gop_i < 4; ++gop_i) {
             for (int i = ref_count_used; i < MAX_REF_IDX; ++i) {
-                three_level_hierarchical_pred_struct[gop_i].ref_list0[i] = 0;
-                three_level_hierarchical_pred_struct[gop_i].ref_list1[i] = 0;
+                prediction_structure_config_array[2].entry_array[gop_i].ref_list0[i] = 0;
+                prediction_structure_config_array[2].entry_array[gop_i].ref_list1[i] = 0;
             }
         }
 
@@ -2030,8 +2030,8 @@ EbErrorType prediction_structure_group_ctor(PredictionStructureGroup *pred_struc
 
     for (int gop_i = 1; gop_i < 32; ++gop_i) {
         for (int i = 1; i < MAX_REF_IDX; ++i) {
-            six_level_hierarchical_pred_struct[gop_i].ref_list0[i] = 0;
-            six_level_hierarchical_pred_struct[gop_i].ref_list1[i] = 0;
+            prediction_structure_config_array[5].entry_array[gop_i].ref_list0[i] = 0;
+            prediction_structure_config_array[5].entry_array[gop_i].ref_list1[i] = 0;
         }
     }
 


### PR DESCRIPTION
This PR fixes issues in manual prediction structure scheme:

1. Move updating dependent lists for I slice from I slice to the start of the next minigop, because DPB management in manual prediction structure scheme needs processing frames in encoding order in a minigop, and I slice is always the first frame in encoding order but the last frame in display order in a minigop.
  
2. Fix merge issue for level5, YUV decoded from the streams made by the same manual and fixed prediction structures respectively can be bit identical.
  