### PR TITLE
Skip depth optimisation

### DIFF
--- a/Source/Lib/Encoder/Codec/EbCodingUnit.h
+++ b/Source/Lib/Encoder/Codec/EbCodingUnit.h
@@ -358,6 +358,7 @@ typedef struct BlkStruct {
     int32_t        ii_wedge_sign;
     uint8_t        filter_intra_mode;
     PaletteInfo    palette_info;
+    uint8_t        do_not_process_block;
 } BlkStruct;
 
 typedef struct OisCandidate {

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -2116,11 +2116,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
         context_ptr->best_me_cand_only_flag = EB_FALSE;
 
     // Set skip_depth
-    if(MR_MODE)
-        context_ptr->skip_depth = 0;
-    else if (context_ptr->pd_pass == PD_PASS_0)
-        context_ptr->skip_depth = 0;
-    else if (context_ptr->pd_pass == PD_PASS_1)
+    if(MR_MODE || context_ptr->pd_pass <= PD_PASS_1)
         context_ptr->skip_depth = 0;
     else
         context_ptr->skip_depth =

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -2115,6 +2115,17 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
     else
         context_ptr->best_me_cand_only_flag = EB_FALSE;
 
+    // Set skip_depth
+    if(MR_MODE)
+        context_ptr->skip_depth = 0;
+    else if (context_ptr->pd_pass == PD_PASS_0)
+        context_ptr->skip_depth = 0;
+    else if (context_ptr->pd_pass == PD_PASS_1)
+        context_ptr->skip_depth = 0;
+    else
+        context_ptr->skip_depth =
+        pcs_ptr->parent_pcs_ptr->sc_content_detected ? 1 : 0;
+
 #if ENHANCED_ME_MV
     // Set perform_me_mv_1_8_pel_ref
     if (context_ptr->pd_pass == PD_PASS_0)

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
@@ -298,6 +298,7 @@ typedef struct ModeDecisionContext {
     uint8_t              inject_inter_candidates;
     uint8_t              intra_similar_mode;
 #endif
+    uint8_t              skip_depth;
     uint8_t *            cfl_temp_luma_recon;
     uint16_t *           cfl_temp_luma_recon16bit;
     EbBool               spatial_sse_full_loop;

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -7801,7 +7801,6 @@ static void set_child_to_be_skipped(
     if (context_ptr->md_blk_arr_nsq[blk_index].split_flag && blk_geom->sq_size > 4) {
         //Set first child to be considered
         child_block_idx_1 = blk_index + d1_depth_offset[sb_size == BLOCK_128X128][blk_geom->depth];
-        const BlockGeom * child1_blk_geom = get_blk_geom_mds(child_block_idx_1);
         uint32_t child1_tot_d1_blocks = get_number_of_blocks(child_block_idx_1);
         for (block_1d_idx = 0; block_1d_idx < child1_tot_d1_blocks; block_1d_idx++)
             context_ptr->md_blk_arr_nsq[child_block_idx_1 + block_1d_idx].do_not_process_block = 1;
@@ -7813,7 +7812,6 @@ static void set_child_to_be_skipped(
                 depth_step - 1);
         //Set second child to be considered
         child_block_idx_2 = child_block_idx_1 + ns_depth_offset[sb_size == BLOCK_128X128][blk_geom->depth + 1];
-        const BlockGeom * child2_blk_geom = get_blk_geom_mds(child_block_idx_2);
         uint32_t child2_tot_d1_blocks = get_number_of_blocks(child_block_idx_2);
         for (block_1d_idx = 0; block_1d_idx < child2_tot_d1_blocks; block_1d_idx++)
             context_ptr->md_blk_arr_nsq[child_block_idx_2 + block_1d_idx].do_not_process_block = 1;
@@ -7825,7 +7823,6 @@ static void set_child_to_be_skipped(
                 depth_step - 1);
         //Set third child to be considered
         child_block_idx_3 = child_block_idx_2 + ns_depth_offset[sb_size == BLOCK_128X128][blk_geom->depth + 1];
-        const BlockGeom * child3_blk_geom = get_blk_geom_mds(child_block_idx_3);
         uint32_t child3_tot_d1_blocks = get_number_of_blocks(child_block_idx_3);
         for (block_1d_idx = 0; block_1d_idx < child3_tot_d1_blocks; block_1d_idx++)
             context_ptr->md_blk_arr_nsq[child_block_idx_3 + block_1d_idx].do_not_process_block = 1;
@@ -7837,7 +7834,6 @@ static void set_child_to_be_skipped(
                 depth_step - 1);
         //Set forth child to be considered
         child_block_idx_4 = child_block_idx_3 + ns_depth_offset[sb_size == BLOCK_128X128][blk_geom->depth + 1];
-        const BlockGeom * child4_blk_geom = get_blk_geom_mds(child_block_idx_4);
         uint32_t child4_tot_d1_blocks = get_number_of_blocks(child_block_idx_4);
         for (block_1d_idx = 0; block_1d_idx < child4_tot_d1_blocks; block_1d_idx++)
             context_ptr->md_blk_arr_nsq[child_block_idx_4 + block_1d_idx].do_not_process_block = 1;

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -7772,6 +7772,20 @@ void update_skip_next_nsq_for_a_b_shapes(ModeDecisionContext *context_ptr, uint6
 }
 #endif
 /***********************************
+get the number of total block in a
+branch
+***********************************/
+uint32_t get_number_of_blocks(
+    uint32_t block_idx
+) {
+    const BlockGeom * blk_geom = get_blk_geom_mds(block_idx);
+    uint32_t tot_d1_blocks =
+            blk_geom->sq_size == 128 ? 17 :
+            blk_geom->sq_size > 8 ? 25 :
+            blk_geom->sq_size == 8 ? 5 : 1;
+    return tot_d1_blocks;
+}
+/***********************************
 Mark the blocks of the lower depth
 to be skipped
 ***********************************/
@@ -7788,13 +7802,9 @@ static void set_child_to_be_skipped(
         //Set first child to be considered
         child_block_idx_1 = blk_index + d1_depth_offset[sb_size == BLOCK_128X128][blk_geom->depth];
         const BlockGeom * child1_blk_geom = get_blk_geom_mds(child_block_idx_1);
-        uint32_t child1_tot_d1_blocks =
-            child1_blk_geom->sq_size == 128 ? 17 :
-            child1_blk_geom->sq_size > 8 ? 25 :
-            child1_blk_geom->sq_size == 8 ? 5 : 1;
-        for (block_1d_idx = 0; block_1d_idx < child1_tot_d1_blocks; block_1d_idx++) {
+        uint32_t child1_tot_d1_blocks = get_number_of_blocks(child_block_idx_1);
+        for (block_1d_idx = 0; block_1d_idx < child1_tot_d1_blocks; block_1d_idx++)
             context_ptr->md_blk_arr_nsq[child_block_idx_1 + block_1d_idx].do_not_process_block = 1;
-        }
         if (depth_step > 1)
             set_child_to_be_skipped(
                 context_ptr,
@@ -7804,13 +7814,9 @@ static void set_child_to_be_skipped(
         //Set second child to be considered
         child_block_idx_2 = child_block_idx_1 + ns_depth_offset[sb_size == BLOCK_128X128][blk_geom->depth + 1];
         const BlockGeom * child2_blk_geom = get_blk_geom_mds(child_block_idx_2);
-        uint32_t child2_tot_d1_blocks =
-            child2_blk_geom->sq_size == 128 ? 17 :
-            child2_blk_geom->sq_size > 8 ? 25 :
-            child2_blk_geom->sq_size == 8 ? 5 : 1;
-        for (block_1d_idx = 0; block_1d_idx < child2_tot_d1_blocks; block_1d_idx++) {
+        uint32_t child2_tot_d1_blocks = get_number_of_blocks(child_block_idx_2);
+        for (block_1d_idx = 0; block_1d_idx < child2_tot_d1_blocks; block_1d_idx++)
             context_ptr->md_blk_arr_nsq[child_block_idx_2 + block_1d_idx].do_not_process_block = 1;
-        }
         if (depth_step > 1)
             set_child_to_be_skipped(
                 context_ptr,
@@ -7820,13 +7826,9 @@ static void set_child_to_be_skipped(
         //Set third child to be considered
         child_block_idx_3 = child_block_idx_2 + ns_depth_offset[sb_size == BLOCK_128X128][blk_geom->depth + 1];
         const BlockGeom * child3_blk_geom = get_blk_geom_mds(child_block_idx_3);
-        uint32_t child3_tot_d1_blocks =
-            child3_blk_geom->sq_size == 128 ? 17 :
-            child3_blk_geom->sq_size > 8 ? 25 :
-            child3_blk_geom->sq_size == 8 ? 5 : 1;
-        for (block_1d_idx = 0; block_1d_idx < child3_tot_d1_blocks; block_1d_idx++) {
+        uint32_t child3_tot_d1_blocks = get_number_of_blocks(child_block_idx_3);
+        for (block_1d_idx = 0; block_1d_idx < child3_tot_d1_blocks; block_1d_idx++)
             context_ptr->md_blk_arr_nsq[child_block_idx_3 + block_1d_idx].do_not_process_block = 1;
-        }
         if (depth_step > 1)
             set_child_to_be_skipped(
                 context_ptr,
@@ -7836,13 +7838,9 @@ static void set_child_to_be_skipped(
         //Set forth child to be considered
         child_block_idx_4 = child_block_idx_3 + ns_depth_offset[sb_size == BLOCK_128X128][blk_geom->depth + 1];
         const BlockGeom * child4_blk_geom = get_blk_geom_mds(child_block_idx_4);
-        uint32_t child4_tot_d1_blocks =
-            child4_blk_geom->sq_size == 128 ? 17 :
-            child4_blk_geom->sq_size > 8 ? 25 :
-            child4_blk_geom->sq_size == 8 ? 5 : 1;
-        for (block_1d_idx = 0; block_1d_idx < child4_tot_d1_blocks; block_1d_idx++) {
+        uint32_t child4_tot_d1_blocks = get_number_of_blocks(child_block_idx_4);
+        for (block_1d_idx = 0; block_1d_idx < child4_tot_d1_blocks; block_1d_idx++)
             context_ptr->md_blk_arr_nsq[child_block_idx_4 + block_1d_idx].do_not_process_block = 1;
-        }
         if (depth_step > 1)
             set_child_to_be_skipped(
                 context_ptr,

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -8234,7 +8234,7 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
 #if ENHANCED_SQ_WEIGHT
             if (pcs_ptr->parent_pcs_ptr->sb_geom[sb_addr].block_is_allowed[blk_ptr->mds_idx] &&
                 !skip_next_nsq && !skip_next_sq &&
-                !sq_weight_based_nsq_skip && 
+                !sq_weight_based_nsq_skip &&
                 !skip_next_depth) {
 #else
             if (pcs_ptr->parent_pcs_ptr->sb_geom[sb_addr].block_is_allowed[blk_ptr->mds_idx] &&

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -800,6 +800,7 @@ void init_sq_nsq_block(SequenceControlSet *scs_ptr, ModeDecisionContext *context
             context_ptr->md_blk_arr_nsq[blk_idx].part               = PARTITION_SPLIT;
             context_ptr->md_local_blk_unit[blk_idx].tested_blk_flag = EB_FALSE;
         }
+        context_ptr->md_blk_arr_nsq[blk_idx].do_not_process_block = 0;
         ++blk_idx;
     } while (blk_idx < scs_ptr->max_block_cnt);
 }
@@ -7770,7 +7771,82 @@ void update_skip_next_nsq_for_a_b_shapes(ModeDecisionContext *context_ptr, uint6
     }
 }
 #endif
+static void set_child_to_be_skipped(
+    ModeDecisionContext   *context_ptr,
+    uint32_t    blk_index,
+    int32_t     sb_size,
+    int8_t      depth_step) {
+    uint32_t child_block_idx_1, child_block_idx_2, child_block_idx_3, child_block_idx_4;
+    uint32_t block_1d_idx;
+    const BlockGeom * blk_geom = get_blk_geom_mds(blk_index);
 
+    if (context_ptr->md_blk_arr_nsq[blk_index].split_flag && blk_geom->sq_size > 4) {
+        //Set first child to be considered
+        child_block_idx_1 = blk_index + d1_depth_offset[sb_size == BLOCK_128X128][blk_geom->depth];
+        const BlockGeom * child1_blk_geom = get_blk_geom_mds(child_block_idx_1);
+        uint32_t child1_tot_d1_blocks =
+            child1_blk_geom->sq_size == 128 ? 17 :
+            child1_blk_geom->sq_size > 8 ? 25 :
+            child1_blk_geom->sq_size == 8 ? 5 : 1;
+        for (block_1d_idx = 0; block_1d_idx < child1_tot_d1_blocks; block_1d_idx++) {
+            context_ptr->md_blk_arr_nsq[child_block_idx_1 + block_1d_idx].do_not_process_block = 1;
+        }
+        if (depth_step > 1)
+            set_child_to_be_skipped(
+                context_ptr,
+                child_block_idx_1,
+                sb_size,
+                depth_step - 1);
+        //Set second child to be considered
+        child_block_idx_2 = child_block_idx_1 + ns_depth_offset[sb_size == BLOCK_128X128][blk_geom->depth + 1];
+        const BlockGeom * child2_blk_geom = get_blk_geom_mds(child_block_idx_2);
+        uint32_t child2_tot_d1_blocks =
+            child2_blk_geom->sq_size == 128 ? 17 :
+            child2_blk_geom->sq_size > 8 ? 25 :
+            child2_blk_geom->sq_size == 8 ? 5 : 1;
+        for (block_1d_idx = 0; block_1d_idx < child2_tot_d1_blocks; block_1d_idx++) {
+            context_ptr->md_blk_arr_nsq[child_block_idx_2 + block_1d_idx].do_not_process_block = 1;
+        }
+        if (depth_step > 1)
+            set_child_to_be_skipped(
+                context_ptr,
+                child_block_idx_2,
+                sb_size,
+                depth_step - 1);
+        //Set third child to be considered
+        child_block_idx_3 = child_block_idx_2 + ns_depth_offset[sb_size == BLOCK_128X128][blk_geom->depth + 1];
+        const BlockGeom * child3_blk_geom = get_blk_geom_mds(child_block_idx_3);
+        uint32_t child3_tot_d1_blocks =
+            child3_blk_geom->sq_size == 128 ? 17 :
+            child3_blk_geom->sq_size > 8 ? 25 :
+            child3_blk_geom->sq_size == 8 ? 5 : 1;
+        for (block_1d_idx = 0; block_1d_idx < child3_tot_d1_blocks; block_1d_idx++) {
+            context_ptr->md_blk_arr_nsq[child_block_idx_3 + block_1d_idx].do_not_process_block = 1;
+        }
+        if (depth_step > 1)
+            set_child_to_be_skipped(
+                context_ptr,
+                child_block_idx_3,
+                sb_size,
+                depth_step - 1);
+        //Set forth child to be considered
+        child_block_idx_4 = child_block_idx_3 + ns_depth_offset[sb_size == BLOCK_128X128][blk_geom->depth + 1];
+        const BlockGeom * child4_blk_geom = get_blk_geom_mds(child_block_idx_4);
+        uint32_t child4_tot_d1_blocks =
+            child4_blk_geom->sq_size == 128 ? 17 :
+            child4_blk_geom->sq_size > 8 ? 25 :
+            child4_blk_geom->sq_size == 8 ? 5 : 1;
+        for (block_1d_idx = 0; block_1d_idx < child4_tot_d1_blocks; block_1d_idx++) {
+            context_ptr->md_blk_arr_nsq[child_block_idx_4 + block_1d_idx].do_not_process_block = 1;
+        }
+        if (depth_step > 1)
+            set_child_to_be_skipped(
+                context_ptr,
+                child_block_idx_4,
+                sb_size,
+                depth_step - 1);
+    }
+}
 EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
                                        const MdcSbData *const mdcResultTbPtr, SuperBlock *sb_ptr,
                                        uint16_t sb_origin_x, uint16_t sb_origin_y, uint32_t sb_addr,
@@ -7982,6 +8058,7 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
                                            MAX_CU_COST};
     Part     nsq_shape_table[NUMBER_OF_SHAPES] = {
         PART_N, PART_H, PART_V, PART_HA, PART_HB, PART_VA, PART_VB, PART_H4, PART_V4, PART_S};
+    uint8_t skip_next_depth = 0;
     do {
         blk_idx_mds = leaf_data_array[blk_index].mds_idx;
 
@@ -8153,10 +8230,12 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
 #if ENHANCED_SQ_WEIGHT
             uint8_t sq_weight_based_nsq_skip = update_skip_nsq_shapes(scs_ptr, pcs_ptr, context_ptr);
 #endif
+            skip_next_depth = context_ptr->blk_ptr->do_not_process_block;
 #if ENHANCED_SQ_WEIGHT
             if (pcs_ptr->parent_pcs_ptr->sb_geom[sb_addr].block_is_allowed[blk_ptr->mds_idx] &&
                 !skip_next_nsq && !skip_next_sq &&
-                !sq_weight_based_nsq_skip) {
+                !sq_weight_based_nsq_skip && 
+                !skip_next_depth) {
 #else
             if (pcs_ptr->parent_pcs_ptr->sb_geom[sb_addr].block_is_allowed[blk_ptr->mds_idx] &&
                 !skip_next_nsq && !skip_next_sq && !auto_max_partition_block_skip) {
@@ -8167,7 +8246,7 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
                                 bestcandidate_buffers);
             }
 #if ENHANCED_SQ_WEIGHT
-            else if (sq_weight_based_nsq_skip) {
+            else if (sq_weight_based_nsq_skip || skip_next_depth) {
 #else
             else if (auto_max_partition_block_skip) {
 #endif
@@ -8260,6 +8339,30 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
                 depth_cost[scs_ptr->static_config.super_block_size == 128
                                ? context_ptr->blk_geom->depth
                                : context_ptr->blk_geom->depth + 1] += nsq_cost[nsq_shape_table[0]];
+                if (context_ptr->skip_depth && scs_ptr->sb_geom[sb_addr].is_complete_sb) {
+                    if (context_ptr->pd_pass > PD_PASS_1) {
+                        uint64_t sq_cost = nsq_cost[0]; // sq cost
+                        uint64_t best_nsq_cost = MAX_CU_COST;
+                        skip_next_depth = 0;
+                        // Derive best nsq cost
+                        for (i = 1; i < NUMBER_OF_SHAPES; ++i)
+                            if (nsq_cost[i] < best_nsq_cost)
+                                best_nsq_cost = nsq_cost[i];
+                        // Compare sq vs best nsq
+                        uint64_t th = 30;
+                        if (best_nsq_cost != MAX_CU_COST) {
+                            if (sq_cost < best_nsq_cost) {
+                                if ((best_nsq_cost - sq_cost) * 100 > (sq_cost * th)) {
+                                    set_child_to_be_skipped(
+                                        context_ptr,
+                                        context_ptr->blk_geom->sqi_mds,
+                                        scs_ptr->seq_header.sb_size,
+                                        1);
+                                }
+                            }
+                        }
+                    }
+                }
             }
 
             uint32_t last_blk_index_mds =

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -7771,6 +7771,10 @@ void update_skip_next_nsq_for_a_b_shapes(ModeDecisionContext *context_ptr, uint6
     }
 }
 #endif
+/***********************************
+Mark the blocks of the lower depth
+to be skipped
+***********************************/
 static void set_child_to_be_skipped(
     ModeDecisionContext   *context_ptr,
     uint32_t    blk_index,


### PR DESCRIPTION
## Description
This feature consists of skipping depth +1 when the cost of the square partition is better than the cost of the non-square partitions in the current depth. This feature is enabled only for screen content.

## Results
* BDrate: 0.55%
* Speed: 19%
* Memory: 0%


InputSequence | Resolution | Bdrate PSNR-YUV | Bdrate SSIM-YUV | Encoding time   deviation
-- | -- | -- | -- | --
MINECRAFT_60f_420 | 1920x1080 | 0.37% | 0.35% | 3.85%
SlideEditing_1280x720_30_60f | 1280x720 | 0.45% | 0.54% | 27.45%
SlideShow_1280x720_20_60f | 1280x720 | 0.45% | 0.70% | 32.75%
wikipedia_420 | 1920x1080 | 0.67% | 0.86% | 12.55%
  | Average | 0.49% | 0.61% | 19.15%

