### PR TITLE
packetization_kernel: pack entire temproal unit for a output buffer

### DIFF
--- a/Source/Lib/Encoder/Codec/EbEncodeContext.h
+++ b/Source/Lib/Encoder/Codec/EbEncodeContext.h
@@ -79,6 +79,9 @@ typedef struct EncodeContext {
     // Picture Decision Reorder Queue
     PictureDecisionReorderEntry **picture_decision_reorder_queue;
     uint32_t                      picture_decision_reorder_queue_head_index;
+    //hold undisplayed frame for show existing frame. It's ordered with pts Descend.
+    EbObjectWrapper              *picture_decision_undisplayed_queue[REF_FRAMES];
+    uint32_t                      picture_decision_undisplayed_queue_count;
 
     // Picture Manager Reorder Queue
     PictureManagerReorderEntry **picture_manager_reorder_queue;

--- a/Source/Lib/Encoder/Codec/EbPacketizationReorderQueue.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationReorderQueue.c
@@ -6,9 +6,16 @@
 #include <stdlib.h>
 #include "EbPacketizationReorderQueue.h"
 
+static void packetization_reorder_entry_dctor(EbPtr p) {
+    PacketizationReorderEntry* obj = (PacketizationReorderEntry*)p;
+    EB_DELETE(obj->bitstream_ptr);
+}
+
 EbErrorType packetization_reorder_entry_ctor(PacketizationReorderEntry *entry_ptr,
                                              uint32_t                   picture_number) {
+    entry_ptr->dctor = packetization_reorder_entry_dctor;
     entry_ptr->picture_number = picture_number;
-
+    //16 should enough for show existing frame
+    EB_NEW(entry_ptr->bitstream_ptr, bitstream_ctor, 16);
     return EB_ErrorNone;
 }

--- a/Source/Lib/Encoder/Codec/EbPacketizationReorderQueue.h
+++ b/Source/Lib/Encoder/Codec/EbPacketizationReorderQueue.h
@@ -10,6 +10,7 @@
 #include "EbSystemResourceManager.h"
 #include "EbPredictionStructure.h"
 #include "EbObject.h"
+#include "EbEntropyCodingObject.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -37,6 +38,10 @@ typedef struct PacketizationReorderEntry {
     EbBool     show_frame;
     EbBool     has_show_existing;
     uint8_t    show_existing_frame;
+    //small size bitstream for show existing frame
+    Bitstream *bitstream_ptr;
+    //valid when has_show_existing is true
+    int64_t    next_pts;
     uint8_t    is_alt_ref;
 } PacketizationReorderEntry;
 


### PR DESCRIPTION
Currently, we output one frame per get ouptut, and the "show existing frame" shares the same pts with the previous frame.
This will introduce jitter to "show existing frame" and the previous frame.
We should output a temporal unit a time.
A temporal unit includes one TD + zero or more undisplay frame + one display frame.
And we need to stamp a different pts for show existing frame since it is a displayable frame.

after apply this patch, ffmpeg will not report error for following test command:
ffmpeg -i 320x240.y4m -c:v libsvt_av1 -vframes 100 test.mkv  -y &&  ffmpeg -c:v libdav1d -i test.mkv -f null /dev/null

and ffmpeg will not insert td for every frame if we use following command:
ffmpeg -i 320x240.y4m -c:v libsvt_av1 -vframes 100 test.ivf  -y

fixes https://github.com/OpenVisualCloud/SVT-AV1/issues/129, fixes https://github.com/OpenVisualCloud/SVT-AV1/issues/33