### PR TITLE
add e2e tests in GitHub CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,13 +119,13 @@ jobs:
         path: ./svtav1-master.tar.gz
 
   # Compile and run tests in shards with only one compiler
-  quicktest:
+  unit-tests:
     runs-on: ubuntu-18.04
     env: { 'CC': 'gcc-9', 'CXX': 'g++-9' }
     strategy:
       matrix:
         index: [ 0, 1, 2, 3, 4, 5, 6, 7 ]
-    name: 'Tests (Ubuntu 18.04, GCC 9.x) Shard ${{ matrix.index }}'
+    name: 'Unit Tests (Ubuntu 18.04, GCC 9.x) Shard ${{ matrix.index }}'
     steps:
       - name: Install dependencies
         run: sudo apt-get install -y nasm yasm cmake gcc-9 g++-9
@@ -136,3 +136,25 @@ jobs:
         run: ./Build/linux/build.sh release test
       - name: Run unit tests shard
         run: env GTEST_TOTAL_SHARDS=8 GTEST_SHARD_INDEX=${{ matrix.index }} ./Bin/Release/SvtAv1UnitTests
+
+  e2e-tests:
+    runs-on: ubuntu-18.04
+    env: { 'CC': 'gcc-9', 'CXX': 'g++-9' }
+    strategy:
+      matrix:
+        index: [ 0, 1, 2, 3, 4, 5, 6, 7 ]
+    name: 'E2E Tests (Ubuntu 18.04, GCC 9.x) Shard ${{ matrix.index }}'
+    steps:
+      - name: Install dependencies
+        run: sudo apt-get install -y nasm yasm cmake gcc-9 g++-9
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: Compile SVT-AV1 (Release, Tests and TestVectors)
+        run: |
+          ./Build/linux/build.sh release test
+          pushd ./Build/linux/Release
+          make TestVectors
+          popd
+      - name: Run unit tests shard
+        run: env SVT_AV1_TEST_VECTOR_PATH="./test/vectors" GTEST_TOTAL_SHARDS=8 GTEST_SHARD_INDEX=${{ matrix.index }} ./Bin/Release/SvtAv1E2ETests


### PR DESCRIPTION
1. add e2e tests with GTest sharded mode to accelerate: parallel running e2e tests in multiple tasks.