### PR TITLE
Fix compilation error for old gcc

### DIFF
--- a/Source/Lib/Common/ASM_AVX512/CMakeLists.txt
+++ b/Source/Lib/Common/ASM_AVX512/CMakeLists.txt
@@ -17,6 +17,7 @@ include_directories(${PROJECT_SOURCE_DIR}/Source/API/
 link_directories(${PROJECT_SOURCE_DIR}/Source/Lib/Common/ASM_SSSE3/)
 
 set(flags_to_test
+    -mavx2
     -mavx512f
     -mavx512bw
     -mavx512dq

--- a/Source/Lib/Common/ASM_AVX512/convolve_avx512.h
+++ b/Source/Lib/Common/ASM_AVX512/convolve_avx512.h
@@ -15,6 +15,8 @@
 #include "synonyms_avx2.h"
 #include "synonyms_avx512.h"
 
+#ifndef NON_AVX512_SUPPORT
+
 static INLINE __m512i eb_mm512_broadcast_i64x2(const __m128i v) {
 #ifdef _WIN32
     // Work around of Visual Studio warning C4305: 'function': truncation from
@@ -1094,5 +1096,7 @@ static INLINE void jnt_no_avg_round_store_64_avx512(const __m512i res[2], const 
     d[1] = jnt_no_avg_round_avx512(res[1], offset);
     jnt_no_avg_store_64_avx512(d[0], d[1], dst);
 }
+
+#endif  // !NON_AVX512_SUPPORT
 
 #endif // AOM_DSP_X86_CONVOLVE_AVX512_H_

--- a/Source/Lib/Common/ASM_AVX512/synonyms_avx512.h
+++ b/Source/Lib/Common/ASM_AVX512/synonyms_avx512.h
@@ -15,6 +15,8 @@
 #include <immintrin.h>
 #include "synonyms.h"
 
+#ifndef NON_AVX512_SUPPORT
+
 /**
   * Various reusable shorthands for x86 SIMD intrinsics.
   *
@@ -44,5 +46,7 @@ static INLINE void zz_store_512(void *const a, const __m512i v) {
 static INLINE void zz_storeu_512(void *const a, const __m512i v) {
     _mm512_storeu_si512((__m512i *)a, v);
 }
+
+#endif  // !NON_AVX512_SUPPORT
 
 #endif // AOM_DSP_X86_SYNONYMS_AVX512_H_

--- a/Source/Lib/Common/Codec/EbBlend_a64_mask.c
+++ b/Source/Lib/Common/Codec/EbBlend_a64_mask.c
@@ -15,7 +15,6 @@
  */
 
 #include <assert.h>
-#include "smmintrin.h"
 
 #include "EbDefinitions.h"
 

--- a/Source/Lib/Encoder/ASM_AVX2/EbNoiseExtractAVX2.h
+++ b/Source/Lib/Encoder/ASM_AVX2/EbNoiseExtractAVX2.h
@@ -39,32 +39,6 @@ void noise_extract_luma_strong_avx2_intrin(EbPictureBufferDesc *input_picture_pt
                                            EbPictureBufferDesc *denoised_picture_ptr,
                                            uint32_t sb_origin_y, uint32_t sb_origin_x);
 
-void chroma_strong_avx2_intrin(__m256i top, __m256i curr, __m256i bottom, __m256i curr_prev,
-                               __m256i curr_next, __m256i top_prev, __m256i top_next,
-                               __m256i bottom_prev, __m256i bottom_next, uint8_t *ptr_denoised);
-
-void luma_weak_filter_avx2_intrin(__m256i top, __m256i curr, __m256i bottom, __m256i curr_prev,
-                                  __m256i curr_next, uint8_t *ptr_denoised, uint8_t *ptr_noise);
-
-void chroma_weak_luma_strong_filter_avx2_intrin(__m256i top, __m256i curr, __m256i bottom,
-                                                __m256i curr_prev, __m256i curr_next,
-                                                __m256i top_prev, __m256i top_next,
-                                                __m256i bottom_prev, __m256i bottom_next,
-                                                uint8_t *ptr_denoised);
-
-void luma_weak_filter_128_avx2_intrin(__m128i top, __m128i curr, __m128i bottom, __m128i curr_prev,
-                                      __m128i curr_next, uint8_t *ptr_denoised, uint8_t *ptr_noise);
-
-void chroma_strong_128_avx2_intrin(__m128i top, __m128i curr, __m128i bottom, __m128i curr_prev,
-                                   __m128i curr_next, __m128i top_prev, __m128i top_next,
-                                   __m128i bottom_prev, __m128i bottom_next, uint8_t *ptr_denoised);
-
-void chroma_weak_luma_strong_filter_128_avx2_intrin(__m128i top, __m128i curr, __m128i bottom,
-                                                    __m128i curr_prev, __m128i curr_next,
-                                                    __m128i top_prev, __m128i top_next,
-                                                    __m128i bottom_prev, __m128i bottom_next,
-                                                    uint8_t *ptr_denoised);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR fixes the compilation issue when using old version of gcc, e.g. 4.8.5.
Unnecessary intrinsic data type usage in header files are removed.