### PR TITLE
fix memory leaks for tile encoder

### DIFF
--- a/Source/Lib/Encoder/Codec/EbEncDecSegments.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecSegments.c
@@ -20,6 +20,11 @@ static void enc_dec_segments_dctor(EbPtr p) {
     EB_FREE_ARRAY(obj->valid_sb_count_array);
     EB_FREE_ARRAY(obj->dep_map.dependency_map);
     EB_FREE_ARRAY(obj->row_array);
+
+    EB_FREE_ARRAY(obj->dep_map.dependency_map);
+    EB_FREE_ARRAY(obj->valid_sb_count_array);
+    EB_FREE_ARRAY(obj->y_start_array);
+    EB_FREE_ARRAY(obj->x_start_array);
 }
 
 EbErrorType enc_dec_segments_ctor(EncDecSegments *segments_ptr, uint32_t segment_col_count,

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.c
@@ -36,9 +36,9 @@ static void mode_decision_context_dctor(EbPtr p) {
     EB_DELETE_PTR_ARRAY(obj->candidate_buffer_ptr_array, MAX_NFL_BUFF);
 #if TXS_DEPTH_2
     EB_FREE_ARRAY(obj->candidate_buffer_tx_depth_1->candidate_ptr);
-    EB_FREE_ARRAY(obj->candidate_buffer_tx_depth_1);
+    EB_DELETE(obj->candidate_buffer_tx_depth_1);
     EB_FREE_ARRAY(obj->candidate_buffer_tx_depth_2->candidate_ptr);
-    EB_FREE_ARRAY(obj->candidate_buffer_tx_depth_2);
+    EB_DELETE(obj->candidate_buffer_tx_depth_2);
 #else
     EB_FREE_ARRAY(obj->scratch_candidate_buffer->candidate_ptr);
     EB_DELETE(obj->scratch_candidate_buffer);

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.c
@@ -129,11 +129,10 @@ EbErrorType me_sb_results_ctor(MeSbResults *obj_ptr, uint32_t max_number_of_blks
 void picture_control_set_dctor(EbPtr p) {
     PictureControlSet *obj = (PictureControlSet *)p;
     uint16_t tile_cnt = obj->tile_row_count * obj->tile_column_count;
-    uint16_t tile_row_cnt = obj->tile_row_count;
     uint8_t            depth;
     av1_hash_table_destroy(&obj->hash_table);
     EB_FREE_ALIGNED_ARRAY(obj->tpl_mvs);
-    EB_DELETE_PTR_ARRAY(obj->enc_dec_segment_ctrl, tile_row_cnt);
+    EB_DELETE_PTR_ARRAY(obj->enc_dec_segment_ctrl, tile_cnt);
     EB_DELETE_PTR_ARRAY(obj->ep_intra_luma_mode_neighbor_array, tile_cnt);
     EB_DELETE_PTR_ARRAY(obj->ep_intra_chroma_mode_neighbor_array, tile_cnt);
     EB_DELETE_PTR_ARRAY(obj->ep_mv_neighbor_array, tile_cnt);


### PR DESCRIPTION
Bin/Debug/SvtAv1EncApp -i in.yuv -w 176 -h 144 -b out.ivf -tile-rows 1 -tile-columns 1
you will get the leak print out