### PR TITLE
Bug fixes in decoder related to segment id, delta lf, film grain, etc

### DIFF
--- a/Source/App/DecApp/EbDecAppMain.c
+++ b/Source/App/DecApp/EbDecAppMain.c
@@ -22,31 +22,29 @@
 #endif
 
 int init_pic_buffer(EbSvtIOFormat *pic_buffer, CliInput *cli, EbSvtAv1DecConfiguration *config) {
+    /* FilmGrain module req. even dim. for internal operation */
+    pic_buffer->y_stride = cli->width & 1 ? cli->width + 1 : cli->width;
     switch (cli->fmt) {
     case EB_YUV400:
         pic_buffer->cb_stride = INT32_MAX;
         pic_buffer->cr_stride = INT32_MAX;
-        pic_buffer->y_stride  = cli->width;
         break;
     case EB_YUV420:
         pic_buffer->cb_stride = cli->width / 2;
         pic_buffer->cr_stride = cli->width / 2;
-        pic_buffer->y_stride  = cli->width;
         break;
     case EB_YUV422:
         pic_buffer->cb_stride = cli->width / 2;
         pic_buffer->cr_stride = cli->width / 2;
-        pic_buffer->y_stride  = cli->width;
         break;
     case EB_YUV444:
         pic_buffer->cb_stride = cli->width;
         pic_buffer->cr_stride = cli->width;
-        pic_buffer->y_stride  = cli->width;
         break;
     default: fprintf(stderr, "Unsupported colour format. \n"); return 0;
     }
     pic_buffer->width     = cli->width;
-    pic_buffer->height    = cli->width;
+    pic_buffer->height    = cli->height;
     pic_buffer->luma_ext  = NULL;
     pic_buffer->cb_ext    = NULL;
     pic_buffer->cr_ext    = NULL;
@@ -194,8 +192,11 @@ int32_t main(int32_t argc, char *argv[]) {
         recon_buffer                     = (EbBufferHeaderType *)malloc(sizeof(EbBufferHeaderType));
         recon_buffer->p_buffer           = (uint8_t *)malloc(sizeof(EbSvtIOFormat));
 
+        /* FilmGrain module req. even dim. for internal operation */
+        int w = (cli.width & 1) ? (cli.width + 1) : cli.width;
+        int h = (cli.height & 1) ? (cli.height + 1) : cli.height;
         int size = (config_ptr->max_bit_depth == EB_EIGHT_BIT) ? sizeof(uint8_t) : sizeof(uint16_t);
-        size     = size * cli.height * cli.width;
+        size     = size * w * h;
 
         ((EbSvtIOFormat *)recon_buffer->p_buffer)->luma = (uint8_t *)malloc(size);
         ((EbSvtIOFormat *)recon_buffer->p_buffer)->cb   = (uint8_t *)malloc(size >> 2);

--- a/Source/Lib/Common/Codec/Av1Common.h
+++ b/Source/Lib/Common/Codec/Av1Common.h
@@ -42,6 +42,7 @@ typedef struct Av1Common {
     int32_t      mi_rows;
     int32_t      mi_cols;
     int32_t      ref_frame_sign_bias[REF_FRAMES]; /* Two state 0, 1 */
+    uint8_t *    last_frame_seg_map;
     InterpFilter interp_filter;
     int32_t      mi_stride;
 

--- a/Source/Lib/Common/Codec/EbAv1Structs.h
+++ b/Source/Lib/Common/Codec/EbAv1Structs.h
@@ -310,6 +310,8 @@ typedef struct QuantizationParams {
     /*!< Specifies the level in the quantizer matrix that should be used for
      * each plane decoding */
     uint8_t qm[MAX_MB_PLANE];
+    /*!< qindex for every segment ID */
+    uint8_t qindex[MAX_SEGMENTS];
 } QuantizationParams;
 typedef struct DeltaQParams {
     /*!< Specifies whether quantizer index delta values are present */
@@ -459,9 +461,6 @@ typedef struct FrameHeader {
     /*!< Specifies the expected output order hint for each reference frame */
     uint32_t ref_order_hint[REF_FRAMES];
 
-    /*!< Specifies the expected output order for each reference frame */
-    uint32_t order_hints[REF_FRAMES];
-
     /*!< 1: Indicates that intra block copy may be used in this frame.
      *   0: Indicates that intra block copy is not allowed in this frame */
     uint8_t allow_intrabc;
@@ -475,6 +474,9 @@ typedef struct FrameHeader {
      *  0: Signifies that the corresponding reference picture slot is not valid
      *     for use as a reference picture*/
     uint32_t ref_valid[REF_FRAMES];
+
+    /*!< Specifies the frame id for each reference frame */
+    uint32_t ref_frame_id[REF_FRAMES];
 
     /*!< Frame Size structure */
     FrameSize frame_size;

--- a/Source/Lib/Decoder/Codec/EbDecBitstream.c
+++ b/Source/Lib/Decoder/Codec/EbDecBitstream.c
@@ -35,6 +35,7 @@ void dec_bits_init(Bitstrm *bs, const uint8_t *data, size_t numbytes) {
 Bitstream offset and consumes the bits. Section: 4.10.2 -> f(n) */
 uint32_t dec_get_bits(Bitstrm *bs, uint32_t numbits) {
     uint32_t bits_read;
+    if (0 == numbits) return 0;
     GET_BITS(bits_read, bs->buf, bs->bit_ofst, bs->cur_word, bs->nxt_word, numbits);
     return bits_read;
 }

--- a/Source/Lib/Decoder/Codec/EbDecHandle.h
+++ b/Source/Lib/Decoder/Codec/EbDecHandle.h
@@ -85,6 +85,10 @@ typedef struct EbDecPicBuf {
     /* film grain */
     AomFilmGrain film_grain_params;
 
+    // Inter frame reference frame delta for loop filter
+    int8_t ref_deltas[REF_FRAMES];
+    // 0 = ZERO_MV, MV
+    int8_t mode_deltas[MAX_MODE_LF_DELTAS];
 } EbDecPicBuf;
 
 /* Frame level buffers */
@@ -221,6 +225,8 @@ typedef struct EbDecHandle {
     // Prepare ref_frame_map for the next frame.
     EbDecPicBuf *next_ref_frame_map[REF_FRAMES];
 
+    /* For Reference frame loading process */
+    EbDecPicBuf *prev_frame;
     /* TODO: Move to buffer pool. */
     EbDecPicBuf *cur_pic_buf[DEC_MAX_NUM_FRM_PRLL];
 

--- a/Source/Lib/Decoder/Codec/EbDecMemInit.c
+++ b/Source/Lib/Decoder/Codec/EbDecMemInit.c
@@ -60,28 +60,30 @@ EbErrorType dec_eb_recon_picture_buffer_desc_ctor(
     picture_buffer_desc_ptr->color_format = picture_buffer_desc_init_data_ptr->color_format;
     picture_buffer_desc_ptr->stride_y = picture_buffer_desc_init_data_ptr->max_width +
         picture_buffer_desc_init_data_ptr->left_padding + picture_buffer_desc_init_data_ptr->right_padding;
-    if(picture_buffer_desc_ptr->color_format == EB_YUV420 ||
-       picture_buffer_desc_ptr->color_format == EB_YUV422)
-        picture_buffer_desc_ptr->stride_cb = picture_buffer_desc_ptr->stride_cr
-            = picture_buffer_desc_ptr->stride_y >> 1;
-    else if (picture_buffer_desc_ptr->color_format == EB_YUV444)
-        picture_buffer_desc_ptr->stride_cb = picture_buffer_desc_ptr->stride_cr
-            = picture_buffer_desc_ptr->stride_y;
+    uint32_t height_y = (picture_buffer_desc_init_data_ptr->max_height + picture_buffer_desc_init_data_ptr->top_padding
+        + picture_buffer_desc_init_data_ptr->bot_padding);
+
     picture_buffer_desc_ptr->origin_x = picture_buffer_desc_init_data_ptr->left_padding;
     picture_buffer_desc_ptr->origin_y = picture_buffer_desc_init_data_ptr->top_padding;
     picture_buffer_desc_ptr->origin_bot_y = picture_buffer_desc_init_data_ptr->bot_padding;
 
-    picture_buffer_desc_ptr->luma_size = (picture_buffer_desc_init_data_ptr->max_width +
-        picture_buffer_desc_init_data_ptr->left_padding + picture_buffer_desc_init_data_ptr->right_padding) *
-        (picture_buffer_desc_init_data_ptr->max_height + picture_buffer_desc_init_data_ptr->top_padding
-            + picture_buffer_desc_init_data_ptr->bot_padding);
+    picture_buffer_desc_ptr->luma_size = (picture_buffer_desc_ptr->stride_y) * height_y;
 
-    if (picture_buffer_desc_ptr->color_format == EB_YUV420) // 420
-        picture_buffer_desc_ptr->chroma_size = picture_buffer_desc_ptr->luma_size >> 2;
-    else if (picture_buffer_desc_ptr->color_format == EB_YUV422) // 422
-        picture_buffer_desc_ptr->chroma_size = picture_buffer_desc_ptr->luma_size >> 1;
-    else if (picture_buffer_desc_ptr->color_format == EB_YUV444) // 444
-        picture_buffer_desc_ptr->chroma_size = picture_buffer_desc_ptr->luma_size;
+    uint32_t stride_c = 0, height_c = 0;
+    if (picture_buffer_desc_ptr->color_format == EB_YUV420) {// 420
+        stride_c = (picture_buffer_desc_ptr->stride_y + 1) >> 1;
+        height_c = (height_y + 1) >> 1;
+    }
+    else if (picture_buffer_desc_ptr->color_format == EB_YUV422) {// 422
+        stride_c = (picture_buffer_desc_ptr->stride_y + 1) >> 1;
+        height_c = height_y;
+    }
+    else if (picture_buffer_desc_ptr->color_format == EB_YUV444) {// 444
+        stride_c = picture_buffer_desc_ptr->stride_y;
+        height_c = height_y;
+    }
+    picture_buffer_desc_ptr->stride_cb = picture_buffer_desc_ptr->stride_cr = stride_c;
+    picture_buffer_desc_ptr->chroma_size = (stride_c * height_c);
 
     picture_buffer_desc_ptr->packed_flag = EB_FALSE;
 

--- a/Source/Lib/Decoder/Codec/EbDecParseInterBlock.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseInterBlock.c
@@ -17,7 +17,7 @@
 #include "EbDecParseInterBlock.h"
 #include "EbCommonUtils.h"
 #include "EbWarpedMotion.h"
-
+#include "EbLog.h"
 
 typedef const int (*ColorCost)[PALETTE_SIZES][PALETTE_COLOR_INDEX_CONTEXTS][PALETTE_COLORS];
 typedef AomCdfProb (*MapCdf)[PALETTE_SIZES][PALETTE_COLOR_INDEX_CONTEXTS];

--- a/Source/Lib/Decoder/Codec/EbDecPicMgr.h
+++ b/Source/Lib/Decoder/Codec/EbDecPicMgr.h
@@ -42,6 +42,8 @@ void         svt_setup_frame_buf_refs(EbDecHandle *dec_handle_ptr);
 
 ScaleFactors *get_ref_scale_factors(EbDecHandle *dec_handle_ptr, const MvReferenceFrame ref_frame);
 
+EbDecPicBuf *get_primary_ref_frame_buf(EbDecHandle *dec_handle_ptr);
+
 void svt_set_frame_refs(EbDecHandle *dec_handle_ptr, int32_t lst_map_idx, int32_t gld_map_idx);
 
 #ifdef __cplusplus

--- a/Source/Lib/Decoder/Codec/EbDecProcess.c
+++ b/Source/Lib/Decoder/Codec/EbDecProcess.c
@@ -1324,7 +1324,8 @@ void dec_av1_loop_restoration_filter_frame_mt(
     eb_release_mutex(dec_mt_frame_data->temp_mutex);
 
     volatile uint32_t *num_threads_lred = &dec_mt_frame_data->num_threads_lred;
-    while (*num_threads_lred != dec_handle->dec_config.threads);
+    while (*num_threads_lred != dec_handle->dec_config.threads &&
+            EB_FALSE == dec_mt_frame_data->end_flag);
 }
 
 void *dec_all_stage_kernel(void *input_ptr) {
@@ -1403,4 +1404,8 @@ void dec_sync_all_threads(EbDecHandle *dec_handle_ptr) {
 
     while (dec_mt_frame_data->num_threads_exited != dec_handle_ptr->dec_config.threads - 1)
         eb_sleep_ms(5);
+
+    /*Destroying lib created thread's*/
+    EB_DESTROY_THREAD_ARRAY(dec_handle_ptr->decode_thread_handle_array,
+                            dec_handle_ptr->dec_config.threads - 1);
 }

--- a/Source/Lib/Decoder/Codec/EbDecRestoration.c
+++ b/Source/Lib/Decoder/Codec/EbDecRestoration.c
@@ -243,8 +243,10 @@ void eb_dec_av1_loop_restoration_filter_unit(uint8_t need_bounadaries,
            restoration unit */
         const int32_t nominal_stripe_height =
             full_stripe_height - ((tile_stripe == 0) ? runit_offset : 0);
+        /*In wiener filter leaf level function assumes always h to be multiple of 2.
+          we can see assert related to h in this function->eb_av1_wiener_convolve_add_src_avx2*/
         const int32_t h = AOMMIN(nominal_stripe_height,
-            remaining_stripes.v_end - remaining_stripes.v_start);
+            ((remaining_stripes.v_end - remaining_stripes.v_start) + 1) & ~1);
 
         if (need_bounadaries)
             setup_processing_stripe_boundary(&remaining_stripes,


### PR DESCRIPTION
Following are the changes:
1. Bug Fixes related to film_grain: chroma_scaling_from_luma, odd resolution supprt
2. Fixes related to Storing of qindex for each segment id & segment_id from prev frame
3. Bug Fixes related to parsing of DeltaFrameIdLength & delta_lf
4. LF bug_fixes related to odd resolution & lossless mode
5. MT bug fix related to a hang at the end
6. Bug fix related to early exit in Motion field projection 
7. Super_res bug fixes related to smaller frame dim.( less than 16)
