### PR TITLE
build: fix debug build for gcc

### DIFF
--- a/Source/Lib/Encoder/ASM_AVX2/EbNoiseExtractAVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbNoiseExtractAVX2.c
@@ -18,7 +18,7 @@ EB_EXTERN EB_ALIGN(16) const uint8_t weak_chroma_filter[2][32] = {
      1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2},
 };
 
-inline void luma_weak_filter_avx2_intrin(__m256i top, __m256i curr, __m256i bottom,
+static inline void luma_weak_filter_avx2_intrin(__m256i top, __m256i curr, __m256i bottom,
                                          __m256i curr_prev, __m256i curr_next,
                                          uint8_t *ptr_denoised, uint8_t *ptr_noise) {
     __m256i top_first_half, bottom_first_half, filter_first_half, filter_second_half,
@@ -63,9 +63,10 @@ inline void luma_weak_filter_avx2_intrin(__m256i top, __m256i curr, __m256i bott
 
     _mm256_storeu_si256((__m256i *)(ptr_noise), _mm256_subs_epu8(curr, filter_first_half));
 }
-inline void luma_weak_filter_128_avx2_intrin(__m128i top, __m128i curr, __m128i bottom,
+static inline void luma_weak_filter_128_avx2_intrin(__m128i top, __m128i curr, __m128i bottom,
                                              __m128i curr_prev, __m128i curr_next,
                                              uint8_t *ptr_denoised, uint8_t *ptr_noise) {
+
     __m128i top_first_half, bottom_first_half, filter_first_half, filter_second_half,
         curr_next_first_half, curr_next_second_half, weights, curr_left_mid_first_half_weight,
         curr_left_mid_first_halflo, curr_left_mid_first_halfhi;
@@ -100,7 +101,7 @@ inline void luma_weak_filter_128_avx2_intrin(__m128i top, __m128i curr, __m128i 
 
     _mm_storel_epi64((__m128i *)(ptr_noise), _mm_subs_epu8(curr, filter_first_half));
 }
-inline void chroma_weak_luma_strong_filter_avx2_intrin(__m256i top, __m256i curr, __m256i bottom,
+static inline void chroma_weak_luma_strong_filter_avx2_intrin(__m256i top, __m256i curr, __m256i bottom,
                                                        __m256i curr_prev, __m256i curr_next,
                                                        __m256i top_prev, __m256i top_next,
                                                        __m256i bottom_prev, __m256i bottom_next,
@@ -186,7 +187,7 @@ inline void chroma_weak_luma_strong_filter_avx2_intrin(__m256i top, __m256i curr
     _mm256_storeu_si256((__m256i *)(ptr_denoised), filter_first_half);
 }
 
-inline void chroma_weak_luma_strong_filter_128_avx2_intrin(__m128i top, __m128i curr,
+static inline void chroma_weak_luma_strong_filter_128_avx2_intrin(__m128i top, __m128i curr,
                                                            __m128i bottom, __m128i curr_prev,
                                                            __m128i curr_next, __m128i top_prev,
                                                            __m128i top_next, __m128i bottom_prev,
@@ -254,7 +255,7 @@ inline void chroma_weak_luma_strong_filter_128_avx2_intrin(__m128i top, __m128i 
     _mm_storel_epi64((__m128i *)(ptr_denoised), filter_first_half);
 }
 
-inline void chroma_strong_avx2_intrin(__m256i top, __m256i curr, __m256i bottom, __m256i curr_prev,
+static inline void chroma_strong_avx2_intrin(__m256i top, __m256i curr, __m256i bottom, __m256i curr_prev,
                                       __m256i curr_next, __m256i top_prev, __m256i top_next,
                                       __m256i bottom_prev, __m256i bottom_next,
                                       uint8_t *ptr_denoised) {
@@ -366,7 +367,7 @@ inline void chroma_strong_avx2_intrin(__m256i top, __m256i curr, __m256i bottom,
     _mm256_storeu_si256((__m256i *)(ptr_denoised), curr_left_mid_first_halflo);
 }
 
-inline void chroma_strong_128_avx2_intrin(__m128i top, __m128i curr, __m128i bottom,
+static inline void chroma_strong_128_avx2_intrin(__m128i top, __m128i curr, __m128i bottom,
                                           __m128i curr_prev, __m128i curr_next, __m128i top_prev,
                                           __m128i top_next, __m128i bottom_prev,
                                           __m128i bottom_next, uint8_t *ptr_denoised) {


### PR DESCRIPTION
debug build will show following errors:

../../../../Bin/Debug/libSvtAv1Enc.so.0.8.1: undefined reference to `luma_weak_filter_128_avx2_intrin'
../../../../Bin/Debug/libSvtAv1Enc.so.0.8.1: undefined reference to `luma_weak_filter_avx2_intrin'
../../../../Bin/Debug/libSvtAv1Enc.so.0.8.1: undefined reference to `chroma_strong_avx2_intrin'
../../../../Bin/Debug/libSvtAv1Enc.so.0.8.1: undefined reference to `chroma_strong_128_avx2_intrin'
../../../../Bin/Debug/libSvtAv1Enc.so.0.8.1: undefined reference to `chroma_weak_luma_strong_filter_128_avx2_intrin'
../../../../Bin/Debug/libSvtAv1Enc.so.0.8.1: undefined reference to `chroma_weak_luma_strong_filter_avx2_intrin'
collect2: error: ld returned 1 exit status

make the inline function in .c as static will fix the problem.