### PR TITLE
Travis: disable coveralls for the moment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ addons:
 stages:
   - name: test
     if: type != pull_request
-  - name: unittest
 
 # Default scripts
 before_install:
@@ -231,24 +230,3 @@ matrix:
       script:
         - *base_script
         - travis_wait 60 valgrind -- SvtAv1EncApp -enc-mode 4 -i akiyo_cif.y4m -n 20 -b test1.ivf
-
-    # Unittests on Linux and macOS
-    - name: Unit Tests Linux+gcc
-      stage: unittest
-      env: build_type=release CMAKE_EFLAGS="-DBUILD_TESTING=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/
-      script:
-        - *base_script
-        - &unittests |
-          cd $TRAVIS_BUILD_DIR/Build/linux/${build_type:-Release}
-          make TestVectors
-          cd $TRAVIS_BUILD_DIR
-          SvtAv1UnitTests
-          SvtAv1ApiTests
-          SvtAv1E2ETests
-    - name: Unit Tests osx+clang
-      os: osx
-      compiler: clang
-      env: build_type=release CMAKE_EFLAGS="-DBUILD_TESTING=ON" SVT_AV1_TEST_VECTOR_PATH=$TRAVIS_BUILD_DIR/test/vectors/
-      script:
-        - *base_script
-        - *unittests

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,10 @@ addons:
       - ccache
       - python
     update: true # Remove when Travis macOS images get updated
-notifications:
-  webhooks: https://coveralls.io/webhook
 
 # Pipeline stages
 stages:
   - name: test
-  - name: coveralls+valgrind
     if: type != pull_request
   - name: unittest
 
@@ -222,47 +219,6 @@ matrix:
         - diff test-pr-8bit-m0.ivf test-master-8bit-m0.ivf
         - diff test-pr-10bit-m8.ivf test-master-10bit-m8.ivf
         - diff test-pr-10bit-m0.ivf test-master-10bit-m0.ivf
-
-    # Coveralls on Linux and macOS
-    - name: Coveralls Linux+gcc
-      stage: coveralls+valgrind
-      env: COVERALLS_PARALLEL=true build_type=debug CMAKE_EFLAGS="-DCOVERAGE=ON"
-      addons:
-        apt:
-          packages:
-            - *native_deps
-            - python3-pip
-      script:
-        - *base_script
-        - &coveralls_script |
-          pip3 install --user cpp-coveralls
-          export PATH=/Users/travis/Library/Python/3.7/bin:${PATH}
-          SvtAv1EncApp -enc-mode 8 -i akiyo_cif.y4m -n 150 -b test1.ivf
-          git clone https://github.com/FFmpeg/FFmpeg ffmpeg --depth=1 --branch release/4.2 && cd ffmpeg &&
-          git apply $TRAVIS_BUILD_DIR/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch &&
-          ffmpegconfig=(--disable-everything --enable-{libsvtav1,encoder={libaom_av1,libsvt_av1,rawvideo},decoder={h264,rawvideo,yuv4,libaom_av1},muxer={fifo,matroska,ivf,mp4,rawvideo,webm,yuv4mpegpipe},demuxer={h264,ivf,matroska,mpegts,rawvideo,yuv4mpegpipe},parser={av1,h264,mpeg4video},bsf={av1_metadata,h264_metadata},protocol={data,file,pipe,unix},filter={fifo,fps,libvmaf,psnr,ssim,vmafmotion}})
-          sudo chown -R travis: $HOME/.ccache
-          export CFLAGS=""
-          if ! ./configure ${ffmpegconfig[@]}; then cat ffbuild/config.log; fi &&
-          make -s -j$(if [ $TRAVIS_OS_NAME = osx ]; then sysctl -n hw.ncpu; else nproc; fi) >/dev/null &&
-          sudo make install && cd $TRAVIS_BUILD_DIR &&
-          ffmpeg -i akiyo_cif.y4m -vframes 150 -c:v libsvt_av1 test.mp4 &&
-          ffmpeg -i bus_cif.y4m -nostdin -f rawvideo -pix_fmt yuv420p - | SvtAv1EncApp -i stdin -w 352 -h 288 -fps 30 -n 150 -b test2.ivf
-      after_script: &after_coveralls_script |
-        if [ $CC = "clang" ] && [ $TRAVIS_OS_NAME = linux ]; then
-          GCOV_FILE=llvm-cov GCOV_OPTIONS='gcov -pl'
-        else
-          GCOV_FILE=gcov GCOV_OPTIONS='\-lp'
-        fi
-        coveralls --root $TRAVIS_BUILD_DIR -i Source -E ".*gtest.*" -E ".*CMakeFiles.*" -E ".*third_party.*" -E ".*test/FilmGrainTest.cc" -E ".*ffmpeg.*" --gcov $GCOV_FILE --gcov-options "$GCOV_OPTIONS"
-    - name: Coveralls osx+clang
-      os: osx
-      compiler: clang
-      env: COVERALLS_PARALLEL=true build_type=debug CMAKE_EFLAGS="-DCOVERAGE=ON"
-      script:
-        - *base_script
-        - *coveralls_script
-      after_script: *after_coveralls_script
 
     # Valgrind on Linux and macOS
     - name: Valgrind

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/OpenVisualCloud/SVT-AV1?branch=master&svg=true)](https://ci.appveyor.com/project/OpenVisualCloud/SVT-AV1)
 [![Travis Build Status](https://travis-ci.com/OpenVisualCloud/SVT-AV1.svg?branch=master)](https://travis-ci.com/OpenVisualCloud/SVT-AV1)
-[![Coverage Status](https://coveralls.io/repos/github/OpenVisualCloud/SVT-AV1/badge.svg?branch=master)](https://coveralls.io/github/OpenVisualCloud/SVT-AV1?branch=master)
 
 The Scalable Video Technology for AV1 (SVT-AV1 Encoder and Decoder) is an AV1-compliant encoder/decoder library core. The SVT-AV1 encoder development is a work-in-progress targeting performance levels applicable to both VOD and Live encoding / transcoding video applications. The SVT-AV1 decoder implementation is targeting future codec research activities.
 


### PR DESCRIPTION
Since our coveralls is not reporting an accurate coverage number, we will disable the CI hook for now. When this is fixed, this commit can be reverted. 