### PR TITLE
Chroma search optimization

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -34,6 +34,12 @@
 extern "C" {
 #endif
 
+#define CHROMA_SEARCH_OPT        1 // Move chroma search to be done on the best intra candidate survived from MD stage 2
+#if CHROMA_SEARCH_OPT
+#define INFR_OPT                 1 // lossless
+#define MOVE_OPT                 1 // semi-lossless
+#define COMP_OPT                 1 // lossy
+#endif
 #define OIS_MEM              1 //reduce memory consumption due to ois struct
 
 
@@ -162,8 +168,15 @@ enum {
 #define BLOCK_MAX_COUNT_SB_64 1101 // TODO: reduce alloction for 64x64
 #define MAX_TXB_COUNT 4 // Maximum number of transform blocks.
 #define MAX_NFL 125 // Maximum number of candidates MD can support
+#if INFR_OPT
+#define MAX_NFL_BUFF_Y \
+    (MAX_NFL + CAND_CLASS_TOTAL) //need one extra temp buffer for each fast loop call
+#define MAX_NFL_BUFF \
+    (MAX_NFL_BUFF_Y + 84) //need one extra temp buffer for each fast loop call
+#else
 #define MAX_NFL_BUFF \
     (MAX_NFL + CAND_CLASS_TOTAL) //need one extra temp buffer for each fast loop call
+#endif
 #define MAX_LAD 120 // max lookahead-distance 2x60fps
 #define ROUND_UV(x) (((x) >> 3) << 3)
 #define AV1_PROB_COST_SHIFT 9
@@ -2746,6 +2759,9 @@ static const uint8_t intra_area_th_class_1[MAX_HIERARCHICAL_LEVEL][MAX_TEMPORAL_
 #define CHROMA_MODE_1  1 // Fast chroma search @ MD
 #define CHROMA_MODE_2  2 // Chroma blind @ MD + CFL @ EP
 #define CHROMA_MODE_3  3 // Chroma blind @ MD + no CFL @ EP
+#if MOVE_OPT
+#define CHROMA_MODE_01  4 // Full chroma search @ last MD stage.
+#endif
 
 typedef enum EbCleanUpMode
 {

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -1417,7 +1417,11 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
 
     } else // use specified level
         context_ptr->chroma_level = scs_ptr->static_config.set_chroma_mode;
-
+#if MOVE_OPT
+    context_ptr->chroma_level = (pcs_ptr->enc_mode > ENC_M0 &&
+        context_ptr->chroma_level == CHROMA_MODE_0) ? CHROMA_MODE_01 :
+        context_ptr->chroma_level;
+#endif
     // Set the full loop escape level
     // Level                Settings
     // 0                    Off
@@ -1732,8 +1736,11 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
             context_ptr->spatial_sse_full_loop = EB_FALSE;
     else
         context_ptr->spatial_sse_full_loop = scs_ptr->static_config.spatial_sse_fl;
-
+#if MOVE_OPT
+    if (context_ptr->chroma_level <= CHROMA_MODE_1 || context_ptr->chroma_level == CHROMA_MODE_01)
+#else
     if (context_ptr->chroma_level <= CHROMA_MODE_1)
+#endif
         context_ptr->blk_skip_decision = EB_TRUE;
     else
         context_ptr->blk_skip_decision = EB_FALSE;

--- a/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
@@ -21,9 +21,7 @@
 #include "aom_dsp_rtcd.h"
 #include "EbRateDistortionCost.h"
 
-
-
-extern void av1_set_ref_frame(MvReferenceFrame *rf, int8_t ref_frame_type);
+extern void             av1_set_ref_frame(MvReferenceFrame *rf, int8_t ref_frame_type);
 extern AomVarianceFnPtr mefn_ptr[BlockSizeS_ALL];
 
 static INLINE MV clamp_mv_to_umv_border_sb(const MacroBlockD *xd, const MV *src_mv, int32_t bw,
@@ -36,7 +34,7 @@ static INLINE MV clamp_mv_to_umv_border_sb(const MacroBlockD *xd, const MV *src_
     const int32_t spel_top    = (AOM_INTERP_EXTEND + bh) << SUBPEL_BITS;
     const int32_t spel_bottom = spel_top - SUBPEL_SHIFTS;
     MV            clamped_mv  = {(int16_t)(src_mv->row * (1 << (1 - ss_y))),
-                                 (int16_t)(src_mv->col * (1 << (1 - ss_x)))};
+                     (int16_t)(src_mv->col * (1 << (1 - ss_x)))};
     assert(ss_x <= 1);
     assert(ss_y <= 1);
 
@@ -131,7 +129,6 @@ void av1_make_masked_inter_predictor(uint8_t *src_ptr, uint32_t src_stride, uint
                                    bitdepth);
 }
 
-
 #define MAX_MASK_VALUE (1 << WEDGE_WEIGHT_BITS)
 
 /**
@@ -175,82 +172,82 @@ uint64_t av1_wedge_sse_from_residuals_c(const int16_t *r1, const int16_t *d, con
     return ROUND_POWER_OF_TWO(csse, 2 * WEDGE_WEIGHT_BITS);
 }
 static const uint8_t bsize_curvfit_model_cat_lookup[BlockSizeS_ALL] = {
-        0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3, 3, 3, 0, 0, 1, 1, 2, 2};
+    0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 3, 3, 3, 0, 0, 1, 1, 2, 2};
 static int          sse_norm_curvfit_model_cat_lookup(double sse_norm) { return (sse_norm > 16.0); }
 static const double interp_rgrid_curv[4][65] = {
-        {
-                0.000000,    0.000000,    0.000000,    0.000000,    0.000000,    0.000000,    0.000000,
-                0.000000,    0.000000,    0.000000,    0.000000,    23.801499,   28.387688,   33.388795,
-                42.298282,   41.525408,   51.597692,   49.566271,   54.632979,   60.321507,   67.730678,
-                75.766165,   85.324032,   96.600012,   120.839562,  173.917577,  255.974908,  354.107573,
-                458.063476,  562.345966,  668.568424,  772.072881,  878.598490,  982.202274,  1082.708946,
-                1188.037853, 1287.702240, 1395.588773, 1490.825830, 1584.231230, 1691.386090, 1766.822555,
-                1869.630904, 1926.743565, 2002.949495, 2047.431137, 2138.486068, 2154.743767, 2209.242472,
-                2277.593051, 2290.996432, 2307.452938, 2343.567091, 2397.654644, 2469.425868, 2558.591037,
-                2664.860422, 2787.944296, 2927.552932, 3083.396602, 3255.185579, 3442.630134, 3645.440541,
-                3863.327072, 4096.000000,
-        },
-        {
-                0.000000,    0.000000,    0.000000,    0.000000,    0.000000,    0.000000,    0.000000,
-                0.000000,    0.000000,    0.000000,    0.000000,    8.998436,    9.439592,    9.731837,
-                10.865931,   11.561347,   12.578139,   14.205101,   16.770584,   19.094853,   21.330863,
-                23.298907,   26.901921,   34.501017,   57.891733,   112.234763,  194.853189,  288.302032,
-                380.499422,  472.625309,  560.226809,  647.928463,  734.155122,  817.489721,  906.265783,
-                999.260562,  1094.489206, 1197.062998, 1293.296825, 1378.926484, 1472.760990, 1552.663779,
-                1635.196884, 1692.451951, 1759.741063, 1822.162720, 1916.515921, 1966.686071, 2031.647506,
-                2033.700134, 2087.847688, 2161.688858, 2242.536028, 2334.023491, 2436.337802, 2549.665519,
-                2674.193198, 2810.107395, 2957.594666, 3116.841567, 3288.034655, 3471.360486, 3667.005616,
-                3875.156602, 4096.000000,
-        },
-        {
-                0.000000,    0.000000,    0.000000,    0.000000,    0.000000,    0.000000,    0.000000,
-                0.000000,    0.000000,    0.000000,    0.000000,    2.377584,    2.557185,    2.732445,
-                2.851114,    3.281800,    3.765589,    4.342578,    5.145582,    5.611038,    6.642238,
-                7.945977,    11.800522,   17.346624,   37.501413,   87.216800,   165.860942,  253.865564,
-                332.039345,  408.518863,  478.120452,  547.268590,  616.067676,  680.022540,  753.863541,
-                834.529973,  919.489191,  1008.264989, 1092.230318, 1173.971886, 1249.514122, 1330.510941,
-                1399.523249, 1466.923387, 1530.533471, 1586.515722, 1695.197774, 1746.648696, 1837.136959,
-                1909.075485, 1975.074651, 2060.159200, 2155.335095, 2259.762505, 2373.710437, 2497.447898,
-                2631.243895, 2775.367434, 2930.087523, 3095.673170, 3272.393380, 3460.517161, 3660.313520,
-                3872.051464, 4096.000000,
-        },
-        {
-                0.000000,    0.000000,    0.000000,    0.000000,    0.000000,    0.000000,    0.000000,
-                0.000000,    0.000000,    0.000000,    0.000000,    0.296997,    0.342545,    0.403097,
-                0.472889,    0.614483,    0.842937,    1.050824,    1.326663,    1.717750,    2.530591,
-                3.582302,    6.995373,    9.973335,    24.042464,   56.598240,   113.680735,  180.018689,
-                231.050567,  266.101082,  294.957934,  323.326511,  349.434429,  380.443211,  408.171987,
-                441.214916,  475.716772,  512.900000,  551.186939,  592.364455,  624.527378,  661.940693,
-                679.185473,  724.800679,  764.781792,  873.050019,  950.299001,  939.292954,  1052.406153,
-                1033.893184, 1112.182406, 1219.174326, 1337.296681, 1471.648357, 1622.492809, 1790.093491,
-                1974.713858, 2176.617364, 2396.067465, 2633.327614, 2888.661266, 3162.331876, 3454.602899,
-                3765.737789, 4096.000000,
-        },
+    {
+        0.000000,    0.000000,    0.000000,    0.000000,    0.000000,    0.000000,    0.000000,
+        0.000000,    0.000000,    0.000000,    0.000000,    23.801499,   28.387688,   33.388795,
+        42.298282,   41.525408,   51.597692,   49.566271,   54.632979,   60.321507,   67.730678,
+        75.766165,   85.324032,   96.600012,   120.839562,  173.917577,  255.974908,  354.107573,
+        458.063476,  562.345966,  668.568424,  772.072881,  878.598490,  982.202274,  1082.708946,
+        1188.037853, 1287.702240, 1395.588773, 1490.825830, 1584.231230, 1691.386090, 1766.822555,
+        1869.630904, 1926.743565, 2002.949495, 2047.431137, 2138.486068, 2154.743767, 2209.242472,
+        2277.593051, 2290.996432, 2307.452938, 2343.567091, 2397.654644, 2469.425868, 2558.591037,
+        2664.860422, 2787.944296, 2927.552932, 3083.396602, 3255.185579, 3442.630134, 3645.440541,
+        3863.327072, 4096.000000,
+    },
+    {
+        0.000000,    0.000000,    0.000000,    0.000000,    0.000000,    0.000000,    0.000000,
+        0.000000,    0.000000,    0.000000,    0.000000,    8.998436,    9.439592,    9.731837,
+        10.865931,   11.561347,   12.578139,   14.205101,   16.770584,   19.094853,   21.330863,
+        23.298907,   26.901921,   34.501017,   57.891733,   112.234763,  194.853189,  288.302032,
+        380.499422,  472.625309,  560.226809,  647.928463,  734.155122,  817.489721,  906.265783,
+        999.260562,  1094.489206, 1197.062998, 1293.296825, 1378.926484, 1472.760990, 1552.663779,
+        1635.196884, 1692.451951, 1759.741063, 1822.162720, 1916.515921, 1966.686071, 2031.647506,
+        2033.700134, 2087.847688, 2161.688858, 2242.536028, 2334.023491, 2436.337802, 2549.665519,
+        2674.193198, 2810.107395, 2957.594666, 3116.841567, 3288.034655, 3471.360486, 3667.005616,
+        3875.156602, 4096.000000,
+    },
+    {
+        0.000000,    0.000000,    0.000000,    0.000000,    0.000000,    0.000000,    0.000000,
+        0.000000,    0.000000,    0.000000,    0.000000,    2.377584,    2.557185,    2.732445,
+        2.851114,    3.281800,    3.765589,    4.342578,    5.145582,    5.611038,    6.642238,
+        7.945977,    11.800522,   17.346624,   37.501413,   87.216800,   165.860942,  253.865564,
+        332.039345,  408.518863,  478.120452,  547.268590,  616.067676,  680.022540,  753.863541,
+        834.529973,  919.489191,  1008.264989, 1092.230318, 1173.971886, 1249.514122, 1330.510941,
+        1399.523249, 1466.923387, 1530.533471, 1586.515722, 1695.197774, 1746.648696, 1837.136959,
+        1909.075485, 1975.074651, 2060.159200, 2155.335095, 2259.762505, 2373.710437, 2497.447898,
+        2631.243895, 2775.367434, 2930.087523, 3095.673170, 3272.393380, 3460.517161, 3660.313520,
+        3872.051464, 4096.000000,
+    },
+    {
+        0.000000,    0.000000,    0.000000,    0.000000,    0.000000,    0.000000,    0.000000,
+        0.000000,    0.000000,    0.000000,    0.000000,    0.296997,    0.342545,    0.403097,
+        0.472889,    0.614483,    0.842937,    1.050824,    1.326663,    1.717750,    2.530591,
+        3.582302,    6.995373,    9.973335,    24.042464,   56.598240,   113.680735,  180.018689,
+        231.050567,  266.101082,  294.957934,  323.326511,  349.434429,  380.443211,  408.171987,
+        441.214916,  475.716772,  512.900000,  551.186939,  592.364455,  624.527378,  661.940693,
+        679.185473,  724.800679,  764.781792,  873.050019,  950.299001,  939.292954,  1052.406153,
+        1033.893184, 1112.182406, 1219.174326, 1337.296681, 1471.648357, 1622.492809, 1790.093491,
+        1974.713858, 2176.617364, 2396.067465, 2633.327614, 2888.661266, 3162.331876, 3454.602899,
+        3765.737789, 4096.000000,
+    },
 };
 
 static const double interp_dgrid_curv[2][65] = {
-        {
-                16.000000, 15.962891, 15.925174, 15.886888, 15.848074, 15.808770, 15.769015, 15.728850,
-                15.688313, 15.647445, 15.606284, 15.564870, 15.525918, 15.483820, 15.373330, 15.126844,
-                14.637442, 14.184387, 13.560070, 12.880717, 12.165995, 11.378144, 10.438769, 9.130790,
-                7.487633,  5.688649,  4.267515,  3.196300,  2.434201,  1.834064,  1.369920,  1.035921,
-                0.775279,  0.574895,  0.427232,  0.314123,  0.233236,  0.171440,  0.128188,  0.092762,
-                0.067569,  0.049324,  0.036330,  0.027008,  0.019853,  0.015539,  0.011093,  0.008733,
-                0.007624,  0.008105,  0.005427,  0.004065,  0.003427,  0.002848,  0.002328,  0.001865,
-                0.001457,  0.001103,  0.000801,  0.000550,  0.000348,  0.000193,  0.000085,  0.000021,
-                0.000000,
-        },
-        {
-                16.000000, 15.996116, 15.984769, 15.966413, 15.941505, 15.910501, 15.873856, 15.832026,
-                15.785466, 15.734633, 15.679981, 15.621967, 15.560961, 15.460157, 15.288367, 15.052462,
-                14.466922, 13.921212, 13.073692, 12.222005, 11.237799, 9.985848,  8.898823,  7.423519,
-                5.995325,  4.773152,  3.744032,  2.938217,  2.294526,  1.762412,  1.327145,  1.020728,
-                0.765535,  0.570548,  0.425833,  0.313825,  0.232959,  0.171324,  0.128174,  0.092750,
-                0.067558,  0.049319,  0.036330,  0.027008,  0.019853,  0.015539,  0.011093,  0.008733,
-                0.007624,  0.008105,  0.005427,  0.004065,  0.003427,  0.002848,  0.002328,  0.001865,
-                0.001457,  0.001103,  0.000801,  0.000550,  0.000348,  0.000193,  0.000085,  0.000021,
-                -0.000000,
-        },
+    {
+        16.000000, 15.962891, 15.925174, 15.886888, 15.848074, 15.808770, 15.769015, 15.728850,
+        15.688313, 15.647445, 15.606284, 15.564870, 15.525918, 15.483820, 15.373330, 15.126844,
+        14.637442, 14.184387, 13.560070, 12.880717, 12.165995, 11.378144, 10.438769, 9.130790,
+        7.487633,  5.688649,  4.267515,  3.196300,  2.434201,  1.834064,  1.369920,  1.035921,
+        0.775279,  0.574895,  0.427232,  0.314123,  0.233236,  0.171440,  0.128188,  0.092762,
+        0.067569,  0.049324,  0.036330,  0.027008,  0.019853,  0.015539,  0.011093,  0.008733,
+        0.007624,  0.008105,  0.005427,  0.004065,  0.003427,  0.002848,  0.002328,  0.001865,
+        0.001457,  0.001103,  0.000801,  0.000550,  0.000348,  0.000193,  0.000085,  0.000021,
+        0.000000,
+    },
+    {
+        16.000000, 15.996116, 15.984769, 15.966413, 15.941505, 15.910501, 15.873856, 15.832026,
+        15.785466, 15.734633, 15.679981, 15.621967, 15.560961, 15.460157, 15.288367, 15.052462,
+        14.466922, 13.921212, 13.073692, 12.222005, 11.237799, 9.985848,  8.898823,  7.423519,
+        5.995325,  4.773152,  3.744032,  2.938217,  2.294526,  1.762412,  1.327145,  1.020728,
+        0.765535,  0.570548,  0.425833,  0.313825,  0.232959,  0.171324,  0.128174,  0.092750,
+        0.067558,  0.049319,  0.036330,  0.027008,  0.019853,  0.015539,  0.011093,  0.008733,
+        0.007624,  0.008105,  0.005427,  0.004065,  0.003427,  0.002848,  0.002328,  0.001865,
+        0.001457,  0.001103,  0.000801,  0.000550,  0.000348,  0.000193,  0.000085,  0.000021,
+        -0.000000,
+    },
 };
 
 /*
@@ -305,7 +302,7 @@ static void model_rd_with_curvfit(PictureControlSet *picture_control_set_ptr, Bl
     (void)plane_bsize;
     const int dequant_shift = 3;
     int32_t   current_q_index =
-            picture_control_set_ptr->parent_pcs_ptr->frm_hdr.quantization_params.base_q_idx;
+        picture_control_set_ptr->parent_pcs_ptr->frm_hdr.quantization_params.base_q_idx;
     Dequants *const dequants  = &picture_control_set_ptr->parent_pcs_ptr->deq;
     int16_t         quantizer = dequants->y_dequant_q3[current_q_index][1];
 
@@ -411,11 +408,11 @@ static void pick_wedge(PictureControlSet *picture_control_set_ptr, ModeDecisionC
                        const int16_t *const residual1, const int16_t *const diff10,
                        int8_t *const best_wedge_sign, int8_t *const best_wedge_index) {
     uint8_t hbd_mode_decision = context_ptr->hbd_mode_decision == EB_DUAL_BIT_MD
-                                ? EB_8_BIT_MD
-                                : context_ptr->hbd_mode_decision;
+                                    ? EB_8_BIT_MD
+                                    : context_ptr->hbd_mode_decision;
     EbPictureBufferDesc *src_pic =
-            hbd_mode_decision ? picture_control_set_ptr->input_frame16bit
-                              : picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
+        hbd_mode_decision ? picture_control_set_ptr->input_frame16bit
+                          : picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
     const int bw = block_size_wide[bsize];
     const int bh = block_size_high[bsize];
     const int N  = bw * bh;
@@ -447,11 +444,11 @@ static void pick_wedge(PictureControlSet *picture_control_set_ptr, ModeDecisionC
         uint8_t *src_buf = src_pic->buffer_y + (context_ptr->blk_origin_x + src_pic->origin_x) +
                            (context_ptr->blk_origin_y + src_pic->origin_y) * src_pic->stride_y;
         aom_subtract_block(
-                bh, bw, residual0, bw, src_buf /*src->buf*/, src_pic->stride_y /*src->stride*/, p0, bw);
+            bh, bw, residual0, bw, src_buf /*src->buf*/, src_pic->stride_y /*src->stride*/, p0, bw);
     }
     int64_t sign_limit =
-            ((int64_t)aom_sum_squares_i16(residual0, N) - (int64_t)aom_sum_squares_i16(residual1, N)) *
-            (1 << WEDGE_WEIGHT_BITS) / 2;
+        ((int64_t)aom_sum_squares_i16(residual0, N) - (int64_t)aom_sum_squares_i16(residual1, N)) *
+        (1 << WEDGE_WEIGHT_BITS) / 2;
     int16_t *ds = residual0;
 
     av1_wedge_compute_delta_squares(ds, residual0, residual1, N);
@@ -466,7 +463,7 @@ static void pick_wedge(PictureControlSet *picture_control_set_ptr, ModeDecisionC
         sse  = ROUND_POWER_OF_TWO(sse, bd_round);
 
         model_rd_with_curvfit(
-                picture_control_set_ptr, bsize, sse, N, &rate, &dist, context_ptr->full_lambda);
+            picture_control_set_ptr, bsize, sse, N, &rate, &dist, context_ptr->full_lambda);
 
         rd = RDCOST(context_ptr->full_lambda, rate, dist);
 
@@ -478,44 +475,43 @@ static void pick_wedge(PictureControlSet *picture_control_set_ptr, ModeDecisionC
     }
 }
 
-
 static int8_t estimate_wedge_sign(PictureControlSet *  picture_control_set_ptr,
                                   ModeDecisionContext *context_ptr, const BlockSize bsize,
                                   const uint8_t *pred0, int stride0, const uint8_t *pred1,
                                   int stride1) {
     uint8_t hbd_mode_decision = context_ptr->hbd_mode_decision == EB_DUAL_BIT_MD
-                                ? EB_8_BIT_MD
-                                : context_ptr->hbd_mode_decision;
+                                    ? EB_8_BIT_MD
+                                    : context_ptr->hbd_mode_decision;
     static const BlockSize split_qtr[BlockSizeS_ALL] = {//                            4X4
-            BLOCK_INVALID,
-            // 4X8,        8X4,           8X8
-            BLOCK_INVALID,
-            BLOCK_INVALID,
-            BLOCK_4X4,
-            // 8X16,       16X8,          16X16
-            BLOCK_4X8,
-            BLOCK_8X4,
-            BLOCK_8X8,
-            // 16X32,      32X16,         32X32
-            BLOCK_8X16,
-            BLOCK_16X8,
-            BLOCK_16X16,
-            // 32X64,      64X32,         64X64
-            BLOCK_16X32,
-            BLOCK_32X16,
-            BLOCK_32X32,
-            // 64x128,     128x64,        128x128
-            BLOCK_32X64,
-            BLOCK_64X32,
-            BLOCK_64X64,
-            // 4X16,       16X4,          8X32
-            BLOCK_INVALID,
-            BLOCK_INVALID,
-            BLOCK_4X16,
-            // 32X8,       16X64,         64X16
-            BLOCK_16X4,
-            BLOCK_8X32,
-            BLOCK_32X8};
+                                                        BLOCK_INVALID,
+                                                        // 4X8,        8X4,           8X8
+                                                        BLOCK_INVALID,
+                                                        BLOCK_INVALID,
+                                                        BLOCK_4X4,
+                                                        // 8X16,       16X8,          16X16
+                                                        BLOCK_4X8,
+                                                        BLOCK_8X4,
+                                                        BLOCK_8X8,
+                                                        // 16X32,      32X16,         32X32
+                                                        BLOCK_8X16,
+                                                        BLOCK_16X8,
+                                                        BLOCK_16X16,
+                                                        // 32X64,      64X32,         64X64
+                                                        BLOCK_16X32,
+                                                        BLOCK_32X16,
+                                                        BLOCK_32X32,
+                                                        // 64x128,     128x64,        128x128
+                                                        BLOCK_32X64,
+                                                        BLOCK_64X32,
+                                                        BLOCK_64X64,
+                                                        // 4X16,       16X4,          8X32
+                                                        BLOCK_INVALID,
+                                                        BLOCK_INVALID,
+                                                        BLOCK_4X16,
+                                                        // 32X8,       16X64,         64X16
+                                                        BLOCK_16X4,
+                                                        BLOCK_8X32,
+                                                        BLOCK_32X8};
 
     const int bw = block_size_wide[bsize];
     const int bh = block_size_high[bsize];
@@ -527,9 +523,9 @@ static int8_t estimate_wedge_sign(PictureControlSet *  picture_control_set_ptr,
     (void)f_index;
 
     const AomVarianceFnPtr *fn_ptr = &mefn_ptr[bsize];
-    EbPictureBufferDesc *        src_pic =
-            hbd_mode_decision ? picture_control_set_ptr->input_frame16bit
-                              : picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
+    EbPictureBufferDesc *   src_pic =
+        hbd_mode_decision ? picture_control_set_ptr->input_frame16bit
+                          : picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
     uint8_t *src_buf = src_pic->buffer_y + (context_ptr->blk_origin_x + src_pic->origin_x) +
                        (context_ptr->blk_origin_y + src_pic->origin_y) * src_pic->stride_y;
 
@@ -559,17 +555,17 @@ static int8_t estimate_wedge_sign(PictureControlSet *  picture_control_set_ptr,
                &esq[1][3]);
 
     tl =
-            ((int64_t)esq[0][0] + esq[0][1] + esq[0][2]) - ((int64_t)esq[1][0] + esq[1][1] + esq[1][2]);
+        ((int64_t)esq[0][0] + esq[0][1] + esq[0][2]) - ((int64_t)esq[1][0] + esq[1][1] + esq[1][2]);
     br =
-            ((int64_t)esq[1][3] + esq[1][1] + esq[1][2]) - ((int64_t)esq[0][3] + esq[0][1] + esq[0][2]);
+        ((int64_t)esq[1][3] + esq[1][1] + esq[1][2]) - ((int64_t)esq[0][3] + esq[0][1] + esq[0][2]);
     return (tl + br > 0);
 }
 // Choose the best wedge index the specified sign
 int64_t pick_wedge_fixed_sign(ModeDecisionCandidate *candidate_ptr,
                               PictureControlSet *    picture_control_set_ptr,
                               ModeDecisionContext *  context_ptr,
-        //const AV1_COMP *const cpi,
-        //const MACROBLOCK *const x,
+                              //const AV1_COMP *const cpi,
+                              //const MACROBLOCK *const x,
                               const BlockSize bsize, const int16_t *const residual1,
                               const int16_t *const diff10, const int8_t wedge_sign,
                               int8_t *const best_wedge_index) {
@@ -593,7 +589,7 @@ int64_t pick_wedge_fixed_sign(ModeDecisionCandidate *candidate_ptr,
         sse  = av1_wedge_sse_from_residuals(residual1, diff10, mask, N);
         sse  = ROUND_POWER_OF_TWO(sse, bd_round);
         model_rd_with_curvfit(
-                picture_control_set_ptr, bsize, /*0,*/ sse, N, &rate, &dist, context_ptr->full_lambda);
+            picture_control_set_ptr, bsize, /*0,*/ sse, N, &rate, &dist, context_ptr->full_lambda);
         // model_rd_sse_fn[MODELRD_TYPE_MASKED_COMPOUND](cpi, x, bsize, 0, sse, N, &rate, &dist);
         // rate += x->wedge_idx_cost[bsize][wedge_index];
         rate += candidate_ptr->md_rate_estimation_ptr->wedge_idx_fac_bits[bsize][wedge_index];
@@ -627,7 +623,7 @@ static void pick_interinter_wedge(ModeDecisionCandidate * candidate_ptr,
     if (picture_control_set_ptr->parent_pcs_ptr->wedge_mode == 2 ||
         picture_control_set_ptr->parent_pcs_ptr->wedge_mode == 3) {
         wedge_sign =
-                estimate_wedge_sign(picture_control_set_ptr, context_ptr, bsize, p0, bw, p1, bw);
+            estimate_wedge_sign(picture_control_set_ptr, context_ptr, bsize, p0, bw, p1, bw);
     } else {
         pick_wedge(picture_control_set_ptr,
                    context_ptr,
@@ -649,8 +645,8 @@ static void pick_interinter_seg(PictureControlSet *     picture_control_set_ptr,
                                 const uint8_t *const p0, const uint8_t *const p1,
                                 const int16_t *const residual1, const int16_t *const diff10) {
     uint8_t hbd_mode_decision = context_ptr->hbd_mode_decision == EB_DUAL_BIT_MD
-                                ? EB_8_BIT_MD
-                                : context_ptr->hbd_mode_decision;
+                                    ? EB_8_BIT_MD
+                                    : context_ptr->hbd_mode_decision;
     const int         bw = block_size_wide[bsize];
     const int         bh = block_size_high[bsize];
     const int         N  = 1 << num_pels_log2_lookup[bsize];
@@ -669,17 +665,17 @@ static void pick_interinter_seg(PictureControlSet *     picture_control_set_ptr,
         // build mask and inverse
         if (hbd_mode_decision)
             av1_build_compound_diffwtd_mask_highbd(
-                    tmp_mask[cur_mask_type], cur_mask_type, p0, bw, p1, bw, bh, bw, EB_10BIT);
+                tmp_mask[cur_mask_type], cur_mask_type, p0, bw, p1, bw, bh, bw, EB_10BIT);
         else
             av1_build_compound_diffwtd_mask(
-                    tmp_mask[cur_mask_type], cur_mask_type, p0, bw, p1, bw, bh, bw);
+                tmp_mask[cur_mask_type], cur_mask_type, p0, bw, p1, bw, bh, bw);
         // compute rd for mask
         uint64_t sse = av1_wedge_sse_from_residuals(residual1, diff10, tmp_mask[cur_mask_type], N);
 
         sse = ROUND_POWER_OF_TWO(sse, bd_round);
 
         model_rd_with_curvfit(
-                picture_control_set_ptr, bsize, sse, N, &rate, &dist, context_ptr->full_lambda);
+            picture_control_set_ptr, bsize, sse, N, &rate, &dist, context_ptr->full_lambda);
 
         const int64_t rd0 = RDCOST(context_ptr->full_lambda, rate, dist);
 
@@ -719,7 +715,6 @@ void pick_interinter_mask(ModeDecisionCandidate *candidate_ptr,
     else
         assert(0);
 }
-
 
 //
 int64_t aom_highbd_sse_c(const uint8_t *a8, int a_stride, const uint8_t *b8, int b_stride,
@@ -808,8 +803,8 @@ void model_rd_for_sb_with_curvfit(PictureControlSet *  picture_control_set_ptr,
     *out_dist_sum = dist_sum;
 }
 
-int  get_comp_index_context_enc(PictureParentControlSet *pcs_ptr, int cur_frame_index,
-                                int bck_frame_index, int fwd_frame_index, const MacroBlockD *xd);
+int get_comp_index_context_enc(PictureParentControlSet *pcs_ptr, int cur_frame_index,
+                               int bck_frame_index, int fwd_frame_index, const MacroBlockD *xd);
 
 void combine_interintra(InterIntraMode mode, int8_t use_wedge_interintra, int wedge_index,
                         int wedge_sign, BlockSize bsize, BlockSize plane_bsize, uint8_t *comppred,
@@ -856,21 +851,21 @@ void combine_interintra(InterIntraMode mode, int8_t use_wedge_interintra, int we
 }
 
 extern void eb_av1_predict_intra_block(
-        TileInfo *tile, STAGE stage, const BlockGeom *blk_geom, const Av1Common *cm, int32_t wpx,
-        int32_t hpx, TxSize tx_size, PredictionMode mode, int32_t angle_delta, int32_t use_palette,
-        PaletteInfo *palette_info, FilterIntraMode filter_intra_mode, uint8_t *topNeighArray,
-        uint8_t *leftNeighArray, EbPictureBufferDesc *recon_buffer, int32_t col_off, int32_t row_off,
-        int32_t plane, BlockSize bsize, uint32_t tu_org_x_pict, uint32_t tu_org_y_pict,
-        uint32_t bl_org_x_pict, uint32_t bl_org_y_pict, uint32_t bl_org_x_mb, uint32_t bl_org_y_mb,
-        ModeInfo **mi_grid_base, SeqHeader *seq_header_ptr);
+    TileInfo *tile, STAGE stage, const BlockGeom *blk_geom, const Av1Common *cm, int32_t wpx,
+    int32_t hpx, TxSize tx_size, PredictionMode mode, int32_t angle_delta, int32_t use_palette,
+    PaletteInfo *palette_info, FilterIntraMode filter_intra_mode, uint8_t *topNeighArray,
+    uint8_t *leftNeighArray, EbPictureBufferDesc *recon_buffer, int32_t col_off, int32_t row_off,
+    int32_t plane, BlockSize bsize, uint32_t tu_org_x_pict, uint32_t tu_org_y_pict,
+    uint32_t bl_org_x_pict, uint32_t bl_org_y_pict, uint32_t bl_org_x_mb, uint32_t bl_org_y_mb,
+    ModeInfo **mi_grid_base, SeqHeader *seq_header_ptr);
 extern void eb_av1_predict_intra_block_16bit(
-        TileInfo *tile, STAGE stage, const BlockGeom *blk_geom, const Av1Common *cm, int32_t wpx,
-        int32_t hpx, TxSize tx_size, PredictionMode mode, int32_t angle_delta, int32_t use_palette,
-        PaletteInfo *palette_info, FilterIntraMode filter_intra_mode, uint16_t *topNeighArray,
-        uint16_t *leftNeighArray, EbPictureBufferDesc *recon_buffer, int32_t col_off, int32_t row_off,
-        int32_t plane, BlockSize bsize, uint32_t tu_org_x_pict, uint32_t tu_org_y_pict,
-        uint32_t bl_org_x_pict, uint32_t bl_org_y_pict, uint32_t bl_org_x_mb, uint32_t bl_org_y_mb,
-        ModeInfo **mi_grid_base, SeqHeader *seq_header_ptr);
+    TileInfo *tile, STAGE stage, const BlockGeom *blk_geom, const Av1Common *cm, int32_t wpx,
+    int32_t hpx, TxSize tx_size, PredictionMode mode, int32_t angle_delta, int32_t use_palette,
+    PaletteInfo *palette_info, FilterIntraMode filter_intra_mode, uint16_t *topNeighArray,
+    uint16_t *leftNeighArray, EbPictureBufferDesc *recon_buffer, int32_t col_off, int32_t row_off,
+    int32_t plane, BlockSize bsize, uint32_t tu_org_x_pict, uint32_t tu_org_y_pict,
+    uint32_t bl_org_x_pict, uint32_t bl_org_y_pict, uint32_t bl_org_x_mb, uint32_t bl_org_y_mb,
+    ModeInfo **mi_grid_base, SeqHeader *seq_header_ptr);
 
 struct build_prediction_hbd_ctxt {
     const AV1_COMMON *cm;
@@ -937,7 +932,7 @@ static INLINE void foreach_overlappable_nb_above(uint8_t is16bit, const AV1_COMM
          above_mi_col += mi_step) {
         ModeInfo /*MbModeInfo*/ **above_mi = prev_row_mi + above_mi_col;
         mi_step =
-                AOMMIN(mi_size_wide[above_mi[0]->mbmi.block_mi.sb_type], mi_size_wide[BLOCK_64X64]);
+            AOMMIN(mi_size_wide[above_mi[0]->mbmi.block_mi.sb_type], mi_size_wide[BLOCK_64X64]);
         // If we're considering a block with width 4, it should be treated as
         // half of a pair of blocks with chroma information in the second. Move
         // above_mi_col back to the start of the pair if needed, set above_mbmi
@@ -980,7 +975,7 @@ static INLINE void foreach_overlappable_nb_left(uint8_t is16bit, const AV1_COMMO
          left_mi_row += mi_step) {
         ModeInfo **left_mi = prev_col_mi + left_mi_row * xd->mi_stride;
         mi_step =
-                AOMMIN(mi_size_high[left_mi[0]->mbmi.block_mi.sb_type], mi_size_high[BLOCK_64X64]);
+            AOMMIN(mi_size_high[left_mi[0]->mbmi.block_mi.sb_type], mi_size_high[BLOCK_64X64]);
         if (mi_step == 1) {
             left_mi_row &= ~1;
             left_mi = prev_col_mi + (left_mi_row + 1) * xd->mi_stride;
@@ -1010,15 +1005,15 @@ int av1_skip_u4x4_pred_in_obmc(BlockSize bsize, int dir, int subsampling_x, int 
     const BlockSize bsize_plane = get_plane_block_size(bsize, subsampling_x, subsampling_y);
     switch (bsize_plane) {
 #if DISABLE_CHROMA_U8X8_OBMC
-        case BLOCK_4X4:
+    case BLOCK_4X4:
     case BLOCK_8X4:
     case BLOCK_4X8: return 1; break;
 #else
-        case BLOCK_4X4:
-        case BLOCK_8X4:
-        case BLOCK_4X8: return dir == 0; break;
+    case BLOCK_4X4:
+    case BLOCK_8X4:
+    case BLOCK_4X8: return dir == 0; break;
 #endif
-        default: return 0;
+    default: return 0;
     }
 }
 
@@ -1040,18 +1035,18 @@ void av1_setup_build_prediction_by_above_pred(MacroBlockD *xd, int rel_mi_col,
 
     if (is16bit)
         ctxt->ref_pic_list0 = ((EbReferenceObject *)ctxt->picture_control_set_ptr
-                ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
-                ->object_ptr)
-                ->reference_picture16bit;
+                                   ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
+                                   ->object_ptr)
+                                  ->reference_picture16bit;
     else
         ctxt->ref_pic_list0 = ((EbReferenceObject *)ctxt->picture_control_set_ptr
-                ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
-                ->object_ptr)
-                ->reference_picture;
+                                   ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
+                                   ->object_ptr)
+                                  ->reference_picture;
 
     xd->mb_to_left_edge = 8 * MI_SIZE * (-above_mi_col);
     xd->mb_to_right_edge =
-            ctxt->mb_to_far_edge + (xd->n4_w - rel_mi_col - above_mi_width) * MI_SIZE * 8;
+        ctxt->mb_to_far_edge + (xd->n4_w - rel_mi_col - above_mi_width) * MI_SIZE * 8;
 }
 void av1_setup_build_prediction_by_left_pred(MacroBlockD *xd, int rel_mi_row,
                                              uint8_t left_mi_height, MbModeInfo *left_mbmi,
@@ -1069,28 +1064,28 @@ void av1_setup_build_prediction_by_left_pred(MacroBlockD *xd, int rel_mi_row,
 
     if (is16bit)
         ctxt->ref_pic_list0 = ((EbReferenceObject *)ctxt->picture_control_set_ptr
-                ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
-                ->object_ptr)
-                ->reference_picture16bit;
+                                   ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
+                                   ->object_ptr)
+                                  ->reference_picture16bit;
     else
         ctxt->ref_pic_list0 = ((EbReferenceObject *)ctxt->picture_control_set_ptr
-                ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
-                ->object_ptr)
-                ->reference_picture;
+                                   ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
+                                   ->object_ptr)
+                                  ->reference_picture;
 
     xd->mb_to_top_edge = 8 * MI_SIZE * (-left_mi_row);
     xd->mb_to_bottom_edge =
-            ctxt->mb_to_far_edge + (xd->n4_h - rel_mi_row - left_mi_height) * MI_SIZE * 8;
+        ctxt->mb_to_far_edge + (xd->n4_h - rel_mi_row - left_mi_height) * MI_SIZE * 8;
 }
 
 EbErrorType get_single_prediction_for_obmc_luma_hbd(
-        uint32_t interp_filters, MacroBlockD *xd, MvUnit *mv_unit, uint16_t pu_origin_x,
-        uint16_t pu_origin_y, uint8_t bwidth, uint8_t bheight, EbPictureBufferDesc *ref_pic_list0,
-        EbPictureBufferDesc *prediction_ptr, uint16_t dst_origin_x, uint16_t dst_origin_y) {
+    uint32_t interp_filters, MacroBlockD *xd, MvUnit *mv_unit, uint16_t pu_origin_x,
+    uint16_t pu_origin_y, uint8_t bwidth, uint8_t bheight, EbPictureBufferDesc *ref_pic_list0,
+    EbPictureBufferDesc *prediction_ptr, uint16_t dst_origin_x, uint16_t dst_origin_y) {
     EbErrorType return_error = EB_ErrorNone;
     uint8_t     is_compound  = 0;
     DECLARE_ALIGNED(
-            32, uint16_t, tmp_dstY[128 * 128]); //move this to context if stack does not hold.
+        32, uint16_t, tmp_dstY[128 * 128]); //move this to context if stack does not hold.
 
     MV                 mv, mv_q4;
     int32_t            subpel_x, subpel_y;
@@ -1114,18 +1109,18 @@ EbErrorType get_single_prediction_for_obmc_luma_hbd(
         dst_stride = prediction_ptr->stride_y;
 
         mv_q4 = clamp_mv_to_umv_border_sb(
-                xd,
-                &mv,
-                bwidth,
-                bheight,
-                0,
-                0); //mv_q4 has 1 extra bit for fractionnal to accomodate chroma when accessing filter coeffs.
+            xd,
+            &mv,
+            bwidth,
+            bheight,
+            0,
+            0); //mv_q4 has 1 extra bit for fractionnal to accomodate chroma when accessing filter coeffs.
         subpel_x = mv_q4.col & SUBPEL_MASK;
         subpel_y = mv_q4.row & SUBPEL_MASK;
         src_ptr  = src_ptr + (mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS);
         conv_params = get_conv_params_no_round(0, 0, 0, tmp_dstY, 128, is_compound, EB_10BIT);
         av1_get_convolve_filter_params(
-                interp_filters, &filter_params_x, &filter_params_y, bwidth, bheight);
+            interp_filters, &filter_params_x, &filter_params_y, bwidth, bheight);
 
         convolveHbd[subpel_x != 0][subpel_y != 0][is_compound](src_ptr,
                                                                src_stride,
@@ -1143,9 +1138,9 @@ EbErrorType get_single_prediction_for_obmc_luma_hbd(
     return return_error;
 }
 EbErrorType get_single_prediction_for_obmc_chroma_hbd(
-        uint32_t interp_filters, MacroBlockD *xd, MvUnit *mv_unit, uint16_t pu_origin_x,
-        uint16_t pu_origin_y, uint8_t bwidth, uint8_t bheight, EbPictureBufferDesc *ref_pic_list0,
-        EbPictureBufferDesc *prediction_ptr, uint16_t dst_origin_x, uint16_t dst_origin_y) {
+    uint32_t interp_filters, MacroBlockD *xd, MvUnit *mv_unit, uint16_t pu_origin_x,
+    uint16_t pu_origin_y, uint8_t bwidth, uint8_t bheight, EbPictureBufferDesc *ref_pic_list0,
+    EbPictureBufferDesc *prediction_ptr, uint16_t dst_origin_x, uint16_t dst_origin_y) {
     EbErrorType return_error = EB_ErrorNone;
     uint8_t     is_compound  = 0;
 
@@ -1171,11 +1166,11 @@ EbErrorType get_single_prediction_for_obmc_chroma_hbd(
             src_ptr = (uint16_t *)ref_pic_list0->buffer_cb +
                       (ref_pic_list0->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
                       (ref_pic_list0->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
-                      ref_pic_list0->stride_cb;
+                          ref_pic_list0->stride_cb;
             dst_ptr = (uint16_t *)prediction_ptr->buffer_cb +
                       (prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
                       (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
-                      prediction_ptr->stride_cb;
+                          prediction_ptr->stride_cb;
             src_stride = ref_pic_list0->stride_cb;
             dst_stride = prediction_ptr->stride_cb;
 
@@ -1183,11 +1178,11 @@ EbErrorType get_single_prediction_for_obmc_chroma_hbd(
             subpel_x = mv_q4.col & SUBPEL_MASK;
             subpel_y = mv_q4.row & SUBPEL_MASK;
             src_ptr =
-                    src_ptr + (mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS);
+                src_ptr + (mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS);
             conv_params = get_conv_params_no_round(0, 0, 0, tmp_dstCb, 64, is_compound, EB_10BIT);
 
             av1_get_convolve_filter_params(
-                    interp_filters, &filter_params_x, &filter_params_y, bwidth, bheight);
+                interp_filters, &filter_params_x, &filter_params_y, bwidth, bheight);
 
             convolveHbd[subpel_x != 0][subpel_y != 0][is_compound](src_ptr,
                                                                    src_stride,
@@ -1206,11 +1201,11 @@ EbErrorType get_single_prediction_for_obmc_chroma_hbd(
             src_ptr = (uint16_t *)ref_pic_list0->buffer_cr +
                       (ref_pic_list0->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
                       (ref_pic_list0->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
-                      ref_pic_list0->stride_cr;
+                          ref_pic_list0->stride_cr;
             dst_ptr = (uint16_t *)prediction_ptr->buffer_cr +
                       (prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
                       (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
-                      prediction_ptr->stride_cr;
+                          prediction_ptr->stride_cr;
             src_stride = ref_pic_list0->stride_cr;
             dst_stride = prediction_ptr->stride_cr;
 
@@ -1218,10 +1213,10 @@ EbErrorType get_single_prediction_for_obmc_chroma_hbd(
             subpel_x = mv_q4.col & SUBPEL_MASK;
             subpel_y = mv_q4.row & SUBPEL_MASK;
             src_ptr =
-                    src_ptr + (mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS);
+                src_ptr + (mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS);
             conv_params = get_conv_params_no_round(0, 0, 0, tmp_dstCr, 64, is_compound, EB_10BIT);
             av1_get_convolve_filter_params(
-                    interp_filters, &filter_params_x, &filter_params_y, bwidth, bheight);
+                interp_filters, &filter_params_x, &filter_params_y, bwidth, bheight);
 
             convolveHbd[subpel_x != 0][subpel_y != 0][is_compound](src_ptr,
                                                                    src_stride,
@@ -1250,7 +1245,7 @@ EbErrorType get_single_prediction_for_obmc_luma(uint32_t interp_filters, MacroBl
     EbErrorType return_error = EB_ErrorNone;
     uint8_t     is_compound  = 0;
     DECLARE_ALIGNED(
-            32, uint16_t, tmp_dstY[128 * 128]); //move this to context if stack does not hold.
+        32, uint16_t, tmp_dstY[128 * 128]); //move this to context if stack does not hold.
 
     MV                 mv, mv_q4;
     int32_t            subpel_x, subpel_y;
@@ -1274,18 +1269,18 @@ EbErrorType get_single_prediction_for_obmc_luma(uint32_t interp_filters, MacroBl
         dst_stride = prediction_ptr->stride_y;
 
         mv_q4 = clamp_mv_to_umv_border_sb(
-                xd,
-                &mv,
-                bwidth,
-                bheight,
-                0,
-                0); //mv_q4 has 1 extra bit for fractionnal to accomodate chroma when accessing filter coeffs.
+            xd,
+            &mv,
+            bwidth,
+            bheight,
+            0,
+            0); //mv_q4 has 1 extra bit for fractionnal to accomodate chroma when accessing filter coeffs.
         subpel_x = mv_q4.col & SUBPEL_MASK;
         subpel_y = mv_q4.row & SUBPEL_MASK;
         src_ptr  = src_ptr + (mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS);
         conv_params = get_conv_params_no_round(0, 0, 0, tmp_dstY, 128, is_compound, EB_8BIT);
         av1_get_convolve_filter_params(
-                interp_filters, &filter_params_x, &filter_params_y, bwidth, bheight);
+            interp_filters, &filter_params_x, &filter_params_y, bwidth, bheight);
 
         convolve[subpel_x != 0][subpel_y != 0][is_compound](src_ptr,
                                                             src_stride,
@@ -1303,9 +1298,9 @@ EbErrorType get_single_prediction_for_obmc_luma(uint32_t interp_filters, MacroBl
 }
 
 EbErrorType get_single_prediction_for_obmc_chroma(
-        uint32_t interp_filters, MacroBlockD *xd, MvUnit *mv_unit, uint16_t pu_origin_x,
-        uint16_t pu_origin_y, uint8_t bwidth, uint8_t bheight, EbPictureBufferDesc *ref_pic_list0,
-        EbPictureBufferDesc *prediction_ptr, uint16_t dst_origin_x, uint16_t dst_origin_y) {
+    uint32_t interp_filters, MacroBlockD *xd, MvUnit *mv_unit, uint16_t pu_origin_x,
+    uint16_t pu_origin_y, uint8_t bwidth, uint8_t bheight, EbPictureBufferDesc *ref_pic_list0,
+    EbPictureBufferDesc *prediction_ptr, uint16_t dst_origin_x, uint16_t dst_origin_y) {
     EbErrorType return_error = EB_ErrorNone;
     uint8_t     is_compound  = 0;
 
@@ -1333,11 +1328,11 @@ EbErrorType get_single_prediction_for_obmc_chroma(
             src_ptr = ref_pic_list0->buffer_cb +
                       (ref_pic_list0->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
                       (ref_pic_list0->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
-                      ref_pic_list0->stride_cb;
+                          ref_pic_list0->stride_cb;
             dst_ptr = prediction_ptr->buffer_cb +
                       (prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
                       (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
-                      prediction_ptr->stride_cb;
+                          prediction_ptr->stride_cb;
             src_stride = ref_pic_list0->stride_cb;
             dst_stride = prediction_ptr->stride_cb;
 
@@ -1345,11 +1340,11 @@ EbErrorType get_single_prediction_for_obmc_chroma(
             subpel_x = mv_q4.col & SUBPEL_MASK;
             subpel_y = mv_q4.row & SUBPEL_MASK;
             src_ptr =
-                    src_ptr + (mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS);
+                src_ptr + (mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS);
             conv_params = get_conv_params_no_round(0, 0, 0, tmp_dstCb, 64, is_compound, EB_8BIT);
 
             av1_get_convolve_filter_params(
-                    interp_filters, &filter_params_x, &filter_params_y, bwidth, bheight);
+                interp_filters, &filter_params_x, &filter_params_y, bwidth, bheight);
 
             convolve[subpel_x != 0][subpel_y != 0][is_compound](src_ptr,
                                                                 src_stride,
@@ -1367,11 +1362,11 @@ EbErrorType get_single_prediction_for_obmc_chroma(
             src_ptr = ref_pic_list0->buffer_cr +
                       (ref_pic_list0->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
                       (ref_pic_list0->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
-                      ref_pic_list0->stride_cr;
+                          ref_pic_list0->stride_cr;
             dst_ptr = prediction_ptr->buffer_cr +
                       (prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
                       (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
-                      prediction_ptr->stride_cr;
+                          prediction_ptr->stride_cr;
             src_stride = ref_pic_list0->stride_cr;
             dst_stride = prediction_ptr->stride_cr;
 
@@ -1379,10 +1374,10 @@ EbErrorType get_single_prediction_for_obmc_chroma(
             subpel_x = mv_q4.col & SUBPEL_MASK;
             subpel_y = mv_q4.row & SUBPEL_MASK;
             src_ptr =
-                    src_ptr + (mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS);
+                src_ptr + (mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS);
             conv_params = get_conv_params_no_round(0, 0, 0, tmp_dstCr, 64, is_compound, EB_8BIT);
             av1_get_convolve_filter_params(
-                    interp_filters, &filter_params_x, &filter_params_y, bwidth, bheight);
+                interp_filters, &filter_params_x, &filter_params_y, bwidth, bheight);
 
             convolve[subpel_x != 0][subpel_y != 0][is_compound](src_ptr,
                                                                 src_stride,
@@ -1409,7 +1404,7 @@ static INLINE void build_prediction_by_above_pred(uint8_t is16bit, MacroBlockD *
     MbModeInfo                    backup_mbmi = *above_mbmi;
 
     av1_setup_build_prediction_by_above_pred(
-            xd, rel_mi_col, above_mi_width, &backup_mbmi, ctxt, num_planes, is16bit);
+        xd, rel_mi_col, above_mi_width, &backup_mbmi, ctxt, num_planes, is16bit);
 
     ctxt->prediction_ptr.origin_x = ctxt->prediction_ptr.origin_y = 0;
     ctxt->prediction_ptr.buffer_y                                 = ctxt->tmp_buf[0];
@@ -1498,7 +1493,7 @@ static INLINE void build_prediction_by_left_pred(uint8_t is16bit, MacroBlockD *x
     MbModeInfo                    backup_mbmi = *left_mbmi;
 
     av1_setup_build_prediction_by_left_pred(
-            xd, rel_mi_row, left_mi_height, &backup_mbmi, ctxt, num_planes, is16bit);
+        xd, rel_mi_row, left_mi_height, &backup_mbmi, ctxt, num_planes, is16bit);
 
     mi_x = ctxt->mi_col << MI_SIZE_LOG2;
     mi_y = left_mi_row << MI_SIZE_LOG2;
@@ -1583,8 +1578,7 @@ static void build_prediction_by_above_preds(EbBool perform_chroma, BlockSize bsi
                                             PictureControlSet *picture_control_set_ptr,
                                             MacroBlockD *xd, int mi_row, int mi_col,
                                             uint8_t *tmp_buf[MAX_MB_PLANE],
-                                            int      tmp_stride[MAX_MB_PLANE],
-                                            uint8_t is16bit) {
+                                            int tmp_stride[MAX_MB_PLANE], uint8_t is16bit) {
     if (!xd->up_available) return;
 
     // Adjust mb_to_bottom_edge to have the correct value for the OBMC
@@ -1626,8 +1620,7 @@ static void build_prediction_by_left_preds(EbBool perform_chroma, BlockSize bsiz
                                            PictureControlSet *picture_control_set_ptr,
                                            MacroBlockD *xd, int mi_row, int mi_col,
                                            uint8_t *tmp_buf[MAX_MB_PLANE],
-                                           int      tmp_stride[MAX_MB_PLANE],
-                                           uint8_t is16bit) {
+                                           int tmp_stride[MAX_MB_PLANE], uint8_t is16bit) {
     if (!xd->left_available) return;
 
     // Adjust mb_to_right_edge to have the correct value for the OBMC
@@ -1686,28 +1679,28 @@ DECLARE_ALIGNED(4, static const uint8_t, obmc_mask_4[4]) = {39, 50, 59, 64};
 static const uint8_t obmc_mask_8[8] = {36, 42, 48, 53, 57, 61, 64, 64};
 
 static const uint8_t obmc_mask_16[16] = {
-        34, 37, 40, 43, 46, 49, 52, 54, 56, 58, 60, 61, 64, 64, 64, 64};
+    34, 37, 40, 43, 46, 49, 52, 54, 56, 58, 60, 61, 64, 64, 64, 64};
 
 static const uint8_t obmc_mask_32[32] = {33, 35, 36, 38, 40, 41, 43, 44, 45, 47, 48,
                                          50, 51, 52, 53, 55, 56, 57, 58, 59, 60, 60,
                                          61, 62, 64, 64, 64, 64, 64, 64, 64, 64};
 
 static const uint8_t obmc_mask_64[64] = {
-        33, 34, 35, 35, 36, 37, 38, 39, 40, 40, 41, 42, 43, 44, 44, 44, 45, 46, 47, 47, 48, 49,
-        50, 51, 51, 51, 52, 52, 53, 54, 55, 56, 56, 56, 57, 57, 58, 58, 59, 60, 60, 60, 60, 60,
-        61, 62, 62, 62, 62, 62, 63, 63, 63, 63, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+    33, 34, 35, 35, 36, 37, 38, 39, 40, 40, 41, 42, 43, 44, 44, 44, 45, 46, 47, 47, 48, 49,
+    50, 51, 51, 51, 52, 52, 53, 54, 55, 56, 56, 56, 57, 57, 58, 58, 59, 60, 60, 60, 60, 60,
+    61, 62, 62, 62, 62, 62, 63, 63, 63, 63, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
 };
 
 const uint8_t *av1_get_obmc_mask(int length) {
     switch (length) {
-        case 1: return obmc_mask_1;
-        case 2: return obmc_mask_2;
-        case 4: return obmc_mask_4;
-        case 8: return obmc_mask_8;
-        case 16: return obmc_mask_16;
-        case 32: return obmc_mask_32;
-        case 64: return obmc_mask_64;
-        default: assert(0); return NULL;
+    case 1: return obmc_mask_1;
+    case 2: return obmc_mask_2;
+    case 4: return obmc_mask_4;
+    case 8: return obmc_mask_8;
+    case 16: return obmc_mask_16;
+    case 32: return obmc_mask_32;
+    case 64: return obmc_mask_64;
+    default: assert(0); return NULL;
     }
 }
 
@@ -1731,7 +1724,7 @@ void eb_aom_highbd_blend_a64_hmask_c(uint16_t *dst, uint32_t dst_stride, const u
     for (i = 0; i < h; ++i) {
         for (j = 0; j < w; ++j) {
             dst[i * dst_stride + j] =
-                    AOM_BLEND_A64(mask[j], src0[i * src0_stride + j], src1[i * src1_stride + j]);
+                AOM_BLEND_A64(mask[j], src0[i * src0_stride + j], src1[i * src1_stride + j]);
         }
     }
 }
@@ -1760,8 +1753,8 @@ static INLINE void build_obmc_inter_pred_above(uint8_t is16bit, MacroBlockD *xd,
         if (av1_skip_u4x4_pred_in_obmc(bsize, 0, subsampling_x, subsampling_y)) continue;
 
         const int dst_stride =
-                plane == 0 ? ctxt->final_dst_stride_y
-                           : plane == 1 ? ctxt->final_dst_stride_u : ctxt->final_dst_stride_v;
+            plane == 0 ? ctxt->final_dst_stride_y
+                       : plane == 1 ? ctxt->final_dst_stride_u : ctxt->final_dst_stride_v;
         uint8_t *const dst = plane == 0 ? &ctxt->final_dst_ptr_y[plane_col_pos]
                                         : plane == 1 ? &ctxt->final_dst_ptr_u[plane_col_pos]
                                                      : &ctxt->final_dst_ptr_v[plane_col_pos];
@@ -1809,12 +1802,12 @@ static INLINE void build_obmc_inter_pred_left(uint8_t is16bit, MacroBlockD *xd, 
         if (av1_skip_u4x4_pred_in_obmc(bsize, 1, subsampling_x, subsampling_y)) continue;
 
         const int dst_stride =
-                plane == 0 ? ctxt->final_dst_stride_y
-                           : plane == 1 ? ctxt->final_dst_stride_u : ctxt->final_dst_stride_v;
+            plane == 0 ? ctxt->final_dst_stride_y
+                       : plane == 1 ? ctxt->final_dst_stride_u : ctxt->final_dst_stride_v;
         uint8_t *const dst = plane == 0
-                             ? &ctxt->final_dst_ptr_y[plane_row_pos * dst_stride]
-                             : plane == 1 ? &ctxt->final_dst_ptr_u[plane_row_pos * dst_stride]
-                                          : &ctxt->final_dst_ptr_v[plane_row_pos * dst_stride];
+                                 ? &ctxt->final_dst_ptr_y[plane_row_pos * dst_stride]
+                                 : plane == 1 ? &ctxt->final_dst_ptr_u[plane_row_pos * dst_stride]
+                                              : &ctxt->final_dst_ptr_v[plane_row_pos * dst_stride];
 
         const int            tmp_stride = ctxt->adjacent_stride[plane];
         const uint8_t *const tmp        = &ctxt->adjacent[plane][plane_row_pos * tmp_stride];
@@ -1952,7 +1945,7 @@ static INLINE void calc_target_weighted_pred_left(uint8_t is16bit, MacroBlockD *
                 const uint8_t m0 = mask1d[col];
                 const uint8_t m1 = AOM_BLEND_A64_MAX_ALPHA - m0;
                 wsrc[col]        = (wsrc[col] >> AOM_BLEND_A64_ROUND_BITS) * m0 +
-                                   (tmp[col] << AOM_BLEND_A64_ROUND_BITS) * m1;
+                            (tmp[col] << AOM_BLEND_A64_ROUND_BITS) * m1;
                 mask[col] = (mask[col] >> AOM_BLEND_A64_ROUND_BITS) * m0;
             }
             wsrc += bw;
@@ -1962,15 +1955,14 @@ static INLINE void calc_target_weighted_pred_left(uint8_t is16bit, MacroBlockD *
     }
 }
 
-
 void av1_make_masked_warp_inter_predictor(uint8_t *src_ptr, uint32_t src_stride, uint16_t buf_width,
-                                        uint16_t buf_height, uint8_t *dst_ptr,
-                                        uint32_t dst_stride, const BlockGeom *blk_geom,
-                                        uint8_t bwidth, uint8_t bheight,
-                                        ConvolveParams *        conv_params,
-                                        InterInterCompoundData *comp_data, uint8_t bitdepth,
-                                        uint8_t plane, uint16_t pu_origin_x, uint16_t pu_origin_y,
-                                        EbWarpedMotionParams *wm_params_l1) {
+                                          uint16_t buf_height, uint8_t *dst_ptr,
+                                          uint32_t dst_stride, const BlockGeom *blk_geom,
+                                          uint8_t bwidth, uint8_t bheight,
+                                          ConvolveParams *        conv_params,
+                                          InterInterCompoundData *comp_data, uint8_t bitdepth,
+                                          uint8_t plane, uint16_t pu_origin_x, uint16_t pu_origin_y,
+                                          EbWarpedMotionParams *wm_params_l1) {
     EbBool is16bit = (EbBool)(bitdepth > EB_8BIT);
 
     //We come here when we have a prediction done using regular path for the ref0 stored in conv_param.dst.
@@ -2101,7 +2093,7 @@ static void calc_target_weighted_pred(PictureControlSet *  picture_control_set_p
     if (xd->up_available) {
         const int overlap = AOMMIN(block_size_high[bsize], block_size_high[BLOCK_64X64]) >> 1;
         struct calc_target_weighted_pred_ctxt ctxt = {
-                mask_buf, wsrc_buf, above, above_stride, overlap};
+            mask_buf, wsrc_buf, above, above_stride, overlap};
 
         foreach_overlappable_nb_above(is16bit,
                                       cm,
@@ -2121,7 +2113,7 @@ static void calc_target_weighted_pred(PictureControlSet *  picture_control_set_p
     if (xd->left_available) {
         const int overlap = AOMMIN(block_size_wide[bsize], block_size_wide[BLOCK_64X64]) >> 1;
         struct calc_target_weighted_pred_ctxt ctxt = {
-                mask_buf, wsrc_buf, left, left_stride, overlap};
+            mask_buf, wsrc_buf, left, left_stride, overlap};
 
         foreach_overlappable_nb_left(is16bit,
                                      cm,
@@ -2134,7 +2126,7 @@ static void calc_target_weighted_pred(PictureControlSet *  picture_control_set_p
 
     EbPictureBufferDesc *src_pic = picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
     const uint8_t *      src = src_pic->buffer_y + (context_ptr->blk_origin_x + src_pic->origin_x) +
-                               (context_ptr->blk_origin_y + src_pic->origin_y) * src_pic->stride_y;
+                         (context_ptr->blk_origin_y + src_pic->origin_y) * src_pic->stride_y;
 
     for (int row = 0; row < bh; ++row) {
         for (int col = 0; col < bw; ++col) { wsrc_buf[col] = src[col] * src_scale - wsrc_buf[col]; }
@@ -2242,10 +2234,10 @@ void precompute_obmc_data(PictureControlSet *  picture_control_set_ptr,
 }
 
 static void chroma_plane_warped_motion_prediction_sub8x8(
-        PictureControlSet *picture_control_set_ptr, uint8_t compound_idx, BlkStruct *blk_ptr,
-        const BlockGeom *blk_geom, uint8_t bwidth, uint8_t bheight, uint8_t is_compound,
-        uint8_t bit_depth, int32_t src_stride, int32_t dst_stride, uint8_t *src_ptr_l0,
-        uint8_t *src_ptr_l1, uint8_t *dst_ptr, MvReferenceFrame rf[2], MvUnit *mv_unit) {
+    PictureControlSet *picture_control_set_ptr, uint8_t compound_idx, BlkStruct *blk_ptr,
+    const BlockGeom *blk_geom, uint8_t bwidth, uint8_t bheight, uint8_t is_compound,
+    uint8_t bit_depth, int32_t src_stride, int32_t dst_stride, uint8_t *src_ptr_l0,
+    uint8_t *src_ptr_l1, uint8_t *dst_ptr, MvReferenceFrame rf[2], MvUnit *mv_unit) {
     EbBool is16bit = (EbBool)(bit_depth > EB_8BIT);
     DECLARE_ALIGNED(32, uint16_t, tmp_dst[64 * 64]);
     const uint32_t     interp_filters = 0;
@@ -2261,13 +2253,13 @@ static void chroma_plane_warped_motion_prediction_sub8x8(
 #endif
 
     MV mv_q4 = clamp_mv_to_umv_border_sb(
-            blk_ptr->av1xd, &mv_l0, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
+        blk_ptr->av1xd, &mv_l0, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
     int32_t subpel_x = mv_q4.col & SUBPEL_MASK;
     int32_t subpel_y = mv_q4.row & SUBPEL_MASK;
     src_ptr_l0       = src_ptr_l0 + (is16bit ? 2 : 1) * ((mv_q4.row >> SUBPEL_BITS) * src_stride +
-                                                         (mv_q4.col >> SUBPEL_BITS));
+                                                   (mv_q4.col >> SUBPEL_BITS));
     ConvolveParams conv_params =
-            get_conv_params_no_round(0, 0, 0, tmp_dst, 64, is_compound, bit_depth);
+        get_conv_params_no_round(0, 0, 0, tmp_dst, 64, is_compound, bit_depth);
 
     av1_get_convolve_filter_params(interp_filters,
                                    &filter_params_x,
@@ -2308,23 +2300,23 @@ static void chroma_plane_warped_motion_prediction_sub8x8(
         mv_l1.row = mv_unit->mv[REF_LIST_1].y;
 
         mv_q4 = clamp_mv_to_umv_border_sb(
-                blk_ptr->av1xd, &mv_l1, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
+            blk_ptr->av1xd, &mv_l1, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
         subpel_x   = mv_q4.col & SUBPEL_MASK;
         subpel_y   = mv_q4.row & SUBPEL_MASK;
         src_ptr_l1 = src_ptr_l1 + (is16bit ? 2 : 1) * ((mv_q4.row >> SUBPEL_BITS) * src_stride +
                                                        (mv_q4.col >> SUBPEL_BITS));
 
         av1_dist_wtd_comp_weight_assign(
-                &picture_control_set_ptr->parent_pcs_ptr->scs_ptr->seq_header,
-                picture_control_set_ptr->parent_pcs_ptr->cur_order_hint, // cur_frame_index,
-                picture_control_set_ptr->parent_pcs_ptr->ref_order_hint[rf[0] - 1], // bck_frame_index,
-                picture_control_set_ptr->parent_pcs_ptr->ref_order_hint[rf[1] - 1], // fwd_frame_index,
-                compound_idx,
-                0, // order_idx,
-                &conv_params.fwd_offset,
-                &conv_params.bck_offset,
-                &conv_params.use_dist_wtd_comp_avg,
-                is_compound);
+            &picture_control_set_ptr->parent_pcs_ptr->scs_ptr->seq_header,
+            picture_control_set_ptr->parent_pcs_ptr->cur_order_hint, // cur_frame_index,
+            picture_control_set_ptr->parent_pcs_ptr->ref_order_hint[rf[0] - 1], // bck_frame_index,
+            picture_control_set_ptr->parent_pcs_ptr->ref_order_hint[rf[1] - 1], // fwd_frame_index,
+            compound_idx,
+            0, // order_idx,
+            &conv_params.fwd_offset,
+            &conv_params.bck_offset,
+            &conv_params.use_dist_wtd_comp_avg,
+            is_compound);
         conv_params.use_jnt_comp_avg = conv_params.use_dist_wtd_comp_avg;
         av1_get_convolve_filter_params(interp_filters,
                                        &filter_params_x,
@@ -2335,47 +2327,47 @@ static void chroma_plane_warped_motion_prediction_sub8x8(
         conv_params.do_average = 1;
         if (bit_depth == EB_8BIT)
             convolve[subpel_x != 0][subpel_y != 0][is_compound](
-                    src_ptr_l1,
-                    src_stride,
-                    dst_ptr,
-                    dst_stride,
-                    bwidth,
-                    bheight,
-                    &filter_params_x, //puSize > 8 ? &av1RegularFilter : &av1RegularFilterW4,
-                    &filter_params_y, //puSize > 8 ? &av1RegularFilter : &av1RegularFilterW4,
-                    subpel_x,
-                    subpel_y,
-                    &conv_params);
+                src_ptr_l1,
+                src_stride,
+                dst_ptr,
+                dst_stride,
+                bwidth,
+                bheight,
+                &filter_params_x, //puSize > 8 ? &av1RegularFilter : &av1RegularFilterW4,
+                &filter_params_y, //puSize > 8 ? &av1RegularFilter : &av1RegularFilterW4,
+                subpel_x,
+                subpel_y,
+                &conv_params);
         else
             convolveHbd[subpel_x != 0][subpel_y != 0][is_compound](
-                    (uint16_t *)src_ptr_l1,
-                    src_stride,
-                    (uint16_t *)dst_ptr,
-                    dst_stride,
-                    bwidth,
-                    bheight,
-                    &filter_params_x, //puSize > 8 ? &av1RegularFilter : &av1RegularFilterW4,
-                    &filter_params_y, //puSize > 8 ? &av1RegularFilter : &av1RegularFilterW4,
-                    subpel_x,
-                    subpel_y,
-                    &conv_params,
-                    bit_depth);
+                (uint16_t *)src_ptr_l1,
+                src_stride,
+                (uint16_t *)dst_ptr,
+                dst_stride,
+                bwidth,
+                bheight,
+                &filter_params_x, //puSize > 8 ? &av1RegularFilter : &av1RegularFilterW4,
+                &filter_params_y, //puSize > 8 ? &av1RegularFilter : &av1RegularFilterW4,
+                subpel_x,
+                subpel_y,
+                &conv_params,
+                bit_depth);
     }
 }
 
 static void plane_warped_motion_prediction(
-        PictureControlSet *picture_control_set_ptr, uint8_t compound_idx,
-        InterInterCompoundData *interinter_comp, uint16_t pu_origin_x, uint16_t pu_origin_y,
-        const BlockGeom *blk_geom, uint8_t bwidth, uint8_t bheight, EbWarpedMotionParams *wm_params_l0,
-        EbWarpedMotionParams *wm_params_l1, uint8_t is_compound, uint8_t bit_depth, int32_t src_stride,
-        int32_t dst_stride, uint16_t buf_width, uint16_t buf_height, uint8_t ss_x, uint8_t ss_y,
-        uint8_t *src_ptr_l0, uint8_t *src_ptr_l1, uint8_t *dst_ptr, uint8_t plane,
-        MvReferenceFrame rf[2]) {
+    PictureControlSet *picture_control_set_ptr, uint8_t compound_idx,
+    InterInterCompoundData *interinter_comp, uint16_t pu_origin_x, uint16_t pu_origin_y,
+    const BlockGeom *blk_geom, uint8_t bwidth, uint8_t bheight, EbWarpedMotionParams *wm_params_l0,
+    EbWarpedMotionParams *wm_params_l1, uint8_t is_compound, uint8_t bit_depth, int32_t src_stride,
+    int32_t dst_stride, uint16_t buf_width, uint16_t buf_height, uint8_t ss_x, uint8_t ss_y,
+    uint8_t *src_ptr_l0, uint8_t *src_ptr_l1, uint8_t *dst_ptr, uint8_t plane,
+    MvReferenceFrame rf[2]) {
     EbBool is16bit = (EbBool)(bit_depth > EB_8BIT);
 
     if (!is_compound) {
         ConvolveParams conv_params =
-                get_conv_params_no_round(0, 0, 0, NULL, 128, is_compound, bit_depth);
+            get_conv_params_no_round(0, 0, 0, NULL, 128, is_compound, bit_depth);
 
         eb_av1_warp_plane(wm_params_l0,
                           (int)is16bit,
@@ -2395,21 +2387,21 @@ static void plane_warped_motion_prediction(
                           &conv_params);
     } else {
         DECLARE_ALIGNED(
-                32, uint16_t, tmp_dstY[128 * 128]); //move this to context if stack does not hold.
+            32, uint16_t, tmp_dstY[128 * 128]); //move this to context if stack does not hold.
 
         ConvolveParams conv_params =
-                get_conv_params_no_round(0, 0, 0, tmp_dstY, 128, is_compound, bit_depth);
+            get_conv_params_no_round(0, 0, 0, tmp_dstY, 128, is_compound, bit_depth);
         av1_dist_wtd_comp_weight_assign(
-                &picture_control_set_ptr->parent_pcs_ptr->scs_ptr->seq_header,
-                picture_control_set_ptr->parent_pcs_ptr->cur_order_hint, // cur_frame_index,
-                picture_control_set_ptr->parent_pcs_ptr->ref_order_hint[rf[0] - 1], // bck_frame_index,
-                picture_control_set_ptr->parent_pcs_ptr->ref_order_hint[rf[1] - 1], // fwd_frame_index,
-                compound_idx,
-                0, // order_idx,
-                &conv_params.fwd_offset,
-                &conv_params.bck_offset,
-                &conv_params.use_dist_wtd_comp_avg,
-                is_compound);
+            &picture_control_set_ptr->parent_pcs_ptr->scs_ptr->seq_header,
+            picture_control_set_ptr->parent_pcs_ptr->cur_order_hint, // cur_frame_index,
+            picture_control_set_ptr->parent_pcs_ptr->ref_order_hint[rf[0] - 1], // bck_frame_index,
+            picture_control_set_ptr->parent_pcs_ptr->ref_order_hint[rf[1] - 1], // fwd_frame_index,
+            compound_idx,
+            0, // order_idx,
+            &conv_params.fwd_offset,
+            &conv_params.bck_offset,
+            &conv_params.use_dist_wtd_comp_avg,
+            is_compound);
         conv_params.use_jnt_comp_avg = conv_params.use_dist_wtd_comp_avg;
 
         conv_params.do_average = 0;
@@ -2469,12 +2461,11 @@ static void plane_warped_motion_prediction(
     }
 }
 
-
 #define SWITCHABLE_INTERP_RATE_FACTOR 1
 extern int32_t eb_av1_get_pred_context_switchable_interp(
-        NeighborArrayUnit *ref_frame_type_neighbor_array, MvReferenceFrame rf0, MvReferenceFrame rf1,
-        NeighborArrayUnit32 *interpolation_type_neighbor_array, uint32_t blk_origin_x,
-        uint32_t blk_origin_y, int32_t dir);
+    NeighborArrayUnit *ref_frame_type_neighbor_array, MvReferenceFrame rf0, MvReferenceFrame rf1,
+    NeighborArrayUnit32 *interpolation_type_neighbor_array, uint32_t blk_origin_x,
+    uint32_t blk_origin_y, int32_t dir);
 
 int32_t eb_av1_get_switchable_rate(ModeDecisionCandidateBuffer *candidate_buffer_ptr,
                                    const Av1Common *const cm, ModeDecisionContext *md_context_ptr) {
@@ -2486,20 +2477,20 @@ int32_t eb_av1_get_switchable_rate(ModeDecisionCandidateBuffer *candidate_buffer
             MvReferenceFrame rf[2];
             av1_set_ref_frame(rf, candidate_buffer_ptr->candidate_ptr->ref_frame_type);
             const int32_t ctx = eb_av1_get_pred_context_switchable_interp(
-                    md_context_ptr->ref_frame_type_neighbor_array,
-                    rf[0],
-                    rf[1],
-                    md_context_ptr->interpolation_type_neighbor_array,
-                    md_context_ptr->blk_origin_x,
-                    md_context_ptr->blk_origin_y,
-                    dir);
+                md_context_ptr->ref_frame_type_neighbor_array,
+                rf[0],
+                rf[1],
+                md_context_ptr->interpolation_type_neighbor_array,
+                md_context_ptr->blk_origin_x,
+                md_context_ptr->blk_origin_y,
+                dir);
 
             const InterpFilter filter = av1_extract_interp_filter(
-                    /*mbmi*/ candidate_buffer_ptr->candidate_ptr->interp_filters, dir);
+                /*mbmi*/ candidate_buffer_ptr->candidate_ptr->interp_filters, dir);
             assert(ctx < SWITCHABLE_FILTER_CONTEXTS);
             assert(filter < SWITCHABLE_FILTERS);
             inter_filter_cost +=
-                    /*x->switchable_interp_costs*/ md_context_ptr->md_rate_estimation_ptr
+                /*x->switchable_interp_costs*/ md_context_ptr->md_rate_estimation_ptr
                     ->switchable_interp_fac_bitss[ctx][filter];
         }
         return SWITCHABLE_INTERP_RATE_FACTOR * inter_filter_cost;
@@ -2525,13 +2516,13 @@ static void model_rd_norm(int32_t xsq_q10, int32_t *r_q10, int32_t *d_q10) {
     // where r = exp(-sqrt(2) * x) and x = qpstep / sqrt(variance),
     // and H(x) is the binary entropy function.
     static const int32_t rate_tab_q10[] = {
-            65536, 6086, 5574, 5275, 5063, 4899, 4764, 4651, 4553, 4389, 4255, 4142, 4044, 3958, 3881,
-            3811,  3748, 3635, 3538, 3453, 3376, 3307, 3244, 3186, 3133, 3037, 2952, 2877, 2809, 2747,
-            2690,  2638, 2589, 2501, 2423, 2353, 2290, 2232, 2179, 2130, 2084, 2001, 1928, 1862, 1802,
-            1748,  1698, 1651, 1608, 1530, 1460, 1398, 1342, 1290, 1243, 1199, 1159, 1086, 1021, 963,
-            911,   864,  821,  781,  745,  680,  623,  574,  530,  490,  455,  424,  395,  345,  304,
-            269,   239,  213,  190,  171,  154,  126,  104,  87,   73,   61,   52,   44,   38,   28,
-            21,    16,   12,   10,   8,    6,    5,    3,    2,    1,    1,    1,    0,    0,
+        65536, 6086, 5574, 5275, 5063, 4899, 4764, 4651, 4553, 4389, 4255, 4142, 4044, 3958, 3881,
+        3811,  3748, 3635, 3538, 3453, 3376, 3307, 3244, 3186, 3133, 3037, 2952, 2877, 2809, 2747,
+        2690,  2638, 2589, 2501, 2423, 2353, 2290, 2232, 2179, 2130, 2084, 2001, 1928, 1862, 1802,
+        1748,  1698, 1651, 1608, 1530, 1460, 1398, 1342, 1290, 1243, 1199, 1159, 1086, 1021, 963,
+        911,   864,  821,  781,  745,  680,  623,  574,  530,  490,  455,  424,  395,  345,  304,
+        269,   239,  213,  190,  171,  154,  126,  104,  87,   73,   61,   52,   44,   38,   28,
+        21,    16,   12,   10,   8,    6,    5,    3,    2,    1,    1,    1,    0,    0,
     };
     // Normalized distortion:
     // This table models the normalized distortion for a Laplacian source
@@ -2541,25 +2532,25 @@ static void model_rd_norm(int32_t xsq_q10, int32_t *r_q10, int32_t *d_q10) {
     // where x = qpstep / sqrt(variance).
     // Note the actual distortion is Dn * variance.
     static const int32_t dist_tab_q10[] = {
-            0,    0,    1,    1,    1,    2,    2,    2,    3,    3,    4,    5,    5,    6,    7,
-            7,    8,    9,    11,   12,   13,   15,   16,   17,   18,   21,   24,   26,   29,   31,
-            34,   36,   39,   44,   49,   54,   59,   64,   69,   73,   78,   88,   97,   106,  115,
-            124,  133,  142,  151,  167,  184,  200,  215,  231,  245,  260,  274,  301,  327,  351,
-            375,  397,  418,  439,  458,  495,  528,  559,  587,  613,  637,  659,  680,  717,  749,
-            777,  801,  823,  842,  859,  874,  899,  919,  936,  949,  960,  969,  977,  983,  994,
-            1001, 1006, 1010, 1013, 1015, 1017, 1018, 1020, 1022, 1022, 1023, 1023, 1023, 1024,
+        0,    0,    1,    1,    1,    2,    2,    2,    3,    3,    4,    5,    5,    6,    7,
+        7,    8,    9,    11,   12,   13,   15,   16,   17,   18,   21,   24,   26,   29,   31,
+        34,   36,   39,   44,   49,   54,   59,   64,   69,   73,   78,   88,   97,   106,  115,
+        124,  133,  142,  151,  167,  184,  200,  215,  231,  245,  260,  274,  301,  327,  351,
+        375,  397,  418,  439,  458,  495,  528,  559,  587,  613,  637,  659,  680,  717,  749,
+        777,  801,  823,  842,  859,  874,  899,  919,  936,  949,  960,  969,  977,  983,  994,
+        1001, 1006, 1010, 1013, 1015, 1017, 1018, 1020, 1022, 1022, 1023, 1023, 1023, 1024,
     };
     static const int32_t xsq_iq_q10[] = {
-            0,      4,      8,      12,     16,     20,     24,     28,     32,     40,     48,
-            56,     64,     72,     80,     88,     96,     112,    128,    144,    160,    176,
-            192,    208,    224,    256,    288,    320,    352,    384,    416,    448,    480,
-            544,    608,    672,    736,    800,    864,    928,    992,    1120,   1248,   1376,
-            1504,   1632,   1760,   1888,   2016,   2272,   2528,   2784,   3040,   3296,   3552,
-            3808,   4064,   4576,   5088,   5600,   6112,   6624,   7136,   7648,   8160,   9184,
-            10208,  11232,  12256,  13280,  14304,  15328,  16352,  18400,  20448,  22496,  24544,
-            26592,  28640,  30688,  32736,  36832,  40928,  45024,  49120,  53216,  57312,  61408,
-            65504,  73696,  81888,  90080,  98272,  106464, 114656, 122848, 131040, 147424, 163808,
-            180192, 196576, 212960, 229344, 245728,
+        0,      4,      8,      12,     16,     20,     24,     28,     32,     40,     48,
+        56,     64,     72,     80,     88,     96,     112,    128,    144,    160,    176,
+        192,    208,    224,    256,    288,    320,    352,    384,    416,    448,    480,
+        544,    608,    672,    736,    800,    864,    928,    992,    1120,   1248,   1376,
+        1504,   1632,   1760,   1888,   2016,   2272,   2528,   2784,   3040,   3296,   3552,
+        3808,   4064,   4576,   5088,   5600,   6112,   6624,   7136,   7648,   8160,   9184,
+        10208,  11232,  12256,  13280,  14304,  15328,  16352,  18400,  20448,  22496,  24544,
+        26592,  28640,  30688,  32736,  36832,  40928,  45024,  49120,  53216,  57312,  61408,
+        65504,  73696,  81888,  90080,  98272,  106464, 114656, 122848, 131040, 147424, 163808,
+        180192, 196576, 212960, 229344, 245728,
     };
     const int32_t tmp     = (xsq_q10 >> 2) + 8;
     const int32_t k       = get_msb(tmp) - 3;
@@ -2634,27 +2625,27 @@ extern void model_rd_for_sb(PictureControlSet *  picture_control_set_ptr,
     uint64_t total_sse = 0;
 
     EbPictureBufferDesc *input_picture_ptr =
-            bit_depth > 8 ? picture_control_set_ptr->input_frame16bit
-                          : picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
+        bit_depth > 8 ? picture_control_set_ptr->input_frame16bit
+                      : picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
     const uint32_t input_offset =
-            (md_context_ptr->blk_origin_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_y +
-            (md_context_ptr->blk_origin_x + input_picture_ptr->origin_x);
+        (md_context_ptr->blk_origin_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_y +
+        (md_context_ptr->blk_origin_x + input_picture_ptr->origin_x);
     const uint32_t input_chroma_offset =
-            ((md_context_ptr->blk_origin_y + input_picture_ptr->origin_y) *
+        ((md_context_ptr->blk_origin_y + input_picture_ptr->origin_y) *
              input_picture_ptr->stride_cb +
-             (md_context_ptr->blk_origin_x + input_picture_ptr->origin_x)) /
-            2;
+         (md_context_ptr->blk_origin_x + input_picture_ptr->origin_x)) /
+        2;
     const uint32_t prediction_offset =
-            prediction_ptr->origin_x + md_context_ptr->blk_geom->origin_x +
-            (prediction_ptr->origin_y + md_context_ptr->blk_geom->origin_y) * prediction_ptr->stride_y;
+        prediction_ptr->origin_x + md_context_ptr->blk_geom->origin_x +
+        (prediction_ptr->origin_y + md_context_ptr->blk_geom->origin_y) * prediction_ptr->stride_y;
     const uint32_t prediction_chroma_offset =
-            (prediction_ptr->origin_x + md_context_ptr->blk_geom->origin_x +
-             (prediction_ptr->origin_y + md_context_ptr->blk_geom->origin_y) *
+        (prediction_ptr->origin_x + md_context_ptr->blk_geom->origin_x +
+         (prediction_ptr->origin_y + md_context_ptr->blk_geom->origin_y) *
              prediction_ptr->stride_cb) /
-            2;
+        2;
 
     EbSpatialFullDistType spatial_full_dist_type_fun =
-            bit_depth > 8 ? full_distortion_kernel16_bits : spatial_full_distortion_kernel;
+        bit_depth > 8 ? full_distortion_kernel16_bits : spatial_full_distortion_kernel;
 
     for (plane = plane_from; plane <= plane_to; ++plane) {
         uint64_t sse;
@@ -2694,17 +2685,17 @@ extern void model_rd_for_sb(PictureControlSet *  picture_control_set_ptr,
         total_sse += sse;
 
         int32_t current_q_index =
-                picture_control_set_ptr->parent_pcs_ptr->frm_hdr.quantization_params.base_q_idx;
+            picture_control_set_ptr->parent_pcs_ptr->frm_hdr.quantization_params.base_q_idx;
         Dequants *const dequants = &picture_control_set_ptr->parent_pcs_ptr->deq;
 
         int16_t quantizer = dequants->y_dequant_q3[current_q_index][1];
         model_rd_from_sse(
-                plane == 0 ? md_context_ptr->blk_geom->bsize : md_context_ptr->blk_geom->bsize_uv,
-                quantizer,
-                bit_depth,
-                sse,
-                &rate,
-                &dist);
+            plane == 0 ? md_context_ptr->blk_geom->bsize : md_context_ptr->blk_geom->bsize_uv,
+            quantizer,
+            bit_depth,
+            sse,
+            &rate,
+            &dist);
 
         rate_sum += rate;
         dist_sum += dist;
@@ -2754,15 +2745,15 @@ static INLINE int32_t av1_is_interp_needed(ModeDecisionCandidateBuffer *candidat
 
 #define DUAL_FILTER_SET_SIZE (SWITCHABLE_FILTERS * SWITCHABLE_FILTERS)
 static const int32_t filter_sets[DUAL_FILTER_SET_SIZE][2] = {
-        {0, 0},
-        {0, 1},
-        {0, 2},
-        {1, 0},
-        {1, 1},
-        {1, 2},
-        {2, 0},
-        {2, 1},
-        {2, 2},
+    {0, 0},
+    {0, 1},
+    {0, 2},
+    {1, 0},
+    {1, 1},
+    {1, 2},
+    {2, 0},
+    {2, 1},
+    {2, 2},
 };
 
 void interpolation_filter_search(PictureControlSet *          picture_control_set_ptr,
@@ -2773,11 +2764,20 @@ void interpolation_filter_search(PictureControlSet *          picture_control_se
                                  EbPictureBufferDesc *ref_pic_list1, uint8_t hbd_mode_decision,
                                  uint8_t bit_depth) {
     const Av1Common *cm = picture_control_set_ptr->parent_pcs_ptr->av1_cm; //&cpi->common;
-    EbBool           use_uv =
-            (md_context_ptr->blk_geom->has_uv && md_context_ptr->chroma_level <= CHROMA_MODE_1 &&
-             md_context_ptr->interpolation_search_level != IT_SEARCH_FAST_LOOP_UV_BLIND)
+#if MOVE_OPT
+    EbBool use_uv = (md_context_ptr->blk_geom->has_uv &&
+                     (md_context_ptr->chroma_level == CHROMA_MODE_01 ||
+                      md_context_ptr->chroma_level <= CHROMA_MODE_1) &&
+                     md_context_ptr->interpolation_search_level != IT_SEARCH_FAST_LOOP_UV_BLIND)
+                        ? EB_TRUE
+                        : EB_FALSE;
+#else
+    EbBool use_uv =
+        (md_context_ptr->blk_geom->has_uv && md_context_ptr->chroma_level <= CHROMA_MODE_1 &&
+         md_context_ptr->interpolation_search_level != IT_SEARCH_FAST_LOOP_UV_BLIND)
             ? EB_TRUE
             : EB_FALSE;
+#endif
     const int32_t num_planes      = use_uv ? MAX_MB_PLANE : 1;
     int64_t       rd              = INT64_MAX;
     int32_t       switchable_rate = 0;
@@ -2793,42 +2793,41 @@ void interpolation_filter_search(PictureControlSet *          picture_control_se
 
     //set_default_interp_filters(mbmi, assign_filter);
     /*mbmi*/ candidate_buffer_ptr->candidate_ptr->interp_filters = //EIGHTTAP_REGULAR ;
-                     av1_broadcast_interp_filter(av1_unswitchable_filter(assign_filter));
+        av1_broadcast_interp_filter(av1_unswitchable_filter(assign_filter));
 
     switchable_rate = eb_av1_get_switchable_rate(candidate_buffer_ptr, cm, md_context_ptr);
 
-    av1_inter_prediction(
-            picture_control_set_ptr,
-            candidate_buffer_ptr->candidate_ptr->interp_filters,
-            md_context_ptr->blk_ptr,
-            candidate_buffer_ptr->candidate_ptr->ref_frame_type,
-            &mv_unit,
-            0,
-            SIMPLE_TRANSLATION,
-            0,
-            0,
+    av1_inter_prediction(picture_control_set_ptr,
+                         candidate_buffer_ptr->candidate_ptr->interp_filters,
+                         md_context_ptr->blk_ptr,
+                         candidate_buffer_ptr->candidate_ptr->ref_frame_type,
+                         &mv_unit,
+                         0,
+                         SIMPLE_TRANSLATION,
+                         0,
+                         0,
 
-            candidate_buffer_ptr->candidate_ptr->compound_idx,
-            &candidate_buffer_ptr->candidate_ptr->interinter_comp,
-            &md_context_ptr->sb_ptr->tile_info,
-            md_context_ptr->luma_recon_neighbor_array,
-            md_context_ptr->cb_recon_neighbor_array,
-            md_context_ptr->cr_recon_neighbor_array,
-            0, //No inter-intra for IFSearch
-            candidate_buffer_ptr->candidate_ptr->interintra_mode,
-            candidate_buffer_ptr->candidate_ptr->use_wedge_interintra,
-            candidate_buffer_ptr->candidate_ptr->interintra_wedge_index,
-            md_context_ptr->blk_origin_x,
-            md_context_ptr->blk_origin_y,
-            md_context_ptr->blk_geom->bwidth,
-            md_context_ptr->blk_geom->bheight,
-            ref_pic_list0,
-            ref_pic_list1,
-            prediction_ptr,
-            md_context_ptr->blk_geom->origin_x,
-            md_context_ptr->blk_geom->origin_y,
-            use_uv,
-            hbd_mode_decision ? EB_10BIT : EB_8BIT);
+                         candidate_buffer_ptr->candidate_ptr->compound_idx,
+                         &candidate_buffer_ptr->candidate_ptr->interinter_comp,
+                         &md_context_ptr->sb_ptr->tile_info,
+                         md_context_ptr->luma_recon_neighbor_array,
+                         md_context_ptr->cb_recon_neighbor_array,
+                         md_context_ptr->cr_recon_neighbor_array,
+                         0, //No inter-intra for IFSearch
+                         candidate_buffer_ptr->candidate_ptr->interintra_mode,
+                         candidate_buffer_ptr->candidate_ptr->use_wedge_interintra,
+                         candidate_buffer_ptr->candidate_ptr->interintra_wedge_index,
+                         md_context_ptr->blk_origin_x,
+                         md_context_ptr->blk_origin_y,
+                         md_context_ptr->blk_geom->bwidth,
+                         md_context_ptr->blk_geom->bheight,
+                         ref_pic_list0,
+                         ref_pic_list1,
+                         prediction_ptr,
+                         md_context_ptr->blk_geom->origin_x,
+                         md_context_ptr->blk_geom->origin_y,
+                         use_uv,
+                         hbd_mode_decision ? EB_10BIT : EB_8BIT);
     model_rd_for_sb(picture_control_set_ptr,
                     prediction_ptr,
                     md_context_ptr,
@@ -2860,42 +2859,42 @@ void interpolation_filter_search(PictureControlSet *          picture_control_se
                 // EIGHTTAP_REGULAR mode is calculated beforehand
                 for (i = 1; i < SWITCHABLE_FILTERS; ++i) {
                     /*mbmi*/ candidate_buffer_ptr->candidate_ptr->interp_filters =
-                                     (InterpFilter)av1_make_interp_filters((InterpFilter)filter_sets[i][0],
-                                                                           (InterpFilter)filter_sets[i][1]);
+                        (InterpFilter)av1_make_interp_filters((InterpFilter)filter_sets[i][0],
+                                                              (InterpFilter)filter_sets[i][1]);
 
                     tmp_rs = eb_av1_get_switchable_rate(candidate_buffer_ptr, cm, md_context_ptr);
 
                     av1_inter_prediction(
-                            picture_control_set_ptr,
-                            candidate_buffer_ptr->candidate_ptr->interp_filters,
-                            md_context_ptr->blk_ptr,
-                            candidate_buffer_ptr->candidate_ptr->ref_frame_type,
-                            &mv_unit,
-                            0,
-                            SIMPLE_TRANSLATION,
-                            0,
-                            0,
-                            candidate_buffer_ptr->candidate_ptr->compound_idx,
-                            &candidate_buffer_ptr->candidate_ptr->interinter_comp,
-                            &md_context_ptr->sb_ptr->tile_info,
-                            md_context_ptr->luma_recon_neighbor_array,
-                            md_context_ptr->cb_recon_neighbor_array,
-                            md_context_ptr->cr_recon_neighbor_array,
-                            0, //No inter-intra for IFSearch
-                            candidate_buffer_ptr->candidate_ptr->interintra_mode,
-                            candidate_buffer_ptr->candidate_ptr->use_wedge_interintra,
-                            candidate_buffer_ptr->candidate_ptr->interintra_wedge_index,
-                            md_context_ptr->blk_origin_x,
-                            md_context_ptr->blk_origin_y,
-                            md_context_ptr->blk_geom->bwidth,
-                            md_context_ptr->blk_geom->bheight,
-                            ref_pic_list0,
-                            ref_pic_list1,
-                            prediction_ptr,
-                            md_context_ptr->blk_geom->origin_x,
-                            md_context_ptr->blk_geom->origin_y,
-                            use_uv,
-                            hbd_mode_decision ? EB_10BIT : EB_8BIT);
+                        picture_control_set_ptr,
+                        candidate_buffer_ptr->candidate_ptr->interp_filters,
+                        md_context_ptr->blk_ptr,
+                        candidate_buffer_ptr->candidate_ptr->ref_frame_type,
+                        &mv_unit,
+                        0,
+                        SIMPLE_TRANSLATION,
+                        0,
+                        0,
+                        candidate_buffer_ptr->candidate_ptr->compound_idx,
+                        &candidate_buffer_ptr->candidate_ptr->interinter_comp,
+                        &md_context_ptr->sb_ptr->tile_info,
+                        md_context_ptr->luma_recon_neighbor_array,
+                        md_context_ptr->cb_recon_neighbor_array,
+                        md_context_ptr->cr_recon_neighbor_array,
+                        0, //No inter-intra for IFSearch
+                        candidate_buffer_ptr->candidate_ptr->interintra_mode,
+                        candidate_buffer_ptr->candidate_ptr->use_wedge_interintra,
+                        candidate_buffer_ptr->candidate_ptr->interintra_wedge_index,
+                        md_context_ptr->blk_origin_x,
+                        md_context_ptr->blk_origin_y,
+                        md_context_ptr->blk_geom->bwidth,
+                        md_context_ptr->blk_geom->bheight,
+                        ref_pic_list0,
+                        ref_pic_list1,
+                        prediction_ptr,
+                        md_context_ptr->blk_geom->origin_x,
+                        md_context_ptr->blk_geom->origin_y,
+                        use_uv,
+                        hbd_mode_decision ? EB_10BIT : EB_8BIT);
                     model_rd_for_sb(picture_control_set_ptr,
                                     prediction_ptr,
                                     md_context_ptr,
@@ -2919,42 +2918,42 @@ void interpolation_filter_search(PictureControlSet *          picture_control_se
                 for (i = best_dual_mode + SWITCHABLE_FILTERS; i < filter_set_size;
                      i += SWITCHABLE_FILTERS) {
                     /*mbmi*/ candidate_buffer_ptr->candidate_ptr->interp_filters =
-                                     av1_make_interp_filters((InterpFilter)filter_sets[i][0],
-                                                             (InterpFilter)filter_sets[i][1]);
+                        av1_make_interp_filters((InterpFilter)filter_sets[i][0],
+                                                (InterpFilter)filter_sets[i][1]);
 
                     tmp_rs = eb_av1_get_switchable_rate(candidate_buffer_ptr, cm, md_context_ptr);
 
                     av1_inter_prediction(
-                            picture_control_set_ptr,
-                            candidate_buffer_ptr->candidate_ptr->interp_filters,
-                            md_context_ptr->blk_ptr,
-                            candidate_buffer_ptr->candidate_ptr->ref_frame_type,
-                            &mv_unit,
-                            0,
-                            SIMPLE_TRANSLATION,
-                            0,
-                            0,
-                            candidate_buffer_ptr->candidate_ptr->compound_idx,
-                            &candidate_buffer_ptr->candidate_ptr->interinter_comp,
-                            &md_context_ptr->sb_ptr->tile_info,
-                            md_context_ptr->luma_recon_neighbor_array,
-                            md_context_ptr->cb_recon_neighbor_array,
-                            md_context_ptr->cr_recon_neighbor_array,
-                            0, //No inter-intra for IFSearch
-                            candidate_buffer_ptr->candidate_ptr->interintra_mode,
-                            candidate_buffer_ptr->candidate_ptr->use_wedge_interintra,
-                            candidate_buffer_ptr->candidate_ptr->interintra_wedge_index,
-                            md_context_ptr->blk_origin_x,
-                            md_context_ptr->blk_origin_y,
-                            md_context_ptr->blk_geom->bwidth,
-                            md_context_ptr->blk_geom->bheight,
-                            ref_pic_list0,
-                            ref_pic_list1,
-                            prediction_ptr,
-                            md_context_ptr->blk_geom->origin_x,
-                            md_context_ptr->blk_geom->origin_y,
-                            use_uv,
-                            hbd_mode_decision ? EB_10BIT : EB_8BIT);
+                        picture_control_set_ptr,
+                        candidate_buffer_ptr->candidate_ptr->interp_filters,
+                        md_context_ptr->blk_ptr,
+                        candidate_buffer_ptr->candidate_ptr->ref_frame_type,
+                        &mv_unit,
+                        0,
+                        SIMPLE_TRANSLATION,
+                        0,
+                        0,
+                        candidate_buffer_ptr->candidate_ptr->compound_idx,
+                        &candidate_buffer_ptr->candidate_ptr->interinter_comp,
+                        &md_context_ptr->sb_ptr->tile_info,
+                        md_context_ptr->luma_recon_neighbor_array,
+                        md_context_ptr->cb_recon_neighbor_array,
+                        md_context_ptr->cr_recon_neighbor_array,
+                        0, //No inter-intra for IFSearch
+                        candidate_buffer_ptr->candidate_ptr->interintra_mode,
+                        candidate_buffer_ptr->candidate_ptr->use_wedge_interintra,
+                        candidate_buffer_ptr->candidate_ptr->interintra_wedge_index,
+                        md_context_ptr->blk_origin_x,
+                        md_context_ptr->blk_origin_y,
+                        md_context_ptr->blk_geom->bwidth,
+                        md_context_ptr->blk_geom->bheight,
+                        ref_pic_list0,
+                        ref_pic_list1,
+                        prediction_ptr,
+                        md_context_ptr->blk_geom->origin_x,
+                        md_context_ptr->blk_geom->origin_y,
+                        use_uv,
+                        hbd_mode_decision ? EB_10BIT : EB_8BIT);
                     model_rd_for_sb(picture_control_set_ptr,
                                     prediction_ptr,
                                     md_context_ptr,
@@ -2979,46 +2978,46 @@ void interpolation_filter_search(PictureControlSet *          picture_control_se
                     int64_t tmp_rd;
 
                     if (/*cm->seq_params.enable_dual_filter*/ picture_control_set_ptr
-                                                                      ->parent_pcs_ptr->scs_ptr->seq_header.enable_dual_filter == 0)
+                            ->parent_pcs_ptr->scs_ptr->seq_header.enable_dual_filter == 0)
                         if (filter_sets[i][0] != filter_sets[i][1]) continue;
 
                     /*mbmi*/ candidate_buffer_ptr->candidate_ptr->interp_filters =
-                                     av1_make_interp_filters((InterpFilter)filter_sets[i][0],
-                                                             (InterpFilter)filter_sets[i][1]);
+                        av1_make_interp_filters((InterpFilter)filter_sets[i][0],
+                                                (InterpFilter)filter_sets[i][1]);
 
                     tmp_rs = eb_av1_get_switchable_rate(candidate_buffer_ptr, cm, md_context_ptr);
 
                     av1_inter_prediction(
-                            picture_control_set_ptr,
-                            candidate_buffer_ptr->candidate_ptr->interp_filters,
-                            md_context_ptr->blk_ptr,
-                            candidate_buffer_ptr->candidate_ptr->ref_frame_type,
-                            &mv_unit,
-                            0,
-                            SIMPLE_TRANSLATION,
-                            0,
-                            0,
-                            candidate_buffer_ptr->candidate_ptr->compound_idx,
-                            &candidate_buffer_ptr->candidate_ptr->interinter_comp,
-                            &md_context_ptr->sb_ptr->tile_info,
-                            md_context_ptr->luma_recon_neighbor_array,
-                            md_context_ptr->cb_recon_neighbor_array,
-                            md_context_ptr->cr_recon_neighbor_array,
-                            0, //No inter-intra for IFSearch
-                            candidate_buffer_ptr->candidate_ptr->interintra_mode,
-                            candidate_buffer_ptr->candidate_ptr->use_wedge_interintra,
-                            candidate_buffer_ptr->candidate_ptr->interintra_wedge_index,
-                            md_context_ptr->blk_origin_x,
-                            md_context_ptr->blk_origin_y,
-                            md_context_ptr->blk_geom->bwidth,
-                            md_context_ptr->blk_geom->bheight,
-                            ref_pic_list0,
-                            ref_pic_list1,
-                            prediction_ptr,
-                            md_context_ptr->blk_geom->origin_x,
-                            md_context_ptr->blk_geom->origin_y,
-                            use_uv,
-                            hbd_mode_decision ? EB_10BIT : EB_8BIT);
+                        picture_control_set_ptr,
+                        candidate_buffer_ptr->candidate_ptr->interp_filters,
+                        md_context_ptr->blk_ptr,
+                        candidate_buffer_ptr->candidate_ptr->ref_frame_type,
+                        &mv_unit,
+                        0,
+                        SIMPLE_TRANSLATION,
+                        0,
+                        0,
+                        candidate_buffer_ptr->candidate_ptr->compound_idx,
+                        &candidate_buffer_ptr->candidate_ptr->interinter_comp,
+                        &md_context_ptr->sb_ptr->tile_info,
+                        md_context_ptr->luma_recon_neighbor_array,
+                        md_context_ptr->cb_recon_neighbor_array,
+                        md_context_ptr->cr_recon_neighbor_array,
+                        0, //No inter-intra for IFSearch
+                        candidate_buffer_ptr->candidate_ptr->interintra_mode,
+                        candidate_buffer_ptr->candidate_ptr->use_wedge_interintra,
+                        candidate_buffer_ptr->candidate_ptr->interintra_wedge_index,
+                        md_context_ptr->blk_origin_x,
+                        md_context_ptr->blk_origin_y,
+                        md_context_ptr->blk_geom->bwidth,
+                        md_context_ptr->blk_geom->bheight,
+                        ref_pic_list0,
+                        ref_pic_list1,
+                        prediction_ptr,
+                        md_context_ptr->blk_geom->origin_x,
+                        md_context_ptr->blk_geom->origin_y,
+                        use_uv,
+                        hbd_mode_decision ? EB_10BIT : EB_8BIT);
 
                     model_rd_for_sb(picture_control_set_ptr,
                                     prediction_ptr,
@@ -3045,7 +3044,6 @@ void interpolation_filter_search(PictureControlSet *          picture_control_se
         }
     }
 }
-
 
 EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr, MvUnit *mv_unit,
                                      uint8_t ref_frame_type, uint8_t compound_idx,
@@ -3076,21 +3074,24 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
 #if WARP_IMPROVEMENT
     if (mv_unit->pred_direction == UNI_PRED_LIST_0 || mv_unit->pred_direction == BI_PRED) {
         // Y
-        src_ptr_l0 = ref_pic_list0->buffer_y + (is16bit ? 2 : 1)
-                                               * (ref_pic_list0->origin_x + ref_pic_list0->origin_y * ref_pic_list0->stride_y);
-        src_ptr_l1 = is_compound ? ref_pic_list1->buffer_y + (is16bit ? 2 : 1)
-                                                             * (ref_pic_list1->origin_x + ref_pic_list1->origin_y * ref_pic_list1->stride_y)
+        src_ptr_l0 = ref_pic_list0->buffer_y +
+                     (is16bit ? 2 : 1) * (ref_pic_list0->origin_x +
+                                          ref_pic_list0->origin_y * ref_pic_list0->stride_y);
+        src_ptr_l1 = is_compound ? ref_pic_list1->buffer_y +
+                                       (is16bit ? 2 : 1) *
+                                           (ref_pic_list1->origin_x +
+                                            ref_pic_list1->origin_y * ref_pic_list1->stride_y)
                                  : NULL;
         src_stride = ref_pic_list0->stride_y;
-        buf_width = ref_pic_list0->width;
+        buf_width  = ref_pic_list0->width;
         buf_height = ref_pic_list0->height;
-    }
-    else{ //UNI_PRED_LIST_1
-        src_ptr_l0 = ref_pic_list1->buffer_y + (is16bit ? 2 : 1)
-                                               * (ref_pic_list1->origin_x + ref_pic_list1->origin_y * ref_pic_list1->stride_y);
+    } else { //UNI_PRED_LIST_1
+        src_ptr_l0 = ref_pic_list1->buffer_y +
+                     (is16bit ? 2 : 1) * (ref_pic_list1->origin_x +
+                                          ref_pic_list1->origin_y * ref_pic_list1->stride_y);
         src_ptr_l1 = NULL;
         src_stride = ref_pic_list1->stride_y;
-        buf_width = ref_pic_list1->width;
+        buf_width  = ref_pic_list1->width;
         buf_height = ref_pic_list1->height;
     }
 #else
@@ -3110,9 +3111,9 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
     buf_height = ref_pic_list0->height;
 #endif
     dst_ptr =
-            prediction_ptr->buffer_y +
-            (is16bit ? 2 : 1) * (prediction_ptr->origin_x + dst_origin_x +
-                                 (prediction_ptr->origin_y + dst_origin_y) * prediction_ptr->stride_y);
+        prediction_ptr->buffer_y +
+        (is16bit ? 2 : 1) * (prediction_ptr->origin_x + dst_origin_x +
+                             (prediction_ptr->origin_y + dst_origin_y) * prediction_ptr->stride_y);
     dst_stride = prediction_ptr->stride_y;
 
     // Warp plane
@@ -3147,19 +3148,21 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
             // Cb
 #if WARP_IMPROVEMENT
             if (mv_unit->pred_direction == UNI_PRED_LIST_0 || mv_unit->pred_direction == BI_PRED) {
-                src_ptr_l0 = ref_pic_list0->buffer_cb + (is16bit ? 2 : 1)
-                                                        * (ref_pic_list0->origin_x / 2
-                                                           + (ref_pic_list0->origin_y / 2) * ref_pic_list0->stride_cb);
-                src_ptr_l1 = is_compound ? ref_pic_list1->buffer_cb + (is16bit ? 2 : 1)
-                                                                      * (ref_pic_list1->origin_x / 2
-                                                                         + (ref_pic_list1->origin_y / 2) * ref_pic_list1->stride_cb)
+                src_ptr_l0 =
+                    ref_pic_list0->buffer_cb +
+                    (is16bit ? 2 : 1) * (ref_pic_list0->origin_x / 2 +
+                                         (ref_pic_list0->origin_y / 2) * ref_pic_list0->stride_cb);
+                src_ptr_l1 = is_compound ? ref_pic_list1->buffer_cb +
+                                               (is16bit ? 2 : 1) * (ref_pic_list1->origin_x / 2 +
+                                                                    (ref_pic_list1->origin_y / 2) *
+                                                                        ref_pic_list1->stride_cb)
                                          : NULL;
                 src_stride = ref_pic_list0->stride_cb;
-            }
-            else { //UNI_PRED_LIST_1
-                src_ptr_l0 = ref_pic_list1->buffer_cb + (is16bit ? 2 : 1)
-                                                        * (ref_pic_list1->origin_x / 2
-                                                           + (ref_pic_list1->origin_y / 2) * ref_pic_list1->stride_cb);
+            } else { //UNI_PRED_LIST_1
+                src_ptr_l0 =
+                    ref_pic_list1->buffer_cb +
+                    (is16bit ? 2 : 1) * (ref_pic_list1->origin_x / 2 +
+                                         (ref_pic_list1->origin_y / 2) * ref_pic_list1->stride_cb);
                 src_ptr_l1 = NULL;
                 src_stride = ref_pic_list1->stride_cb;
             }
@@ -3176,9 +3179,9 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
             src_stride = ref_pic_list0->stride_cb;
 #endif
             dst_ptr =
-                    prediction_ptr->buffer_cb +
-                    (is16bit ? 2 : 1) * ((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
-                                         (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
+                prediction_ptr->buffer_cb +
+                (is16bit ? 2 : 1) * ((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
+                                     (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
                                          prediction_ptr->stride_cb);
             dst_stride = prediction_ptr->stride_cb;
 
@@ -3209,19 +3212,21 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
             // Cr
 #if WARP_IMPROVEMENT
             if (mv_unit->pred_direction == UNI_PRED_LIST_0 || mv_unit->pred_direction == BI_PRED) {
-                src_ptr_l0 = ref_pic_list0->buffer_cr + (is16bit ? 2 : 1)
-                                                        * (ref_pic_list0->origin_x / 2
-                                                           + (ref_pic_list0->origin_y / 2) * ref_pic_list0->stride_cr);
-                src_ptr_l1 = is_compound ? ref_pic_list1->buffer_cr + (is16bit ? 2 : 1)
-                                                                      * (ref_pic_list1->origin_x / 2
-                                                                         + (ref_pic_list1->origin_y / 2) * ref_pic_list1->stride_cr)
+                src_ptr_l0 =
+                    ref_pic_list0->buffer_cr +
+                    (is16bit ? 2 : 1) * (ref_pic_list0->origin_x / 2 +
+                                         (ref_pic_list0->origin_y / 2) * ref_pic_list0->stride_cr);
+                src_ptr_l1 = is_compound ? ref_pic_list1->buffer_cr +
+                                               (is16bit ? 2 : 1) * (ref_pic_list1->origin_x / 2 +
+                                                                    (ref_pic_list1->origin_y / 2) *
+                                                                        ref_pic_list1->stride_cr)
                                          : NULL;
                 src_stride = ref_pic_list0->stride_cr;
-            }
-            else { //UNI_PRED_LIST_1
-                src_ptr_l0 = ref_pic_list1->buffer_cr + (is16bit ? 2 : 1)
-                                                        * (ref_pic_list1->origin_x / 2
-                                                           + (ref_pic_list1->origin_y / 2) * ref_pic_list1->stride_cr);
+            } else { //UNI_PRED_LIST_1
+                src_ptr_l0 =
+                    ref_pic_list1->buffer_cr +
+                    (is16bit ? 2 : 1) * (ref_pic_list1->origin_x / 2 +
+                                         (ref_pic_list1->origin_y / 2) * ref_pic_list1->stride_cr);
                 src_ptr_l1 = NULL;
                 src_stride = ref_pic_list1->stride_cr;
             }
@@ -3238,9 +3243,9 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
             src_stride = ref_pic_list0->stride_cr;
 #endif
             dst_ptr =
-                    prediction_ptr->buffer_cr +
-                    (is16bit ? 2 : 1) * ((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
-                                         (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
+                prediction_ptr->buffer_cr +
+                (is16bit ? 2 : 1) * ((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
+                                     (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
                                          prediction_ptr->stride_cr);
             dst_stride = prediction_ptr->stride_cr;
 
@@ -3273,19 +3278,26 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
             // Cb
 #if WARP_IMPROVEMENT
             if (mv_unit->pred_direction == UNI_PRED_LIST_0 || mv_unit->pred_direction == BI_PRED) {
-                src_ptr_l0 = ref_pic_list0->buffer_cb + (is16bit ? 2 : 1)
-                                                        * ((ref_pic_list0->origin_x + ((pu_origin_x >> 3) << 3)) / 2
-                                                           + (ref_pic_list0->origin_y + ((pu_origin_y >> 3) << 3)) / 2 * ref_pic_list0->stride_cb);
-                src_ptr_l1 = is_compound ? ref_pic_list1->buffer_cb + (is16bit ? 2 : 1)
-                                                                      * ((ref_pic_list1->origin_x + ((pu_origin_x >> 3) << 3)) / 2
-                                                                         + (ref_pic_list1->origin_y + ((pu_origin_y >> 3) << 3)) / 2 * ref_pic_list1->stride_cb)
-                                         : NULL;
+                src_ptr_l0 =
+                    ref_pic_list0->buffer_cb +
+                    (is16bit ? 2 : 1) * ((ref_pic_list0->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
+                                         (ref_pic_list0->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
+                                             ref_pic_list0->stride_cb);
+                src_ptr_l1 =
+                    is_compound
+                        ? ref_pic_list1->buffer_cb +
+                              (is16bit ? 2 : 1) *
+                                  ((ref_pic_list1->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
+                                   (ref_pic_list1->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
+                                       ref_pic_list1->stride_cb)
+                        : NULL;
                 src_stride = ref_pic_list0->stride_cb;
-            }
-            else { //UNI_PRED_LIST_1
-                src_ptr_l0 = ref_pic_list1->buffer_cb + (is16bit ? 2 : 1)
-                                                        * ((ref_pic_list1->origin_x + ((pu_origin_x >> 3) << 3)) / 2
-                                                           + (ref_pic_list1->origin_y + ((pu_origin_y >> 3) << 3)) / 2 * ref_pic_list1->stride_cb);
+            } else { //UNI_PRED_LIST_1
+                src_ptr_l0 =
+                    ref_pic_list1->buffer_cb +
+                    (is16bit ? 2 : 1) * ((ref_pic_list1->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
+                                         (ref_pic_list1->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
+                                             ref_pic_list1->stride_cb);
                 src_ptr_l1 = NULL;
                 src_stride = ref_pic_list1->stride_cb;
             }
@@ -3305,9 +3317,9 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
             src_stride = ref_pic_list0->stride_cb;
 #endif
             dst_ptr =
-                    prediction_ptr->buffer_cb +
-                    (is16bit ? 2 : 1) * ((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
-                                         (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
+                prediction_ptr->buffer_cb +
+                (is16bit ? 2 : 1) * ((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
+                                     (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
                                          prediction_ptr->stride_cb);
             dst_stride = prediction_ptr->stride_cb;
 
@@ -3330,19 +3342,26 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
             // Cr
 #if WARP_IMPROVEMENT
             if (mv_unit->pred_direction == UNI_PRED_LIST_0 || mv_unit->pred_direction == BI_PRED) {
-                src_ptr_l0 = ref_pic_list0->buffer_cr + (is16bit ? 2 : 1)
-                                                        * ((ref_pic_list0->origin_x + ((pu_origin_x >> 3) << 3)) / 2
-                                                           + (ref_pic_list0->origin_y + ((pu_origin_y >> 3) << 3)) / 2 * ref_pic_list0->stride_cr);
-                src_ptr_l1 = is_compound ? ref_pic_list1->buffer_cr + (is16bit ? 2 : 1)
-                                                                      * ((ref_pic_list1->origin_x + ((pu_origin_x >> 3) << 3)) / 2
-                                                                         + (ref_pic_list1->origin_y + ((pu_origin_y >> 3) << 3)) / 2 * ref_pic_list1->stride_cr)
-                                         : NULL;
+                src_ptr_l0 =
+                    ref_pic_list0->buffer_cr +
+                    (is16bit ? 2 : 1) * ((ref_pic_list0->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
+                                         (ref_pic_list0->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
+                                             ref_pic_list0->stride_cr);
+                src_ptr_l1 =
+                    is_compound
+                        ? ref_pic_list1->buffer_cr +
+                              (is16bit ? 2 : 1) *
+                                  ((ref_pic_list1->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
+                                   (ref_pic_list1->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
+                                       ref_pic_list1->stride_cr)
+                        : NULL;
                 src_stride = ref_pic_list0->stride_cr;
-            }
-            else { //UNI_PRED_LIST_1
-                src_ptr_l0 = ref_pic_list1->buffer_cr + (is16bit ? 2 : 1)
-                                                        * ((ref_pic_list1->origin_x + ((pu_origin_x >> 3) << 3)) / 2
-                                                           + (ref_pic_list1->origin_y + ((pu_origin_y >> 3) << 3)) / 2 * ref_pic_list1->stride_cr);
+            } else { //UNI_PRED_LIST_1
+                src_ptr_l0 =
+                    ref_pic_list1->buffer_cr +
+                    (is16bit ? 2 : 1) * ((ref_pic_list1->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
+                                         (ref_pic_list1->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
+                                             ref_pic_list1->stride_cr);
                 src_ptr_l1 = NULL;
                 src_stride = ref_pic_list1->stride_cr;
             }
@@ -3362,9 +3381,9 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
             src_stride = ref_pic_list0->stride_cr;
 #endif
             dst_ptr =
-                    prediction_ptr->buffer_cr +
-                    (is16bit ? 2 : 1) * ((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
-                                         (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
+                prediction_ptr->buffer_cr +
+                (is16bit ? 2 : 1) * ((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
+                                     (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
                                          prediction_ptr->stride_cb);
             dst_stride = prediction_ptr->stride_cr;
 
@@ -3389,26 +3408,25 @@ EbErrorType warped_motion_prediction(PictureControlSet *picture_control_set_ptr,
     return return_error;
 }
 
-int32_t   is_inter_block(const BlockModeInfo *mbmi);
-
+int32_t is_inter_block(const BlockModeInfo *mbmi);
 
 EbErrorType av1_inter_prediction(
-        PictureControlSet *picture_control_set_ptr, uint32_t interp_filters, BlkStruct *blk_ptr,
-        uint8_t ref_frame_type, MvUnit *mv_unit, uint8_t use_intrabc, MotionMode motion_mode,
-        uint8_t use_precomputed_obmc, struct ModeDecisionContext *md_context, uint8_t compound_idx,
-        InterInterCompoundData *interinter_comp, TileInfo *tile,
-        NeighborArrayUnit *luma_recon_neighbor_array, NeighborArrayUnit *cb_recon_neighbor_array,
-        NeighborArrayUnit *cr_recon_neighbor_array, uint8_t is_interintra_used,
-        InterIntraMode interintra_mode, uint8_t use_wedge_interintra, int32_t interintra_wedge_index,
-        uint16_t pu_origin_x, uint16_t pu_origin_y, uint8_t bwidth, uint8_t bheight,
-        EbPictureBufferDesc *ref_pic_list0, EbPictureBufferDesc *ref_pic_list1,
-        EbPictureBufferDesc *prediction_ptr, uint16_t dst_origin_x, uint16_t dst_origin_y,
-        EbBool perform_chroma, uint8_t bit_depth) {
-    uint8_t is16bit = bit_depth > EB_8BIT;
+    PictureControlSet *picture_control_set_ptr, uint32_t interp_filters, BlkStruct *blk_ptr,
+    uint8_t ref_frame_type, MvUnit *mv_unit, uint8_t use_intrabc, MotionMode motion_mode,
+    uint8_t use_precomputed_obmc, struct ModeDecisionContext *md_context, uint8_t compound_idx,
+    InterInterCompoundData *interinter_comp, TileInfo *tile,
+    NeighborArrayUnit *luma_recon_neighbor_array, NeighborArrayUnit *cb_recon_neighbor_array,
+    NeighborArrayUnit *cr_recon_neighbor_array, uint8_t is_interintra_used,
+    InterIntraMode interintra_mode, uint8_t use_wedge_interintra, int32_t interintra_wedge_index,
+    uint16_t pu_origin_x, uint16_t pu_origin_y, uint8_t bwidth, uint8_t bheight,
+    EbPictureBufferDesc *ref_pic_list0, EbPictureBufferDesc *ref_pic_list1,
+    EbPictureBufferDesc *prediction_ptr, uint16_t dst_origin_x, uint16_t dst_origin_y,
+    EbBool perform_chroma, uint8_t bit_depth) {
+    uint8_t     is16bit      = bit_depth > EB_8BIT;
     EbErrorType return_error = EB_ErrorNone;
     uint8_t     is_compound  = (mv_unit->pred_direction == BI_PRED) ? 1 : 0;
     DECLARE_ALIGNED(
-            32, uint16_t, tmp_dstY[128 * 128]); //move this to context if stack does not hold.
+        32, uint16_t, tmp_dstY[128 * 128]); //move this to context if stack does not hold.
     DECLARE_ALIGNED(32, uint16_t, tmp_dstCb[64 * 64]);
     DECLARE_ALIGNED(32, uint16_t, tmp_dstCr[64 * 64]);
 
@@ -3464,23 +3482,23 @@ EbErrorType av1_inter_prediction(
                     miPtr[miX + miY * xd->mi_stride].mbmi.block_mi.ref_frame[0] = rf[0];
                     if (mv_unit->pred_direction == UNI_PRED_LIST_0) {
                         miPtr[miX + miY * xd->mi_stride].mbmi.block_mi.mv[0].as_mv.col =
-                                mv_unit->mv[REF_LIST_0].x;
+                            mv_unit->mv[REF_LIST_0].x;
                         miPtr[miX + miY * xd->mi_stride].mbmi.block_mi.mv[0].as_mv.row =
-                                mv_unit->mv[REF_LIST_0].y;
+                            mv_unit->mv[REF_LIST_0].y;
                     } else if (mv_unit->pred_direction == UNI_PRED_LIST_1) {
                         miPtr[miX + miY * xd->mi_stride].mbmi.block_mi.mv[0].as_mv.col =
-                                mv_unit->mv[REF_LIST_1].x;
+                            mv_unit->mv[REF_LIST_1].x;
                         miPtr[miX + miY * xd->mi_stride].mbmi.block_mi.mv[0].as_mv.row =
-                                mv_unit->mv[REF_LIST_1].y;
+                            mv_unit->mv[REF_LIST_1].y;
                     } else {
                         miPtr[miX + miY * xd->mi_stride].mbmi.block_mi.mv[0].as_mv.col =
-                                mv_unit->mv[REF_LIST_0].x;
+                            mv_unit->mv[REF_LIST_0].x;
                         miPtr[miX + miY * xd->mi_stride].mbmi.block_mi.mv[0].as_mv.row =
-                                mv_unit->mv[REF_LIST_0].y;
+                            mv_unit->mv[REF_LIST_0].y;
                         miPtr[miX + miY * xd->mi_stride].mbmi.block_mi.mv[1].as_mv.col =
-                                mv_unit->mv[REF_LIST_1].x;
+                            mv_unit->mv[REF_LIST_1].x;
                         miPtr[miX + miY * xd->mi_stride].mbmi.block_mi.mv[1].as_mv.row =
-                                mv_unit->mv[REF_LIST_1].y;
+                            mv_unit->mv[REF_LIST_1].y;
                     }
                 }
             }
@@ -3539,45 +3557,46 @@ EbErrorType av1_inter_prediction(
                     assert(bw < 8 || bh < 8);
 
                     conv_params = get_conv_params_no_round(
-                            0, 0, 0, tmp_dstCb, BLOCK_SIZE_64, is_compound, bit_depth);
+                        0, 0, 0, tmp_dstCb, BLOCK_SIZE_64, is_compound, bit_depth);
                     conv_params.use_jnt_comp_avg = 0;
                     uint8_t ref_idx = get_ref_frame_idx(this_mbmi->block_mi.ref_frame[0]);
                     assert(ref_idx < REF_LIST_MAX_DEPTH);
 
                     EbPictureBufferDesc *ref_pic =
-                            this_mbmi->block_mi.ref_frame[0] == LAST_FRAME ||
-                            this_mbmi->block_mi.ref_frame[0] == LAST2_FRAME ||
-                            this_mbmi->block_mi.ref_frame[0] == LAST3_FRAME ||
-                            this_mbmi->block_mi.ref_frame[0] == GOLDEN_FRAME
+                        this_mbmi->block_mi.ref_frame[0] == LAST_FRAME ||
+                                this_mbmi->block_mi.ref_frame[0] == LAST2_FRAME ||
+                                this_mbmi->block_mi.ref_frame[0] == LAST3_FRAME ||
+                                this_mbmi->block_mi.ref_frame[0] == GOLDEN_FRAME
                             ? (is16bit ? ((EbReferenceObject *)(picture_control_set_ptr
-                                    ->ref_pic_ptr_array[REF_LIST_0]
-                            [ref_idx]
-                                    ->object_ptr))
-                                    ->reference_picture16bit
+                                                                    ->ref_pic_ptr_array[REF_LIST_0]
+                                                                                       [ref_idx]
+                                                                    ->object_ptr))
+                                             ->reference_picture16bit
                                        : ((EbReferenceObject *)(picture_control_set_ptr
-                                            ->ref_pic_ptr_array[REF_LIST_0]
-                                    [ref_idx]
-                                            ->object_ptr))
-                                       ->reference_picture)
+                                                                    ->ref_pic_ptr_array[REF_LIST_0]
+                                                                                       [ref_idx]
+                                                                    ->object_ptr))
+                                             ->reference_picture)
                             : (is16bit ? ((EbReferenceObject *)(picture_control_set_ptr
-                                    ->ref_pic_ptr_array[REF_LIST_1]
-                            [ref_idx]
-                                    ->object_ptr))
-                                    ->reference_picture16bit
+                                                                    ->ref_pic_ptr_array[REF_LIST_1]
+                                                                                       [ref_idx]
+                                                                    ->object_ptr))
+                                             ->reference_picture16bit
                                        : ((EbReferenceObject *)(picture_control_set_ptr
-                                            ->ref_pic_ptr_array[REF_LIST_1]
-                                    [ref_idx]
-                                            ->object_ptr))
-                                       ->reference_picture);
+                                                                    ->ref_pic_ptr_array[REF_LIST_1]
+                                                                                       [ref_idx]
+                                                                    ->object_ptr))
+                                             ->reference_picture);
                     src_ptr =
-                            ref_pic->buffer_cb +
-                            (((ref_pic->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
-                              (ref_pic->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
-                              ref_pic->stride_cb) << is16bit);
+                        ref_pic->buffer_cb +
+                        (((ref_pic->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
+                          (ref_pic->origin_y + ((pu_origin_y >> 3) << 3)) / 2 * ref_pic->stride_cb)
+                         << is16bit);
                     dst_ptr = prediction_ptr->buffer_cb +
                               (((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
                                 (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
-                                prediction_ptr->stride_cb) << is16bit);
+                                    prediction_ptr->stride_cb)
+                               << is16bit);
                     src_stride = ref_pic->stride_cb;
                     dst_stride = prediction_ptr->stride_cb;
                     src_ptr += (x + y * ref_pic->stride_cb) << is16bit;
@@ -3585,96 +3604,104 @@ EbErrorType av1_inter_prediction(
 
                     const MV mv = this_mbmi->block_mi.mv[0].as_mv;
                     mv_q4       = clamp_mv_to_umv_border_sb(
-                            blk_ptr->av1xd, &mv, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
+                        blk_ptr->av1xd, &mv, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
                     subpel_x = mv_q4.col & SUBPEL_MASK;
                     subpel_y = mv_q4.row & SUBPEL_MASK;
-                    src_ptr += ((mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS)) << is16bit;
+                    src_ptr +=
+                        ((mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS))
+                        << is16bit;
 
-                    av1_get_convolve_filter_params(interp_filters, &filter_params_x,
-                                                   &filter_params_y, blk_geom->bwidth_uv, blk_geom->bheight_uv);
+                    av1_get_convolve_filter_params(interp_filters,
+                                                   &filter_params_x,
+                                                   &filter_params_y,
+                                                   blk_geom->bwidth_uv,
+                                                   blk_geom->bheight_uv);
 
                     if (is16bit)
-                        convolveHbd[subpel_x != 0][subpel_y != 0][is_compound](
-                                (uint16_t *)src_ptr,
-                                src_stride,
-                                (uint16_t *)dst_ptr,
-                                dst_stride,
-                                b4_w,
-                                b4_h,
-                                &filter_params_x,
-                                &filter_params_y,
-                                subpel_x,
-                                subpel_y,
-                                &conv_params,
-                                bit_depth);
+                        convolveHbd[subpel_x != 0][subpel_y != 0][is_compound]((uint16_t *)src_ptr,
+                                                                               src_stride,
+                                                                               (uint16_t *)dst_ptr,
+                                                                               dst_stride,
+                                                                               b4_w,
+                                                                               b4_h,
+                                                                               &filter_params_x,
+                                                                               &filter_params_y,
+                                                                               subpel_x,
+                                                                               subpel_y,
+                                                                               &conv_params,
+                                                                               bit_depth);
                     else
-                        convolve[subpel_x != 0][subpel_y != 0][is_compound](
-                                src_ptr,
-                                src_stride,
-                                dst_ptr,
-                                dst_stride,
-                                b4_w,
-                                b4_h,
-                                &filter_params_x,
-                                &filter_params_y,
-                                subpel_x,
-                                subpel_y,
-                                &conv_params);
+                        convolve[subpel_x != 0][subpel_y != 0][is_compound](src_ptr,
+                                                                            src_stride,
+                                                                            dst_ptr,
+                                                                            dst_stride,
+                                                                            b4_w,
+                                                                            b4_h,
+                                                                            &filter_params_x,
+                                                                            &filter_params_y,
+                                                                            subpel_x,
+                                                                            subpel_y,
+                                                                            &conv_params);
 
                     //Cr
                     conv_params = get_conv_params_no_round(
-                            0, 0, 0, tmp_dstCr, BLOCK_SIZE_64, is_compound, bit_depth);
+                        0, 0, 0, tmp_dstCr, BLOCK_SIZE_64, is_compound, bit_depth);
                     conv_params.use_jnt_comp_avg = 0;
 
-                    src_ptr = ref_pic->buffer_cr +
-                              (((ref_pic->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
-                                (ref_pic->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
-                                ref_pic->stride_cr) << is16bit);
+                    src_ptr =
+                        ref_pic->buffer_cr +
+                        (((ref_pic->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
+                          (ref_pic->origin_y + ((pu_origin_y >> 3) << 3)) / 2 * ref_pic->stride_cr)
+                         << is16bit);
                     dst_ptr = prediction_ptr->buffer_cr +
                               (((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
                                 (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
-                                prediction_ptr->stride_cr) << is16bit);
+                                    prediction_ptr->stride_cr)
+                               << is16bit);
                     src_stride = ref_pic->stride_cr;
                     dst_stride = prediction_ptr->stride_cr;
                     src_ptr += (x + y * ref_pic->stride_cr) << is16bit;
                     dst_ptr += (x + y * prediction_ptr->stride_cr) << is16bit;
 
                     mv_q4 = clamp_mv_to_umv_border_sb(
-                            blk_ptr->av1xd, &mv, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
+                        blk_ptr->av1xd, &mv, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
                     subpel_x = mv_q4.col & SUBPEL_MASK;
                     subpel_y = mv_q4.row & SUBPEL_MASK;
-                    src_ptr += ((mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS)) << is16bit;
+                    src_ptr +=
+                        ((mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS))
+                        << is16bit;
 
-                    av1_get_convolve_filter_params(interp_filters, &filter_params_x,
-                                                   &filter_params_y, blk_geom->bwidth_uv, blk_geom->bheight_uv);
+                    av1_get_convolve_filter_params(interp_filters,
+                                                   &filter_params_x,
+                                                   &filter_params_y,
+                                                   blk_geom->bwidth_uv,
+                                                   blk_geom->bheight_uv);
 
                     if (is16bit)
-                        convolveHbd[subpel_x != 0][subpel_y != 0][is_compound](
-                                (uint16_t *)src_ptr,
-                                src_stride,
-                                (uint16_t *)dst_ptr,
-                                dst_stride,
-                                b4_w,
-                                b4_h,
-                                &filter_params_x,
-                                &filter_params_y,
-                                subpel_x,
-                                subpel_y,
-                                &conv_params,
-                                bit_depth);
+                        convolveHbd[subpel_x != 0][subpel_y != 0][is_compound]((uint16_t *)src_ptr,
+                                                                               src_stride,
+                                                                               (uint16_t *)dst_ptr,
+                                                                               dst_stride,
+                                                                               b4_w,
+                                                                               b4_h,
+                                                                               &filter_params_x,
+                                                                               &filter_params_y,
+                                                                               subpel_x,
+                                                                               subpel_y,
+                                                                               &conv_params,
+                                                                               bit_depth);
                     else
-                        convolve[subpel_x != 0][subpel_y != 0][is_compound](
-                                src_ptr,
-                                src_stride,
-                                dst_ptr,
-                                dst_stride,
-                                b4_w,
-                                b4_h,
-                                &filter_params_x,
-                                &filter_params_y,
-                                subpel_x,
-                                subpel_y,
-                                &conv_params);
+                        convolve[subpel_x != 0][subpel_y != 0][is_compound](src_ptr,
+                                                                            src_stride,
+                                                                            dst_ptr,
+                                                                            dst_stride,
+                                                                            b4_w,
+                                                                            b4_h,
+                                                                            &filter_params_x,
+                                                                            &filter_params_y,
+                                                                            subpel_x,
+                                                                            subpel_y,
+                                                                            &conv_params);
 
                     ++col;
                 }
@@ -3692,75 +3719,77 @@ EbErrorType av1_inter_prediction(
         assert(ref_pic_list0 != NULL);
         src_ptr = ref_pic_list0->buffer_y +
                   ((ref_pic_list0->origin_x + pu_origin_x +
-                    (ref_pic_list0->origin_y + pu_origin_y) *
-                    ref_pic_list0->stride_y) << is16bit);
+                    (ref_pic_list0->origin_y + pu_origin_y) * ref_pic_list0->stride_y)
+                   << is16bit);
         dst_ptr = prediction_ptr->buffer_y +
                   ((prediction_ptr->origin_x + dst_origin_x +
-                    (prediction_ptr->origin_y + dst_origin_y) *
-                    prediction_ptr->stride_y) << is16bit);
+                    (prediction_ptr->origin_y + dst_origin_y) * prediction_ptr->stride_y)
+                   << is16bit);
         src_stride = ref_pic_list0->stride_y;
         dst_stride = prediction_ptr->stride_y;
 
         mv_q4 = clamp_mv_to_umv_border_sb(
-                blk_ptr->av1xd,
-                &mv,
-                bwidth,
-                bheight,
-                0,
-                0); //mv_q4 has 1 extra bit for fractionnal to accomodate chroma when accessing filter coeffs.
+            blk_ptr->av1xd,
+            &mv,
+            bwidth,
+            bheight,
+            0,
+            0); //mv_q4 has 1 extra bit for fractionnal to accomodate chroma when accessing filter coeffs.
         subpel_x = mv_q4.col & SUBPEL_MASK;
         subpel_y = mv_q4.row & SUBPEL_MASK;
-        src_ptr += ((mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS)) << is16bit;
+        src_ptr += ((mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS))
+                   << is16bit;
         conv_params = get_conv_params_no_round(0, 0, 0, tmp_dstY, 128, is_compound, bit_depth);
-        av1_get_convolve_filter_params(interp_filters, &filter_params_x,
-                                       &filter_params_y, bwidth, bheight);
+        av1_get_convolve_filter_params(
+            interp_filters, &filter_params_x, &filter_params_y, bwidth, bheight);
 
         if (is16bit)
-            convolveHbd[subpel_x != 0][subpel_y != 0][is_compound](
-                    (uint16_t *)src_ptr,
-                    src_stride,
-                    (uint16_t *)dst_ptr,
-                    dst_stride,
-                    bwidth,
-                    bheight,
-                    &filter_params_x,
-                    &filter_params_y,
-                    subpel_x,
-                    subpel_y,
-                    &conv_params,
-                    bit_depth);
+            convolveHbd[subpel_x != 0][subpel_y != 0][is_compound]((uint16_t *)src_ptr,
+                                                                   src_stride,
+                                                                   (uint16_t *)dst_ptr,
+                                                                   dst_stride,
+                                                                   bwidth,
+                                                                   bheight,
+                                                                   &filter_params_x,
+                                                                   &filter_params_y,
+                                                                   subpel_x,
+                                                                   subpel_y,
+                                                                   &conv_params,
+                                                                   bit_depth);
         else
-            convolve[subpel_x != 0][subpel_y != 0][is_compound](
-                    src_ptr,
-                    src_stride,
-                    dst_ptr,
-                    dst_stride,
-                    bwidth,
-                    bheight,
-                    &filter_params_x,
-                    &filter_params_y,
-                    subpel_x,
-                    subpel_y,
-                    &conv_params);
+            convolve[subpel_x != 0][subpel_y != 0][is_compound](src_ptr,
+                                                                src_stride,
+                                                                dst_ptr,
+                                                                dst_stride,
+                                                                bwidth,
+                                                                bheight,
+                                                                &filter_params_x,
+                                                                &filter_params_y,
+                                                                subpel_x,
+                                                                subpel_y,
+                                                                &conv_params);
 
         if (perform_chroma && blk_geom->has_uv && sub8x8_inter == 0) {
             //List0-Cb
             src_ptr = ref_pic_list0->buffer_cb +
                       (((ref_pic_list0->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
                         (ref_pic_list0->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
-                        ref_pic_list0->stride_cb) << is16bit);
+                            ref_pic_list0->stride_cb)
+                       << is16bit);
             dst_ptr = prediction_ptr->buffer_cb +
                       (((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
                         (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
-                        prediction_ptr->stride_cb) << is16bit);
+                            prediction_ptr->stride_cb)
+                       << is16bit);
             src_stride = ref_pic_list0->stride_cb;
             dst_stride = prediction_ptr->stride_cb;
 
             mv_q4 = clamp_mv_to_umv_border_sb(
-                    blk_ptr->av1xd, &mv, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
+                blk_ptr->av1xd, &mv, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
             subpel_x = mv_q4.col & SUBPEL_MASK;
             subpel_y = mv_q4.row & SUBPEL_MASK;
-            src_ptr += ((mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS)) << is16bit;
+            src_ptr += ((mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS))
+                       << is16bit;
             conv_params = get_conv_params_no_round(0, 0, 0, tmp_dstCb, 64, is_compound, bit_depth);
 
             av1_get_convolve_filter_params(interp_filters,
@@ -3769,8 +3798,7 @@ EbErrorType av1_inter_prediction(
                                            blk_geom->bwidth_uv,
                                            blk_geom->bheight_uv);
 
-            if (use_intrabc && (subpel_x != 0 || subpel_y != 0))
-            {
+            if (use_intrabc && (subpel_x != 0 || subpel_y != 0)) {
                 if (is16bit)
                     highbd_convolve_2d_for_intrabc((const uint16_t *)src_ptr,
                                                    src_stride,
@@ -3792,59 +3820,57 @@ EbErrorType av1_inter_prediction(
                                             subpel_x,
                                             subpel_y,
                                             &conv_params);
-            }
-            else
-            {
+            } else {
                 if (is16bit)
-                    convolveHbd[subpel_x != 0][subpel_y != 0][is_compound](
-                            (uint16_t *)src_ptr,
-                            src_stride,
-                            (uint16_t *)dst_ptr,
-                            dst_stride,
-                            blk_geom->bwidth_uv,
-                            blk_geom->bheight_uv,
-                            &filter_params_x,
-                            &filter_params_y,
-                            subpel_x,
-                            subpel_y,
-                            &conv_params,
-                            bit_depth);
+                    convolveHbd[subpel_x != 0][subpel_y != 0][is_compound]((uint16_t *)src_ptr,
+                                                                           src_stride,
+                                                                           (uint16_t *)dst_ptr,
+                                                                           dst_stride,
+                                                                           blk_geom->bwidth_uv,
+                                                                           blk_geom->bheight_uv,
+                                                                           &filter_params_x,
+                                                                           &filter_params_y,
+                                                                           subpel_x,
+                                                                           subpel_y,
+                                                                           &conv_params,
+                                                                           bit_depth);
                 else
-                    convolve[subpel_x != 0][subpel_y != 0][is_compound](
-                            src_ptr,
-                            src_stride,
-                            dst_ptr,
-                            dst_stride,
-                            blk_geom->bwidth_uv,
-                            blk_geom->bheight_uv,
-                            &filter_params_x,
-                            &filter_params_y,
-                            subpel_x,
-                            subpel_y,
-                            &conv_params);
+                    convolve[subpel_x != 0][subpel_y != 0][is_compound](src_ptr,
+                                                                        src_stride,
+                                                                        dst_ptr,
+                                                                        dst_stride,
+                                                                        blk_geom->bwidth_uv,
+                                                                        blk_geom->bheight_uv,
+                                                                        &filter_params_x,
+                                                                        &filter_params_y,
+                                                                        subpel_x,
+                                                                        subpel_y,
+                                                                        &conv_params);
             }
 
             //List0-Cr
             src_ptr = ref_pic_list0->buffer_cr +
                       (((ref_pic_list0->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
                         (ref_pic_list0->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
-                        ref_pic_list0->stride_cr) << is16bit);
+                            ref_pic_list0->stride_cr)
+                       << is16bit);
             dst_ptr = prediction_ptr->buffer_cr +
                       (((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
                         (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
-                        prediction_ptr->stride_cr) << is16bit);
+                            prediction_ptr->stride_cr)
+                       << is16bit);
             src_stride = ref_pic_list0->stride_cr;
             dst_stride = prediction_ptr->stride_cr;
 
             mv_q4 = clamp_mv_to_umv_border_sb(
-                    blk_ptr->av1xd, &mv, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
+                blk_ptr->av1xd, &mv, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
             subpel_x = mv_q4.col & SUBPEL_MASK;
             subpel_y = mv_q4.row & SUBPEL_MASK;
-            src_ptr += ((mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS)) << is16bit;
+            src_ptr += ((mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS))
+                       << is16bit;
             conv_params = get_conv_params_no_round(0, 0, 0, tmp_dstCr, 64, is_compound, bit_depth);
 
-            if (use_intrabc && (subpel_x != 0 || subpel_y != 0))
-            {
+            if (use_intrabc && (subpel_x != 0 || subpel_y != 0)) {
                 if (is16bit)
                     highbd_convolve_2d_for_intrabc((const uint16_t *)src_ptr,
                                                    src_stride,
@@ -3866,36 +3892,32 @@ EbErrorType av1_inter_prediction(
                                             subpel_x,
                                             subpel_y,
                                             &conv_params);
-            }
-            else
-            {
+            } else {
                 if (is16bit)
-                    convolveHbd[subpel_x != 0][subpel_y != 0][is_compound](
-                            (uint16_t *)src_ptr,
-                            src_stride,
-                            (uint16_t *)dst_ptr,
-                            dst_stride,
-                            blk_geom->bwidth_uv,
-                            blk_geom->bheight_uv,
-                            &filter_params_x,
-                            &filter_params_y,
-                            subpel_x,
-                            subpel_y,
-                            &conv_params,
-                            bit_depth);
+                    convolveHbd[subpel_x != 0][subpel_y != 0][is_compound]((uint16_t *)src_ptr,
+                                                                           src_stride,
+                                                                           (uint16_t *)dst_ptr,
+                                                                           dst_stride,
+                                                                           blk_geom->bwidth_uv,
+                                                                           blk_geom->bheight_uv,
+                                                                           &filter_params_x,
+                                                                           &filter_params_y,
+                                                                           subpel_x,
+                                                                           subpel_y,
+                                                                           &conv_params,
+                                                                           bit_depth);
                 else
-                    convolve[subpel_x != 0][subpel_y != 0][is_compound](
-                            src_ptr,
-                            src_stride,
-                            dst_ptr,
-                            dst_stride,
-                            blk_geom->bwidth_uv,
-                            blk_geom->bheight_uv,
-                            &filter_params_x,
-                            &filter_params_y,
-                            subpel_x,
-                            subpel_y,
-                            &conv_params);
+                    convolve[subpel_x != 0][subpel_y != 0][is_compound](src_ptr,
+                                                                        src_stride,
+                                                                        dst_ptr,
+                                                                        dst_stride,
+                                                                        blk_geom->bwidth_uv,
+                                                                        blk_geom->bheight_uv,
+                                                                        &filter_params_x,
+                                                                        &filter_params_y,
+                                                                        subpel_x,
+                                                                        subpel_y,
+                                                                        &conv_params);
             }
         }
     }
@@ -3907,130 +3929,141 @@ EbErrorType av1_inter_prediction(
         assert(ref_pic_list1 != NULL);
         src_ptr = ref_pic_list1->buffer_y +
                   ((ref_pic_list1->origin_x + pu_origin_x +
-                    (ref_pic_list1->origin_y + pu_origin_y) *
-                    ref_pic_list1->stride_y) << is16bit);
+                    (ref_pic_list1->origin_y + pu_origin_y) * ref_pic_list1->stride_y)
+                   << is16bit);
         dst_ptr = prediction_ptr->buffer_y +
                   ((prediction_ptr->origin_x + dst_origin_x +
-                    (prediction_ptr->origin_y + dst_origin_y) *
-                    prediction_ptr->stride_y) << is16bit);
+                    (prediction_ptr->origin_y + dst_origin_y) * prediction_ptr->stride_y)
+                   << is16bit);
         src_stride = ref_pic_list1->stride_y;
         dst_stride = prediction_ptr->stride_y;
 
         mv_q4 = clamp_mv_to_umv_border_sb(
-                blk_ptr->av1xd,
-                &mv,
-                bwidth,
-                bheight,
-                0,
-                0); //mv_q4 has 1 extra bit for fractionnal to accomodate chroma when accessing filter coeffs.
+            blk_ptr->av1xd,
+            &mv,
+            bwidth,
+            bheight,
+            0,
+            0); //mv_q4 has 1 extra bit for fractionnal to accomodate chroma when accessing filter coeffs.
         subpel_x = mv_q4.col & SUBPEL_MASK;
         subpel_y = mv_q4.row & SUBPEL_MASK;
 
-        src_ptr += ((mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS)) << is16bit;
-        conv_params = get_conv_params_no_round(0, (mv_unit->pred_direction == BI_PRED) ? 1 : 0, 0, tmp_dstY, 128, is_compound, bit_depth);
+        src_ptr += ((mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS))
+                   << is16bit;
+        conv_params = get_conv_params_no_round(0,
+                                               (mv_unit->pred_direction == BI_PRED) ? 1 : 0,
+                                               0,
+                                               tmp_dstY,
+                                               128,
+                                               is_compound,
+                                               bit_depth);
 
         av1_get_convolve_filter_params(
-                interp_filters, &filter_params_x, &filter_params_y, bwidth, bheight);
+            interp_filters, &filter_params_x, &filter_params_y, bwidth, bheight);
 
         //the luma data is applied to chroma below
         av1_dist_wtd_comp_weight_assign(
-                &picture_control_set_ptr->parent_pcs_ptr->scs_ptr->seq_header,
-                picture_control_set_ptr->parent_pcs_ptr->cur_order_hint, // cur_frame_index,
-                picture_control_set_ptr->parent_pcs_ptr->ref_order_hint[rf[0] - 1], // bck_frame_index,
-                picture_control_set_ptr->parent_pcs_ptr->ref_order_hint[rf[1] - 1], // fwd_frame_index,
-                compound_idx,
-                0, // order_idx,
-                &conv_params.fwd_offset,
-                &conv_params.bck_offset,
-                &conv_params.use_dist_wtd_comp_avg,
-                is_compound);
+            &picture_control_set_ptr->parent_pcs_ptr->scs_ptr->seq_header,
+            picture_control_set_ptr->parent_pcs_ptr->cur_order_hint, // cur_frame_index,
+            picture_control_set_ptr->parent_pcs_ptr->ref_order_hint[rf[0] - 1], // bck_frame_index,
+            picture_control_set_ptr->parent_pcs_ptr->ref_order_hint[rf[1] - 1], // fwd_frame_index,
+            compound_idx,
+            0, // order_idx,
+            &conv_params.fwd_offset,
+            &conv_params.bck_offset,
+            &conv_params.use_dist_wtd_comp_avg,
+            is_compound);
 
         conv_params.use_jnt_comp_avg = conv_params.use_dist_wtd_comp_avg;
 
         if (is_compound && is_masked_compound_type(interinter_comp->type)) {
             conv_params.do_average = 0;
             av1_make_masked_inter_predictor(
-                    src_ptr,
-                    src_stride,
-                    dst_ptr,
-                    dst_stride,
-                    blk_geom,
-                    bwidth,
-                    bheight,
-                    &filter_params_x,
-                    &filter_params_y,
-                    subpel_x,
-                    subpel_y,
-                    &conv_params,
-                    interinter_comp,
-                    bit_depth,
-                    0//plane=Luma  seg_mask is computed based on luma and used for chroma
+                src_ptr,
+                src_stride,
+                dst_ptr,
+                dst_stride,
+                blk_geom,
+                bwidth,
+                bheight,
+                &filter_params_x,
+                &filter_params_y,
+                subpel_x,
+                subpel_y,
+                &conv_params,
+                interinter_comp,
+                bit_depth,
+                0 //plane=Luma  seg_mask is computed based on luma and used for chroma
             );
-        }
-        else
-        {
+        } else {
             if (is16bit)
-                convolveHbd[subpel_x != 0][subpel_y != 0][is_compound](
-                        (uint16_t *)src_ptr,
-                        src_stride,
-                        (uint16_t *)dst_ptr,
-                        dst_stride,
-                        bwidth,
-                        bheight,
-                        &filter_params_x,
-                        &filter_params_y,
-                        subpel_x,
-                        subpel_y,
-                        &conv_params,
-                        bit_depth);
+                convolveHbd[subpel_x != 0][subpel_y != 0][is_compound]((uint16_t *)src_ptr,
+                                                                       src_stride,
+                                                                       (uint16_t *)dst_ptr,
+                                                                       dst_stride,
+                                                                       bwidth,
+                                                                       bheight,
+                                                                       &filter_params_x,
+                                                                       &filter_params_y,
+                                                                       subpel_x,
+                                                                       subpel_y,
+                                                                       &conv_params,
+                                                                       bit_depth);
             else
-                convolve[subpel_x != 0][subpel_y != 0][is_compound](
-                        src_ptr,
-                        src_stride,
-                        dst_ptr,
-                        dst_stride,
-                        bwidth,
-                        bheight,
-                        &filter_params_x,
-                        &filter_params_y,
-                        subpel_x,
-                        subpel_y,
-                        &conv_params);
+                convolve[subpel_x != 0][subpel_y != 0][is_compound](src_ptr,
+                                                                    src_stride,
+                                                                    dst_ptr,
+                                                                    dst_stride,
+                                                                    bwidth,
+                                                                    bheight,
+                                                                    &filter_params_x,
+                                                                    &filter_params_y,
+                                                                    subpel_x,
+                                                                    subpel_y,
+                                                                    &conv_params);
         }
         if (perform_chroma && blk_geom->has_uv && sub8x8_inter == 0) {
             //List0-Cb
             src_ptr = ref_pic_list1->buffer_cb +
                       (((ref_pic_list1->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
                         (ref_pic_list1->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
-                        ref_pic_list1->stride_cb) << is16bit);
+                            ref_pic_list1->stride_cb)
+                       << is16bit);
             dst_ptr = prediction_ptr->buffer_cb +
                       (((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
                         (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
-                        prediction_ptr->stride_cb) << is16bit);
+                            prediction_ptr->stride_cb)
+                       << is16bit);
             src_stride = ref_pic_list1->stride_cb;
             dst_stride = prediction_ptr->stride_cb;
 
             mv_q4 = clamp_mv_to_umv_border_sb(
-                    blk_ptr->av1xd, &mv, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
+                blk_ptr->av1xd, &mv, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
             subpel_x = mv_q4.col & SUBPEL_MASK;
             subpel_y = mv_q4.row & SUBPEL_MASK;
-            src_ptr += ((mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS)) << is16bit;
-            conv_params = get_conv_params_no_round(0, (mv_unit->pred_direction == BI_PRED) ? 1 : 0, 0,
-                                                   tmp_dstCb, 64, is_compound, bit_depth);
+            src_ptr += ((mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS))
+                       << is16bit;
+            conv_params = get_conv_params_no_round(0,
+                                                   (mv_unit->pred_direction == BI_PRED) ? 1 : 0,
+                                                   0,
+                                                   tmp_dstCb,
+                                                   64,
+                                                   is_compound,
+                                                   bit_depth);
 
             av1_dist_wtd_comp_weight_assign(
-                    &picture_control_set_ptr->parent_pcs_ptr->scs_ptr->seq_header,
-                    picture_control_set_ptr->parent_pcs_ptr->cur_order_hint, // cur_frame_index,
-                    picture_control_set_ptr->parent_pcs_ptr
-                            ->ref_order_hint[rf[0] - 1], // bck_frame_index,
-                    picture_control_set_ptr->parent_pcs_ptr
-                            ->ref_order_hint[rf[1] - 1], // fwd_frame_index,
-                    compound_idx,
-                    0, // order_idx,
-                    &conv_params.fwd_offset,
-                    &conv_params.bck_offset,
-                    &conv_params.use_dist_wtd_comp_avg,
-                    is_compound);
+                &picture_control_set_ptr->parent_pcs_ptr->scs_ptr->seq_header,
+                picture_control_set_ptr->parent_pcs_ptr->cur_order_hint, // cur_frame_index,
+                picture_control_set_ptr->parent_pcs_ptr
+                    ->ref_order_hint[rf[0] - 1], // bck_frame_index,
+                picture_control_set_ptr->parent_pcs_ptr
+                    ->ref_order_hint[rf[1] - 1], // fwd_frame_index,
+                compound_idx,
+                0, // order_idx,
+                &conv_params.fwd_offset,
+                &conv_params.bck_offset,
+                &conv_params.use_dist_wtd_comp_avg,
+                is_compound);
 
             conv_params.use_jnt_comp_avg = conv_params.use_dist_wtd_comp_avg;
 
@@ -4043,138 +4076,138 @@ EbErrorType av1_inter_prediction(
             if (is_compound && is_masked_compound_type(interinter_comp->type)) {
                 conv_params.do_average = 0;
                 av1_make_masked_inter_predictor(
-                        src_ptr,
-                        src_stride,
-                        dst_ptr,
-                        dst_stride,
-                        blk_geom,
-                        blk_geom->bwidth_uv,
-                        blk_geom->bheight_uv,
-                        &filter_params_x,
-                        &filter_params_y,
-                        subpel_x,
-                        subpel_y,
-                        &conv_params,
-                        interinter_comp,
-                        bit_depth,
-                        1 //plane=cb  seg_mask is computed based on luma and used for chroma
+                    src_ptr,
+                    src_stride,
+                    dst_ptr,
+                    dst_stride,
+                    blk_geom,
+                    blk_geom->bwidth_uv,
+                    blk_geom->bheight_uv,
+                    &filter_params_x,
+                    &filter_params_y,
+                    subpel_x,
+                    subpel_y,
+                    &conv_params,
+                    interinter_comp,
+                    bit_depth,
+                    1 //plane=cb  seg_mask is computed based on luma and used for chroma
                 );
-            }
-            else
-            {
+            } else {
                 if (is16bit)
-                    convolveHbd[subpel_x != 0][subpel_y != 0][is_compound](
-                            (uint16_t *)src_ptr,
-                            src_stride,
-                            (uint16_t *)dst_ptr,
-                            dst_stride,
-                            blk_geom->bwidth_uv,
-                            blk_geom->bheight_uv,
-                            &filter_params_x,
-                            &filter_params_y,
-                            subpel_x,
-                            subpel_y,
-                            &conv_params,
-                            bit_depth);
+                    convolveHbd[subpel_x != 0][subpel_y != 0][is_compound]((uint16_t *)src_ptr,
+                                                                           src_stride,
+                                                                           (uint16_t *)dst_ptr,
+                                                                           dst_stride,
+                                                                           blk_geom->bwidth_uv,
+                                                                           blk_geom->bheight_uv,
+                                                                           &filter_params_x,
+                                                                           &filter_params_y,
+                                                                           subpel_x,
+                                                                           subpel_y,
+                                                                           &conv_params,
+                                                                           bit_depth);
                 else
-                    convolve[subpel_x != 0][subpel_y != 0][is_compound](
-                            src_ptr,
-                            src_stride,
-                            dst_ptr,
-                            dst_stride,
-                            blk_geom->bwidth_uv,
-                            blk_geom->bheight_uv,
-                            &filter_params_x,
-                            &filter_params_y,
-                            subpel_x,
-                            subpel_y,
-                            &conv_params);
+                    convolve[subpel_x != 0][subpel_y != 0][is_compound](src_ptr,
+                                                                        src_stride,
+                                                                        dst_ptr,
+                                                                        dst_stride,
+                                                                        blk_geom->bwidth_uv,
+                                                                        blk_geom->bheight_uv,
+                                                                        &filter_params_x,
+                                                                        &filter_params_y,
+                                                                        subpel_x,
+                                                                        subpel_y,
+                                                                        &conv_params);
             }
 
             //List1-Cr
             src_ptr = ref_pic_list1->buffer_cr +
                       (((ref_pic_list1->origin_x + ((pu_origin_x >> 3) << 3)) / 2 +
                         (ref_pic_list1->origin_y + ((pu_origin_y >> 3) << 3)) / 2 *
-                        ref_pic_list1->stride_cr) << is16bit);
+                            ref_pic_list1->stride_cr)
+                       << is16bit);
             dst_ptr = prediction_ptr->buffer_cr +
                       (((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
                         (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
-                        prediction_ptr->stride_cr) << is16bit);
+                            prediction_ptr->stride_cr)
+                       << is16bit);
             src_stride = ref_pic_list1->stride_cr;
             dst_stride = prediction_ptr->stride_cr;
 
             mv_q4 = clamp_mv_to_umv_border_sb(
-                    blk_ptr->av1xd, &mv, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
+                blk_ptr->av1xd, &mv, blk_geom->bwidth_uv, blk_geom->bheight_uv, 1, 1);
             subpel_x = mv_q4.col & SUBPEL_MASK;
             subpel_y = mv_q4.row & SUBPEL_MASK;
-            src_ptr += ((mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS)) << is16bit;
-            conv_params = get_conv_params_no_round(0, (mv_unit->pred_direction == BI_PRED) ? 1 : 0, 0,
-                                                   tmp_dstCr, 64, is_compound, bit_depth);
+            src_ptr += ((mv_q4.row >> SUBPEL_BITS) * src_stride + (mv_q4.col >> SUBPEL_BITS))
+                       << is16bit;
+            conv_params = get_conv_params_no_round(0,
+                                                   (mv_unit->pred_direction == BI_PRED) ? 1 : 0,
+                                                   0,
+                                                   tmp_dstCr,
+                                                   64,
+                                                   is_compound,
+                                                   bit_depth);
             av1_dist_wtd_comp_weight_assign(
-                    &picture_control_set_ptr->parent_pcs_ptr->scs_ptr->seq_header,
-                    picture_control_set_ptr->parent_pcs_ptr->cur_order_hint, // cur_frame_index,
-                    picture_control_set_ptr->parent_pcs_ptr
-                            ->ref_order_hint[rf[0] - 1], // bck_frame_index,
-                    picture_control_set_ptr->parent_pcs_ptr
-                            ->ref_order_hint[rf[1] - 1], // fwd_frame_index,
-                    compound_idx,
-                    0, // order_idx,
-                    &conv_params.fwd_offset,
-                    &conv_params.bck_offset,
-                    &conv_params.use_dist_wtd_comp_avg,
-                    is_compound);
+                &picture_control_set_ptr->parent_pcs_ptr->scs_ptr->seq_header,
+                picture_control_set_ptr->parent_pcs_ptr->cur_order_hint, // cur_frame_index,
+                picture_control_set_ptr->parent_pcs_ptr
+                    ->ref_order_hint[rf[0] - 1], // bck_frame_index,
+                picture_control_set_ptr->parent_pcs_ptr
+                    ->ref_order_hint[rf[1] - 1], // fwd_frame_index,
+                compound_idx,
+                0, // order_idx,
+                &conv_params.fwd_offset,
+                &conv_params.bck_offset,
+                &conv_params.use_dist_wtd_comp_avg,
+                is_compound);
 
             conv_params.use_jnt_comp_avg = conv_params.use_dist_wtd_comp_avg;
 
             if (is_compound && is_masked_compound_type(interinter_comp->type)) {
                 conv_params.do_average = 0;
                 av1_make_masked_inter_predictor(
-                        src_ptr,
-                        src_stride,
-                        dst_ptr,
-                        dst_stride,
-                        blk_geom,
-                        blk_geom->bwidth_uv,
-                        blk_geom->bheight_uv,
-                        &filter_params_x,
-                        &filter_params_y,
-                        subpel_x,
-                        subpel_y,
-                        &conv_params,
-                        interinter_comp,
-                        bit_depth,
-                        1 //plane=Cr  seg_mask is computed based on luma and used for chroma
+                    src_ptr,
+                    src_stride,
+                    dst_ptr,
+                    dst_stride,
+                    blk_geom,
+                    blk_geom->bwidth_uv,
+                    blk_geom->bheight_uv,
+                    &filter_params_x,
+                    &filter_params_y,
+                    subpel_x,
+                    subpel_y,
+                    &conv_params,
+                    interinter_comp,
+                    bit_depth,
+                    1 //plane=Cr  seg_mask is computed based on luma and used for chroma
                 );
-            }
-            else
-            {
+            } else {
                 if (is16bit)
-                    convolveHbd[subpel_x != 0][subpel_y != 0][is_compound](
-                            (uint16_t *)src_ptr,
-                            src_stride,
-                            (uint16_t *)dst_ptr,
-                            dst_stride,
-                            blk_geom->bwidth_uv,
-                            blk_geom->bheight_uv,
-                            &filter_params_x,
-                            &filter_params_y,
-                            subpel_x,
-                            subpel_y,
-                            &conv_params,
-                            bit_depth);
+                    convolveHbd[subpel_x != 0][subpel_y != 0][is_compound]((uint16_t *)src_ptr,
+                                                                           src_stride,
+                                                                           (uint16_t *)dst_ptr,
+                                                                           dst_stride,
+                                                                           blk_geom->bwidth_uv,
+                                                                           blk_geom->bheight_uv,
+                                                                           &filter_params_x,
+                                                                           &filter_params_y,
+                                                                           subpel_x,
+                                                                           subpel_y,
+                                                                           &conv_params,
+                                                                           bit_depth);
                 else
-                    convolve[subpel_x != 0][subpel_y != 0][is_compound](
-                            src_ptr,
-                            src_stride,
-                            dst_ptr,
-                            dst_stride,
-                            blk_geom->bwidth_uv,
-                            blk_geom->bheight_uv,
-                            &filter_params_x,
-                            &filter_params_y,
-                            subpel_x,
-                            subpel_y,
-                            &conv_params);
+                    convolve[subpel_x != 0][subpel_y != 0][is_compound](src_ptr,
+                                                                        src_stride,
+                                                                        dst_ptr,
+                                                                        dst_stride,
+                                                                        blk_geom->bwidth_uv,
+                                                                        blk_geom->bheight_uv,
+                                                                        &filter_params_x,
+                                                                        &filter_params_y,
+                                                                        subpel_x,
+                                                                        subpel_y,
+                                                                        &conv_params);
             }
         }
     }
@@ -4202,8 +4235,8 @@ EbErrorType av1_inter_prediction(
             const int       ssy         = plane ? 1 : 0;
             const BlockSize plane_bsize = get_plane_block_size(blk_geom->bsize, ssx, ssy);
             //av1_build_interintra_predictors_sbp
-            uint8_t    topNeighArray[(64 * 2 + 1) << 1];
-            uint8_t    leftNeighArray[(64 * 2 + 1) << 1];
+            uint8_t topNeighArray[(64 * 2 + 1) << 1];
+            uint8_t leftNeighArray[(64 * 2 + 1) << 1];
 
             uint32_t blk_originx_uv = (pu_origin_x >> 3 << 3) >> 1;
             uint32_t blk_originy_uv = (pu_origin_y >> 3 << 3) >> 1;
@@ -4211,25 +4244,28 @@ EbErrorType av1_inter_prediction(
             if (plane == 0) {
                 dst_ptr = prediction_ptr->buffer_y +
                           ((prediction_ptr->origin_x + dst_origin_x +
-                            (prediction_ptr->origin_y + dst_origin_y)
-                            * prediction_ptr->stride_y) << is16bit);
-                dst_stride = prediction_ptr->stride_y;
+                            (prediction_ptr->origin_y + dst_origin_y) * prediction_ptr->stride_y)
+                           << is16bit);
+                dst_stride   = prediction_ptr->stride_y;
                 intra_stride = intra_pred_desc.stride_y;
 
                 if (pu_origin_y != 0)
-                    memcpy(topNeighArray + ((uint64_t)1 << is16bit),
-                           luma_recon_neighbor_array->top_array + ((uint64_t)pu_origin_x << is16bit),
-                           blk_geom->bwidth * 2 << is16bit);
+                    memcpy(
+                        topNeighArray + ((uint64_t)1 << is16bit),
+                        luma_recon_neighbor_array->top_array + ((uint64_t)pu_origin_x << is16bit),
+                        blk_geom->bwidth * 2 << is16bit);
 
                 if (pu_origin_x != 0)
-                    memcpy(leftNeighArray + ((uint64_t)1 << is16bit),
-                           luma_recon_neighbor_array->left_array + ((uint64_t)pu_origin_y << is16bit),
-                           blk_geom->bheight * 2 << is16bit);
+                    memcpy(
+                        leftNeighArray + ((uint64_t)1 << is16bit),
+                        luma_recon_neighbor_array->left_array + ((uint64_t)pu_origin_y << is16bit),
+                        blk_geom->bheight * 2 << is16bit);
 
                 if (pu_origin_y != 0 && pu_origin_x != 0)
                     topNeighArray[0] = leftNeighArray[0] =
-                            luma_recon_neighbor_array->top_left_array[(MAX_PICTURE_HEIGHT_SIZE
-                                                                       + pu_origin_x - pu_origin_y) << is16bit];
+                        luma_recon_neighbor_array
+                            ->top_left_array[(MAX_PICTURE_HEIGHT_SIZE + pu_origin_x - pu_origin_y)
+                                             << is16bit];
 
             }
 
@@ -4237,145 +4273,154 @@ EbErrorType av1_inter_prediction(
                 dst_ptr = prediction_ptr->buffer_cb +
                           (((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
                             (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
-                            prediction_ptr->stride_cb) << is16bit);
-                dst_stride = prediction_ptr->stride_cb;
+                                prediction_ptr->stride_cb)
+                           << is16bit);
+                dst_stride   = prediction_ptr->stride_cb;
                 intra_stride = intra_pred_desc.stride_cb;
 
                 if (blk_originy_uv != 0)
-                    memcpy(topNeighArray + ((uint64_t)1 << is16bit),
-                           cb_recon_neighbor_array->top_array + ((uint64_t)blk_originx_uv << is16bit),
-                           blk_geom->bwidth_uv * 2 << is16bit);
+                    memcpy(
+                        topNeighArray + ((uint64_t)1 << is16bit),
+                        cb_recon_neighbor_array->top_array + ((uint64_t)blk_originx_uv << is16bit),
+                        blk_geom->bwidth_uv * 2 << is16bit);
 
                 if (blk_originx_uv != 0)
-                    memcpy(leftNeighArray + ((uint64_t)1 << is16bit),
-                           cb_recon_neighbor_array->left_array + ((uint64_t)blk_originy_uv << is16bit),
-                           blk_geom->bheight_uv * 2 << is16bit);
+                    memcpy(
+                        leftNeighArray + ((uint64_t)1 << is16bit),
+                        cb_recon_neighbor_array->left_array + ((uint64_t)blk_originy_uv << is16bit),
+                        blk_geom->bheight_uv * 2 << is16bit);
 
                 if (blk_originy_uv != 0 && blk_originx_uv != 0)
                     topNeighArray[0] = leftNeighArray[0] =
-                            cb_recon_neighbor_array->top_left_array[(MAX_PICTURE_HEIGHT_SIZE / 2
-                                                                     + blk_originx_uv - blk_originy_uv / 2) << is16bit];
-            }
-            else {
+                        cb_recon_neighbor_array->top_left_array
+                            [(MAX_PICTURE_HEIGHT_SIZE / 2 + blk_originx_uv - blk_originy_uv / 2)
+                             << is16bit];
+            } else {
                 dst_ptr = prediction_ptr->buffer_cr +
                           (((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
                             (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
-                            prediction_ptr->stride_cr) << is16bit);
-                dst_stride = prediction_ptr->stride_cr;
+                                prediction_ptr->stride_cr)
+                           << is16bit);
+                dst_stride   = prediction_ptr->stride_cr;
                 intra_stride = intra_pred_desc.stride_cr;
 
                 if (blk_originy_uv != 0)
-                    memcpy(topNeighArray + ((uint64_t)1 << is16bit),
-                           cr_recon_neighbor_array->top_array + ((uint64_t)blk_originx_uv << is16bit),
-                           blk_geom->bwidth_uv * 2 << is16bit);
+                    memcpy(
+                        topNeighArray + ((uint64_t)1 << is16bit),
+                        cr_recon_neighbor_array->top_array + ((uint64_t)blk_originx_uv << is16bit),
+                        blk_geom->bwidth_uv * 2 << is16bit);
 
                 if (blk_originx_uv != 0)
-                    memcpy(leftNeighArray + ((uint64_t)1 << is16bit),
-                           cr_recon_neighbor_array->left_array + ((uint64_t)blk_originy_uv << is16bit),
-                           blk_geom->bheight_uv * 2 << is16bit);
+                    memcpy(
+                        leftNeighArray + ((uint64_t)1 << is16bit),
+                        cr_recon_neighbor_array->left_array + ((uint64_t)blk_originy_uv << is16bit),
+                        blk_geom->bheight_uv * 2 << is16bit);
 
                 if (blk_originy_uv != 0 && blk_originx_uv != 0)
                     topNeighArray[0] = leftNeighArray[0] =
-                            cr_recon_neighbor_array->top_left_array[(MAX_PICTURE_HEIGHT_SIZE / 2
-                                                                     + blk_originx_uv - blk_originy_uv / 2) << is16bit];
+                        cr_recon_neighbor_array->top_left_array
+                            [(MAX_PICTURE_HEIGHT_SIZE / 2 + blk_originx_uv - blk_originy_uv / 2)
+                             << is16bit];
             }
             TxSize tx_size        = blk_geom->txsize[0][0]; // Nader - Intra 128x128 not supported
             TxSize tx_size_Chroma = blk_geom->txsize_uv[0][0]; //Nader - Intra 128x128 not supported
 
             if (is16bit)
                 eb_av1_predict_intra_block_16bit(
-                        tile,
-                        !ED_STAGE,
-                        blk_geom,
-                        picture_control_set_ptr->parent_pcs_ptr->av1_cm,    //const Av1Common *cm,
-                        plane ? blk_geom->bwidth_uv : blk_geom->bwidth,     //int32_t wpx,
-                        plane ? blk_geom->bheight_uv : blk_geom->bheight,   //int32_t hpx,
-                        plane ? tx_size_Chroma : tx_size,                   //TxSize tx_size,
-                        interintra_to_intra_mode[interintra_mode],          //PredictionMode mode,
-                        0,
-                        0,                                                  //int32_t use_palette,
-                        NULL,
-                        FILTER_INTRA_MODES,                                 // FilterIntraMode filter_intra_mode,
-                        (uint16_t *)topNeighArray + 1,
-                        (uint16_t *)leftNeighArray + 1,
-                        &intra_pred_desc,                                   //uint8_t *dst,
-                        //int32_t dst_stride,
-                        0,                                                  //int32_t col_off,
-                        0,                                                  //int32_t row_off,
-                        plane,                                              //int32_t plane,
-                        blk_geom->bsize,                                    //uint32_t puSize,
-                        dst_origin_x,
-                        dst_origin_y,
-                        pu_origin_x,
-                        pu_origin_y,
-                        0,                                                  //uint32_t cuOrgX used only for prediction Ptr
-                        0,                                                   //uint32_t cuOrgY used only for prediction Ptr
-                        picture_control_set_ptr->mi_grid_base,
-                        &((SequenceControlSet *)picture_control_set_ptr->scs_wrapper_ptr->object_ptr)->seq_header);
+                    tile,
+                    !ED_STAGE,
+                    blk_geom,
+                    picture_control_set_ptr->parent_pcs_ptr->av1_cm, //const Av1Common *cm,
+                    plane ? blk_geom->bwidth_uv : blk_geom->bwidth, //int32_t wpx,
+                    plane ? blk_geom->bheight_uv : blk_geom->bheight, //int32_t hpx,
+                    plane ? tx_size_Chroma : tx_size, //TxSize tx_size,
+                    interintra_to_intra_mode[interintra_mode], //PredictionMode mode,
+                    0,
+                    0, //int32_t use_palette,
+                    NULL,
+                    FILTER_INTRA_MODES, // FilterIntraMode filter_intra_mode,
+                    (uint16_t *)topNeighArray + 1,
+                    (uint16_t *)leftNeighArray + 1,
+                    &intra_pred_desc, //uint8_t *dst,
+                    //int32_t dst_stride,
+                    0, //int32_t col_off,
+                    0, //int32_t row_off,
+                    plane, //int32_t plane,
+                    blk_geom->bsize, //uint32_t puSize,
+                    dst_origin_x,
+                    dst_origin_y,
+                    pu_origin_x,
+                    pu_origin_y,
+                    0, //uint32_t cuOrgX used only for prediction Ptr
+                    0, //uint32_t cuOrgY used only for prediction Ptr
+                    picture_control_set_ptr->mi_grid_base,
+                    &((SequenceControlSet *)picture_control_set_ptr->scs_wrapper_ptr->object_ptr)
+                         ->seq_header);
             else
                 eb_av1_predict_intra_block(
-                        tile,
-                        !ED_STAGE,
-                        blk_geom,
-                        picture_control_set_ptr->parent_pcs_ptr->av1_cm,    //const Av1Common *cm,
-                        plane ? blk_geom->bwidth_uv : blk_geom->bwidth,     //int32_t wpx,
-                        plane ? blk_geom->bheight_uv : blk_geom->bheight,   //int32_t hpx,
-                        plane ? tx_size_Chroma : tx_size,                   //TxSize tx_size,
-                        interintra_to_intra_mode[interintra_mode],          //PredictionMode mode,
-                        0,
-                        0,                                                  //int32_t use_palette,
-                        NULL,
-                        FILTER_INTRA_MODES,                                 // FilterIntraMode filter_intra_mode,
-                        topNeighArray + 1,
-                        leftNeighArray + 1,
-                        &intra_pred_desc,                                   //uint8_t *dst,
-                        //int32_t dst_stride,
-                        0,                                                  //int32_t col_off,
-                        0,                                                  //int32_t row_off,
-                        plane,                                              //int32_t plane,
-                        blk_geom->bsize,                                    //uint32_t puSize,
-                        dst_origin_x,
-                        dst_origin_y,
-                        pu_origin_x,
-                        pu_origin_y,
-                        0,                                                  //uint32_t cuOrgX used only for prediction Ptr
-                        0,                                                   //uint32_t cuOrgY used only for prediction Ptr
-                        picture_control_set_ptr->mi_grid_base,
-                        &((SequenceControlSet *)picture_control_set_ptr->scs_wrapper_ptr->object_ptr)->seq_header);
+                    tile,
+                    !ED_STAGE,
+                    blk_geom,
+                    picture_control_set_ptr->parent_pcs_ptr->av1_cm, //const Av1Common *cm,
+                    plane ? blk_geom->bwidth_uv : blk_geom->bwidth, //int32_t wpx,
+                    plane ? blk_geom->bheight_uv : blk_geom->bheight, //int32_t hpx,
+                    plane ? tx_size_Chroma : tx_size, //TxSize tx_size,
+                    interintra_to_intra_mode[interintra_mode], //PredictionMode mode,
+                    0,
+                    0, //int32_t use_palette,
+                    NULL,
+                    FILTER_INTRA_MODES, // FilterIntraMode filter_intra_mode,
+                    topNeighArray + 1,
+                    leftNeighArray + 1,
+                    &intra_pred_desc, //uint8_t *dst,
+                    //int32_t dst_stride,
+                    0, //int32_t col_off,
+                    0, //int32_t row_off,
+                    plane, //int32_t plane,
+                    blk_geom->bsize, //uint32_t puSize,
+                    dst_origin_x,
+                    dst_origin_y,
+                    pu_origin_x,
+                    pu_origin_y,
+                    0, //uint32_t cuOrgX used only for prediction Ptr
+                    0, //uint32_t cuOrgY used only for prediction Ptr
+                    picture_control_set_ptr->mi_grid_base,
+                    &((SequenceControlSet *)picture_control_set_ptr->scs_wrapper_ptr->object_ptr)
+                         ->seq_header);
 
             //combine_interintra
 
             if (is16bit)
                 combine_interintra_highbd(
-                        interintra_mode,
-                        use_wedge_interintra,
-                        interintra_wedge_index,
-                        INTERINTRA_WEDGE_SIGN,
-                        blk_geom->bsize,
-                        plane_bsize,
-                        dst_ptr,
-                        dst_stride,
-                        dst_ptr, // Inter pred buff
-                        dst_stride, // Inter pred stride
-                        (plane == 0) ? intra_pred
-                                     : (plane == 1) ? intra_pred_cb : intra_pred_cr, // Intra pred buff
-                        intra_stride, // Intra pred stride
-                        bit_depth);
+                    interintra_mode,
+                    use_wedge_interintra,
+                    interintra_wedge_index,
+                    INTERINTRA_WEDGE_SIGN,
+                    blk_geom->bsize,
+                    plane_bsize,
+                    dst_ptr,
+                    dst_stride,
+                    dst_ptr, // Inter pred buff
+                    dst_stride, // Inter pred stride
+                    (plane == 0) ? intra_pred
+                                 : (plane == 1) ? intra_pred_cb : intra_pred_cr, // Intra pred buff
+                    intra_stride, // Intra pred stride
+                    bit_depth);
             else
                 combine_interintra(
-                        interintra_mode,
-                        use_wedge_interintra,
-                        interintra_wedge_index,
-                        INTERINTRA_WEDGE_SIGN,
-                        blk_geom->bsize,
-                        plane_bsize,
-                        dst_ptr,
-                        dst_stride,
-                        dst_ptr, // Inter pred buff
-                        dst_stride, // Inter pred stride
-                        (plane == 0) ? intra_pred
-                                     : (plane == 1) ? intra_pred_cb : intra_pred_cr, // Intra pred buff
-                        intra_stride); // Intra pred stride
+                    interintra_mode,
+                    use_wedge_interintra,
+                    interintra_wedge_index,
+                    INTERINTRA_WEDGE_SIGN,
+                    blk_geom->bsize,
+                    plane_bsize,
+                    dst_ptr,
+                    dst_stride,
+                    dst_ptr, // Inter pred buff
+                    dst_stride, // Inter pred stride
+                    (plane == 0) ? intra_pred
+                                 : (plane == 1) ? intra_pred_cb : intra_pred_cr, // Intra pred buff
+                    intra_stride); // Intra pred stride
         }
     }
 
@@ -4409,58 +4454,69 @@ EbErrorType av1_inter_prediction(
             dst_buf2[1] = md_context->obmc_buff_1 + (MAX_SB_SQUARE << is16bit);
             dst_buf2[2] = md_context->obmc_buff_1 + (MAX_SB_SQUARE * 2 << is16bit);
         } else {
-            build_prediction_by_above_preds(
-                    perform_chroma,
-                    blk_geom->bsize, picture_control_set_ptr, blk_ptr->av1xd, mi_row, mi_col, dst_buf1,
-                    dst_stride1, is16bit);
+            build_prediction_by_above_preds(perform_chroma,
+                                            blk_geom->bsize,
+                                            picture_control_set_ptr,
+                                            blk_ptr->av1xd,
+                                            mi_row,
+                                            mi_col,
+                                            dst_buf1,
+                                            dst_stride1,
+                                            is16bit);
 
-            build_prediction_by_left_preds(
-                    perform_chroma,
-                    blk_geom->bsize, picture_control_set_ptr, blk_ptr->av1xd, mi_row, mi_col, dst_buf2,
-                    dst_stride2, is16bit);
+            build_prediction_by_left_preds(perform_chroma,
+                                           blk_geom->bsize,
+                                           picture_control_set_ptr,
+                                           blk_ptr->av1xd,
+                                           mi_row,
+                                           mi_col,
+                                           dst_buf2,
+                                           dst_stride2,
+                                           is16bit);
         }
 
-        uint8_t *final_dst_ptr_y  = prediction_ptr->buffer_y +
-                                    ((prediction_ptr->origin_x + dst_origin_x +
-                                      (prediction_ptr->origin_y + dst_origin_y)
-                                      * prediction_ptr->stride_y) << is16bit);
-        uint16_t  final_dst_stride_y = prediction_ptr->stride_y;
+        uint8_t *final_dst_ptr_y =
+            prediction_ptr->buffer_y +
+            ((prediction_ptr->origin_x + dst_origin_x +
+              (prediction_ptr->origin_y + dst_origin_y) * prediction_ptr->stride_y)
+             << is16bit);
+        uint16_t final_dst_stride_y = prediction_ptr->stride_y;
 
         uint8_t *final_dst_ptr_u = prediction_ptr->buffer_cb +
                                    (((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
                                      (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
-                                     prediction_ptr->stride_cb) << is16bit);
-        uint16_t  final_dst_stride_u = prediction_ptr->stride_cb;
+                                         prediction_ptr->stride_cb)
+                                    << is16bit);
+        uint16_t final_dst_stride_u = prediction_ptr->stride_cb;
 
         uint8_t *final_dst_ptr_v = prediction_ptr->buffer_cr +
                                    (((prediction_ptr->origin_x + ((dst_origin_x >> 3) << 3)) / 2 +
                                      (prediction_ptr->origin_y + ((dst_origin_y >> 3) << 3)) / 2 *
-                                     prediction_ptr->stride_cr) << is16bit);
-        uint16_t  final_dst_stride_v = prediction_ptr->stride_cr;
+                                         prediction_ptr->stride_cr)
+                                    << is16bit);
+        uint16_t final_dst_stride_v = prediction_ptr->stride_cr;
 
-        av1_build_obmc_inter_prediction(
-                final_dst_ptr_y,
-                final_dst_stride_y,
-                final_dst_ptr_u,
-                final_dst_stride_u,
-                final_dst_ptr_v,
-                final_dst_stride_v,
-                perform_chroma,
-                blk_geom->bsize,
-                picture_control_set_ptr,
-                blk_ptr->av1xd,
-                mi_row,
-                mi_col,
-                dst_buf1,
-                dst_stride1,
-                dst_buf2,
-                dst_stride2,
-                is16bit); // is16bit
+        av1_build_obmc_inter_prediction(final_dst_ptr_y,
+                                        final_dst_stride_y,
+                                        final_dst_ptr_u,
+                                        final_dst_stride_u,
+                                        final_dst_ptr_v,
+                                        final_dst_stride_v,
+                                        perform_chroma,
+                                        blk_geom->bsize,
+                                        picture_control_set_ptr,
+                                        blk_ptr->av1xd,
+                                        mi_row,
+                                        mi_col,
+                                        dst_buf1,
+                                        dst_stride1,
+                                        dst_buf2,
+                                        dst_stride2,
+                                        is16bit); // is16bit
     }
 
     return return_error;
 }
-
 
 void search_compound_diff_wedge(PictureControlSet *    picture_control_set_ptr,
                                 ModeDecisionContext *  context_ptr,
@@ -4468,11 +4524,11 @@ void search_compound_diff_wedge(PictureControlSet *    picture_control_set_ptr,
     //if (*calc_pred_masked_compound)
     {
         uint8_t hbd_mode_decision = context_ptr->hbd_mode_decision == EB_DUAL_BIT_MD
-                                    ? EB_8_BIT_MD
-                                    : context_ptr->hbd_mode_decision;
+                                        ? EB_8_BIT_MD
+                                        : context_ptr->hbd_mode_decision;
         EbPictureBufferDesc *src_pic =
-                hbd_mode_decision ? picture_control_set_ptr->input_frame16bit
-                                  : picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
+            hbd_mode_decision ? picture_control_set_ptr->input_frame16bit
+                              : picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
         uint32_t            bwidth  = context_ptr->blk_geom->bwidth;
         uint32_t            bheight = context_ptr->blk_geom->bheight;
         EbPictureBufferDesc pred_desc;
@@ -4504,25 +4560,25 @@ void search_compound_diff_wedge(PictureControlSet *    picture_control_set_ptr,
         assert(list_idx1 < MAX_NUM_OF_REF_PIC_LIST);
         if (ref_idx_l0 >= 0)
             ref_pic_list0 = hbd_mode_decision ? ((EbReferenceObject *)picture_control_set_ptr
-                    ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
-                    ->object_ptr)
-                    ->reference_picture16bit
+                                                     ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
+                                                     ->object_ptr)
+                                                    ->reference_picture16bit
                                               : ((EbReferenceObject *)picture_control_set_ptr
-                            ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
-                            ->object_ptr)
-                                    ->reference_picture;
+                                                     ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
+                                                     ->object_ptr)
+                                                    ->reference_picture;
         else
             ref_pic_list0 = (EbPictureBufferDesc *)EB_NULL;
 
         if (ref_idx_l1 >= 0)
             ref_pic_list1 = hbd_mode_decision ? ((EbReferenceObject *)picture_control_set_ptr
-                    ->ref_pic_ptr_array[list_idx1][ref_idx_l1]
-                    ->object_ptr)
-                    ->reference_picture16bit
+                                                     ->ref_pic_ptr_array[list_idx1][ref_idx_l1]
+                                                     ->object_ptr)
+                                                    ->reference_picture16bit
                                               : ((EbReferenceObject *)picture_control_set_ptr
-                            ->ref_pic_ptr_array[list_idx1][ref_idx_l1]
-                            ->object_ptr)
-                                    ->reference_picture;
+                                                     ->ref_pic_ptr_array[list_idx1][ref_idx_l1]
+                                                     ->object_ptr)
+                                                    ->reference_picture;
         else
             ref_pic_list1 = (EbPictureBufferDesc *)EB_NULL;
 
@@ -4532,78 +4588,76 @@ void search_compound_diff_wedge(PictureControlSet *    picture_control_set_ptr,
         pred_desc.buffer_y     = context_ptr->pred0;
 
         //we call the regular inter prediction path here(no compound)
-        av1_inter_prediction(
-                picture_control_set_ptr,
-                0, //fixed interpolation filter for compound search
-                context_ptr->blk_ptr,
-                candidate_ptr->ref_frame_type,
-                &mv_unit,
-                0, //use_intrabc,
-                SIMPLE_TRANSLATION,
-                0,
-                0,
-                1, //compound_idx not used
-                NULL, // interinter_comp not used
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                0,
-                0,
-                0,
-                0,
-                context_ptr->blk_origin_x,
-                context_ptr->blk_origin_y,
-                bwidth,
-                bheight,
-                ref_pic_list0,
-                ref_pic_list1,
-                &pred_desc, //output
-                0, //output origin_x,
-                0, //output origin_y,
-                0, //do chroma
-                hbd_mode_decision ? EB_10BIT : EB_8BIT);
+        av1_inter_prediction(picture_control_set_ptr,
+                             0, //fixed interpolation filter for compound search
+                             context_ptr->blk_ptr,
+                             candidate_ptr->ref_frame_type,
+                             &mv_unit,
+                             0, //use_intrabc,
+                             SIMPLE_TRANSLATION,
+                             0,
+                             0,
+                             1, //compound_idx not used
+                             NULL, // interinter_comp not used
+                             NULL,
+                             NULL,
+                             NULL,
+                             NULL,
+                             0,
+                             0,
+                             0,
+                             0,
+                             context_ptr->blk_origin_x,
+                             context_ptr->blk_origin_y,
+                             bwidth,
+                             bheight,
+                             ref_pic_list0,
+                             ref_pic_list1,
+                             &pred_desc, //output
+                             0, //output origin_x,
+                             0, //output origin_y,
+                             0, //do chroma
+                             hbd_mode_decision ? EB_10BIT : EB_8BIT);
 
         //ref1 prediction
         mv_unit.pred_direction = UNI_PRED_LIST_1;
         pred_desc.buffer_y     = context_ptr->pred1;
 
         //we call the regular inter prediction path here(no compound)
-        av1_inter_prediction(
-                picture_control_set_ptr,
-                0, //fixed interpolation filter for compound search
-                context_ptr->blk_ptr,
-                candidate_ptr->ref_frame_type,
-                &mv_unit,
-                0, //use_intrabc,
-                SIMPLE_TRANSLATION,
-                0,
-                0,
-                1, //compound_idx not used
-                NULL, // interinter_comp not useds
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                0,
-                0,
-                0,
-                0,
-                context_ptr->blk_origin_x,
-                context_ptr->blk_origin_y,
-                bwidth,
-                bheight,
-                ref_pic_list0,
-                ref_pic_list1,
-                &pred_desc, //output
-                0, //output origin_x,
-                0, //output origin_y,
-                0, //do chroma
-                hbd_mode_decision ? EB_10BIT : EB_8BIT);
+        av1_inter_prediction(picture_control_set_ptr,
+                             0, //fixed interpolation filter for compound search
+                             context_ptr->blk_ptr,
+                             candidate_ptr->ref_frame_type,
+                             &mv_unit,
+                             0, //use_intrabc,
+                             SIMPLE_TRANSLATION,
+                             0,
+                             0,
+                             1, //compound_idx not used
+                             NULL, // interinter_comp not useds
+                             NULL,
+                             NULL,
+                             NULL,
+                             NULL,
+                             0,
+                             0,
+                             0,
+                             0,
+                             context_ptr->blk_origin_x,
+                             context_ptr->blk_origin_y,
+                             bwidth,
+                             bheight,
+                             ref_pic_list0,
+                             ref_pic_list1,
+                             &pred_desc, //output
+                             0, //output origin_x,
+                             0, //output origin_y,
+                             0, //do chroma
+                             hbd_mode_decision ? EB_10BIT : EB_8BIT);
         if (hbd_mode_decision) {
             uint16_t *src_buf_hbd =
-                    (uint16_t *)src_pic->buffer_y + (context_ptr->blk_origin_x + src_pic->origin_x) +
-                    (context_ptr->blk_origin_y + src_pic->origin_y) * src_pic->stride_y;
+                (uint16_t *)src_pic->buffer_y + (context_ptr->blk_origin_x + src_pic->origin_x) +
+                (context_ptr->blk_origin_y + src_pic->origin_y) * src_pic->stride_y;
             aom_highbd_subtract_block(bheight,
                                       bwidth,
                                       context_ptr->residual1,
@@ -4652,10 +4706,10 @@ void search_compound_diff_wedge(PictureControlSet *    picture_control_set_ptr,
 
                 unsigned int sse;
                 (void)fn_ptr->vf(
-                        context_ptr->pred0, bwidth, context_ptr->pred1, pred_desc.stride_y, &sse);
+                    context_ptr->pred0, bwidth, context_ptr->pred1, pred_desc.stride_y, &sse);
 
                 context_ptr->prediction_mse =
-                        ROUND_POWER_OF_TWO(sse, num_pels_log2_lookup[context_ptr->blk_geom->bsize]);
+                    ROUND_POWER_OF_TWO(sse, num_pels_log2_lookup[context_ptr->blk_geom->bsize]);
                 context_ptr->variance_ready = 1;
             }
     }
@@ -4678,7 +4732,7 @@ EbErrorType inter_pu_prediction_av1(uint8_t hbd_mode_decision, ModeDecisionConte
     EbPictureBufferDesc *        ref_pic_list1 = (EbPictureBufferDesc *)EB_NULL;
     ModeDecisionCandidate *const candidate_ptr = candidate_buffer_ptr->candidate_ptr;
     SequenceControlSet *         scs_ptr =
-            ((SequenceControlSet *)(picture_control_set_ptr->scs_wrapper_ptr->object_ptr));
+        ((SequenceControlSet *)(picture_control_set_ptr->scs_wrapper_ptr->object_ptr));
 
     Mv mv_0;
     Mv mv_1;
@@ -4688,52 +4742,57 @@ EbErrorType inter_pu_prediction_av1(uint8_t hbd_mode_decision, ModeDecisionConte
     mv_1.y = candidate_buffer_ptr->candidate_ptr->motion_vector_yl1;
     MvUnit mv_unit;
     mv_unit.pred_direction =
-            candidate_buffer_ptr->candidate_ptr->prediction_direction[md_context_ptr->pu_itr];
+        candidate_buffer_ptr->candidate_ptr->prediction_direction[md_context_ptr->pu_itr];
     mv_unit.mv[0] = mv_0;
     mv_unit.mv[1] = mv_1;
 
     if (candidate_buffer_ptr->candidate_ptr->use_intrabc) {
         if (!hbd_mode_decision)
             ref_pic_list0 = ((EbReferenceObject *)picture_control_set_ptr->parent_pcs_ptr
-                    ->reference_picture_wrapper_ptr->object_ptr)
-                    ->reference_picture;
+                                 ->reference_picture_wrapper_ptr->object_ptr)
+                                ->reference_picture;
         else
             ref_pic_list0 = ((EbReferenceObject *)picture_control_set_ptr->parent_pcs_ptr
-                    ->reference_picture_wrapper_ptr->object_ptr)
-                    ->reference_picture16bit;
+                                 ->reference_picture_wrapper_ptr->object_ptr)
+                                ->reference_picture16bit;
 
-        av1_inter_prediction(
-                picture_control_set_ptr,
-                candidate_buffer_ptr->candidate_ptr->interp_filters,
-                md_context_ptr->blk_ptr,
-                candidate_buffer_ptr->candidate_ptr->ref_frame_type,
-                &mv_unit,
-                1, //use_intrabc
-                SIMPLE_TRANSLATION,
-                0,
-                0,
-                1, //1 for avg
-                &candidate_buffer_ptr->candidate_ptr->interinter_comp,
-                NULL,
-                NULL,
-                NULL,
-                NULL,
-                0,
-                0,
-                0,
-                0,
-                md_context_ptr->blk_origin_x,
-                md_context_ptr->blk_origin_y,
-                md_context_ptr->blk_geom->bwidth,
-                md_context_ptr->blk_geom->bheight,
-                ref_pic_list0,
-                0, //ref_pic_list1,
-                candidate_buffer_ptr->prediction_ptr,
-                md_context_ptr->blk_geom->origin_x,
-                md_context_ptr->blk_geom->origin_y,
-                md_context_ptr->chroma_level <= CHROMA_MODE_1 &&
-                md_context_ptr->md_staging_skip_inter_chroma_pred == EB_FALSE,
-                hbd_mode_decision ? EB_10BIT : EB_8BIT);
+        av1_inter_prediction(picture_control_set_ptr,
+                             candidate_buffer_ptr->candidate_ptr->interp_filters,
+                             md_context_ptr->blk_ptr,
+                             candidate_buffer_ptr->candidate_ptr->ref_frame_type,
+                             &mv_unit,
+                             1, //use_intrabc
+                             SIMPLE_TRANSLATION,
+                             0,
+                             0,
+                             1, //1 for avg
+                             &candidate_buffer_ptr->candidate_ptr->interinter_comp,
+                             NULL,
+                             NULL,
+                             NULL,
+                             NULL,
+                             0,
+                             0,
+                             0,
+                             0,
+                             md_context_ptr->blk_origin_x,
+                             md_context_ptr->blk_origin_y,
+                             md_context_ptr->blk_geom->bwidth,
+                             md_context_ptr->blk_geom->bheight,
+                             ref_pic_list0,
+                             0, //ref_pic_list1,
+                             candidate_buffer_ptr->prediction_ptr,
+                             md_context_ptr->blk_geom->origin_x,
+                             md_context_ptr->blk_geom->origin_y,
+#if MOVE_OPT
+                             (md_context_ptr->chroma_level == CHROMA_MODE_01 ||
+                              md_context_ptr->chroma_level <= CHROMA_MODE_1) &&
+                                 md_context_ptr->md_staging_skip_inter_chroma_pred == EB_FALSE,
+#else
+                             md_context_ptr->chroma_level <= CHROMA_MODE_1 &&
+                                 md_context_ptr->md_staging_skip_inter_chroma_pred == EB_FALSE,
+#endif
+                             hbd_mode_decision ? EB_10BIT : EB_8BIT);
 
         return return_error;
     }
@@ -4754,36 +4813,38 @@ EbErrorType inter_pu_prediction_av1(uint8_t hbd_mode_decision, ModeDecisionConte
 
     if (ref_idx_l0 >= 0) {
         ref_pic_list0 = hbd_mode_decision ? ((EbReferenceObject *)picture_control_set_ptr
-                ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
-                ->object_ptr)
-                ->reference_picture16bit
+                                                 ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
+                                                 ->object_ptr)
+                                                ->reference_picture16bit
                                           : ((EbReferenceObject *)picture_control_set_ptr
-                        ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
-                        ->object_ptr)
-                                ->reference_picture;
+                                                 ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
+                                                 ->object_ptr)
+                                                ->reference_picture;
     }
 
     if (ref_idx_l1 >= 0) {
         ref_pic_list1 = hbd_mode_decision ? ((EbReferenceObject *)picture_control_set_ptr
-                ->ref_pic_ptr_array[list_idx1][ref_idx_l1]
-                ->object_ptr)
-                ->reference_picture16bit
+                                                 ->ref_pic_ptr_array[list_idx1][ref_idx_l1]
+                                                 ->object_ptr)
+                                                ->reference_picture16bit
                                           : ((EbReferenceObject *)picture_control_set_ptr
-                        ->ref_pic_ptr_array[list_idx1][ref_idx_l1]
-                        ->object_ptr)
-                                ->reference_picture;
+                                                 ->ref_pic_ptr_array[list_idx1][ref_idx_l1]
+                                                 ->object_ptr)
+                                                ->reference_picture;
     }
 
     if (picture_control_set_ptr->parent_pcs_ptr->frm_hdr.allow_warped_motion &&
         candidate_ptr->motion_mode != WARPED_CAUSAL) {
-        wm_count_samples(md_context_ptr->blk_ptr,
-                         ((SequenceControlSet *)picture_control_set_ptr->scs_wrapper_ptr->object_ptr)->seq_header.sb_size,
-                         md_context_ptr->blk_geom,
-                         md_context_ptr->blk_origin_x,
-                         md_context_ptr->blk_origin_y,
-                         candidate_ptr->ref_frame_type,
-                         picture_control_set_ptr,
-                         &candidate_ptr->num_proj_ref);
+        wm_count_samples(
+            md_context_ptr->blk_ptr,
+            ((SequenceControlSet *)picture_control_set_ptr->scs_wrapper_ptr->object_ptr)
+                ->seq_header.sb_size,
+            md_context_ptr->blk_geom,
+            md_context_ptr->blk_origin_x,
+            md_context_ptr->blk_origin_y,
+            candidate_ptr->ref_frame_type,
+            picture_control_set_ptr,
+            &candidate_ptr->num_proj_ref);
     }
 
     uint8_t bit_depth = EB_8BIT;
@@ -4811,8 +4872,14 @@ EbErrorType inter_pu_prediction_av1(uint8_t hbd_mode_decision, ModeDecisionConte
                                  &candidate_ptr->wm_params_l0,
                                  &candidate_ptr->wm_params_l1,
                                  bit_depth,
+#if MOVE_OPT
+                                 (md_context_ptr->chroma_level == CHROMA_MODE_01 ||
+                                  md_context_ptr->chroma_level <= CHROMA_MODE_1) &&
+                                     md_context_ptr->md_staging_skip_inter_chroma_pred == EB_FALSE);
+#else
                                  md_context_ptr->chroma_level <= CHROMA_MODE_1 &&
-                                 md_context_ptr->md_staging_skip_inter_chroma_pred == EB_FALSE);
+                                     md_context_ptr->md_staging_skip_inter_chroma_pred == EB_FALSE);
+#endif
 
         return return_error;
     }
@@ -4821,7 +4888,7 @@ EbErrorType inter_pu_prediction_av1(uint8_t hbd_mode_decision, ModeDecisionConte
     else {
         if (md_context_ptr->md_staging_skip_interpolation_search == EB_FALSE) {
             uint16_t capped_size =
-                    md_context_ptr->interpolation_filter_search_blk_size == 0
+                md_context_ptr->interpolation_filter_search_blk_size == 0
                     ? 4
                     : md_context_ptr->interpolation_filter_search_blk_size == 1 ? 8 : 16;
 
@@ -4831,15 +4898,15 @@ EbErrorType inter_pu_prediction_av1(uint8_t hbd_mode_decision, ModeDecisionConte
                     hbd_mode_decision == EB_DUAL_BIT_MD) {
                     if (ref_idx_l0 >= 0)
                         ref_pic_list0 = ((EbReferenceObject *)picture_control_set_ptr
-                                ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
-                                ->object_ptr)
-                                ->reference_picture;
+                                             ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
+                                             ->object_ptr)
+                                            ->reference_picture;
 
                     if (ref_idx_l1 >= 0)
                         ref_pic_list1 = ((EbReferenceObject *)picture_control_set_ptr
-                                ->ref_pic_ptr_array[list_idx1][ref_idx_l1]
-                                ->object_ptr)
-                                ->reference_picture;
+                                             ->ref_pic_ptr_array[list_idx1][ref_idx_l1]
+                                             ->object_ptr)
+                                            ->reference_picture;
                 }
                 interpolation_filter_search(picture_control_set_ptr,
                                             candidate_buffer_ptr->prediction_ptr_temp,
@@ -4849,22 +4916,22 @@ EbErrorType inter_pu_prediction_av1(uint8_t hbd_mode_decision, ModeDecisionConte
                                             ref_pic_list0,
                                             ref_pic_list1,
                                             md_context_ptr->hbd_mode_decision == EB_DUAL_BIT_MD
-                                            ? EB_8_BIT_MD
-                                            : md_context_ptr->hbd_mode_decision,
+                                                ? EB_8_BIT_MD
+                                                : md_context_ptr->hbd_mode_decision,
                                             bit_depth);
                 if (md_context_ptr->hbd_mode_decision == EB_DUAL_BIT_MD &&
                     hbd_mode_decision == EB_DUAL_BIT_MD) {
                     if (ref_idx_l0 >= 0)
                         ref_pic_list0 = ((EbReferenceObject *)picture_control_set_ptr
-                                ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
-                                ->object_ptr)
-                                ->reference_picture16bit;
+                                             ->ref_pic_ptr_array[list_idx0][ref_idx_l0]
+                                             ->object_ptr)
+                                            ->reference_picture16bit;
 
                     if (ref_idx_l1 >= 0)
                         ref_pic_list1 = ((EbReferenceObject *)picture_control_set_ptr
-                                ->ref_pic_ptr_array[list_idx1][ref_idx_l1]
-                                ->object_ptr)
-                                ->reference_picture16bit;
+                                             ->ref_pic_ptr_array[list_idx1][ref_idx_l1]
+                                             ->object_ptr)
+                                            ->reference_picture16bit;
                 }
             }
         }
@@ -4884,39 +4951,43 @@ EbErrorType inter_pu_prediction_av1(uint8_t hbd_mode_decision, ModeDecisionConte
         cr_recon_neighbor_array   = md_context_ptr->cr_recon_neighbor_array16bit;
     }
 
-    av1_inter_prediction(
-            picture_control_set_ptr,
-            candidate_buffer_ptr->candidate_ptr->interp_filters,
-            md_context_ptr->blk_ptr,
-            candidate_buffer_ptr->candidate_ptr->ref_frame_type,
-            &mv_unit,
-            candidate_buffer_ptr->candidate_ptr->use_intrabc,
-            candidate_buffer_ptr->candidate_ptr->motion_mode, //MD
-            1,
-            md_context_ptr,
-            candidate_buffer_ptr->candidate_ptr->compound_idx,
-            &candidate_buffer_ptr->candidate_ptr->interinter_comp,
-            &md_context_ptr->sb_ptr->tile_info,
-            luma_recon_neighbor_array,
-            cb_recon_neighbor_array,
-            cr_recon_neighbor_array,
-            candidate_ptr->is_interintra_used,
-            candidate_ptr->interintra_mode,
-            candidate_ptr->use_wedge_interintra,
-            candidate_ptr->interintra_wedge_index,
-            md_context_ptr->blk_origin_x,
-            md_context_ptr->blk_origin_y,
-            md_context_ptr->blk_geom->bwidth,
-            md_context_ptr->blk_geom->bheight,
-            ref_pic_list0,
-            ref_pic_list1,
-            candidate_buffer_ptr->prediction_ptr,
-            md_context_ptr->blk_geom->origin_x,
-            md_context_ptr->blk_geom->origin_y,
-            md_context_ptr->chroma_level <= CHROMA_MODE_1 &&
-            md_context_ptr->md_staging_skip_inter_chroma_pred == EB_FALSE,
-            hbd_mode_decision ? EB_10BIT : EB_8BIT);
+    av1_inter_prediction(picture_control_set_ptr,
+                         candidate_buffer_ptr->candidate_ptr->interp_filters,
+                         md_context_ptr->blk_ptr,
+                         candidate_buffer_ptr->candidate_ptr->ref_frame_type,
+                         &mv_unit,
+                         candidate_buffer_ptr->candidate_ptr->use_intrabc,
+                         candidate_buffer_ptr->candidate_ptr->motion_mode, //MD
+                         1,
+                         md_context_ptr,
+                         candidate_buffer_ptr->candidate_ptr->compound_idx,
+                         &candidate_buffer_ptr->candidate_ptr->interinter_comp,
+                         &md_context_ptr->sb_ptr->tile_info,
+                         luma_recon_neighbor_array,
+                         cb_recon_neighbor_array,
+                         cr_recon_neighbor_array,
+                         candidate_ptr->is_interintra_used,
+                         candidate_ptr->interintra_mode,
+                         candidate_ptr->use_wedge_interintra,
+                         candidate_ptr->interintra_wedge_index,
+                         md_context_ptr->blk_origin_x,
+                         md_context_ptr->blk_origin_y,
+                         md_context_ptr->blk_geom->bwidth,
+                         md_context_ptr->blk_geom->bheight,
+                         ref_pic_list0,
+                         ref_pic_list1,
+                         candidate_buffer_ptr->prediction_ptr,
+                         md_context_ptr->blk_geom->origin_x,
+                         md_context_ptr->blk_geom->origin_y,
+#if MOVE_OPT
+                         (md_context_ptr->chroma_level == CHROMA_MODE_01 ||
+                          md_context_ptr->chroma_level <= CHROMA_MODE_1) &&
+                             md_context_ptr->md_staging_skip_inter_chroma_pred == EB_FALSE,
+#else
+                         md_context_ptr->chroma_level <= CHROMA_MODE_1 &&
+                             md_context_ptr->md_staging_skip_inter_chroma_pred == EB_FALSE,
+#endif
+                         hbd_mode_decision ? EB_10BIT : EB_8BIT);
 
     return return_error;
 }
-

--- a/Source/Lib/Encoder/Codec/EbIntraPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbIntraPrediction.c
@@ -3486,7 +3486,12 @@ EbErrorType eb_av1_intra_prediction_cl(
         PredictionMode mode;
         // Hsan: plane should be derived @ an earlier stage (e.g. @ the call of perform_fast_loop())
         int32_t start_plane = (md_context_ptr->uv_search_path) ? 1 : 0;
+#if MOVE_OPT
+        int32_t end_plane = (md_context_ptr->blk_geom->has_uv &&
+            (md_context_ptr->chroma_level == CHROMA_MODE_01 || md_context_ptr->chroma_level <= CHROMA_MODE_1)) ? (int)MAX_MB_PLANE : 1;
+#else
         int32_t end_plane = (md_context_ptr->blk_geom->has_uv && md_context_ptr->chroma_level <= CHROMA_MODE_1) ? (int)MAX_MB_PLANE : 1;
+#endif
 
         for (int32_t plane = start_plane; plane < end_plane; ++plane) {
             if (plane == 0) {
@@ -3561,7 +3566,12 @@ EbErrorType eb_av1_intra_prediction_cl(
         PredictionMode mode;
         // Hsan: plane should be derived @ an earlier stage (e.g. @ the call of perform_fast_loop())
         int32_t start_plane = (md_context_ptr->uv_search_path) ? 1 : 0;
+#if MOVE_OPT
+        int32_t end_plane = (md_context_ptr->blk_geom->has_uv &&
+            (md_context_ptr->chroma_level == CHROMA_MODE_01 || md_context_ptr->chroma_level <= CHROMA_MODE_1)) ? (int)MAX_MB_PLANE : 1;
+#else
         int32_t end_plane = (md_context_ptr->blk_geom->has_uv && md_context_ptr->chroma_level <= CHROMA_MODE_1) ? (int)MAX_MB_PLANE : 1;
+#endif
         for (int32_t plane = start_plane; plane < end_plane; ++plane) {
             if (plane == 0) {
                 if (md_context_ptr->blk_origin_y != 0)

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
@@ -24,7 +24,13 @@ extern "C" {
 /**************************************
      * Defines
      **************************************/
+#if INFR_OPT
+#define MODE_DECISION_CANDIDATE_MAX_COUNT_Y 1855
+#define MODE_DECISION_CANDIDATE_MAX_COUNT \
+    (MODE_DECISION_CANDIDATE_MAX_COUNT_Y + 84)
+#else
 #define MODE_DECISION_CANDIDATE_MAX_COUNT 1855
+#endif
 #define DEPTH_ONE_STEP 21
 #define DEPTH_TWO_STEP 5
 #define DEPTH_THREE_STEP 1
@@ -288,6 +294,9 @@ typedef struct ModeDecisionContext {
     uint32_t md_stage_1_total_count;
     uint32_t md_stage_2_total_count;
     uint32_t md_stage_3_total_count;
+#if COMP_OPT
+    uint32_t md_stage_3_total_intra_count;
+#endif
 
     uint8_t combine_class12; // 1:class1 and 2 are combined.
 

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -207,8 +207,11 @@ void mode_decision_update_neighbor_arrays(PictureControlSet *  pcs_ptr,
                                    bwdith,
                                    bheight,
                                    NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
-
+#if MOVE_OPT
+    if (context_ptr->blk_geom->has_uv && (context_ptr->chroma_level == CHROMA_MODE_01 || context_ptr->chroma_level <= CHROMA_MODE_1)) {
+#else
     if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+#endif
         //  Update chroma CB cbf and Dc context
         {
             uint8_t dc_sign_level_coeff = (int32_t)context_ptr->blk_ptr->quantized_dc[1][0];
@@ -299,7 +302,11 @@ void mode_decision_update_neighbor_arrays(PictureControlSet *  pcs_ptr,
         }
 
         if (intraMdOpenLoop == EB_FALSE) {
+#if MOVE_OPT
+            if (context_ptr->blk_geom->has_uv && (context_ptr->chroma_level == CHROMA_MODE_01 || context_ptr->chroma_level <= CHROMA_MODE_1)) {
+#else
             if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+#endif
                 update_recon_neighbor_array(context_ptr->cb_recon_neighbor_array,
                                             context_ptr->blk_ptr->neigh_top_recon[1],
                                             context_ptr->blk_ptr->neigh_left_recon[1],
@@ -341,7 +348,11 @@ void mode_decision_update_neighbor_arrays(PictureControlSet *  pcs_ptr,
         }
 
         if (intraMdOpenLoop == EB_FALSE && context_ptr->blk_geom->has_uv &&
+#if MOVE_OPT
+            (context_ptr->chroma_level == CHROMA_MODE_01 || context_ptr->chroma_level <= CHROMA_MODE_1)) {
+#else
             context_ptr->chroma_level <= CHROMA_MODE_1) {
+#endif
             update_recon_neighbor_array16bit(context_ptr->cb_recon_neighbor_array16bit,
                                              context_ptr->blk_ptr->neigh_top_recon_16bit[1],
                                              context_ptr->blk_ptr->neigh_left_recon_16bit[1],
@@ -488,7 +499,11 @@ void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *cont
                            blk_geom->bheight,
                            NEIGHBOR_ARRAY_UNIT_FULL_MASK);
         }
+#if MOVE_OPT
+        if (blk_geom->has_uv && (context_ptr->chroma_level == CHROMA_MODE_01 || context_ptr->chroma_level <= CHROMA_MODE_1)) {
+#else
         if (blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+#endif
 #if TILES_PARALLEL
             copy_neigh_arr(pcs_ptr->md_cb_recon_neighbor_array[src_idx][tile_idx],
                            pcs_ptr->md_cb_recon_neighbor_array[dst_idx][tile_idx],
@@ -543,7 +558,11 @@ void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *cont
                            NEIGHBOR_ARRAY_UNIT_FULL_MASK);
         }
 
+#if MOVE_OPT
+        if (blk_geom->has_uv && (context_ptr->chroma_level == CHROMA_MODE_01 || context_ptr->chroma_level <= CHROMA_MODE_1)) {
+#else
         if (blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+#endif
 #if TILES_PARALLEL
             copy_neigh_arr(pcs_ptr->md_cb_recon_neighbor_array16bit[src_idx][tile_idx],
                            pcs_ptr->md_cb_recon_neighbor_array16bit[dst_idx][tile_idx],
@@ -611,8 +630,11 @@ void copy_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *cont
                    blk_geom->bwidth,
                    blk_geom->bheight,
                    NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
-
+#if MOVE_OPT
+    if (blk_geom->has_uv && (context_ptr->chroma_level == CHROMA_MODE_01 || context_ptr->chroma_level <= CHROMA_MODE_1)) {
+#else
     if (blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+#endif
 #if TILES_PARALLEL
         copy_neigh_arr(pcs_ptr->md_cb_dc_sign_level_coeff_neighbor_array[src_idx][tile_idx],
                        pcs_ptr->md_cb_dc_sign_level_coeff_neighbor_array[dst_idx][tile_idx],
@@ -1014,7 +1036,11 @@ void av1_perform_inverse_transform_recon(PictureControlSet *          pcs_ptr,
             //CHROMA
             uint8_t tx_depth = candidate_buffer->candidate_ptr->tx_depth;
             if (tx_depth == 0 || txb_itr == 0) {
+#if MOVE_OPT
+                if (context_ptr->chroma_level == CHROMA_MODE_01 || context_ptr->chroma_level <= CHROMA_MODE_1) {
+#else
                 if (context_ptr->chroma_level <= CHROMA_MODE_1) {
+#endif
                     uint32_t chroma_txb_width =
                         tx_size_wide[context_ptr->blk_geom->txsize_uv[tx_depth][txb_itr]];
                     uint32_t chroma_txb_height =
@@ -1191,8 +1217,12 @@ void fast_loop_core(ModeDecisionCandidateBuffer *candidate_buffer, PictureContro
                                context_ptr->blk_geom->bwidth));
         }
     }
-
+#if MOVE_OPT
+    if (context_ptr->blk_geom->has_uv &&
+        (context_ptr->chroma_level == CHROMA_MODE_01 || context_ptr->chroma_level <= CHROMA_MODE_1) &&
+#else
     if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1 &&
+#endif
         context_ptr->md_staging_skip_inter_chroma_pred == EB_FALSE) {
         if (use_ssd) {
             EbSpatialFullDistType spatial_full_dist_type_fun = context_ptr->hbd_mode_decision
@@ -1941,7 +1971,10 @@ void construct_best_sorted_arrays_md_stage_3(struct ModeDecisionContext *  conte
     uint32_t i, id;
     uint32_t id_inter = 0;
     uint32_t id_intra = fullReconCandidateCount - 1;
-
+#if COMP_OPT
+    if (context_ptr->chroma_level == CHROMA_MODE_01)
+        context_ptr->md_stage_3_total_intra_count = 0;
+#endif
     for (i = 0; i < fullReconCandidateCount; ++i) {
         id = sorted_candidate_index_array[i];
         if (buffer_ptr_array[id]->candidate_ptr->type == INTER_MODE) {
@@ -1950,6 +1983,10 @@ void construct_best_sorted_arrays_md_stage_3(struct ModeDecisionContext *  conte
             assert(buffer_ptr_array[id]->candidate_ptr->type == INTRA_MODE);
             best_candidate_index_array[id_intra--] = id;
         }
+#if COMP_OPT
+        if (context_ptr->chroma_level == CHROMA_MODE_01)
+            context_ptr->md_stage_3_total_intra_count += buffer_ptr_array[id]->candidate_ptr->type == INTRA_MODE ? 1 : 0;
+#endif
     }
 
     sort_array_index_fast_cost_ptr(
@@ -4790,7 +4827,12 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
     uint16_t cb_qp = context_ptr->qp;
     uint16_t cr_qp = context_ptr->qp;
     if (context_ptr->md_staging_skip_full_chroma == EB_FALSE) {
+#if MOVE_OPT
+    if (context_ptr->blk_geom->has_uv &&
+        (context_ptr->chroma_level == CHROMA_MODE_01 || context_ptr->chroma_level <= CHROMA_MODE_1)) {
+#else
         if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+#endif
             //Cb Residual
             residual_kernel(input_picture_ptr->buffer_cb,
                             input_cb_origin_in_index,
@@ -4835,7 +4877,12 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
                            input_cb_origin_in_index,
                            blk_chroma_origin_index);
         }
+#if MOVE_OPT
+        if (context_ptr->blk_geom->has_uv &&
+            (context_ptr->chroma_level == CHROMA_MODE_01 || context_ptr->chroma_level <= CHROMA_MODE_1)) {
+#else
         if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+#endif
             full_loop_r(sb_ptr,
                         candidate_buffer,
                         context_ptr,
@@ -4863,7 +4910,11 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
         }
 
         // Check independant chroma vs. cfl
+#if MOVE_OPT
+        if (context_ptr->blk_geom->has_uv && (context_ptr->chroma_level == CHROMA_MODE_0 || context_ptr->chroma_level == CHROMA_MODE_01)){
+#else
         if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level == CHROMA_MODE_0) {
+#endif
             if (candidate_buffer->candidate_ptr->type == INTRA_MODE &&
                 (candidate_buffer->candidate_ptr->intra_chroma_mode == UV_CFL_PRED ||
                  candidate_buffer->candidate_ptr->intra_chroma_mode == UV_DC_PRED)) {
@@ -5054,7 +5105,28 @@ void md_stage_3(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *blk_p
                 return;
             }
         }
+#if MOVE_OPT
+        if (context_ptr->chroma_level == CHROMA_MODE_01) {
+            if (context_ptr->blk_geom->sq_size < 128) {
+                if (context_ptr->blk_geom->has_uv) {
+                    if (candidate_ptr->type == INTRA_MODE) {
+                        uint32_t intra_chroma_mode = candidate_ptr->intra_chroma_mode != UV_CFL_PRED ?
+                            context_ptr->best_uv_mode[candidate_ptr->intra_luma_mode][MAX_ANGLE_DELTA + candidate_ptr->angle_delta[PLANE_TYPE_Y]] :
+                            UV_CFL_PRED;
+                        int32_t angle_delta = candidate_ptr->intra_chroma_mode != UV_CFL_PRED ?
+                            context_ptr->best_uv_angle[candidate_ptr->intra_luma_mode][MAX_ANGLE_DELTA + candidate_ptr->angle_delta[PLANE_TYPE_Y]] : 0;
+                        uint8_t is_directional_chroma_mode_flag = candidate_ptr->intra_chroma_mode != UV_CFL_PRED ?
+                            (uint8_t)av1_is_directional_mode((PredictionMode)(context_ptr->best_uv_mode[candidate_ptr->intra_luma_mode][MAX_ANGLE_DELTA + candidate_ptr->angle_delta[PLANE_TYPE_Y]])) : 0;
 
+                        candidate_ptr->intra_chroma_mode = intra_chroma_mode;
+                        candidate_ptr->angle_delta[PLANE_TYPE_UV] = angle_delta;
+                        candidate_ptr->is_directional_chroma_mode_flag = is_directional_chroma_mode_flag;
+
+                    }
+                }
+            }
+        }
+#endif
         full_loop_core(pcs_ptr,
                        sb_ptr,
                        blk_ptr,
@@ -5565,6 +5637,24 @@ void order_nsq_table(PictureControlSet *pcs_ptr, ModeDecisionContext *context_pt
         }
     }
 }
+#if MOVE_OPT
+void init_chroma_mode(ModeDecisionContext   *context_ptr) {
+    context_ptr->uv_search_path = EB_TRUE;
+    EbBool use_angle_delta = av1_use_angle_delta(context_ptr->blk_geom->bsize);
+    for (uint8_t intra_mode = DC_PRED; intra_mode <= PAETH_PRED; ++intra_mode) {
+        uint8_t angleDeltaCandidateCount = (use_angle_delta && av1_is_directional_mode((PredictionMode)intra_mode)) ? 7 : 1;
+        uint8_t angle_delta_shift = 1;
+        for (uint8_t angleDeltaCounter = 0; angleDeltaCounter < angleDeltaCandidateCount; ++angleDeltaCounter) {
+            int32_t angle_delta = CLIP(angle_delta_shift * (angleDeltaCandidateCount == 1 ? 0 : angleDeltaCounter - (angleDeltaCandidateCount >> 1)), -MAX_ANGLE_DELTA, MAX_ANGLE_DELTA);
+            context_ptr->best_uv_mode[intra_mode][MAX_ANGLE_DELTA + angle_delta] = intra_mode;
+            context_ptr->best_uv_angle[intra_mode][MAX_ANGLE_DELTA + angle_delta] = angle_delta;
+            context_ptr->best_uv_cost[intra_mode][MAX_ANGLE_DELTA + angle_delta] = (uint64_t)~0;
+        }
+    }
+    // End uv search path
+    context_ptr->uv_search_path = EB_FALSE;
+}
+#endif
 void search_best_independent_uv_mode(PictureControlSet *  pcs_ptr,
                                      EbPictureBufferDesc *input_picture_ptr,
                                      uint32_t             input_cb_origin_in_index,
@@ -5583,7 +5673,19 @@ void search_best_independent_uv_mode(PictureControlSet *  pcs_ptr,
     int distortion[UV_PAETH_PRED + 1][(MAX_ANGLE_DELTA << 1) + 1];
 
     ModeDecisionCandidate *candidate_array     = context_ptr->fast_candidate_array;
+#if INFR_OPT
+    uint32_t start_fast_buffer_index = MODE_DECISION_CANDIDATE_MAX_COUNT_Y;
+    uint32_t start_full_buffer_index = MAX_NFL_BUFF_Y;
+    uint32_t uv_mode_total_count = start_fast_buffer_index;
+#else
     uint8_t                uv_mode_total_count = 0;
+#endif
+#if MOVE_OPT
+    EbBool tem_md_staging_skip_rdoq = context_ptr->md_staging_skip_rdoq;
+    if (context_ptr->chroma_level == CHROMA_MODE_01) {
+        context_ptr->md_staging_skip_rdoq = 0;
+    }
+#endif
     for (uv_mode = UV_DC_PRED; uv_mode <= UV_PAETH_PRED; uv_mode++) {
         uint8_t uv_angle_delta_candidate_count =
             (use_angle_delta && av1_is_directional_mode((PredictionMode)uv_mode)) ? 7 : 1;
@@ -5635,11 +5737,18 @@ void search_best_independent_uv_mode(PictureControlSet *  pcs_ptr,
         }
     }
     // Fast-loop search uv_mode
+#if INFR_OPT
+    uv_mode_total_count = uv_mode_total_count - start_fast_buffer_index;
+#endif
     for (uint8_t uv_mode_count = 0; uv_mode_count < uv_mode_total_count; uv_mode_count++) {
+#if INFR_OPT
+        ModeDecisionCandidateBuffer   *candidate_buffer = context_ptr->candidate_buffer_ptr_array[uv_mode_count + start_full_buffer_index];
+        candidate_buffer->candidate_ptr = &context_ptr->fast_candidate_array[uv_mode_count + start_fast_buffer_index];
+#else
         ModeDecisionCandidateBuffer *candidate_buffer =
             context_ptr->candidate_buffer_ptr_array[uv_mode_count];
         candidate_buffer->candidate_ptr = &context_ptr->fast_candidate_array[uv_mode_count];
-
+#endif
         context_ptr->md_staging_skip_inter_chroma_pred = EB_FALSE;
         product_prediction_fun_table[candidate_buffer->candidate_ptr->type](
             context_ptr->hbd_mode_decision, context_ptr, pcs_ptr, candidate_buffer);
@@ -5683,18 +5792,32 @@ void search_best_independent_uv_mode(PictureControlSet *  pcs_ptr,
     }
 
     // Sort uv_mode (in terms of distortion only)
+#if INFR_OPT
+    uint32_t uv_cand_buff_indices[MAX_NFL_BUFF_Y];
+    memset(uv_cand_buff_indices, 0xFFFFFFFF, MAX_NFL_BUFF_Y * sizeof(uint32_t));
+#else
     uint32_t uv_cand_buff_indices[MAX_NFL_BUFF];
     memset(uv_cand_buff_indices, 0xFFFFFFFF, MAX_NFL_BUFF * sizeof(uint32_t));
+#endif
     sort_fast_cost_based_candidates(
         context_ptr,
+#if INFR_OPT
+        start_full_buffer_index,
+#else
         0,
+#endif
         uv_mode_total_count, //how many cand buffers to sort. one of the buffers can have max cost.
         uv_cand_buff_indices);
 
     // Reset *(candidate_buffer->fast_cost_ptr)
     for (uint8_t uv_mode_count = 0; uv_mode_count < uv_mode_total_count; uv_mode_count++) {
+#if INFR_OPT
+        ModeDecisionCandidateBuffer *candidate_buffer =
+            context_ptr->candidate_buffer_ptr_array[uv_mode_count + start_full_buffer_index];
+#else
         ModeDecisionCandidateBuffer *candidate_buffer =
             context_ptr->candidate_buffer_ptr_array[uv_mode_count];
+#endif
         *(candidate_buffer->fast_cost_ptr) = MAX_CU_COST;
     }
 
@@ -5710,10 +5833,17 @@ void search_best_independent_uv_mode(PictureControlSet *  pcs_ptr,
     // Full-loop search uv_mode
     for (uint8_t uv_mode_count = 0; uv_mode_count < MIN(uv_mode_total_count, uv_mode_nfl_count);
          uv_mode_count++) {
+#if INFR_OPT
+        ModeDecisionCandidateBuffer *candidate_buffer =
+            context_ptr->candidate_buffer_ptr_array[uv_cand_buff_indices[uv_mode_count]];
+        candidate_buffer->candidate_ptr =
+            &context_ptr->fast_candidate_array[uv_cand_buff_indices[uv_mode_count]- start_full_buffer_index + start_fast_buffer_index];
+#else
         ModeDecisionCandidateBuffer *candidate_buffer =
             context_ptr->candidate_buffer_ptr_array[uv_cand_buff_indices[uv_mode_count]];
         candidate_buffer->candidate_ptr =
             &context_ptr->fast_candidate_array[uv_cand_buff_indices[uv_mode_count]];
+#endif
         uint16_t cb_qp                               = context_ptr->qp;
         uint16_t cr_qp                               = context_ptr->qp;
         uint64_t cb_coeff_bits                       = 0;
@@ -5809,8 +5939,13 @@ void search_best_independent_uv_mode(PictureControlSet *  pcs_ptr,
             for (uint8_t uv_mode_count = 0;
                  uv_mode_count < MIN(uv_mode_total_count, uv_mode_nfl_count);
                  uv_mode_count++) {
+#if INFR_OPT
+                ModeDecisionCandidate *candidate_ptr =
+                    &(context_ptr->fast_candidate_array[uv_cand_buff_indices[uv_mode_count] - start_full_buffer_index + start_fast_buffer_index]);
+#else
                 ModeDecisionCandidate *candidate_ptr =
                     &(context_ptr->fast_candidate_array[uv_cand_buff_indices[uv_mode_count]]);
+#endif
 
                 candidate_ptr->intra_luma_mode = intra_mode;
                 candidate_ptr->is_directional_mode_flag =
@@ -5865,7 +6000,11 @@ void search_best_independent_uv_mode(PictureControlSet *  pcs_ptr,
             }
         }
     }
-
+#if MOVE_OPT
+    if (context_ptr->chroma_level == CHROMA_MODE_01) {
+        context_ptr->md_staging_skip_rdoq = tem_md_staging_skip_rdoq;
+    }
+#endif
     // End uv search path
     context_ptr->uv_search_path = EB_FALSE;
 }
@@ -6079,6 +6218,15 @@ void md_encode_block(SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
                 }
             }
         }
+#if MOVE_OPT
+        else if (context_ptr->chroma_level == CHROMA_MODE_01) {
+            if (context_ptr->blk_geom->sq_size < 128) {
+                if (context_ptr->blk_geom->has_uv) {
+                    init_chroma_mode(context_ptr);
+                }
+            }
+        }
+#endif
 
         FrameHeader *frm_hdr       = &pcs_ptr->parent_pcs_ptr->frm_hdr;
         context_ptr->geom_offset_x = 0;
@@ -6315,7 +6463,26 @@ void md_encode_block(SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
                                                 candidate_buffer_ptr_array,
                                                 context_ptr->best_candidate_index_array,
                                                 context_ptr->sorted_candidate_index_array);
-
+#if MOVE_OPT
+        // Search the best independent intra chroma mode
+        if (context_ptr->chroma_level == CHROMA_MODE_01) {
+            // Initialize uv_search_path
+            context_ptr->uv_search_path = EB_FALSE;
+            if (context_ptr->blk_geom->sq_size < 128) {
+                if (context_ptr->blk_geom->has_uv) {
+#if COMP_OPT
+                    if (context_ptr->md_stage_3_total_intra_count)
+#endif
+                        search_best_independent_uv_mode(pcs_ptr,
+                                                        input_picture_ptr,
+                                                        input_cb_origin_in_index,
+                                                        input_cb_origin_in_index,
+                                                        blk_chroma_origin_index,
+                                                        context_ptr);
+                }
+            }
+        }
+#endif
         // 3rd Full-Loop
         context_ptr->md_stage = MD_STAGE_3;
         md_stage_3(pcs_ptr,
@@ -6401,7 +6568,12 @@ void md_encode_block(SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
                        recon_ptr->buffer_y + rec_luma_offset +
                            (context_ptr->blk_geom->bheight - 1) * recon_ptr->stride_y,
                        context_ptr->blk_geom->bwidth);
+#if MOVE_OPT
+                if (context_ptr->blk_geom->has_uv &&
+                    (context_ptr->chroma_level == CHROMA_MODE_01 || context_ptr->chroma_level <= CHROMA_MODE_1)) {
+#else
                 if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+#endif
                     memcpy(blk_ptr->neigh_top_recon[1],
                            recon_ptr->buffer_cb + rec_cb_offset +
                                (context_ptr->blk_geom->bheight_uv - 1) * recon_ptr->stride_cb,
@@ -6416,8 +6588,12 @@ void md_encode_block(SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
                     blk_ptr->neigh_left_recon[0][j] =
                         recon_ptr->buffer_y[rec_luma_offset + context_ptr->blk_geom->bwidth - 1 +
                                             j * recon_ptr->stride_y];
-
+#if MOVE_OPT
+                if (context_ptr->blk_geom->has_uv &&
+                    (context_ptr->chroma_level == CHROMA_MODE_01 || context_ptr->chroma_level <= CHROMA_MODE_1)) {
+#else
                 if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+#endif
                     for (j = 0; j < context_ptr->blk_geom->bheight_uv; ++j) {
                         blk_ptr->neigh_left_recon[1][j] =
                             recon_ptr->buffer_cb[rec_cb_offset + context_ptr->blk_geom->bwidth_uv -
@@ -6434,7 +6610,12 @@ void md_encode_block(SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
                            sz * (rec_luma_offset +
                                  (context_ptr->blk_geom->bheight - 1) * recon_ptr->stride_y),
                        sz * context_ptr->blk_geom->bwidth);
+#if MOVE_OPT
+                if (context_ptr->blk_geom->has_uv &&
+                    (context_ptr->chroma_level == CHROMA_MODE_01 || context_ptr->chroma_level <= CHROMA_MODE_1)) {
+#else
                 if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+#endif
                     memcpy(blk_ptr->neigh_top_recon_16bit[1],
                            recon_ptr->buffer_cb +
                                sz * (rec_cb_offset + (context_ptr->blk_geom->bheight_uv - 1) *
@@ -6452,8 +6633,12 @@ void md_encode_block(SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
                         ((uint16_t *)
                              recon_ptr->buffer_y)[rec_luma_offset + context_ptr->blk_geom->bwidth -
                                                   1 + j * recon_ptr->stride_y];
-
+#if MOVE_OPT
+                if (context_ptr->blk_geom->has_uv &&
+                    (context_ptr->chroma_level == CHROMA_MODE_01 || context_ptr->chroma_level <= CHROMA_MODE_1)) {
+#else
                 if (context_ptr->blk_geom->has_uv && context_ptr->chroma_level <= CHROMA_MODE_1) {
+#endif
                     for (j = 0; j < context_ptr->blk_geom->bheight_uv; ++j) {
                         blk_ptr->neigh_left_recon_16bit[1][j] =
                             ((uint16_t *)recon_ptr


### PR DESCRIPTION
## Description
Perform the Chroma search algorithm just before the last md stage and only when at least one intra mode make it to this stage.
This change is enabled only in encode mode M1 for the moment.

## Related issue
#1047 

## Performance
* Bdrate 0.02% Bdrate loss
* Speed 3.5% speed up
* Memory 1% increase 