### PR TITLE
Moved IFS from MD_STAGE_1 to MD_STAGE_3

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -87,6 +87,7 @@ extern "C" {
 #define HIGH_PRECISION_MV_QTHRESH 150
 
 #define ENHANCED_MULTI_PASS_PD_MD_STAGING_SETTINGS 1 // Updated Multi-Pass-PD and MD-Staging Settings
+#define IFS_MD_STAGE_3 1 // Moved IFS from MD_STAGE_1 to MD_STAGE_3
 
 // Actions in the second pass: Frame and SB QP assignment and temporal filtering strenght change
 //FOR DEBUGGING - Do not remove

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -5885,7 +5885,11 @@ void md_stage_1(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *blk_p
         candidate_ptr    = candidate_buffer->candidate_ptr;
 
         context_ptr->md_staging_skip_full_pred            = EB_FALSE;
+#if IFS_MD_STAGE_3
+        context_ptr->md_staging_skip_interpolation_search = EB_TRUE;
+#else
         context_ptr->md_staging_skip_interpolation_search = EB_FALSE;
+#endif
         context_ptr->md_staging_skip_inter_chroma_pred    = EB_TRUE;
         candidate_buffer->candidate_ptr->interp_filters   = 0;
         full_loop_core(pcs_ptr,
@@ -5986,9 +5990,13 @@ void md_stage_3(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *blk_p
 
         // Set MD Staging full_loop_core settings
         context_ptr->md_staging_skip_full_pred = context_ptr->md_staging_mode == MD_STAGING_MODE_0;
+#if IFS_MD_STAGE_3
+        context_ptr->md_staging_skip_interpolation_search = EB_FALSE;
+#else
         context_ptr->md_staging_skip_interpolation_search =
             (context_ptr->md_staging_mode == MD_STAGING_MODE_1 ||
              context_ptr->md_staging_mode == MD_STAGING_MODE_2);
+#endif
         context_ptr->md_staging_skip_inter_chroma_pred = EB_FALSE;
         context_ptr->md_staging_tx_size_mode = EB_TRUE;
         context_ptr->md_staging_tx_search =


### PR DESCRIPTION
## Description

Moved IFS from MD_STAGE_1 to MD_STAGE_3.

## Testing and Performance
Data generated on the full objective-1-fast data set in context in enc-mode 0. 

| Speed Deviation| BD-Rate Deviation|
| -- | --
| 4.45% | 0.02%|