### PR TITLE
Travis CI: Fix dependencies not installing on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
       - yasm
       - ccache
       - python
+    update: true # Remove when Travis macOS images get updated
 notifications:
   webhooks: https://coveralls.io/webhook
 


### PR DESCRIPTION
An error in Homebrew caused yasm to fail to install on macOS. This PR migrates that by updating Homebrew before install.

See https://github.com/Homebrew/homebrew-bundle/issues/646 and https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/7