### PR TITLE
CI: Speed up AppVeyor by dropping VS debug job

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 image: Visual Studio 2019
-configuration:
-  - Debug
-  - Release
+configuration: Release
 
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,11 @@ configuration: Release
 skip_branch_with_pr: true
 skip_commits:
   files:
-    - .github/*
-    - Docs/*
-    - .travis.yml
-    - .gitignore
-    - *.md
+    - '.github/*'
+    - 'Docs/*'
+    - '.travis.yml'
+    - '.gitignore'
+    - '*.md'
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
   MSYSTEM: MINGW64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,13 @@
 image: Visual Studio 2019
 configuration: Release
 skip_branch_with_pr: true
-
+skip_commits:
+  files:
+    - .github/*
+    - Docs/*
+    - .travis.yml
+    - .gitignore
+    - *.md
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
   MSYSTEM: MINGW64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 image: Visual Studio 2019
 configuration: Release
+skip_branch_with_pr: true
 
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true


### PR DESCRIPTION
As of this moment, AppVeyor is now 40 jobs behind, with an average of 25 minutes per job that's over 16 hours. We should speed it up significantly, this PR starts that by dropping the Visual Studio debug job.

@1480c1 What do you think about further options to speedup AppVeyor?