### PR TITLE
Enhanced I_SICE QP assignment

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -33,7 +33,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
+#define QPS_CHANGE_II            1 // Change the QP assignment for I
 #define OMARK_LAMBDA                1 // 2. fix lambda calculation for HBD0
 #define OMARK_HBD1_CDEF             1 // 3. fix CDEF lambda for hbd1/2
 #define OMARK_HBD0_ED               1 // 4. fix ED lambda for hbd0

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -5115,7 +5115,11 @@ static int adaptive_qindex_calc(PictureControlSet *pcs_ptr, RATE_CONTROL *rc, in
 }
 
 #if QPS_CHANGE
+#if QPS_CHANGE_II
+#define DEFAULT_KF_BOOST 2700
+#else
 #define DEFAULT_KF_BOOST 2300
+#endif
 #define DEFAULT_GF_BOOST 1350
 /******************************************************
  * cqp_qindex_calc
@@ -5180,8 +5184,11 @@ static int cqp_qindex_calc(
             q_val * delta_rate_new[pcs_ptr->parent_pcs_ptr->hierarchical_levels]
             [pcs_ptr->parent_pcs_ptr->temporal_layer_index],
             bit_depth);
-
+#if QPS_CHANGE_II
+        active_best_quality = (int32_t)(qindex + delta_qindex);
+#else
         active_best_quality = MAX((int32_t)(qindex + delta_qindex), (pcs_ptr->ref_pic_qp_array[0][0] << 2) + 2);
+#endif
     }
     q = active_best_quality;
     clamp(q, active_best_quality, active_worst_quality);


### PR DESCRIPTION
## Description

Enhanced I_SICE QP assignment.

## Testing and Performance

full AOM 8 bit and 10 bits list

AOM list | Speed Deviation | BD-Rate Deviation
-- | -- | --
8bit |1.41% | -0.21%
10bit |1.31% | -0.28%


Signed-off-by: anaghdin <amir.naghdinezhad@intel.com>