### PR TITLE
asm: change aligned read/store to unaligned read/store

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/EbHighbdIntraPrediction_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbHighbdIntraPrediction_AVX2.c
@@ -1365,9 +1365,9 @@ static INLINE void load_right_weights_8(const uint16_t *const above, __m256i *co
     *r = _mm256_set1_epi16((uint16_t)above[7]);
 
     // 0 1 2 3  0 1 2 3
-    weights[0] = _mm256_load_si256((const __m256i *)(sm_weights_d_8 + 0x00));
+    weights[0] = _mm256_loadu_si256((const __m256i *)(sm_weights_d_8 + 0x00));
     // 4 5 6 7  4 5 6 7
-    weights[1] = _mm256_load_si256((const __m256i *)(sm_weights_d_8 + 0x10));
+    weights[1] = _mm256_loadu_si256((const __m256i *)(sm_weights_d_8 + 0x10));
 }
 
 static INLINE __m256i load_left_4(const uint16_t *const left, const __m256i r) {
@@ -1448,7 +1448,7 @@ static INLINE void smooth_pred_8x4(const __m256i *const  weights_w,
                                    const uint16_t *const sm_weights_h, const __m256i *const rep,
                                    const __m256i *const ab, const __m256i lr, uint16_t **const dst,
                                    const ptrdiff_t stride) {
-    const __m256i weights_h = _mm256_load_si256((const __m256i *)sm_weights_h);
+    const __m256i weights_h = _mm256_loadu_si256((const __m256i *)sm_weights_h);
     smooth_pred_8x2(weights_w, weights_h, rep[0], ab, lr, dst, stride);
     smooth_pred_8x2(weights_w, weights_h, rep[1], ab, lr, dst, stride);
 }
@@ -1528,9 +1528,9 @@ static INLINE void load_right_weights_16(const uint16_t *const above, __m256i *c
     *r = _mm256_set1_epi16((uint16_t)above[15]);
 
     //  0  1  2  3   8  9 10 11
-    weights[0] = _mm256_load_si256((const __m256i *)(sm_weights_16 + 0x00));
+    weights[0] = _mm256_loadu_si256((const __m256i *)(sm_weights_16 + 0x00));
     //  4  5  6  7  12 13 14 15
-    weights[1] = _mm256_load_si256((const __m256i *)(sm_weights_16 + 0x10));
+    weights[1] = _mm256_loadu_si256((const __m256i *)(sm_weights_16 + 0x10));
 }
 
 static INLINE void prepare_ab(const uint16_t *const above, const __m256i b, __m256i *const ab) {
@@ -1564,7 +1564,7 @@ static INLINE void smooth_pred_16x4(const __m256i *const  weights_w,
                                     const uint16_t *const sm_weights_h, const __m256i *const rep,
                                     const __m256i *const ab, const __m256i lr, uint16_t **const dst,
                                     const ptrdiff_t stride) {
-    const __m256i weights_h = _mm256_load_si256((const __m256i *)sm_weights_h);
+    const __m256i weights_h = _mm256_loadu_si256((const __m256i *)sm_weights_h);
     smooth_pred_16(weights_w, weights_h, rep[0], ab, lr, dst, stride);
     smooth_pred_16(weights_w, weights_h, rep[1], ab, lr, dst, stride);
     smooth_pred_16(weights_w, weights_h, rep[2], ab, lr, dst, stride);
@@ -1793,21 +1793,21 @@ static INLINE void load_right_weights_64(const uint16_t *const above, __m256i *c
     *r = _mm256_set1_epi16((uint16_t)above[63]);
 
     //  0  1  2  3   8  9 10 11
-    weights[0] = _mm256_load_si256((const __m256i *)(sm_weights_64 + 0x00));
+    weights[0] = _mm256_loadu_si256((const __m256i *)(sm_weights_64 + 0x00));
     //  4  5  6  7  12 13 14 15
-    weights[1] = _mm256_load_si256((const __m256i *)(sm_weights_64 + 0x10));
+    weights[1] = _mm256_loadu_si256((const __m256i *)(sm_weights_64 + 0x10));
     // 16 17 18 19  24 25 26 27
-    weights[2] = _mm256_load_si256((const __m256i *)(sm_weights_64 + 0x20));
+    weights[2] = _mm256_loadu_si256((const __m256i *)(sm_weights_64 + 0x20));
     // 20 21 22 23  28 29 30 31
-    weights[3] = _mm256_load_si256((const __m256i *)(sm_weights_64 + 0x30));
+    weights[3] = _mm256_loadu_si256((const __m256i *)(sm_weights_64 + 0x30));
     // 32 33 34 35  40 41 42 43
-    weights[4] = _mm256_load_si256((const __m256i *)(sm_weights_64 + 0x40));
+    weights[4] = _mm256_loadu_si256((const __m256i *)(sm_weights_64 + 0x40));
     // 36 37 38 39  44 45 46 47
-    weights[5] = _mm256_load_si256((const __m256i *)(sm_weights_64 + 0x50));
+    weights[5] = _mm256_loadu_si256((const __m256i *)(sm_weights_64 + 0x50));
     // 48 49 50 51  56 57 58 59
-    weights[6] = _mm256_load_si256((const __m256i *)(sm_weights_64 + 0x60));
+    weights[6] = _mm256_loadu_si256((const __m256i *)(sm_weights_64 + 0x60));
     // 52 53 54 55  60 61 62 63
-    weights[7] = _mm256_load_si256((const __m256i *)(sm_weights_64 + 0x70));
+    weights[7] = _mm256_loadu_si256((const __m256i *)(sm_weights_64 + 0x70));
 }
 
 static INLINE void init_64(const uint16_t *const above, const uint16_t *const left, const int32_t h,
@@ -2349,7 +2349,7 @@ static INLINE void smooth_v_pred_8x2(const __m256i weights, const __m256i rep,
 static INLINE void smooth_v_pred_8x4(const uint16_t *const sm_weights_h, const __m256i *const rep,
                                      const __m256i *const ab, uint16_t **const dst,
                                      const ptrdiff_t stride) {
-    const __m256i weights = _mm256_load_si256((const __m256i *)sm_weights_h);
+    const __m256i weights = _mm256_loadu_si256((const __m256i *)sm_weights_h);
     smooth_v_pred_8x2(weights, rep[0], ab, dst, stride);
     smooth_v_pred_8x2(weights, rep[1], ab, dst, stride);
 }
@@ -2446,7 +2446,7 @@ static INLINE void smooth_v_pred_16(const __m256i weights, const __m256i rep,
 static INLINE void smooth_v_pred_16x4(const uint16_t *const sm_weights_h, const __m256i *const rep,
                                       const __m256i *const ab, uint16_t **const dst,
                                       const ptrdiff_t stride) {
-    const __m256i weights = _mm256_load_si256((const __m256i *)sm_weights_h);
+    const __m256i weights = _mm256_loadu_si256((const __m256i *)sm_weights_h);
     smooth_v_pred_16(weights, rep[0], ab, dst, stride);
     smooth_v_pred_16(weights, rep[1], ab, dst, stride);
     smooth_v_pred_16(weights, rep[2], ab, dst, stride);
@@ -2560,7 +2560,7 @@ static INLINE void smooth_v_pred_32(const __m256i weights, const __m256i rep,
 static INLINE void smooth_v_pred_32x4(const uint16_t *const sm_weights_h, const __m256i *const rep,
                                       const __m256i *const ab, uint16_t **const dst,
                                       const ptrdiff_t stride) {
-    const __m256i weights = _mm256_load_si256((const __m256i *)sm_weights_h);
+    const __m256i weights = _mm256_loadu_si256((const __m256i *)sm_weights_h);
     smooth_v_pred_32(weights, rep[0], ab, dst, stride);
     smooth_v_pred_32(weights, rep[1], ab, dst, stride);
     smooth_v_pred_32(weights, rep[2], ab, dst, stride);
@@ -2672,7 +2672,7 @@ static INLINE void smooth_v_pred_64(const __m256i weights, const __m256i rep,
 static INLINE void smooth_v_pred_64x4(const uint16_t *const sm_weights_h, const __m256i *const rep,
                                       const __m256i *const ab, uint16_t **const dst,
                                       const ptrdiff_t stride) {
-    const __m256i weights = _mm256_load_si256((const __m256i *)sm_weights_h);
+    const __m256i weights = _mm256_loadu_si256((const __m256i *)sm_weights_h);
     smooth_v_pred_64(weights, rep[0], ab, dst, stride);
     smooth_v_pred_64(weights, rep[1], ab, dst, stride);
     smooth_v_pred_64(weights, rep[2], ab, dst, stride);

--- a/Source/Lib/Common/ASM_AVX2/EbIntraPrediction_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbIntraPrediction_Intrinsic_AVX2.c
@@ -107,12 +107,12 @@ static INLINE void get_gradient_hist_avx2_internal(const __m256i *src1, const __
     //AOMMIN(quotA, 6)
     quot = _mm256_min_epi16(quot, val_6_i16);
 
-    _mm256_store_si256((__m256i *)dy_mask_array, dy_mask);
-    _mm256_store_si256((__m256i *)quot_array, quot);
-    _mm256_store_si256((__m256i *)remd_array, remd);
-    _mm256_store_si256((__m256i *)sn_array, sn);
-    _mm256_store_si256((__m256i *)temp_array, tmp1_32);
-    _mm256_store_si256((__m256i *)&temp_array[8], tmp2_32);
+    _mm256_storeu_si256((__m256i *)dy_mask_array, dy_mask);
+    _mm256_storeu_si256((__m256i *)quot_array, quot);
+    _mm256_storeu_si256((__m256i *)remd_array, remd);
+    _mm256_storeu_si256((__m256i *)sn_array, sn);
+    _mm256_storeu_si256((__m256i *)temp_array, tmp1_32);
+    _mm256_storeu_si256((__m256i *)&temp_array[8], tmp2_32);
 }
 
 void av1_get_gradient_hist_avx2(const uint8_t *src, int src_stride, int rows, int cols,
@@ -2119,7 +2119,7 @@ static void dr_prediction_z2_hxw_avx2(int32_t H, int32_t W, uint8_t *dst, ptrdif
                 base_y_c256 = _mm256_srai_epi16(y_c256, frac_bits_y);
                 mask256     = _mm256_cmpgt_epi16(min_base_y256, base_y_c256);
                 base_y_c256 = _mm256_andnot_si256(mask256, base_y_c256);
-                _mm256_store_si256((__m256i *)base_y_c, base_y_c256); /**/
+                _mm256_storeu_si256((__m256i *)base_y_c, base_y_c256); /**/
 
                 a0_y        = _mm256_setr_epi16(left[base_y_c[0]],
                                          left[base_y_c[1]],
@@ -2138,7 +2138,7 @@ static void dr_prediction_z2_hxw_avx2(int32_t H, int32_t W, uint8_t *dst, ptrdif
                                          left[base_y_c[14]],
                                          left[base_y_c[15]]);
                 base_y_c256 = _mm256_add_epi16(base_y_c256, c1);
-                _mm256_store_si256((__m256i *)base_y_c, base_y_c256);
+                _mm256_storeu_si256((__m256i *)base_y_c, base_y_c256);
 
                 a1_y = _mm256_setr_epi16(left[base_y_c[0]],
                                          left[base_y_c[1]],
@@ -3325,7 +3325,7 @@ static void highbd_dr_prediction_z2_nx8_32bit_avx2(int32_t N, uint16_t *dst, ptr
             base_y_c256 = _mm256_srai_epi32(y_c256, frac_bits_y);
             mask256     = _mm256_cmpgt_epi32(min_base_y256, base_y_c256);
             base_y_c256 = _mm256_andnot_si256(mask256, base_y_c256);
-            _mm256_store_si256((__m256i *)base_y_c, base_y_c256);
+            _mm256_storeu_si256((__m256i *)base_y_c, base_y_c256);
 
             a0_y = _mm256_cvtepu16_epi32(_mm_setr_epi16(left[base_y_c[0]],
                                                         left[base_y_c[1]],
@@ -3468,7 +3468,7 @@ static void highbd_dr_prediction_z2_hxw_avx2(int32_t H, int32_t W, uint16_t *dst
                 base_y_c256 = _mm256_srai_epi16(y_c256, frac_bits_y);
                 mask256     = _mm256_cmpgt_epi16(min_base_y256, base_y_c256);
                 base_y_c256 = _mm256_andnot_si256(mask256, base_y_c256);
-                _mm256_store_si256((__m256i *)base_y_c, base_y_c256);
+                _mm256_storeu_si256((__m256i *)base_y_c, base_y_c256);
 
                 a0_y        = _mm256_setr_epi16(left[base_y_c[0]],
                                          left[base_y_c[1]],
@@ -3487,7 +3487,7 @@ static void highbd_dr_prediction_z2_hxw_avx2(int32_t H, int32_t W, uint16_t *dst
                                          left[base_y_c[14]],
                                          left[base_y_c[15]]);
                 base_y_c256 = _mm256_add_epi16(base_y_c256, c1);
-                _mm256_store_si256((__m256i *)base_y_c, base_y_c256);
+                _mm256_storeu_si256((__m256i *)base_y_c, base_y_c256);
 
                 a1_y = _mm256_setr_epi16(left[base_y_c[0]],
                                          left[base_y_c[1]],
@@ -3652,14 +3652,14 @@ static void highbd_dr_prediction_z2_hxw_32bit_avx2(int32_t H, int32_t W, uint16_
                 base_y_c256 = _mm256_srai_epi32(y_c256, frac_bits_y);
                 mask256     = _mm256_cmpgt_epi32(min_base_y256, base_y_c256);
                 base_y_c256 = _mm256_andnot_si256(mask256, base_y_c256);
-                _mm256_store_si256((__m256i *)base_y_c, base_y_c256);
+                _mm256_storeu_si256((__m256i *)base_y_c, base_y_c256);
                 c256 = _mm256_setr_epi32(
                     9 + j, 10 + j, 11 + j, 12 + j, 13 + j, 14 + j, 15 + j, 16 + j);
                 y_c_1_256   = _mm256_sub_epi32(r6, _mm256_mullo_epi32(c256, dy256));
                 base_y_c256 = _mm256_srai_epi32(y_c_1_256, frac_bits_y);
                 mask256     = _mm256_cmpgt_epi32(min_base_y256, base_y_c256);
                 base_y_c256 = _mm256_andnot_si256(mask256, base_y_c256);
-                _mm256_store_si256((__m256i *)(base_y_c + 8), base_y_c256);
+                _mm256_storeu_si256((__m256i *)(base_y_c + 8), base_y_c256);
 
                 a0_y = _mm256_cvtepu16_epi32(_mm_setr_epi16(left[base_y_c[0]],
                                                             left[base_y_c[1]],

--- a/Source/Lib/Common/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
@@ -69,10 +69,10 @@ void compressed_packmsb_avx2_intrin(uint8_t *in8_bit_buffer, uint32_t in8_stride
             out_s0_s15  = _mm256_inserti128_si256(concat2, _mm256_castsi256_si128(concat3), 1);
             out_s16_s31 = _mm256_inserti128_si256(concat3, _mm256_extracti128_si256(concat2, 1), 0);
 
-            _mm256_store_si256((__m256i *)out16_bit_buffer, out0_15);
-            _mm256_store_si256((__m256i *)(out16_bit_buffer + 16), out16_31);
-            _mm256_store_si256((__m256i *)(out16_bit_buffer + out_stride), out_s0_s15);
-            _mm256_store_si256((__m256i *)(out16_bit_buffer + out_stride + 16), out_s16_s31);
+            _mm256_storeu_si256((__m256i *)out16_bit_buffer, out0_15);
+            _mm256_storeu_si256((__m256i *)(out16_bit_buffer + 16), out16_31);
+            _mm256_storeu_si256((__m256i *)(out16_bit_buffer + out_stride), out_s0_s15);
+            _mm256_storeu_si256((__m256i *)(out16_bit_buffer + out_stride + 16), out_s16_s31);
 
             in8_bit_buffer += in8_stride << 1;
             inn_bit_buffer += inn_stride << 1;
@@ -126,10 +126,10 @@ void compressed_packmsb_avx2_intrin(uint8_t *in8_bit_buffer, uint32_t in8_stride
             out32_47  = _mm256_inserti128_si256(concat2, _mm256_castsi256_si128(concat3), 1);
             out_48_63 = _mm256_inserti128_si256(concat3, _mm256_extracti128_si256(concat2, 1), 0);
 
-            _mm256_store_si256((__m256i *)out16_bit_buffer, out_0_15);
-            _mm256_store_si256((__m256i *)(out16_bit_buffer + 16), out16_31);
-            _mm256_store_si256((__m256i *)(out16_bit_buffer + 32), out32_47);
-            _mm256_store_si256((__m256i *)(out16_bit_buffer + 48), out_48_63);
+            _mm256_storeu_si256((__m256i *)out16_bit_buffer, out_0_15);
+            _mm256_storeu_si256((__m256i *)(out16_bit_buffer + 16), out16_31);
+            _mm256_storeu_si256((__m256i *)(out16_bit_buffer + 32), out32_47);
+            _mm256_storeu_si256((__m256i *)(out16_bit_buffer + 48), out_48_63);
 
             in8_bit_buffer += in8_stride;
             inn_bit_buffer += inn_stride;
@@ -369,10 +369,10 @@ void eb_enc_msb_pack2d_avx2_intrin_al(uint8_t *in8_bit_buffer, uint32_t in8_stri
             out_s0_s15  = _mm256_inserti128_si256(concat2, _mm256_castsi256_si128(concat3), 1);
             out_s16_s31 = _mm256_inserti128_si256(concat3, _mm256_extracti128_si256(concat2, 1), 0);
 
-            _mm256_store_si256((__m256i *)out16_bit_buffer, out0_15);
-            _mm256_store_si256((__m256i *)(out16_bit_buffer + 16), out16_31);
-            _mm256_store_si256((__m256i *)(out16_bit_buffer + out_stride), out_s0_s15);
-            _mm256_store_si256((__m256i *)(out16_bit_buffer + out_stride + 16), out_s16_s31);
+            _mm256_storeu_si256((__m256i *)out16_bit_buffer, out0_15);
+            _mm256_storeu_si256((__m256i *)(out16_bit_buffer + 16), out16_31);
+            _mm256_storeu_si256((__m256i *)(out16_bit_buffer + out_stride), out_s0_s15);
+            _mm256_storeu_si256((__m256i *)(out16_bit_buffer + out_stride + 16), out_s16_s31);
 
             in8_bit_buffer += in8_stride << 1;
             //inn_bit_buffer += inn_stride << 1;
@@ -417,15 +417,15 @@ void eb_enc_msb_pack2d_avx2_intrin_al(uint8_t *in8_bit_buffer, uint32_t in8_stri
             out_s32_s47 = _mm256_inserti128_si256(concat6, _mm256_castsi256_si128(concat7), 1);
             out_s48_s63 = _mm256_inserti128_si256(concat7, _mm256_extracti128_si256(concat6, 1), 0);
 
-            _mm256_store_si256((__m256i *)out16_bit_buffer, out_0_15);
-            _mm256_store_si256((__m256i *)(out16_bit_buffer + 16), out16_31);
-            _mm256_store_si256((__m256i *)(out16_bit_buffer + 32), out32_47);
-            _mm256_store_si256((__m256i *)(out16_bit_buffer + 48), out_48_63);
+            _mm256_storeu_si256((__m256i *)out16_bit_buffer, out_0_15);
+            _mm256_storeu_si256((__m256i *)(out16_bit_buffer + 16), out16_31);
+            _mm256_storeu_si256((__m256i *)(out16_bit_buffer + 32), out32_47);
+            _mm256_storeu_si256((__m256i *)(out16_bit_buffer + 48), out_48_63);
 
-            _mm256_store_si256((__m256i *)(out16_bit_buffer + out_stride), out_s0_s15);
-            _mm256_store_si256((__m256i *)(out16_bit_buffer + out_stride + 16), out_s16_s31);
-            _mm256_store_si256((__m256i *)(out16_bit_buffer + out_stride + 32), out_s32_s47);
-            _mm256_store_si256((__m256i *)(out16_bit_buffer + out_stride + 48), out_s48_s63);
+            _mm256_storeu_si256((__m256i *)(out16_bit_buffer + out_stride), out_s0_s15);
+            _mm256_storeu_si256((__m256i *)(out16_bit_buffer + out_stride + 16), out_s16_s31);
+            _mm256_storeu_si256((__m256i *)(out16_bit_buffer + out_stride + 32), out_s32_s47);
+            _mm256_storeu_si256((__m256i *)(out16_bit_buffer + out_stride + 48), out_s48_s63);
 
             in8_bit_buffer += in8_stride << 1;
             //inn_bit_buffer += inn_stride << 1;

--- a/Source/Lib/Common/ASM_AVX2/aom_subpixel_8t_intrin_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/aom_subpixel_8t_intrin_avx2.c
@@ -235,7 +235,7 @@ static void aom_filter_block1d4_h4_avx2(const uint8_t *src_ptr, ptrdiff_t src_pi
     const __m256i filters_reg32 = MM256_BROADCASTSI128_SI256(filters_reg);
 
     first_filters = _mm256_shuffle_epi8(filters_reg32, _mm256_set1_epi32(0x5040302u));
-    filt1_reg     = _mm256_load_si256((__m256i const *)(filt4_d4_global_avx2));
+    filt1_reg     = _mm256_loadu_si256((__m256i const *)(filt4_d4_global_avx2));
 
     // multiple the size of the source and destination stride by two
     src_stride = src_pixels_per_line << 1;
@@ -318,8 +318,8 @@ static void aom_filter_block1d4_h8_avx2(const uint8_t *src_ptr, ptrdiff_t src_pi
     // duplicate only the second 32 bits
     second_filters = _mm256_shuffle_epi32(filters_reg32, 0x55);
 
-    filt1_reg = _mm256_load_si256((__m256i const *)filt_d4_global_avx2);
-    filt2_reg = _mm256_load_si256((__m256i const *)(filt_d4_global_avx2 + 32));
+    filt1_reg = _mm256_loadu_si256((__m256i const *)filt_d4_global_avx2);
+    filt2_reg = _mm256_loadu_si256((__m256i const *)(filt_d4_global_avx2 + 32));
 
     // multiple the size of the source and destination stride by two
     src_stride = src_pixels_per_line << 1;
@@ -420,8 +420,8 @@ static void aom_filter_block1d8_h4_avx2(const uint8_t *src_ptr, ptrdiff_t src_pi
     // across 256 bit register
     third_filters = _mm256_shuffle_epi8(filters_reg32, _mm256_set1_epi16(0x504u));
 
-    filt2_reg = _mm256_load_si256((__m256i const *)(filt_global_avx2 + 32));
-    filt3_reg = _mm256_load_si256((__m256i const *)(filt_global_avx2 + 32 * 2));
+    filt2_reg = _mm256_loadu_si256((__m256i const *)(filt_global_avx2 + 32));
+    filt3_reg = _mm256_loadu_si256((__m256i const *)(filt_global_avx2 + 32 * 2));
 
     // multiply the size of the source and destination stride by two
     src_stride = src_pixels_per_line << 1;
@@ -517,10 +517,10 @@ static void aom_filter_block1d8_h8_avx2(const uint8_t *src_ptr, ptrdiff_t src_pi
     // across 256 bit register
     forth_filters = _mm256_shuffle_epi8(filters_reg32, _mm256_set1_epi16(0x706u));
 
-    filt1_reg = _mm256_load_si256((__m256i const *)filt_global_avx2);
-    filt2_reg = _mm256_load_si256((__m256i const *)(filt_global_avx2 + 32));
-    filt3_reg = _mm256_load_si256((__m256i const *)(filt_global_avx2 + 32 * 2));
-    filt4_reg = _mm256_load_si256((__m256i const *)(filt_global_avx2 + 32 * 3));
+    filt1_reg = _mm256_loadu_si256((__m256i const *)filt_global_avx2);
+    filt2_reg = _mm256_loadu_si256((__m256i const *)(filt_global_avx2 + 32));
+    filt3_reg = _mm256_loadu_si256((__m256i const *)(filt_global_avx2 + 32 * 2));
+    filt4_reg = _mm256_loadu_si256((__m256i const *)(filt_global_avx2 + 32 * 3));
 
     // multiple the size of the source and destination stride by two
     src_stride = src_pixels_per_line << 1;
@@ -637,8 +637,8 @@ static void aom_filter_block1d16_h4_avx2(const uint8_t *src_ptr, ptrdiff_t src_p
     // across 256 bit register
     third_filters = _mm256_shuffle_epi8(filters_reg32, _mm256_set1_epi16(0x504u));
 
-    filt2_reg = _mm256_load_si256((__m256i const *)(filt_global_avx2 + 32));
-    filt3_reg = _mm256_load_si256((__m256i const *)(filt_global_avx2 + 32 * 2));
+    filt2_reg = _mm256_loadu_si256((__m256i const *)(filt_global_avx2 + 32));
+    filt3_reg = _mm256_loadu_si256((__m256i const *)(filt_global_avx2 + 32 * 2));
 
     // multiply the size of the source and destination stride by two
     src_stride = src_pixels_per_line << 1;
@@ -756,10 +756,10 @@ static void aom_filter_block1d16_h8_avx2(const uint8_t *src_ptr, ptrdiff_t src_p
     // across 256 bit register
     forth_filters = _mm256_shuffle_epi8(filters_reg32, _mm256_set1_epi16(0x706u));
 
-    filt1_reg = _mm256_load_si256((__m256i const *)filt_global_avx2);
-    filt2_reg = _mm256_load_si256((__m256i const *)(filt_global_avx2 + 32));
-    filt3_reg = _mm256_load_si256((__m256i const *)(filt_global_avx2 + 32 * 2));
-    filt4_reg = _mm256_load_si256((__m256i const *)(filt_global_avx2 + 32 * 3));
+    filt1_reg = _mm256_loadu_si256((__m256i const *)filt_global_avx2);
+    filt2_reg = _mm256_loadu_si256((__m256i const *)(filt_global_avx2 + 32));
+    filt3_reg = _mm256_loadu_si256((__m256i const *)(filt_global_avx2 + 32 * 2));
+    filt4_reg = _mm256_loadu_si256((__m256i const *)(filt_global_avx2 + 32 * 3));
 
     // multiple the size of the source and destination stride by two
     src_stride = src_pixels_per_line << 1;

--- a/Source/Lib/Common/ASM_AVX2/convolve_2d_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/convolve_2d_avx2.c
@@ -143,9 +143,9 @@ static void convolve_2d_sr_hor_6tap_avx2(const uint8_t *const src, const int32_t
     int16_t *      im      = im_block;
     __m256i        coeffs_256[3], filt_256[3];
 
-    filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-    filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-    filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
+    filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+    filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+    filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
 
     prepare_half_coeffs_6tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
@@ -203,10 +203,10 @@ static void convolve_2d_sr_hor_8tap_avx2(const uint8_t *const src, const int32_t
     int16_t *      im      = im_block;
     __m256i        coeffs_256[4], filt_256[4];
 
-    filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-    filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-    filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
-    filt_256[3] = _mm256_load_si256((__m256i const *)filt4_global_avx);
+    filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+    filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+    filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
+    filt_256[3] = _mm256_loadu_si256((__m256i const *)filt4_global_avx);
 
     prepare_half_coeffs_8tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
@@ -318,7 +318,7 @@ static void convolve_2d_sr_ver_2tap_avx2(const int16_t *const im_block, const in
         } else if (w == 16) {
             __m256i s_256[2], r[4];
 
-            s_256[0] = _mm256_load_si256((__m256i *)im);
+            s_256[0] = _mm256_loadu_si256((__m256i *)im);
 
             do {
                 xy_y_convolve_2tap_16x2_avx2(im, s_256, &coeffs_256, r);
@@ -330,8 +330,8 @@ static void convolve_2d_sr_ver_2tap_avx2(const int16_t *const im_block, const in
         } else if (w == 32) {
             __m256i s_256[2][2];
 
-            s_256[0][0] = _mm256_load_si256((__m256i *)(im + 0 * 16));
-            s_256[0][1] = _mm256_load_si256((__m256i *)(im + 1 * 16));
+            s_256[0][0] = _mm256_loadu_si256((__m256i *)(im + 0 * 16));
+            s_256[0][1] = _mm256_loadu_si256((__m256i *)(im + 1 * 16));
 
             do {
                 xy_y_convolve_2tap_32_all_avx2(im + 32, s_256[0], s_256[1], &coeffs_256, dst);
@@ -344,10 +344,10 @@ static void convolve_2d_sr_ver_2tap_avx2(const int16_t *const im_block, const in
         } else if (w == 64) {
             __m256i s_256[2][4];
 
-            s_256[0][0] = _mm256_load_si256((__m256i *)(im + 0 * 16));
-            s_256[0][1] = _mm256_load_si256((__m256i *)(im + 1 * 16));
-            s_256[0][2] = _mm256_load_si256((__m256i *)(im + 2 * 16));
-            s_256[0][3] = _mm256_load_si256((__m256i *)(im + 3 * 16));
+            s_256[0][0] = _mm256_loadu_si256((__m256i *)(im + 0 * 16));
+            s_256[0][1] = _mm256_loadu_si256((__m256i *)(im + 1 * 16));
+            s_256[0][2] = _mm256_loadu_si256((__m256i *)(im + 2 * 16));
+            s_256[0][3] = _mm256_loadu_si256((__m256i *)(im + 3 * 16));
 
             do {
                 xy_y_convolve_2tap_32_all_avx2(
@@ -447,7 +447,7 @@ static void convolve_2d_sr_ver_2tap_half_avx2(const int16_t *const im_block, con
     } else if (w == 16) {
         __m256i s_256[2], r[2];
 
-        s_256[0] = _mm256_load_si256((__m256i *)im);
+        s_256[0] = _mm256_loadu_si256((__m256i *)im);
 
         do {
             xy_y_convolve_2tap_16x2_half_pel_avx2(im, s_256, r);
@@ -461,8 +461,8 @@ static void convolve_2d_sr_ver_2tap_half_avx2(const int16_t *const im_block, con
     } else if (w == 32) {
         __m256i s_256[2][2];
 
-        s_256[0][0] = _mm256_load_si256((__m256i *)(im + 0 * 16));
-        s_256[0][1] = _mm256_load_si256((__m256i *)(im + 1 * 16));
+        s_256[0][0] = _mm256_loadu_si256((__m256i *)(im + 0 * 16));
+        s_256[0][1] = _mm256_loadu_si256((__m256i *)(im + 1 * 16));
 
         do {
             xy_y_convolve_2tap_half_pel_32_all_avx2(im + 32, s_256[0], s_256[1], dst);
@@ -475,10 +475,10 @@ static void convolve_2d_sr_ver_2tap_half_avx2(const int16_t *const im_block, con
     } else if (w == 64) {
         __m256i s_256[2][4];
 
-        s_256[0][0] = _mm256_load_si256((__m256i *)(im + 0 * 16));
-        s_256[0][1] = _mm256_load_si256((__m256i *)(im + 1 * 16));
-        s_256[0][2] = _mm256_load_si256((__m256i *)(im + 2 * 16));
-        s_256[0][3] = _mm256_load_si256((__m256i *)(im + 3 * 16));
+        s_256[0][0] = _mm256_loadu_si256((__m256i *)(im + 0 * 16));
+        s_256[0][1] = _mm256_loadu_si256((__m256i *)(im + 1 * 16));
+        s_256[0][2] = _mm256_loadu_si256((__m256i *)(im + 2 * 16));
+        s_256[0][3] = _mm256_loadu_si256((__m256i *)(im + 3 * 16));
 
         do {
             xy_y_convolve_2tap_half_pel_32_all_avx2(im + 64, s_256[0] + 0, s_256[1] + 0, dst);

--- a/Source/Lib/Common/ASM_AVX2/convolve_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/convolve_avx2.c
@@ -1187,9 +1187,9 @@ void eb_av1_convolve_x_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *
     } else {
         __m256i filt_256[4];
 
-        filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-        filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-        filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
+        filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+        filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+        filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
 
         if (is_convolve_6tap(filter_params_x->filter_ptr)) {
             // horz_filt as 6 tap
@@ -1245,7 +1245,7 @@ void eb_av1_convolve_x_sr_avx2(const uint8_t *src, int32_t src_stride, uint8_t *
             // horz_filt as 8 tap
             const uint8_t *src_ptr = src - 3;
 
-            filt_256[3] = _mm256_load_si256((__m256i const *)filt4_global_avx);
+            filt_256[3] = _mm256_loadu_si256((__m256i const *)filt4_global_avx);
 
             prepare_half_coeffs_8tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 

--- a/Source/Lib/Common/ASM_AVX2/convolve_avx2.h
+++ b/Source/Lib/Common/ASM_AVX2/convolve_avx2.h
@@ -421,34 +421,34 @@ static INLINE void prepare_coeffs_8tap_avx2(const InterpFilterParams *const filt
 
 static INLINE void load_16bit_5rows_avx2(const int16_t *const src, const ptrdiff_t stride,
                                          __m256i dst[5]) {
-    dst[0] = _mm256_load_si256((__m256i *)(src + 0 * stride));
-    dst[1] = _mm256_load_si256((__m256i *)(src + 1 * stride));
-    dst[2] = _mm256_load_si256((__m256i *)(src + 2 * stride));
-    dst[3] = _mm256_load_si256((__m256i *)(src + 3 * stride));
-    dst[4] = _mm256_load_si256((__m256i *)(src + 4 * stride));
+    dst[0] = _mm256_loadu_si256((__m256i *)(src + 0 * stride));
+    dst[1] = _mm256_loadu_si256((__m256i *)(src + 1 * stride));
+    dst[2] = _mm256_loadu_si256((__m256i *)(src + 2 * stride));
+    dst[3] = _mm256_loadu_si256((__m256i *)(src + 3 * stride));
+    dst[4] = _mm256_loadu_si256((__m256i *)(src + 4 * stride));
 }
 
 static INLINE void load_16bit_7rows_avx2(const int16_t *const src, const ptrdiff_t stride,
                                          __m256i dst[7]) {
-    dst[0] = _mm256_load_si256((__m256i *)(src + 0 * stride));
-    dst[1] = _mm256_load_si256((__m256i *)(src + 1 * stride));
-    dst[2] = _mm256_load_si256((__m256i *)(src + 2 * stride));
-    dst[3] = _mm256_load_si256((__m256i *)(src + 3 * stride));
-    dst[4] = _mm256_load_si256((__m256i *)(src + 4 * stride));
-    dst[5] = _mm256_load_si256((__m256i *)(src + 5 * stride));
-    dst[6] = _mm256_load_si256((__m256i *)(src + 6 * stride));
+    dst[0] = _mm256_loadu_si256((__m256i *)(src + 0 * stride));
+    dst[1] = _mm256_loadu_si256((__m256i *)(src + 1 * stride));
+    dst[2] = _mm256_loadu_si256((__m256i *)(src + 2 * stride));
+    dst[3] = _mm256_loadu_si256((__m256i *)(src + 3 * stride));
+    dst[4] = _mm256_loadu_si256((__m256i *)(src + 4 * stride));
+    dst[5] = _mm256_loadu_si256((__m256i *)(src + 5 * stride));
+    dst[6] = _mm256_loadu_si256((__m256i *)(src + 6 * stride));
 }
 
 SIMD_INLINE void load_16bit_8rows_avx2(const int16_t *const src, const ptrdiff_t stride,
                                        __m256i dst[8]) {
-    dst[0] = _mm256_load_si256((__m256i *)(src + 0 * stride));
-    dst[1] = _mm256_load_si256((__m256i *)(src + 1 * stride));
-    dst[2] = _mm256_load_si256((__m256i *)(src + 2 * stride));
-    dst[3] = _mm256_load_si256((__m256i *)(src + 3 * stride));
-    dst[4] = _mm256_load_si256((__m256i *)(src + 4 * stride));
-    dst[5] = _mm256_load_si256((__m256i *)(src + 5 * stride));
-    dst[6] = _mm256_load_si256((__m256i *)(src + 6 * stride));
-    dst[7] = _mm256_load_si256((__m256i *)(src + 7 * stride));
+    dst[0] = _mm256_loadu_si256((__m256i *)(src + 0 * stride));
+    dst[1] = _mm256_loadu_si256((__m256i *)(src + 1 * stride));
+    dst[2] = _mm256_loadu_si256((__m256i *)(src + 2 * stride));
+    dst[3] = _mm256_loadu_si256((__m256i *)(src + 3 * stride));
+    dst[4] = _mm256_loadu_si256((__m256i *)(src + 4 * stride));
+    dst[5] = _mm256_loadu_si256((__m256i *)(src + 5 * stride));
+    dst[6] = _mm256_loadu_si256((__m256i *)(src + 6 * stride));
+    dst[7] = _mm256_loadu_si256((__m256i *)(src + 7 * stride));
 }
 
 SIMD_INLINE void loadu_unpack_16bit_5rows_avx2(const int16_t *const src, const ptrdiff_t stride,
@@ -678,7 +678,7 @@ static INLINE void xy_x_round_store_8x2_sse2(const __m128i res[2], int16_t *cons
 
 static INLINE void xy_x_round_store_8x2_avx2(const __m256i res, int16_t *const dst) {
     const __m256i d = xy_x_round_avx2(res);
-    _mm256_store_si256((__m256i *)dst, d);
+    _mm256_storeu_si256((__m256i *)dst, d);
 }
 
 static INLINE void xy_x_round_store_32_avx2(const __m256i res[2], int16_t *const dst) {
@@ -688,8 +688,8 @@ static INLINE void xy_x_round_store_32_avx2(const __m256i res[2], int16_t *const
     r[1]             = xy_x_round_avx2(res[1]);
     const __m256i d0 = _mm256_inserti128_si256(r[0], _mm256_extracti128_si256(r[1], 0), 1);
     const __m256i d1 = _mm256_inserti128_si256(r[1], _mm256_extracti128_si256(r[0], 1), 0);
-    _mm256_store_si256((__m256i *)dst, d0);
-    _mm256_store_si256((__m256i *)(dst + 16), d1);
+    _mm256_storeu_si256((__m256i *)dst, d0);
+    _mm256_storeu_si256((__m256i *)(dst + 16), d1);
 }
 
 static INLINE __m128i xy_y_round_sse2(const __m128i src) {
@@ -1313,8 +1313,8 @@ static INLINE void xy_x_2tap_32_avx2(const uint8_t *const src, const __m256i coe
     const __m256i d1 = xy_x_round_avx2(r[1]);
     // d0 = _mm256_inserti128_si256(d0, _mm256_extracti128_si256(d1, 0), 1);
     // d1 = _mm256_inserti128_si256(d1, _mm256_extracti128_si256(d0, 1), 0);
-    _mm256_store_si256((__m256i *)dst, d0);
-    _mm256_store_si256((__m256i *)(dst + 16), d1);
+    _mm256_storeu_si256((__m256i *)dst, d0);
+    _mm256_storeu_si256((__m256i *)(dst + 16), d1);
 }
 
 static INLINE void xy_x_6tap_32_avx2(const uint8_t *const src, const __m256i coeffs[3],
@@ -1324,8 +1324,8 @@ static INLINE void xy_x_6tap_32_avx2(const uint8_t *const src, const __m256i coe
     x_convolve_6tap_32_avx2(src, coeffs, filt, r);
     const __m256i d0 = xy_x_round_avx2(r[0]);
     const __m256i d1 = xy_x_round_avx2(r[1]);
-    _mm256_store_si256((__m256i *)dst, d0);
-    _mm256_store_si256((__m256i *)(dst + 16), d1);
+    _mm256_storeu_si256((__m256i *)dst, d0);
+    _mm256_storeu_si256((__m256i *)(dst + 16), d1);
 }
 
 static INLINE void xy_x_8tap_32_avx2(const uint8_t *const src, const __m256i coeffs[4],
@@ -1335,8 +1335,8 @@ static INLINE void xy_x_8tap_32_avx2(const uint8_t *const src, const __m256i coe
     x_convolve_8tap_32_avx2(src, coeffs, filt, r);
     const __m256i d0 = xy_x_round_avx2(r[0]);
     const __m256i d1 = xy_x_round_avx2(r[1]);
-    _mm256_store_si256((__m256i *)dst, d0);
-    _mm256_store_si256((__m256i *)(dst + 16), d1);
+    _mm256_storeu_si256((__m256i *)dst, d0);
+    _mm256_storeu_si256((__m256i *)(dst + 16), d1);
 }
 
 static INLINE __m128i xy_y_convolve_2tap_2x2_sse2(const int16_t *const src, __m128i s_32[2],
@@ -1417,9 +1417,9 @@ static INLINE __m256i xy_y_convolve_2tap_8x2_half_pel_avx2(const int16_t *const 
 
 static INLINE void xy_y_convolve_2tap_16x2_half_pel_avx2(const int16_t *const src, __m256i s_256[2],
                                                          __m256i r[2]) {
-    s_256[1] = _mm256_load_si256((__m256i *)(src + 16));
+    s_256[1] = _mm256_loadu_si256((__m256i *)(src + 16));
     r[0]     = _mm256_add_epi16(s_256[0], s_256[1]);
-    s_256[0] = _mm256_load_si256((__m256i *)(src + 2 * 16));
+    s_256[0] = _mm256_loadu_si256((__m256i *)(src + 2 * 16));
     r[1]     = _mm256_add_epi16(s_256[1], s_256[0]);
 }
 
@@ -1432,17 +1432,17 @@ static INLINE void xy_y_store_16x2_avx2(const __m256i r[2], uint8_t *const dst,
 
 static INLINE void xy_y_convolve_2tap_16x2_avx2(const int16_t *const src, __m256i s[2],
                                                 const __m256i coeffs[1], __m256i r[4]) {
-    s[1] = _mm256_load_si256((__m256i *)(src + 16));
+    s[1] = _mm256_loadu_si256((__m256i *)(src + 16));
     xy_y_convolve_2tap_16_avx2(s[0], s[1], coeffs, r + 0);
-    s[0] = _mm256_load_si256((__m256i *)(src + 2 * 16));
+    s[0] = _mm256_loadu_si256((__m256i *)(src + 2 * 16));
     xy_y_convolve_2tap_16_avx2(s[1], s[0], coeffs, r + 2);
 }
 
 static INLINE void xy_y_convolve_2tap_32_avx2(const int16_t *const src, const __m256i s0[2],
                                               __m256i s1[2], const __m256i coeffs[1],
                                               __m256i r[4]) {
-    s1[0] = _mm256_load_si256((__m256i *)src);
-    s1[1] = _mm256_load_si256((__m256i *)(src + 16));
+    s1[0] = _mm256_loadu_si256((__m256i *)src);
+    s1[1] = _mm256_loadu_si256((__m256i *)(src + 16));
     xy_y_convolve_2tap_16_avx2(s0[0], s1[0], coeffs, r + 0);
     xy_y_convolve_2tap_16_avx2(s0[1], s1[1], coeffs, r + 2);
 }
@@ -1459,8 +1459,8 @@ static INLINE void xy_y_convolve_2tap_32_all_avx2(const int16_t *const src, cons
 static INLINE void xy_y_convolve_2tap_half_pel_32_avx2(const int16_t *const src,
                                                        const __m256i s0[2], __m256i s1[2],
                                                        __m256i r[2]) {
-    s1[0] = _mm256_load_si256((__m256i *)src);
-    s1[1] = _mm256_load_si256((__m256i *)(src + 16));
+    s1[0] = _mm256_loadu_si256((__m256i *)src);
+    s1[1] = _mm256_loadu_si256((__m256i *)(src + 16));
     r[0]  = _mm256_add_epi16(s0[0], s1[0]);
     r[1]  = _mm256_add_epi16(s0[1], s1[1]);
 }
@@ -1785,10 +1785,10 @@ static INLINE void xy_y_convolve_8tap_8x2_half_pel_avx2(const int16_t *const src
 SIMD_INLINE void xy_y_convolve_8tap_16x2_avx2(const int16_t *const src, const ptrdiff_t stride,
                                               const __m256i coeffs[4], __m256i s_256[8],
                                               __m256i ss_256[8], __m256i tt_256[8], __m256i r[4]) {
-    s_256[7]  = _mm256_load_si256((__m256i *)(src + 7 * stride));
+    s_256[7]  = _mm256_loadu_si256((__m256i *)(src + 7 * stride));
     ss_256[3] = _mm256_unpacklo_epi16(s_256[6], s_256[7]);
     ss_256[7] = _mm256_unpackhi_epi16(s_256[6], s_256[7]);
-    s_256[6]  = _mm256_load_si256((__m256i *)(src + 8 * stride));
+    s_256[6]  = _mm256_loadu_si256((__m256i *)(src + 8 * stride));
     tt_256[3] = _mm256_unpacklo_epi16(s_256[7], s_256[6]);
     tt_256[7] = _mm256_unpackhi_epi16(s_256[7], s_256[6]);
 
@@ -1815,7 +1815,7 @@ static INLINE void xy_y_convolve_8tap_16x2_half_pel_avx2(const int16_t *const sr
                                                          const __m256i coeffs[4], __m256i s_256[8],
                                                          __m256i r[4]) {
     __m256i a_256[4], ss_256[4];
-    s_256[7] = _mm256_load_si256((__m256i *)(src + 7 * stride));
+    s_256[7] = _mm256_loadu_si256((__m256i *)(src + 7 * stride));
 
     a_256[0]  = _mm256_add_epi16(s_256[0], s_256[7]);
     a_256[1]  = _mm256_add_epi16(s_256[1], s_256[6]);
@@ -1834,7 +1834,7 @@ static INLINE void xy_y_convolve_8tap_16x2_half_pel_avx2(const int16_t *const sr
     s_256[0] = s_256[2];
     s_256[2] = s_256[4];
     s_256[4] = s_256[6];
-    s_256[6] = _mm256_load_si256((__m256i *)(src + 8 * stride));
+    s_256[6] = _mm256_loadu_si256((__m256i *)(src + 8 * stride));
 
     a_256[0]  = _mm256_add_epi16(s_256[1], s_256[6]);
     s_256[1]  = s_256[3];

--- a/Source/Lib/Common/ASM_AVX2/highbd_convolve_2d_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/highbd_convolve_2d_avx2.c
@@ -92,7 +92,7 @@ void eb_av1_highbd_convolve_2d_sr_avx2(const uint16_t *src, int32_t src_stride, 
                 __m256i res_odd1  = _mm256_packs_epi32(res_odd, res_odd);
                 __m256i res       = _mm256_unpacklo_epi16(res_even1, res_odd1);
 
-                _mm256_store_si256((__m256i *)&im_block[i * im_stride], res);
+                _mm256_storeu_si256((__m256i *)&im_block[i * im_stride], res);
             }
         }
 

--- a/Source/Lib/Common/ASM_AVX2/highbd_jnt_convolve_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/highbd_jnt_convolve_avx2.c
@@ -299,7 +299,7 @@ void eb_av1_highbd_jnt_convolve_2d_avx2(const uint16_t *src, int32_t src_stride,
                 __m256i res_odd1  = _mm256_packs_epi32(res_odd, res_odd);
                 __m256i res       = _mm256_unpacklo_epi16(res_even1, res_odd1);
 
-                _mm256_store_si256((__m256i *)&im_block[i * im_stride], res);
+                _mm256_storeu_si256((__m256i *)&im_block[i * im_stride], res);
             }
         }
 

--- a/Source/Lib/Common/ASM_AVX2/jnt_convolve_2d_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/jnt_convolve_2d_avx2.c
@@ -139,9 +139,9 @@ static void jnt_convolve_2d_hor_6tap_avx2(const uint8_t *src, const int32_t src_
     int16_t *      im      = im_block;
     __m256i        coeffs_256[3], filt_256[3];
 
-    filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-    filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-    filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
+    filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+    filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+    filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
 
     prepare_half_coeffs_6tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
@@ -199,10 +199,10 @@ static void jnt_convolve_2d_hor_8tap_avx2(const uint8_t *src, const int32_t src_
     int16_t *      im      = im_block;
     __m256i        coeffs_256[4], filt_256[4];
 
-    filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-    filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-    filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
-    filt_256[3] = _mm256_load_si256((__m256i const *)filt4_global_avx);
+    filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+    filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+    filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
+    filt_256[3] = _mm256_loadu_si256((__m256i const *)filt4_global_avx);
 
     prepare_half_coeffs_8tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
@@ -415,7 +415,7 @@ static void jnt_convolve_2d_ver_2tap_avx2(const int16_t *const im_block, const i
         } else if (w == 16) {
             __m256i s_256[2], r[4];
 
-            s_256[0] = _mm256_load_si256((__m256i *)im);
+            s_256[0] = _mm256_loadu_si256((__m256i *)im);
 
             if (conv_params->do_average) {
                 if (conv_params->use_jnt_comp_avg) {
@@ -451,8 +451,8 @@ static void jnt_convolve_2d_ver_2tap_avx2(const int16_t *const im_block, const i
         } else if (w == 32) {
             __m256i s_256[2][2], r[4];
 
-            s_256[0][0] = _mm256_load_si256((__m256i *)(im + 0 * 16));
-            s_256[0][1] = _mm256_load_si256((__m256i *)(im + 1 * 16));
+            s_256[0][0] = _mm256_loadu_si256((__m256i *)(im + 0 * 16));
+            s_256[0][1] = _mm256_loadu_si256((__m256i *)(im + 1 * 16));
 
             if (conv_params->do_average) {
                 if (conv_params->use_jnt_comp_avg) {
@@ -506,10 +506,10 @@ static void jnt_convolve_2d_ver_2tap_avx2(const int16_t *const im_block, const i
         } else if (w == 64) {
             __m256i s_256[2][4];
 
-            s_256[0][0] = _mm256_load_si256((__m256i *)(im + 0 * 16));
-            s_256[0][1] = _mm256_load_si256((__m256i *)(im + 1 * 16));
-            s_256[0][2] = _mm256_load_si256((__m256i *)(im + 2 * 16));
-            s_256[0][3] = _mm256_load_si256((__m256i *)(im + 3 * 16));
+            s_256[0][0] = _mm256_loadu_si256((__m256i *)(im + 0 * 16));
+            s_256[0][1] = _mm256_loadu_si256((__m256i *)(im + 1 * 16));
+            s_256[0][2] = _mm256_loadu_si256((__m256i *)(im + 2 * 16));
+            s_256[0][3] = _mm256_loadu_si256((__m256i *)(im + 3 * 16));
 
             if (conv_params->do_average) {
                 if (conv_params->use_jnt_comp_avg) {
@@ -984,7 +984,7 @@ static void jnt_convolve_2d_ver_2tap_half_avx2(const int16_t *const im_block, co
         } else if (w == 16) {
             __m256i s_256[2], r[2];
 
-            s_256[0] = _mm256_load_si256((__m256i *)im);
+            s_256[0] = _mm256_loadu_si256((__m256i *)im);
 
             if (conv_params->do_average) {
                 if (conv_params->use_jnt_comp_avg) {
@@ -1021,8 +1021,8 @@ static void jnt_convolve_2d_ver_2tap_half_avx2(const int16_t *const im_block, co
         } else if (w == 32) {
             __m256i s_256[2][2], r[2];
 
-            s_256[0][0] = _mm256_load_si256((__m256i *)(im + 0 * 16));
-            s_256[0][1] = _mm256_load_si256((__m256i *)(im + 1 * 16));
+            s_256[0][0] = _mm256_loadu_si256((__m256i *)(im + 0 * 16));
+            s_256[0][1] = _mm256_loadu_si256((__m256i *)(im + 1 * 16));
 
             if (conv_params->do_average) {
                 if (conv_params->use_jnt_comp_avg) {
@@ -1075,10 +1075,10 @@ static void jnt_convolve_2d_ver_2tap_half_avx2(const int16_t *const im_block, co
         } else if (w == 64) {
             __m256i s_256[2][4];
 
-            s_256[0][0] = _mm256_load_si256((__m256i *)(im + 0 * 16));
-            s_256[0][1] = _mm256_load_si256((__m256i *)(im + 1 * 16));
-            s_256[0][2] = _mm256_load_si256((__m256i *)(im + 2 * 16));
-            s_256[0][3] = _mm256_load_si256((__m256i *)(im + 3 * 16));
+            s_256[0][0] = _mm256_loadu_si256((__m256i *)(im + 0 * 16));
+            s_256[0][1] = _mm256_loadu_si256((__m256i *)(im + 1 * 16));
+            s_256[0][2] = _mm256_loadu_si256((__m256i *)(im + 2 * 16));
+            s_256[0][3] = _mm256_loadu_si256((__m256i *)(im + 3 * 16));
 
             if (conv_params->do_average) {
                 if (conv_params->use_jnt_comp_avg) {

--- a/Source/Lib/Common/ASM_AVX2/jnt_convolve_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/jnt_convolve_avx2.c
@@ -3508,9 +3508,9 @@ static void jnt_convolve_x_6tap_avx2(const uint8_t *const src, const int32_t src
     int32_t        y            = h;
     __m256i        coeffs_256[3], filt_256[3];
 
-    filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-    filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-    filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
+    filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+    filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+    filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
 
     prepare_half_coeffs_6tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
@@ -3759,10 +3759,10 @@ static void jnt_convolve_x_8tap_avx2(const uint8_t *const src, const int32_t src
     int32_t        y            = h;
     __m256i        coeffs_256[4], filt_256[4];
 
-    filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-    filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-    filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
-    filt_256[3] = _mm256_load_si256((__m256i const *)filt4_global_avx);
+    filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+    filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+    filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
+    filt_256[3] = _mm256_loadu_si256((__m256i const *)filt4_global_avx);
 
     prepare_half_coeffs_8tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 

--- a/Source/Lib/Common/ASM_AVX2/selfguided_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/selfguided_avx2.c
@@ -42,14 +42,14 @@ static INLINE void add_32bit_8x8(const __m256i neighbor, __m256i r[8]) {
 
 static INLINE void store_32bit_8x8(const __m256i r[8], int32_t *const buf,
                                    const int32_t buf_stride) {
-    _mm256_store_si256((__m256i *)(buf + 0 * buf_stride), r[0]);
-    _mm256_store_si256((__m256i *)(buf + 1 * buf_stride), r[1]);
-    _mm256_store_si256((__m256i *)(buf + 2 * buf_stride), r[2]);
-    _mm256_store_si256((__m256i *)(buf + 3 * buf_stride), r[3]);
-    _mm256_store_si256((__m256i *)(buf + 4 * buf_stride), r[4]);
-    _mm256_store_si256((__m256i *)(buf + 5 * buf_stride), r[5]);
-    _mm256_store_si256((__m256i *)(buf + 6 * buf_stride), r[6]);
-    _mm256_store_si256((__m256i *)(buf + 7 * buf_stride), r[7]);
+    _mm256_storeu_si256((__m256i *)(buf + 0 * buf_stride), r[0]);
+    _mm256_storeu_si256((__m256i *)(buf + 1 * buf_stride), r[1]);
+    _mm256_storeu_si256((__m256i *)(buf + 2 * buf_stride), r[2]);
+    _mm256_storeu_si256((__m256i *)(buf + 3 * buf_stride), r[3]);
+    _mm256_storeu_si256((__m256i *)(buf + 4 * buf_stride), r[4]);
+    _mm256_storeu_si256((__m256i *)(buf + 5 * buf_stride), r[5]);
+    _mm256_storeu_si256((__m256i *)(buf + 6 * buf_stride), r[6]);
+    _mm256_storeu_si256((__m256i *)(buf + 7 * buf_stride), r[7]);
 }
 
 static AOM_FORCE_INLINE void integral_images(const uint8_t *src, int32_t src_stride, int32_t width,
@@ -109,7 +109,7 @@ static AOM_FORCE_INLINE void integral_images(const uint8_t *src, int32_t src_str
 
             transpose_32bit_8x8_avx2(r32, r32);
 
-            const __m256i d_top = _mm256_load_si256((__m256i *)(dt - buf_stride + x));
+            const __m256i d_top = _mm256_loadu_si256((__m256i *)(dt - buf_stride + x));
             add_32bit_8x8(d_top, r32);
             store_32bit_8x8(r32, dt + x, buf_stride);
 
@@ -128,7 +128,7 @@ static AOM_FORCE_INLINE void integral_images(const uint8_t *src, int32_t src_str
 
             transpose_32bit_8x8_avx2(r32, r32);
 
-            const __m256i c_top = _mm256_load_si256((__m256i *)(ct - buf_stride + x));
+            const __m256i c_top = _mm256_loadu_si256((__m256i *)(ct - buf_stride + x));
             add_32bit_8x8(c_top, r32);
             store_32bit_8x8(r32, ct + x, buf_stride);
             x += 8;
@@ -136,8 +136,8 @@ static AOM_FORCE_INLINE void integral_images(const uint8_t *src, int32_t src_str
 
         /* Used in calc_ab and calc_ab_fast, when calc out of right border */
         for (int ln = 0; ln < 8; ++ln) {
-            _mm256_store_si256((__m256i *)(ct + x + ln * buf_stride), zero);
-            _mm256_store_si256((__m256i *)(dt + x + ln * buf_stride), zero);
+            _mm256_storeu_si256((__m256i *)(ct + x + ln * buf_stride), zero);
+            _mm256_storeu_si256((__m256i *)(dt + x + ln * buf_stride), zero);
         }
 
         src_t += 8 * src_stride;
@@ -205,7 +205,7 @@ static AOM_FORCE_INLINE void integral_images_highbd(const uint16_t *src, int32_t
 
             transpose_32bit_8x8_avx2(a32, a32);
 
-            const __m256i c_top = _mm256_load_si256((__m256i *)(ct - buf_stride + x));
+            const __m256i c_top = _mm256_loadu_si256((__m256i *)(ct - buf_stride + x));
             add_32bit_8x8(c_top, a32);
             store_32bit_8x8(a32, ct + x, buf_stride);
 
@@ -214,7 +214,7 @@ static AOM_FORCE_INLINE void integral_images_highbd(const uint16_t *src, int32_t
 
             transpose_32bit_8x8_avx2(r32, r32);
 
-            const __m256i d_top = _mm256_load_si256((__m256i *)(dt - buf_stride + x));
+            const __m256i d_top = _mm256_loadu_si256((__m256i *)(dt - buf_stride + x));
             add_32bit_8x8(d_top, r32);
             store_32bit_8x8(r32, dt + x, buf_stride);
             x += 8;
@@ -222,8 +222,8 @@ static AOM_FORCE_INLINE void integral_images_highbd(const uint16_t *src, int32_t
 
         /* Used in calc_ab and calc_ab_fast, when calc out of right border */
         for (int ln = 0; ln < 8; ++ln) {
-            _mm256_store_si256((__m256i *)(ct + x + ln * buf_stride), zero);
-            _mm256_store_si256((__m256i *)(dt + x + ln * buf_stride), zero);
+            _mm256_storeu_si256((__m256i *)(ct + x + ln * buf_stride), zero);
+            _mm256_storeu_si256((__m256i *)(dt + x + ln * buf_stride), zero);
         }
 
         src_t += 8 * src_stride;

--- a/Source/Lib/Common/ASM_AVX2/synonyms_avx2.h
+++ b/Source/Lib/Common/ASM_AVX2/synonyms_avx2.h
@@ -28,7 +28,7 @@ static INLINE __m256i yy_load_256(const void *const a) {
 #ifdef EB_TEST_SIMD_ALIGN
     if ((intptr_t)a % 32) SVT_LOG("\n yy_load_256() NOT 32-byte aligned!!!\n");
 #endif
-    return _mm256_load_si256((const __m256i *)a);
+    return _mm256_loadu_si256((const __m256i *)a);
 }
 
 static INLINE __m256i yy_loadu_256(const void *const a) {
@@ -39,7 +39,7 @@ static INLINE void yy_store_256(void *const a, const __m256i v) {
 #ifdef EB_TEST_SIMD_ALIGN
     if ((intptr_t)a % 32) SVT_LOG("\n yy_store_256() NOT 32-byte aligned!!!\n");
 #endif
-    _mm256_store_si256((__m256i *)a, v);
+    _mm256_storeu_si256((__m256i *)a, v);
 }
 
 static INLINE void yy_storeu_256(void *const a, const __m256i v) {

--- a/Source/Lib/Common/ASM_AVX2/txfm_common_avx2.h
+++ b/Source/Lib/Common/ASM_AVX2/txfm_common_avx2.h
@@ -85,7 +85,7 @@ static INLINE void btf_32_add_sub_out_avx2(__m256i *out0, __m256i *out1, __m256i
 }
 
 static INLINE __m256i load_16bit_to_16bit_avx2(const int16_t *a) {
-    return _mm256_load_si256((const __m256i *)a);
+    return _mm256_loadu_si256((const __m256i *)a);
 }
 
 static INLINE void load_buffer_16bit_to_16bit_avx2(const int16_t *in, int stride, __m256i *out,
@@ -275,7 +275,7 @@ static INLINE void store_rect_16bit_to_32bit_w8_avx2(const __m256i a, int32_t *c
     const __m256i temp = _mm256_permute2f128_si256(b_lo, b_hi, 0x31);
     _mm_storeu_si128((__m128i *)b, _mm256_castsi256_si128(b_lo));
     _mm_storeu_si128((__m128i *)(b + 4), _mm256_castsi256_si128(b_hi));
-    _mm256_store_si256((__m256i *)(b + 64), temp);
+    _mm256_storeu_si256((__m256i *)(b + 64), temp);
 }
 
 static INLINE void store_rect_buffer_16bit_to_32bit_w8_avx2(const __m256i *const in,

--- a/Source/Lib/Common/ASM_AVX2/warp_plane_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/warp_plane_avx2.c
@@ -360,10 +360,10 @@ static INLINE void prepare_horizontal_filter_coeff_alpha0_avx2(int beta, int sx,
 
     const __m256i res_0 = _mm256_inserti128_si256(_mm256_castsi128_si256(tmp_0), tmp_1, 0x1);
 
-    coeff[0] = _mm256_shuffle_epi8(res_0, _mm256_load_si256((__m256i *)shuffle_alpha0_mask01_avx2));
-    coeff[1] = _mm256_shuffle_epi8(res_0, _mm256_load_si256((__m256i *)shuffle_alpha0_mask23_avx2));
-    coeff[2] = _mm256_shuffle_epi8(res_0, _mm256_load_si256((__m256i *)shuffle_alpha0_mask45_avx2));
-    coeff[3] = _mm256_shuffle_epi8(res_0, _mm256_load_si256((__m256i *)shuffle_alpha0_mask67_avx2));
+    coeff[0] = _mm256_shuffle_epi8(res_0, _mm256_loadu_si256((__m256i *)shuffle_alpha0_mask01_avx2));
+    coeff[1] = _mm256_shuffle_epi8(res_0, _mm256_loadu_si256((__m256i *)shuffle_alpha0_mask23_avx2));
+    coeff[2] = _mm256_shuffle_epi8(res_0, _mm256_loadu_si256((__m256i *)shuffle_alpha0_mask45_avx2));
+    coeff[3] = _mm256_shuffle_epi8(res_0, _mm256_loadu_si256((__m256i *)shuffle_alpha0_mask67_avx2));
 }
 
 static INLINE void horizontal_filter_avx2(const __m256i src, __m256i *horz_out, int sx, int alpha,
@@ -662,10 +662,10 @@ static INLINE void prepare_vertical_filter_coeffs_gamma0_avx2(int delta, int sy,
 
     __m256i res_0 = _mm256_inserti128_si256(_mm256_castsi128_si256(filt_0), filt_1, 0x1);
 
-    coeffs[0] = _mm256_shuffle_epi8(res_0, _mm256_load_si256((__m256i *)shuffle_gamma0_mask0_avx2));
-    coeffs[1] = _mm256_shuffle_epi8(res_0, _mm256_load_si256((__m256i *)shuffle_gamma0_mask1_avx2));
-    coeffs[2] = _mm256_shuffle_epi8(res_0, _mm256_load_si256((__m256i *)shuffle_gamma0_mask2_avx2));
-    coeffs[3] = _mm256_shuffle_epi8(res_0, _mm256_load_si256((__m256i *)shuffle_gamma0_mask3_avx2));
+    coeffs[0] = _mm256_shuffle_epi8(res_0, _mm256_loadu_si256((__m256i *)shuffle_gamma0_mask0_avx2));
+    coeffs[1] = _mm256_shuffle_epi8(res_0, _mm256_loadu_si256((__m256i *)shuffle_gamma0_mask1_avx2));
+    coeffs[2] = _mm256_shuffle_epi8(res_0, _mm256_loadu_si256((__m256i *)shuffle_gamma0_mask2_avx2));
+    coeffs[3] = _mm256_shuffle_epi8(res_0, _mm256_loadu_si256((__m256i *)shuffle_gamma0_mask3_avx2));
 
     coeffs[4] = coeffs[0];
     coeffs[5] = coeffs[1];
@@ -1216,10 +1216,10 @@ void eb_av1_warp_affine_avx2(const int32_t *mat, const uint8_t *ref, int width, 
     const int16_t const5 = (1 << (FILTER_BITS - reduce_bits_horiz));
 
     __m256i shuffle_src[4];
-    shuffle_src[0] = _mm256_load_si256((__m256i *)shuffle_src0);
-    shuffle_src[1] = _mm256_load_si256((__m256i *)shuffle_src1);
-    shuffle_src[2] = _mm256_load_si256((__m256i *)shuffle_src2);
-    shuffle_src[3] = _mm256_load_si256((__m256i *)shuffle_src3);
+    shuffle_src[0] = _mm256_loadu_si256((__m256i *)shuffle_src0);
+    shuffle_src[1] = _mm256_loadu_si256((__m256i *)shuffle_src1);
+    shuffle_src[2] = _mm256_loadu_si256((__m256i *)shuffle_src2);
+    shuffle_src[3] = _mm256_loadu_si256((__m256i *)shuffle_src3);
 
     for (i = 0; i < p_height; i += 8) {
         for (j = 0; j < p_width; j += 8) {

--- a/Source/Lib/Common/ASM_AVX512/convolve_2d_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/convolve_2d_avx512.c
@@ -113,9 +113,9 @@ static void convolve_2d_sr_hor_6tap_avx512(const uint8_t *const src, const int32
     if (w <= 16) {
         __m256i coeffs_256[3], filt_256[3];
 
-        filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-        filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-        filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
+        filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+        filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+        filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
         prepare_half_coeffs_6tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
         if (w == 8) {
@@ -185,10 +185,10 @@ static void convolve_2d_sr_hor_8tap_avx512(const uint8_t *const src, const int32
     if (w <= 16) {
         __m256i coeffs_256[4], filt_256[4];
 
-        filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-        filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-        filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
-        filt_256[3] = _mm256_load_si256((__m256i const *)filt4_global_avx);
+        filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+        filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+        filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
+        filt_256[3] = _mm256_loadu_si256((__m256i const *)filt4_global_avx);
 
         prepare_half_coeffs_8tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
@@ -315,7 +315,7 @@ static void convolve_2d_sr_ver_2tap_avx512(const int16_t *const im_block, const 
 
             assert(w == 16);
 
-            s_256[0] = _mm256_load_si256((__m256i *)im);
+            s_256[0] = _mm256_loadu_si256((__m256i *)im);
 
             do {
                 xy_y_convolve_2tap_16x2_avx2(im, s_256, &coeffs_256, r);
@@ -433,7 +433,7 @@ static void convolve_2d_sr_ver_2tap_half_avx512(const int16_t *const im_block, c
     } else if (w == 16) {
         __m256i s_256[2], r[2];
 
-        s_256[0] = _mm256_load_si256((__m256i *)im);
+        s_256[0] = _mm256_loadu_si256((__m256i *)im);
 
         do {
             xy_y_convolve_2tap_16x2_half_pel_avx2(im, s_256, r);

--- a/Source/Lib/Common/ASM_AVX512/convolve_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/convolve_avx512.c
@@ -1301,9 +1301,9 @@ void eb_av1_convolve_x_sr_avx512(const uint8_t *src, int32_t src_stride, uint8_t
 
                 prepare_half_coeffs_6tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
-                filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-                filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-                filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
+                filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+                filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+                filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
 
                 if (w == 8) {
                     do {
@@ -1370,10 +1370,10 @@ void eb_av1_convolve_x_sr_avx512(const uint8_t *src, int32_t src_stride, uint8_t
 
                 prepare_half_coeffs_8tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
-                filt_256[3] = _mm256_load_si256((__m256i const *)filt4_global_avx);
-                filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-                filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-                filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
+                filt_256[3] = _mm256_loadu_si256((__m256i const *)filt4_global_avx);
+                filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+                filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+                filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
 
                 if (w == 8) {
                     do {

--- a/Source/Lib/Common/ASM_AVX512/jnt_convolve_2d_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/jnt_convolve_2d_avx512.c
@@ -332,9 +332,9 @@ static void jnt_convolve_2d_hor_6tap_avx512(const uint8_t *src, const int32_t sr
     if (w <= 16) {
         __m256i coeffs_256[3], filt_256[3];
 
-        filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-        filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-        filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
+        filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+        filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+        filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
 
         prepare_half_coeffs_6tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
@@ -405,10 +405,10 @@ static void jnt_convolve_2d_hor_8tap_avx512(const uint8_t *src, const int32_t sr
     if (w <= 16) {
         __m256i coeffs_256[4], filt_256[4];
 
-        filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-        filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-        filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
-        filt_256[3] = _mm256_load_si256((__m256i const *)filt4_global_avx);
+        filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+        filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+        filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
+        filt_256[3] = _mm256_loadu_si256((__m256i const *)filt4_global_avx);
 
         prepare_half_coeffs_8tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
@@ -636,7 +636,7 @@ static void jnt_convolve_2d_ver_2tap_avx512(const int16_t *const im_block, const
 
             assert(w == 16);
 
-            s_256[0] = _mm256_load_si256((__m256i *)im);
+            s_256[0] = _mm256_loadu_si256((__m256i *)im);
 
             if (conv_params->do_average) {
                 if (conv_params->use_jnt_comp_avg) {
@@ -1077,7 +1077,7 @@ static void jnt_convolve_2d_ver_2tap_half_avx512(const int16_t *const im_block, 
 
             assert(w == 16);
 
-            s_256[0] = _mm256_load_si256((__m256i *)im);
+            s_256[0] = _mm256_loadu_si256((__m256i *)im);
 
             if (conv_params->do_average) {
                 if (conv_params->use_jnt_comp_avg) {

--- a/Source/Lib/Common/ASM_AVX512/jnt_convolve_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/jnt_convolve_avx512.c
@@ -3363,9 +3363,9 @@ static void jnt_convolve_x_6tap_avx512(const uint8_t *const src, const int32_t s
                 const __m256i offset_comp_avg_256 = _mm256_set1_epi32(offset_comp_avg);
                 __m256i       coeffs_256[3], filt_256[3];
 
-                filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-                filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-                filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
+                filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+                filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+                filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
                 prepare_half_coeffs_6tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
                 if (w == 8) {
@@ -3476,9 +3476,9 @@ static void jnt_convolve_x_6tap_avx512(const uint8_t *const src, const int32_t s
                 const __m256i offset_avg_256 = _mm256_set1_epi16(offset_avg);
                 __m256i       coeffs_256[3], filt_256[3];
 
-                filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-                filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-                filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
+                filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+                filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+                filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
                 prepare_half_coeffs_6tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
                 if (w == 8) {
@@ -3571,9 +3571,9 @@ static void jnt_convolve_x_6tap_avx512(const uint8_t *const src, const int32_t s
             const __m256i offset_no_avg_256 = _mm256_set1_epi16(offset_no_avg);
             __m256i       coeffs_256[3], filt_256[3];
 
-            filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-            filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-            filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
+            filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+            filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+            filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
             prepare_half_coeffs_6tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
             if (w == 8) {
@@ -3678,10 +3678,10 @@ static void jnt_convolve_x_8tap_avx512(const uint8_t *const src, const int32_t s
             if (w <= 16) {
                 __m256i coeffs_256[4], filt_256[4];
 
-                filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-                filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-                filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
-                filt_256[3] = _mm256_load_si256((__m256i const *)filt4_global_avx);
+                filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+                filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+                filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
+                filt_256[3] = _mm256_loadu_si256((__m256i const *)filt4_global_avx);
                 prepare_half_coeffs_8tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
                 if (w == 8) {
@@ -3792,10 +3792,10 @@ static void jnt_convolve_x_8tap_avx512(const uint8_t *const src, const int32_t s
             if (w <= 16) {
                 __m256i coeffs_256[4], filt_256[4];
 
-                filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-                filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-                filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
-                filt_256[3] = _mm256_load_si256((__m256i const *)filt4_global_avx);
+                filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+                filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+                filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
+                filt_256[3] = _mm256_loadu_si256((__m256i const *)filt4_global_avx);
                 prepare_half_coeffs_8tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
                 if (w == 8) {
@@ -3889,10 +3889,10 @@ static void jnt_convolve_x_8tap_avx512(const uint8_t *const src, const int32_t s
         if (w <= 16) {
             __m256i coeffs_256[4], filt_256[4];
 
-            filt_256[0] = _mm256_load_si256((__m256i const *)filt1_global_avx);
-            filt_256[1] = _mm256_load_si256((__m256i const *)filt2_global_avx);
-            filt_256[2] = _mm256_load_si256((__m256i const *)filt3_global_avx);
-            filt_256[3] = _mm256_load_si256((__m256i const *)filt4_global_avx);
+            filt_256[0] = _mm256_loadu_si256((__m256i const *)filt1_global_avx);
+            filt_256[1] = _mm256_loadu_si256((__m256i const *)filt2_global_avx);
+            filt_256[2] = _mm256_loadu_si256((__m256i const *)filt3_global_avx);
+            filt_256[3] = _mm256_loadu_si256((__m256i const *)filt4_global_avx);
             prepare_half_coeffs_8tap_avx2(filter_params_x, subpel_x_q4, coeffs_256);
 
             if (w == 8) {

--- a/Source/Lib/Encoder/ASM_AVX2/EbTransforms_Intrinsic_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbTransforms_Intrinsic_AVX2.c
@@ -10,7 +10,7 @@
 
 static INLINE void energy_computation_kernel_avx2(const int32_t *const in, __m256i *const sum256) {
     const __m256i zero      = _mm256_setzero_si256();
-    const __m256i input     = _mm256_load_si256((__m256i *)in);
+    const __m256i input     = _mm256_loadu_si256((__m256i *)in);
     const __m256i in_lo     = _mm256_unpacklo_epi32(input, zero);
     const __m256i in_hi     = _mm256_unpackhi_epi32(input, zero);
     const __m256i energy_lo = _mm256_mul_epi32(in_lo, in_lo);
@@ -63,17 +63,17 @@ static INLINE void clean_256_bytes_avx2(int32_t *buf, const uint32_t height) {
     uint32_t      h    = height;
 
     do {
-        _mm256_store_si256((__m256i *)(buf + 0 * 8), zero);
-        _mm256_store_si256((__m256i *)(buf + 1 * 8), zero);
-        _mm256_store_si256((__m256i *)(buf + 2 * 8), zero);
-        _mm256_store_si256((__m256i *)(buf + 3 * 8), zero);
+        _mm256_storeu_si256((__m256i *)(buf + 0 * 8), zero);
+        _mm256_storeu_si256((__m256i *)(buf + 1 * 8), zero);
+        _mm256_storeu_si256((__m256i *)(buf + 2 * 8), zero);
+        _mm256_storeu_si256((__m256i *)(buf + 3 * 8), zero);
         buf += 64;
     } while (--h);
 }
 
 static INLINE void copy_32_bytes_avx2(const int32_t *src, int32_t *dst) {
-    const __m256i val = _mm256_load_si256((__m256i *)(src + 0 * 8));
-    _mm256_store_si256((__m256i *)(dst + 0 * 8), val);
+    const __m256i val = _mm256_loadu_si256((__m256i *)(src + 0 * 8));
+    _mm256_storeu_si256((__m256i *)(dst + 0 * 8), val);
 }
 
 static INLINE void copy_256x_bytes_avx2(const int32_t *src, int32_t *dst, const uint32_t height) {

--- a/Source/Lib/Encoder/ASM_AVX2/fft_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/fft_avx2.c
@@ -18,11 +18,11 @@ extern void eb_aom_transpose_float_sse2(const float *A, float *b, int32_t n);
 extern void eb_aom_fft_unpack_2d_output_sse2(const float *col_fft, float *output, int32_t n);
 
 // Generate the 1d forward transforms for float using _mm256
-GEN_FFT_8(static INLINE void, avx2, float, __m256, _mm256_load_ps, _mm256_store_ps, _mm256_set1_ps,
+GEN_FFT_8(static INLINE void, avx2, float, __m256, _mm256_loadu_ps, _mm256_storeu_ps, _mm256_set1_ps,
           _mm256_add_ps, _mm256_sub_ps, _mm256_mul_ps);
-GEN_FFT_16(static INLINE void, avx2, float, __m256, _mm256_load_ps, _mm256_store_ps, _mm256_set1_ps,
+GEN_FFT_16(static INLINE void, avx2, float, __m256, _mm256_loadu_ps, _mm256_storeu_ps, _mm256_set1_ps,
            _mm256_add_ps, _mm256_sub_ps, _mm256_mul_ps);
-GEN_FFT_32(static INLINE void, avx2, float, __m256, _mm256_load_ps, _mm256_store_ps, _mm256_set1_ps,
+GEN_FFT_32(static INLINE void, avx2, float, __m256, _mm256_loadu_ps, _mm256_storeu_ps, _mm256_set1_ps,
            _mm256_add_ps, _mm256_sub_ps, _mm256_mul_ps);
 
 void eb_aom_fft8x8_float_avx2(const float *input, float *temp, float *output) {
@@ -59,11 +59,11 @@ void eb_aom_fft32x32_float_avx2(const float *input, float *temp, float *output) 
 }
 
 // Generate the 1d inverse transforms for float using _mm256
-GEN_IFFT_8(static INLINE void, avx2, float, __m256, _mm256_load_ps, _mm256_store_ps, _mm256_set1_ps,
+GEN_IFFT_8(static INLINE void, avx2, float, __m256, _mm256_loadu_ps, _mm256_storeu_ps, _mm256_set1_ps,
            _mm256_add_ps, _mm256_sub_ps, _mm256_mul_ps);
-GEN_IFFT_16(static INLINE void, avx2, float, __m256, _mm256_load_ps, _mm256_store_ps,
+GEN_IFFT_16(static INLINE void, avx2, float, __m256, _mm256_loadu_ps, _mm256_storeu_ps,
             _mm256_set1_ps, _mm256_add_ps, _mm256_sub_ps, _mm256_mul_ps);
-GEN_IFFT_32(static INLINE void, avx2, float, __m256, _mm256_load_ps, _mm256_store_ps,
+GEN_IFFT_32(static INLINE void, avx2, float, __m256, _mm256_loadu_ps, _mm256_storeu_ps,
             _mm256_set1_ps, _mm256_add_ps, _mm256_sub_ps, _mm256_mul_ps);
 
 void eb_aom_ifft8x8_float_avx2(const float *input, float *temp, float *output) {

--- a/Source/Lib/Encoder/ASM_AVX2/highbd_fwd_txfm_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/highbd_fwd_txfm_avx2.c
@@ -1011,10 +1011,10 @@ static void fidtx16x16_avx2(const __m256i *in, __m256i *out, int8_t bit, int32_t
 static INLINE void write_buffer_16x16(const __m256i *res, int32_t *output) {
     int32_t fact = -1, index = -1;
     for (int32_t i = 0; i < 8; i++) {
-        _mm256_store_si256((__m256i *)(output + (++fact) * 16), res[++index]);
-        _mm256_store_si256((__m256i *)(output + (fact)*16 + 8), res[++index]);
-        _mm256_store_si256((__m256i *)(output + (++fact) * 16), res[++index]);
-        _mm256_store_si256((__m256i *)(output + (fact)*16 + 8), res[++index]);
+        _mm256_storeu_si256((__m256i *)(output + (++fact) * 16), res[++index]);
+        _mm256_storeu_si256((__m256i *)(output + (fact)*16 + 8), res[++index]);
+        _mm256_storeu_si256((__m256i *)(output + (++fact) * 16), res[++index]);
+        _mm256_storeu_si256((__m256i *)(output + (fact)*16 + 8), res[++index]);
     }
 }
 

--- a/Source/Lib/Encoder/ASM_AVX2/pickrst_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/pickrst_avx2.c
@@ -119,7 +119,7 @@ static INLINE uint16_t find_average_highbd_avx2(const uint16_t *src, int32_t h_s
             } while (--i);
         } else {
             const int32_t w16  = width - leftover;
-            const __m256i mask = _mm256_load_si256((__m256i *)(mask_16bit[leftover]));
+            const __m256i mask = _mm256_loadu_si256((__m256i *)(mask_16bit[leftover]));
 
             do {
                 __m256i ss = _mm256_setzero_si256();
@@ -167,7 +167,7 @@ static INLINE uint16_t find_average_highbd_avx2(const uint16_t *src, int32_t h_s
             } while (--i);
         } else {
             const int32_t w16  = width - leftover;
-            const __m256i mask = _mm256_load_si256((__m256i *)(mask_16bit[leftover]));
+            const __m256i mask = _mm256_loadu_si256((__m256i *)(mask_16bit[leftover]));
 
             do {
                 __m256i ss = _mm256_setzero_si256();
@@ -218,7 +218,7 @@ static INLINE void sub_avg_block_avx2(const uint8_t *src, const int32_t src_stri
             const __m128i s  = _mm_loadu_si128((__m128i *)(src + j));
             const __m256i ss = _mm256_cvtepu8_epi16(s);
             const __m256i d  = _mm256_sub_epi16(ss, a);
-            _mm256_store_si256((__m256i *)(dst + j), d);
+            _mm256_storeu_si256((__m256i *)(dst + j), d);
             j += 16;
         } while (j < width);
 
@@ -241,7 +241,7 @@ static INLINE void sub_avg_block_highbd_avx2(const uint16_t *src, const int32_t 
         do {
             const __m256i s = _mm256_loadu_si256((__m256i *)(src + j));
             const __m256i d = _mm256_sub_epi16(s, a);
-            _mm256_store_si256((__m256i *)(dst + j), d);
+            _mm256_storeu_si256((__m256i *)(dst + j), d);
             j += 16;
         } while (j < width);
 
@@ -326,8 +326,8 @@ static INLINE void stats_left_win3_avx2(const __m256i src, const int16_t *d, con
                                         __m256i sum[WIENER_WIN_3TAP - 1]) {
     __m256i dgds[WIENER_WIN_3TAP - 1];
 
-    dgds[0] = _mm256_load_si256((__m256i *)(d + 1 * d_stride));
-    dgds[1] = _mm256_load_si256((__m256i *)(d + 2 * d_stride));
+    dgds[0] = _mm256_loadu_si256((__m256i *)(d + 1 * d_stride));
+    dgds[1] = _mm256_loadu_si256((__m256i *)(d + 2 * d_stride));
 
     madd_avx2(src, dgds[0], &sum[0]);
     madd_avx2(src, dgds[1], &sum[1]);
@@ -337,10 +337,10 @@ static INLINE void stats_left_win5_avx2(const __m256i src, const int16_t *d, con
                                         __m256i sum[WIENER_WIN_CHROMA - 1]) {
     __m256i dgds[WIENER_WIN_CHROMA - 1];
 
-    dgds[0] = _mm256_load_si256((__m256i *)(d + 1 * d_stride));
-    dgds[1] = _mm256_load_si256((__m256i *)(d + 2 * d_stride));
-    dgds[2] = _mm256_load_si256((__m256i *)(d + 3 * d_stride));
-    dgds[3] = _mm256_load_si256((__m256i *)(d + 4 * d_stride));
+    dgds[0] = _mm256_loadu_si256((__m256i *)(d + 1 * d_stride));
+    dgds[1] = _mm256_loadu_si256((__m256i *)(d + 2 * d_stride));
+    dgds[2] = _mm256_loadu_si256((__m256i *)(d + 3 * d_stride));
+    dgds[3] = _mm256_loadu_si256((__m256i *)(d + 4 * d_stride));
 
     madd_avx2(src, dgds[0], &sum[0]);
     madd_avx2(src, dgds[1], &sum[1]);
@@ -352,12 +352,12 @@ static INLINE void stats_left_win7_avx2(const __m256i src, const int16_t *d, con
                                         __m256i sum[WIENER_WIN - 1]) {
     __m256i dgds[WIENER_WIN - 1];
 
-    dgds[0] = _mm256_load_si256((__m256i *)(d + 1 * d_stride));
-    dgds[1] = _mm256_load_si256((__m256i *)(d + 2 * d_stride));
-    dgds[2] = _mm256_load_si256((__m256i *)(d + 3 * d_stride));
-    dgds[3] = _mm256_load_si256((__m256i *)(d + 4 * d_stride));
-    dgds[4] = _mm256_load_si256((__m256i *)(d + 5 * d_stride));
-    dgds[5] = _mm256_load_si256((__m256i *)(d + 6 * d_stride));
+    dgds[0] = _mm256_loadu_si256((__m256i *)(d + 1 * d_stride));
+    dgds[1] = _mm256_loadu_si256((__m256i *)(d + 2 * d_stride));
+    dgds[2] = _mm256_loadu_si256((__m256i *)(d + 3 * d_stride));
+    dgds[3] = _mm256_loadu_si256((__m256i *)(d + 4 * d_stride));
+    dgds[4] = _mm256_loadu_si256((__m256i *)(d + 5 * d_stride));
+    dgds[5] = _mm256_loadu_si256((__m256i *)(d + 6 * d_stride));
 
     madd_avx2(src, dgds[0], &sum[0]);
     madd_avx2(src, dgds[1], &sum[1]);
@@ -882,7 +882,7 @@ static INLINE void compute_stats_win3_avx2(const int16_t *const d, const int32_t
     const int32_t w16         = width & ~15;
     const int32_t h4          = height & ~3;
     const int32_t h8          = height & ~7;
-    const __m256i mask        = _mm256_load_si256((__m256i *)(mask_16bit[width - w16]));
+    const __m256i mask        = _mm256_loadu_si256((__m256i *)(mask_16bit[width - w16]));
     int32_t       i, j, x, y;
 
     if (bit_depth == AOM_BITS_8) {
@@ -899,15 +899,15 @@ static INLINE void compute_stats_win3_avx2(const int16_t *const d, const int32_t
             do {
                 x = 0;
                 do {
-                    const __m256i src = _mm256_load_si256((__m256i *)(s_t + x));
-                    const __m256i dgd = _mm256_load_si256((__m256i *)(d_t + x));
+                    const __m256i src = _mm256_loadu_si256((__m256i *)(s_t + x));
+                    const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + x));
                     stats_top_win3_avx2(src, dgd, d_t + j + x, d_stride, sum_m, sum_h);
                     x += 16;
                 } while (x < w16);
 
                 if (w16 != width) {
-                    const __m256i src      = _mm256_load_si256((__m256i *)(s_t + w16));
-                    const __m256i dgd      = _mm256_load_si256((__m256i *)(d_t + w16));
+                    const __m256i src      = _mm256_loadu_si256((__m256i *)(s_t + w16));
+                    const __m256i dgd      = _mm256_loadu_si256((__m256i *)(d_t + w16));
                     const __m256i src_mask = _mm256_and_si256(src, mask);
                     const __m256i dgd_mask = _mm256_and_si256(dgd, mask);
                     stats_top_win3_avx2(src_mask, dgd_mask, d_t + j + w16, d_stride, sum_m, sum_h);
@@ -979,15 +979,15 @@ static INLINE void compute_stats_win3_avx2(const int16_t *const d, const int32_t
                 do {
                     x = 0;
                     do {
-                        const __m256i src = _mm256_load_si256((__m256i *)(s_t + x));
-                        const __m256i dgd = _mm256_load_si256((__m256i *)(d_t + x));
+                        const __m256i src = _mm256_loadu_si256((__m256i *)(s_t + x));
+                        const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + x));
                         stats_top_win3_avx2(src, dgd, d_t + j + x, d_stride, row_m, row_h);
                         x += 16;
                     } while (x < w16);
 
                     if (w16 != width) {
-                        const __m256i src      = _mm256_load_si256((__m256i *)(s_t + w16));
-                        const __m256i dgd      = _mm256_load_si256((__m256i *)(d_t + w16));
+                        const __m256i src      = _mm256_loadu_si256((__m256i *)(s_t + w16));
+                        const __m256i dgd      = _mm256_loadu_si256((__m256i *)(d_t + w16));
                         const __m256i src_mask = _mm256_and_si256(src, mask);
                         const __m256i dgd_mask = _mm256_and_si256(dgd, mask);
                         stats_top_win3_avx2(
@@ -1466,7 +1466,7 @@ static INLINE void compute_stats_win5_avx2(const int16_t *const d, const int32_t
     const int32_t wiener_win2 = wiener_win * wiener_win;
     const int32_t w16         = width & ~15;
     const int32_t h8          = height & ~7;
-    const __m256i mask        = _mm256_load_si256((__m256i *)(mask_16bit[width - w16]));
+    const __m256i mask        = _mm256_loadu_si256((__m256i *)(mask_16bit[width - w16]));
     int32_t       i, j, x, y;
 
     if (bit_depth == AOM_BITS_8) {
@@ -1483,15 +1483,15 @@ static INLINE void compute_stats_win5_avx2(const int16_t *const d, const int32_t
             do {
                 x = 0;
                 do {
-                    const __m256i src = _mm256_load_si256((__m256i *)(s_t + x));
-                    const __m256i dgd = _mm256_load_si256((__m256i *)(d_t + x));
+                    const __m256i src = _mm256_loadu_si256((__m256i *)(s_t + x));
+                    const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + x));
                     stats_top_win5_avx2(src, dgd, d_t + j + x, d_stride, sum_m, sum_h);
                     x += 16;
                 } while (x < w16);
 
                 if (w16 != width) {
-                    const __m256i src      = _mm256_load_si256((__m256i *)(s_t + w16));
-                    const __m256i dgd      = _mm256_load_si256((__m256i *)(d_t + w16));
+                    const __m256i src      = _mm256_loadu_si256((__m256i *)(s_t + w16));
+                    const __m256i dgd      = _mm256_loadu_si256((__m256i *)(d_t + w16));
                     const __m256i src_mask = _mm256_and_si256(src, mask);
                     const __m256i dgd_mask = _mm256_and_si256(dgd, mask);
                     stats_top_win5_avx2(src_mask, dgd_mask, d_t + j + w16, d_stride, sum_m, sum_h);
@@ -1569,15 +1569,15 @@ static INLINE void compute_stats_win5_avx2(const int16_t *const d, const int32_t
                 do {
                     x = 0;
                     do {
-                        const __m256i src = _mm256_load_si256((__m256i *)(s_t + x));
-                        const __m256i dgd = _mm256_load_si256((__m256i *)(d_t + x));
+                        const __m256i src = _mm256_loadu_si256((__m256i *)(s_t + x));
+                        const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + x));
                         stats_top_win5_avx2(src, dgd, d_t + j + x, d_stride, row_m, row_h);
                         x += 16;
                     } while (x < w16);
 
                     if (w16 != width) {
-                        const __m256i src      = _mm256_load_si256((__m256i *)(s_t + w16));
-                        const __m256i dgd      = _mm256_load_si256((__m256i *)(d_t + w16));
+                        const __m256i src      = _mm256_loadu_si256((__m256i *)(s_t + w16));
+                        const __m256i dgd      = _mm256_loadu_si256((__m256i *)(d_t + w16));
                         const __m256i src_mask = _mm256_and_si256(src, mask);
                         const __m256i dgd_mask = _mm256_and_si256(dgd, mask);
                         stats_top_win5_avx2(
@@ -2189,7 +2189,7 @@ static INLINE void compute_stats_win7_avx2(const int16_t *const d, const int32_t
     const int32_t wiener_win2 = wiener_win * wiener_win;
     const int32_t w16         = width & ~15;
     const int32_t h8          = height & ~7;
-    const __m256i mask        = _mm256_load_si256((__m256i *)(mask_16bit[width - w16]));
+    const __m256i mask        = _mm256_loadu_si256((__m256i *)(mask_16bit[width - w16]));
     int32_t       i, j, x, y;
 
     if (bit_depth == AOM_BITS_8) {
@@ -2206,15 +2206,15 @@ static INLINE void compute_stats_win7_avx2(const int16_t *const d, const int32_t
             do {
                 x = 0;
                 do {
-                    const __m256i src = _mm256_load_si256((__m256i *)(s_t + x));
-                    const __m256i dgd = _mm256_load_si256((__m256i *)(d_t + x));
+                    const __m256i src = _mm256_loadu_si256((__m256i *)(s_t + x));
+                    const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + x));
                     stats_top_win7_avx2(src, dgd, d_t + j + x, d_stride, sum_m, sum_h);
                     x += 16;
                 } while (x < w16);
 
                 if (w16 != width) {
-                    const __m256i src      = _mm256_load_si256((__m256i *)(s_t + w16));
-                    const __m256i dgd      = _mm256_load_si256((__m256i *)(d_t + w16));
+                    const __m256i src      = _mm256_loadu_si256((__m256i *)(s_t + w16));
+                    const __m256i dgd      = _mm256_loadu_si256((__m256i *)(d_t + w16));
                     const __m256i src_mask = _mm256_and_si256(src, mask);
                     const __m256i dgd_mask = _mm256_and_si256(dgd, mask);
                     stats_top_win7_avx2(src_mask, dgd_mask, d_t + j + w16, d_stride, sum_m, sum_h);
@@ -2301,15 +2301,15 @@ static INLINE void compute_stats_win7_avx2(const int16_t *const d, const int32_t
                 do {
                     x = 0;
                     do {
-                        const __m256i src = _mm256_load_si256((__m256i *)(s_t + x));
-                        const __m256i dgd = _mm256_load_si256((__m256i *)(d_t + x));
+                        const __m256i src = _mm256_loadu_si256((__m256i *)(s_t + x));
+                        const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + x));
                         stats_top_win7_avx2(src, dgd, d_t + j + x, d_stride, row_m, row_h);
                         x += 16;
                     } while (x < w16);
 
                     if (w16 != width) {
-                        const __m256i src      = _mm256_load_si256((__m256i *)(s_t + w16));
-                        const __m256i dgd      = _mm256_load_si256((__m256i *)(d_t + w16));
+                        const __m256i src      = _mm256_loadu_si256((__m256i *)(s_t + w16));
+                        const __m256i dgd      = _mm256_loadu_si256((__m256i *)(d_t + w16));
                         const __m256i src_mask = _mm256_and_si256(src, mask);
                         const __m256i dgd_mask = _mm256_and_si256(dgd, mask);
                         stats_top_win7_avx2(

--- a/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
@@ -3965,7 +3965,7 @@ void get_eight_horizontal_search_point_results_8x8_16x16_pu_avx512_intrin(
     s3       = _mm_adds_epu16(sumsad01, sumsad23);
 
     //sotore the 8 SADs(16x8 SADs)
-    _mm_store_si128((__m128i *)p_sad16x16, s3);
+    _mm_storeu_si128((__m128i *)p_sad16x16, s3);
     //find the best for 16x16
     s3 = _mm_minpos_epu16(s3);
 

--- a/Source/Lib/Encoder/ASM_AVX512/highbd_fwd_txfm_AVX512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/highbd_fwd_txfm_AVX512.c
@@ -1388,7 +1388,7 @@ static INLINE void load_buffer_32x32_avx512(const int16_t *input, __m512i *outpu
 
     for (i = 0; i < 32; ++i) {
         temp[0] = _mm256_loadu_si256((const __m256i *)(input + 0 * 16));
-        temp[1] = _mm256_load_si256((const __m256i *)(input + 1 * 16));
+        temp[1] = _mm256_loadu_si256((const __m256i *)(input + 1 * 16));
 
         output[0] = _mm512_cvtepi16_epi32(temp[0]);
         output[1] = _mm512_cvtepi16_epi32(temp[1]);

--- a/Source/Lib/Encoder/ASM_AVX512/pickrst_avx512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/pickrst_avx512.c
@@ -107,10 +107,10 @@ static INLINE __m512i mask16_avx512(const int32_t leftover) {
 
     if (leftover >= 16) {
         mask_l = _mm256_set1_epi8(-1);
-        mask_h = _mm256_load_si256((__m256i *)(mask_16bit[leftover - 16]));
+        mask_h = _mm256_loadu_si256((__m256i *)(mask_16bit[leftover - 16]));
     } else {
         mask_h = _mm256_setzero_si256();
-        mask_l = _mm256_load_si256((__m256i *)(mask_16bit[leftover]));
+        mask_l = _mm256_loadu_si256((__m256i *)(mask_16bit[leftover]));
     }
 
     return _mm512_inserti64x4(_mm512_castsi256_si512(mask_l), mask_h, 1);

--- a/Source/Lib/Encoder/ASM_SSE2/fft_sse2.c
+++ b/Source/Lib/Encoder/ASM_SSE2/fft_sse2.c
@@ -15,15 +15,15 @@ s * PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 #include "fft_common.h"
 
 static INLINE void transpose4x4(const float *A, float *b, const int32_t lda, const int32_t ldb) {
-    __m128 row1 = _mm_load_ps(&A[0 * lda]);
-    __m128 row2 = _mm_load_ps(&A[1 * lda]);
-    __m128 row3 = _mm_load_ps(&A[2 * lda]);
-    __m128 row4 = _mm_load_ps(&A[3 * lda]);
+    __m128 row1 = _mm_loadu_ps(&A[0 * lda]);
+    __m128 row2 = _mm_loadu_ps(&A[1 * lda]);
+    __m128 row3 = _mm_loadu_ps(&A[2 * lda]);
+    __m128 row4 = _mm_loadu_ps(&A[3 * lda]);
     _MM_TRANSPOSE4_PS(row1, row2, row3, row4);
-    _mm_store_ps(&b[0 * ldb], row1);
-    _mm_store_ps(&b[1 * ldb], row2);
-    _mm_store_ps(&b[2 * ldb], row3);
-    _mm_store_ps(&b[3 * ldb], row4);
+    _mm_storeu_ps(&b[0 * ldb], row1);
+    _mm_storeu_ps(&b[1 * ldb], row2);
+    _mm_storeu_ps(&b[2 * ldb], row3);
+    _mm_storeu_ps(&b[3 * ldb], row4);
 }
 
 void eb_aom_transpose_float_sse2(const float *A, float *b, int32_t n) {
@@ -62,14 +62,14 @@ void eb_aom_fft_unpack_2d_output_sse2(const float *packed, float *output, int32_
         }
 
         for (int32_t c = 4; c < n2; c += 4) {
-            __m128 real1 = _mm_load_ps(packed + r * n + c);
-            __m128 real2 = _mm_load_ps(packed + (r + n2) * n + c + n2);
-            __m128 imag1 = _mm_load_ps(packed + (r + n2) * n + c);
-            __m128 imag2 = _mm_load_ps(packed + r * n + c + n2);
+            __m128 real1 = _mm_loadu_ps(packed + r * n + c);
+            __m128 real2 = _mm_loadu_ps(packed + (r + n2) * n + c + n2);
+            __m128 imag1 = _mm_loadu_ps(packed + (r + n2) * n + c);
+            __m128 imag2 = _mm_loadu_ps(packed + r * n + c + n2);
             real1        = _mm_sub_ps(real1, real2);
             imag1        = _mm_add_ps(imag1, imag2);
-            _mm_store_ps(output + 2 * (r * n + c), _mm_unpacklo_ps(real1, imag1));
-            _mm_store_ps(output + 2 * (r * n + c + 2), _mm_unpackhi_ps(real1, imag1));
+            _mm_storeu_ps(output + 2 * (r * n + c), _mm_unpacklo_ps(real1, imag1));
+            _mm_storeu_ps(output + 2 * (r * n + c + 2), _mm_unpackhi_ps(real1, imag1));
         }
 
         int32_t r2                    = r + n2;
@@ -83,20 +83,20 @@ void eb_aom_fft_unpack_2d_output_sse2(const float *packed, float *output, int32_
             output[2 * (r2 * n + c) + 1] = -packed[(r3 + n2) * n + c] + packed[r3 * n + c + n2];
         }
         for (int32_t c = 4; c < n2; c += 4) {
-            __m128 real1 = _mm_load_ps(packed + r3 * n + c);
-            __m128 real2 = _mm_load_ps(packed + (r3 + n2) * n + c + n2);
-            __m128 imag1 = _mm_load_ps(packed + (r3 + n2) * n + c);
-            __m128 imag2 = _mm_load_ps(packed + r3 * n + c + n2);
+            __m128 real1 = _mm_loadu_ps(packed + r3 * n + c);
+            __m128 real2 = _mm_loadu_ps(packed + (r3 + n2) * n + c + n2);
+            __m128 imag1 = _mm_loadu_ps(packed + (r3 + n2) * n + c);
+            __m128 imag2 = _mm_loadu_ps(packed + r3 * n + c + n2);
             real1        = _mm_add_ps(real1, real2);
             imag1        = _mm_sub_ps(imag2, imag1);
-            _mm_store_ps(output + 2 * (r2 * n + c), _mm_unpacklo_ps(real1, imag1));
-            _mm_store_ps(output + 2 * (r2 * n + c + 2), _mm_unpackhi_ps(real1, imag1));
+            _mm_storeu_ps(output + 2 * (r2 * n + c), _mm_unpacklo_ps(real1, imag1));
+            _mm_storeu_ps(output + 2 * (r2 * n + c + 2), _mm_unpackhi_ps(real1, imag1));
         }
     }
 }
 
 // Generate definitions for 1d transforms using float and __mm128
-GEN_FFT_4(static INLINE void, sse2, float, __m128, _mm_load_ps, _mm_store_ps, _mm_set1_ps,
+GEN_FFT_4(static INLINE void, sse2, float, __m128, _mm_loadu_ps, _mm_storeu_ps, _mm_set1_ps,
           _mm_add_ps, _mm_sub_ps);
 
 void eb_aom_fft4x4_float_sse2(const float *input, float *temp, float *output) {
@@ -111,7 +111,7 @@ void eb_aom_fft4x4_float_sse2(const float *input, float *temp, float *output) {
 }
 
 // Generate definitions for 1d inverse transforms using float and mm128
-GEN_IFFT_4(static INLINE void, sse2, float, __m128, _mm_load_ps, _mm_store_ps, _mm_set1_ps,
+GEN_IFFT_4(static INLINE void, sse2, float, __m128, _mm_loadu_ps, _mm_storeu_ps, _mm_set1_ps,
            _mm_add_ps, _mm_sub_ps);
 
 void eb_aom_ifft4x4_float_sse2(const float *input, float *temp, float *output) {


### PR DESCRIPTION
this is a follow up for https://github.com/OpenVisualCloud/SVT-AV1/pull/853

following assembly code changed:
_mm_load_ps,
_mm_store_ps,
_mm256_load_si256,
_mm256_store_si256,
_mm256_load_ps,
_mm256_store_ps,

enc-mode 8 and 4 are tested, no obvious fps drop.