### PR TITLE
Bug fixes in decoder related to segment id, delta lf, film grain, etc

### DIFF
--- a/Source/App/DecApp/EbDecAppMain.c
+++ b/Source/App/DecApp/EbDecAppMain.c
@@ -22,31 +22,29 @@
 #endif
 
 int init_pic_buffer(EbSvtIOFormat *pic_buffer, CliInput *cli, EbSvtAv1DecConfiguration *config) {
+    /* FilmGrain module req. even dim. for internal operation */
+    pic_buffer->y_stride = cli->width & 1 ? cli->width + 1 : cli->width;
     switch (cli->fmt) {
     case EB_YUV400:
         pic_buffer->cb_stride = INT32_MAX;
         pic_buffer->cr_stride = INT32_MAX;
-        pic_buffer->y_stride  = cli->width;
         break;
     case EB_YUV420:
         pic_buffer->cb_stride = cli->width / 2;
         pic_buffer->cr_stride = cli->width / 2;
-        pic_buffer->y_stride  = cli->width;
         break;
     case EB_YUV422:
         pic_buffer->cb_stride = cli->width / 2;
         pic_buffer->cr_stride = cli->width / 2;
-        pic_buffer->y_stride  = cli->width;
         break;
     case EB_YUV444:
         pic_buffer->cb_stride = cli->width;
         pic_buffer->cr_stride = cli->width;
-        pic_buffer->y_stride  = cli->width;
         break;
     default: fprintf(stderr, "Unsupported colour format. \n"); return 0;
     }
     pic_buffer->width     = cli->width;
-    pic_buffer->height    = cli->width;
+    pic_buffer->height    = cli->height;
     pic_buffer->luma_ext  = NULL;
     pic_buffer->cb_ext    = NULL;
     pic_buffer->cr_ext    = NULL;
@@ -194,8 +192,11 @@ int32_t main(int32_t argc, char *argv[]) {
         recon_buffer                     = (EbBufferHeaderType *)malloc(sizeof(EbBufferHeaderType));
         recon_buffer->p_buffer           = (uint8_t *)malloc(sizeof(EbSvtIOFormat));
 
+        /* FilmGrain module req. even dim. for internal operation */
+        int w = (cli.width & 1) ? (cli.width + 1) : cli.width;
+        int h = (cli.height & 1) ? (cli.height + 1) : cli.height;
         int size = (config_ptr->max_bit_depth == EB_EIGHT_BIT) ? sizeof(uint8_t) : sizeof(uint16_t);
-        size     = size * cli.height * cli.width;
+        size     = size * w * h;
 
         ((EbSvtIOFormat *)recon_buffer->p_buffer)->luma = (uint8_t *)malloc(size);
         ((EbSvtIOFormat *)recon_buffer->p_buffer)->cb   = (uint8_t *)malloc(size >> 2);

--- a/Source/Lib/Common/Codec/Av1Common.h
+++ b/Source/Lib/Common/Codec/Av1Common.h
@@ -42,6 +42,7 @@ typedef struct Av1Common {
     int32_t      mi_rows;
     int32_t      mi_cols;
     int32_t      ref_frame_sign_bias[REF_FRAMES]; /* Two state 0, 1 */
+    uint8_t *    last_frame_seg_map;
     InterpFilter interp_filter;
     int32_t      mi_stride;
 

--- a/Source/Lib/Common/Codec/EbAv1Structs.h
+++ b/Source/Lib/Common/Codec/EbAv1Structs.h
@@ -313,6 +313,8 @@ typedef struct QuantizationParams {
     /*!< Specifies the level in the quantizer matrix that should be used for
      * each plane decoding */
     uint8_t qm[MAX_MB_PLANE];
+    /*!< qindex for every segment ID */
+    uint8_t qindex[MAX_SEGMENTS];
 } QuantizationParams;
 typedef struct DeltaQParams {
     /*!< Specifies whether quantizer index delta values are present */
@@ -462,9 +464,6 @@ typedef struct FrameHeader {
     /*!< Specifies the expected output order hint for each reference frame */
     uint32_t ref_order_hint[REF_FRAMES];
 
-    /*!< Specifies the expected output order for each reference frame */
-    uint32_t order_hints[REF_FRAMES];
-
     /*!< 1: Indicates that intra block copy may be used in this frame.
      *   0: Indicates that intra block copy is not allowed in this frame */
     uint8_t allow_intrabc;
@@ -478,6 +477,9 @@ typedef struct FrameHeader {
      *  0: Signifies that the corresponding reference picture slot is not valid
      *     for use as a reference picture*/
     uint32_t ref_valid[REF_FRAMES];
+
+    /*!< Specifies the frame id for each reference frame */
+    uint32_t ref_frame_id[REF_FRAMES];
 
     /*!< Frame Size structure */
     FrameSize frame_size;

--- a/Source/Lib/Decoder/Codec/EbDecBitstream.c
+++ b/Source/Lib/Decoder/Codec/EbDecBitstream.c
@@ -35,6 +35,7 @@ void dec_bits_init(Bitstrm *bs, const uint8_t *data, size_t numbytes) {
 Bitstream offset and consumes the bits. Section: 4.10.2 -> f(n) */
 uint32_t dec_get_bits(Bitstrm *bs, uint32_t numbits) {
     uint32_t bits_read;
+    if (0 == numbits) return 0;
     GET_BITS(bits_read, bs->buf, bs->bit_ofst, bs->cur_word, bs->nxt_word, numbits);
     return bits_read;
 }

--- a/Source/Lib/Decoder/Codec/EbDecHandle.c
+++ b/Source/Lib/Decoder/Codec/EbDecHandle.c
@@ -121,6 +121,22 @@ static EbErrorType eb_dec_handle_ctor(EbDecHandle **decHandleDblPtr, EbComponent
     return return_error;
 }
 
+/* FilmGrain module req. even dim. for internal operation
+   For odd luma, chroma uses data from even pixel in luma*/
+static void copy_even(uint8_t *luma, uint32_t wd,
+                 uint32_t ht, uint32_t stride, int32_t use_hbd) {
+    if ((wd & 1) == 0 && (ht & 1) == 0) return;
+    if (wd & 1) {
+        for (uint32_t i = 0; i < ht; ++i)
+            luma[i * (stride << use_hbd) + (wd << use_hbd)] =
+                luma[i *(stride << use_hbd) + ((wd - 1) << use_hbd)];
+        wd = wd + 1;
+    }
+    if (ht & 1) {
+        memcpy(&luma[ht *  (stride << use_hbd)], &luma[(ht - 1) * (stride << use_hbd)],
+            sizeof(*luma) * (wd << use_hbd));
+    }
+}
 /* Copy from recon buffer to out buffer! */
 int svt_dec_out_buf(EbDecHandle *dec_handle_ptr, EbBufferHeaderType *p_buffer) {
     EbPictureBufferDesc *recon_picture_buf = dec_handle_ptr->cur_pic_buf[0]->ps_pic_buf;
@@ -139,6 +155,9 @@ int svt_dec_out_buf(EbDecHandle *dec_handle_ptr, EbBufferHeaderType *p_buffer) {
     uint32_t wd = dec_handle_ptr->frame_header.frame_size.superres_upscaled_width;
     uint32_t ht = dec_handle_ptr->frame_header.frame_size.frame_height;
     uint32_t i, sx = 0, sy = 0;
+    /* FilmGrain module req. even dim. for internal operation */
+    int even_w = (wd & 1) ? (wd + 1) : wd;
+    int even_h = (ht & 1) ? (ht + 1) : ht;
 
     if (out_img->height != ht || out_img->width != wd ||
         out_img->color_fmt != recon_picture_buf->color_format ||
@@ -146,7 +165,8 @@ int svt_dec_out_buf(EbDecHandle *dec_handle_ptr, EbBufferHeaderType *p_buffer) {
         int size = (dec_handle_ptr->seq_header.color_config.bit_depth == EB_EIGHT_BIT)
                        ? sizeof(uint8_t)
                        : sizeof(uint16_t);
-        int luma_size   = size * ht * wd;
+
+        int luma_size = size * even_w * even_h;
         int chroma_size = -1;
 
         out_img->color_fmt = recon_picture_buf->color_format;
@@ -173,7 +193,8 @@ int svt_dec_out_buf(EbDecHandle *dec_handle_ptr, EbBufferHeaderType *p_buffer) {
         default: SVT_LOG("Unsupported colour format. \n"); return 0;
         }
 
-        out_img->y_stride = wd;
+        /* FilmGrain module req. even dim. for internal operation */
+        out_img->y_stride = even_w;
         out_img->width    = wd;
         out_img->height   = ht;
         if (out_img->bit_depth != (EbBitDepth)recon_picture_buf->bit_depth) {
@@ -318,13 +339,13 @@ int svt_dec_out_buf(EbDecHandle *dec_handle_ptr, EbBufferHeaderType *p_buffer) {
             case EB_10BIT: film_grain_ptr->bit_depth = 10; break;
             default: assert(0);
             }
-
+            copy_even(luma, wd, ht, out_img->y_stride, use_high_bit_depth);
             eb_av1_add_film_grain_run(film_grain_ptr,
                                       luma,
                                       cb,
                                       cr,
-                                      ht,
-                                      wd,
+                                      even_h,/*(ht & 1 ? ht + 1 : ht),*/
+                                      even_w,/*(wd & 1 ? wd + 1 : ht),*/
                                       out_img->y_stride,
                                       out_img->cb_stride,
                                       use_high_bit_depth,

--- a/Source/Lib/Decoder/Codec/EbDecHandle.h
+++ b/Source/Lib/Decoder/Codec/EbDecHandle.h
@@ -85,6 +85,10 @@ typedef struct EbDecPicBuf {
     /* film grain */
     AomFilmGrain film_grain_params;
 
+    // Inter frame reference frame delta for loop filter
+    int8_t ref_deltas[REF_FRAMES];
+    // 0 = ZERO_MV, MV
+    int8_t mode_deltas[MAX_MODE_LF_DELTAS];
 } EbDecPicBuf;
 
 /* Frame level buffers */
@@ -221,6 +225,8 @@ typedef struct EbDecHandle {
     // Prepare ref_frame_map for the next frame.
     EbDecPicBuf *next_ref_frame_map[REF_FRAMES];
 
+    /* For Reference frame loading process */
+    EbDecPicBuf *prev_frame;
     /* TODO: Move to buffer pool. */
     EbDecPicBuf *cur_pic_buf[DEC_MAX_NUM_FRM_PRLL];
 

--- a/Source/Lib/Decoder/Codec/EbDecMemInit.c
+++ b/Source/Lib/Decoder/Codec/EbDecMemInit.c
@@ -60,28 +60,30 @@ EbErrorType dec_eb_recon_picture_buffer_desc_ctor(
     picture_buffer_desc_ptr->color_format = picture_buffer_desc_init_data_ptr->color_format;
     picture_buffer_desc_ptr->stride_y = picture_buffer_desc_init_data_ptr->max_width +
         picture_buffer_desc_init_data_ptr->left_padding + picture_buffer_desc_init_data_ptr->right_padding;
-    if(picture_buffer_desc_ptr->color_format == EB_YUV420 ||
-       picture_buffer_desc_ptr->color_format == EB_YUV422)
-        picture_buffer_desc_ptr->stride_cb = picture_buffer_desc_ptr->stride_cr
-            = picture_buffer_desc_ptr->stride_y >> 1;
-    else if (picture_buffer_desc_ptr->color_format == EB_YUV444)
-        picture_buffer_desc_ptr->stride_cb = picture_buffer_desc_ptr->stride_cr
-            = picture_buffer_desc_ptr->stride_y;
+    uint32_t height_y = (picture_buffer_desc_init_data_ptr->max_height + picture_buffer_desc_init_data_ptr->top_padding
+        + picture_buffer_desc_init_data_ptr->bot_padding);
+
     picture_buffer_desc_ptr->origin_x = picture_buffer_desc_init_data_ptr->left_padding;
     picture_buffer_desc_ptr->origin_y = picture_buffer_desc_init_data_ptr->top_padding;
     picture_buffer_desc_ptr->origin_bot_y = picture_buffer_desc_init_data_ptr->bot_padding;
 
-    picture_buffer_desc_ptr->luma_size = (picture_buffer_desc_init_data_ptr->max_width +
-        picture_buffer_desc_init_data_ptr->left_padding + picture_buffer_desc_init_data_ptr->right_padding) *
-        (picture_buffer_desc_init_data_ptr->max_height + picture_buffer_desc_init_data_ptr->top_padding
-            + picture_buffer_desc_init_data_ptr->bot_padding);
+    picture_buffer_desc_ptr->luma_size = (picture_buffer_desc_ptr->stride_y) * height_y;
 
-    if (picture_buffer_desc_ptr->color_format == EB_YUV420) // 420
-        picture_buffer_desc_ptr->chroma_size = picture_buffer_desc_ptr->luma_size >> 2;
-    else if (picture_buffer_desc_ptr->color_format == EB_YUV422) // 422
-        picture_buffer_desc_ptr->chroma_size = picture_buffer_desc_ptr->luma_size >> 1;
-    else if (picture_buffer_desc_ptr->color_format == EB_YUV444) // 444
-        picture_buffer_desc_ptr->chroma_size = picture_buffer_desc_ptr->luma_size;
+    uint32_t stride_c = 0, height_c = 0;
+    if (picture_buffer_desc_ptr->color_format == EB_YUV420) {// 420
+        stride_c = (picture_buffer_desc_ptr->stride_y + 1) >> 1;
+        height_c = (height_y + 1) >> 1;
+    }
+    else if (picture_buffer_desc_ptr->color_format == EB_YUV422) {// 422
+        stride_c = (picture_buffer_desc_ptr->stride_y + 1) >> 1;
+        height_c = height_y;
+    }
+    else if (picture_buffer_desc_ptr->color_format == EB_YUV444) {// 444
+        stride_c = picture_buffer_desc_ptr->stride_y;
+        height_c = height_y;
+    }
+    picture_buffer_desc_ptr->stride_cb = picture_buffer_desc_ptr->stride_cr = stride_c;
+    picture_buffer_desc_ptr->chroma_size = (stride_c * height_c);
 
     picture_buffer_desc_ptr->packed_flag = EB_FALSE;
 

--- a/Source/Lib/Decoder/Codec/EbDecParseInterBlock.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseInterBlock.c
@@ -17,7 +17,7 @@
 #include "EbDecParseInterBlock.h"
 #include "EbCommonUtils.h"
 #include "EbWarpedMotion.h"
-
+#include "EbLog.h"
 
 typedef const int (*ColorCost)[PALETTE_SIZES][PALETTE_COLOR_INDEX_CONTEXTS][PALETTE_COLORS];
 typedef AomCdfProb (*MapCdf)[PALETTE_SIZES][PALETTE_COLOR_INDEX_CONTEXTS];

--- a/Source/Lib/Decoder/Codec/EbDecParseObu.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseObu.c
@@ -139,6 +139,7 @@ void read_timing_info(Bitstrm *bs, EbTimingInfo *timing_info) {
     PRINT("equal_picture_interval", timing_info->equal_picture_interval);
     if (timing_info->equal_picture_interval) {
         timing_info->num_ticks_per_picture = dec_get_bits_uvlc(bs) + 1;
+        PRINT("num_ticks_per_picture", timing_info->num_ticks_per_picture);
         if ((timing_info->num_ticks_per_picture) == UINT32_MAX)
             return; // EB_DecUnsupportedBitstream;
     }
@@ -322,8 +323,8 @@ EbErrorType read_sequence_header_obu(Bitstrm *bs, SeqHeader *seq_header) {
                   seq_header->operating_point[i].initial_display_delay_present_for_this_op);
             if (seq_header->operating_point[i].initial_display_delay_present_for_this_op)
                 seq_header->operating_point[i].initial_display_delay = dec_get_bits(bs, 4) + 1;
-            PRINT("initial_display_delay_minus_1",
-                  seq_header->operating_point[i].initial_display_delay - 1);
+            PRINT("initial_display_delay",
+                  seq_header->operating_point[i].initial_display_delay);
         }
     }
 
@@ -348,7 +349,7 @@ EbErrorType read_sequence_header_obu(Bitstrm *bs, SeqHeader *seq_header) {
         seq_header->delta_frame_id_length = dec_get_bits(bs, 4) + 2;
         PRINT("delta_frame_id_length", seq_header->delta_frame_id_length);
         seq_header->frame_id_length = dec_get_bits(bs, 3) + 1;
-        PRINT("additional_frame_id_length_minus_1", seq_header->frame_id_length - 1);
+        PRINT("frame_id_length", seq_header->frame_id_length + seq_header->delta_frame_id_length);
         if (seq_header->frame_id_length - 1 > 16) return EB_Corrupt_Frame;
     }
 
@@ -519,7 +520,6 @@ void superres_params(Bitstrm *bs, SeqHeader *seq_header, FrameHeader *frame_info
     if (use_superres) {
         coded_denom                                 = dec_get_bits(bs, SUPERRES_SCALE_BITS);
         frame_info->frame_size.superres_denominator = coded_denom + SUPERRES_SCALE_DENOMINATOR_MIN;
-        PRINT_FRAME("coded_denom", frame_info->frame_size.superres_denominator);
     } else
         frame_info->frame_size.superres_denominator = SCALE_NUMERATOR;
     frame_info->frame_size.superres_upscaled_width = frame_info->frame_size.frame_width;
@@ -527,6 +527,20 @@ void superres_params(Bitstrm *bs, SeqHeader *seq_header, FrameHeader *frame_info
         (frame_info->frame_size.superres_upscaled_width * SCALE_NUMERATOR +
          (frame_info->frame_size.superres_denominator / 2)) /
         frame_info->frame_size.superres_denominator;
+
+    if (frame_info->frame_size.superres_denominator != SCALE_NUMERATOR) {
+        /* We need to ensure the constraint in "Appendix A" of the spec:
+        * FrameWidth is greater than or equal to 16
+        * FrameHeight is greater than or equal to 16
+        For this, we clamp the downscaled dimension to at least 16. One
+        exception: if original dimension itself was < 16, then we keep the
+        downscaled dimension to be same as the original, to ensure that resizin
+        is valid.*/
+        const int min_w = MIN(16, frame_info->frame_size.superres_upscaled_width);
+        frame_info->frame_size.frame_width = MAX(min_w, frame_info->frame_size.frame_width);
+    }
+
+    PRINT_FRAME("superres_scale_denominator", frame_info->frame_size.superres_denominator)
 }
 
 // Read frame size
@@ -830,11 +844,7 @@ void read_segmentation_params(Bitstrm *bs, EbDecHandle *dec_handle_ptr, FrameHea
     int                 feature_value, feature_enabled, clipped_value, bits_to_read, limit, i, j;
     SegmentationParams *seg_params = &frame_info->segmentation_params;
     EbDecPicBuf *       cur_buf    = dec_handle_ptr->cur_pic_buf[0];
-    EbDecPicBuf *       prev_buf   = NULL;
-    if (frame_info->primary_ref_frame != PRIMARY_REF_NONE) {
-        prev_buf = get_ref_frame_buf(dec_handle_ptr, frame_info->primary_ref_frame + 1);
-        if (prev_buf == NULL) assert(0);
-    }
+    EbDecPicBuf *       prev_buf = dec_handle_ptr->prev_frame;
 
     seg_params->segmentation_enabled = dec_get_bits(bs, 1);
     PRINT_FRAME("segmentation_enabled", seg_params->segmentation_enabled);
@@ -846,7 +856,20 @@ void read_segmentation_params(Bitstrm *bs, EbDecHandle *dec_handle_ptr, FrameHea
         segfeatures_copy(&cur_buf->seg_params, seg_params);
         return;
     }
-
+    {
+        EbDecPicBuf *prev_frame   = dec_handle_ptr->prev_frame;
+        dec_handle_ptr->cm.last_frame_seg_map = NULL;
+        if (prev_frame) {
+            uint32_t prev_mi_cols = 2 * ((prev_frame->frame_width + 7) >> 3);
+            uint32_t prev_mi_rows = 2 * ((prev_frame->frame_height + 7) >> 3);
+            if (seg_params->segmentation_enabled      &&
+                (frame_info->mi_rows == prev_mi_rows) &&
+                (frame_info->mi_cols == prev_mi_cols))
+            {
+                dec_handle_ptr->cm.last_frame_seg_map = prev_frame->segment_maps;
+            }
+        }
+    }
     if (frame_info->primary_ref_frame == PRIMARY_REF_NONE) {
         seg_params->segmentation_update_map      = 1;
         seg_params->segmentation_temporal_update = 0;
@@ -880,7 +903,7 @@ void read_segmentation_params(Bitstrm *bs, EbDecHandle *dec_handle_ptr, FrameHea
                         feature_value = dec_get_bits(bs, bits_to_read);
                         clipped_value = CLIP3(0, limit, feature_value);
                     }
-                    PRINT_FRAME("feature_value", feature_value)
+                    PRINT_FRAME("data", clipped_value)
                 }
                 if (clipped_value < 0) {
                     assert(segmentation_feature_signed[j]);
@@ -907,64 +930,88 @@ void read_segmentation_params(Bitstrm *bs, EbDecHandle *dec_handle_ptr, FrameHea
     }
 }
 
-void read_loop_filter_params(Bitstrm *bs, FrameHeader *frame_info, int num_planes) {
+static void av1_set_default_ref_and_mode_deltas(int8_t *ref_deltas, int8_t *mode_deltas) {
+    assert(ref_deltas != NULL);
+    assert(mode_deltas != NULL);
+
+    ref_deltas[INTRA_FRAME] = 1;
+    ref_deltas[LAST_FRAME] = 0;
+    ref_deltas[LAST2_FRAME] = 0;
+    ref_deltas[LAST3_FRAME] = 0;
+    ref_deltas[BWDREF_FRAME] = 0;
+    ref_deltas[GOLDEN_FRAME] = -1;
+    ref_deltas[ALTREF_FRAME] = -1;
+    ref_deltas[ALTREF2_FRAME] = -1;
+
+    mode_deltas[0] = 0;
+    mode_deltas[1] = 0;
+}
+
+void read_loop_filter_params(Bitstrm *bs, EbDecHandle *dec_handle, int num_planes) {
+    FrameHeader *frame_info = &dec_handle->frame_header;
     int i;
+    struct LoopFilter *lf = &frame_info->loop_filter_params;
+
     if (frame_info->coded_lossless || frame_info->allow_intrabc) {
-        frame_info->loop_filter_params.filter_level[0]           = 0;
-        frame_info->loop_filter_params.filter_level[1]           = 0;
-        frame_info->loop_filter_params.ref_deltas[INTRA_FRAME]   = 1;
-        frame_info->loop_filter_params.ref_deltas[LAST_FRAME]    = 0;
-        frame_info->loop_filter_params.ref_deltas[LAST2_FRAME]   = 0;
-        frame_info->loop_filter_params.ref_deltas[LAST3_FRAME]   = 0;
-        frame_info->loop_filter_params.ref_deltas[BWDREF_FRAME]  = 0;
-        frame_info->loop_filter_params.ref_deltas[GOLDEN_FRAME]  = -1;
-        frame_info->loop_filter_params.ref_deltas[ALTREF_FRAME]  = -1;
-        frame_info->loop_filter_params.ref_deltas[ALTREF2_FRAME] = -1;
-        for (i = 0; i < 2; i++) frame_info->loop_filter_params.mode_deltas[i] = 0;
+        lf->filter_level[0] = 0;
+        lf->filter_level[1] = 0;
+
+        av1_set_default_ref_and_mode_deltas(dec_handle->cur_pic_buf[0]->ref_deltas,
+                                            dec_handle->cur_pic_buf[0]->mode_deltas);
         return;
     }
-    frame_info->loop_filter_params.filter_level[0] = dec_get_bits(bs, 6);
-    frame_info->loop_filter_params.filter_level[1] = dec_get_bits(bs, 6);
-    PRINT_FRAME("loop_filter_level[0]", frame_info->loop_filter_params.filter_level[0]);
-    PRINT_FRAME("loop_filter_level[1]", frame_info->loop_filter_params.filter_level[1]);
+
+    if (dec_handle->prev_frame) {
+        // write deltas to frame buffer
+        memcpy(lf->ref_deltas, dec_handle->prev_frame->ref_deltas, REF_FRAMES);
+        memcpy(lf->mode_deltas, dec_handle->prev_frame->mode_deltas, MAX_MODE_LF_DELTAS);
+    }
+    else {
+        av1_set_default_ref_and_mode_deltas(lf->ref_deltas, lf->mode_deltas);
+    }
+
+    lf->filter_level[0] = dec_get_bits(bs, 6);
+    lf->filter_level[1] = dec_get_bits(bs, 6);
+    PRINT_FRAME("loop_filter_level[0]", lf->filter_level[0]);
+    PRINT_FRAME("loop_filter_level[1]", lf->filter_level[1]);
     if (num_planes > 1) {
-        if (frame_info->loop_filter_params.filter_level[0] ||
-            frame_info->loop_filter_params.filter_level[1]) {
-            frame_info->loop_filter_params.filter_level_u = dec_get_bits(bs, 6);
-            frame_info->loop_filter_params.filter_level_v = dec_get_bits(bs, 6);
-            PRINT_FRAME("loop_filter_level[2]", frame_info->loop_filter_params.filter_level_u);
-            PRINT_FRAME("loop_filter_level[3]", frame_info->loop_filter_params.filter_level_v);
+        if (lf->filter_level[0] || lf->filter_level[1]) {
+            lf->filter_level_u = dec_get_bits(bs, 6);
+            lf->filter_level_v = dec_get_bits(bs, 6);
+            PRINT_FRAME("loop_filter_level[2]", lf->filter_level_u);
+            PRINT_FRAME("loop_filter_level[3]", lf->filter_level_v);
         }
     }
-    frame_info->loop_filter_params.sharpness_level        = dec_get_bits(bs, 3);
-    frame_info->loop_filter_params.mode_ref_delta_enabled = dec_get_bits(bs, 1);
-    PRINT_FRAME("loop_filter_sharpness", frame_info->loop_filter_params.sharpness_level);
-    PRINT_FRAME("loop_filter_delta_enabled", frame_info->loop_filter_params.mode_ref_delta_enabled);
+    lf->sharpness_level = dec_get_bits(bs, 3);
+    lf->mode_ref_delta_enabled = dec_get_bits(bs, 1);
+    PRINT_FRAME("loop_filter_sharpness", lf->sharpness_level);
+    PRINT_FRAME("loop_filter_delta_enabled", lf->mode_ref_delta_enabled);
 
-    if (frame_info->loop_filter_params.mode_ref_delta_enabled == 1) {
-        frame_info->loop_filter_params.mode_ref_delta_update = dec_get_bits(bs, 1);
-        PRINT_FRAME("loop_filter_delta_update",
-                    frame_info->loop_filter_params.mode_ref_delta_update);
+    if (lf->mode_ref_delta_enabled == 1) {
+        lf->mode_ref_delta_update = dec_get_bits(bs, 1);
+        PRINT_FRAME("loop_filter_delta_update", lf->mode_ref_delta_update);
 
-        if (frame_info->loop_filter_params.mode_ref_delta_update == 1) {
+        if (lf->mode_ref_delta_update == 1) {
             for (i = 0; i < TOTAL_REFS_PER_FRAME; i++) {
                 PRINT_NAME("Some read");
                 if (dec_get_bits(bs, 1) == 1) {
-                    frame_info->loop_filter_params.ref_deltas[i] = dec_get_bits_su(bs, 1 + 6);
-                    PRINT_FRAME("frame_info->loop_filter_params.loop_filter_ref_deltas[i]",
-                                frame_info->loop_filter_params.ref_deltas[i]);
+                    lf->ref_deltas[i] = dec_get_bits_su(bs, 1 + 6);
+                    PRINT_FRAME("lf_ref_deltas[i]", lf->ref_deltas[i]);
                 }
             }
             for (i = 0; i < 2; i++) {
                 PRINT_NAME("Some read");
                 if (dec_get_bits(bs, 1) == 1) {
-                    frame_info->loop_filter_params.mode_deltas[i] = dec_get_bits_su(bs, 1 + 6);
-                    PRINT_FRAME("loop_filter_mode_deltas[i]",
-                                frame_info->loop_filter_params.mode_deltas[i]);
+                    lf->mode_deltas[i] = dec_get_bits_su(bs, 1 + 6);
+                    PRINT_FRAME("lf_mode_deltas[i]", lf->mode_deltas[i]);
                 }
             }
         }
     }
+
+    /*write deltas to prev_frame buffer*/
+    memcpy(dec_handle->cur_pic_buf[0]->ref_deltas, lf->ref_deltas, REF_FRAMES);
+    memcpy(dec_handle->cur_pic_buf[0]->mode_deltas, lf->mode_deltas, MAX_MODE_LF_DELTAS);
 }
 
 void read_tx_mode(Bitstrm *bs, FrameHeader *frame_info) {
@@ -1131,11 +1178,7 @@ void read_global_param(Bitstrm *bs, EbDecHandle *dec_handle, TransformationType 
     mx        = (1 << abs_bits);
 
     EbDecPicBuf *cur_buf  = dec_handle->cur_pic_buf[0];
-    EbDecPicBuf *prev_buf = NULL;
-    if (frame_info->primary_ref_frame != PRIMARY_REF_NONE) {
-        prev_buf = get_ref_frame_buf(dec_handle, frame_info->primary_ref_frame + 1);
-        if (prev_buf == NULL) assert(0);
-    }
+    EbDecPicBuf *prev_buf = dec_handle->prev_frame;
 
     GlobalMotionParams *gm_params = prev_buf != NULL ? prev_buf->global_motion : prev_gm_params;
     r                             = (gm_params[ref_idx].gm_params[idx] >> prec_diff) - sub;
@@ -1737,7 +1780,7 @@ void read_uncompressed_header(Bitstrm *bs, EbDecHandle *dec_handle_ptr, ObuHeade
     int          have_prev_frame_id, diff_frame_id;
     int          last_frame_idx;
     uint32_t     prev_frame_id = 0;
-    uint8_t      expected_frame_id, display_frame_id;
+    uint32_t     expected_frame_id, display_frame_id;
 
     if (seq_header->frame_id_numbers_present_flag) {
         id_len = seq_header->frame_id_length - 1 + seq_header->delta_frame_id_length - 2 + 3;
@@ -1820,7 +1863,6 @@ void read_uncompressed_header(Bitstrm *bs, EbDecHandle *dec_handle_ptr, ObuHeade
             // TODO: Need to differentate RefOrderHint and ref_order_hint
             frame_info->ref_order_hint[i] = 0;
         }
-        for (i = 0; i < REFS_PER_FRAME; i++) frame_info->order_hints[LAST_FRAME + i] = 0;
     }
     frame_info->disable_cdf_update = dec_get_bits(bs, 1);
     PRINT_FRAME("disable_cdf_update", frame_info->disable_cdf_update);
@@ -1951,6 +1993,7 @@ void read_uncompressed_header(Bitstrm *bs, EbDecHandle *dec_handle_ptr, ObuHeade
                 PRINT_FRAME("allow_intrabc", frame_info->allow_intrabc);
             }
         }
+        dec_handle_ptr->prev_frame = NULL;
     } else {
         if (!seq_header->order_hint_info.enable_order_hint)
             frame_refs_short_signaling = 0;
@@ -1968,11 +2011,13 @@ void read_uncompressed_header(Bitstrm *bs, EbDecHandle *dec_handle_ptr, ObuHeade
 
         //int DeltaFrameId;
         for (i = 0; i < INTER_REFS_PER_FRAME; i++) {
+            int ref_frm_id;
             if (!frame_refs_short_signaling) {
                 frame_info->ref_frame_idx[i] = dec_get_bits(bs, 3);
                 PRINT_FRAME("ref_frame_idx", frame_info->ref_frame_idx[i]);
                 dec_handle_ptr->remapped_ref_idx[i] = frame_info->ref_frame_idx[i];
             }
+            ref_frm_id = dec_handle_ptr->remapped_ref_idx[i];
 
             frame_info->ref_frame_sign_bias[LAST_FRAME + i] = 0;
 
@@ -1982,7 +2027,10 @@ void read_uncompressed_header(Bitstrm *bs, EbDecHandle *dec_handle_ptr, ObuHeade
                 expected_frame_id = ((frame_info->current_frame_id + (1 << id_len) -
                                       (delta_frame_id_length_minus_1 + 1)) %
                                      (1 << id_len));
-                if (expected_frame_id != frame_info->ref_frame_idx[i]) return; // EB_Corrupt_Frame;
+                if (expected_frame_id != frame_info->ref_frame_id[ref_frm_id]) {
+                    assert(0);
+                    return; // EB_Corrupt_Frame;
+                }
             }
         }
         if (frame_size_override_flag && !frame_info->error_resilient_mode)
@@ -1993,12 +2041,21 @@ void read_uncompressed_header(Bitstrm *bs, EbDecHandle *dec_handle_ptr, ObuHeade
         }
         if (frame_info->force_integer_mv)
             frame_info->allow_high_precision_mv = 0;
-        else
+        else {
             frame_info->allow_high_precision_mv = dec_get_bits(bs, 1);
-        PRINT_FRAME("allow_high_precision_mv", frame_info->allow_high_precision_mv);
+            PRINT_FRAME("allow_high_precision_mv", frame_info->allow_high_precision_mv);
+        }
         read_interpolation_filter(bs, frame_info);
         frame_info->is_motion_mode_switchable = dec_get_bits(bs, 1);
         PRINT_FRAME("is_motion_mode_switchable", frame_info->is_motion_mode_switchable);
+        dec_handle_ptr->prev_frame = get_primary_ref_frame_buf(dec_handle_ptr);
+        if (frame_info->primary_ref_frame != PRIMARY_REF_NONE &&
+            dec_handle_ptr->prev_frame == NULL)
+        {
+            SVT_LOG("Reference frame containing this frame's initial "
+                "frame context is unavailable.");
+            assert(0);
+        }
         if (frame_info->error_resilient_mode || !seq_header->order_hint_info.enable_ref_frame_mvs)
             frame_info->use_ref_frame_mvs = 0;
         else
@@ -2073,8 +2130,7 @@ void read_uncompressed_header(Bitstrm *bs, EbDecHandle *dec_handle_ptr, ObuHeade
                         frame_info->quantization_params.base_q_idx);
     else
         /* Load CDF */
-        master_parse_ctx->init_frm_ctx =
-            get_ref_frame_buf(dec_handle_ptr, frame_info->primary_ref_frame + 1)->final_frm_ctx;
+        master_parse_ctx->init_frm_ctx = dec_handle_ptr->prev_frame->final_frm_ctx;
 
     TilesInfo tiles_info = dec_handle_ptr->frame_header.tiles_info;
 
@@ -2100,6 +2156,7 @@ void read_uncompressed_header(Bitstrm *bs, EbDecHandle *dec_handle_ptr, ObuHeade
     for (int i = 0; i < MAX_SEGMENTS; ++i) {
         int qindex = get_qindex(
             &frame_info->segmentation_params, i, frame_info->quantization_params.base_q_idx);
+        frame_info->quantization_params.qindex[i] = qindex;
         frame_info->lossless_array[i] =
             qindex == 0 && frame_info->quantization_params.delta_q_dc[AOM_PLANE_Y] == 0 &&
             frame_info->quantization_params.delta_q_ac[AOM_PLANE_U] == 0 &&
@@ -2128,7 +2185,7 @@ void read_uncompressed_header(Bitstrm *bs, EbDecHandle *dec_handle_ptr, ObuHeade
     frame_info->all_lossless =
         frame_info->coded_lossless &&
         (frame_info->frame_size.frame_width == frame_info->frame_size.superres_upscaled_width);
-    read_loop_filter_params(bs, frame_info, num_planes);
+    read_loop_filter_params(bs, dec_handle_ptr, num_planes);
     read_frame_cdef_params(bs, frame_info, seq_header, num_planes);
     read_lr_params(bs, frame_info, seq_header, num_planes);
     read_tx_mode(bs, frame_info);
@@ -2159,7 +2216,7 @@ void read_uncompressed_header(Bitstrm *bs, EbDecHandle *dec_handle_ptr, ObuHeade
 
     /* TODO: Should be moved to caller */
     if (dec_handle_ptr->dec_config.threads == 1) {
-        if (!frame_info->show_existing_frame && frame_info->use_ref_frame_mvs)
+        if (!frame_info->show_existing_frame)
             svt_setup_motion_field(dec_handle_ptr, NULL);
     }
 }

--- a/Source/Lib/Decoder/Codec/EbDecPicMgr.h
+++ b/Source/Lib/Decoder/Codec/EbDecPicMgr.h
@@ -42,6 +42,8 @@ void         svt_setup_frame_buf_refs(EbDecHandle *dec_handle_ptr);
 
 ScaleFactors *get_ref_scale_factors(EbDecHandle *dec_handle_ptr, const MvReferenceFrame ref_frame);
 
+EbDecPicBuf *get_primary_ref_frame_buf(EbDecHandle *dec_handle_ptr);
+
 void svt_set_frame_refs(EbDecHandle *dec_handle_ptr, int32_t lst_map_idx, int32_t gld_map_idx);
 
 #ifdef __cplusplus

--- a/Source/Lib/Decoder/Codec/EbDecProcess.c
+++ b/Source/Lib/Decoder/Codec/EbDecProcess.c
@@ -1324,7 +1324,8 @@ void dec_av1_loop_restoration_filter_frame_mt(
     eb_release_mutex(dec_mt_frame_data->temp_mutex);
 
     volatile uint32_t *num_threads_lred = &dec_mt_frame_data->num_threads_lred;
-    while (*num_threads_lred != dec_handle->dec_config.threads);
+    while (*num_threads_lred != dec_handle->dec_config.threads &&
+            EB_FALSE == dec_mt_frame_data->end_flag);
 }
 
 void *dec_all_stage_kernel(void *input_ptr) {
@@ -1403,4 +1404,8 @@ void dec_sync_all_threads(EbDecHandle *dec_handle_ptr) {
 
     while (dec_mt_frame_data->num_threads_exited != dec_handle_ptr->dec_config.threads - 1)
         eb_sleep_ms(5);
+
+    /*Destroying lib created thread's*/
+    EB_DESTROY_THREAD_ARRAY(dec_handle_ptr->decode_thread_handle_array,
+                            dec_handle_ptr->dec_config.threads - 1);
 }

--- a/Source/Lib/Decoder/Codec/EbDecRestoration.c
+++ b/Source/Lib/Decoder/Codec/EbDecRestoration.c
@@ -243,8 +243,10 @@ void eb_dec_av1_loop_restoration_filter_unit(uint8_t need_bounadaries,
            restoration unit */
         const int32_t nominal_stripe_height =
             full_stripe_height - ((tile_stripe == 0) ? runit_offset : 0);
+        /*In wiener filter leaf level function assumes always h to be multiple of 2.
+          we can see assert related to h in this function->eb_av1_wiener_convolve_add_src_avx2*/
         const int32_t h = AOMMIN(nominal_stripe_height,
-            remaining_stripes.v_end - remaining_stripes.v_start);
+            ((remaining_stripes.v_end - remaining_stripes.v_start) + 1) & ~1);
 
         if (need_bounadaries)
             setup_processing_stripe_boundary(&remaining_stripes,


### PR DESCRIPTION
Following are the changes:

Bug Fixes related to film_grain: chroma_scaling_from_luma, odd resolution supprt
Fixes related to Storing of qindex for each segment id & segment_id from prev frame
Bug Fixes related to parsing of DeltaFrameIdLength & delta_lf
LF bug_fixes related to odd resolution & lossless mode
MT bug fix related to a hang at the end
Bug fix related to early exit in Motion field projection
Super_res bug fixes related to smaller frame dim.( less than 16)
