### PR TITLE
Bug fixes in decoder related to segment id, delta lf, film grain, etc

### DIFF
--- a/Source/App/DecApp/EbDecAppMain.c
+++ b/Source/App/DecApp/EbDecAppMain.c
@@ -22,31 +22,29 @@
 #endif
 
 int init_pic_buffer(EbSvtIOFormat *pic_buffer, CliInput *cli, EbSvtAv1DecConfiguration *config) {
+    /* FilmGrain module req. even dim. for internal operation */
+    pic_buffer->y_stride = cli->width & 1 ? cli->width + 1 : cli->width;
     switch (cli->fmt) {
     case EB_YUV400:
         pic_buffer->cb_stride = INT32_MAX;
         pic_buffer->cr_stride = INT32_MAX;
-        pic_buffer->y_stride  = cli->width;
         break;
     case EB_YUV420:
         pic_buffer->cb_stride = cli->width / 2;
         pic_buffer->cr_stride = cli->width / 2;
-        pic_buffer->y_stride  = cli->width;
         break;
     case EB_YUV422:
         pic_buffer->cb_stride = cli->width / 2;
         pic_buffer->cr_stride = cli->width / 2;
-        pic_buffer->y_stride  = cli->width;
         break;
     case EB_YUV444:
         pic_buffer->cb_stride = cli->width;
         pic_buffer->cr_stride = cli->width;
-        pic_buffer->y_stride  = cli->width;
         break;
     default: fprintf(stderr, "Unsupported colour format. \n"); return 0;
     }
     pic_buffer->width     = cli->width;
-    pic_buffer->height    = cli->width;
+    pic_buffer->height    = cli->height;
     pic_buffer->luma_ext  = NULL;
     pic_buffer->cb_ext    = NULL;
     pic_buffer->cr_ext    = NULL;
@@ -194,8 +192,11 @@ int32_t main(int32_t argc, char *argv[]) {
         recon_buffer                     = (EbBufferHeaderType *)malloc(sizeof(EbBufferHeaderType));
         recon_buffer->p_buffer           = (uint8_t *)malloc(sizeof(EbSvtIOFormat));
 
+        /* FilmGrain module req. even dim. for internal operation */
+        int w = (cli.width & 1) ? (cli.width + 1) : cli.width;
+        int h = (cli.height & 1) ? (cli.height + 1) : cli.height;
         int size = (config_ptr->max_bit_depth == EB_EIGHT_BIT) ? sizeof(uint8_t) : sizeof(uint16_t);
-        size     = size * cli.height * cli.width;
+        size     = size * w * h;
 
         ((EbSvtIOFormat *)recon_buffer->p_buffer)->luma = (uint8_t *)malloc(size);
         ((EbSvtIOFormat *)recon_buffer->p_buffer)->cb   = (uint8_t *)malloc(size >> 2);

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -1026,6 +1026,20 @@ static void write_ivf_stream_header(EbConfig *config) {
 
     return;
 }
+static void update_prev_ivf_header(EbConfig *config) {
+    char header[4]; // only for the number of bytes
+    if (config && config->bitstream_file && config->byte_count_since_ivf != 0) {
+        fseeko(config->bitstream_file,
+               (-(int32_t)(config->byte_count_since_ivf + IVF_FRAME_HEADER_SIZE)),
+               SEEK_CUR);
+        mem_put_le32(&header[0], (int32_t)(config->byte_count_since_ivf));
+        fwrite(header, 1, 4, config->bitstream_file);
+        fseeko(config->bitstream_file,
+               (config->byte_count_since_ivf + IVF_FRAME_HEADER_SIZE - 4),
+               SEEK_CUR);
+        config->byte_count_since_ivf = 0;
+    }
+}
 
 static void write_ivf_frame_header(EbConfig *config, uint32_t byte_count) {
     char    header[IVF_FRAME_HEADER_SIZE];
@@ -1141,6 +1155,10 @@ AppExitConditionType process_output_stream_buffer(EbConfig *config, EbAppContext
             return APP_ExitConditionError;
         } else if (stream_status != EB_NoErrorEmptyQueue) {
             is_alt_ref        = (header_ptr->flags & EB_BUFFERFLAG_IS_ALT_REF);
+            EbBool  has_tiles = (EbBool)(app_call_back->eb_enc_parameters.tile_columns ||
+                                        app_call_back->eb_enc_parameters.tile_rows);
+            uint8_t obu_frame_header_size =
+                has_tiles ? OBU_FRAME_HEADER_SIZE + 1 : OBU_FRAME_HEADER_SIZE;
             if (!(header_ptr->flags & EB_BUFFERFLAG_IS_ALT_REF))
                 ++(config->performance_context.frame_count);
             *total_latency += (uint64_t)header_ptr->n_tick_count;
@@ -1169,10 +1187,78 @@ AppExitConditionType process_output_stream_buffer(EbConfig *config, EbAppContext
                     !(header_ptr->flags & EB_BUFFERFLAG_IS_ALT_REF)) {
                     write_ivf_stream_header(config);
                 }
-                write_ivf_frame_header(config, header_ptr->n_filled_len);
-                fwrite(header_ptr->p_buffer, 1, header_ptr->n_filled_len, stream_file);
-            }
 
+                switch (
+                    header_ptr->flags &
+                    0x00000006) { // Check for the flags EB_BUFFERFLAG_HAS_TD and EB_BUFFERFLAG_SHOW_EXT
+                case (EB_BUFFERFLAG_HAS_TD | EB_BUFFERFLAG_SHOW_EXT):
+
+                    // terminate previous ivf packet, update the combined size of packets sent
+                    update_prev_ivf_header(config);
+
+                    // Write a new IVF frame header to file as a TD is in the packet
+                    write_ivf_frame_header(
+                        config, header_ptr->n_filled_len - (obu_frame_header_size + TD_SIZE));
+                    fwrite(header_ptr->p_buffer,
+                           1,
+                           header_ptr->n_filled_len - (obu_frame_header_size + TD_SIZE),
+                           stream_file);
+
+                    // An EB_BUFFERFLAG_SHOW_EXT means that another TD has been added to the packet to show another frame, a new IVF is needed
+                    write_ivf_frame_header(config, (obu_frame_header_size + TD_SIZE));
+                    fwrite(header_ptr->p_buffer + header_ptr->n_filled_len -
+                               (obu_frame_header_size + TD_SIZE),
+                           1,
+                           (obu_frame_header_size + TD_SIZE),
+                           stream_file);
+
+                    break;
+
+                case (EB_BUFFERFLAG_HAS_TD):
+
+                    // terminate previous ivf packet, update the combined size of packets sent
+                    update_prev_ivf_header(config);
+
+                    // Write a new IVF frame header to file as a TD is in the packet
+                    write_ivf_frame_header(config, header_ptr->n_filled_len);
+                    fwrite(header_ptr->p_buffer, 1, header_ptr->n_filled_len, stream_file);
+
+                    break;
+
+                case (EB_BUFFERFLAG_SHOW_EXT):
+
+                    // this case means that there's only one TD in this packet and is relater
+                    fwrite(header_ptr->p_buffer,
+                           1,
+                           header_ptr->n_filled_len - (obu_frame_header_size + TD_SIZE),
+                           stream_file);
+                    // this packet will be part of the previous IVF header
+                    config->byte_count_since_ivf +=
+                        (header_ptr->n_filled_len - (obu_frame_header_size + TD_SIZE));
+
+                    // terminate previous ivf packet, update the combined size of packets sent
+                    update_prev_ivf_header(config);
+
+                    // An EB_BUFFERFLAG_SHOW_EXT means that another TD has been added to the packet to show another frame, a new IVF is needed
+                    write_ivf_frame_header(config, (obu_frame_header_size + TD_SIZE));
+                    fwrite(header_ptr->p_buffer + header_ptr->n_filled_len -
+                               (obu_frame_header_size + TD_SIZE),
+                           1,
+                           (obu_frame_header_size + TD_SIZE),
+                           stream_file);
+
+                    break;
+
+                default:
+
+                    // This is a packet without a TD, write it straight to file
+                    fwrite(header_ptr->p_buffer, 1, header_ptr->n_filled_len, stream_file);
+
+                    // this packet will be part of the previous IVF header
+                    config->byte_count_since_ivf += (header_ptr->n_filled_len);
+                    break;
+                }
+            }
             config->performance_context.byte_count += header_ptr->n_filled_len;
 
             if (config->stat_report && !(header_ptr->flags & EB_BUFFERFLAG_IS_ALT_REF))

--- a/Source/Lib/Common/Codec/Av1Common.h
+++ b/Source/Lib/Common/Codec/Av1Common.h
@@ -42,6 +42,7 @@ typedef struct Av1Common {
     int32_t      mi_rows;
     int32_t      mi_cols;
     int32_t      ref_frame_sign_bias[REF_FRAMES]; /* Two state 0, 1 */
+    uint8_t *    last_frame_seg_map;
     InterpFilter interp_filter;
     int32_t      mi_stride;
 

--- a/Source/Lib/Common/Codec/EbAv1Structs.h
+++ b/Source/Lib/Common/Codec/EbAv1Structs.h
@@ -310,6 +310,8 @@ typedef struct QuantizationParams {
     /*!< Specifies the level in the quantizer matrix that should be used for
      * each plane decoding */
     uint8_t qm[MAX_MB_PLANE];
+    /*!< qindex for every segment ID */
+    uint8_t qindex[MAX_SEGMENTS];
 } QuantizationParams;
 typedef struct DeltaQParams {
     /*!< Specifies whether quantizer index delta values are present */
@@ -459,9 +461,6 @@ typedef struct FrameHeader {
     /*!< Specifies the expected output order hint for each reference frame */
     uint32_t ref_order_hint[REF_FRAMES];
 
-    /*!< Specifies the expected output order for each reference frame */
-    uint32_t order_hints[REF_FRAMES];
-
     /*!< 1: Indicates that intra block copy may be used in this frame.
      *   0: Indicates that intra block copy is not allowed in this frame */
     uint8_t allow_intrabc;
@@ -475,6 +474,9 @@ typedef struct FrameHeader {
      *  0: Signifies that the corresponding reference picture slot is not valid
      *     for use as a reference picture*/
     uint32_t ref_valid[REF_FRAMES];
+
+    /*!< Specifies the frame id for each reference frame */
+    uint32_t ref_frame_id[REF_FRAMES];
 
     /*!< Frame Size structure */
     FrameSize frame_size;

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -609,7 +609,11 @@ typedef enum MdStagingMode {
 #define INTER_NEW_NFL 16
 #define INTER_PRED_NFL 16
 #endif
+#if MR_MODE
+#define BEST_CANDIDATE_COUNT 23
+#else
 #define BEST_CANDIDATE_COUNT 4
+#endif
 #define MAX_REF_TYPE_CAND 30
 #define PRUNE_REC_TH 5
 #define PRUNE_REF_ME_TH 2

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -33,6 +33,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+
+#define NSQ_HV                          1 // skip NSQ partitions based on H vs V costs
+
 #define JAN6_PRESETS                        1
 #if 1
 #define M0_FEB23_ADOPTIONS                  1

--- a/Source/Lib/Decoder/Codec/EbDecBitstream.c
+++ b/Source/Lib/Decoder/Codec/EbDecBitstream.c
@@ -35,6 +35,7 @@ void dec_bits_init(Bitstrm *bs, const uint8_t *data, size_t numbytes) {
 Bitstream offset and consumes the bits. Section: 4.10.2 -> f(n) */
 uint32_t dec_get_bits(Bitstrm *bs, uint32_t numbits) {
     uint32_t bits_read;
+    if (0 == numbits) return 0;
     GET_BITS(bits_read, bs->buf, bs->bit_ofst, bs->cur_word, bs->nxt_word, numbits);
     return bits_read;
 }

--- a/Source/Lib/Decoder/Codec/EbDecHandle.h
+++ b/Source/Lib/Decoder/Codec/EbDecHandle.h
@@ -85,6 +85,10 @@ typedef struct EbDecPicBuf {
     /* film grain */
     AomFilmGrain film_grain_params;
 
+    // Inter frame reference frame delta for loop filter
+    int8_t ref_deltas[REF_FRAMES];
+    // 0 = ZERO_MV, MV
+    int8_t mode_deltas[MAX_MODE_LF_DELTAS];
 } EbDecPicBuf;
 
 /* Frame level buffers */
@@ -221,6 +225,8 @@ typedef struct EbDecHandle {
     // Prepare ref_frame_map for the next frame.
     EbDecPicBuf *next_ref_frame_map[REF_FRAMES];
 
+    /* For Reference frame loading process */
+    EbDecPicBuf *prev_frame;
     /* TODO: Move to buffer pool. */
     EbDecPicBuf *cur_pic_buf[DEC_MAX_NUM_FRM_PRLL];
 

--- a/Source/Lib/Decoder/Codec/EbDecMemInit.c
+++ b/Source/Lib/Decoder/Codec/EbDecMemInit.c
@@ -60,28 +60,30 @@ EbErrorType dec_eb_recon_picture_buffer_desc_ctor(
     picture_buffer_desc_ptr->color_format = picture_buffer_desc_init_data_ptr->color_format;
     picture_buffer_desc_ptr->stride_y = picture_buffer_desc_init_data_ptr->max_width +
         picture_buffer_desc_init_data_ptr->left_padding + picture_buffer_desc_init_data_ptr->right_padding;
-    if(picture_buffer_desc_ptr->color_format == EB_YUV420 ||
-       picture_buffer_desc_ptr->color_format == EB_YUV422)
-        picture_buffer_desc_ptr->stride_cb = picture_buffer_desc_ptr->stride_cr
-            = picture_buffer_desc_ptr->stride_y >> 1;
-    else if (picture_buffer_desc_ptr->color_format == EB_YUV444)
-        picture_buffer_desc_ptr->stride_cb = picture_buffer_desc_ptr->stride_cr
-            = picture_buffer_desc_ptr->stride_y;
+    uint32_t height_y = (picture_buffer_desc_init_data_ptr->max_height + picture_buffer_desc_init_data_ptr->top_padding
+        + picture_buffer_desc_init_data_ptr->bot_padding);
+
     picture_buffer_desc_ptr->origin_x = picture_buffer_desc_init_data_ptr->left_padding;
     picture_buffer_desc_ptr->origin_y = picture_buffer_desc_init_data_ptr->top_padding;
     picture_buffer_desc_ptr->origin_bot_y = picture_buffer_desc_init_data_ptr->bot_padding;
 
-    picture_buffer_desc_ptr->luma_size = (picture_buffer_desc_init_data_ptr->max_width +
-        picture_buffer_desc_init_data_ptr->left_padding + picture_buffer_desc_init_data_ptr->right_padding) *
-        (picture_buffer_desc_init_data_ptr->max_height + picture_buffer_desc_init_data_ptr->top_padding
-            + picture_buffer_desc_init_data_ptr->bot_padding);
+    picture_buffer_desc_ptr->luma_size = (picture_buffer_desc_ptr->stride_y) * height_y;
 
-    if (picture_buffer_desc_ptr->color_format == EB_YUV420) // 420
-        picture_buffer_desc_ptr->chroma_size = picture_buffer_desc_ptr->luma_size >> 2;
-    else if (picture_buffer_desc_ptr->color_format == EB_YUV422) // 422
-        picture_buffer_desc_ptr->chroma_size = picture_buffer_desc_ptr->luma_size >> 1;
-    else if (picture_buffer_desc_ptr->color_format == EB_YUV444) // 444
-        picture_buffer_desc_ptr->chroma_size = picture_buffer_desc_ptr->luma_size;
+    uint32_t stride_c = 0, height_c = 0;
+    if (picture_buffer_desc_ptr->color_format == EB_YUV420) {// 420
+        stride_c = (picture_buffer_desc_ptr->stride_y + 1) >> 1;
+        height_c = (height_y + 1) >> 1;
+    }
+    else if (picture_buffer_desc_ptr->color_format == EB_YUV422) {// 422
+        stride_c = (picture_buffer_desc_ptr->stride_y + 1) >> 1;
+        height_c = height_y;
+    }
+    else if (picture_buffer_desc_ptr->color_format == EB_YUV444) {// 444
+        stride_c = picture_buffer_desc_ptr->stride_y;
+        height_c = height_y;
+    }
+    picture_buffer_desc_ptr->stride_cb = picture_buffer_desc_ptr->stride_cr = stride_c;
+    picture_buffer_desc_ptr->chroma_size = (stride_c * height_c);
 
     picture_buffer_desc_ptr->packed_flag = EB_FALSE;
 

--- a/Source/Lib/Decoder/Codec/EbDecParseInterBlock.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseInterBlock.c
@@ -17,7 +17,7 @@
 #include "EbDecParseInterBlock.h"
 #include "EbCommonUtils.h"
 #include "EbWarpedMotion.h"
-
+#include "EbLog.h"
 
 typedef const int (*ColorCost)[PALETTE_SIZES][PALETTE_COLOR_INDEX_CONTEXTS][PALETTE_COLORS];
 typedef AomCdfProb (*MapCdf)[PALETTE_SIZES][PALETTE_COLOR_INDEX_CONTEXTS];

--- a/Source/Lib/Decoder/Codec/EbDecPicMgr.h
+++ b/Source/Lib/Decoder/Codec/EbDecPicMgr.h
@@ -42,6 +42,8 @@ void         svt_setup_frame_buf_refs(EbDecHandle *dec_handle_ptr);
 
 ScaleFactors *get_ref_scale_factors(EbDecHandle *dec_handle_ptr, const MvReferenceFrame ref_frame);
 
+EbDecPicBuf *get_primary_ref_frame_buf(EbDecHandle *dec_handle_ptr);
+
 void svt_set_frame_refs(EbDecHandle *dec_handle_ptr, int32_t lst_map_idx, int32_t gld_map_idx);
 
 #ifdef __cplusplus

--- a/Source/Lib/Decoder/Codec/EbDecProcess.c
+++ b/Source/Lib/Decoder/Codec/EbDecProcess.c
@@ -1324,7 +1324,8 @@ void dec_av1_loop_restoration_filter_frame_mt(
     eb_release_mutex(dec_mt_frame_data->temp_mutex);
 
     volatile uint32_t *num_threads_lred = &dec_mt_frame_data->num_threads_lred;
-    while (*num_threads_lred != dec_handle->dec_config.threads);
+    while (*num_threads_lred != dec_handle->dec_config.threads &&
+            EB_FALSE == dec_mt_frame_data->end_flag);
 }
 
 void *dec_all_stage_kernel(void *input_ptr) {
@@ -1403,4 +1404,8 @@ void dec_sync_all_threads(EbDecHandle *dec_handle_ptr) {
 
     while (dec_mt_frame_data->num_threads_exited != dec_handle_ptr->dec_config.threads - 1)
         eb_sleep_ms(5);
+
+    /*Destroying lib created thread's*/
+    EB_DESTROY_THREAD_ARRAY(dec_handle_ptr->decode_thread_handle_array,
+                            dec_handle_ptr->dec_config.threads - 1);
 }

--- a/Source/Lib/Decoder/Codec/EbDecRestoration.c
+++ b/Source/Lib/Decoder/Codec/EbDecRestoration.c
@@ -243,8 +243,10 @@ void eb_dec_av1_loop_restoration_filter_unit(uint8_t need_bounadaries,
            restoration unit */
         const int32_t nominal_stripe_height =
             full_stripe_height - ((tile_stripe == 0) ? runit_offset : 0);
+        /*In wiener filter leaf level function assumes always h to be multiple of 2.
+          we can see assert related to h in this function->eb_av1_wiener_convolve_add_src_avx2*/
         const int32_t h = AOMMIN(nominal_stripe_height,
-            remaining_stripes.v_end - remaining_stripes.v_start);
+            ((remaining_stripes.v_end - remaining_stripes.v_start) + 1) & ~1);
 
         if (need_bounadaries)
             setup_processing_stripe_boundary(&remaining_stripes,

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -2125,6 +2125,26 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
         context_ptr->sq_weight = scs_ptr->static_config.sq_weight;
 #endif
 #endif
+
+
+#if NSQ_HV
+    //nsq_hv_level  needs sq_weight to be ON
+    //0: OFF
+    //1: ON 10% + skip HA/HB/H4  or skip VA/VB/V4
+    //2: ON 10% + skip HA/HB  or skip VA/VB   ,  5% + skip H4  or skip V4
+    if (MR_MODE || context_ptr->pd_pass < PD_PASS_2)
+        context_ptr->nsq_hv_level = 0;
+    else if (pcs_ptr->enc_mode <= ENC_M3) {
+        context_ptr->nsq_hv_level = 1;
+        assert(context_ptr->sq_weight != (uint32_t)~0);
+    }
+    else {
+        context_ptr->nsq_hv_level = 2;
+        assert(context_ptr->sq_weight != (uint32_t)~0);
+    }
+#endif
+
+
     // Set pred ME full search area
     if (context_ptr->pd_pass == PD_PASS_0) {
 #if M0_FEB22_ADOPTIONS

--- a/Source/Lib/Encoder/Codec/EbEncodeContext.h
+++ b/Source/Lib/Encoder/Codec/EbEncodeContext.h
@@ -79,9 +79,6 @@ typedef struct EncodeContext {
     // Picture Decision Reorder Queue
     PictureDecisionReorderEntry **picture_decision_reorder_queue;
     uint32_t                      picture_decision_reorder_queue_head_index;
-    //hold undisplayed frame for show existing frame. It's ordered with pts Descend.
-    EbObjectWrapper              *picture_decision_undisplayed_queue[REF_FRAMES];
-    uint32_t                      picture_decision_undisplayed_queue_count;
 
     // Picture Manager Reorder Queue
     PictureManagerReorderEntry **picture_manager_reorder_queue;

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
@@ -379,7 +379,9 @@ typedef struct ModeDecisionContext {
     uint8_t *    left_txfm_context;
     // square cost weighting for deciding if a/b shapes could be skipped
     uint32_t sq_weight;
-
+#if NSQ_HV
+    uint32_t nsq_hv_level;
+#endif
     // signal for enabling shortcut to skip search depths
     MD_COMP_TYPE compound_types_to_try;
     uint8_t      best_me_cand_only_flag;

--- a/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
@@ -15,7 +15,6 @@
 #include "EbTime.h"
 #include "EbModeDecisionProcess.h"
 #include "EbPictureDemuxResults.h"
-#include "EbLog.h"
 #define DETAILED_FRAME_OUTPUT 0
 
 /**************************************
@@ -77,6 +76,33 @@ EbErrorType packetization_context_ctor(EbThreadContext *  thread_context_ptr,
     EB_MALLOC_ARRAY(context_ptr->pps_config, 1);
 
     return EB_ErrorNone;
+}
+#define TD_SIZE 2
+#define OBU_FRAME_HEADER_SIZE 3
+#define TILES_GROUP_SIZE 1
+
+// Write TD after offsetting the stream buffer
+static void write_td(EbBufferHeaderType *out_str_ptr, EbBool show_ex, EbBool has_tiles) {
+    uint8_t td_buff[TD_SIZE] = {0, 0};
+    uint8_t obu_frame_header_size =
+        has_tiles ? OBU_FRAME_HEADER_SIZE + TILES_GROUP_SIZE : OBU_FRAME_HEADER_SIZE;
+    if (out_str_ptr && (out_str_ptr->n_alloc_len > (out_str_ptr->n_filled_len + 2))) {
+        uint8_t *src_address =
+            (show_ex == EB_FALSE)
+                ? out_str_ptr->p_buffer
+                : out_str_ptr->p_buffer + out_str_ptr->n_filled_len - (obu_frame_header_size);
+
+        uint8_t *dst_address = src_address + TD_SIZE;
+
+        uint32_t move_size =
+            (show_ex == EB_FALSE) ? out_str_ptr->n_filled_len : (obu_frame_header_size);
+
+        memmove(dst_address, src_address, move_size);
+
+        encode_td_av1((uint8_t *)(&td_buff));
+
+        EB_MEMCPY(src_address, &td_buff, TD_SIZE);
+    }
 }
 
 void update_rc_rate_tables(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) {
@@ -305,288 +331,6 @@ void update_rc_rate_tables(PictureControlSet *pcs_ptr, SequenceControlSet *scs_p
         }
     }
 }
-
-static inline int get_reorder_queue_pos(const EncodeContext *encode_context_ptr, int delta) {
-    return (encode_context_ptr->packetization_reorder_queue_head_index + delta) % PACKETIZATION_REORDER_QUEUE_MAX_DEPTH;
-}
-
-static inline PacketizationReorderEntry* get_reorder_queue_entry(const EncodeContext *encode_context_ptr, int delta) {
-    int pos = get_reorder_queue_pos(encode_context_ptr, delta);
-    return encode_context_ptr->packetization_reorder_queue[pos];
-}
-
-static uint32_t count_frames_in_next_tu(const EncodeContext *encode_context_ptr, int *data_size) {
-    const PacketizationReorderEntry *queue_entry_ptr;
-    const EbBufferHeaderType *       output_stream_ptr;
-    int                              i = 0;
-    *data_size                         = 0;
-    do {
-        queue_entry_ptr                = get_reorder_queue_entry(encode_context_ptr, i);
-        const EbObjectWrapper *wrapper = queue_entry_ptr->output_stream_wrapper_ptr;
-        //not a completed td
-        if (!wrapper) return 0;
-
-        output_stream_ptr = (EbBufferHeaderType *)wrapper->object_ptr;
-        *data_size += output_stream_ptr->n_filled_len;
-
-        i++;
-        //we have a td when we got a displable frame
-        if (queue_entry_ptr->show_frame) break;
-    } while (i < PACKETIZATION_REORDER_QUEUE_MAX_DEPTH);
-    return i;
-}
-
-static int pts_descend(const void *pa, const void*pb) {
-    EbObjectWrapper* a = *(EbObjectWrapper**)pa;
-    EbObjectWrapper* b = *(EbObjectWrapper**)pb;
-    EbBufferHeaderType *ba = (EbBufferHeaderType *)(a->object_ptr);
-    EbBufferHeaderType *bb = (EbBufferHeaderType *)(b->object_ptr);
-    return (int)(bb->pts - ba->pts);
-}
-
-static void push_undisplayed_frame(EncodeContext *encode_context_ptr, EbObjectWrapper *wrapper) {
-    if (encode_context_ptr->picture_decision_undisplayed_queue_count >= REF_FRAMES) {
-        SVT_ERROR("bug, too many frames in undisplayed queue");
-        return;
-    }
-    uint32_t count = encode_context_ptr->picture_decision_undisplayed_queue_count;
-    encode_context_ptr->picture_decision_undisplayed_queue[count++] = wrapper;
-    encode_context_ptr->picture_decision_undisplayed_queue_count = count;
-}
-
-static EbObjectWrapper *pop_undisplayed_frame(EncodeContext *encode_context_ptr) {
-    uint32_t count = encode_context_ptr->picture_decision_undisplayed_queue_count;
-    if (!count) {
-        SVT_ERROR("bug, no frame in undisplayed queue");
-        return NULL;
-    }
-    count--;
-    EbObjectWrapper *ret = encode_context_ptr->picture_decision_undisplayed_queue[count];
-    encode_context_ptr->picture_decision_undisplayed_queue_count = count;
-    return ret;
-}
-
-static void sort_undisplayed_frame(EncodeContext* encode_context_ptr) {
-    qsort(&encode_context_ptr->picture_decision_undisplayed_queue[0],
-          encode_context_ptr->picture_decision_undisplayed_queue_count,
-          sizeof(EbObjectWrapper *),
-          pts_descend);
-}
-
-#if DETAILED_FRAME_OUTPUT
-static void print_detailed_frame_info(PacketizationContext* context_ptr, const PacketizationReorderEntry *queue_entry_ptr) {
-    int32_t i;
-    uint8_t showTab[] = {'H', 'V'};
-
-    //Countinuity count check of visible frames
-    if (queue_entry_ptr->show_frame) {
-        if (context_ptr->disp_order_continuity_count == queue_entry_ptr->poc)
-            context_ptr->disp_order_continuity_count++;
-        else {
-            SVT_LOG("SVT [ERROR]: disp_order_continuity_count Error1 POC:%i\n",
-                    (int32_t)queue_entry_ptr->poc);
-            exit(0);
-        }
-    }
-
-    if (queue_entry_ptr->has_show_existing) {
-        if (context_ptr->disp_order_continuity_count ==
-            context_ptr->dpb_disp_order[queue_entry_ptr->show_existing_frame])
-            context_ptr->disp_order_continuity_count++;
-        else {
-            SVT_LOG("SVT [ERROR]: disp_order_continuity_count Error2 POC:%i\n",
-                    (int32_t)queue_entry_ptr->poc);
-            exit(0);
-        }
-    }
-
-    //update total number of shown frames
-    if (queue_entry_ptr->show_frame) context_ptr->tot_shown_frames++;
-    if (queue_entry_ptr->has_show_existing) context_ptr->tot_shown_frames++;
-
-    //implement the GOP here - Serial dec order
-    if (queue_entry_ptr->frame_type == KEY_FRAME) {
-        //reset the DPB on a Key frame
-        for (i = 0; i < 8; i++) {
-            context_ptr->dpb_dec_order[i]  = queue_entry_ptr->picture_number;
-            context_ptr->dpb_disp_order[i] = queue_entry_ptr->poc;
-        }
-        SVT_LOG("%i  %i  %c ****KEY***** %i frames\n",
-                (int32_t)queue_entry_ptr->picture_number,
-                (int32_t)queue_entry_ptr->poc,
-                showTab[queue_entry_ptr->show_frame],
-                (int32_t)context_ptr->tot_shown_frames);
-    } else {
-        int32_t LASTrefIdx = queue_entry_ptr->av1_ref_signal.ref_dpb_index[0];
-        int32_t BWDrefIdx  = queue_entry_ptr->av1_ref_signal.ref_dpb_index[4];
-
-        if (queue_entry_ptr->frame_type == INTER_FRAME) {
-            if (queue_entry_ptr->has_show_existing)
-                SVT_LOG("%i (%i  %i)    %i  (%i  %i)   %c  showEx: %i   %i frames\n",
-                        (int32_t)queue_entry_ptr->picture_number,
-                        (int32_t)context_ptr->dpb_dec_order[LASTrefIdx],
-                        (int32_t)context_ptr->dpb_dec_order[BWDrefIdx],
-                        (int32_t)queue_entry_ptr->poc,
-                        (int32_t)context_ptr->dpb_disp_order[LASTrefIdx],
-                        (int32_t)context_ptr->dpb_disp_order[BWDrefIdx],
-                        showTab[queue_entry_ptr->show_frame],
-                        (int32_t)context_ptr
-                            ->dpb_disp_order[queue_entry_ptr->show_existing_frame],
-                        (int32_t)context_ptr->tot_shown_frames);
-            else
-                SVT_LOG("%i (%i  %i)    %i  (%i  %i)   %c  %i frames\n",
-                        (int32_t)queue_entry_ptr->picture_number,
-                        (int32_t)context_ptr->dpb_dec_order[LASTrefIdx],
-                        (int32_t)context_ptr->dpb_dec_order[BWDrefIdx],
-                        (int32_t)queue_entry_ptr->poc,
-                        (int32_t)context_ptr->dpb_disp_order[LASTrefIdx],
-                        (int32_t)context_ptr->dpb_disp_order[BWDrefIdx],
-                        showTab[queue_entry_ptr->show_frame],
-                        (int32_t)context_ptr->tot_shown_frames);
-
-            if (queue_entry_ptr->ref_poc_list0 !=
-                context_ptr->dpb_disp_order[LASTrefIdx]) {
-                SVT_LOG("L0 MISMATCH POC:%i\n", (int32_t)queue_entry_ptr->poc);
-                exit(0);
-            }
-//TODO: how to enable this?
-#if 0
-            if (scs_ptr->static_config.hierarchical_levels == 3 &&
-                queue_entry_ptr->slice_type == B_SLICE &&
-                queue_entry_ptr->ref_poc_list1 !=
-                    context_ptr->dpb_disp_order[BWDrefIdx]) {
-                SVT_LOG("L1 MISMATCH POC:%i\n", (int32_t)queue_entry_ptr->poc);
-                exit(0);
-            }
-#endif
-            for (int rr = 0; rr < 7; rr++) {
-                uint8_t dpb_spot = queue_entry_ptr->av1_ref_signal.ref_dpb_index[rr];
-
-                if (queue_entry_ptr->ref_poc_array[rr] !=
-                    context_ptr->dpb_disp_order[dpb_spot])
-                    SVT_LOG("REF_POC MISMATCH POC:%i  ref:%i\n",
-                            (int32_t)queue_entry_ptr->poc,
-                            rr);
-            }
-        } else {
-            if (queue_entry_ptr->has_show_existing)
-                SVT_LOG("%i  %i  %c   showEx: %i ----INTRA---- %i frames \n",
-                        (int32_t)queue_entry_ptr->picture_number,
-                        (int32_t)queue_entry_ptr->poc,
-                        showTab[queue_entry_ptr->show_frame],
-                        (int32_t)context_ptr
-                            ->dpb_disp_order[queue_entry_ptr->show_existing_frame],
-                        (int32_t)context_ptr->tot_shown_frames);
-            else
-                SVT_LOG("%i  %i  %c   ----INTRA---- %i frames\n",
-                        (int32_t)queue_entry_ptr->picture_number,
-                        (int32_t)queue_entry_ptr->poc,
-                        (int32_t)showTab[queue_entry_ptr->show_frame],
-                        (int32_t)context_ptr->tot_shown_frames);
-        }
-
-        //Update the DPB
-        for (i = 0; i < 8; i++) {
-            if ((queue_entry_ptr->av1_ref_signal.refresh_frame_mask >> i) & 1) {
-                context_ptr->dpb_dec_order[i]  = queue_entry_ptr->picture_number;
-                context_ptr->dpb_disp_order[i] = queue_entry_ptr->poc;
-            }
-        }
-    }
-}
-#endif
-
-static void collect_frames_info(PacketizationContext* context_ptr, const EncodeContext *encode_context_ptr, int frames) {
-    for (int i = 0; i < frames; i++) {
-        PacketizationReorderEntry *queue_entry_ptr = get_reorder_queue_entry(encode_context_ptr, i);
-        EbBufferHeaderType        *output_stream_ptr = (EbBufferHeaderType *) queue_entry_ptr->output_stream_wrapper_ptr->object_ptr;
-#if DETAILED_FRAME_OUTPUT
-        print_detailed_frame_info(context_ptr, queue_entry_ptr) ;
-#else
-        (void)context_ptr;
-#endif
-        // Calculate frame latency in milliseconds
-        double   latency               = 0.0;
-        uint64_t finish_time_seconds   = 0;
-        uint64_t finish_time_u_seconds = 0;
-        eb_finish_time(&finish_time_seconds, &finish_time_u_seconds);
-
-        eb_compute_overall_elapsed_time_ms(queue_entry_ptr->start_time_seconds,
-                                            queue_entry_ptr->start_time_u_seconds,
-                                            finish_time_seconds,
-                                            finish_time_u_seconds,
-                                            &latency);
-
-        output_stream_ptr->n_tick_count  = (uint32_t)latency;
-        output_stream_ptr->p_app_private = queue_entry_ptr->out_meta_data;
-        if (queue_entry_ptr->is_alt_ref)
-            output_stream_ptr->flags |= (uint32_t)EB_BUFFERFLAG_IS_ALT_REF;
-
-    }
-}
-
-#define TD_SIZE 2
-
-//a tu start with a td, + 0 more not displable frame, + 1 display frame
-static void encode_tu(EncodeContext *encode_context_ptr, int frames, int total_bytes,
-                      EbBufferHeaderType *output_stream_ptr) {
-    total_bytes += TD_SIZE;
-    if (total_bytes > (int)output_stream_ptr->n_alloc_len) {
-        SVT_ERROR("encode size(%d) is too large", total_bytes);
-        return;
-    }
-    uint8_t *dst                    = output_stream_ptr->p_buffer + total_bytes;
-    //we use last frame's output_stream_ptr to hold entire tu, so we need copy backward.
-    int last = frames - 1;
-    for (int i = last; i >= 0; i--) {
-        PacketizationReorderEntry *queue_entry_ptr = get_reorder_queue_entry(encode_context_ptr, i);
-        EbObjectWrapper* wrapper = queue_entry_ptr->output_stream_wrapper_ptr;
-        EbBufferHeaderType *       src_stream_ptr = (EbBufferHeaderType *)wrapper->object_ptr;
-        uint32_t size = src_stream_ptr->n_filled_len;
-        dst -= size;
-        memmove(dst, src_stream_ptr->p_buffer, size);
-        if (i != last) {
-            //lost frame is displayable frame, other are unsidplayed
-            push_undisplayed_frame(encode_context_ptr, wrapper);
-        }
-    }
-    if (frames > 1)
-        sort_undisplayed_frame(encode_context_ptr);
-    dst -= TD_SIZE;
-    encode_td_av1(dst);
-    output_stream_ptr->n_filled_len = total_bytes;
-    output_stream_ptr->flags |= EB_BUFFERFLAG_HAS_TD;
-}
-
-static void encode_show_existing(EncodeContext *encode_context_ptr,
-                                 PacketizationReorderEntry *queue_entry_ptr,
-                                 EbBufferHeaderType        *output_stream_ptr) {
-    uint8_t* dst = output_stream_ptr->p_buffer;
-
-    encode_td_av1(dst);
-    output_stream_ptr->n_filled_len = TD_SIZE;
-
-    // Copy Slice Header to the Output Bitstream
-    copy_payload(queue_entry_ptr->bitstream_ptr,
-                 output_stream_ptr->p_buffer,
-                 (uint32_t *)&(output_stream_ptr->n_filled_len),
-                 (uint32_t *)&(output_stream_ptr->n_alloc_len),
-                 encode_context_ptr);
-
-    output_stream_ptr->flags |= (EB_BUFFERFLAG_SHOW_EXT | EB_BUFFERFLAG_HAS_TD);
-}
-
-static void release_frames(EncodeContext *encode_context_ptr, int frames) {
-    for (int i = 0; i < frames; i++) {
-        PacketizationReorderEntry *queue_entry_ptr = get_reorder_queue_entry(encode_context_ptr, i);
-        queue_entry_ptr->out_meta_data = (EbLinkedListNode *)EB_NULL;
-        // Reset the Reorder Queue Entry
-        queue_entry_ptr->picture_number += PACKETIZATION_REORDER_QUEUE_MAX_DEPTH;
-        queue_entry_ptr->output_stream_wrapper_ptr = (EbObjectWrapper *)EB_NULL;
-    }
-    encode_context_ptr->packetization_reorder_queue_head_index = get_reorder_queue_pos(encode_context_ptr, frames);
-}
-
 void *packetization_kernel(void *input_ptr) {
     // Context
     EbThreadContext *     thread_context_ptr = (EbThreadContext *)input_ptr;
@@ -617,7 +361,6 @@ void *packetization_kernel(void *input_ptr) {
     int32_t                    queue_entry_index;
     PacketizationReorderEntry *queue_entry_ptr;
     EbLinkedListNode *         app_data_ll_head_temp_ptr;
-    uint32_t                   frames;
 
     context_ptr->tot_shown_frames            = 0;
     context_ptr->disp_order_continuity_count = 0;
@@ -666,8 +409,9 @@ void *packetization_kernel(void *input_ptr) {
                 : 0;
         output_stream_ptr->n_filled_len = 0;
         output_stream_ptr->pts          = pcs_ptr->parent_pcs_ptr->input_ptr->pts;
-        //we output one temporal unit a time, so dts alwasy equals to pts.
-        output_stream_ptr->dts          = output_stream_ptr->pts;
+        //minus (1 << MAX_HIERARCHICAL_LEVEL) to make sure the dts never larger than pts.
+        output_stream_ptr->dts          = pcs_ptr->parent_pcs_ptr->decode_order -
+                                 (uint64_t)(1 << MAX_HIERARCHICAL_LEVEL) + 1;
         output_stream_ptr->pic_type =
             pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag
                 ? pcs_ptr->parent_pcs_ptr->idr_flag ? EB_AV1_KEY_PICTURE : pcs_ptr->slice_type
@@ -741,8 +485,17 @@ void *packetization_kernel(void *input_ptr) {
                      encode_context_ptr);
         if (pcs_ptr->parent_pcs_ptr->has_show_existing) {
             // Reset the Bitstream before writing to it
-            reset_bitstream(queue_entry_ptr->bitstream_ptr->output_bitstream_ptr);
-            write_frame_header_av1(queue_entry_ptr->bitstream_ptr, scs_ptr, pcs_ptr, 1);
+            reset_bitstream(pcs_ptr->bitstream_ptr->output_bitstream_ptr);
+            write_frame_header_av1(pcs_ptr->bitstream_ptr, scs_ptr, pcs_ptr, 1);
+
+            // Copy Slice Header to the Output Bitstream
+            copy_payload(pcs_ptr->bitstream_ptr,
+                         output_stream_ptr->p_buffer,
+                         (uint32_t *)&(output_stream_ptr->n_filled_len),
+                         (uint32_t *)&(output_stream_ptr->n_alloc_len),
+                         encode_context_ptr);
+
+            output_stream_ptr->flags |= EB_BUFFERFLAG_SHOW_EXT;
         }
 
         // Send the number of bytes per frame to RC
@@ -761,7 +514,7 @@ void *packetization_kernel(void *input_ptr) {
         queue_entry_ptr->ref_poc_list0 = pcs_ptr->parent_pcs_ptr->ref_pic_poc_array[REF_LIST_0][0];
         queue_entry_ptr->ref_poc_list1 = pcs_ptr->parent_pcs_ptr->ref_pic_poc_array[REF_LIST_1][0];
         memcpy(queue_entry_ptr->ref_poc_array,
-               pcs_ptr->parent_pcs_ptr->av1_ref_signal.ref_poc_array,
+               pcs_ptr->parent_pcs_ptr->av1RefSignal.ref_poc_array,
                7 * sizeof(uint64_t));
 #endif
         queue_entry_ptr->show_frame          = frm_hdr->show_frame;
@@ -813,29 +566,185 @@ void *packetization_kernel(void *input_ptr) {
         //****************************************************
         // Process the head of the queue
         //****************************************************
-        // Look at head of queue and see if we got a td
-        int total_bytes;
-        while ((frames = count_frames_in_next_tu(encode_context_ptr, &total_bytes))) {
-            collect_frames_info(context_ptr, encode_context_ptr, frames);
-            //last frame in a termporal unit is a displable frame. only the last frame has pts.
-            //so we collect all bitstream to last frames' output buffer.
-            queue_entry_ptr           = get_reorder_queue_entry(encode_context_ptr, frames - 1);
+        // Look at head of queue and see if any picture is ready to go
+        queue_entry_ptr = encode_context_ptr->packetization_reorder_queue
+                              [encode_context_ptr->packetization_reorder_queue_head_index];
+
+        while (queue_entry_ptr->output_stream_wrapper_ptr != EB_NULL) {
+            EbBool has_tiles =
+                (EbBool)(scs_ptr->static_config.tile_columns || scs_ptr->static_config.tile_rows);
             output_stream_wrapper_ptr = queue_entry_ptr->output_stream_wrapper_ptr;
             output_stream_ptr         = (EbBufferHeaderType *)output_stream_wrapper_ptr->object_ptr;
 
-            encode_tu(encode_context_ptr, frames, total_bytes, output_stream_ptr);
-            eb_post_full_object(output_stream_wrapper_ptr);
             if (queue_entry_ptr->has_show_existing) {
-                EbObjectWrapper *existed = pop_undisplayed_frame(encode_context_ptr);
-                if (existed) {
-                    EbBufferHeaderType *existed_output_stream_ptr = (EbBufferHeaderType *)existed->object_ptr;
-                    encode_show_existing(encode_context_ptr, queue_entry_ptr, existed_output_stream_ptr);
-                    eb_post_full_object(existed);
+                write_td(output_stream_ptr, EB_TRUE, has_tiles);
+                output_stream_ptr->n_filled_len += TD_SIZE;
+            }
+
+            if (encode_context_ptr->td_needed == EB_TRUE) {
+                output_stream_ptr->flags |= (uint32_t)EB_BUFFERFLAG_HAS_TD;
+                write_td(output_stream_ptr, EB_FALSE, has_tiles);
+                encode_context_ptr->td_needed = EB_FALSE;
+                output_stream_ptr->n_filled_len += TD_SIZE;
+            }
+
+            if (queue_entry_ptr->has_show_existing || queue_entry_ptr->show_frame)
+                encode_context_ptr->td_needed = EB_TRUE;
+
+#if DETAILED_FRAME_OUTPUT
+            {
+                int32_t i;
+                uint8_t showTab[] = {'H', 'V'};
+
+                //Countinuity count check of visible frames
+                if (queue_entry_ptr->show_frame) {
+                    if (context_ptr->disp_order_continuity_count == queue_entry_ptr->poc)
+                        context_ptr->disp_order_continuity_count++;
+                    else {
+                        SVT_LOG("SVT [ERROR]: disp_order_continuity_count Error1 POC:%i\n",
+                                (int32_t)queue_entry_ptr->poc);
+                        exit(0);
+                    }
+                }
+
+                if (queue_entry_ptr->has_show_existing) {
+                    if (context_ptr->disp_order_continuity_count ==
+                        context_ptr->dpb_disp_order[queue_entry_ptr->show_existing_frame])
+                        context_ptr->disp_order_continuity_count++;
+                    else {
+                        SVT_LOG("SVT [ERROR]: disp_order_continuity_count Error2 POC:%i\n",
+                                (int32_t)queue_entry_ptr->poc);
+                        exit(0);
+                    }
+                }
+
+                //update total number of shown frames
+                if (queue_entry_ptr->show_frame) context_ptr->tot_shown_frames++;
+                if (queue_entry_ptr->has_show_existing) context_ptr->tot_shown_frames++;
+
+                //implement the GOP here - Serial dec order
+                if (queue_entry_ptr->frame_type == KEY_FRAME) {
+                    //reset the DPB on a Key frame
+                    for (i = 0; i < 8; i++) {
+                        context_ptr->dpb_dec_order[i]  = queue_entry_ptr->picture_number;
+                        context_ptr->dpb_disp_order[i] = queue_entry_ptr->poc;
+                    }
+                    SVT_LOG("%i  %i  %c ****KEY***** %i frames\n",
+                            (int32_t)queue_entry_ptr->picture_number,
+                            (int32_t)queue_entry_ptr->poc,
+                            showTab[queue_entry_ptr->show_frame],
+                            (int32_t)context_ptr->tot_shown_frames);
+                } else {
+                    int32_t LASTrefIdx = queue_entry_ptr->av1_ref_signal.ref_dpb_index[0];
+                    int32_t BWDrefIdx  = queue_entry_ptr->av1_ref_signal.ref_dpb_index[4];
+
+                    if (queue_entry_ptr->frame_type == INTER_FRAME) {
+                        if (queue_entry_ptr->has_show_existing)
+                            SVT_LOG("%i (%i  %i)    %i  (%i  %i)   %c  showEx: %i   %i frames\n",
+                                    (int32_t)queue_entry_ptr->picture_number,
+                                    (int32_t)context_ptr->dpb_dec_order[LASTrefIdx],
+                                    (int32_t)context_ptr->dpb_dec_order[BWDrefIdx],
+                                    (int32_t)queue_entry_ptr->poc,
+                                    (int32_t)context_ptr->dpb_disp_order[LASTrefIdx],
+                                    (int32_t)context_ptr->dpb_disp_order[BWDrefIdx],
+                                    showTab[queue_entry_ptr->show_frame],
+                                    (int32_t)context_ptr
+                                        ->dpb_disp_order[queue_entry_ptr->show_existing_frame],
+                                    (int32_t)context_ptr->tot_shown_frames);
+                        else
+                            SVT_LOG("%i (%i  %i)    %i  (%i  %i)   %c  %i frames\n",
+                                    (int32_t)queue_entry_ptr->picture_number,
+                                    (int32_t)context_ptr->dpb_dec_order[LASTrefIdx],
+                                    (int32_t)context_ptr->dpb_dec_order[BWDrefIdx],
+                                    (int32_t)queue_entry_ptr->poc,
+                                    (int32_t)context_ptr->dpb_disp_order[LASTrefIdx],
+                                    (int32_t)context_ptr->dpb_disp_order[BWDrefIdx],
+                                    showTab[queue_entry_ptr->show_frame],
+                                    (int32_t)context_ptr->tot_shown_frames);
+
+                        if (queue_entry_ptr->ref_poc_list0 !=
+                            context_ptr->dpb_disp_order[LASTrefIdx]) {
+                            SVT_LOG("L0 MISMATCH POC:%i\n", (int32_t)queue_entry_ptr->poc);
+                            exit(0);
+                        }
+                        if (scs_ptr->static_config.hierarchical_levels == 3 &&
+                            queue_entry_ptr->slice_type == B_SLICE &&
+                            queue_entry_ptr->ref_poc_list1 !=
+                                context_ptr->dpb_disp_order[BWDrefIdx]) {
+                            SVT_LOG("L1 MISMATCH POC:%i\n", (int32_t)queue_entry_ptr->poc);
+                            exit(0);
+                        }
+
+                        for (int rr = 0; rr < 7; rr++) {
+                            uint8_t dpb_spot = queue_entry_ptr->av1RefSignal.refDpbIndex[rr];
+
+                            if (queue_entry_ptr->ref_poc_array[rr] !=
+                                context_ptr->dpbDispOrder[dpb_spot])
+                                SVT_LOG("REF_POC MISMATCH POC:%i  ref:%i\n",
+                                        (int32_t)queue_entry_ptr->poc,
+                                        rr);
+                        }
+                    } else {
+                        if (queue_entry_ptr->has_show_existing)
+                            SVT_LOG("%i  %i  %c   showEx: %i ----INTRA---- %i frames \n",
+                                    (int32_t)queue_entry_ptr->picture_number,
+                                    (int32_t)queue_entry_ptr->poc,
+                                    showTab[queue_entry_ptr->show_frame],
+                                    (int32_t)context_ptr
+                                        ->dpb_disp_order[queue_entry_ptr->show_existing_frame],
+                                    (int32_t)context_ptr->tot_shown_frames);
+                        else
+                            SVT_LOG("%i  %i  %c   ----INTRA---- %i frames\n",
+                                    (int32_t)queue_entry_ptr->picture_number,
+                                    (int32_t)queue_entry_ptr->poc,
+                                    (int32_t)showTab[queue_entry_ptr->show_frame],
+                                    (int32_t)context_ptr->tot_shown_frames);
+                    }
+
+                    //Update the DPB
+                    for (i = 0; i < 8; i++) {
+                        if ((queue_entry_ptr->av1_ref_signal.refresh_frame_mask >> i) & 1) {
+                            context_ptr->dpb_dec_order[i]  = queue_entry_ptr->picture_number;
+                            context_ptr->dpb_disp_order[i] = queue_entry_ptr->poc;
+                        }
+                    }
                 }
             }
-            release_frames(encode_context_ptr, frames);
+#endif
+            // Calculate frame latency in milliseconds
+            double   latency               = 0.0;
+            uint64_t finish_time_seconds   = 0;
+            uint64_t finish_time_u_seconds = 0;
+            eb_finish_time(&finish_time_seconds, &finish_time_u_seconds);
+
+            eb_compute_overall_elapsed_time_ms(queue_entry_ptr->start_time_seconds,
+                                               queue_entry_ptr->start_time_u_seconds,
+                                               finish_time_seconds,
+                                               finish_time_u_seconds,
+                                               &latency);
+
+            output_stream_ptr->n_tick_count  = (uint32_t)latency;
+            output_stream_ptr->p_app_private = queue_entry_ptr->out_meta_data;
+            if (queue_entry_ptr->is_alt_ref)
+                output_stream_ptr->flags |= (uint32_t)EB_BUFFERFLAG_IS_ALT_REF;
+
+            eb_post_full_object(output_stream_wrapper_ptr);
+            queue_entry_ptr->out_meta_data = (EbLinkedListNode *)EB_NULL;
+
+            // Reset the Reorder Queue Entry
+            queue_entry_ptr->picture_number += PACKETIZATION_REORDER_QUEUE_MAX_DEPTH;
+            queue_entry_ptr->output_stream_wrapper_ptr = (EbObjectWrapper *)EB_NULL;
+
+            // Increment the Reorder Queue head Ptr
+            encode_context_ptr->packetization_reorder_queue_head_index =
+                (encode_context_ptr->packetization_reorder_queue_head_index ==
+                 PACKETIZATION_REORDER_QUEUE_MAX_DEPTH - 1)
+                    ? 0
+                    : encode_context_ptr->packetization_reorder_queue_head_index + 1;
+
+            queue_entry_ptr = encode_context_ptr->packetization_reorder_queue
+                                  [encode_context_ptr->packetization_reorder_queue_head_index];
         }
     }
     return EB_NULL;
-
 }

--- a/Source/Lib/Encoder/Codec/EbPacketizationReorderQueue.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationReorderQueue.c
@@ -6,16 +6,9 @@
 #include <stdlib.h>
 #include "EbPacketizationReorderQueue.h"
 
-static void packetization_reorder_entry_dctor(EbPtr p) {
-    PacketizationReorderEntry* obj = (PacketizationReorderEntry*)p;
-    EB_DELETE(obj->bitstream_ptr);
-}
-
 EbErrorType packetization_reorder_entry_ctor(PacketizationReorderEntry *entry_ptr,
                                              uint32_t                   picture_number) {
-    entry_ptr->dctor = packetization_reorder_entry_dctor;
     entry_ptr->picture_number = picture_number;
-    //16 should enough for show existing frame
-    EB_NEW(entry_ptr->bitstream_ptr, bitstream_ctor, 16);
+
     return EB_ErrorNone;
 }

--- a/Source/Lib/Encoder/Codec/EbPacketizationReorderQueue.h
+++ b/Source/Lib/Encoder/Codec/EbPacketizationReorderQueue.h
@@ -10,7 +10,6 @@
 #include "EbSystemResourceManager.h"
 #include "EbPredictionStructure.h"
 #include "EbObject.h"
-#include "EbEntropyCodingObject.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -38,10 +37,6 @@ typedef struct PacketizationReorderEntry {
     EbBool     show_frame;
     EbBool     has_show_existing;
     uint8_t    show_existing_frame;
-    //small size bitstream for show existing frame
-    Bitstream *bitstream_ptr;
-    //valid when has_show_existing is true
-    int64_t    next_pts;
     uint8_t    is_alt_ref;
 } PacketizationReorderEntry;
 

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -4409,10 +4409,16 @@ void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context
 void    predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
                              EbPictureBufferDesc *input_picture_ptr, uint32_t input_origin_index,
                              uint32_t blk_origin_index) {
-#if !ENHANCED_ME_MV
+#if !ENHANCED_ME_MV || M0_FEB22_ADOPTIONS
     const SequenceControlSet *scs_ptr = (SequenceControlSet *)pcs_ptr->scs_wrapper_ptr->object_ptr;
 #endif
     EbBool                    use_ssd           = EB_TRUE;
+#if M0_FEB22_ADOPTIONS
+#if !MR_MODE
+    if (pcs_ptr->parent_pcs_ptr->sc_content_detected)
+        use_ssd = EB_FALSE;
+#endif
+#endif
     uint8_t                   hbd_mode_decision = context_ptr->hbd_mode_decision == EB_DUAL_BIT_MD
                                     ? EB_8_BIT_MD
                                     : context_ptr->hbd_mode_decision;

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -4323,6 +4323,11 @@ void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context
     input_picture_ptr = hbd_mode_decision ? pcs_ptr->input_frame16bit
         : pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
 
+    //Update input origin
+    input_origin_index =
+        (context_ptr->blk_origin_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_y +
+        (context_ptr->blk_origin_x + input_picture_ptr->origin_x);
+
     for (uint32_t ref_it = 0; ref_it < pcs_ptr->parent_pcs_ptr->tot_ref_frame_types; ++ref_it) {
         MvReferenceFrame ref_pair = pcs_ptr->parent_pcs_ptr->ref_frame_type_arr[ref_it];
 
@@ -4413,12 +4418,11 @@ void    predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *co
                                     : context_ptr->hbd_mode_decision;
     input_picture_ptr = hbd_mode_decision ? pcs_ptr->input_frame16bit
                                           : pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
-#if !ENHANCED_ME_MV
     //Update input origin
     input_origin_index =
         (context_ptr->blk_origin_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_y +
         (context_ptr->blk_origin_x + input_picture_ptr->origin_x);
-#endif
+
     // Reset valid_refined_mv
     memset(context_ptr->valid_refined_mv, 0, 8); // [2][4]
 

--- a/test/e2e_test/SvtAv1E2EFramework.cc
+++ b/test/e2e_test/SvtAv1E2EFramework.cc
@@ -557,6 +557,23 @@ void SvtAv1E2ETestFramework::write_output_header() {
         fwrite(header, 1, IVF_STREAM_HEADER_SIZE, output_file_->file);
 }
 
+static void update_prev_ivf_header(
+    svt_av1_e2e_test::SvtAv1E2ETestFramework::IvfFile *ivf) {
+    char header[4];  // only for the number of bytes
+    if (ivf && ivf->file && ivf->byte_count_since_ivf != 0) {
+        fseeko(
+            ivf->file,
+            (-(int32_t)(ivf->byte_count_since_ivf + IVF_FRAME_HEADER_SIZE)),
+            SEEK_CUR);
+        mem_put_le32(&header[0], (int32_t)(ivf->byte_count_since_ivf));
+        fwrite(header, 1, 4, ivf->file);
+        fseeko(ivf->file,
+                 (ivf->byte_count_since_ivf + IVF_FRAME_HEADER_SIZE - 4),
+                 SEEK_CUR);
+        ivf->byte_count_since_ivf = 0;
+    }
+}
+
 static void write_ivf_frame_header(
     svt_av1_e2e_test::SvtAv1E2ETestFramework::IvfFile *ivf,
     uint32_t byte_count) {
@@ -582,13 +599,77 @@ static void write_ivf_frame_header(
 
 void SvtAv1E2ETestFramework::write_compress_data(
     const EbBufferHeaderType *output) {
-    write_ivf_frame_header(
-        output_file_,
-        output->n_filled_len);
-    fwrite(output->p_buffer,
-        1,
-        output->n_filled_len,
-        output_file_->file);
+    // Check for the flags EB_BUFFERFLAG_HAS_TD and
+    // EB_BUFFERFLAG_SHOW_EXT
+    switch (output->flags & 0x00000006) {
+    case (EB_BUFFERFLAG_HAS_TD | EB_BUFFERFLAG_SHOW_EXT):
+        // terminate previous ivf packet, update the combined size of
+        // packets sent
+        update_prev_ivf_header(output_file_);
+
+        // Write a new IVF frame header to file as a TD is in the packet
+        write_ivf_frame_header(
+            output_file_,
+            output->n_filled_len - (obu_frame_header_size_ + TD_SIZE));
+        fwrite(output->p_buffer,
+               1,
+               output->n_filled_len - (obu_frame_header_size_ + TD_SIZE),
+               output_file_->file);
+
+        // An EB_BUFFERFLAG_SHOW_EXT means that another TD has been added to
+        // the packet to show another frame, a new IVF is needed
+        write_ivf_frame_header(output_file_,
+                               (obu_frame_header_size_ + TD_SIZE));
+        fwrite(output->p_buffer + output->n_filled_len -
+                   (obu_frame_header_size_ + TD_SIZE),
+               1,
+               (obu_frame_header_size_ + TD_SIZE),
+               output_file_->file);
+
+        break;
+    case (EB_BUFFERFLAG_HAS_TD):
+        // terminate previous ivf packet, update the combined size of
+        // packets sent
+        update_prev_ivf_header(output_file_);
+
+        // Write a new IVF frame header to file as a TD is in the packet
+        write_ivf_frame_header(output_file_, output->n_filled_len);
+        fwrite(output->p_buffer, 1, output->n_filled_len, output_file_->file);
+        break;
+    case (EB_BUFFERFLAG_SHOW_EXT):
+        // this case means that there's only one TD in this packet and is
+        // relater
+        fwrite(output->p_buffer,
+               1,
+               output->n_filled_len - (obu_frame_header_size_ + TD_SIZE),
+               output_file_->file);
+        // this packet will be part of the previous IVF header
+        output_file_->byte_count_since_ivf +=
+            (output->n_filled_len - (obu_frame_header_size_ + TD_SIZE));
+
+        // terminate previous ivf packet, update the combined size of
+        // packets sent
+        update_prev_ivf_header(output_file_);
+
+        // An EB_BUFFERFLAG_SHOW_EXT means that another TD has been added to
+        // the packet to show another frame, a new IVF is needed
+        write_ivf_frame_header(output_file_,
+                               (obu_frame_header_size_ + TD_SIZE));
+        fwrite(output->p_buffer + output->n_filled_len -
+                   (obu_frame_header_size_ + TD_SIZE),
+               1,
+               (obu_frame_header_size_ + TD_SIZE),
+               output_file_->file);
+
+        break;
+    default:
+        // This is a packet without a TD, write it straight to file
+        fwrite(output->p_buffer, 1, output->n_filled_len, output_file_->file);
+
+        // this packet will be part of the previous IVF header
+        output_file_->byte_count_since_ivf += (output->n_filled_len);
+        break;
+    }
 }
 
 void SvtAv1E2ETestFramework::process_compress_data(
@@ -600,7 +681,15 @@ void SvtAv1E2ETestFramework::process_compress_data(
         return;
     }
 
-    decode_compress_data(data->p_buffer, data->n_filled_len);
+    if (data->flags & EB_BUFFERFLAG_SHOW_EXT) {
+        uint32_t first_part_size =
+            data->n_filled_len - obu_frame_header_size_ - TD_SIZE;
+        decode_compress_data(data->p_buffer, first_part_size);
+        decode_compress_data(data->p_buffer + first_part_size,
+                             obu_frame_header_size_ + TD_SIZE);
+    } else {
+        decode_compress_data(data->p_buffer, data->n_filled_len);
+    }
 }
 
 void SvtAv1E2ETestFramework::decode_compress_data(const uint8_t *data,


### PR DESCRIPTION
Following are the changes:

    Bug Fixes related to film_grain: chroma_scaling_from_luma, odd resolution supprt
    Fixes related to Storing of qindex for each segment id & segment_id from prev frame
    Bug Fixes related to parsing of DeltaFrameIdLength & delta_lf
    LF bug_fixes related to odd resolution & lossless mode
    MT bug fix related to a hang at the end
    Bug fix related to early exit in Motion field projection
    Super_res bug fixes related to smaller frame dim.( less than 16)
