### PR TITLE
Fix crash during res release if res failed to allocate

### DIFF
--- a/Source/Lib/Common/Codec/EbObject.h
+++ b/Source/Lib/Common/Codec/EbObject.h
@@ -30,7 +30,7 @@
   }
 
   A* o;
-  EB_NEW(a_ctor, o);
+  EB_NEW(o, a_ctor);
   //...
   EB_RELEASE(o);
 

--- a/Source/Lib/Common/Codec/EbSystemResourceManager.c
+++ b/Source/Lib/Common/Codec/EbSystemResourceManager.c
@@ -374,11 +374,11 @@ static EbErrorType eb_object_wrapper_ctor(EbObjectWrapper *wrapper, EbSystemReso
     EbErrorType ret;
 
     wrapper->dctor = eb_object_wrapper_dctor;
-    ret            = object_creator(&wrapper->object_ptr, object_init_data_ptr);
-    if (ret != EB_ErrorNone) return ret;
     wrapper->release_enable      = EB_TRUE;
     wrapper->system_resource_ptr = resource;
     wrapper->object_destroyer    = object_destroyer;
+    ret                          = object_creator(&wrapper->object_ptr, object_init_data_ptr);
+    if (ret != EB_ErrorNone) return ret;
     return EB_ErrorNone;
 }
 

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -3700,9 +3700,11 @@ void eb_input_buffer_header_destroyer(    EbPtr p)
 {
     EbBufferHeaderType *obj = (EbBufferHeaderType*)p;
     EbPictureBufferDesc* buf = (EbPictureBufferDesc*)obj->p_buffer;
-    EB_FREE_ALIGNED_ARRAY(buf->buffer_bit_inc_y);
-    EB_FREE_ALIGNED_ARRAY(buf->buffer_bit_inc_cb);
-    EB_FREE_ALIGNED_ARRAY(buf->buffer_bit_inc_cr);
+    if (buf) {
+        EB_FREE_ALIGNED_ARRAY(buf->buffer_bit_inc_y);
+        EB_FREE_ALIGNED_ARRAY(buf->buffer_bit_inc_cb);
+        EB_FREE_ALIGNED_ARRAY(buf->buffer_bit_inc_cr);
+    }
 
     EB_DELETE(buf);
     EB_FREE(obj);

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -3675,6 +3675,7 @@ EbErrorType eb_input_buffer_header_creator(
     EbPtr *object_dbl_ptr,
     EbPtr  object_init_data_ptr)
 {
+    EbErrorType return_error = EB_ErrorNone;
     EbBufferHeaderType* input_buffer;
     SequenceControlSet        *scs_ptr = (SequenceControlSet*)object_init_data_ptr;
 
@@ -3684,9 +3685,11 @@ EbErrorType eb_input_buffer_header_creator(
     // Initialize Header
     input_buffer->size = sizeof(EbBufferHeaderType);
 
-    allocate_frame_buffer(
+    return_error = allocate_frame_buffer(
         scs_ptr,
         input_buffer);
+    if (return_error != EB_ErrorNone)
+        return return_error;
 
     input_buffer->p_app_private = NULL;
 


### PR DESCRIPTION
In eb_object_wrapper_ctor, if object_creator failed, object_destroyer assignment is lost.
when eb_object_wrapper_dctor is called, object_destroyer is not being called, instead EB_DELETE
which crashes.

Signed-off-by: Jun Tian <jun.tian@intel.com>