### PR TITLE
16b pipeline support in decoder

### DIFF
--- a/Source/API/EbSvtAv1Dec.h
+++ b/Source/API/EbSvtAv1Dec.h
@@ -118,6 +118,12 @@ typedef struct EbSvtAv1DecConfiguration {
     uint32_t active_channel_count;
 
     uint32_t stat_report;
+
+    /* Decoder internal bit-depth is set to 16-bit even if the bitstream is 8-bit
+     *
+     * Default is 0. */
+    EbBool decoder_16bit_pipeline;
+
 } EbSvtAv1DecConfiguration;
 
 /* STEP 1: Call the library to construct a Component Handle.

--- a/Source/App/DecApp/EbDecParamParser.c
+++ b/Source/App/DecApp/EbDecParamParser.c
@@ -30,6 +30,14 @@ static void set_limit_frame(const char *value, EbSvtAv1DecConfiguration *cfg) {
 static void set_bit_depth(const char *value, EbSvtAv1DecConfiguration *cfg) {
     cfg->max_bit_depth = strtoul(value, NULL, 0);
 };
+static void set_decoder_16bit_pipeline(const char *value, EbSvtAv1DecConfiguration *cfg) {
+    cfg->decoder_16bit_pipeline = (EbBool)strtoul(value, NULL, 0);
+    if (cfg->decoder_16bit_pipeline != 1 && cfg->decoder_16bit_pipeline != 0) {
+        fprintf(stderr,
+                "Warning : Invalid value for decoder_16bit_pipeline, setting value to 0. \n");
+        cfg->decoder_16bit_pipeline = 0;
+    }
+};
 static void set_pic_width(const char *value, EbSvtAv1DecConfiguration *cfg) {
     cfg->max_picture_width = strtoul(value, NULL, 0);
 };
@@ -61,6 +69,7 @@ ConfigEntry config_entry[] = {
     {LIMIT_FRAME_TOKEN, "LimitFrame", 1, set_limit_frame},
     // Picture properties
     {BIT_DEPTH_TOKEN, "InputBitDepth", 1, set_bit_depth},
+    {DECODER_16BIT_PIPELINE, "Decoder16BitPipeline", 1, set_decoder_16bit_pipeline},
     {PIC_WIDTH_TOKEN, "PictureWidth", 1, set_pic_width},
     {PIC_HEIGHT_TOKEN, "PictureHeight", 1, set_pic_height},
     {COLOUR_SPACE_TOKEN, "InputColourSpace", 1, set_colour_space},
@@ -87,6 +96,7 @@ static void show_help() {
     H0( " -fps-frm                  Show fps after each frame decoded\n");
     H0( " -fps-summary              Show fps summary");
     H0( " -skip-film-grain          Disable Film Grain");
+    H0( " -16bit-pipeline           Enable 16b pipeline. [1 - enable, 0 - disable]");
 
     exit(1);
 }

--- a/Source/App/DecApp/EbDecParamParser.h
+++ b/Source/App/DecApp/EbDecParamParser.h
@@ -34,6 +34,7 @@
 #define SKIP_FRAME_TOKEN "-skip"
 #define LIMIT_FRAME_TOKEN "-limit"
 #define BIT_DEPTH_TOKEN "-bit-depth"
+#define DECODER_16BIT_PIPELINE "-16bit-pipeline"
 #define PIC_WIDTH_TOKEN "-w"
 #define PIC_HEIGHT_TOKEN "-h"
 #define COLOUR_SPACE_TOKEN "-colour-space"

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -138,6 +138,7 @@ extern "C" {
 #define MRP_31B_SUPPORT 1
 #define TILES_PARALLEL 1
 #define LOW_DELAY_TUNE 1 // Tuning the 0B, 1B and 3B settings
+#define COMMON_16BIT 1 // 16Bit pipeline support for common
 #define ENCDEC_16BIT 0 // 16Bit pipeline support for encdec ( do not enable )
 #if ENCDEC_16BIT
 #define SHUT_FILTERING 0 //1

--- a/Source/Lib/Common/Codec/EbInterPrediction.c
+++ b/Source/Lib/Common/Codec/EbInterPrediction.c
@@ -1954,18 +1954,30 @@ const uint8_t *av1_get_compound_type_mask(const InterInterCompoundData *const co
     }
 }
 
+#if COMMON_16BIT
+void build_masked_compound_no_round(uint8_t *dst, int dst_stride, const CONV_BUF_TYPE *src0,
+                                    int src0_stride, const CONV_BUF_TYPE *src1, int src1_stride,
+                                    const InterInterCompoundData *const comp_data,
+                                    uint8_t *seg_mask, BlockSize sb_type, int h, int w,
+                                    ConvolveParams *conv_params, uint8_t bit_depth,
+                                    EbBool use_16bit_pipeline) {
+#else
 void build_masked_compound_no_round(uint8_t *dst, int dst_stride, const CONV_BUF_TYPE *src0,
                                     int src0_stride, const CONV_BUF_TYPE *src1, int src1_stride,
                                     const InterInterCompoundData *const comp_data,
                                     uint8_t *seg_mask, BlockSize sb_type, int h, int w,
                                     ConvolveParams *conv_params, uint8_t bit_depth) {
+#endif
     // Derive subsampling from h and w passed in. May be refactored to
     // pass in subsampling factors directly.
     const int      subh = (2 << mi_size_high_log2[sb_type]) == h;
     const int      subw = (2 << mi_size_wide_log2[sb_type]) == w;
     const uint8_t *mask = av1_get_compound_type_mask(comp_data, seg_mask, sb_type);
-
+#if COMMON_16BIT
+    if (bit_depth > EB_8BIT || use_16bit_pipeline) {
+#else
     if (bit_depth > EB_8BIT) {
+#endif
         aom_highbd_blend_a64_d16_mask(dst,
                                       dst_stride,
                                       src0,

--- a/Source/Lib/Common/Codec/EbInterPrediction.h
+++ b/Source/Lib/Common/Codec/EbInterPrediction.h
@@ -130,13 +130,21 @@ typedef struct WedgeParamsType
         int *fwd_offset, int *bck_offset,
         int *use_dist_wtd_comp_avg,
         int is_compound);
-
+#if COMMON_16BIT
+    void build_masked_compound_no_round(uint8_t *dst, int dst_stride, const CONV_BUF_TYPE *src0,
+                                        int src0_stride, const CONV_BUF_TYPE *src1, int src1_stride,
+                                        const InterInterCompoundData *const comp_data,
+                                        uint8_t *seg_mask, BlockSize sb_type, int h, int w,
+                                        ConvolveParams *conv_params, uint8_t bd,
+                                        EbBool use_16bit_pipeline);
+#else
     void build_masked_compound_no_round(uint8_t *dst, int dst_stride,
         const CONV_BUF_TYPE *src0, int src0_stride,
         const CONV_BUF_TYPE *src1, int src1_stride,
         const InterInterCompoundData *const comp_data, uint8_t *seg_mask,
         BlockSize sb_type, int h, int w, ConvolveParams *conv_params,
         uint8_t bd);
+#endif
 #if ENCDEC_16BIT
     void build_masked_compound_no_round_hbd(uint8_t *dst, int dst_stride,
         const CONV_BUF_TYPE *src0, int src0_stride,

--- a/Source/Lib/Common/Codec/EbPictureBufferDesc.h
+++ b/Source/Lib/Common/Codec/EbPictureBufferDesc.h
@@ -63,6 +63,8 @@ typedef struct EbPictureBufferDesc {
 
     EbBool   film_grain_flag; // Indicates if film grain parameters are present for the frame
     uint32_t buffer_enable_mask;
+    /* internal bit-depth is set to 16b even if the bitstream is 8b */
+    EbBool use_16bit_pipeline;
 } EbPictureBufferDesc;
 
 #define YV12_FLAG_HIGHBITDEPTH 8

--- a/Source/Lib/Common/Codec/EbSuperRes.c
+++ b/Source/Lib/Common/Codec/EbSuperRes.c
@@ -216,9 +216,19 @@ void highbd_upscale_normative_rect(const uint8_t *const input, int height, int w
     }
 }
 
+#if COMMON_16BIT
+void av1_upscale_normative_rows(const Av1Common *cm, const uint8_t *src, int src_stride,
+                                uint8_t *dst, int dst_stride, int rows, int sub_x, int bd,
+                                EbBool use_16bit_pipeline) {
+#else
 void av1_upscale_normative_rows(const Av1Common *cm, const uint8_t *src, int src_stride,
                                 uint8_t *dst, int dst_stride, int rows, int sub_x, int bd) {
+#endif
+#if COMMON_16BIT
+    int       high_bd                = bd > EB_8BIT || use_16bit_pipeline;
+#else
     int       high_bd                = bd > 8;
+#endif
     const int downscaled_plane_width = ROUND_POWER_OF_TWO(cm->frm_size.frame_width, sub_x);
     const int upscaled_plane_width =
         ROUND_POWER_OF_TWO(cm->frm_size.superres_upscaled_width, sub_x);

--- a/Source/Lib/Decoder/Codec/EbDecCdef.c
+++ b/Source/Lib/Decoder/Codec/EbDecCdef.c
@@ -86,7 +86,12 @@ void svt_cdef_block(EbDecHandle *dec_handle, int32_t *mi_wide_l2, int32_t *mi_hi
     CurFrameBuf *        frame_buf         = &master_frame_buf->cur_frame_bufs[0];
     EbPictureBufferDesc *recon_picture_ptr = dec_handle->cur_pic_buf[0]->ps_pic_buf;
 
-    int8_t        use_highbd = dec_handle->seq_header.color_config.bit_depth > 8;
+#if DEC_16BIT_PIPELINE
+    int8_t use_highbd = (dec_handle->seq_header.color_config.bit_depth > EB_8BIT ||
+        dec_handle->decoder_16bit_pipeline);
+#else
+    int8_t use_highbd = (dec_handle->seq_header.color_config.bit_depth > EB_8BIT);
+#endif
     const int32_t cdef_mask  = 1;
     uint32_t      cdef_count;
     int32_t       coeff_shift = AOMMAX(recon_picture_ptr->bit_depth - 8, 0);

--- a/Source/Lib/Decoder/Codec/EbDecHandle.h
+++ b/Source/Lib/Decoder/Codec/EbDecHandle.h
@@ -38,6 +38,8 @@ extern "C" {
 #define DEC_PAD_VALUE    (128+32)
 #endif
 
+#define DEC_16BIT_PIPELINE  1 // 16Bit pipeline support for dec
+
 /* Maximum number of frames in parallel */
 #define DEC_MAX_NUM_FRM_PRLL 1
 /** Maximum picture buffers needed **/
@@ -247,6 +249,10 @@ typedef struct EbDecHandle {
     EbBool                start_thread_process;
     EbHandle              thread_semaphore;
     struct DecThreadCtxt *thread_ctxt_pa;
+#if DEC_16BIT_PIPELINE
+    /* Decoder internal bit-depth is set to 16b even if the bitstream is 8b */
+    EbBool decoder_16bit_pipeline;
+#endif
 } EbDecHandle;
 
 /* Thread level context data */

--- a/Source/Lib/Decoder/Codec/EbDecInterPrediction.c
+++ b/Source/Lib/Decoder/Codec/EbDecInterPrediction.c
@@ -401,17 +401,30 @@ static INLINE void extend_mc_border(void *src, int32_t *src_stride,
 }
 #endif //MC_DYNAMIC_PAD
 
+#if DEC_16BIT_PIPELINE
 void svt_make_inter_predictor(PartitionInfo *part_info, int32_t ref, void *src, int32_t src_stride,
                               void *dst_mod, int32_t dst_stride, EbDecPicBuf *ref_buf,
                               int32_t pre_x, int32_t pre_y, int32_t bw, int32_t bh,
-                              ConvolveParams *conv_params, int32_t plane, int32_t do_warp) {
+                              ConvolveParams *conv_params, int32_t plane,
+                              int32_t do_warp, EbBool is16b){
+#else
+void svt_make_inter_predictor(PartitionInfo *part_info, int32_t ref, void *src, int32_t src_stride,
+                              void *dst_mod, int32_t dst_stride, EbDecPicBuf *ref_buf,
+                              int32_t pre_x, int32_t pre_y, int32_t bw, int32_t bh,
+                              ConvolveParams *conv_params, int32_t plane,
+                              int32_t do_warp){
+#endif
     const BlockModeInfo *mi         = part_info->mi;
     const int32_t        is_intrabc = is_intrabc_block(mi);
 
     const int32_t ss_x      = plane ? part_info->subsampling_x : 0;
     const int32_t ss_y      = plane ? part_info->subsampling_y : 0;
     int32_t       bit_depth = ref_buf->ps_pic_buf->bit_depth;
+#if DEC_16BIT_PIPELINE
+    int32_t       highbd    = bit_depth > EB_8BIT || is16b;
+#else
     int32_t       highbd    = bit_depth > EB_8BIT;
+#endif
 
     /*ScaleFactor*/
     const struct ScaleFactors *const sf =
@@ -592,12 +605,19 @@ void svt_make_inter_predictor(PartitionInfo *part_info, int32_t ref, void *src, 
                             is_intrabc);
     }
 }
-
+#if DEC_16BIT_PIPELINE
+void svt_make_masked_inter_predictor(PartitionInfo *part_info, int32_t ref, void *src,
+                                     int32_t src_stride, void *dst_ptr, int32_t dst_stride,
+                                     EbDecPicBuf *ref_buf, int32_t pre_x, int32_t pre_y, int32_t bw,
+                                     int32_t bh, ConvolveParams *conv_params, int32_t plane,
+                                     uint8_t *seg_mask, int32_t do_warp , EbBool is16b) {
+#else
 void svt_make_masked_inter_predictor(PartitionInfo *part_info, int32_t ref, void *src,
                                      int32_t src_stride, void *dst_ptr, int32_t dst_stride,
                                      EbDecPicBuf *ref_buf, int32_t pre_x, int32_t pre_y, int32_t bw,
                                      int32_t bh, ConvolveParams *conv_params, int32_t plane,
                                      uint8_t *seg_mask, int32_t do_warp) {
+#endif
     InterInterCompoundData *comp_data = &part_info->mi->inter_inter_compound;
     const BlockSize         bsize     = part_info->mi->sb_type;
     int32_t                 bit_depth = ref_buf->ps_pic_buf->bit_depth;
@@ -619,6 +639,23 @@ void svt_make_masked_inter_predictor(PartitionInfo *part_info, int32_t ref, void
     assert(conv_params->do_average == 0);
     assert(conv_params->is_compound == 1);
 
+#if DEC_16BIT_PIPELINE
+    svt_make_inter_predictor(part_info,
+                             ref,
+                             src,
+                             src_stride,
+                             dst_ptr,
+                             dst_stride,
+                             ref_buf,
+                             pre_x,
+                             pre_y,
+                             bw,
+                             bh,
+                             conv_params,
+                             plane,
+                             do_warp,
+                             is16b);
+#else
     svt_make_inter_predictor(part_info,
                              ref,
                              src,
@@ -633,6 +670,7 @@ void svt_make_masked_inter_predictor(PartitionInfo *part_info, int32_t ref, void
                              conv_params,
                              plane,
                              do_warp);
+#endif
 
     if (!plane && comp_data->type == COMPOUND_DIFFWTD) {
         //CHKN  for DIFF: need to compute the mask  comp_data->seg_mask is
@@ -650,6 +688,23 @@ void svt_make_masked_inter_predictor(PartitionInfo *part_info, int32_t ref, void
                                             bit_depth);
     }
 
+#if COMMON_16BIT && DEC_16BIT_PIPELINE
+    build_masked_compound_no_round((uint8_t *)dst_ptr,
+                                   dst_stride,
+                                   org_dst,
+                                   org_dst_stride,
+                                   tmp_buf16,
+                                   tmp_buf_stride,
+                                   comp_data,
+                                   seg_mask,
+                                   bsize,
+                                   bh,
+                                   bw,
+                                   conv_params,
+                                   (uint8_t)bit_depth,
+                                   is16b
+                                  );
+#else
     build_masked_compound_no_round((uint8_t *)dst_ptr,
                                    dst_stride,
                                    org_dst,
@@ -663,17 +718,27 @@ void svt_make_masked_inter_predictor(PartitionInfo *part_info, int32_t ref, void
                                    bw,
                                    conv_params,
                                    (uint8_t)bit_depth);
+#endif
 }
 
+#if DEC_16BIT_PIPELINE
+void av1_combine_interintra(PartitionInfo *part_info, BlockSize bsize, int plane,
+                            uint8_t *inter_pred, int inter_stride, uint8_t *intra_pred,
+                            int intra_stride, EbBitDepthEnum bit_depth, EbBool is16b) {
+#else
 void av1_combine_interintra(PartitionInfo *part_info, BlockSize bsize, int plane,
                             uint8_t *inter_pred, int inter_stride, uint8_t *intra_pred,
                             int intra_stride, EbBitDepthEnum bit_depth) {
+#endif
     BlockModeInfo * mi          = part_info->mi;
     int32_t         sub_x       = (plane > 0) ? part_info->subsampling_x : 0;
     int32_t         sub_y       = (plane > 0) ? part_info->subsampling_y : 0;
     const BlockSize plane_bsize = get_plane_block_size(bsize, sub_x, sub_y);
-
+#if DEC_16BIT_PIPELINE
+    if (bit_depth > EB_8BIT || is16b) {
+#else
     if (bit_depth > EB_8BIT) {
+#endif
         /*As per spec we r considering interitra_wedge_sign is always "zero"*/
         /*Check buffers, Aom  2nd time inter_pred buffer plane is plane independent */
         combine_interintra_highbd(mi->interintra_mode_params.interintra_mode,
@@ -711,6 +776,10 @@ void av1_build_intra_predictors_for_interintra(DecModCtxt *dec_mod_ctxt, Partiti
                                                void *pv_blk_recon_buf, int32_t recon_stride,
                                                BlockSize bsize, int32_t plane, uint8_t *dst,
                                                int dst_stride, EbBitDepthEnum bit_depth) {
+#if DEC_16BIT_PIPELINE
+    EbDecHandle *dec_handle = (EbDecHandle *)dec_mod_ctxt->dec_handle_ptr;
+    EbBool is16b = dec_handle->decoder_16bit_pipeline;
+#endif
     BlockModeInfo *mi          = part_info->mi;
     int32_t        sub_x       = (plane > 0) ? part_info->subsampling_x : 0;
     int32_t        sub_y       = (plane > 0) ? part_info->subsampling_y : 0;
@@ -724,7 +793,11 @@ void av1_build_intra_predictors_for_interintra(DecModCtxt *dec_mod_ctxt, Partiti
 
     void *pv_top_neighbor_array, *pv_left_neighbor_array;
 
+#if DEC_16BIT_PIPELINE
+    if (bit_depth == EB_8BIT && !is16b) {
+#else
     if (bit_depth == EB_8BIT) {
+#endif
         EbByte buf = (EbByte)pv_blk_recon_buf;
 
         pv_top_neighbor_array  = (void *)(buf - recon_stride);
@@ -736,6 +809,23 @@ void av1_build_intra_predictors_for_interintra(DecModCtxt *dec_mod_ctxt, Partiti
     }
 
     /*Calling Intra prediction */
+#if DEC_16BIT_PIPELINE
+    svtav1_predict_intra_block(part_info,
+                               plane,
+                               max_txsize_rect_lookup[plane_bsize],
+                               &dec_mod_ctxt->cur_tile_info,
+                               (void *)dst,
+                               dst_stride,
+                               pv_top_neighbor_array,
+                               pv_left_neighbor_array,
+                               recon_stride,
+                               dec_mod_ctxt->seq_header,
+                               mode,
+                               0,
+                               0,
+                               bit_depth,
+                               is16b);
+#else
     svtav1_predict_intra_block(part_info,
                                plane,
                                max_txsize_rect_lookup[plane_bsize],
@@ -750,13 +840,23 @@ void av1_build_intra_predictors_for_interintra(DecModCtxt *dec_mod_ctxt, Partiti
                                0,
                                0,
                                bit_depth);
+#endif
 }
 
 /* Build interintra_predictors */
 void av1_build_interintra_predictors(DecModCtxt *dec_mod_ctxt, PartitionInfo *part_info, void *pred,
                                      int32_t stride, int plane, BlockSize bsize,
+#if DEC_16BIT_PIPELINE
+                                     EbBitDepthEnum bit_depth, EbBool is16b) {
+#else
                                      EbBitDepthEnum bit_depth) {
+#endif
+
+#if DEC_16BIT_PIPELINE
+    if (bit_depth > EB_8BIT || is16b) {
+#else
     if (bit_depth > EB_8BIT) {
+#endif
         DECLARE_ALIGNED(16, uint16_t, intrapredictor[MAX_SB_SQUARE]);
         av1_build_intra_predictors_for_interintra(dec_mod_ctxt,
                                                   part_info,
@@ -774,7 +874,12 @@ void av1_build_interintra_predictors(DecModCtxt *dec_mod_ctxt, PartitionInfo *pa
                                stride,
                                (uint8_t *)intrapredictor,
                                MAX_SB_SIZE,
+#if DEC_16BIT_PIPELINE
+                               bit_depth,
+                               is16b);
+#else
                                bit_depth);
+#endif
     } else {
         DECLARE_ALIGNED(16, uint8_t, intrapredictor[MAX_SB_SQUARE]);
         av1_build_intra_predictors_for_interintra(dec_mod_ctxt,
@@ -786,8 +891,13 @@ void av1_build_interintra_predictors(DecModCtxt *dec_mod_ctxt, PartitionInfo *pa
                                                   intrapredictor,
                                                   MAX_SB_SIZE,
                                                   bit_depth);
+#if DEC_16BIT_PIPELINE
+        av1_combine_interintra(
+            part_info, bsize, plane, pred, stride, intrapredictor, MAX_SB_SIZE, bit_depth, is16b);
+#else
         av1_combine_interintra(
             part_info, bsize, plane, pred, stride, intrapredictor, MAX_SB_SIZE, bit_depth);
+#endif
     }
 }
 
@@ -806,7 +916,12 @@ void svtav1_predict_inter_block_plane(DecModCtxt *dec_mod_ctx, EbDecHandle *dec_
     //temporary buffer for joint compound, move this to context if stack does not hold.
     DECLARE_ALIGNED(32, uint16_t, tmp_dst[128 * 128]);
 
+#if DEC_16BIT_PIPELINE
+    EbBool is16b = dec_hdl->decoder_16bit_pipeline;
+    int32_t highbd = bit_depth > EB_8BIT || is16b;
+#else
     int32_t highbd = bit_depth > EB_8BIT;
+#endif
 
     const BlockSize bsize     = mi->sb_type;
     const int32_t   ss_x      = plane ? part_info->subsampling_x : 0;
@@ -915,7 +1030,12 @@ void svtav1_predict_inter_block_plane(DecModCtxt *dec_mod_ctx, EbDecHandle *dec_
                                                 &conv_params,
                                                 plane,
                                                 dec_mod_ctx->seg_mask,
+#if DEC_16BIT_PIPELINE
+                                                do_warp,
+                                                is16b);
+#else
                                                 do_warp);
+#endif
             } else {
                 svt_make_inter_predictor(part_info,
                                          ref,
@@ -930,7 +1050,12 @@ void svtav1_predict_inter_block_plane(DecModCtxt *dec_mod_ctx, EbDecHandle *dec_
                                          bh,
                                          &conv_params,
                                          plane,
+#if DEC_16BIT_PIPELINE
+                                         do_warp,
+                                         is16b);
+#else
                                          do_warp);
+#endif
             }
         }
     }
@@ -1002,7 +1127,12 @@ void svtav1_predict_inter_block(DecModCtxt *dec_mod_ctxt, EbDecHandle *dec_hdl,
                                             recon_stride,
                                             plane,
                                             bsize,
+#if DEC_16BIT_PIPELINE
+                                            recon_picture_buf->bit_depth,
+                                            dec_hdl->decoder_16bit_pipeline);
+#else
                                             recon_picture_buf->bit_depth);
+#endif
         }
     }
     if (part_info->mi->motion_mode == OBMC_CAUSAL) {

--- a/Source/Lib/Decoder/Codec/EbDecIntraPrediction.h
+++ b/Source/Lib/Decoder/Codec/EbDecIntraPrediction.h
@@ -20,14 +20,29 @@ void svt_av1_predict_intra(DecModCtxt *dec_mod_ctxt, PartitionInfo *part_info, i
                            int32_t recon_stride, EbBitDepthEnum bit_depth, int32_t blk_mi_col_off,
                            int32_t blk_mi_row_off);
 
+#if DEC_16BIT_PIPELINE
+void svtav1_predict_intra_block(PartitionInfo *xd, int32_t plane, TxSize tx_size, TileInfo *td,
+                                void *pv_pred_buf, int32_t pred_stride, void *top_neigh_array,
+                                void *left_neigh_array, int32_t ref_stride, SeqHeader *seq_header,
+                                const PredictionMode mode, int32_t blk_mi_col_off,
+                                int32_t blk_mi_row_off, EbBitDepthEnum bit_depth, EbBool is16b);
+#else
 void svtav1_predict_intra_block(PartitionInfo *xd, int32_t plane, TxSize tx_size, TileInfo *td,
                                 void *pv_pred_buf, int32_t pred_stride, void *top_neigh_array,
                                 void *left_neigh_array, int32_t ref_stride, SeqHeader *seq_header,
                                 const PredictionMode mode, int32_t blk_mi_col_off,
                                 int32_t blk_mi_row_off, EbBitDepthEnum bit_depth);
+#endif
 
+#if DEC_16BIT_PIPELINE
 void cfl_store_tx(PartitionInfo *xd, CflCtx *cfl_ctx, int row, int col, TxSize tx_size,
-                  BlockSize bsize, EbColorConfig *cc, uint8_t *dst_buff, uint32_t dst_stride);
+                  BlockSize bsize, EbColorConfig *cc, uint8_t *dst_buff,
+                  uint32_t dst_stride, EbBool is16b);
+#else
+void cfl_store_tx(PartitionInfo *xd, CflCtx *cfl_ctx, int row, int col, TxSize tx_size,
+                  BlockSize bsize, EbColorConfig *cc, uint8_t *dst_buff,
+                  uint32_t dst_stride);
+#endif
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Decoder/Codec/EbDecLF.c
+++ b/Source/Lib/Decoder/Codec/EbDecLF.c
@@ -291,7 +291,12 @@ void dec_av1_filter_block_plane_vert(EbDecHandle *dec_handle,
 {
     FrameHeader *frm_hdr = &dec_handle->frame_header;
     EbColorConfig *color_config = &dec_handle->seq_header.color_config;
-    EbBitDepthEnum is16bit = recon_picture_buf->bit_depth > 8;
+#if DEC_16BIT_PIPELINE
+    EbBitDepthEnum is16bit = (recon_picture_buf->bit_depth > EB_8BIT ||
+        dec_handle->decoder_16bit_pipeline);
+#else
+    EbBitDepthEnum is16bit = recon_picture_buf->bit_depth > EB_8BIT;
+#endif
     int32_t sub_x = color_config->subsampling_x;
     int32_t sub_y = color_config->subsampling_y;
     uint8_t no_lf_luma = !(frm_hdr->loop_filter_params.filter_level[0]) &&
@@ -490,7 +495,12 @@ void dec_av1_filter_block_plane_horz(EbDecHandle *dec_handle, SBInfo *sb_info,
     FrameHeader *frm_hdr        = &dec_handle->frame_header;
     EbColorConfig *color_config = &dec_handle->seq_header.color_config;
 
-    EbBool is16bit = recon_picture_buf->bit_depth > 8;
+#if DEC_16BIT_PIPELINE
+    EbBool is16bit = (recon_picture_buf->bit_depth > EB_8BIT ||
+        dec_handle->decoder_16bit_pipeline);
+#else
+    EbBool is16bit = recon_picture_buf->bit_depth > EB_8BIT;
+#endif
 
     int32_t sub_x = color_config->subsampling_x;
     int32_t sub_y = color_config->subsampling_y;

--- a/Source/Lib/Decoder/Codec/EbDecMemInit.h
+++ b/Source/Lib/Decoder/Codec/EbDecMemInit.h
@@ -78,9 +78,14 @@ extern EbMemoryMapEntry                 *memory_map_end_address;
                 (((n_elements) + (8 - ((n_elements) % 8))) + sizeof(EbMemoryMapEntry)); \
         svt_dec_lib_malloc_count++;                                                     \
     }
-
+#if DEC_16BIT_PIPELINE
+EbErrorType dec_eb_recon_picture_buffer_desc_ctor(EbPtr *object_dbl_ptr,
+                                                  EbPtr  object_init_data_ptr,
+                                                  EbBool is_16bit_pipeline);
+#else
 EbErrorType dec_eb_recon_picture_buffer_desc_ctor(EbPtr *object_dbl_ptr,
                                                   EbPtr  object_init_data_ptr);
+#endif
 
 EbErrorType dec_mem_init(EbDecHandle *dec_handle_ptr);
 

--- a/Source/Lib/Decoder/Codec/EbDecObmc.c
+++ b/Source/Lib/Decoder/Codec/EbDecObmc.c
@@ -55,7 +55,12 @@ static INLINE void build_obmc_inter_pred_above(
     int above_tmp_stride[MAX_MB_PLANE], uint8_t *curr_blk_recon_buf[MAX_MB_PLANE],
     int32_t curr_recon_stride[MAX_MB_PLANE], const int num_planes) {
     EbPictureBufferDesc *recon_picture_buf = dec_handle->cur_pic_buf[0]->ps_pic_buf;
+#if DEC_16BIT_PIPELINE
+    const int            is_hbd            = ((recon_picture_buf->bit_depth != EB_8BIT) ||
+                                              recon_picture_buf->use_16bit_pipeline ) ? 1 : 0;
+#else
     const int            is_hbd            = (recon_picture_buf->bit_depth != EB_8BIT) ? 1 : 0;
+#endif
     const int overlap = AOMMIN(block_size_high[bsize], block_size_high[BLOCK_64X64]) >> 1;
     uint8_t * above_buf;
     int32_t   above_stride;
@@ -69,8 +74,11 @@ static INLINE void build_obmc_inter_pred_above(
         const int bh    = overlap >> sub_y;
 
         if (av1_skip_u4x4_pred_in_obmc(bsize, 0, sub_x, sub_y)) continue;
-
+#if DEC_16BIT_PIPELINE
+        if (is_hbd) {
+#else
         if (recon_picture_buf->bit_depth != EB_8BIT) {
+#endif
             above_buf =
                 (uint8_t *)((uint16_t *)above_tmp_buf[plane] + ((rel_mi_col * MI_SIZE) >> sub_x) +
                             0 /*No y-offset for obmc above pred*/);
@@ -122,7 +130,12 @@ static INLINE void build_obmc_inter_pred_left(
     uint8_t *curr_blk_recon_buf[MAX_MB_PLANE], int32_t curr_recon_stride[MAX_MB_PLANE],
     const int num_planes) {
     EbPictureBufferDesc *recon_picture_buf = dec_handle->cur_pic_buf[0]->ps_pic_buf;
+#if DEC_16BIT_PIPELINE
+    const int            is_hbd            = ((recon_picture_buf->bit_depth != EB_8BIT) ||
+                                              recon_picture_buf->use_16bit_pipeline ) ? 1 : 0;
+#else
     const int            is_hbd            = (recon_picture_buf->bit_depth != EB_8BIT) ? 1 : 0;
+#endif
     const int overlap = AOMMIN(block_size_wide[bsize], block_size_wide[BLOCK_64X64]) >> 1;
 
     uint8_t *left_buf;
@@ -137,7 +150,11 @@ static INLINE void build_obmc_inter_pred_left(
 
         if (av1_skip_u4x4_pred_in_obmc(bsize, 1, sub_x, sub_y)) continue;
 
+#if DEC_16BIT_PIPELINE
+        if (is_hbd) {
+#else
         if (recon_picture_buf->bit_depth != EB_8BIT) {
+#endif
             left_buf    = (uint8_t *)((uint16_t *)left_tmp_buf[plane] +
                                    ((MI_SIZE * rel_mi_row * left_tmp_stride[plane]) >> sub_y) +
                                    0 /*No x offst for left obmc pred*/);
@@ -223,7 +240,12 @@ static INLINE void dec_build_prediction_by_above_pred(
         uint8_t sub_x = (plane > 0) ? backup_pi->subsampling_x : 0;
         uint8_t sub_y = (plane > 0) ? backup_pi->subsampling_y : 0;
 
+#if DEC_16BIT_PIPELINE
+        if ((recon_picture_buf->bit_depth != EB_8BIT) ||
+             recon_picture_buf->use_16bit_pipeline){
+#else
         if (recon_picture_buf->bit_depth != EB_8BIT) {
+#endif
             tmp_recon_buf =
                 (uint8_t *)((uint16_t *)tmp_buf[plane] + ((rel_mi_col * MI_SIZE) >> sub_x) +
                             0 /*No y-offset for obmc above pred*/);
@@ -381,7 +403,12 @@ static INLINE void dec_build_prediction_by_left_pred(
         int32_t sub_x = (plane > 0) ? backup_pi->subsampling_x : 0;
         int32_t sub_y = (plane > 0) ? backup_pi->subsampling_y : 0;
 
+#if DEC_16BIT_PIPELINE
+        if ((recon_picture_buf->bit_depth != EB_8BIT) ||
+            recon_picture_buf->use_16bit_pipeline) {
+#else
         if (recon_picture_buf->bit_depth != EB_8BIT) {
+#endif
             tmp_recon_buf = (uint8_t *)((uint16_t *)tmp_buf[plane] +
                                         ((MI_SIZE * rel_mi_row * tmp_stride[plane]) >> sub_y) +
                                         0 /*No x offst for left obmc pred*/);

--- a/Source/Lib/Decoder/Codec/EbDecParseInterBlock.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseInterBlock.c
@@ -2324,7 +2324,13 @@ void palette_tokens(EbDecHandle *dec_handle, ParseCtxt *parse_ctx, PartitionInfo
                                     sub_x,
                                     sub_y);
                 uint16_t *palette = parse_ctx->palette_colors[plane_itr];
+#if DEC_16BIT_PIPELINE
+                if (recon_picture_buf->bit_depth == EB_8BIT &&
+                    !(dec_handle->decoder_16bit_pipeline))
+                {
+#else
                 if (recon_picture_buf->bit_depth == EB_8BIT) {
+#endif
                     uint8_t *temp_buf = (uint8_t *)blk_recon_buf;
                     for (int i = 0; i < block_height; i++) {
                         for (int j = 0; j < block_width; j++) {

--- a/Source/Lib/Decoder/Codec/EbDecParseObu.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseObu.c
@@ -2032,13 +2032,16 @@ void read_uncompressed_header(Bitstrm *bs, EbDecHandle *dec_handle_ptr, ObuHeade
         dec_handle_ptr->dec_config.max_color_format = EB_YUV444;
 
     dec_handle_ptr->cur_pic_buf[0] =
+#if DEC_16BIT_PIPELINE
+        dec_pic_mgr_get_cur_pic(dec_handle_ptr);
+#else
         dec_pic_mgr_get_cur_pic(dec_handle_ptr->pv_pic_mgr,
                                 &dec_handle_ptr->seq_header,
                                 &dec_handle_ptr->frame_header,
                                 dec_handle_ptr->seq_header.color_config.mono_chrome
                                     ? EB_YUV400
                                     : dec_handle_ptr->dec_config.max_color_format);
-
+#endif
     svt_setup_frame_buf_refs(dec_handle_ptr);
     /*Temporal MVs allocation */
     check_add_tplmv_buf(dec_handle_ptr);

--- a/Source/Lib/Decoder/Codec/EbDecPicMgr.c
+++ b/Source/Lib/Decoder/Codec/EbDecPicMgr.c
@@ -110,8 +110,18 @@ static INLINE EbErrorType mvs_8x8_memory_alloc(TemporalMvRef **mvs, FrameHeader 
 *
 *******************************************************************************
 */
+#if DEC_16BIT_PIPELINE
+EbDecPicBuf *dec_pic_mgr_get_cur_pic(EbDecHandle *dec_handle_ptr) {
+    EbDecPicMgr *ps_pic_mgr = (EbDecPicMgr *)dec_handle_ptr->pv_pic_mgr;
+    SeqHeader   *seq_header = &dec_handle_ptr->seq_header;
+    FrameHeader *frame_info = &dec_handle_ptr->frame_header;
+    EbColorFormat color_format = seq_header->color_config.mono_chrome
+                                     ? EB_YUV400
+                                     : dec_handle_ptr->dec_config.max_color_format;
+#else
 EbDecPicBuf *dec_pic_mgr_get_cur_pic(EbDecPicMgr *ps_pic_mgr, SeqHeader *seq_header,
                                      FrameHeader *frame_info, EbColorFormat color_format) {
+#endif
     int32_t      i;
     EbDecPicBuf *pic_buf = NULL;
     /* TODO: Add lock and unlock for MT */
@@ -166,7 +176,13 @@ EbDecPicBuf *dec_pic_mgr_get_cur_pic(EbDecPicMgr *ps_pic_mgr, SeqHeader *seq_hea
         input_pic_buf_desc_init_data.split_mode = EB_FALSE;
 
         EbErrorType return_error = dec_eb_recon_picture_buffer_desc_ctor(
-            (EbPtr *)&(ps_pic_mgr->as_dec_pic[i].ps_pic_buf), (EbPtr)&input_pic_buf_desc_init_data);
+            (EbPtr *)&(ps_pic_mgr->as_dec_pic[i].ps_pic_buf),
+#if DEC_16BIT_PIPELINE
+            (EbPtr)&input_pic_buf_desc_init_data,
+            dec_handle_ptr->decoder_16bit_pipeline);
+#else
+            (EbPtr)&input_pic_buf_desc_init_data);
+#endif
         if (return_error != EB_ErrorNone) return NULL;
 
         ps_pic_mgr->as_dec_pic[i].size = frame_size;

--- a/Source/Lib/Decoder/Codec/EbDecPicMgr.h
+++ b/Source/Lib/Decoder/Codec/EbDecPicMgr.h
@@ -29,9 +29,12 @@ typedef struct RefFrameInfo {
 
 EbErrorType dec_pic_mgr_init(EbDecHandle *dec_handle_ptr);
 
+#if DEC_16BIT_PIPELINE
+EbDecPicBuf *dec_pic_mgr_get_cur_pic(EbDecHandle *dec_handle_ptr);
+#else
 EbDecPicBuf *dec_pic_mgr_get_cur_pic(EbDecPicMgr *ps_pic_mgr, SeqHeader *seq_header,
                                      FrameHeader *frame_info, EbColorFormat color_format);
-
+#endif
 void dec_pic_mgr_update_ref_pic(EbDecHandle *dec_handle_ptr, int32_t frame_decoded,
                                 int32_t refresh_frame_flags);
 

--- a/Source/Lib/Decoder/Codec/EbDecProcess.c
+++ b/Source/Lib/Decoder/Codec/EbDecProcess.c
@@ -43,10 +43,17 @@ void dec_loop_filter_row(EbDecHandle *dec_handle_ptr,
                          LfCtxt *lf_ctxt,
                          uint32_t y_sb_index,
                          int32_t plane_start, int32_t plane_end);
+#if COMMON_16BIT && DEC_16BIT_PIPELINE
+void save_deblock_boundary_lines(uint8_t *src_buf, int32_t src_stride, int32_t src_width,
+                                 int32_t src_height, const Av1Common *cm, int32_t plane,
+                                 int32_t row, int32_t stripe, int32_t use_highbd, int32_t is_above,
+                                 RestorationStripeBoundaries *boundaries, EbBool use_16bit_pipeline);
+#else
 void save_deblock_boundary_lines(uint8_t *src_buf, int32_t src_stride, int32_t src_width,
                                  int32_t src_height, const Av1Common *cm, int32_t plane,
                                  int32_t row, int32_t stripe, int32_t use_highbd, int32_t is_above,
                                  RestorationStripeBoundaries *boundaries);
+#endif
 void save_cdef_boundary_lines(uint8_t *src_buf, int32_t src_stride, int32_t src_width,
                               const Av1Common *cm, int32_t plane, int32_t row, int32_t stripe,
                               int32_t use_highbd, int32_t is_above,
@@ -391,8 +398,12 @@ EbErrorType dec_system_resource_init(EbDecHandle *dec_handle_ptr, TilesInfo *til
                 thread_ctxt_pa[i].dec_mod_ctxt = dec_mod_ctxt_arr[i];
                 EB_CREATE_SEMAPHORE(thread_ctxt_pa[i].thread_semaphore,
                     0, 100000);
-                int use_highbd =
-                    (dec_handle_ptr->seq_header.color_config.bit_depth > 8);
+#if DEC_16BIT_PIPELINE
+                int use_highbd = (dec_handle_ptr->seq_header.color_config.bit_depth > EB_8BIT ||
+                    dec_handle_ptr->decoder_16bit_pipeline);
+#else
+                int use_highbd = (dec_handle_ptr->seq_header.color_config.bit_depth > EB_8BIT);
+#endif
                 EB_MALLOC_DEC(uint8_t *,
                               thread_ctxt_pa[i].dst,
                               (MAX_SB_SIZE + 8) * RESTORATION_PROC_UNIT_SIZE *
@@ -645,7 +656,12 @@ static INLINE void dec_save_lf_boundary_lines_sb_row(EbDecHandle *  dec_handle,
     FrameSize *frame_size = &dec_handle->frame_header.frame_size;
     EbBool     sb_128     = dec_handle->seq_header.sb_size == BLOCK_128X128;
     int32_t    num64s     = sb_128 ? 1 : 0;
-    const int  use_highbd = (dec_handle->seq_header.color_config.bit_depth > 8);
+#if DEC_16BIT_PIPELINE
+    const int use_highbd = (dec_handle->seq_header.color_config.bit_depth > EB_8BIT ||
+        dec_handle->decoder_16bit_pipeline);
+#else
+    const int use_highbd = (dec_handle->seq_header.color_config.bit_depth > EB_8BIT);
+#endif
     LrCtxt *   lr_ctxt    = (LrCtxt *)dec_handle->pv_lr_ctxt;
     int32_t frame_stripe /* 64 strip */, plane_height;
     for (int32_t p = 0; p < num_planes; ++p) {
@@ -688,7 +704,12 @@ static INLINE void dec_save_lf_boundary_lines_sb_row(EbDecHandle *  dec_handle,
                                             frame_stripe,
                                             use_highbd,
                                             1,
+#if DEC_16BIT_PIPELINE
+                                            boundaries,
+                                            dec_handle->decoder_16bit_pipeline);
+#else
                                             boundaries);
+#endif
             }
             if (use_deblock_below) {
                 save_deblock_boundary_lines(src[p],
@@ -701,7 +722,12 @@ static INLINE void dec_save_lf_boundary_lines_sb_row(EbDecHandle *  dec_handle,
                                             frame_stripe,
                                             use_highbd,
                                             0,
+#if DEC_16BIT_PIPELINE
+                                            boundaries,
+                                            dec_handle->decoder_16bit_pipeline);
+#else
                                             boundaries);
+#endif
             }
         }
     }
@@ -714,8 +740,12 @@ static INLINE void dec_save_CDEF_boundary_lines_SB_row(
 {
     Av1Common *     cm         = &dec_handle->cm;
     FrameSize *     frame_size = &dec_handle->frame_header.frame_size;
-    const int       use_highbd =
-        (dec_handle->seq_header.color_config.bit_depth > 8);
+#if DEC_16BIT_PIPELINE
+    const int use_highbd = (dec_handle->seq_header.color_config.bit_depth > EB_8BIT ||
+        dec_handle->decoder_16bit_pipeline);
+#else
+    const int use_highbd = (dec_handle->seq_header.color_config.bit_depth > EB_8BIT);
+#endif
     LrCtxt *        lr_ctxt    = (LrCtxt *)dec_handle->pv_lr_ctxt;
     int32_t         frame_stripe /* 64 strip */;
     DecMtFrameData *dec_mt_frame_data =
@@ -1219,7 +1249,12 @@ void dec_av1_loop_restoration_filter_frame_mt(
     uint32_t pad_height = recon_picture_buf->origin_y;
 
     int32_t shift = 0;
+#if DEC_16BIT_PIPELINE
+    if ((recon_picture_buf->bit_depth != EB_8BIT) ||
+        recon_picture_buf->use_16bit_pipeline) shift = 1;
+#else
     if (recon_picture_buf->bit_depth != EB_8BIT) shift = 1;
+#endif
 
     int32_t recon_stride[MAX_MB_PLANE];
     recon_stride[AOM_PLANE_Y] = recon_picture_buf->stride_y << shift;

--- a/Source/Lib/Decoder/Codec/EbDecRestoration.c
+++ b/Source/Lib/Decoder/Codec/EbDecRestoration.c
@@ -24,10 +24,18 @@
 #include "EbPictureOperators.h"
 #include "EbRestoration.h"
 
+#if COMMON_16BIT && DEC_16BIT_PIPELINE
+void save_tile_row_boundary_lines(uint8_t *src, int32_t src_stride, int32_t src_width,
+                                  int32_t src_height, int32_t use_highbd, int32_t plane,
+                                  Av1Common *cm, int32_t after_cdef,
+                                  RestorationStripeBoundaries *boundaries,
+                                  EbBool use_16bit_pipeline);
+#else
 void save_tile_row_boundary_lines(uint8_t *src, int32_t src_stride, int32_t src_width,
                                   int32_t src_height, int32_t use_highbd, int32_t plane,
                                   Av1Common *cm, int32_t after_cdef,
                                   RestorationStripeBoundaries *boundaries);
+#endif
 
 void lr_generate_padding(
     EbByte   src_pic, //output paramter, pointer to the source picture(0,0).
@@ -126,8 +134,12 @@ void lr_pad_pic(EbPictureBufferDesc *recon_picture_buf, FrameHeader *frame_hdr,
     FrameSize *frame_size = &frame_hdr->frame_size;
     uint8_t    sx         = color_cfg->subsampling_x;
     uint8_t    sy         = color_cfg->subsampling_y;
-
+#if DEC_16BIT_PIPELINE
+    if (recon_picture_buf->bit_depth == EB_8BIT &&
+        (!recon_picture_buf->use_16bit_pipeline)) {
+#else
     if (recon_picture_buf->bit_depth == EB_8BIT) {
+#endif
         // Y samples
         lr_generate_padding(recon_picture_buf->buffer_y + recon_picture_buf->origin_x +
                                 recon_picture_buf->stride_y * recon_picture_buf->origin_y,
@@ -275,7 +287,12 @@ void dec_av1_loop_restoration_filter_row(EbDecHandle *dec_handle, int32_t sb_row
     const int32_t num_planes = av1_num_planes(&dec_handle->seq_header.
         color_config);
     int bit_depth = dec_handle->seq_header.color_config.bit_depth;
-    int use_highbd = bit_depth > 8;
+#if DEC_16BIT_PIPELINE
+    int use_highbd = (bit_depth > EB_8BIT ||
+        dec_handle->decoder_16bit_pipeline);
+#else
+    int use_highbd = (bit_depth > EB_8BIT);
+#endif
     int w_y = 0, tile_stripe0 = 0;
     int tile_w_y = tile_rect[AOM_PLANE_Y].right - tile_rect[AOM_PLANE_Y].left;
     int tile_h_y = tile_rect[AOM_PLANE_Y].bottom - tile_rect[AOM_PLANE_Y].top;
@@ -508,7 +525,12 @@ void dec_av1_loop_restoration_filter_frame(EbDecHandle *dec_handle, int optimize
 void dec_av1_loop_restoration_save_boundary_lines(EbDecHandle *dec_handle,
                                                   int after_cdef) {
     const int num_planes = av1_num_planes(&dec_handle->seq_header.color_config);
-    const int use_highbd = (dec_handle->seq_header.color_config.bit_depth > 8);
+#if DEC_16BIT_PIPELINE
+    const int use_highbd = (dec_handle->seq_header.color_config.bit_depth > EB_8BIT ||
+        dec_handle->decoder_16bit_pipeline);
+#else
+    const int use_highbd = (dec_handle->seq_header.color_config.bit_depth > EB_8BIT);
+#endif
 
     for (int p = 0; p < num_planes; ++p) {
         LrCtxt *   lr_ctxt    = (LrCtxt *)dec_handle->pv_lr_ctxt;
@@ -529,6 +551,18 @@ void dec_av1_loop_restoration_save_boundary_lines(EbDecHandle *dec_handle,
         int32_t  src_stride = stride;
         RestorationStripeBoundaries *boundaries = &lr_ctxt->boundaries[p];
 
+#if COMMON_16BIT && DEC_16BIT_PIPELINE
+        save_tile_row_boundary_lines(src_buf,
+                                     src_stride,
+                                     crop_width,
+                                     crop_height,
+                                     use_highbd,
+                                     p,
+                                     &dec_handle->cm,
+                                     after_cdef,
+                                     boundaries,
+                                     dec_handle->decoder_16bit_pipeline);
+#else
         save_tile_row_boundary_lines(src_buf,
                                      src_stride,
                                      crop_width,
@@ -538,5 +572,7 @@ void dec_av1_loop_restoration_save_boundary_lines(EbDecHandle *dec_handle,
                                      &dec_handle->cm,
                                      after_cdef,
                                      boundaries);
+#endif
+
     }
 }

--- a/Source/Lib/Decoder/Codec/EbDecSuperRes.c
+++ b/Source/Lib/Decoder/Codec/EbDecSuperRes.c
@@ -24,7 +24,11 @@
 
 
 void av1_upscale_normative_rows(const Av1Common *cm, const uint8_t *src, int src_stride,
+#if DEC_16BIT_PIPELINE
+                                uint8_t *dst, int dst_stride, int rows, int sub_x, int bd,EbBool use_16bit_pipeline);
+#else
                                 uint8_t *dst, int dst_stride, int rows, int sub_x, int bd);
+#endif
 
 void av1_upscale_normative_and_extend_frame(struct Av1Common *cm, FrameHeader *frm_hdr,
                                             SeqHeader *seq_hdr, EbPictureBufferDesc *src,
@@ -47,7 +51,12 @@ void av1_upscale_normative_and_extend_frame(struct Av1Common *cm, FrameHeader *f
                                    dst_stride,
                                    frm_hdr->frame_size.frame_height >> sub_x,
                                    sub_x,
+#if DEC_16BIT_PIPELINE
+                                   src->bit_depth,
+                                   dst->use_16bit_pipeline);
+#else
                                    src->bit_depth);
+#endif
     }
 }
 
@@ -77,9 +86,13 @@ EbErrorType copy_recon(SeqHeader *seq_hdr, EbPictureBufferDesc *recon_picture_sr
     recon_picture_dst->buffer_enable_mask = seq_hdr->color_config.mono_chrome
                                                 ? PICTURE_BUFFER_DESC_LUMA_MASK
                                                 : PICTURE_BUFFER_DESC_FULL_MASK;
-
+#if DEC_16BIT_PIPELINE
+    recon_picture_dst->use_16bit_pipeline = recon_picture_src->use_16bit_pipeline;
+    uint32_t bytes_per_pixel = (recon_picture_dst->bit_depth > EB_8BIT ||
+                                recon_picture_dst->use_16bit_pipeline) ? 2 : 1;
+#else
     uint32_t bytes_per_pixel = (recon_picture_dst->bit_depth == EB_8BIT) ? 1 : 2;
-
+#endif
     // Allocate the Picture Buffers (luma & chroma)
     if (recon_picture_dst->buffer_enable_mask & PICTURE_BUFFER_DESC_Y_FLAG) {
         EB_ALLIGN_MALLOC_DEC(EbByte,
@@ -106,7 +119,12 @@ EbErrorType copy_recon(SeqHeader *seq_hdr, EbPictureBufferDesc *recon_picture_sr
     } else
         recon_picture_dst->buffer_cr = 0;
 
-    int use_highbd = (seq_hdr->color_config.bit_depth > 8);
+#if DEC_16BIT_PIPELINE
+    int use_highbd = (seq_hdr->color_config.bit_depth > EB_8BIT ||
+        recon_picture_src->use_16bit_pipeline);
+#else
+    int use_highbd = (seq_hdr->color_config.bit_depth > EB_8BIT);
+#endif
 
     for (int plane = 0; plane < num_planes; ++plane) {
         uint8_t *src_buf, *dst_buf;
@@ -150,9 +168,12 @@ void av1_superres_upscale(Av1Common *cm, FrameHeader *frm_hdr, SeqHeader *seq_hd
         ps_recon_pic_temp = NULL;
         assert(0);
     }
-
+#if DEC_16BIT_PIPELINE
+    uint32_t bytes_per_pixel = (recon_picture_src->bit_depth > EB_8BIT ||
+                                recon_picture_src->use_16bit_pipeline) ? 2 : 1;
+#else
     uint32_t bytes_per_pixel = (recon_picture_src->bit_depth == EB_8BIT) ? 1 : 2;
-
+#endif
     memset(recon_picture_src->buffer_y, 0, recon_picture_src->luma_size * bytes_per_pixel);
     memset(recon_picture_src->buffer_cb, 0, recon_picture_src->chroma_size * bytes_per_pixel);
     memset(recon_picture_src->buffer_cr, 0, recon_picture_src->chroma_size * bytes_per_pixel);

--- a/Source/Lib/Decoder/Codec/EbDecUtils.c
+++ b/Source/Lib/Decoder/Codec/EbDecUtils.c
@@ -55,8 +55,11 @@ void derive_blk_pointers(EbPictureBufferDesc *recon_picture_buf, int32_t plane, 
             ((recon_picture_buf->origin_x >> sub_x) + blk_col_px);
         *recon_stride = recon_picture_buf->stride_cr;
     }
-
+#if DEC_16BIT_PIPELINE
+    if (recon_picture_buf->bit_depth != EB_8BIT || recon_picture_buf->use_16bit_pipeline) { //16bit
+#else
     if (recon_picture_buf->bit_depth != EB_8BIT) { //16bit
+#endif
         if (plane == 0)
             *pp_blk_recon_buf = (void *)((uint16_t *)recon_picture_buf->buffer_y + block_offset);
         else if (plane == 1)
@@ -85,7 +88,13 @@ void pad_row(EbPictureBufferDesc *recon_picture_buf,
     int32_t shift = 0;
     assert(!(pad_width & 1));
     assert(!(pad_height & 1));
+#if DEC_16BIT_PIPELINE
+    if ((recon_picture_buf->bit_depth == EB_8BIT) &&
+        (!recon_picture_buf->use_16bit_pipeline) )
+    {
+#else
     if (recon_picture_buf->bit_depth == EB_8BIT) {
+#endif
         if (flags & LEFT) {
             generate_padding_l(buf_y, stride_y,
                 row_height, pad_width);
@@ -257,7 +266,11 @@ void pad_pic(EbDecHandle *dec_handle_ptr)
 
     assert(recon_picture_buf->color_format <= EB_YUV444);
     int32_t shift = 0;
+#if DEC_16BIT_PIPELINE
+    if (recon_picture_buf->bit_depth != EB_8BIT || recon_picture_buf->use_16bit_pipeline)
+#else
     if (recon_picture_buf->bit_depth != EB_8BIT)
+#endif
         shift = 1;
 
     uint16_t stride_y = recon_picture_buf->stride_y << shift;

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -7564,7 +7564,7 @@ EB_EXTERN void av1_encode_pass_16bit(SequenceControlSet *scs_ptr, PictureControl
                         dst_stride = recon_buffer_8bit->stride_y;
 
                         convert_16bit_to_8bit(dst_16bit,
-                            dst_stride_16bit, 
+                            dst_stride_16bit,
                             dst,
                             dst_stride,
                             context_ptr->blk_geom->bwidth,

--- a/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
@@ -116,6 +116,24 @@ void av1_make_masked_inter_predictor(uint8_t *src_ptr, uint32_t src_stride, uint
                                             bitdepth);
     }
 
+#if COMMON_16BIT
+    build_masked_compound_no_round(dst_ptr,
+                                   dst_stride,
+                                   org_dst,
+                                   org_dst_stride,
+                                   tmp_buf16,
+                                   tmp_buf_stride,
+                                   comp_data,
+                                   seg_mask,
+                                   blk_geom->bsize,
+                                   bheight,
+                                   bwidth,
+                                   conv_params,
+                                   bitdepth,
+                                   0 /* Can be modified once encoder adds support for 16bit pipeline
+                                     Or can be merged with av1_make_masked_inter_predictor_hbd once ENCDEC_16BIT is enabled*/
+                                   );
+#else
     build_masked_compound_no_round(dst_ptr,
                                    dst_stride,
                                    org_dst,
@@ -129,6 +147,8 @@ void av1_make_masked_inter_predictor(uint8_t *src_ptr, uint32_t src_stride, uint
                                    bwidth,
                                    conv_params,
                                    bitdepth);
+#endif
+
 }
 #if ENCDEC_16BIT
 void av1_make_masked_inter_predictor_hbd(uint8_t *src_ptr, uint32_t src_stride, uint8_t *dst_ptr,
@@ -2491,6 +2511,24 @@ void av1_make_masked_warp_inter_predictor(uint8_t *src_ptr, uint32_t src_stride,
                                        conv_params,
                                        bitdepth);
 #else
+#if COMMON_16BIT
+    build_masked_compound_no_round(dst_ptr,
+                                   dst_stride,
+                                   org_dst,
+                                   org_dst_stride,
+                                   tmp_buf16,
+                                   tmp_buf_stride,
+                                   comp_data,
+                                   seg_mask,
+                                   blk_geom->bsize,
+                                   bheight,
+                                   bwidth,
+                                   conv_params,
+                                   bitdepth,
+                                   0 /* Can be modified once encoder adds support for 16bit pipeline
+                                     Or can be merged with av1_make_masked_inter_predictor_hbd once ENCDEC_16BIT is enabled*/
+                                   );
+#else
     build_masked_compound_no_round(dst_ptr,
                                    dst_stride,
                                    org_dst,
@@ -2504,6 +2542,7 @@ void av1_make_masked_warp_inter_predictor(uint8_t *src_ptr, uint32_t src_stride,
                                    bwidth,
                                    conv_params,
                                    bitdepth);
+#endif
 #endif
 }
 

--- a/Source/Lib/Encoder/Codec/EbRestProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRestProcess.c
@@ -63,8 +63,14 @@ void restoration_seg_search(int32_t *rst_tmpbuf, Yv12BufferConfig *org_fts,
                             PictureControlSet *pcs_ptr, uint32_t segment_index);
 void rest_finish_search(PictureParentControlSet *p_pcs_ptr, Macroblock *x, Av1Common *const cm);
 
+#if COMMON_16BIT
+void av1_upscale_normative_rows(const Av1Common *cm, const uint8_t *src,
+                                int src_stride, uint8_t *dst, int dst_stride, int rows, int sub_x,
+                                int bd, EbBool use_16bit_pipeline);
+#else
 void av1_upscale_normative_rows(const Av1Common *cm, const uint8_t *src,
                                 int src_stride, uint8_t *dst, int dst_stride, int rows, int sub_x, int bd);
+#endif
 
 #if DEBUG_UPSCALING
 void save_YUV_to_file(char *filename, EbByte buffer_y, EbByte buffer_u, EbByte buffer_v,
@@ -448,10 +454,17 @@ void eb_av1_superres_upscale_frame(struct Av1Common *cm,
                                 sub_x, sub_y);
         derive_blk_pointers_enc(dst, plane, 0, 0, (void *) &dst_buf, &dst_stride,
                                 sub_x, sub_y);
-
+#if COMMON_16BIT
+        av1_upscale_normative_rows(cm, (const uint8_t *) src_buf, src_stride, dst_buf,
+                                   dst_stride, src->height >> sub_x,
+                                   sub_x, src->bit_depth,
+                                    0 /* Can be modified once encoder adds support for 16bit pipeline*/
+                                   );
+#else
         av1_upscale_normative_rows(cm, (const uint8_t *) src_buf, src_stride, dst_buf,
                                    dst_stride, src->height >> sub_x,
                                    sub_x, src->bit_depth);
+#endif
     }
 
     // free the memory


### PR DESCRIPTION
16b pipeline support is added in decoder.

Encoder is verified to produce identical bit-streams for limited tests for enc-mode 0 and 8.

Decoder library changes are under DEC_16BIT_PIPELINE macro.
Common changes are under COMMON_16BIT macro.