### PR TITLE
16bit pipeline for filter

### DIFF
--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -152,6 +152,13 @@ typedef struct EbSvtAv1EncConfiguration {
      *
      * Default is 8. */
     uint32_t encoder_bit_depth;
+    /* Specifies whether to use 16bit pipeline.
+     *
+     * 0: 8 bit pipeline.
+     * 1: 16 bit pipeline.
+     * Now 16bit pipeline is only enabled in filter
+     * Default is 0. */
+    EbBool encoder_16bit_pipeline;
     /* Specifies the chroma subsampleing format of input video.
      *
      * 0 = mono.

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -47,6 +47,7 @@
 #define FRAME_RATE_NUMERATOR_TOKEN "-fps-num"
 #define FRAME_RATE_DENOMINATOR_TOKEN "-fps-denom"
 #define ENCODER_BIT_DEPTH "-bit-depth"
+#define ENCODER_16BIT_PIPELINE "-16bit-pipeline"
 #define ENCODER_COLOR_FORMAT "-color-format"
 #define INPUT_COMPRESSED_TEN_BIT_FORMAT "-compressed-ten-bit-format"
 #define ENCMODE_TOKEN "-enc-mode"
@@ -265,6 +266,9 @@ static void set_frame_rate_denominator(const char *value, EbConfig *cfg) {
 };
 static void set_encoder_bit_depth(const char *value, EbConfig *cfg) {
     cfg->encoder_bit_depth = strtoul(value, NULL, 0);
+}
+static void set_encoder_16bit_pipeline(const char *value, EbConfig *cfg) {
+    cfg->encoder_16bit_pipeline = (EbBool)strtoul(value, NULL, 0);
 }
 static void set_encoder_color_format(const char *value, EbConfig *cfg) {
     cfg->encoder_color_format = strtoul(value, NULL, 0);
@@ -1044,6 +1048,7 @@ ConfigEntry config_entry[] = {
      "FrameRateDenominator",
      set_frame_rate_denominator},
     {SINGLE_INPUT, ENCODER_BIT_DEPTH, "EncoderBitDepth", set_encoder_bit_depth},
+    {SINGLE_INPUT, ENCODER_16BIT_PIPELINE, "Encoder16BitPipeline", set_encoder_16bit_pipeline},
     {SINGLE_INPUT, ENCODER_COLOR_FORMAT, "EncoderColorFormat", set_encoder_color_format},
     {SINGLE_INPUT,
      INPUT_COMPRESSED_TEN_BIT_FORMAT,
@@ -1247,6 +1252,7 @@ void eb_config_ctor(EbConfig *config_ptr) {
     config_ptr->error_log_file       = stderr;
     config_ptr->frame_rate           = 30 << 16;
     config_ptr->encoder_bit_depth    = 8;
+    config_ptr->encoder_16bit_pipeline = 0;
     config_ptr->encoder_color_format = 1; //EB_YUV420
     config_ptr->buffered_input       = -1;
 

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -173,6 +173,7 @@ typedef struct EbConfig {
     uint32_t      injector;
     uint32_t      speed_control_flag;
     uint32_t      encoder_bit_depth;
+    EbBool        encoder_16bit_pipeline;
     uint32_t      encoder_color_format;
     uint32_t      compressed_ten_bit_format;
     uint32_t      source_width;

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -172,6 +172,7 @@ EbErrorType copy_configuration_parameters(EbConfig *config, EbAppContext *callba
     callback_data->eb_enc_parameters.active_channel_count     = config->active_channel_count;
     callback_data->eb_enc_parameters.high_dynamic_range_input = config->high_dynamic_range_input;
     callback_data->eb_enc_parameters.encoder_bit_depth        = config->encoder_bit_depth;
+    callback_data->eb_enc_parameters.encoder_16bit_pipeline   = config->encoder_16bit_pipeline;
     callback_data->eb_enc_parameters.encoder_color_format =
         (EbColorFormat)config->encoder_color_format;
     callback_data->eb_enc_parameters.compressed_ten_bit_format = config->compressed_ten_bit_format;

--- a/Source/Lib/Common/Codec/EbRestoration.c
+++ b/Source/Lib/Common/Codec/EbRestoration.c
@@ -1890,14 +1890,13 @@ EbErrorType eb_av1_alloc_restoration_buffers(Av1Common *cm) {
     // Now we need to allocate enough space to store the line buffers for the
     // stripes
     const int32_t frame_w    = cm->frm_size.superres_upscaled_width;
-    const int32_t use_highbd = cm->use_highbitdepth ? 1 : 0;
 
     for (int32_t p = 0; p < num_planes; ++p) {
         const int32_t is_uv    = p > 0;
         const int32_t ss_x     = is_uv && cm->subsampling_x;
         const int32_t plane_w  = ((frame_w + ss_x) >> ss_x) + 2 * RESTORATION_EXTRA_HORZ;
         const int32_t stride   = ALIGN_POWER_OF_TWO(plane_w, 5);
-        const int32_t buf_size = num_stripes * stride * RESTORATION_CTX_VERT << use_highbd;
+        const int32_t buf_size = num_stripes * stride * RESTORATION_CTX_VERT << 1;
         RestorationStripeBoundaries *boundaries = &cm->rst_info[p].boundaries;
 
         {

--- a/Source/Lib/Encoder/Codec/EbDlfProcess.c
+++ b/Source/Lib/Encoder/Codec/EbDlfProcess.c
@@ -69,7 +69,7 @@ EbErrorType dlf_context_ctor(EbThreadContext *thread_context_ptr, const EbEncHan
     temp_lf_recon_desc_init_data.split_mode   = EB_FALSE;
     temp_lf_recon_desc_init_data.color_format = color_format;
 
-    if (is_16bit) {
+    if (scs_ptr->static_config.encoder_16bit_pipeline || is_16bit) {
         temp_lf_recon_desc_init_data.bit_depth = EB_16BIT;
         EB_NEW(context_ptr->temp_lf_recon_picture16bit_ptr,
                eb_recon_picture_buffer_desc_ctor,
@@ -113,6 +113,127 @@ void *dlf_kernel(void *input_ptr) {
 
         EbBool is_16bit = (EbBool)(scs_ptr->static_config.encoder_bit_depth > EB_8BIT);
 
+        // TODO: remove the copy when entire 16bit pipeline is ready
+        if (scs_ptr->static_config.encoder_16bit_pipeline &&
+            scs_ptr->static_config.encoder_bit_depth == EB_8BIT) {
+            EbPictureBufferDesc *recon_buffer, *recon_buffer_8bit;
+            if (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE) {
+                recon_buffer = ((EbReferenceObject *)
+                    pcs_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)
+                    ->reference_picture16bit;
+                recon_buffer_8bit = ((EbReferenceObject *)
+                    pcs_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)
+                    ->reference_picture;
+            } else {
+                recon_buffer = pcs_ptr->recon_picture16bit_ptr;
+                recon_buffer_8bit = pcs_ptr->recon_picture_ptr;
+            }
+            //copy recon from 8bit to 16bit
+            uint8_t*  recon_8bit;
+            int32_t   recon_stride_8bit;
+            uint16_t* recon_16bit;
+            int32_t   recon_stride_16bit;
+            // Y
+            recon_16bit = (uint16_t*)(recon_buffer->buffer_y)
+                        + recon_buffer->origin_x
+                        + recon_buffer->origin_y * recon_buffer->stride_y;
+            recon_stride_16bit = recon_buffer->stride_y;
+            recon_8bit  = recon_buffer_8bit->buffer_y
+                        + recon_buffer_8bit->origin_x
+                        + recon_buffer_8bit->origin_y * recon_buffer_8bit->stride_y;
+            recon_stride_8bit = recon_buffer_8bit->stride_y;
+            for (int j = 0; j < recon_buffer->height; j++) {
+                for (int i = 0; i < recon_buffer->width; i++) {
+                    recon_16bit[i + j * recon_stride_16bit] =
+                        (uint16_t)recon_8bit[i + j * recon_stride_8bit];
+                }
+            }
+            // Cb
+            recon_16bit = (uint16_t*)(recon_buffer->buffer_cb)
+                        + recon_buffer->origin_x / 2
+                        + recon_buffer->origin_y / 2 * recon_buffer->stride_cb;
+            recon_stride_16bit = recon_buffer->stride_cb;
+            recon_8bit  = recon_buffer_8bit->buffer_cb
+                        + recon_buffer_8bit->origin_x / 2
+                        + recon_buffer_8bit->origin_y / 2 * recon_buffer_8bit->stride_cb;
+            recon_stride_8bit = recon_buffer_8bit->stride_cb;
+            for (int j = 0; j < recon_buffer->height / 2; j++) {
+                for (int i = 0; i < recon_buffer->width / 2; i++) {
+                    recon_16bit[i + j * recon_stride_16bit] =
+                        (uint16_t)recon_8bit[i + j * recon_stride_8bit];
+                }
+            }
+            // Cr
+            recon_16bit = (uint16_t*)(recon_buffer->buffer_cr)
+                        + recon_buffer->origin_x / 2
+                        + recon_buffer->origin_y / 2 * recon_buffer->stride_cr;
+            recon_stride_16bit = recon_buffer->stride_cr;
+            recon_8bit  = recon_buffer_8bit->buffer_cr
+                        + recon_buffer_8bit->origin_x / 2
+                        + recon_buffer_8bit->origin_y / 2 * recon_buffer_8bit->stride_cr;
+            recon_stride_8bit = recon_buffer_8bit->stride_cr;
+            for (int j = 0; j < recon_buffer->height / 2; j++) {
+                for (int i = 0; i < recon_buffer->width / 2; i++) {
+                    recon_16bit[i + j * recon_stride_16bit] =
+                        (uint16_t)recon_8bit[i + j * recon_stride_8bit];
+                }
+            }
+
+            // //copy input from 8bit to 16bit
+            uint8_t*  input_8bit;
+            int32_t   input_stride_8bit;
+            uint16_t* input_16bit;
+            int32_t   input_stride_16bit;
+            EbPictureBufferDesc* input_buffer_8bit = (EbPictureBufferDesc *)
+                pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
+            EbPictureBufferDesc* input_buffer = (EbPictureBufferDesc*)pcs_ptr->input_frame16bit;
+            // Y
+            input_16bit = (uint16_t*)(input_buffer->buffer_y)
+                        + input_buffer->origin_x
+                        + input_buffer->origin_y * input_buffer->stride_y;
+            input_stride_16bit = input_buffer->stride_y;
+            input_8bit  = input_buffer_8bit->buffer_y
+                        + input_buffer_8bit->origin_x
+                        + input_buffer_8bit->origin_y * input_buffer_8bit->stride_y;
+            input_stride_8bit = input_buffer_8bit->stride_y;
+            for (int j = 0; j < input_buffer->height; j++) {
+                for (int i = 0; i < input_buffer->width; i++) {
+                    input_16bit[i + j * input_stride_16bit] =
+                        (uint16_t)input_8bit[i + j * input_stride_8bit];
+                }
+            }
+            // Cb
+            input_16bit = (uint16_t*)(input_buffer->buffer_cb)
+                        + input_buffer->origin_x / 2
+                        + input_buffer->origin_y / 2 * input_buffer->stride_cb;
+            input_stride_16bit = input_buffer->stride_cb;
+            input_8bit  = input_buffer_8bit->buffer_cb
+                        + input_buffer_8bit->origin_x / 2
+                        + input_buffer_8bit->origin_y / 2 * input_buffer_8bit->stride_cb;
+            input_stride_8bit = input_buffer_8bit->stride_cb;
+            for (int j = 0; j < input_buffer->height / 2; j++) {
+                for (int i = 0; i < input_buffer->width / 2; i++) {
+                    input_16bit[i + j * input_stride_16bit] =
+                        (uint16_t)input_8bit[i + j * input_stride_8bit];
+                }
+            }
+            // Cr
+            input_16bit = (uint16_t*)(input_buffer->buffer_cr)
+                        + input_buffer->origin_x / 2
+                        + input_buffer->origin_y / 2 * input_buffer->stride_cr;
+            input_stride_16bit = input_buffer->stride_cr;
+            input_8bit  = input_buffer_8bit->buffer_cr
+                        + input_buffer_8bit->origin_x / 2
+                        + input_buffer_8bit->origin_y / 2 * input_buffer_8bit->stride_cr;
+            input_stride_8bit = input_buffer_8bit->stride_cr;
+            for (int j = 0; j < input_buffer->height / 2; j++) {
+                for (int i = 0; i < input_buffer->width / 2; i++) {
+                    input_16bit[i + j * input_stride_16bit] =
+                        (uint16_t)input_8bit[i + j * input_stride_8bit];
+                }
+            }
+        }
+
         EbBool dlf_enable_flag = (EbBool)pcs_ptr->parent_pcs_ptr->loop_filter_mode;
 #if TILES_PARALLEL
         uint16_t total_tile_cnt = pcs_ptr->parent_pcs_ptr->av1_cm->tiles_info.tile_cols *
@@ -127,9 +248,8 @@ void *dlf_kernel(void *input_ptr) {
             EbPictureBufferDesc *recon_buffer =
                 is_16bit ? pcs_ptr->recon_picture16bit_ptr : pcs_ptr->recon_picture_ptr;
 
-            if (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE)
-                //get the 16bit form of the input SB
-                if (is_16bit)
+            if (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE) {
+                if (scs_ptr->static_config.encoder_16bit_pipeline || is_16bit)
                     recon_buffer =
                         ((EbReferenceObject *)
                              pcs_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)
@@ -139,10 +259,10 @@ void *dlf_kernel(void *input_ptr) {
                         ((EbReferenceObject *)
                              pcs_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)
                             ->reference_picture;
-            else // non ref pictures
-                recon_buffer =
+            } else {
+                recon_buffer = scs_ptr->static_config.encoder_16bit_pipeline ||
                     is_16bit ? pcs_ptr->recon_picture16bit_ptr : pcs_ptr->recon_picture_ptr;
-
+            }
             eb_av1_loop_filter_init(pcs_ptr);
 
             if (pcs_ptr->parent_pcs_ptr->loop_filter_mode == 2) {
@@ -169,6 +289,75 @@ void *dlf_kernel(void *input_ptr) {
             eb_av1_loop_filter_frame(recon_buffer, pcs_ptr, 0, 3);
         }
 
+        // TODO: remove the copy when entire 16bit pipeline is ready
+        if (scs_ptr->static_config.encoder_16bit_pipeline &&
+            scs_ptr->static_config.encoder_bit_depth == EB_8BIT &&
+            !scs_ptr->seq_header.enable_restoration &&
+            !scs_ptr->seq_header.enable_cdef) {
+            EbPictureBufferDesc *recon_buffer, *recon_buffer_8bit;
+            if (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE) {
+                recon_buffer = ((EbReferenceObject *)
+                    pcs_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)
+                    ->reference_picture16bit;
+                recon_buffer_8bit = ((EbReferenceObject *)
+                    pcs_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)
+                    ->reference_picture;
+            } else {
+                recon_buffer = pcs_ptr->recon_picture16bit_ptr;
+                recon_buffer_8bit = pcs_ptr->recon_picture_ptr;
+            }
+            //copy recon from 16bit to 8bit
+            uint8_t*  recon_8bit;
+            int32_t   recon_stride_8bit;
+            uint16_t* recon_16bit;
+            int32_t   recon_stride_16bit;
+            // Y
+            recon_16bit = (uint16_t*)(recon_buffer->buffer_y)
+                        + recon_buffer->origin_x
+                        + recon_buffer->origin_y * recon_buffer->stride_y;
+            recon_stride_16bit = recon_buffer->stride_y;
+            recon_8bit  = recon_buffer_8bit->buffer_y
+                        + recon_buffer_8bit->origin_x
+                        + recon_buffer_8bit->origin_y * recon_buffer_8bit->stride_y;
+            recon_stride_8bit = recon_buffer_8bit->stride_y;
+            for (int j = 0; j < recon_buffer->height; j++) {
+                for (int i = 0; i < recon_buffer->width; i++) {
+                    recon_8bit[i + j * recon_stride_8bit] =
+                        (uint8_t)recon_16bit[i + j * recon_stride_16bit];
+                }
+            }
+            // Cb
+            recon_16bit = (uint16_t*)(recon_buffer->buffer_cb)
+                        + recon_buffer->origin_x / 2
+                        + recon_buffer->origin_y / 2 * recon_buffer->stride_cb;
+            recon_stride_16bit = recon_buffer->stride_cb;
+            recon_8bit  = recon_buffer_8bit->buffer_cb
+                        + recon_buffer_8bit->origin_x / 2
+                        + recon_buffer_8bit->origin_y / 2 * recon_buffer_8bit->stride_cb;
+            recon_stride_8bit = recon_buffer_8bit->stride_cb;
+            for (int j = 0; j < recon_buffer->height / 2; j++) {
+                for (int i = 0; i < recon_buffer->width / 2; i++) {
+                    recon_8bit[i + j * recon_stride_8bit] =
+                        (uint8_t)recon_16bit[i + j * recon_stride_16bit];
+                }
+            }
+            // Cr
+            recon_16bit = (uint16_t*)(recon_buffer->buffer_cr)
+                        + recon_buffer->origin_x / 2
+                        + recon_buffer->origin_y / 2 * recon_buffer->stride_cr;
+            recon_stride_16bit = recon_buffer->stride_cr;
+            recon_8bit  = recon_buffer_8bit->buffer_cr
+                        + recon_buffer_8bit->origin_x / 2
+                        + recon_buffer_8bit->origin_y / 2 * recon_buffer_8bit->stride_cr;
+            recon_stride_8bit = recon_buffer_8bit->stride_cr;
+            for (int j = 0; j < recon_buffer->height / 2; j++) {
+                for (int i = 0; i < recon_buffer->width / 2; i++) {
+                    recon_8bit[i + j * recon_stride_8bit] =
+                        (uint8_t)recon_16bit[i + j * recon_stride_16bit];
+                }
+            }
+        }
+
         //pre-cdef prep
         {
             Av1Common *          cm = pcs_ptr->parent_pcs_ptr->av1_cm;
@@ -190,13 +379,21 @@ void *dlf_kernel(void *input_ptr) {
                 else
                     recon_picture_ptr = pcs_ptr->recon_picture_ptr;
             }
-
+            if (scs_ptr->static_config.encoder_16bit_pipeline) {
+                if (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE) {
+                    recon_picture_ptr = ((EbReferenceObject *)
+                        pcs_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)
+                        ->reference_picture16bit;
+                } else {
+                    recon_picture_ptr = pcs_ptr->recon_picture16bit_ptr;
+                }
+                cm->use_highbitdepth = 1;
+            }
             link_eb_to_aom_buffer_desc(recon_picture_ptr, cm->frame_to_show);
-
             if (scs_ptr->seq_header.enable_restoration)
                 eb_av1_loop_restoration_save_boundary_lines(cm->frame_to_show, cm, 0);
             if (scs_ptr->seq_header.enable_cdef && pcs_ptr->parent_pcs_ptr->cdef_filter_mode) {
-                if (is_16bit) {
+                if (scs_ptr->static_config.encoder_16bit_pipeline || is_16bit) {
                     pcs_ptr->src[0] = (uint16_t *)recon_picture_ptr->buffer_y +
                                       (recon_picture_ptr->origin_x +
                                        recon_picture_ptr->origin_y * recon_picture_ptr->stride_y);

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.c
@@ -455,6 +455,9 @@ EbErrorType picture_control_set_ctor(PictureControlSet *object_ptr, EbPtr object
                eb_recon_picture_buffer_desc_ctor,
                (EbPtr)&input_pic_buf_desc_init_data);
     }
+    EB_NEW(object_ptr->recon_picture16bit_ptr,
+           eb_recon_picture_buffer_desc_ctor,
+           (EbPtr)&coeff_buffer_desc_init_data);
     // Film Grain Picture Buffer
     if (init_data_ptr->film_grain_noise_level) {
         if (is_16bit) {
@@ -468,7 +471,7 @@ EbErrorType picture_control_set_ctor(PictureControlSet *object_ptr, EbPtr object
         }
     }
 
-    if (is_16bit) {
+    {
         EB_NEW(object_ptr->input_frame16bit,
                eb_picture_buffer_desc_ctor,
                (EbPtr)&coeff_buffer_desc_init_data);

--- a/Source/Lib/Encoder/Codec/EbReferenceObject.c
+++ b/Source/Lib/Encoder/Codec/EbReferenceObject.c
@@ -174,6 +174,12 @@ EbErrorType eb_reference_object_ctor(EbReferenceObject *reference_object,
             picture_buffer_desc_init_data_ptr,
             picture_buffer_desc_init_data_16bit_ptr.bit_depth);
     }
+    picture_buffer_desc_init_data_16bit_ptr.split_mode = EB_FALSE;
+    picture_buffer_desc_init_data_16bit_ptr.bit_depth  = EB_10BIT;
+    EB_NEW(reference_object->reference_picture16bit,
+           eb_picture_buffer_desc_ctor,
+           (EbPtr)&picture_buffer_desc_init_data_16bit_ptr);
+    picture_buffer_desc_init_data_16bit_ptr.bit_depth = EB_8BIT;
     if (picture_buffer_desc_init_data_ptr->mfmv) {
         //MFMV map is 8x8 based.
         uint32_t  mi_rows  = reference_object->reference_picture->height >> MI_SIZE_LOG2;


### PR DESCRIPTION
This PR introduces the changes for 16bit pipeline, which controls whether to use 16bit pipeline for filter (dlf, cdef, rest) according to a new cfg parameter `-16bit-pipeline`.

Currently, recon is copied to recon16 before filter, while recon16 is copied back to recon after filter. The code for copy can be removed once the 16bit pipeline is ready the entire encoding process.