### PR TITLE
Prune Compound/Inter From Similar Blocks

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -36,7 +36,7 @@ extern "C" {
 
 
 #define COMP_SIMILAR        1 //use previously coded similar blocks to prune compound modes
-
+#define INTRA_SIMILAR       1 //If previous similar block is intra, do not inject any inter
 #define OIS_MEM              1 //reduce memory consumption due to ois struct
 
 

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -34,6 +34,9 @@
 extern "C" {
 #endif
 
+
+#define COMP_SIMILAR        1 //use previously coded similar blocks to prune compound modes
+
 #define OIS_MEM              1 //reduce memory consumption due to ois struct
 
 

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -1926,7 +1926,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
     //0: OFF
     //1: If previous similar block is not compound, do not inject compound
     //2: If previous similar block is not compound, do not inject compound
-    //   else consider the compound modes up the similar’s one
+    //   else consider the compound modes up the mode for the similar block
     if (pcs_ptr->enc_mode <= ENC_M3)
         context_ptr->comp_similar_mode = 1;
     else

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -1921,6 +1921,17 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
                 ? FULL_PEL_REF_WINDOW_HEIGHT_EXTENDED
                 : FULL_PEL_REF_WINDOW_HEIGHT;
     }
+#if COMP_SIMILAR
+    //comp_similar_mode
+    //0: OFF
+    //1: If previous similar block is not compound, do not inject compound
+    //2: If previous similar block is not compound, do not inject compound
+    //   else consider the compound modes up the similar’s one
+    if (pcs_ptr->enc_mode <= ENC_M3)
+        context_ptr->comp_similar_mode = 1;
+    else
+        context_ptr->comp_similar_mode = 2;
+#else
 
     // set compound_types_to_try
     if (context_ptr->pd_pass == PD_PASS_0)
@@ -1934,6 +1945,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
         else
             context_ptr->compound_types_to_try = MD_COMP_AVG;
     }
+#endif
     // Set coeff_based_nsq_cand_reduction
     if (context_ptr->pd_pass == PD_PASS_0)
         context_ptr->coeff_based_nsq_cand_reduction = EB_FALSE;

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -1946,6 +1946,14 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
             context_ptr->compound_types_to_try = MD_COMP_AVG;
     }
 #endif
+
+#if  INTRA_SIMILAR
+    //intra_similar_mode
+    //0: OFF
+    //1: If previous similar block is intra, do not inject any inter
+    context_ptr->intra_similar_mode = 1;
+#endif
+
     // Set coeff_based_nsq_cand_reduction
     if (context_ptr->pd_pass == PD_PASS_0)
         context_ptr->coeff_based_nsq_cand_reduction = EB_FALSE;

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -5749,8 +5749,11 @@ EbErrorType generate_md_stage_0_cand(
         assert(context_ptr->fast_candidate_array[i].palette_info.pmi.palette_size[1] == 0);
     }
 
-
+#if INTRA_SIMILAR
+    if (slice_type != I_SLICE && context_ptr->inject_inter_candidates) {
+#else
     if (slice_type != I_SLICE) {
+#endif
             inject_inter_candidates(
                 pcs_ptr,
                 context_ptr,

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
@@ -262,6 +262,11 @@ typedef struct ModeDecisionContext {
     uint8_t              predictive_me_level;
     uint8_t              interpolation_filter_search_blk_size;
     uint8_t              redundant_blk;
+#if COMP_SIMILAR
+    uint8_t              similar_blk_avail;
+    uint16_t             similar_blk_mds;
+    uint8_t              comp_similar_mode;
+#endif
     uint8_t *            cfl_temp_luma_recon;
     uint16_t *           cfl_temp_luma_recon16bit;
     EbBool               spatial_sse_full_loop;

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
@@ -267,6 +267,10 @@ typedef struct ModeDecisionContext {
     uint16_t             similar_blk_mds;
     uint8_t              comp_similar_mode;
 #endif
+#if INTRA_SIMILAR
+    uint8_t              inject_inter_candidates;
+    uint8_t              intra_similar_mode;
+#endif
     uint8_t *            cfl_temp_luma_recon;
     uint16_t *           cfl_temp_luma_recon16bit;
     EbBool               spatial_sse_full_loop;

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -1131,6 +1131,9 @@ EbErrorType signal_derivation_multi_processes_oq(
         else
             pcs_ptr->compound_mode = scs_ptr->static_config.compound_level;
 
+        if (pcs_ptr->wedge_mode > 0 && pcs_ptr->compound_mode != 2)
+            SVT_LOG("wedge_mode set but will not be active\n");
+
         // Set frame end cdf update mode      Settings
         // 0                                     OFF
         // 1                                     ON

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -5277,8 +5277,8 @@ void check_redundant_block(const BlockGeom *blk_geom, ModeDecisionContext *conte
 #if COMP_SIMILAR
 /*
    search for a valid previously encoded similar
-   block (block having the same location and shape , but different neighbours
-   as the current block).
+   block (block having the same location and shape as the current block,
+   but where neighboring blocks are different from those for the current block)
 */
 void check_similar_block(const BlockGeom * blk_geom,
     ModeDecisionContext *context_ptr,
@@ -5297,7 +5297,8 @@ void check_similar_block(const BlockGeom * blk_geom,
     }
 }
 /******************************************************
-* Derive md  Settings  at he block level
+* Derive md Settings(feature signals) that could be
+  changed  at the block level
 ******************************************************/
 EbErrorType signal_derivation_block(
     PictureControlSet     *pcs,

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -5274,6 +5274,63 @@ void check_redundant_block(const BlockGeom *blk_geom, ModeDecisionContext *conte
     }
 }
 
+#if COMP_SIMILAR
+/*
+   search for a valid previously encoded similar
+   block (block having the same location and shape , but different neighbours
+   as the current block).
+*/
+void check_similar_block(const BlockGeom * blk_geom,
+    ModeDecisionContext *context_ptr,
+    uint8_t * similar_blk_avail,
+    uint16_t *similar_blk_mds)
+{
+    if (blk_geom->similar) {
+        for (int it = 0; it < blk_geom->similar_list.list_size; it++) {
+            if (context_ptr->md_local_blk_unit[blk_geom->similar_list.blk_mds_table[it]].avail_blk_flag)
+            {
+                *similar_blk_mds = blk_geom->similar_list.blk_mds_table[it];
+                *similar_blk_avail = 1;
+                break;
+            }
+        }
+    }
+}
+/******************************************************
+* Derive md  Settings  at he block level
+******************************************************/
+EbErrorType signal_derivation_block(
+    PictureControlSet     *pcs,
+    ModeDecisionContext   *context_ptr) {
+
+    EbErrorType return_error = EB_ErrorNone;
+
+    // set compound_types_to_try
+    if (context_ptr->pd_pass == PD_PASS_0)
+        context_ptr->compound_types_to_try = MD_COMP_AVG;
+    else if (context_ptr->pd_pass == PD_PASS_1)
+        context_ptr->compound_types_to_try = MD_COMP_AVG;
+    else {
+        if (pcs->parent_pcs_ptr->compound_mode)
+            context_ptr->compound_types_to_try = pcs->parent_pcs_ptr->compound_mode == 1 ? MD_COMP_DIFF0 : MD_COMP_WEDGE;
+        else
+            context_ptr->compound_types_to_try = MD_COMP_AVG;
+    }
+
+    BlkStruct *similar_cu = &context_ptr->md_blk_arr_nsq[context_ptr->similar_blk_mds];
+    if (context_ptr->compound_types_to_try > MD_COMP_AVG && context_ptr->similar_blk_avail) {
+        int32_t is_src_compound = similar_cu->pred_mode >= NEAREST_NEARESTMV;
+        if (context_ptr->comp_similar_mode == 1) {
+            context_ptr->compound_types_to_try = !is_src_compound ? MD_COMP_AVG : context_ptr->compound_types_to_try;
+        }
+        else if (context_ptr->comp_similar_mode == 2) {
+            context_ptr->compound_types_to_try = !is_src_compound ? MD_COMP_AVG : similar_cu->interinter_comp.type;
+        }
+    }
+
+    return return_error;
+}
+#endif
 /*******************************************
 * ModeDecision SB
 *   performs CL (SB)
@@ -6008,6 +6065,13 @@ void md_encode_block(SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
         ROUND_UV(blk_geom->origin_x) / 2 + ROUND_UV(blk_geom->origin_y) / 2 * SB_STRIDE_UV;
     BlkStruct *blk_ptr        = context_ptr->blk_ptr;
     candidate_buffer_ptr_array = &(candidate_buffer_ptr_array_base[0]);
+
+#if COMP_SIMILAR
+    signal_derivation_block(
+        pcs_ptr,
+        context_ptr);
+#endif
+
     for (uint8_t ref_idx = 0; ref_idx < MAX_REF_TYPE_CAND; ref_idx++)
         context_ptr->ref_best_cost_sq_table[ref_idx] = MAX_CU_COST;
     EbBool is_nsq_table_used = (pcs_ptr->slice_type == !I_SLICE &&
@@ -6971,6 +7035,11 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
         if (all_blk_init)
             check_redundant_block(blk_geom, context_ptr, &redundant_blk_avail, &redundant_blk_mds);
 
+#if COMP_SIMILAR
+        context_ptr->similar_blk_avail = 0;
+        if (all_blk_init)
+            check_similar_block(blk_geom, context_ptr, &context_ptr->similar_blk_avail, &context_ptr->similar_blk_mds);
+#endif
         if (redundant_blk_avail && context_ptr->redundant_blk) {
             // Copy results
             BlkStruct *src_cu = &context_ptr->md_blk_arr_nsq[redundant_blk_mds];

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -5328,6 +5328,15 @@ EbErrorType signal_derivation_block(
         }
     }
 
+#if INTRA_SIMILAR
+    context_ptr->inject_inter_candidates = 1;
+    if (context_ptr->pd_pass > PD_PASS_1 && context_ptr->similar_blk_avail) {
+        int32_t is_src_intra = similar_cu->pred_mode <= PAETH_PRED;
+        if (context_ptr->intra_similar_mode)
+            context_ptr->inject_inter_candidates = is_src_intra ? 0 : context_ptr->inject_inter_candidates;
+    }
+#endif
+
     return return_error;
 }
 #endif


### PR DESCRIPTION
## Description

 Use  valid previously encoded similar  blocks (block having the same location and shape , but different neighbours  as the current block). to prune the compounds/inter modes to search at MD

## Algorithm Details

1- If previous similar block is not compound, do not inject compound for current block
2- If previous similar block is not compound, do not inject compound for current block
else consider the compound modes up the similar’s one
3- If previous similar block is intra, do not inject inter current block

## Tests and performance
in context of enc-mode 0 using mixed mpeg/aom set (T00)

| Speed Deviation| BD-Rate Deviation|
| -- | --
| 2.52% | 0.00%|