### PR TITLE
Enhanced Nx4 & 4xN INTER candidates and 1/8 Pel ME MVs  refinement

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -62,6 +62,7 @@ extern "C" {
 #define FP_QUANT_BOTH_INTRA_INTER 1 // Add quantize_fp for INTER blocks
 #define ENHANCED_SQ_WEIGHT 1 // tune sq_weight threshold based on block properties
 
+#define ENHANCED_ME_MV 1 // (1) Improved Nx4 and 4xN INTER candidates for all categories: used the parent ME_MV instead of using of the 64x64 ME_MV, (2) Added ME_MV 1 / 8 Pel refinement.
 #define HIGH_PRECISION_MV_QTHRESH 150
 // Actions in the second pass: Frame and SB QP assignment and temporal filtering strenght change
 //FOR DEBUGGING - Do not remove

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -1489,7 +1489,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
     else
         context_ptr->new_nearest_near_comb_injection =
             scs_ptr->static_config.new_nearest_comb_inject;
-
+#if !ENHANCED_ME_MV
     if (context_ptr->pd_pass == PD_PASS_0)
         context_ptr->nx4_4xn_parent_mv_injection = 0;
     else if (context_ptr->pd_pass == PD_PASS_1)
@@ -1507,7 +1507,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
 
     else
         context_ptr->nx4_4xn_parent_mv_injection = scs_ptr->static_config.nx4_4xn_parent_mv_inject;
-
+#endif
     // Set warped motion injection
     // Level                Settings
     // 0                    OFF
@@ -2029,6 +2029,16 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
         context_ptr->best_me_cand_only_flag = EB_FALSE;
     else
         context_ptr->best_me_cand_only_flag = EB_FALSE;
+
+#if ENHANCED_ME_MV
+    // Set perform_me_mv_1_8_pel_ref
+    if (context_ptr->pd_pass == PD_PASS_0)
+        context_ptr->perform_me_mv_1_8_pel_ref = EB_FALSE;
+    else if (context_ptr->pd_pass == PD_PASS_1)
+        context_ptr->perform_me_mv_1_8_pel_ref = EB_FALSE;
+    else
+        context_ptr->perform_me_mv_1_8_pel_ref = (pcs_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv);
+#endif
 
     return return_error;
 }

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -851,6 +851,25 @@ void unipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, Picture
                 if (context_ptr->unipred3x3_injection >= 2) {
                     if (allow_refinement_flag[bipred_index] == 0) continue;
                 }
+#if ENHANCED_ME_MV
+                int16_t to_inject_mv_x;
+                int16_t to_inject_mv_y;
+                if (pcs_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv) {
+                    to_inject_mv_x = context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                                          [REF_LIST_0][list0_ref_index][0] +
+                                     bipred_3x3_x_pos[bipred_index];
+                    to_inject_mv_y = context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                                          [REF_LIST_0][list0_ref_index][1] +
+                                     bipred_3x3_y_pos[bipred_index];
+                } else {
+                    to_inject_mv_x = context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                                          [REF_LIST_0][list0_ref_index][0] +
+                                     (bipred_3x3_x_pos[bipred_index] << 1);
+                    to_inject_mv_y = context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                                          [REF_LIST_0][list0_ref_index][1] +
+                                     (bipred_3x3_y_pos[bipred_index] << 1);
+                }
+#else
                 int16_t to_inject_mv_x;
                 int16_t to_inject_mv_y;
                 if (pcs_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv) {
@@ -874,6 +893,7 @@ void unipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, Picture
                          bipred_3x3_y_pos[bipred_index])
                         << 1;
                 }
+#endif
                 uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_0, list0_ref_index);
                 uint8_t skip_cand          = check_ref_beackout(
                     context_ptr, to_inject_ref_type, context_ptr->blk_geom->shape);
@@ -1001,6 +1021,25 @@ void unipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, Picture
                     if (context_ptr->unipred3x3_injection >= 2) {
                         if (allow_refinement_flag[bipred_index] == 0) continue;
                     }
+#if ENHANCED_ME_MV
+                    int16_t to_inject_mv_x;
+                    int16_t to_inject_mv_y;
+                    if (pcs_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv) {
+                        to_inject_mv_x = context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                                              [REF_LIST_1][list1_ref_index][0] +
+                                         bipred_3x3_x_pos[bipred_index];
+                        to_inject_mv_y = context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                                              [REF_LIST_1][list1_ref_index][1] +
+                                         bipred_3x3_y_pos[bipred_index];
+                    } else {
+                        to_inject_mv_x = context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                                              [REF_LIST_1][list1_ref_index][0] +
+                                         (bipred_3x3_x_pos[bipred_index] << 1);
+                        to_inject_mv_y = context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                                              [REF_LIST_1][list1_ref_index][1] +
+                                         (bipred_3x3_y_pos[bipred_index] << 1);
+                    }
+#else
                     int16_t to_inject_mv_x;
                     int16_t to_inject_mv_y;
                     if (pcs_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv) {
@@ -1034,6 +1073,7 @@ void unipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, Picture
                              bipred_3x3_y_pos[bipred_index])
                             << 1;
                     }
+#endif
                     uint8_t to_inject_ref_type =
                         svt_get_ref_frame_type(REF_LIST_1, list1_ref_index);
                     uint8_t skip_cand = check_ref_beackout(
@@ -1200,6 +1240,40 @@ void bipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, PictureC
                     if (context_ptr->bipred3x3_injection >= 2) {
                         if (allow_refinement_flag[bipred_index] == 0) continue;
                     }
+#if ENHANCED_ME_MV
+                    int16_t to_inject_mv_x_l0 =
+                        context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                             [me_block_results_ptr->ref0_list][list0_ref_index][0];
+                    int16_t to_inject_mv_y_l0 =
+                        context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                             [me_block_results_ptr->ref0_list][list0_ref_index][1];
+
+                    int16_t to_inject_mv_x_l1;
+                    int16_t to_inject_mv_y_l1;
+                    if (pcs_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv) {
+                        to_inject_mv_x_l1 =
+                            context_ptr
+                                ->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                          [me_block_results_ptr->ref1_list][list1_ref_index][0] +
+                            bipred_3x3_x_pos[bipred_index];
+                        to_inject_mv_y_l1 =
+                            context_ptr
+                                ->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                          [me_block_results_ptr->ref1_list][list1_ref_index][1] +
+                            bipred_3x3_y_pos[bipred_index];
+                    } else {
+                        to_inject_mv_x_l1 =
+                            context_ptr
+                                ->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                          [me_block_results_ptr->ref1_list][list1_ref_index][0] +
+                            (bipred_3x3_x_pos[bipred_index] << 1);
+                        to_inject_mv_y_l1 =
+                            context_ptr
+                                ->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                          [me_block_results_ptr->ref1_list][list1_ref_index][1] +
+                            (bipred_3x3_y_pos[bipred_index] << 1);
+                    }
+#else
                     int16_t to_inject_mv_x_l0 =
                         me_results->me_mv_array[context_ptr->me_block_offset][list0_ref_index].x_mv
                         << 1;
@@ -1251,6 +1325,7 @@ void bipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, PictureC
                              bipred_3x3_y_pos[bipred_index])
                             << 1;
                     }
+#endif
                     MvReferenceFrame rf[2];
                     rf[0] =
                         svt_get_ref_frame_type(me_block_results_ptr->ref0_list, list0_ref_index);
@@ -1376,6 +1451,40 @@ void bipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, PictureC
                     if (context_ptr->bipred3x3_injection >= 2) {
                         if (allow_refinement_flag[bipred_index] == 0) continue;
                     }
+
+#if ENHANCED_ME_MV
+                    int16_t to_inject_mv_x_l0;
+                    int16_t to_inject_mv_y_l0;
+                    if (pcs_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv) {
+                        to_inject_mv_x_l0 =
+                            context_ptr
+                                ->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                          [me_block_results_ptr->ref0_list][list0_ref_index][0] +
+                            bipred_3x3_x_pos[bipred_index];
+                        to_inject_mv_y_l0 =
+                            context_ptr
+                                ->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                          [me_block_results_ptr->ref0_list][list0_ref_index][1] +
+                            bipred_3x3_y_pos[bipred_index];
+                    } else {
+                        to_inject_mv_x_l0 =
+                            context_ptr
+                                ->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                          [me_block_results_ptr->ref0_list][list0_ref_index][0] +
+                            (bipred_3x3_x_pos[bipred_index] << 1);
+                        to_inject_mv_y_l0 =
+                            context_ptr
+                                ->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                          [me_block_results_ptr->ref0_list][list0_ref_index][1] +
+                            (bipred_3x3_y_pos[bipred_index] << 1);
+                    }
+                    int16_t to_inject_mv_x_l1 =
+                        context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                             [me_block_results_ptr->ref1_list][list1_ref_index][0];
+                    int16_t to_inject_mv_y_l1 =
+                        context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                             [me_block_results_ptr->ref1_list][list1_ref_index][1];
+#else
                     int16_t to_inject_mv_x_l0;
                     int16_t to_inject_mv_y_l0;
                     if (pcs_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv) {
@@ -1419,7 +1528,7 @@ void bipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, PictureC
                                           list1_ref_index]
                             .y_mv
                         << 1;
-
+#endif
                     MvReferenceFrame rf[2];
                     rf[0] =
                         svt_get_ref_frame_type(me_block_results_ptr->ref0_list, list0_ref_index);
@@ -2087,9 +2196,10 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
         if (rf[1] != NONE_FRAME) {
             {
                 //NEAREST_NEWMV
+#if !ENHANCED_ME_MV
                 const MeSbResults *me_results =
                     pcs_ptr->parent_pcs_ptr->me_results[context_ptr->me_sb_addr];
-
+#endif
                 int16_t to_inject_mv_x_l0 =
                     context_ptr->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds]
                         .ed_ref_mv_stack[ref_pair][0]
@@ -2098,6 +2208,14 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
                     context_ptr->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds]
                         .ed_ref_mv_stack[ref_pair][0]
                         .this_mv.as_mv.row;
+#if ENHANCED_ME_MV
+                int16_t to_inject_mv_x_l1 =
+                    context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds][get_list_idx(rf[1])]
+                                         [ref_idx_1][0];
+                int16_t to_inject_mv_y_l1 =
+                    context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds][get_list_idx(rf[1])]
+                                         [ref_idx_1][1];
+#else
                 int16_t to_inject_mv_x_l1 =
                     me_results
                         ->me_mv_array[context_ptr->me_block_offset]
@@ -2114,7 +2232,7 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
                                       ref_idx_1]
                         .y_mv
                     << 1;
-
+#endif
                 inj_mv = context_ptr->injected_mv_count_bipred == 0 ||
                          mrp_is_already_injected_mv_bipred(context_ptr,
                                                            to_inject_mv_x_l0,
@@ -2212,13 +2330,23 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
 
             {
                 //NEW_NEARESTMV
+#if !ENHANCED_ME_MV
                 const MeSbResults *me_results =
                     pcs_ptr->parent_pcs_ptr->me_results[context_ptr->me_sb_addr];
-
+#endif
+#if ENHANCED_ME_MV
+                int16_t to_inject_mv_x_l0 =
+                    context_ptr
+                        ->sb_me_mv[context_ptr->blk_geom->blkidx_mds][REF_LIST_0][ref_idx_0][0];
+                int16_t to_inject_mv_y_l0 =
+                    context_ptr
+                        ->sb_me_mv[context_ptr->blk_geom->blkidx_mds][REF_LIST_0][ref_idx_0][1];
+#else
                 int16_t to_inject_mv_x_l0 =
                     me_results->me_mv_array[context_ptr->me_block_offset][ref_idx_0].x_mv << 1;
                 int16_t to_inject_mv_y_l0 =
                     me_results->me_mv_array[context_ptr->me_block_offset][ref_idx_0].y_mv << 1;
+#endif
                 int16_t to_inject_mv_x_l1 =
                     context_ptr->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds]
                         .ed_ref_mv_stack[ref_pair][0]
@@ -2336,13 +2464,23 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
                                         ref_mv);
 
                     //NEW_NEARMV
+#if !ENHANCED_ME_MV
                     const MeSbResults *me_results =
                         pcs_ptr->parent_pcs_ptr->me_results[context_ptr->me_sb_addr];
-
+#endif
+#if ENHANCED_ME_MV
+                    int16_t to_inject_mv_x_l0 =
+                        context_ptr
+                            ->sb_me_mv[context_ptr->blk_geom->blkidx_mds][REF_LIST_0][ref_idx_0][0];
+                    int16_t to_inject_mv_y_l0 =
+                        context_ptr
+                            ->sb_me_mv[context_ptr->blk_geom->blkidx_mds][REF_LIST_0][ref_idx_0][1];
+#else
                     int16_t to_inject_mv_x_l0 =
                         me_results->me_mv_array[context_ptr->me_block_offset][ref_idx_0].x_mv << 1;
                     int16_t to_inject_mv_y_l0 =
                         me_results->me_mv_array[context_ptr->me_block_offset][ref_idx_0].y_mv << 1;
+#endif
                     int16_t to_inject_mv_x_l1 = nearmv[1].as_mv.col;
                     int16_t to_inject_mv_y_l1 = nearmv[1].as_mv.row;
 
@@ -2436,11 +2574,20 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
                                         ref_mv);
 
                     //NEAR_NEWMV
+#if !ENHANCED_ME_MV
                     const MeSbResults *me_results =
                         pcs_ptr->parent_pcs_ptr->me_results[context_ptr->me_sb_addr];
-
+#endif
                     int16_t to_inject_mv_x_l0 = nearmv[0].as_mv.col;
                     int16_t to_inject_mv_y_l0 = nearmv[0].as_mv.row;
+#if ENHANCED_ME_MV
+                    int16_t to_inject_mv_x_l1 =
+                        context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                             [get_list_idx(rf[1])][ref_idx_1][0];
+                    int16_t to_inject_mv_y_l1 =
+                        context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                             [get_list_idx(rf[1])][ref_idx_1][1];
+#else
                     int16_t to_inject_mv_x_l1 =
                         me_results
                             ->me_mv_array[context_ptr->me_block_offset]
@@ -2457,7 +2604,7 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
                                           ref_idx_1]
                             .y_mv
                         << 1; //context_ptr->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds].ed_ref_mv_stack[ref_pair][0].comp_mv.as_mv.row;
-
+#endif
                     inj_mv = context_ptr->injected_mv_count_bipred == 0 ||
                              mrp_is_already_injected_mv_bipred(context_ptr,
                                                                to_inject_mv_x_l0,
@@ -2721,8 +2868,17 @@ void inject_warped_motion_candidates(
         if (inter_direction == 0) {
             if (list0_ref_index > context_ptr->md_max_ref_count - 1)
                 continue;
+#if ENHANCED_ME_MV
+            to_inject_mv_x =
+                context_ptr
+                    ->sb_me_mv[context_ptr->blk_geom->blkidx_mds][REF_LIST_0][list0_ref_index][0];
+            to_inject_mv_y =
+                context_ptr
+                    ->sb_me_mv[context_ptr->blk_geom->blkidx_mds][REF_LIST_0][list0_ref_index][1];
+#else
             to_inject_mv_x = me_results->me_mv_array[context_ptr->me_block_offset][list0_ref_index].x_mv << 1;
             to_inject_mv_y = me_results->me_mv_array[context_ptr->me_block_offset][list0_ref_index].y_mv << 1;
+#endif
             uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_0, list0_ref_index);
             uint8_t skip_cand = check_ref_beackout(
                 context_ptr,
@@ -2809,8 +2965,17 @@ void inject_warped_motion_candidates(
         if (inter_direction == 1) {
             if (list1_ref_index > context_ptr->md_max_ref_count - 1)
                 continue;
+#if ENHANCED_ME_MV
+            to_inject_mv_x =
+                context_ptr
+                    ->sb_me_mv[context_ptr->blk_geom->blkidx_mds][REF_LIST_1][list1_ref_index][0];
+            to_inject_mv_y =
+                context_ptr
+                    ->sb_me_mv[context_ptr->blk_geom->blkidx_mds][REF_LIST_1][list1_ref_index][1];
+#else
             to_inject_mv_x = me_results->me_mv_array[context_ptr->me_block_offset][((scs_ptr->mrp_mode == 0) ? 4 : 2) + list1_ref_index].x_mv << 1;
             to_inject_mv_y = me_results->me_mv_array[context_ptr->me_block_offset][((scs_ptr->mrp_mode == 0) ? 4 : 2) + list1_ref_index].y_mv << 1;
+#endif
             uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_1, list1_ref_index);
             uint8_t skip_cand = check_ref_beackout(
                 context_ptr,
@@ -3388,10 +3553,19 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
         ************* */
         if (inter_direction == 0) {
             if (list0_ref_index > context_ptr->md_max_ref_count - 1) continue;
+#if ENHANCED_ME_MV
+            int16_t to_inject_mv_x =
+                context_ptr
+                    ->sb_me_mv[context_ptr->blk_geom->blkidx_mds][REF_LIST_0][list0_ref_index][0];
+            int16_t to_inject_mv_y =
+                context_ptr
+                    ->sb_me_mv[context_ptr->blk_geom->blkidx_mds][REF_LIST_0][list0_ref_index][1];
+#else
             int16_t to_inject_mv_x = me_results->me_mv_array[me_block_offset][list0_ref_index].x_mv
                                      << 1;
             int16_t to_inject_mv_y = me_results->me_mv_array[me_block_offset][list0_ref_index].y_mv
                                      << 1;
+#endif
             uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_0, list0_ref_index);
             uint8_t skip_cand =
                 check_ref_beackout(context_ptr, to_inject_ref_type, context_ptr->blk_geom->shape);
@@ -3519,6 +3693,12 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
            ************* */
             if (inter_direction == 1) {
                 if (list1_ref_index > context_ptr->md_max_ref_count - 1) continue;
+#if ENHANCED_ME_MV
+                int16_t to_inject_mv_x = context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                                              [REF_LIST_1][list1_ref_index][0];
+                int16_t to_inject_mv_y = context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                                              [REF_LIST_1][list1_ref_index][1];
+#else
                 int16_t to_inject_mv_x =
                     me_results
                         ->me_mv_array[me_block_offset]
@@ -3531,6 +3711,7 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
                                      [((scs_ptr->mrp_mode == 0) ? 4 : 2) + list1_ref_index]
                         .y_mv
                     << 1;
+#endif
                 uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_1, list1_ref_index);
                 uint8_t skip_cand          = check_ref_beackout(
                     context_ptr, to_inject_ref_type, context_ptr->blk_geom->shape);
@@ -3657,6 +3838,20 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
                     list1_ref_index > context_ptr->md_max_ref_count - 1)
                     continue;
                 if (inter_direction == 2) {
+#if ENHANCED_ME_MV
+                    int16_t to_inject_mv_x_l0 =
+                        context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                             [me_block_results_ptr->ref0_list][list0_ref_index][0];
+                    int16_t to_inject_mv_y_l0 =
+                        context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                             [me_block_results_ptr->ref0_list][list0_ref_index][1];
+                    int16_t to_inject_mv_x_l1 =
+                        context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                             [me_block_results_ptr->ref1_list][list1_ref_index][0];
+                    int16_t to_inject_mv_y_l1 =
+                        context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
+                                             [me_block_results_ptr->ref1_list][list1_ref_index][1];
+#else
                     int16_t to_inject_mv_x_l0 =
                         me_results->me_mv_array[me_block_offset][list0_ref_index].x_mv << 1;
                     int16_t to_inject_mv_y_l0 =
@@ -3679,6 +3874,7 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
                                           list1_ref_index]
                             .y_mv
                         << 1;
+#endif
                     MvReferenceFrame rf[2];
                     rf[0] =
                         svt_get_ref_frame_type(me_block_results_ptr->ref0_list, list0_ref_index);
@@ -4229,7 +4425,7 @@ void inject_inter_candidates(PictureControlSet *pcs_ptr, ModeDecisionContext *co
                           context_ptr->me_sb_addr,
                           context_ptr->me_block_offset,
                           &cand_total_cnt);
-
+#if !ENHANCED_ME_MV
     if (context_ptr->nx4_4xn_parent_mv_injection) {
         // If Nx4 or 4xN the inject the MV of the aprent block
 
@@ -4276,6 +4472,7 @@ void inject_inter_candidates(PictureControlSet *pcs_ptr, ModeDecisionContext *co
                                   &cand_total_cnt);
         }
     }
+#endif
     if (context_ptr->global_mv_injection) {
 #if GLOBAL_WARPED_MOTION
         if (pcs_ptr->parent_pcs_ptr->gm_level <= GM_DOWN) {

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -2220,10 +2220,9 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
         if (rf[1] != NONE_FRAME) {
             {
                 //NEAREST_NEWMV
-#if !ENHANCED_ME_MV
                 const MeSbResults *me_results =
                     pcs_ptr->parent_pcs_ptr->me_results[context_ptr->me_sb_addr];
-#endif
+
                 int16_t to_inject_mv_x_l0 =
                     context_ptr->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds]
                         .ed_ref_mv_stack[ref_pair][0]
@@ -2357,10 +2356,9 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
 
             {
                 //NEW_NEARESTMV
-#if !ENHANCED_ME_MV
                 const MeSbResults *me_results =
                     pcs_ptr->parent_pcs_ptr->me_results[context_ptr->me_sb_addr];
-#endif
+
 #if ENHANCED_ME_MV
                 int16_t to_inject_mv_x_l0 =
                     context_ptr
@@ -2494,10 +2492,9 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
                                         ref_mv);
 
                     //NEW_NEARMV
-#if !ENHANCED_ME_MV
                     const MeSbResults *me_results =
                         pcs_ptr->parent_pcs_ptr->me_results[context_ptr->me_sb_addr];
-#endif
+
 #if ENHANCED_ME_MV
                     int16_t to_inject_mv_x_l0 =
                         context_ptr
@@ -2606,10 +2603,9 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
                                         ref_mv);
 
                     //NEAR_NEWMV
-#if !ENHANCED_ME_MV
                     const MeSbResults *me_results =
                         pcs_ptr->parent_pcs_ptr->me_results[context_ptr->me_sb_addr];
-#endif
+
                     int16_t to_inject_mv_x_l0 = nearmv[0].as_mv.col;
                     int16_t to_inject_mv_y_l0 = nearmv[0].as_mv.row;
 #if ENHANCED_ME_MV

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
@@ -253,7 +253,11 @@ typedef struct ModeDecisionContext {
     Part                 nsq_table[NSQ_TAB_SIZE];
     uint8_t              full_loop_escape;
     uint8_t              global_mv_injection;
+#if ENHANCED_ME_MV
+    uint8_t              perform_me_mv_1_8_pel_ref;
+#else
     uint8_t              nx4_4xn_parent_mv_injection;
+#endif
     uint8_t              new_nearest_injection;
     uint8_t              new_nearest_near_comb_injection;
     uint8_t              warped_motion_injection;
@@ -267,6 +271,9 @@ typedef struct ModeDecisionContext {
     EbBool               spatial_sse_full_loop;
     EbBool               blk_skip_decision;
     EbBool               trellis_quant_coeff_optimization;
+#if ENHANCED_ME_MV
+    int16_t              sb_me_mv[BLOCK_MAX_COUNT_SB_128][2][4][2];
+#endif
     int16_t              best_spatial_pred_mv[2][4][2];
     int8_t               valid_refined_mv[2][4];
     EbPictureBufferDesc *input_sample16bit_buffer;

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -2386,6 +2386,8 @@ void derive_me_offsets(const SequenceControlSet *scs_ptr, PictureControlSet *pcs
     }
 }
 
+// Copy ME_MVs (generated @ PA) from input buffer (pcs_ptr-> .. ->me_results) to local
+// MD buffers (context_ptr->sb_me_mv)
 void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
                         EbPictureBufferDesc *input_picture_ptr, uint32_t input_origin_index,
                         uint32_t blk_origin_index) {

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -2317,6 +2317,11 @@ void md_sub_pel_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context_
 void    av1_set_ref_frame(MvReferenceFrame *rf, int8_t ref_frame_type);
 uint8_t get_max_drl_index(uint8_t refmvCnt, PredictionMode mode);
 
+#if MUS_ME
+uint8_t is_me_data_present(struct ModeDecisionContext *context_ptr, const MeSbResults *me_results,
+    uint8_t list_idx, uint8_t ref_idx);
+#endif
+
 #if ENHANCED_ME_MV
 void derive_me_offsets(const SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
     ModeDecisionContext *context_ptr) {
@@ -2412,7 +2417,7 @@ void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                 pcs_ptr->parent_pcs_ptr->me_results[context_ptr->me_sb_addr];
 
 #if MUS_ME
-            if (is_me_data_present(context_ptr, me_results, list_idx, ref_idx)) {
+            if (is_me_data_present(context_ptr, me_results, list_idx, ref_idx))
 #endif 
             {
                 int16_t me_mv_x;
@@ -2473,10 +2478,6 @@ void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context
         }
     }
 }
-
-#if MUS_ME
-uint8_t is_me_data_present(struct ModeDecisionContext *context_ptr,const MeSbResults *me_results,
-                           uint8_t list_idx, uint8_t ref_idx);
 #endif
 void    predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
                              EbPictureBufferDesc *input_picture_ptr, uint32_t input_origin_index,
@@ -2528,10 +2529,9 @@ void    predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *co
             uint8_t          ref_idx    = get_ref_frame_idx(rf[0]);
             if (ref_idx > context_ptr->md_max_ref_count - 1) continue;
             // Get the ME MV
-#if !ENHANCED_ME_MV
             const MeSbResults *me_results =
                 pcs_ptr->parent_pcs_ptr->me_results[context_ptr->me_sb_addr];
-#endif
+
 #if MUS_ME
             uint32_t pa_me_distortion = ~0;//any non zero value
             if (is_me_data_present(context_ptr, me_results, list_idx, ref_idx)) {

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -2418,7 +2418,7 @@ void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context
 
 #if MUS_ME
             if (is_me_data_present(context_ptr, me_results, list_idx, ref_idx))
-#endif 
+#endif
             {
                 int16_t me_mv_x;
                 int16_t me_mv_y;
@@ -2535,7 +2535,7 @@ void    predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *co
 #if MUS_ME
             uint32_t pa_me_distortion = ~0;//any non zero value
             if (is_me_data_present(context_ptr, me_results, list_idx, ref_idx)) {
-#endif 
+#endif
             int16_t me_mv_x;
             int16_t me_mv_y;
 #if ENHANCED_ME_MV


### PR DESCRIPTION
## Description

- Parent ME MV (instead of 64x64 ME MV) as Nx4 & 4xN INTER candidates.
- 1/8 Pel ME MVs  refinement

## Author(s)

@hguermaz 

## Type of change

Enhancement.

## Tests and performance
Data generated on the full objective-1-fast data set in context in enc-mode 0. 

| Speed Deviation| BD-Rate Deviation|
| -- | --
| 0.12% | -0.041%|