### PR TITLE
Updated Multi-Pass-PD and MD-Staging Settings

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -63,6 +63,9 @@ extern "C" {
 #define ENHANCED_SQ_WEIGHT 1 // tune sq_weight threshold based on block properties
 
 #define HIGH_PRECISION_MV_QTHRESH 150
+
+#define ENHANCED_MULTI_PASS_PD_MD_STAGING_SETTINGS 1 // Updated Multi-Pass-PD and MD-Staging Settings
+
 // Actions in the second pass: Frame and SB QP assignment and temporal filtering strenght change
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC \

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -4919,8 +4919,11 @@ void md_stage_1(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *blk_p
     context_ptr->md_staging_tx_search        = 0;
     context_ptr->md_staging_skip_full_chroma = EB_TRUE;
     context_ptr->md_staging_skip_rdoq        = EB_TRUE;
+#if ENHANCED_MULTI_PASS_PD_MD_STAGING_SETTINGS
+    context_ptr->md_staging_spatial_sse_full_loop = EB_FALSE;
+#else
     context_ptr->md_staging_spatial_sse_full_loop = context_ptr->spatial_sse_full_loop;
-
+#endif
     for (full_loop_candidate_index = 0;
          full_loop_candidate_index < context_ptr->md_stage_1_count[context_ptr->target_class];
          ++full_loop_candidate_index) {
@@ -4984,9 +4987,11 @@ void md_stage_2(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *blk_p
         context_ptr->md_staging_skip_full_pred            = EB_TRUE;
         context_ptr->md_staging_skip_interpolation_search = EB_TRUE;
         context_ptr->md_staging_skip_inter_chroma_pred    = EB_TRUE;
-
+#if ENHANCED_MULTI_PASS_PD_MD_STAGING_SETTINGS
+        context_ptr->md_staging_spatial_sse_full_loop = EB_FALSE;
+#else
         context_ptr->md_staging_spatial_sse_full_loop = context_ptr->spatial_sse_full_loop;
-
+#endif
         full_loop_core(pcs_ptr,
                        sb_ptr,
                        blk_ptr,


### PR DESCRIPTION
## Description

- Used Spatial Domain Distortion @ only the last stage (PD2/MD_STAGE_3).
- Removed layer check(s) from PD1 settings derivation.

## Author(s)

@hguermaz 

## Type of change

Tuning/Clean-up.

## Tests and performance
Data generated on the full objective-1-fast data set in context in enc-mode 0. 

| Speed Deviation| BD-Rate Deviation|
| -- | --
| 3.67% | -0.023%|