### PR TITLE
Rebase PME_SAD_OPT branch to make it applicable for master

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -73,9 +73,16 @@ extern "C" {
 #define AOM_LEFT_TOP_MARGIN_SCALED(subsampling) \
     (AOM_LEFT_TOP_MARGIN_PX(subsampling) << SCALE_SUBPEL_BITS)
 
-#define H_PEL_SEARCH_WIND 3 // 1/2-pel serach window
-#define Q_PEL_SEARCH_WIND 2 // 1/4-pel serach window
+#define H_PEL_SEARCH_WIND 3 // 1/2-pel search window
+#define Q_PEL_SEARCH_WIND 2 // 1/4-pel search window
 #define HP_REF_OPT 1 // Remove redundant positions.
+
+#define ENABLE_PME_SAD 0
+#define SWITCH_XY_LOOPS_PME_SAD_SSD 0
+#if SWITCH_XY_LOOPS_PME_SAD_SSD
+#define RESTRUCTURE_SAD 1
+#endif
+
 typedef enum MeHpMode {
     EX_HP_MODE        = 0, // Exhaustive  1/2-pel serach mode.
     REFINMENT_HP_MODE = 1 // Refinement 1/2-pel serach mode.

--- a/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_AVX2.h
+++ b/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_AVX2.h
@@ -92,6 +92,19 @@ void sad_loop_kernel_avx2_hme_l0_intrin(
     uint32_t src_stride_raw, // input parameter, source stride (no line skipping)
     int16_t search_area_width, int16_t search_area_height);
 
+#if RESTRUCTURE_SAD
+void pme_sad_loop_kernel_avx2(uint8_t * src, // input parameter, source samples Ptr
+    uint32_t  src_stride, // input parameter, source stride
+    uint8_t * ref, // input parameter, reference samples Ptr
+    uint32_t  ref_stride, // input parameter, reference stride
+    uint32_t  block_height, // input parameter, block height (M)
+    uint32_t  block_width, // input parameter, block width (N)
+    uint32_t *best_sad, int16_t *best_mvx, int16_t *best_mvy,
+    int16_t search_position_start_x, int16_t search_position_start_y,
+    int16_t search_area_width, int16_t search_area_height,
+    int16_t search_step, int16_t mvx, int16_t mvy);
+#endif
+
 void get_eight_horizontal_search_point_results_8x8_16x16_pu_avx2_intrin(
     uint8_t *src, uint32_t src_stride, uint8_t *ref, uint32_t ref_stride, uint32_t *p_best_sad_8x8,
     uint32_t *p_best_mv8x8, uint32_t *p_best_sad_16x16, uint32_t *p_best_mv16x16, uint32_t mv,

--- a/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -5374,6 +5374,1836 @@ void sad_loop_kernel_avx2_hme_l0_intrin(
     *y_search_center = y_best;
 }
 
+#if RESTRUCTURE_SAD
+#define UPDATE_BEST_PME(s, k, offset)                                               \
+    tem_sum_1 = _mm_extract_epi32(s, k);                                            \
+    if (tem_sum_1 < low_sum) {                                                      \
+        low_sum = tem_sum_1;                                                        \
+        x_best  = mvx + (search_position_start_x + (j + offset + k)) * search_step; \
+        y_best  = mvy + (search_position_start_y + i) * search_step;                \
+    }
+
+/*******************************************************************************
+* performs sad search for given block and search area
+* return best sad with its best mvx/mvy
+* Requirement: width   = 4, 8, 16, 24, 32, 48, 64, 128
+* Requirement: block_height <= 128 when width = 64 or 128, <= 64 otherwise
+* Requirement: block_height % 2 = 0 when width = 4 or 8
+*******************************************************************************/
+void pme_sad_loop_kernel_avx2(uint8_t * src, // input parameter, source samples Ptr
+                              uint32_t  src_stride, // input parameter, source stride
+                              uint8_t * ref, // input parameter, reference samples Ptr
+                              uint32_t  ref_stride, // input parameter, reference stride
+                              uint32_t  block_height, // input parameter, block height (M)
+                              uint32_t  block_width, // input parameter, block width (N)
+                              uint32_t *best_sad, int16_t *best_mvx, int16_t *best_mvy,
+                              int16_t search_position_start_x, int16_t search_position_start_y,
+                              int16_t search_area_width, int16_t search_area_height,
+                              int16_t search_step, int16_t mvx, int16_t mvy) {
+    int16_t        x_best = *best_mvx, y_best = *best_mvy;
+    uint32_t       low_sum  = *best_sad;
+    uint32_t       tem_sum_1 = 0;
+    int16_t        i, j;
+    uint32_t       k;
+    const uint8_t *p_ref, *p_src;
+    __m128i        s0, s1, s2, s3, s4, s5, s6, s7 = _mm_set1_epi32(-1);
+    __m256i        ss0, ss1, ss2, ss3, ss4, ss5, ss6, ss7, ss8, ss9, ss10, ss11;
+    __m256i        ss12, ss13, ss14, ss15, ss16, ss17, ss18;
+
+    switch (block_width) {
+    case 4:
+        if (block_height == 4) {
+            uint32_t src_stride_t = 3 * src_stride;
+            uint32_t ref_stride_t = 3 * ref_stride;
+            ss2                 = _mm256_insertf128_si256(
+                _mm256_castsi128_si256(
+                    _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(uint32_t *)src),
+                                       _mm_cvtsi32_si128(*(uint32_t *)(src + src_stride)))),
+                _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(uint32_t *)(src + 2 * src_stride)),
+                                   _mm_cvtsi32_si128(*(uint32_t *)(src + src_stride_t))),
+                0x1);
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_ref = ref + j;
+                    ss3 = ss5 = _mm256_setzero_si256();
+                    ss0       = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                        _mm_loadu_si128((__m128i *)(p_ref + 2 * ref_stride)),
+                        0x1);
+                    ss1 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + ref_stride))),
+                        _mm_loadu_si128((__m128i *)(p_ref + ref_stride_t)),
+                        0x1);
+                    ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                    ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                    p_ref += ref_stride << 2;
+                    ss3     = _mm256_adds_epu16(ss3, ss5);
+                    s3      = _mm_adds_epu16(_mm256_castsi256_si128(ss3),
+                                        _mm256_extracti128_si256(ss3, 1));
+                    s3      = _mm_minpos_epu16(s3);
+                    tem_sum_1 = _mm_extract_epi16(s3, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = mvx + (search_position_start_x +
+                                       (int16_t)(j + _mm_extract_epi16(s3, 1))) *
+                                          search_step;
+                        y_best = mvy + (search_position_start_y + i) * search_step;
+                    }
+                }
+                ref += ref_stride;
+            }
+        } else if (block_height == 8) {
+            uint32_t src_stride_t = 3 * src_stride;
+            uint32_t ref_stride_t = 3 * ref_stride;
+            p_src                = src;
+            ss2                 = _mm256_insertf128_si256(
+                _mm256_castsi128_si256(
+                    _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(uint32_t *)p_src),
+                                       _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride)))),
+                _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(uint32_t *)(p_src + 2 * src_stride)),
+                                   _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride_t))),
+                0x1);
+            p_src += src_stride << 2;
+            ss6 = _mm256_insertf128_si256(
+                _mm256_castsi128_si256(
+                    _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(uint32_t *)p_src),
+                                       _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride)))),
+                _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(uint32_t *)(p_src + 2 * src_stride)),
+                                   _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride_t))),
+                0x1);
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_ref = ref + j;
+                    ss3 = ss5 = _mm256_setzero_si256();
+                    ss0       = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                        _mm_loadu_si128((__m128i *)(p_ref + 2 * ref_stride)),
+                        0x1);
+                    ss1 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + ref_stride))),
+                        _mm_loadu_si128((__m128i *)(p_ref + ref_stride_t)),
+                        0x1);
+                    ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                    ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                    p_ref += ref_stride << 2;
+                    ss0 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                        _mm_loadu_si128((__m128i *)(p_ref + 2 * ref_stride)),
+                        0x1);
+                    ss1 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + ref_stride))),
+                        _mm_loadu_si128((__m128i *)(p_ref + ref_stride_t)),
+                        0x1);
+                    ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss6, 0));
+                    ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss6, 18)); // 010 010
+
+                    ss3     = _mm256_adds_epu16(ss3, ss5);
+                    s3      = _mm_adds_epu16(_mm256_castsi256_si128(ss3),
+                                        _mm256_extracti128_si256(ss3, 1));
+                    s3      = _mm_minpos_epu16(s3);
+                    tem_sum_1 = _mm_extract_epi16(s3, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = mvx + (search_position_start_x +
+                                       (int16_t)(j + _mm_extract_epi16(s3, 1))) *
+                                          search_step;
+                        y_best = mvy + (search_position_start_y + i) * search_step;
+                    }
+                }
+                ref += ref_stride;
+            }
+        } else if (block_height == 16) {
+            uint32_t src_stride_t = 3 * src_stride;
+            uint32_t ref_stride_t = 3 * ref_stride;
+            p_src                = src;
+            ss2                 = _mm256_insertf128_si256(
+                _mm256_castsi128_si256(
+                    _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(uint32_t *)p_src),
+                                       _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride)))),
+                _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(uint32_t *)(p_src + 2 * src_stride)),
+                                   _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride_t))),
+                0x1);
+            p_src += src_stride << 2;
+            ss6 = _mm256_insertf128_si256(
+                _mm256_castsi128_si256(
+                    _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(uint32_t *)p_src),
+                                       _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride)))),
+                _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(uint32_t *)(p_src + 2 * src_stride)),
+                                   _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride_t))),
+                0x1);
+            p_src += src_stride << 2;
+            ss7 = _mm256_insertf128_si256(
+                _mm256_castsi128_si256(
+                    _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(uint32_t *)p_src),
+                                       _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride)))),
+                _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(uint32_t *)(p_src + 2 * src_stride)),
+                                   _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride_t))),
+                0x1);
+            p_src += src_stride << 2;
+            ss8 = _mm256_insertf128_si256(
+                _mm256_castsi128_si256(
+                    _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(uint32_t *)p_src),
+                                       _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride)))),
+                _mm_unpacklo_epi64(_mm_cvtsi32_si128(*(uint32_t *)(p_src + 2 * src_stride)),
+                                   _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride_t))),
+                0x1);
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_ref = ref + j;
+                    ss3 = ss5 = _mm256_setzero_si256();
+                    ss0       = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                        _mm_loadu_si128((__m128i *)(p_ref + 2 * ref_stride)),
+                        0x1);
+                    ss1 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + ref_stride))),
+                        _mm_loadu_si128((__m128i *)(p_ref + ref_stride_t)),
+                        0x1);
+                    ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                    ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                    p_ref += ref_stride << 2;
+                    ss0 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                        _mm_loadu_si128((__m128i *)(p_ref + 2 * ref_stride)),
+                        0x1);
+                    ss1 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + ref_stride))),
+                        _mm_loadu_si128((__m128i *)(p_ref + ref_stride_t)),
+                        0x1);
+                    ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss6, 0));
+                    ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss6, 18)); // 010 010
+                    p_ref += ref_stride << 2;
+                    ss0 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                        _mm_loadu_si128((__m128i *)(p_ref + 2 * ref_stride)),
+                        0x1);
+                    ss1 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + ref_stride))),
+                        _mm_loadu_si128((__m128i *)(p_ref + ref_stride_t)),
+                        0x1);
+                    ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss7, 0));
+                    ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss7, 18)); // 010 010
+                    p_ref += ref_stride << 2;
+                    ss0 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                        _mm_loadu_si128((__m128i *)(p_ref + 2 * ref_stride)),
+                        0x1);
+                    ss1 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + ref_stride))),
+                        _mm_loadu_si128((__m128i *)(p_ref + ref_stride_t)),
+                        0x1);
+                    ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss8, 0));
+                    ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss8, 18)); // 010 010
+
+                    ss3     = _mm256_adds_epu16(ss3, ss5);
+                    s3      = _mm_adds_epu16(_mm256_castsi256_si128(ss3),
+                                        _mm256_extracti128_si256(ss3, 1));
+                    s3      = _mm_minpos_epu16(s3);
+                    tem_sum_1 = _mm_extract_epi16(s3, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = mvx + (search_position_start_x +
+                                       (int16_t)(j + _mm_extract_epi16(s3, 1))) *
+                                          search_step;
+                        y_best = mvy + (search_position_start_y + i) * search_step;
+                    }
+                }
+                ref += ref_stride;
+            }
+        }
+        else if (!(block_height % 4)) {
+            uint32_t src_stride_t = 3 * src_stride;
+            uint32_t ref_stride_t = 3 * ref_stride;
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss5 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k += 4) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_loadu_si128((__m128i *)(p_ref + 2 * ref_stride)),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + ref_stride))),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride_t)),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_unpacklo_epi64(
+                                _mm_cvtsi32_si128(*(uint32_t *)p_src),
+                                _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride)))),
+                            _mm_unpacklo_epi64(
+                                _mm_cvtsi32_si128(*(uint32_t *)(p_src + 2 * src_stride)),
+                                _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride_t))),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        p_src += src_stride << 2;
+                        p_ref += ref_stride << 2;
+                    }
+                    ss3     = _mm256_adds_epu16(ss3, ss5);
+                    s3      = _mm_adds_epu16(_mm256_castsi256_si128(ss3),
+                                        _mm256_extracti128_si256(ss3, 1));
+                    s3      = _mm_minpos_epu16(s3);
+                    tem_sum_1 = _mm_extract_epi16(s3, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = mvx + (search_position_start_x +
+                                       (int16_t)(j + _mm_extract_epi16(s3, 1))) *
+                                          search_step;
+                        y_best = mvy + (search_position_start_y + i) * search_step;
+                    }
+                }
+                ref += ref_stride;
+            }
+        } else {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    s3   = _mm_setzero_si128();
+                    for (k = 0; k < block_height; k += 2) {
+                        s0 = _mm_loadu_si128((__m128i *)p_ref);
+                        s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
+                        s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
+                        s5 = _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride));
+                        s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
+                        s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s1, s5, 0));
+                        p_src += src_stride << 1;
+                        p_ref += ref_stride << 1;
+                    }
+                    s3      = _mm_minpos_epu16(s3);
+                    tem_sum_1 = _mm_extract_epi16(s3, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = mvx + (search_position_start_x +
+                                       (int16_t)(j + _mm_extract_epi16(s3, 1))) *
+                                          search_step;
+                        y_best = mvy + (search_position_start_y + i) * search_step;
+                    }
+                }
+                ref += ref_stride;
+            }
+        }
+        break;
+
+    case 8:
+        if (block_height == 4) {
+            uint32_t src_stride_t = 3 * src_stride;
+            uint32_t ref_stride_t = 3 * ref_stride;
+            p_src                = src;
+            ss2                 = _mm256_insertf128_si256(
+                _mm256_castsi128_si256(
+                    _mm_unpacklo_epi64(_mm_loadl_epi64((__m128i *)p_src),
+                                       _mm_loadl_epi64((__m128i *)(p_src + src_stride)))),
+                _mm_unpacklo_epi64(_mm_loadl_epi64((__m128i *)(p_src + 2 * src_stride)),
+                                   _mm_loadl_epi64((__m128i *)(p_src + src_stride_t))),
+                0x1);
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
+                    ss0                   = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                        _mm_loadu_si128((__m128i *)(p_ref + 2 * ref_stride)),
+                        0x1);
+                    ss1 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + ref_stride))),
+                        _mm_loadu_si128((__m128i *)(p_ref + ref_stride_t)),
+                        0x1);
+                    ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                    ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                    ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                    ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                    p_ref += ref_stride << 2;
+                    ss3 =
+                        _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4), _mm256_adds_epu16(ss5, ss6));
+                    s3      = _mm_adds_epu16(_mm256_castsi256_si128(ss3),
+                                        _mm256_extracti128_si256(ss3, 1));
+                    s3      = _mm_minpos_epu16(s3);
+                    tem_sum_1 = _mm_extract_epi16(s3, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = mvx + (search_position_start_x +
+                                       (int16_t)(j + _mm_extract_epi16(s3, 1))) *
+                                          search_step;
+                        y_best = mvy + (search_position_start_y + i) * search_step;
+                    }
+                }
+                ref += ref_stride;
+            }
+        } else if (block_height == 8) {
+            uint32_t src_stride_t = 3 * src_stride;
+            uint32_t ref_stride_t = 3 * ref_stride;
+            p_src               = src;
+            ss2                 = _mm256_insertf128_si256(
+                _mm256_castsi128_si256(
+                    _mm_unpacklo_epi64(_mm_loadl_epi64((__m128i *)p_src),
+                                       _mm_loadl_epi64((__m128i *)(p_src + src_stride)))),
+                _mm_unpacklo_epi64(_mm_loadl_epi64((__m128i *)(p_src + 2 * src_stride)),
+                                   _mm_loadl_epi64((__m128i *)(p_src + src_stride_t))),
+                0x1);
+            p_src += src_stride << 2;
+            ss7 = _mm256_insertf128_si256(
+                _mm256_castsi128_si256(
+                    _mm_unpacklo_epi64(_mm_loadl_epi64((__m128i *)p_src),
+                                       _mm_loadl_epi64((__m128i *)(p_src + src_stride)))),
+                _mm_unpacklo_epi64(_mm_loadl_epi64((__m128i *)(p_src + 2 * src_stride)),
+                                   _mm_loadl_epi64((__m128i *)(p_src + src_stride_t))),
+                0x1);
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
+                    ss0                   = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                        _mm_loadu_si128((__m128i *)(p_ref + 2 * ref_stride)),
+                        0x1);
+                    ss1 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + ref_stride))),
+                        _mm_loadu_si128((__m128i *)(p_ref + ref_stride_t)),
+                        0x1);
+                    ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                    ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                    ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                    ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                    p_ref += ref_stride << 2;
+                    ss0 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                        _mm_loadu_si128((__m128i *)(p_ref + 2 * ref_stride)),
+                        0x1);
+                    ss1 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + ref_stride))),
+                        _mm_loadu_si128((__m128i *)(p_ref + ref_stride_t)),
+                        0x1);
+                    ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss7, 0));
+                    ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss7, 45)); // 101 101
+                    ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss7, 18)); // 010 010
+                    ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss7, 63)); // 111 111
+                    ss3 =
+                        _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4), _mm256_adds_epu16(ss5, ss6));
+                    s3      = _mm_adds_epu16(_mm256_castsi256_si128(ss3),
+                                        _mm256_extracti128_si256(ss3, 1));
+                    s3      = _mm_minpos_epu16(s3);
+                    tem_sum_1 = _mm_extract_epi16(s3, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = mvx + (search_position_start_x +
+                                       (int16_t)(j + _mm_extract_epi16(s3, 1))) *
+                                          search_step;
+                        y_best = mvy + (search_position_start_y + i) * search_step;
+                    }
+                }
+                ref += ref_stride;
+            }
+        }
+        else if (!(block_height % 4)) {
+            uint32_t src_stride_t = 3 * src_stride;
+            uint32_t ref_stride_t = 3 * ref_stride;
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k += 4) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_loadu_si128((__m128i *)(p_ref + 2 * ref_stride)),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + ref_stride))),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride_t)),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_unpacklo_epi64(
+                                _mm_loadl_epi64((__m128i *)p_src),
+                                _mm_loadl_epi64((__m128i *)(p_src + src_stride)))),
+                            _mm_unpacklo_epi64(_mm_loadl_epi64((__m128i *)(p_src + 2 * src_stride)),
+                                               _mm_loadl_epi64((__m128i *)(p_src + src_stride_t))),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += src_stride << 2;
+                        p_ref += ref_stride << 2;
+                    }
+                    ss3 =
+                        _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4), _mm256_adds_epu16(ss5, ss6));
+                    s3      = _mm_adds_epu16(_mm256_castsi256_si128(ss3),
+                                        _mm256_extracti128_si256(ss3, 1));
+                    s3      = _mm_minpos_epu16(s3);
+                    tem_sum_1 = _mm_extract_epi16(s3, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = mvx + (search_position_start_x +
+                                       (int16_t)(j + _mm_extract_epi16(s3, 1))) *
+                                          search_step;
+                        y_best = mvy + (search_position_start_y + i) * search_step;
+                    }
+                }
+                ref += ref_stride;
+            }
+        } else {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    s3 = s4 = _mm_setzero_si128();
+                    for (k = 0; k < block_height; k += 2) {
+                        s0 = _mm_loadu_si128((__m128i *)p_ref);
+                        s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
+                        s2 = _mm_loadl_epi64((__m128i *)p_src);
+                        s5 = _mm_loadl_epi64((__m128i *)(p_src + src_stride));
+                        s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
+                        s4 = _mm_adds_epu16(s4, _mm_mpsadbw_epu8(s0, s2, 5));
+                        s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s1, s5, 0));
+                        s4 = _mm_adds_epu16(s4, _mm_mpsadbw_epu8(s1, s5, 5));
+                        p_src += src_stride << 1;
+                        p_ref += ref_stride << 1;
+                    }
+                    s3      = _mm_adds_epu16(s3, s4);
+                    s3      = _mm_minpos_epu16(s3);
+                    tem_sum_1 = _mm_extract_epi16(s3, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = mvx + (search_position_start_x +
+                                       (int16_t)(j + _mm_extract_epi16(s3, 1))) *
+                                          search_step;
+                        y_best = mvy + (search_position_start_y + i) * search_step;
+                    }
+                }
+                ref += ref_stride;
+            }
+        }
+        break;
+
+    case 16:
+        if (block_height <= 16 && !(search_area_width & 15)) {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 16; j += 16) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
+                    ss7 = ss9 = ss10 = ss11 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k += 2) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride + 8)),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_loadu_si128((__m128i *)(p_src + src_stride)),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 16))),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride + 16)),
+                            0x1);
+                        ss7  = _mm256_adds_epu16(ss7, _mm256_mpsadbw_epu8(ss1, ss2, 0));
+                        ss11 = _mm256_adds_epu16(ss11, _mm256_mpsadbw_epu8(ss1, ss2, 45));
+                        ss9  = _mm256_adds_epu16(ss9, _mm256_mpsadbw_epu8(ss0, ss2, 18));
+                        ss10 = _mm256_adds_epu16(ss10, _mm256_mpsadbw_epu8(ss0, ss2, 63));
+
+                        p_src += 2 * src_stride;
+                        p_ref += 2 * ref_stride;
+                    }
+                    ss3 =
+                        _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4), _mm256_adds_epu16(ss5, ss6));
+                    s3      = _mm_adds_epu16(_mm256_castsi256_si128(ss3),
+                                        _mm256_extracti128_si256(ss3, 1));
+                    s3      = _mm_minpos_epu16(s3);
+                    tem_sum_1 = _mm_extract_epi16(s3, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = mvx + (search_position_start_x +
+                                       (int16_t)(j + _mm_extract_epi16(s3, 1))) *
+                                          search_step;
+                        y_best = mvy + (search_position_start_y + i) * search_step;
+                        ;
+                    }
+
+                    ss7     = _mm256_adds_epu16(_mm256_adds_epu16(ss7, ss11),
+                                            _mm256_adds_epu16(ss9, ss10));
+                    s7      = _mm_adds_epu16(_mm256_castsi256_si128(ss7),
+                                        _mm256_extracti128_si256(ss7, 1));
+                    s7      = _mm_minpos_epu16(s7);
+                    tem_sum_1 = _mm_extract_epi16(s7, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = mvx + (search_position_start_x +
+                                       (int16_t)(j + 8 + _mm_extract_epi16(s7, 1))) *
+                                          search_step;
+                        y_best = mvy + (search_position_start_y + i) * search_step;
+                    }
+                }
+                ref += ref_stride;
+            }
+        } else if (block_height <= 32) {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k += 2) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride + 8)),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_loadu_si128((__m128i *)(p_src + src_stride)),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += 2 * src_stride;
+                        p_ref += 2 * ref_stride;
+                    }
+                    ss3 =
+                        _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4), _mm256_adds_epu16(ss5, ss6));
+                    s3      = _mm256_castsi256_si128(ss3);
+                    s5      = _mm256_extracti128_si256(ss3, 1);
+                    s4      = _mm_minpos_epu16(s3);
+                    s6      = _mm_minpos_epu16(s5);
+                    s4      = _mm_unpacklo_epi16(s4, s4);
+                    s4      = _mm_unpacklo_epi32(s4, s4);
+                    s4      = _mm_unpacklo_epi64(s4, s4);
+                    s6      = _mm_unpacklo_epi16(s6, s6);
+                    s6      = _mm_unpacklo_epi32(s6, s6);
+                    s6      = _mm_unpacklo_epi64(s6, s6);
+                    s3      = _mm_sub_epi16(s3, s4);
+                    s5      = _mm_adds_epu16(s5, s3);
+                    s5      = _mm_sub_epi16(s5, s6);
+                    s5      = _mm_minpos_epu16(s5);
+                    tem_sum_1 = _mm_extract_epi16(s5, 0);
+                    tem_sum_1 += _mm_extract_epi16(s4, 0);
+                    tem_sum_1 += _mm_extract_epi16(s6, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = mvx + (search_position_start_x +
+                                       (int16_t)(j + _mm_extract_epi16(s5, 1))) *
+                                          search_step;
+                        y_best = mvy + (search_position_start_y + i) * search_step;
+                    }
+                }
+                ref += ref_stride;
+            }
+        } else {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k += 2) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride + 8)),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_loadu_si128((__m128i *)(p_src + src_stride)),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += 2 * src_stride;
+                        p_ref += 2 * ref_stride;
+                    }
+                    ss3     = _mm256_adds_epu16(ss3, ss4);
+                    ss5     = _mm256_adds_epu16(ss5, ss6);
+                    ss0     = _mm256_adds_epu16(ss3, ss5);
+                    s0      = _mm_adds_epu16(_mm256_castsi256_si128(ss0),
+                                        _mm256_extracti128_si256(ss0, 1));
+                    s0      = _mm_minpos_epu16(s0);
+                    tem_sum_1 = _mm_extract_epi16(s0, 0);
+                    if (tem_sum_1 < low_sum) {
+                        if (tem_sum_1 != 0xFFFF) { // no overflow
+                            low_sum = tem_sum_1;
+                            x_best  = mvx + (search_position_start_x +
+                                           (int16_t)(j + _mm_extract_epi16(s0, 1))) *
+                                              search_step;
+                            y_best = mvy + (search_position_start_y + i) * search_step;
+                        } else {
+                            ss4 = _mm256_unpacklo_epi16(ss3, _mm256_setzero_si256());
+                            ss3 = _mm256_unpackhi_epi16(ss3, _mm256_setzero_si256());
+                            ss6 = _mm256_unpacklo_epi16(ss5, _mm256_setzero_si256());
+                            ss5 = _mm256_unpackhi_epi16(ss5, _mm256_setzero_si256());
+                            ss4 = _mm256_add_epi32(ss4, ss6);
+                            ss3 = _mm256_add_epi32(ss3, ss5);
+                            s0  = _mm_add_epi32(_mm256_castsi256_si128(ss4),
+                                               _mm256_extracti128_si256(ss4, 1));
+                            s3  = _mm_add_epi32(_mm256_castsi256_si128(ss3),
+                                               _mm256_extracti128_si256(ss3, 1));
+                            UPDATE_BEST_PME(s0, 0, 0);
+                            UPDATE_BEST_PME(s0, 1, 0);
+                            UPDATE_BEST_PME(s0, 2, 0);
+                            UPDATE_BEST_PME(s0, 3, 0);
+                            UPDATE_BEST_PME(s3, 0, 4);
+                            UPDATE_BEST_PME(s3, 1, 4);
+                            UPDATE_BEST_PME(s3, 2, 4);
+                            UPDATE_BEST_PME(s3, 3, 4);
+                        }
+                    }
+                }
+                ref += ref_stride;
+            }
+        }
+        break;
+
+    case 24:
+        if (block_height <= 16) {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k++) {
+                        ss0 = _mm256_loadu_si256((__m256i *)p_ref);
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 8));
+                        ss2 = _mm256_loadu_si256((__m256i *)p_src);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += src_stride;
+                        p_ref += ref_stride;
+                    }
+                    ss3     = _mm256_adds_epu16(ss3, ss4);
+                    ss5     = _mm256_adds_epu16(ss5, ss6);
+                    s3      = _mm_adds_epu16(_mm256_castsi256_si128(ss3),
+                                        _mm256_extracti128_si256(ss3, 1));
+                    s5      = _mm256_castsi256_si128(ss5);
+                    s4      = _mm_minpos_epu16(s3);
+                    s6      = _mm_minpos_epu16(s5);
+                    s4      = _mm_unpacklo_epi16(s4, s4);
+                    s4      = _mm_unpacklo_epi32(s4, s4);
+                    s4      = _mm_unpacklo_epi64(s4, s4);
+                    s6      = _mm_unpacklo_epi16(s6, s6);
+                    s6      = _mm_unpacklo_epi32(s6, s6);
+                    s6      = _mm_unpacklo_epi64(s6, s6);
+                    s3      = _mm_sub_epi16(s3, s4);
+                    s5      = _mm_adds_epu16(s5, s3);
+                    s5      = _mm_sub_epi16(s5, s6);
+                    s5      = _mm_minpos_epu16(s5);
+                    tem_sum_1 = _mm_extract_epi16(s5, 0);
+                    tem_sum_1 += _mm_extract_epi16(s4, 0);
+                    tem_sum_1 += _mm_extract_epi16(s6, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = mvx + (search_position_start_x +
+                                       (int16_t)(j + _mm_extract_epi16(s5, 1))) *
+                                          search_step;
+                        y_best = mvy + (search_position_start_y + i) * search_step;
+                    }
+                }
+                ref += ref_stride;
+            }
+        } else {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k++) {
+                        ss0 = _mm256_loadu_si256((__m256i *)p_ref);
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 8));
+                        ss2 = _mm256_loadu_si256((__m256i *)p_src);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += src_stride;
+                        p_ref += ref_stride;
+                    }
+                    ss3     = _mm256_adds_epu16(ss3, ss4);
+                    ss5     = _mm256_adds_epu16(ss5, ss6);
+                    s3      = _mm256_castsi256_si128(ss3);
+                    s4      = _mm256_extracti128_si256(ss3, 1);
+                    s5      = _mm256_castsi256_si128(ss5);
+                    s0      = _mm_adds_epu16(_mm_adds_epu16(s3, s4), s5);
+                    s0      = _mm_minpos_epu16(s0);
+                    tem_sum_1 = _mm_extract_epi16(s0, 0);
+                    if (tem_sum_1 < low_sum) {
+                        if (tem_sum_1 != 0xFFFF) { // no overflow
+                            low_sum = tem_sum_1;
+                            x_best  = mvx + (search_position_start_x +
+                                           (int16_t)(j + _mm_extract_epi16(s0, 1))) *
+                                              search_step;
+                            y_best = mvy + (search_position_start_y + i) * search_step;
+                        } else {
+                            s0 = _mm_unpacklo_epi16(s3, _mm_setzero_si128());
+                            s3 = _mm_unpackhi_epi16(s3, _mm_setzero_si128());
+                            s1 = _mm_unpacklo_epi16(s4, _mm_setzero_si128());
+                            s4 = _mm_unpackhi_epi16(s4, _mm_setzero_si128());
+                            s2 = _mm_unpacklo_epi16(s5, _mm_setzero_si128());
+                            s5 = _mm_unpackhi_epi16(s5, _mm_setzero_si128());
+                            s0 = _mm_add_epi32(_mm_add_epi32(s0, s1), s2);
+                            s3 = _mm_add_epi32(_mm_add_epi32(s3, s4), s5);
+                            UPDATE_BEST_PME(s0, 0, 0);
+                            UPDATE_BEST_PME(s0, 1, 0);
+                            UPDATE_BEST_PME(s0, 2, 0);
+                            UPDATE_BEST_PME(s0, 3, 0);
+                            UPDATE_BEST_PME(s3, 0, 4);
+                            UPDATE_BEST_PME(s3, 1, 4);
+                            UPDATE_BEST_PME(s3, 2, 4);
+                            UPDATE_BEST_PME(s3, 3, 4);
+                        }
+                    }
+                }
+                ref += ref_stride;
+            }
+        }
+        break;
+
+    case 32:
+        if (block_height <= 16) {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k++) {
+                        ss0 = _mm256_loadu_si256((__m256i *)p_ref);
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 8));
+                        ss2 = _mm256_loadu_si256((__m256i *)p_src);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += src_stride;
+                        p_ref += ref_stride;
+                    }
+                    ss3 =
+                        _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4), _mm256_adds_epu16(ss5, ss6));
+                    s3      = _mm256_castsi256_si128(ss3);
+                    s5      = _mm256_extracti128_si256(ss3, 1);
+                    s4      = _mm_minpos_epu16(s3);
+                    s6      = _mm_minpos_epu16(s5);
+                    s4      = _mm_unpacklo_epi16(s4, s4);
+                    s4      = _mm_unpacklo_epi32(s4, s4);
+                    s4      = _mm_unpacklo_epi64(s4, s4);
+                    s6      = _mm_unpacklo_epi16(s6, s6);
+                    s6      = _mm_unpacklo_epi32(s6, s6);
+                    s6      = _mm_unpacklo_epi64(s6, s6);
+                    s3      = _mm_sub_epi16(s3, s4);
+                    s5      = _mm_adds_epu16(s5, s3);
+                    s5      = _mm_sub_epi16(s5, s6);
+                    s5      = _mm_minpos_epu16(s5);
+                    tem_sum_1 = _mm_extract_epi16(s5, 0);
+                    tem_sum_1 += _mm_extract_epi16(s4, 0);
+                    tem_sum_1 += _mm_extract_epi16(s6, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = mvx + (search_position_start_x +
+                                       (int16_t)(j + _mm_extract_epi16(s5, 1))) *
+                                          search_step;
+                        y_best = mvy + (search_position_start_y + i) * search_step;
+                    }
+                }
+                ref += ref_stride;
+            }
+        } else if (block_height <= 32) {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k++) {
+                        ss0 = _mm256_loadu_si256((__m256i *)p_ref);
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 8));
+                        ss2 = _mm256_loadu_si256((__m256i *)p_src);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += src_stride;
+                        p_ref += ref_stride;
+                    }
+                    ss3     = _mm256_adds_epu16(ss3, ss4);
+                    ss5     = _mm256_adds_epu16(ss5, ss6);
+                    ss6     = _mm256_adds_epu16(ss3, ss5);
+                    s3      = _mm256_castsi256_si128(ss6);
+                    s4      = _mm256_extracti128_si256(ss6, 1);
+                    s0      = _mm_adds_epu16(s3, s4);
+                    s0      = _mm_minpos_epu16(s0);
+                    tem_sum_1 = _mm_extract_epi16(s0, 0);
+                    if (tem_sum_1 < low_sum) {
+                        if (tem_sum_1 != 0xFFFF) { // no overflow
+                            low_sum = tem_sum_1;
+                            x_best  = mvx + (search_position_start_x +
+                                           (int16_t)(j + _mm_extract_epi16(s0, 1))) *
+                                              search_step;
+                            y_best = mvy + (search_position_start_y + i) * search_step;
+                        } else {
+                            ss4 = _mm256_unpacklo_epi16(ss3, _mm256_setzero_si256());
+                            ss3 = _mm256_unpackhi_epi16(ss3, _mm256_setzero_si256());
+                            ss6 = _mm256_unpacklo_epi16(ss5, _mm256_setzero_si256());
+                            ss5 = _mm256_unpackhi_epi16(ss5, _mm256_setzero_si256());
+                            ss4 = _mm256_add_epi32(ss4, ss6);
+                            ss3 = _mm256_add_epi32(ss3, ss5);
+                            s0  = _mm_add_epi32(_mm256_castsi256_si128(ss4),
+                                               _mm256_extracti128_si256(ss4, 1));
+                            s3  = _mm_add_epi32(_mm256_castsi256_si128(ss3),
+                                               _mm256_extracti128_si256(ss3, 1));
+                            UPDATE_BEST_PME(s0, 0, 0);
+                            UPDATE_BEST_PME(s0, 1, 0);
+                            UPDATE_BEST_PME(s0, 2, 0);
+                            UPDATE_BEST_PME(s0, 3, 0);
+                            UPDATE_BEST_PME(s3, 0, 4);
+                            UPDATE_BEST_PME(s3, 1, 4);
+                            UPDATE_BEST_PME(s3, 2, 4);
+                            UPDATE_BEST_PME(s3, 3, 4);
+                        }
+                    }
+                }
+                ref += ref_stride;
+            }
+        } else {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k++) {
+                        ss0 = _mm256_loadu_si256((__m256i *)p_ref);
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 8));
+                        ss2 = _mm256_loadu_si256((__m256i *)p_src);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += src_stride;
+                        p_ref += ref_stride;
+                    }
+                    ss7 =
+                        _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4), _mm256_adds_epu16(ss5, ss6));
+                    s3      = _mm256_castsi256_si128(ss7);
+                    s4      = _mm256_extracti128_si256(ss7, 1);
+                    s0      = _mm_adds_epu16(s3, s4);
+                    s0      = _mm_minpos_epu16(s0);
+                    tem_sum_1 = _mm_extract_epi16(s0, 0);
+                    if (tem_sum_1 < low_sum) {
+                        if (tem_sum_1 != 0xFFFF) { // no overflow
+                            low_sum = tem_sum_1;
+                            x_best  = mvx + (search_position_start_x +
+                                           (int16_t)(j + _mm_extract_epi16(s0, 1))) *
+                                              search_step;
+                            y_best = mvy + (search_position_start_y + i) * search_step;
+                        } else {
+                            ss0 = _mm256_unpacklo_epi16(ss3, _mm256_setzero_si256());
+                            ss3 = _mm256_unpackhi_epi16(ss3, _mm256_setzero_si256());
+                            ss1 = _mm256_unpacklo_epi16(ss4, _mm256_setzero_si256());
+                            ss4 = _mm256_unpackhi_epi16(ss4, _mm256_setzero_si256());
+                            ss2 = _mm256_unpacklo_epi16(ss5, _mm256_setzero_si256());
+                            ss5 = _mm256_unpackhi_epi16(ss5, _mm256_setzero_si256());
+                            ss7 = _mm256_unpacklo_epi16(ss6, _mm256_setzero_si256());
+                            ss6 = _mm256_unpackhi_epi16(ss6, _mm256_setzero_si256());
+                            ss0 = _mm256_add_epi32(_mm256_add_epi32(ss0, ss1),
+                                                   _mm256_add_epi32(ss2, ss7));
+                            ss3 = _mm256_add_epi32(_mm256_add_epi32(ss3, ss4),
+                                                   _mm256_add_epi32(ss5, ss6));
+                            s0  = _mm_add_epi32(_mm256_castsi256_si128(ss0),
+                                               _mm256_extracti128_si256(ss0, 1));
+                            s3  = _mm_add_epi32(_mm256_castsi256_si128(ss3),
+                                               _mm256_extracti128_si256(ss3, 1));
+                            UPDATE_BEST_PME(s0, 0, 0);
+                            UPDATE_BEST_PME(s0, 1, 0);
+                            UPDATE_BEST_PME(s0, 2, 0);
+                            UPDATE_BEST_PME(s0, 3, 0);
+                            UPDATE_BEST_PME(s3, 0, 4);
+                            UPDATE_BEST_PME(s3, 1, 4);
+                            UPDATE_BEST_PME(s3, 2, 4);
+                            UPDATE_BEST_PME(s3, 3, 4);
+                        }
+                    }
+                }
+                ref += ref_stride;
+            }
+        }
+        break;
+
+    case 48:
+        if (block_height <= 32) {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    s3 = s4 = s5 = s6 = _mm_setzero_si128();
+                    ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k++) {
+                        ss0 = _mm256_loadu_si256((__m256i *)p_ref);
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 8));
+                        ss2 = _mm256_loadu_si256((__m256i *)p_src);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        s0  = _mm_loadu_si128((__m128i *)(p_ref + 32));
+                        s1  = _mm_loadu_si128((__m128i *)(p_ref + 40));
+                        s2  = _mm_loadu_si128((__m128i *)(p_src + 32));
+                        s3  = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
+                        s4  = _mm_adds_epu16(s4, _mm_mpsadbw_epu8(s0, s2, 5));
+                        s5  = _mm_adds_epu16(s5, _mm_mpsadbw_epu8(s1, s2, 2));
+                        s6  = _mm_adds_epu16(s6, _mm_mpsadbw_epu8(s1, s2, 7));
+                        p_src += src_stride;
+                        p_ref += ref_stride;
+                    }
+                    s3      = _mm_adds_epu16(s3, s4);
+                    s5      = _mm_adds_epu16(s5, s6);
+                    s0      = _mm_adds_epu16(s3, s5);
+                    ss3     = _mm256_adds_epu16(ss3, ss4);
+                    ss5     = _mm256_adds_epu16(ss5, ss6);
+                    ss6     = _mm256_adds_epu16(ss3, ss5);
+                    s0      = _mm_adds_epu16(s0,
+                                        _mm_adds_epu16(_mm256_castsi256_si128(ss6),
+                                                       _mm256_extracti128_si256(ss6, 1)));
+                    s0      = _mm_minpos_epu16(s0);
+                    tem_sum_1 = _mm_extract_epi16(s0, 0);
+                    if (tem_sum_1 < low_sum) {
+                        if (tem_sum_1 != 0xFFFF) { // no overflow
+                            low_sum = tem_sum_1;
+                            x_best  = mvx + (search_position_start_x +
+                                           (int16_t)(j + _mm_extract_epi16(s0, 1))) *
+                                              search_step;
+                            y_best = mvy + (search_position_start_y + i) * search_step;
+                        } else {
+                            ss4 = _mm256_unpacklo_epi16(ss3, _mm256_setzero_si256());
+                            ss3 = _mm256_unpackhi_epi16(ss3, _mm256_setzero_si256());
+                            ss6 = _mm256_unpacklo_epi16(ss5, _mm256_setzero_si256());
+                            ss5 = _mm256_unpackhi_epi16(ss5, _mm256_setzero_si256());
+                            ss4 = _mm256_add_epi32(ss4, ss6);
+                            ss3 = _mm256_add_epi32(ss3, ss5);
+                            s0  = _mm_add_epi32(_mm256_castsi256_si128(ss4),
+                                               _mm256_extracti128_si256(ss4, 1));
+                            s1  = _mm_add_epi32(_mm256_castsi256_si128(ss3),
+                                               _mm256_extracti128_si256(ss3, 1));
+                            s0  = _mm_add_epi32(s0, _mm_unpacklo_epi16(s3, _mm_setzero_si128()));
+                            s0  = _mm_add_epi32(s0, _mm_unpacklo_epi16(s5, _mm_setzero_si128()));
+                            s1  = _mm_add_epi32(s1, _mm_unpackhi_epi16(s3, _mm_setzero_si128()));
+                            s1  = _mm_add_epi32(s1, _mm_unpackhi_epi16(s5, _mm_setzero_si128()));
+                            UPDATE_BEST_PME(s0, 0, 0);
+                            UPDATE_BEST_PME(s0, 1, 0);
+                            UPDATE_BEST_PME(s0, 2, 0);
+                            UPDATE_BEST_PME(s0, 3, 0);
+                            UPDATE_BEST_PME(s1, 0, 4);
+                            UPDATE_BEST_PME(s1, 1, 4);
+                            UPDATE_BEST_PME(s1, 2, 4);
+                            UPDATE_BEST_PME(s1, 3, 4);
+                        }
+                    }
+                }
+                ref += ref_stride;
+            }
+        } else {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    s3 = s4 = s5 = s6 = _mm_setzero_si128();
+                    ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k++) {
+                        ss0 = _mm256_loadu_si256((__m256i *)p_ref);
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 8));
+                        ss2 = _mm256_loadu_si256((__m256i *)p_src);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        s0  = _mm_loadu_si128((__m128i *)(p_ref + 32));
+                        s1  = _mm_loadu_si128((__m128i *)(p_ref + 40));
+                        s2  = _mm_loadu_si128((__m128i *)(p_src + 32));
+                        s3  = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
+                        s4  = _mm_adds_epu16(s4, _mm_mpsadbw_epu8(s0, s2, 5));
+                        s5  = _mm_adds_epu16(s5, _mm_mpsadbw_epu8(s1, s2, 2));
+                        s6  = _mm_adds_epu16(s6, _mm_mpsadbw_epu8(s1, s2, 7));
+                        p_src += src_stride;
+                        p_ref += ref_stride;
+                    }
+                    s0      = _mm_adds_epu16(_mm_adds_epu16(s3, s4), _mm_adds_epu16(s5, s6));
+                    ss7     = _mm256_adds_epu16(ss3, ss4);
+                    ss8     = _mm256_adds_epu16(ss5, ss6);
+                    ss7     = _mm256_adds_epu16(ss7, ss8);
+                    s0      = _mm_adds_epu16(s0,
+                                        _mm_adds_epu16(_mm256_castsi256_si128(ss7),
+                                                       _mm256_extracti128_si256(ss7, 1)));
+                    s0      = _mm_minpos_epu16(s0);
+                    tem_sum_1 = _mm_extract_epi16(s0, 0);
+                    if (tem_sum_1 < low_sum) {
+                        if (tem_sum_1 != 0xFFFF) { // no overflow
+                            low_sum = tem_sum_1;
+                            x_best  = mvx + (search_position_start_x +
+                                           (int16_t)(j + _mm_extract_epi16(s0, 1))) *
+                                              search_step;
+                            y_best = mvy + (search_position_start_y + i) * search_step;
+                        } else {
+                            ss0 = _mm256_unpacklo_epi16(ss3, _mm256_setzero_si256());
+                            ss3 = _mm256_unpackhi_epi16(ss3, _mm256_setzero_si256());
+                            ss1 = _mm256_unpacklo_epi16(ss4, _mm256_setzero_si256());
+                            ss4 = _mm256_unpackhi_epi16(ss4, _mm256_setzero_si256());
+                            ss2 = _mm256_unpacklo_epi16(ss5, _mm256_setzero_si256());
+                            ss5 = _mm256_unpackhi_epi16(ss5, _mm256_setzero_si256());
+                            ss7 = _mm256_unpacklo_epi16(ss6, _mm256_setzero_si256());
+                            ss6 = _mm256_unpackhi_epi16(ss6, _mm256_setzero_si256());
+                            ss0 = _mm256_add_epi32(_mm256_add_epi32(ss0, ss1),
+                                                   _mm256_add_epi32(ss2, ss7));
+                            ss3 = _mm256_add_epi32(_mm256_add_epi32(ss3, ss4),
+                                                   _mm256_add_epi32(ss5, ss6));
+                            s0  = _mm_add_epi32(_mm256_castsi256_si128(ss0),
+                                               _mm256_extracti128_si256(ss0, 1));
+                            s1  = _mm_add_epi32(_mm256_castsi256_si128(ss3),
+                                               _mm256_extracti128_si256(ss3, 1));
+                            s0  = _mm_add_epi32(s0, _mm_unpacklo_epi16(s3, _mm_setzero_si128()));
+                            s0  = _mm_add_epi32(s0, _mm_unpacklo_epi16(s4, _mm_setzero_si128()));
+                            s0  = _mm_add_epi32(s0, _mm_unpacklo_epi16(s5, _mm_setzero_si128()));
+                            s0  = _mm_add_epi32(s0, _mm_unpacklo_epi16(s6, _mm_setzero_si128()));
+                            s1  = _mm_add_epi32(s1, _mm_unpackhi_epi16(s3, _mm_setzero_si128()));
+                            s1  = _mm_add_epi32(s1, _mm_unpackhi_epi16(s4, _mm_setzero_si128()));
+                            s1  = _mm_add_epi32(s1, _mm_unpackhi_epi16(s5, _mm_setzero_si128()));
+                            s1  = _mm_add_epi32(s1, _mm_unpackhi_epi16(s6, _mm_setzero_si128()));
+                            UPDATE_BEST_PME(s0, 0, 0);
+                            UPDATE_BEST_PME(s0, 1, 0);
+                            UPDATE_BEST_PME(s0, 2, 0);
+                            UPDATE_BEST_PME(s0, 3, 0);
+                            UPDATE_BEST_PME(s1, 0, 4);
+                            UPDATE_BEST_PME(s1, 1, 4);
+                            UPDATE_BEST_PME(s1, 2, 4);
+                            UPDATE_BEST_PME(s1, 3, 4);
+                        }
+                    }
+                }
+                ref += ref_stride;
+            }
+        }
+        break;
+
+    case 64:
+        if (block_height <= 32) {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k++) {
+                        ss0 = _mm256_loadu_si256((__m256i *)p_ref);
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 8));
+                        ss2 = _mm256_loadu_si256((__m256i *)p_src);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        ss0 = _mm256_loadu_si256((__m256i *)(p_ref + 32));
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 40));
+                        ss2 = _mm256_loadu_si256((__m256i *)(p_src + 32));
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += src_stride;
+                        p_ref += ref_stride;
+                    }
+                    ss7 =
+                        _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4), _mm256_adds_epu16(ss5, ss6));
+                    s3      = _mm256_castsi256_si128(ss7);
+                    s4      = _mm256_extracti128_si256(ss7, 1);
+                    s0      = _mm_adds_epu16(s3, s4);
+                    s0      = _mm_minpos_epu16(s0);
+                    tem_sum_1 = _mm_extract_epi16(s0, 0);
+                    if (tem_sum_1 < low_sum) {
+                        if (tem_sum_1 != 0xFFFF) { // no overflow
+                            low_sum = tem_sum_1;
+                            x_best  = mvx + (search_position_start_x +
+                                           (int16_t)(j + _mm_extract_epi16(s0, 1))) *
+                                              search_step;
+                            y_best = mvy + (search_position_start_y + i) * search_step;
+                        } else {
+                            ss0 = _mm256_unpacklo_epi16(ss3, _mm256_setzero_si256());
+                            ss3 = _mm256_unpackhi_epi16(ss3, _mm256_setzero_si256());
+                            ss1 = _mm256_unpacklo_epi16(ss4, _mm256_setzero_si256());
+                            ss4 = _mm256_unpackhi_epi16(ss4, _mm256_setzero_si256());
+                            ss2 = _mm256_unpacklo_epi16(ss5, _mm256_setzero_si256());
+                            ss5 = _mm256_unpackhi_epi16(ss5, _mm256_setzero_si256());
+                            ss7 = _mm256_unpacklo_epi16(ss6, _mm256_setzero_si256());
+                            ss6 = _mm256_unpackhi_epi16(ss6, _mm256_setzero_si256());
+                            ss0 = _mm256_add_epi32(_mm256_add_epi32(ss0, ss1),
+                                                   _mm256_add_epi32(ss2, ss7));
+                            ss3 = _mm256_add_epi32(_mm256_add_epi32(ss3, ss4),
+                                                   _mm256_add_epi32(ss5, ss6));
+                            s0  = _mm_add_epi32(_mm256_castsi256_si128(ss0),
+                                               _mm256_extracti128_si256(ss0, 1));
+                            s3  = _mm_add_epi32(_mm256_castsi256_si128(ss3),
+                                               _mm256_extracti128_si256(ss3, 1));
+                            UPDATE_BEST_PME(s0, 0, 0);
+                            UPDATE_BEST_PME(s0, 1, 0);
+                            UPDATE_BEST_PME(s0, 2, 0);
+                            UPDATE_BEST_PME(s0, 3, 0);
+                            UPDATE_BEST_PME(s3, 0, 4);
+                            UPDATE_BEST_PME(s3, 1, 4);
+                            UPDATE_BEST_PME(s3, 2, 4);
+                            UPDATE_BEST_PME(s3, 3, 4);
+                        }
+                    }
+                }
+                ref += ref_stride;
+            }
+        } else if (block_height <= 64) {
+            __m256i ss9, ss10;
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = ss6 = ss7 = ss8 = ss9 = ss10 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k++) {
+                        ss0 = _mm256_loadu_si256((__m256i *)p_ref);
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 8));
+                        ss2 = _mm256_loadu_si256((__m256i *)p_src);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        ss0 = _mm256_loadu_si256((__m256i *)(p_ref + 32));
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 40));
+                        ss2 = _mm256_loadu_si256((__m256i *)(p_src + 32));
+                        ss7 = _mm256_adds_epu16(ss7, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss8 = _mm256_adds_epu16(ss8, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss9 = _mm256_adds_epu16(ss9, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss10 =
+                            _mm256_adds_epu16(ss10, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += src_stride;
+                        p_ref += ref_stride;
+                    }
+                    ss0 =
+                        _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4), _mm256_adds_epu16(ss5, ss6));
+                    ss0     = _mm256_adds_epu16(ss0,
+                                            _mm256_adds_epu16(_mm256_adds_epu16(ss7, ss8),
+                                                              _mm256_adds_epu16(ss9, ss10)));
+                    s0      = _mm_adds_epu16(_mm256_castsi256_si128(ss0),
+                                        _mm256_extracti128_si256(ss0, 1));
+                    s0      = _mm_minpos_epu16(s0);
+                    tem_sum_1 = _mm_extract_epi16(s0, 0);
+                    if (tem_sum_1 < low_sum) {
+                        if (tem_sum_1 != 0xFFFF) { // no overflow
+                            low_sum = tem_sum_1;
+                            x_best  = mvx + (search_position_start_x +
+                                           (int16_t)(j + _mm_extract_epi16(s0, 1))) *
+                                              search_step;
+                            y_best = mvy + (search_position_start_y + i) * search_step;
+                        } else {
+                            ss0 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss3, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss4, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss5, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss6, _mm256_setzero_si256())));
+                            ss1 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss3, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss4, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss5, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss6, _mm256_setzero_si256())));
+                            ss2 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss7, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss8, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss9, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss10, _mm256_setzero_si256())));
+                            ss3 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss7, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss8, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss9, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss10, _mm256_setzero_si256())));
+                            ss0 = _mm256_add_epi32(ss0, ss2);
+                            ss1 = _mm256_add_epi32(ss1, ss3);
+                            s0  = _mm_add_epi32(_mm256_castsi256_si128(ss0),
+                                               _mm256_extracti128_si256(ss0, 1));
+                            s3  = _mm_add_epi32(_mm256_castsi256_si128(ss1),
+                                               _mm256_extracti128_si256(ss1, 1));
+                            UPDATE_BEST_PME(s0, 0, 0);
+                            UPDATE_BEST_PME(s0, 1, 0);
+                            UPDATE_BEST_PME(s0, 2, 0);
+                            UPDATE_BEST_PME(s0, 3, 0);
+                            UPDATE_BEST_PME(s3, 0, 4);
+                            UPDATE_BEST_PME(s3, 1, 4);
+                            UPDATE_BEST_PME(s3, 2, 4);
+                            UPDATE_BEST_PME(s3, 3, 4);
+                        }
+                    }
+                }
+                ref += ref_stride;
+            }
+        } else {
+            __m256i ss9, ss10;
+            __m256i ssa1, ssa2, ssa3, ssa4, ssa5, ssa6, ssa7, ssa8;
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = ss6 = ss7 = ss8 = ss9 = ss10 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k++) {
+                        ss0 = _mm256_loadu_si256((__m256i *)p_ref);
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 8));
+                        ss2 = _mm256_loadu_si256((__m256i *)p_src);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        ss0 = _mm256_loadu_si256((__m256i *)(p_ref + 32));
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 40));
+                        ss2 = _mm256_loadu_si256((__m256i *)(p_src + 32));
+                        ss7 = _mm256_adds_epu16(ss7, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss8 = _mm256_adds_epu16(ss8, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss9 = _mm256_adds_epu16(ss9, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss10 =
+                            _mm256_adds_epu16(ss10, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += src_stride;
+                        p_ref += ref_stride;
+                        if (k == 63) {
+                            ssa1 = ss3;
+                            ssa2 = ss4;
+                            ssa3 = ss5;
+                            ssa4 = ss6;
+                            ssa5 = ss7;
+                            ssa6 = ss8;
+                            ssa7 = ss9;
+                            ssa8 = ss10;
+                            ss3 = ss4 = ss5 = ss6 = ss7 = ss8 = ss9 = ss10 = _mm256_setzero_si256();
+                        }
+                    }
+                    ss0 =
+                        _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4), _mm256_adds_epu16(ss5, ss6));
+                    ss0     = _mm256_adds_epu16(ss0,
+                                            _mm256_adds_epu16(_mm256_adds_epu16(ss7, ss8),
+                                                              _mm256_adds_epu16(ss9, ss10)));
+                    ss1     = _mm256_adds_epu16(_mm256_adds_epu16(ssa1, ssa2),
+                                            _mm256_adds_epu16(ssa3, ssa4));
+                    ss1     = _mm256_adds_epu16(ss1,
+                                            _mm256_adds_epu16(_mm256_adds_epu16(ssa5, ssa6),
+                                                              _mm256_adds_epu16(ssa7, ssa8)));
+                    ss0     = _mm256_adds_epu16(ss0, ss1);
+                    s0      = _mm_adds_epu16(_mm256_castsi256_si128(ss0),
+                                        _mm256_extracti128_si256(ss0, 1));
+                    s0      = _mm_minpos_epu16(s0);
+                    tem_sum_1 = _mm_extract_epi16(s0, 0);
+                    if (tem_sum_1 < low_sum) {
+                        if (tem_sum_1 != 0xFFFF) { // no overflow
+                            low_sum = tem_sum_1;
+                            x_best  = mvx + (search_position_start_x +
+                                           (int16_t)(j + _mm_extract_epi16(s0, 1))) *
+                                              search_step;
+                            y_best = mvy + (search_position_start_y + i) * search_step;
+                        } else {
+                            ss0 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss3, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss4, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss5, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss6, _mm256_setzero_si256())));
+                            ss1 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss3, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss4, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss5, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss6, _mm256_setzero_si256())));
+                            ss2 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss7, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss8, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss9, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss10, _mm256_setzero_si256())));
+                            ss3 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss7, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss8, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss9, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss10, _mm256_setzero_si256())));
+                            ss4 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ssa1, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ssa2, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ssa3, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ssa4, _mm256_setzero_si256())));
+                            ss5 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ssa1, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ssa2, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ssa3, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ssa4, _mm256_setzero_si256())));
+                            ss6 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ssa5, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ssa6, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ssa7, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ssa8, _mm256_setzero_si256())));
+                            ss7 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ssa5, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ssa6, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ssa7, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ssa8, _mm256_setzero_si256())));
+                            ss0 = _mm256_add_epi32(ss0, ss2);
+                            ss1 = _mm256_add_epi32(ss1, ss3);
+                            ss2 = _mm256_add_epi32(ss4, ss6);
+                            ss3 = _mm256_add_epi32(ss5, ss7);
+                            ss0 = _mm256_add_epi32(ss0, ss2);
+                            ss1 = _mm256_add_epi32(ss1, ss3);
+                            s0  = _mm_add_epi32(_mm256_castsi256_si128(ss0),
+                                               _mm256_extracti128_si256(ss0, 1));
+                            s3  = _mm_add_epi32(_mm256_castsi256_si128(ss1),
+                                               _mm256_extracti128_si256(ss1, 1));
+                            UPDATE_BEST_PME(s0, 0, 0);
+                            UPDATE_BEST_PME(s0, 1, 0);
+                            UPDATE_BEST_PME(s0, 2, 0);
+                            UPDATE_BEST_PME(s0, 3, 0);
+                            UPDATE_BEST_PME(s3, 0, 4);
+                            UPDATE_BEST_PME(s3, 1, 4);
+                            UPDATE_BEST_PME(s3, 2, 4);
+                            UPDATE_BEST_PME(s3, 3, 4);
+                        }
+                    }
+                }
+                ref += ref_stride;
+            }
+        }
+        break;
+    case 128:
+        if (block_height <= 64) {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = ss6 = ss7 = ss8 = ss9 = ss10 = ss11 = ss12 = ss13 = ss14 =
+                        ss15 = ss16 = ss17 = ss18 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k++) {
+                        ss0 = _mm256_loadu_si256((__m256i *)p_ref);
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 8));
+                        ss2 = _mm256_loadu_si256((__m256i *)p_src);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        ss0 = _mm256_loadu_si256((__m256i *)(p_ref + 32));
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 40));
+                        ss2 = _mm256_loadu_si256((__m256i *)(p_src + 32));
+                        ss7 = _mm256_adds_epu16(ss7, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss8 = _mm256_adds_epu16(ss8, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss9 = _mm256_adds_epu16(ss9, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss10 =
+                            _mm256_adds_epu16(ss10, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        ss0  = _mm256_loadu_si256((__m256i *)(p_ref + 64));
+                        ss1  = _mm256_loadu_si256((__m256i *)(p_ref + 72));
+                        ss2  = _mm256_loadu_si256((__m256i *)(p_src + 64));
+                        ss11 = _mm256_adds_epu16(ss11, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss12 =
+                            _mm256_adds_epu16(ss12, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss13 =
+                            _mm256_adds_epu16(ss13, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss14 =
+                            _mm256_adds_epu16(ss14, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        ss0  = _mm256_loadu_si256((__m256i *)(p_ref + 96));
+                        ss1  = _mm256_loadu_si256((__m256i *)(p_ref + 104));
+                        ss2  = _mm256_loadu_si256((__m256i *)(p_src + 96));
+                        ss15 = _mm256_adds_epu16(ss15, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss16 =
+                            _mm256_adds_epu16(ss16, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss17 =
+                            _mm256_adds_epu16(ss17, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss18 =
+                            _mm256_adds_epu16(ss18, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += src_stride;
+                        p_ref += ref_stride;
+                    }
+                    ss0 =
+                        _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4), _mm256_adds_epu16(ss5, ss6));
+                    ss0     = _mm256_adds_epu16(ss0,
+                                            _mm256_adds_epu16(_mm256_adds_epu16(ss7, ss8),
+                                                              _mm256_adds_epu16(ss9, ss10)));
+                    ss0     = _mm256_adds_epu16(ss0,
+                                            _mm256_adds_epu16(_mm256_adds_epu16(ss11, ss12),
+                                                              _mm256_adds_epu16(ss13, ss14)));
+                    ss0     = _mm256_adds_epu16(ss0,
+                                            _mm256_adds_epu16(_mm256_adds_epu16(ss15, ss16),
+                                                              _mm256_adds_epu16(ss17, ss18)));
+                    s0      = _mm_adds_epu16(_mm256_castsi256_si128(ss0),
+                                        _mm256_extracti128_si256(ss0, 1));
+                    s0      = _mm_minpos_epu16(s0);
+                    tem_sum_1 = _mm_extract_epi16(s0, 0);
+                    if (tem_sum_1 < low_sum) {
+                        if (tem_sum_1 != 0xFFFF) { // no overflow
+                            low_sum = tem_sum_1;
+                            x_best  = mvx + (search_position_start_x +
+                                           (int16_t)(j + _mm_extract_epi16(s0, 1))) *
+                                              search_step;
+                            y_best = mvy + (search_position_start_y + i) * search_step;
+                        } else {
+                            ss0 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss3, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss4, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss5, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss6, _mm256_setzero_si256())));
+                            ss1 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss3, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss4, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss5, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss6, _mm256_setzero_si256())));
+                            ss2 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss7, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss8, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss9, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss10, _mm256_setzero_si256())));
+                            ss3 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss7, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss8, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss9, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss10, _mm256_setzero_si256())));
+                            ss4 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss11, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss12, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss13, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss14, _mm256_setzero_si256())));
+                            ss5 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss11, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss12, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss13, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss14, _mm256_setzero_si256())));
+                            ss6 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss15, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss16, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss17, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss18, _mm256_setzero_si256())));
+                            ss7 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss15, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss16, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss17, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss18, _mm256_setzero_si256())));
+                            ss0 = _mm256_add_epi32(ss0, ss2);
+                            ss1 = _mm256_add_epi32(ss1, ss3);
+                            ss2 = _mm256_add_epi32(ss4, ss6);
+                            ss3 = _mm256_add_epi32(ss5, ss7);
+                            ss0 = _mm256_add_epi32(ss0, ss2);
+                            ss1 = _mm256_add_epi32(ss1, ss3);
+                            s0  = _mm_add_epi32(_mm256_castsi256_si128(ss0),
+                                               _mm256_extracti128_si256(ss0, 1));
+                            s3  = _mm_add_epi32(_mm256_castsi256_si128(ss1),
+                                               _mm256_extracti128_si256(ss1, 1));
+                            UPDATE_BEST_PME(s0, 0, 0);
+                            UPDATE_BEST_PME(s0, 1, 0);
+                            UPDATE_BEST_PME(s0, 2, 0);
+                            UPDATE_BEST_PME(s0, 3, 0);
+                            UPDATE_BEST_PME(s3, 0, 4);
+                            UPDATE_BEST_PME(s3, 1, 4);
+                            UPDATE_BEST_PME(s3, 2, 4);
+                            UPDATE_BEST_PME(s3, 3, 4);
+                        }
+                    }
+                }
+                ref += ref_stride;
+            }
+        } else {
+            __m256i ssa1, ssa2, ssa3, ssa4, ssa5, ssa6, ssa7, ssa8, ssa9, ssa10, ssa11, ssa12,
+                ssa13, ssa14, ssa15, ssa16;
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = ss6 = ss7 = ss8 = ss9 = ss10 = ss11 = ss12 = ss13 = ss14 =
+                        ss15 = ss16 = ss17 = ss18 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k++) {
+                        ss0 = _mm256_loadu_si256((__m256i *)p_ref);
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 8));
+                        ss2 = _mm256_loadu_si256((__m256i *)p_src);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        ss0 = _mm256_loadu_si256((__m256i *)(p_ref + 32));
+                        ss1 = _mm256_loadu_si256((__m256i *)(p_ref + 40));
+                        ss2 = _mm256_loadu_si256((__m256i *)(p_src + 32));
+                        ss7 = _mm256_adds_epu16(ss7, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss8 = _mm256_adds_epu16(ss8, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss9 = _mm256_adds_epu16(ss9, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss10 =
+                            _mm256_adds_epu16(ss10, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        ss0  = _mm256_loadu_si256((__m256i *)(p_ref + 64));
+                        ss1  = _mm256_loadu_si256((__m256i *)(p_ref + 72));
+                        ss2  = _mm256_loadu_si256((__m256i *)(p_src + 64));
+                        ss11 = _mm256_adds_epu16(ss11, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss12 =
+                            _mm256_adds_epu16(ss12, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss13 =
+                            _mm256_adds_epu16(ss13, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss14 =
+                            _mm256_adds_epu16(ss14, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        ss0  = _mm256_loadu_si256((__m256i *)(p_ref + 96));
+                        ss1  = _mm256_loadu_si256((__m256i *)(p_ref + 104));
+                        ss2  = _mm256_loadu_si256((__m256i *)(p_src + 96));
+                        ss15 = _mm256_adds_epu16(ss15, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss16 =
+                            _mm256_adds_epu16(ss16, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss17 =
+                            _mm256_adds_epu16(ss17, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss18 =
+                            _mm256_adds_epu16(ss18, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += src_stride;
+                        p_ref += ref_stride;
+                        if (k == 63) {
+                            ssa1  = ss3;
+                            ssa2  = ss4;
+                            ssa3  = ss5;
+                            ssa4  = ss6;
+                            ssa5  = ss7;
+                            ssa6  = ss8;
+                            ssa7  = ss9;
+                            ssa8  = ss10;
+                            ssa9  = ss11;
+                            ssa10 = ss12;
+                            ssa11 = ss13;
+                            ssa12 = ss14;
+                            ssa13 = ss15;
+                            ssa14 = ss16;
+                            ssa15 = ss17;
+                            ssa16 = ss18;
+                            ss3 = ss4 = ss5 = ss6 = ss7 = ss8 = ss9 = ss10 = ss11 = ss12 = ss13 =
+                                ss14 = ss15 = ss16 = ss17 = ss18 = _mm256_setzero_si256();
+                        }
+                    }
+                    ss0 =
+                        _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4), _mm256_adds_epu16(ss5, ss6));
+                    ss0 = _mm256_adds_epu16(ss0,
+                                            _mm256_adds_epu16(_mm256_adds_epu16(ss7, ss8),
+                                                              _mm256_adds_epu16(ss9, ss10)));
+                    ss0 = _mm256_adds_epu16(ss0,
+                                            _mm256_adds_epu16(_mm256_adds_epu16(ss11, ss12),
+                                                              _mm256_adds_epu16(ss13, ss14)));
+                    ss0 = _mm256_adds_epu16(ss0,
+                                            _mm256_adds_epu16(_mm256_adds_epu16(ss15, ss16),
+                                                              _mm256_adds_epu16(ss17, ss18)));
+                    ss1 = _mm256_adds_epu16(_mm256_adds_epu16(ssa1, ssa2),
+                                            _mm256_adds_epu16(ssa3, ssa4));
+                    ss1 = _mm256_adds_epu16(ss1,
+                                            _mm256_adds_epu16(_mm256_adds_epu16(ssa5, ssa6),
+                                                              _mm256_adds_epu16(ssa7, ssa8)));
+                    ss1 = _mm256_adds_epu16(ss1,
+                                            _mm256_adds_epu16(_mm256_adds_epu16(ssa9, ssa10),
+                                                              _mm256_adds_epu16(ssa11, ssa12)));
+                    ss1 = _mm256_adds_epu16(ss1,
+                                            _mm256_adds_epu16(_mm256_adds_epu16(ssa13, ssa14),
+                                                              _mm256_adds_epu16(ssa15, ssa16)));
+                    ss0 = _mm256_adds_epu16(ss0, ss1);
+
+                    s0      = _mm_adds_epu16(_mm256_castsi256_si128(ss0),
+                                        _mm256_extracti128_si256(ss0, 1));
+                    s0      = _mm_minpos_epu16(s0);
+                    tem_sum_1 = _mm_extract_epi16(s0, 0);
+                    if (tem_sum_1 < low_sum) {
+                        if (tem_sum_1 != 0xFFFF) { // no overflow
+                            low_sum = tem_sum_1;
+                            x_best  = mvx + (search_position_start_x +
+                                           (int16_t)(j + _mm_extract_epi16(s0, 1))) *
+                                              search_step;
+                            y_best = mvy + (search_position_start_y + i) * search_step;
+                        } else {
+                            ss0 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss3, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss4, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss5, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss6, _mm256_setzero_si256())));
+                            ss1 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss3, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss4, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss5, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss6, _mm256_setzero_si256())));
+                            ss2 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss7, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss8, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss9, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss10, _mm256_setzero_si256())));
+                            ss3 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss7, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss8, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss9, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss10, _mm256_setzero_si256())));
+                            ss4 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss11, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss12, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss13, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss14, _mm256_setzero_si256())));
+                            ss5 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss11, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss12, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss13, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss14, _mm256_setzero_si256())));
+                            ss6 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss15, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss16, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ss17, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ss18, _mm256_setzero_si256())));
+                            ss7 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss15, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss16, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ss17, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ss18, _mm256_setzero_si256())));
+                            ss8 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ssa1, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ssa2, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ssa3, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ssa4, _mm256_setzero_si256())));
+                            ss9 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ssa1, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ssa2, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ssa3, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ssa4, _mm256_setzero_si256())));
+                            ss10 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ssa5, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ssa6, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ssa7, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ssa8, _mm256_setzero_si256())));
+                            ss11 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ssa5, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ssa6, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ssa7, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ssa8, _mm256_setzero_si256())));
+                            ss12 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ssa9, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ssa10, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ssa11, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ssa12, _mm256_setzero_si256())));
+                            ss13 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ssa9, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ssa10, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ssa11, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ssa12, _mm256_setzero_si256())));
+                            ss14 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ssa13, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ssa14, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpacklo_epi16(ssa15, _mm256_setzero_si256()),
+                                    _mm256_unpacklo_epi16(ssa16, _mm256_setzero_si256())));
+                            ss15 = _mm256_add_epi32(
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ssa13, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ssa14, _mm256_setzero_si256())),
+                                _mm256_add_epi32(
+                                    _mm256_unpackhi_epi16(ssa15, _mm256_setzero_si256()),
+                                    _mm256_unpackhi_epi16(ssa16, _mm256_setzero_si256())));
+                            ss0 = _mm256_add_epi32(ss0, ss2);
+                            ss1 = _mm256_add_epi32(ss1, ss3);
+                            ss2 = _mm256_add_epi32(ss4, ss6);
+                            ss3 = _mm256_add_epi32(ss5, ss7);
+                            ss4 = _mm256_add_epi32(ss8, ss10);
+                            ss5 = _mm256_add_epi32(ss9, ss11);
+                            ss6 = _mm256_add_epi32(ss12, ss14);
+                            ss7 = _mm256_add_epi32(ss13, ss15);
+                            ss0 = _mm256_add_epi32(ss0, ss2);
+                            ss1 = _mm256_add_epi32(ss1, ss3);
+                            ss2 = _mm256_add_epi32(ss4, ss6);
+                            ss3 = _mm256_add_epi32(ss5, ss7);
+                            ss0 = _mm256_add_epi32(ss0, ss2);
+                            ss1 = _mm256_add_epi32(ss1, ss3);
+                            s0  = _mm_add_epi32(_mm256_castsi256_si128(ss0),
+                                               _mm256_extracti128_si256(ss0, 1));
+                            s3  = _mm_add_epi32(_mm256_castsi256_si128(ss1),
+                                               _mm256_extracti128_si256(ss1, 1));
+                            UPDATE_BEST_PME(s0, 0, 0);
+                            UPDATE_BEST_PME(s0, 1, 0);
+                            UPDATE_BEST_PME(s0, 2, 0);
+                            UPDATE_BEST_PME(s0, 3, 0);
+                            UPDATE_BEST_PME(s3, 0, 4);
+                            UPDATE_BEST_PME(s3, 1, 4);
+                            UPDATE_BEST_PME(s3, 2, 4);
+                            UPDATE_BEST_PME(s3, 3, 4);
+                        }
+                    }
+                }
+                ref += ref_stride;
+            }
+        }
+        break;
+
+    default: assert(0); break;
+    }
+
+    *best_sad = low_sum;
+    *best_mvx = x_best;
+    *best_mvy = y_best;
+}
+#endif
+
 uint32_t eb_aom_sad4x4_avx2(const uint8_t *src_ptr, int src_stride, const uint8_t *ref_ptr,
                             int ref_stride) {
     return compute4x_m_sad_avx2(src_ptr, src_stride, ref_ptr, ref_stride, 4);

--- a/Source/Lib/Encoder/C_DEFAULT/EbComputeSAD_C.h
+++ b/Source/Lib/Encoder/C_DEFAULT/EbComputeSAD_C.h
@@ -42,6 +42,19 @@ void sad_loop_kernel_c(uint8_t * src, // input parameter, source samples Ptr
                        uint32_t src_stride_raw, // input parameter, source stride (no line skipping)
                        int16_t search_area_width, int16_t search_area_height);
 
+#if RESTRUCTURE_SAD
+void pme_sad_loop_kernel_c(uint8_t * src, // input parameter, source samples Ptr
+                           uint32_t  src_stride, // input parameter, source stride
+                           uint8_t * ref, // input parameter, reference samples Ptr
+                           uint32_t  ref_stride, // input parameter, reference stride
+                           uint32_t  block_height, // input parameter, block height (M)
+                           uint32_t  block_width, // input parameter, block width (N)
+                           uint32_t *best_sad, int16_t *best_mvx, int16_t *best_mvy,
+                           int16_t search_position_start_x, int16_t search_position_start_y,
+                           int16_t search_area_width, int16_t search_area_height, int16_t search_step, int16_t mvx,
+                           int16_t mvy);
+#endif
+
 uint32_t nxm_sad_kernel_helper_c(const uint8_t *src, uint32_t src_stride, const uint8_t *ref,
                                  uint32_t ref_stride, uint32_t height, uint32_t width);
 

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -2125,12 +2125,140 @@ void predictive_me_full_pel_search(PictureControlSet *pcs_ptr, ModeDecisionConte
     EbReferenceObject *  ref_obj = pcs_ptr->ref_pic_ptr_array[list_idx][ref_idx]->object_ptr;
     EbPictureBufferDesc *ref_pic =
         hbd_mode_decision ? ref_obj->reference_picture16bit : ref_obj->reference_picture;
+#if RESTRUCTURE_SAD
+    if (use_ssd) {
+#if SWITCH_XY_LOOPS_PME_SAD_SSD
+        for (int32_t refinement_pos_y = search_position_start_y;
+             refinement_pos_y <= search_position_end_y;
+             ++refinement_pos_y) {
+            for (int32_t refinement_pos_x = search_position_start_x;
+                 refinement_pos_x <= search_position_end_x;
+                 ++refinement_pos_x) {
+#else
+        for (int32_t refinement_pos_x = search_position_start_x;
+             refinement_pos_x <= search_position_end_x;
+             ++refinement_pos_x) {
+            for (int32_t refinement_pos_y = search_position_start_y;
+                 refinement_pos_y <= search_position_end_y;
+                 ++refinement_pos_y) {
+#endif
+                uint32_t ref_origin_index =
+                    ref_pic->origin_x +
+                    (context_ptr->blk_origin_x + (mvx >> 3) + refinement_pos_x) +
+                    (context_ptr->blk_origin_y + (mvy >> 3) + ref_pic->origin_y +
+                     refinement_pos_y) * ref_pic->stride_y;
+
+                EbSpatialFullDistType spatial_full_dist_type_fun =
+                    hbd_mode_decision ? full_distortion_kernel16_bits
+                                      : spatial_full_distortion_kernel;
+
+                distortion = (uint32_t)spatial_full_dist_type_fun(input_picture_ptr->buffer_y,
+                                                                  input_origin_index,
+                                                                  input_picture_ptr->stride_y,
+                                                                  ref_pic->buffer_y,
+                                                                  ref_origin_index,
+                                                                  ref_pic->stride_y,
+                                                                  context_ptr->blk_geom->bwidth,
+                                                                  context_ptr->blk_geom->bheight);
+
+                if (distortion < *best_distortion) {
+                    *best_mvx        = mvx + (refinement_pos_x * search_step);
+                    *best_mvy        = mvy + (refinement_pos_y * search_step);
+                    *best_distortion = distortion;
+                }
+            }
+        }
+    } else {
+        uint32_t ref_origin_index =
+            ref_pic->origin_x + (context_ptr->blk_origin_x + (mvx >> 3) + search_position_start_x) +
+            (context_ptr->blk_origin_y + (mvy >> 3) + ref_pic->origin_y + search_position_start_y) *
+                ref_pic->stride_y;
+        assert((context_ptr->blk_geom->bwidth >> 3) < 17);
+        uint32_t search_area_width = search_position_end_x - search_position_start_x + 1;
+        uint32_t search_area_height = search_position_end_y - search_position_start_y + 1;
+        if (search_area_width & 0xfffffff8) {
+            pme_sad_loop_kernel(
+                input_picture_ptr->buffer_y + input_origin_index,
+                input_picture_ptr->stride_y,
+                ref_pic->buffer_y + ref_origin_index,
+                ref_pic->stride_y,
+                context_ptr->blk_geom->bheight,
+                context_ptr->blk_geom->bwidth,
+                best_distortion,
+                best_mvx,
+                best_mvy,
+                search_position_start_x,
+                search_position_start_y,
+                (search_area_width & 0xfffffff8), //pass search_area_width multiple by 8
+                search_area_height,
+                search_step,
+                mvx,
+                mvy);
+        }
+        if (search_area_width & 7) {
+#if SWITCH_XY_LOOPS_PME_SAD_SSD
+            for (int32_t refinement_pos_y = search_position_start_y;
+                 refinement_pos_y <= search_position_end_y;
+                 ++refinement_pos_y) {
+                int32_t refinement_pos_x =
+                    search_position_start_x + (search_area_width & 0xfffffff8);
+                for (; refinement_pos_x <= search_position_end_x;
+                     ++refinement_pos_x) {
+#else
+            int32_t refinement_pos_x = search_position_start_x + (search_area_width & 0xfffffff8);
+            for (; refinement_pos_x <= search_position_end_x; ++refinement_pos_x) {
+                for (int32_t refinement_pos_y = search_position_start_y;
+                     refinement_pos_y <= search_position_end_y;
+                     ++refinement_pos_y) {
+#endif
+                    ref_origin_index = ref_pic->origin_x +
+                                       (context_ptr->blk_origin_x + (mvx >> 3) + refinement_pos_x) +
+                                       (context_ptr->blk_origin_y + (mvy >> 3) + ref_pic->origin_y +
+                                        refinement_pos_y) *
+                                           ref_pic->stride_y;
+                    if (hbd_mode_decision) {
+                        distortion = sad_16b_kernel(
+                            ((uint16_t *)input_picture_ptr->buffer_y) + input_origin_index,
+                            input_picture_ptr->stride_y,
+                            ((uint16_t *)ref_pic->buffer_y) + ref_origin_index,
+                            ref_pic->stride_y,
+                            context_ptr->blk_geom->bheight,
+                            context_ptr->blk_geom->bwidth);
+                    } else {
+                        distortion = nxm_sad_kernel_sub_sampled(
+                            input_picture_ptr->buffer_y + input_origin_index,
+                            input_picture_ptr->stride_y,
+                            ref_pic->buffer_y + ref_origin_index,
+                            ref_pic->stride_y,
+                            context_ptr->blk_geom->bheight,
+                            context_ptr->blk_geom->bwidth);
+                    }
+
+                    if (distortion < *best_distortion) {
+                        *best_mvx        = mvx + (refinement_pos_x * search_step);
+                        *best_mvy        = mvy + (refinement_pos_y * search_step);
+                        *best_distortion = distortion;
+                    }
+                }
+            }
+        }
+    }
+#else
+#if SWITCH_XY_LOOPS_PME_SAD_SSD
+    for (int32_t refinement_pos_y = search_position_start_y;
+         refinement_pos_y <= search_position_end_y;
+         ++refinement_pos_y) {
+        for (int32_t refinement_pos_x = search_position_start_x;
+             refinement_pos_x <= search_position_end_x;
+             ++refinement_pos_x) {
+#else
     for (int32_t refinement_pos_x = search_position_start_x;
          refinement_pos_x <= search_position_end_x;
          ++refinement_pos_x) {
         for (int32_t refinement_pos_y = search_position_start_y;
              refinement_pos_y <= search_position_end_y;
              ++refinement_pos_y) {
+#endif
             uint32_t ref_origin_index =
                 ref_pic->origin_x + (context_ptr->blk_origin_x + (mvx >> 3) + refinement_pos_x) +
                 (context_ptr->blk_origin_y + (mvy >> 3) + ref_pic->origin_y + refinement_pos_y) *
@@ -2154,11 +2282,11 @@ void predictive_me_full_pel_search(PictureControlSet *pcs_ptr, ModeDecisionConte
                 if (hbd_mode_decision) {
                     distortion = sad_16b_kernel(
                         ((uint16_t *)input_picture_ptr->buffer_y) + input_origin_index,
-                        input_picture_ptr->stride_y,
-                        ((uint16_t *)ref_pic->buffer_y) + ref_origin_index,
-                        ref_pic->stride_y,
-                        context_ptr->blk_geom->bheight,
-                        context_ptr->blk_geom->bwidth);
+                                       input_picture_ptr->stride_y,
+                                       ((uint16_t *)ref_pic->buffer_y) + ref_origin_index,
+                                       ref_pic->stride_y,
+                                       context_ptr->blk_geom->bheight,
+                                       context_ptr->blk_geom->bwidth);
                 } else {
                     distortion =
                         nxm_sad_kernel_sub_sampled(input_picture_ptr->buffer_y + input_origin_index,
@@ -2171,13 +2299,15 @@ void predictive_me_full_pel_search(PictureControlSet *pcs_ptr, ModeDecisionConte
             }
 
             if (distortion < *best_distortion) {
-                *best_mvx        = mvx + (refinement_pos_x * search_step);
-                *best_mvy        = mvy + (refinement_pos_y * search_step);
+                *best_mvx = mvx + (refinement_pos_x * search_step);
+                *best_mvy = mvy + (refinement_pos_y * search_step);
                 *best_distortion = distortion;
             }
         }
     }
+#endif
 }
+
 
 void predictive_me_sub_pel_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
                                   EbPictureBufferDesc *input_picture_ptr,
@@ -2509,7 +2639,11 @@ void    predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *co
                                               context_ptr,
                                               input_picture_ptr,
                                               input_origin_index,
+#if ENABLE_PME_SAD
+                                              0,
+#else
                                               use_ssd,
+#endif
                                               list_idx,
                                               ref_idx,
                                               best_mvp_x,

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
@@ -1212,4 +1212,8 @@ void setup_rtcd_internal(CPU_FLAGS flags) {
 
     av1_nn_predict = av1_nn_predict_c;
     if (flags & HAS_SSE3) av1_nn_predict = av1_nn_predict_sse3;
+
+#if RESTRUCTURE_SAD
+    SET_AVX2(pme_sad_loop_kernel, pme_sad_loop_kernel_c, pme_sad_loop_kernel_avx2);
+#endif
 }

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
@@ -1069,6 +1069,9 @@ extern "C" {
     void av1_nn_predict_sse3(const float *input_nodes, const NnConfig *const nn_config, int reduce_prec, float *const output);
     RTCD_EXTERN void(*av1_nn_predict)(const float *input_nodes, const NnConfig *const nn_config, int reduce_prec, float *const output);
 
+#if RESTRUCTURE_SAD
+    RTCD_EXTERN void (*pme_sad_loop_kernel)(uint8_t* src, uint32_t src_stride, uint8_t* ref, uint32_t ref_stride, uint32_t block_height, uint32_t block_width, uint32_t* best_sad, int16_t* best_mvx, int16_t* best_mvy, int16_t search_position_start_x, int16_t search_position_start_y, int16_t search_area_width, int16_t search_area_height, int16_t search_step, int16_t mvx, int16_t mvy);
+#endif
     /* Moved to aom_dsp_rtcd.c file:
     static void setup_rtcd_internal(EbAsm asm_type)
     */


### PR DESCRIPTION
## Description:
Rebase PME_SAD_OPT branch to make it applicable for master

ENABLE_PME_SAD : used SAD instead of SSD for FUll_Pel
SWITCH_XY_LOOPS_PME_SAD: loop over search region width first
RESTRUCTURE_SAD: Restructure SAD calculation for PME full pel to make it simd friendly

Implementation of pme_sad_loop_kernel_avx2 with coressponding UT
Added support for maximum block size from 64x64 to 128x128

Loop unrolling for blocks 4x4, 4x8,4x16,8x4,8x8 pme_sad_loop_kernel_avx2
Speedup compared to previous implementation:
4x4  2.1x
4x8  1.9x
4x16 1.8x
8x4  1.8x
8x8  1.5x

## Performance Impact:
None