### PR TITLE
Shutdown threads in a graceful way

### DIFF
--- a/Source/API/EbSvtAv1.h
+++ b/Source/API/EbSvtAv1.h
@@ -106,6 +106,7 @@ typedef enum EbErrorType {
     EB_ErrorMutexUnresponsive      = (int32_t)0x80002031,
     EB_ErrorDestroyMutexFailed     = (int32_t)0x80002032,
     EB_NoErrorEmptyQueue           = (int32_t)0x80002033,
+    EB_NoErrorFifoShutdown         = (int32_t)0x80002034,
     EB_ErrorMax                    = 0x7FFFFFFF
 } EbErrorType;
 

--- a/Source/Lib/Common/Codec/EbSystemResourceManager.c
+++ b/Source/Lib/Common/Codec/EbSystemResourceManager.c
@@ -377,6 +377,7 @@ static EbErrorType eb_object_wrapper_ctor(EbObjectWrapper *wrapper, EbSystemReso
     ret            = object_creator(&wrapper->object_ptr, object_init_data_ptr);
     if (ret != EB_ErrorNone) return ret;
     wrapper->release_enable      = EB_TRUE;
+    wrapper->quit_signal         = EB_FALSE;
     wrapper->system_resource_ptr = resource;
     wrapper->object_destroyer    = object_destroyer;
     return EB_ErrorNone;

--- a/Source/Lib/Common/Codec/EbSystemResourceManager.h
+++ b/Source/Lib/Common/Codec/EbSystemResourceManager.h
@@ -38,6 +38,9 @@ typedef struct EbObjectWrapper {
     //   pictures in the encoder pipeline.
     EbBool release_enable;
 
+    // quit_signal - a flag that main thread sets to break out from kernels
+    EbBool quit_signal;
+
     // system_resource_ptr - a pointer to the SystemResourceManager
     //   that the object belongs to.
     struct EbSystemResource *system_resource_ptr;
@@ -297,6 +300,18 @@ extern EbErrorType eb_get_full_object_non_blocking(EbFifo *          full_fifo_p
      *      pointer to EbObjectWrapper to be released.
      *********************************************************************/
 extern EbErrorType eb_release_object(EbObjectWrapper *object_ptr);
+
+#define EB_SEND_END_OBJ(fifo_ptr, count)               \
+    for (unsigned int i = 0; i < count; i++) {         \
+        EbObjectWrapper *wrapper_ptr;                  \
+        eb_get_empty_object(fifo_ptr, &wrapper_ptr);   \
+        wrapper_ptr->quit_signal = EB_TRUE;            \
+        eb_post_full_object(wrapper_ptr);              \
+    }
+
+#define EB_CHECK_END_OBJ(wrapper_ptr) \
+    if (wrapper_ptr->quit_signal == EB_TRUE) { break; }
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/Lib/Common/Codec/EbSystemResourceManager.h
+++ b/Source/Lib/Common/Codec/EbSystemResourceManager.h
@@ -301,6 +301,16 @@ extern EbErrorType eb_get_full_object_non_blocking(EbFifo *          full_fifo_p
      *********************************************************************/
 extern EbErrorType eb_release_object(EbObjectWrapper *object_ptr);
 
+/*********************************************************************
+     * eb_shutdown_process
+     *   Notify shut down signal to consumer of EbSystemResource.
+     *   So that the consumer process can break the loop and quit running.
+     *
+     *   resource_ptr
+     *      pointer to the SystemResource.
+     *********************************************************************/
+extern EbErrorType eb_shutdown_process(const EbSystemResource *resource_ptr);
+
 #define EB_GET_FULL_OBJECT(full_fifo_ptr, wrapper_dbl_ptr)                           \
      do {                                                                            \
           EbErrorType err = eb_get_full_object(full_fifo_ptr, wrapper_dbl_ptr);      \

--- a/Source/Lib/Common/Codec/EbSystemResourceManager.h
+++ b/Source/Lib/Common/Codec/EbSystemResourceManager.h
@@ -38,9 +38,6 @@ typedef struct EbObjectWrapper {
     //   pictures in the encoder pipeline.
     EbBool release_enable;
 
-    // quit_signal - a flag that main thread sets to break out from kernels
-    EbBool quit_signal;
-
     // system_resource_ptr - a pointer to the SystemResourceManager
     //   that the object belongs to.
     struct EbSystemResource *system_resource_ptr;
@@ -74,6 +71,9 @@ typedef struct EbFifo {
 
     // last_ptr - pointer to the tail of the Fifo
     EbObjectWrapper *last_ptr;
+
+    // quit_signal - a flag that main thread sets to break out from kernels
+    EbBool quit_signal;
 
     // queue_ptr - pointer to MuxingQueue that the EbFifo is
     //   associated with.
@@ -301,16 +301,11 @@ extern EbErrorType eb_get_full_object_non_blocking(EbFifo *          full_fifo_p
      *********************************************************************/
 extern EbErrorType eb_release_object(EbObjectWrapper *object_ptr);
 
-#define EB_SEND_END_OBJ(fifo_ptr, count)               \
-    for (unsigned int i = 0; i < count; i++) {         \
-        EbObjectWrapper *wrapper_ptr;                  \
-        eb_get_empty_object(fifo_ptr, &wrapper_ptr);   \
-        wrapper_ptr->quit_signal = EB_TRUE;            \
-        eb_post_full_object(wrapper_ptr);              \
-    }
-
-#define EB_CHECK_END_OBJ(wrapper_ptr) \
-    if (wrapper_ptr->quit_signal == EB_TRUE) { break; }
+#define EB_GET_FULL_OBJECT(full_fifo_ptr, wrapper_dbl_ptr)                           \
+     do {                                                                            \
+          EbErrorType err = eb_get_full_object(full_fifo_ptr, wrapper_dbl_ptr);      \
+          if (err == EB_NoErrorFifoShutdown)  return NULL;                           \
+     } while (0)
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Common/Codec/EbThreads.c
+++ b/Source/Lib/Common/Codec/EbThreads.c
@@ -149,11 +149,9 @@ EbErrorType eb_destroy_thread(EbHandle thread_handle) {
     EbErrorType error_return = EB_ErrorNone;
 
 #ifdef _WIN32
-    error_return =
-        !TerminateThread((HANDLE)thread_handle, 0) ? EB_ErrorDestroyThreadFailed : EB_ErrorNone;
+    WaitForSingleObject(thread_handle, INFINITE);
+    error_return = CloseHandle(thread_handle) ? EB_ErrorNone : EB_ErrorDestroyThreadFailed;
 #else
-    error_return =
-        pthread_cancel(*((pthread_t *)thread_handle)) ? EB_ErrorDestroyThreadFailed : EB_ErrorNone;
     pthread_join(*((pthread_t *)thread_handle), NULL);
     free(thread_handle);
 #endif // _WIN32

--- a/Source/Lib/Encoder/Codec/EbCdefProcess.c
+++ b/Source/Lib/Encoder/Codec/EbCdefProcess.c
@@ -513,6 +513,7 @@ void *cdef_kernel(void *input_ptr) {
     for (;;) {
         // Get DLF Results
         eb_get_full_object(context_ptr->cdef_input_fifo_ptr, &dlf_results_wrapper_ptr);
+        EB_CHECK_END_OBJ(dlf_results_wrapper_ptr);
 
         dlf_results_ptr = (DlfResults *)dlf_results_wrapper_ptr->object_ptr;
         pcs_ptr         = (PictureControlSet *)dlf_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbCdefProcess.c
+++ b/Source/Lib/Encoder/Codec/EbCdefProcess.c
@@ -512,8 +512,7 @@ void *cdef_kernel(void *input_ptr) {
 
     for (;;) {
         // Get DLF Results
-        eb_get_full_object(context_ptr->cdef_input_fifo_ptr, &dlf_results_wrapper_ptr);
-        EB_CHECK_END_OBJ(dlf_results_wrapper_ptr);
+        EB_GET_FULL_OBJECT(context_ptr->cdef_input_fifo_ptr, &dlf_results_wrapper_ptr);
 
         dlf_results_ptr = (DlfResults *)dlf_results_wrapper_ptr->object_ptr;
         pcs_ptr         = (PictureControlSet *)dlf_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbDlfProcess.c
+++ b/Source/Lib/Encoder/Codec/EbDlfProcess.c
@@ -105,8 +105,7 @@ void *dlf_kernel(void *input_ptr) {
     // SB Loop variables
     for (;;) {
         // Get EncDec Results
-        eb_get_full_object(context_ptr->dlf_input_fifo_ptr, &enc_dec_results_wrapper_ptr);
-        EB_CHECK_END_OBJ(enc_dec_results_wrapper_ptr);
+        EB_GET_FULL_OBJECT(context_ptr->dlf_input_fifo_ptr, &enc_dec_results_wrapper_ptr);
 
         enc_dec_results_ptr = (EncDecResults *)enc_dec_results_wrapper_ptr->object_ptr;
         pcs_ptr             = (PictureControlSet *)enc_dec_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbDlfProcess.c
+++ b/Source/Lib/Encoder/Codec/EbDlfProcess.c
@@ -106,6 +106,7 @@ void *dlf_kernel(void *input_ptr) {
     for (;;) {
         // Get EncDec Results
         eb_get_full_object(context_ptr->dlf_input_fifo_ptr, &enc_dec_results_wrapper_ptr);
+        EB_CHECK_END_OBJ(enc_dec_results_wrapper_ptr);
 
         enc_dec_results_ptr = (EncDecResults *)enc_dec_results_wrapper_ptr->object_ptr;
         pcs_ptr             = (PictureControlSet *)enc_dec_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -2709,6 +2709,7 @@ void *enc_dec_kernel(void *input_ptr) {
     for (;;) {
         // Get Mode Decision Results
         eb_get_full_object(context_ptr->mode_decision_input_fifo_ptr, &enc_dec_tasks_wrapper_ptr);
+        EB_CHECK_END_OBJ(enc_dec_tasks_wrapper_ptr);
 
         enc_dec_tasks_ptr = (EncDecTasks *)enc_dec_tasks_wrapper_ptr->object_ptr;
         pcs_ptr           = (PictureControlSet *)enc_dec_tasks_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -2708,8 +2708,7 @@ void *enc_dec_kernel(void *input_ptr) {
 
     for (;;) {
         // Get Mode Decision Results
-        eb_get_full_object(context_ptr->mode_decision_input_fifo_ptr, &enc_dec_tasks_wrapper_ptr);
-        EB_CHECK_END_OBJ(enc_dec_tasks_wrapper_ptr);
+        EB_GET_FULL_OBJECT(context_ptr->mode_decision_input_fifo_ptr, &enc_dec_tasks_wrapper_ptr);
 
         enc_dec_tasks_ptr = (EncDecTasks *)enc_dec_tasks_wrapper_ptr->object_ptr;
         pcs_ptr           = (PictureControlSet *)enc_dec_tasks_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c
@@ -555,6 +555,8 @@ void *entropy_coding_kernel(void *input_ptr) {
         // Get Mode Decision Results
 #if TILES_PARALLEL
         eb_get_full_object(context_ptr->enc_dec_input_fifo_ptr, &rest_results_wrapper_ptr);
+        EB_CHECK_END_OBJ(rest_results_wrapper_ptr);
+
         rest_results_ptr = (RestResults *)rest_results_wrapper_ptr->object_ptr;
         pcs_ptr          = (PictureControlSet *)rest_results_ptr->pcs_wrapper_ptr->object_ptr;
 #else

--- a/Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c
@@ -554,14 +554,12 @@ void *entropy_coding_kernel(void *input_ptr) {
     for (;;) {
         // Get Mode Decision Results
 #if TILES_PARALLEL
-        eb_get_full_object(context_ptr->enc_dec_input_fifo_ptr, &rest_results_wrapper_ptr);
-        EB_CHECK_END_OBJ(rest_results_wrapper_ptr);
+        EB_GET_FULL_OBJECT(context_ptr->enc_dec_input_fifo_ptr, &rest_results_wrapper_ptr);
 
         rest_results_ptr = (RestResults *)rest_results_wrapper_ptr->object_ptr;
         pcs_ptr          = (PictureControlSet *)rest_results_ptr->pcs_wrapper_ptr->object_ptr;
 #else
-        eb_get_full_object(context_ptr->enc_dec_input_fifo_ptr, &enc_dec_results_wrapper_ptr);
-        enc_dec_results_ptr = (EncDecResults *)enc_dec_results_wrapper_ptr->object_ptr;
+        EB_GET_FULL_OBJECT(context_ptr->enc_dec_input_fifo_ptr, &enc_dec_results_wrapper_ptr);
         pcs_ptr = (PictureControlSet *)enc_dec_results_ptr->pcs_wrapper_ptr->object_ptr;
 #endif
         scs_ptr = (SequenceControlSet *)pcs_ptr->scs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -866,6 +866,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
         // Get Input Full Object
         eb_get_full_object(context_ptr->motion_estimation_results_input_fifo_ptr,
                            &in_results_wrapper_ptr);
+        EB_CHECK_END_OBJ(in_results_wrapper_ptr);
 
         in_results_ptr = (MotionEstimationResults *)in_results_wrapper_ptr->object_ptr;
         pcs_ptr        = (PictureParentControlSet *)in_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -864,9 +864,8 @@ void *initial_rate_control_kernel(void *input_ptr) {
     uint32_t segment_index;
     for (;;) {
         // Get Input Full Object
-        eb_get_full_object(context_ptr->motion_estimation_results_input_fifo_ptr,
+        EB_GET_FULL_OBJECT(context_ptr->motion_estimation_results_input_fifo_ptr,
                            &in_results_wrapper_ptr);
-        EB_CHECK_END_OBJ(in_results_wrapper_ptr);
 
         in_results_ptr = (MotionEstimationResults *)in_results_wrapper_ptr->object_ptr;
         pcs_ptr        = (PictureParentControlSet *)in_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
@@ -1505,9 +1505,8 @@ void *mode_decision_configuration_kernel(void *input_ptr) {
 
     for (;;) {
         // Get RateControl Results
-        eb_get_full_object(context_ptr->rate_control_input_fifo_ptr,
+        EB_GET_FULL_OBJECT(context_ptr->rate_control_input_fifo_ptr,
                            &rate_control_results_wrapper_ptr);
-        EB_CHECK_END_OBJ(rate_control_results_wrapper_ptr);
 
         rate_control_results_ptr =
             (RateControlResults *)rate_control_results_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
@@ -1507,6 +1507,7 @@ void *mode_decision_configuration_kernel(void *input_ptr) {
         // Get RateControl Results
         eb_get_full_object(context_ptr->rate_control_input_fifo_ptr,
                            &rate_control_results_wrapper_ptr);
+        EB_CHECK_END_OBJ(rate_control_results_wrapper_ptr);
 
         rate_control_results_ptr =
             (RateControlResults *)rate_control_results_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -681,9 +681,8 @@ void *motion_estimation_kernel(void *input_ptr) {
 
     for (;;) {
         // Get Input Full Object
-        eb_get_full_object(context_ptr->picture_decision_results_input_fifo_ptr,
+        EB_GET_FULL_OBJECT(context_ptr->picture_decision_results_input_fifo_ptr,
                            &in_results_wrapper_ptr);
-        EB_CHECK_END_OBJ(in_results_wrapper_ptr);
 
         in_results_ptr = (PictureDecisionResults *)in_results_wrapper_ptr->object_ptr;
         pcs_ptr        = (PictureParentControlSet *)in_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -683,6 +683,7 @@ void *motion_estimation_kernel(void *input_ptr) {
         // Get Input Full Object
         eb_get_full_object(context_ptr->picture_decision_results_input_fifo_ptr,
                            &in_results_wrapper_ptr);
+        EB_CHECK_END_OBJ(in_results_wrapper_ptr);
 
         in_results_ptr = (PictureDecisionResults *)in_results_wrapper_ptr->object_ptr;
         pcs_ptr        = (PictureParentControlSet *)in_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
@@ -628,9 +628,8 @@ void *packetization_kernel(void *input_ptr) {
 
     for (;;) {
         // Get EntropyCoding Results
-        eb_get_full_object(context_ptr->entropy_coding_input_fifo_ptr,
+        EB_GET_FULL_OBJECT(context_ptr->entropy_coding_input_fifo_ptr,
                            &entropy_coding_results_wrapper_ptr);
-        EB_CHECK_END_OBJ(entropy_coding_results_wrapper_ptr);
 
         entropy_coding_results_ptr =
             (EntropyCodingResults *)entropy_coding_results_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
@@ -630,6 +630,8 @@ void *packetization_kernel(void *input_ptr) {
         // Get EntropyCoding Results
         eb_get_full_object(context_ptr->entropy_coding_input_fifo_ptr,
                            &entropy_coding_results_wrapper_ptr);
+        EB_CHECK_END_OBJ(entropy_coding_results_wrapper_ptr);
+
         entropy_coding_results_ptr =
             (EntropyCodingResults *)entropy_coding_results_wrapper_ptr->object_ptr;
         pcs_ptr = (PictureControlSet *)entropy_coding_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
@@ -3878,9 +3878,8 @@ void *picture_analysis_kernel(void *input_ptr) {
 
     for (;;) {
         // Get Input Full Object
-        eb_get_full_object(context_ptr->resource_coordination_results_input_fifo_ptr,
+        EB_GET_FULL_OBJECT(context_ptr->resource_coordination_results_input_fifo_ptr,
                            &in_results_wrapper_ptr);
-        EB_CHECK_END_OBJ(in_results_wrapper_ptr);
 
         in_results_ptr = (ResourceCoordinationResults *)in_results_wrapper_ptr->object_ptr;
         pcs_ptr        = (PictureParentControlSet *)in_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
@@ -3880,6 +3880,7 @@ void *picture_analysis_kernel(void *input_ptr) {
         // Get Input Full Object
         eb_get_full_object(context_ptr->resource_coordination_results_input_fifo_ptr,
                            &in_results_wrapper_ptr);
+        EB_CHECK_END_OBJ(in_results_wrapper_ptr);
 
         in_results_ptr = (ResourceCoordinationResults *)in_results_wrapper_ptr->object_ptr;
         pcs_ptr        = (PictureParentControlSet *)in_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -3426,6 +3426,7 @@ void* picture_decision_kernel(void *input_ptr)
         eb_get_full_object(
             context_ptr->picture_analysis_results_input_fifo_ptr,
             &in_results_wrapper_ptr);
+        EB_CHECK_END_OBJ(in_results_wrapper_ptr);
 
         in_results_ptr = (PictureAnalysisResults*)in_results_wrapper_ptr->object_ptr;
         pcs_ptr = (PictureParentControlSet*)in_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -3423,10 +3423,9 @@ void* picture_decision_kernel(void *input_ptr)
 
     for (;;) {
         // Get Input Full Object
-        eb_get_full_object(
+        EB_GET_FULL_OBJECT(
             context_ptr->picture_analysis_results_input_fifo_ptr,
             &in_results_wrapper_ptr);
-        EB_CHECK_END_OBJ(in_results_wrapper_ptr);
 
         in_results_ptr = (PictureAnalysisResults*)in_results_wrapper_ptr->object_ptr;
         pcs_ptr = (PictureParentControlSet*)in_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -193,8 +193,7 @@ void *picture_manager_kernel(void *input_ptr) {
 
     for (;;) {
         // Get Input Full Object
-        eb_get_full_object(context_ptr->picture_input_fifo_ptr, &input_picture_demux_wrapper_ptr);
-        EB_CHECK_END_OBJ(input_picture_demux_wrapper_ptr);
+        EB_GET_FULL_OBJECT(context_ptr->picture_input_fifo_ptr, &input_picture_demux_wrapper_ptr);
 
         input_picture_demux_ptr =
             (PictureDemuxResults *)input_picture_demux_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -194,6 +194,7 @@ void *picture_manager_kernel(void *input_ptr) {
     for (;;) {
         // Get Input Full Object
         eb_get_full_object(context_ptr->picture_input_fifo_ptr, &input_picture_demux_wrapper_ptr);
+        EB_CHECK_END_OBJ(input_picture_demux_wrapper_ptr);
 
         input_picture_demux_ptr =
             (PictureDemuxResults *)input_picture_demux_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -5490,9 +5490,8 @@ void *rate_control_kernel(void *input_ptr) {
 
     for (;;) {
         // Get RateControl Task
-        eb_get_full_object(context_ptr->rate_control_input_tasks_fifo_ptr,
+        EB_GET_FULL_OBJECT(context_ptr->rate_control_input_tasks_fifo_ptr,
                            &rate_control_tasks_wrapper_ptr);
-        EB_CHECK_END_OBJ(rate_control_tasks_wrapper_ptr);
 
         rate_control_tasks_ptr = (RateControlTasks *)rate_control_tasks_wrapper_ptr->object_ptr;
         task_type              = rate_control_tasks_ptr->task_type;

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -5492,6 +5492,7 @@ void *rate_control_kernel(void *input_ptr) {
         // Get RateControl Task
         eb_get_full_object(context_ptr->rate_control_input_tasks_fifo_ptr,
                            &rate_control_tasks_wrapper_ptr);
+        EB_CHECK_END_OBJ(rate_control_tasks_wrapper_ptr);
 
         rate_control_tasks_ptr = (RateControlTasks *)rate_control_tasks_wrapper_ptr->object_ptr;
         task_type              = rate_control_tasks_ptr->task_type;

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -724,8 +724,7 @@ void *resource_coordination_kernel(void *input_ptr) {
         instance_index = 0;
 
         // Get the Next svt Input Buffer [BLOCKING]
-        eb_get_full_object(context_ptr->input_buffer_fifo_ptr, &eb_input_wrapper_ptr);
-        EB_CHECK_END_OBJ(eb_input_wrapper_ptr);
+        EB_GET_FULL_OBJECT(context_ptr->input_buffer_fifo_ptr, &eb_input_wrapper_ptr);
 
         eb_input_ptr = (EbBufferHeaderType *)eb_input_wrapper_ptr->object_ptr;
         scs_ptr      = context_ptr->scs_instance_array[instance_index]->scs_ptr;

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -725,6 +725,8 @@ void *resource_coordination_kernel(void *input_ptr) {
 
         // Get the Next svt Input Buffer [BLOCKING]
         eb_get_full_object(context_ptr->input_buffer_fifo_ptr, &eb_input_wrapper_ptr);
+        EB_CHECK_END_OBJ(eb_input_wrapper_ptr);
+
         eb_input_ptr = (EbBufferHeaderType *)eb_input_wrapper_ptr->object_ptr;
         scs_ptr      = context_ptr->scs_instance_array[instance_index]->scs_ptr;
 

--- a/Source/Lib/Encoder/Codec/EbRestProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRestProcess.c
@@ -479,6 +479,7 @@ void *rest_kernel(void *input_ptr) {
     for (;;) {
         // Get Cdef Results
         eb_get_full_object(context_ptr->rest_input_fifo_ptr, &cdef_results_wrapper_ptr);
+        EB_CHECK_END_OBJ(cdef_results_wrapper_ptr);
 
         cdef_results_ptr = (CdefResults *)cdef_results_wrapper_ptr->object_ptr;
         pcs_ptr          = (PictureControlSet *)cdef_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbRestProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRestProcess.c
@@ -478,8 +478,7 @@ void *rest_kernel(void *input_ptr) {
 
     for (;;) {
         // Get Cdef Results
-        eb_get_full_object(context_ptr->rest_input_fifo_ptr, &cdef_results_wrapper_ptr);
-        EB_CHECK_END_OBJ(cdef_results_wrapper_ptr);
+        EB_GET_FULL_OBJECT(context_ptr->rest_input_fifo_ptr, &cdef_results_wrapper_ptr);
 
         cdef_results_ptr = (CdefResults *)cdef_results_wrapper_ptr->object_ptr;
         pcs_ptr          = (PictureControlSet *)cdef_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbSourceBasedOperationsProcess.c
+++ b/Source/Lib/Encoder/Codec/EbSourceBasedOperationsProcess.c
@@ -114,9 +114,8 @@ void *source_based_operations_kernel(void *input_ptr) {
 
     for (;;) {
         // Get Input Full Object
-        eb_get_full_object(context_ptr->initial_rate_control_results_input_fifo_ptr,
+        EB_GET_FULL_OBJECT(context_ptr->initial_rate_control_results_input_fifo_ptr,
                            &in_results_wrapper_ptr);
-        EB_CHECK_END_OBJ(in_results_wrapper_ptr);
 
         in_results_ptr = (InitialRateControlResults *)in_results_wrapper_ptr->object_ptr;
         pcs_ptr        = (PictureParentControlSet *)in_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Codec/EbSourceBasedOperationsProcess.c
+++ b/Source/Lib/Encoder/Codec/EbSourceBasedOperationsProcess.c
@@ -116,6 +116,7 @@ void *source_based_operations_kernel(void *input_ptr) {
         // Get Input Full Object
         eb_get_full_object(context_ptr->initial_rate_control_results_input_fifo_ptr,
                            &in_results_wrapper_ptr);
+        EB_CHECK_END_OBJ(in_results_wrapper_ptr);
 
         in_results_ptr = (InitialRateControlResults *)in_results_wrapper_ptr->object_ptr;
         pcs_ptr        = (PictureParentControlSet *)in_results_ptr->pcs_wrapper_ptr->object_ptr;

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -1732,6 +1732,26 @@ __attribute__((visibility("default")))
 EB_API EbErrorType eb_deinit_encoder(EbComponentType *svt_enc_component){
     if(svt_enc_component == NULL)
         return EB_ErrorBadParameter;
+
+    EbEncHandle *handle = (EbEncHandle*)svt_enc_component->p_component_private;
+    if (handle) {
+        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->input_buffer_resource_ptr, 0),                    EB_ResourceCoordinationProcessInitCount);
+        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->resource_coordination_results_resource_ptr, 0),   handle->scs_instance_array[0]->scs_ptr->picture_analysis_process_init_count);
+        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->picture_analysis_results_resource_ptr, 0),        EB_PictureDecisionProcessInitCount);
+        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->picture_decision_results_resource_ptr, 0),        handle->scs_instance_array[0]->scs_ptr->motion_estimation_process_init_count);
+        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->motion_estimation_results_resource_ptr, 0),       EB_InitialRateControlProcessInitCount);
+        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->initial_rate_control_results_resource_ptr, 0),    handle->scs_instance_array[0]->scs_ptr->source_based_operations_process_init_count);
+        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->picture_demux_results_resource_ptr, 0),           EB_PictureManagerProcessInitCount);
+        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->rate_control_tasks_resource_ptr, 0),              EB_RateControlProcessInitCount);
+        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->rate_control_results_resource_ptr, 0),            handle->scs_instance_array[0]->scs_ptr->mode_decision_configuration_process_init_count);
+        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->enc_dec_tasks_resource_ptr, 0),                   handle->scs_instance_array[0]->scs_ptr->enc_dec_process_init_count);
+        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->enc_dec_results_resource_ptr, 0),                 handle->scs_instance_array[0]->scs_ptr->dlf_process_init_count);
+        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->entropy_coding_results_resource_ptr, 0),          EB_PacketizationProcessInitCount);
+        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->dlf_results_resource_ptr, 0),                     handle->scs_instance_array[0]->scs_ptr->cdef_process_init_count);
+        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->cdef_results_resource_ptr, 0),                    handle->scs_instance_array[0]->scs_ptr->rest_process_init_count);
+        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->rest_results_resource_ptr, 0),                    handle->scs_instance_array[0]->scs_ptr->entropy_coding_process_init_count);
+    }
+
     return EB_ErrorNone;
 }
 

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -1735,21 +1735,21 @@ EB_API EbErrorType eb_deinit_encoder(EbComponentType *svt_enc_component){
 
     EbEncHandle *handle = (EbEncHandle*)svt_enc_component->p_component_private;
     if (handle) {
-        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->input_buffer_resource_ptr, 0),                    EB_ResourceCoordinationProcessInitCount);
-        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->resource_coordination_results_resource_ptr, 0),   handle->scs_instance_array[0]->scs_ptr->picture_analysis_process_init_count);
-        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->picture_analysis_results_resource_ptr, 0),        EB_PictureDecisionProcessInitCount);
-        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->picture_decision_results_resource_ptr, 0),        handle->scs_instance_array[0]->scs_ptr->motion_estimation_process_init_count);
-        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->motion_estimation_results_resource_ptr, 0),       EB_InitialRateControlProcessInitCount);
-        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->initial_rate_control_results_resource_ptr, 0),    handle->scs_instance_array[0]->scs_ptr->source_based_operations_process_init_count);
-        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->picture_demux_results_resource_ptr, 0),           EB_PictureManagerProcessInitCount);
-        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->rate_control_tasks_resource_ptr, 0),              EB_RateControlProcessInitCount);
-        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->rate_control_results_resource_ptr, 0),            handle->scs_instance_array[0]->scs_ptr->mode_decision_configuration_process_init_count);
-        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->enc_dec_tasks_resource_ptr, 0),                   handle->scs_instance_array[0]->scs_ptr->enc_dec_process_init_count);
-        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->enc_dec_results_resource_ptr, 0),                 handle->scs_instance_array[0]->scs_ptr->dlf_process_init_count);
-        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->entropy_coding_results_resource_ptr, 0),          EB_PacketizationProcessInitCount);
-        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->dlf_results_resource_ptr, 0),                     handle->scs_instance_array[0]->scs_ptr->cdef_process_init_count);
-        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->cdef_results_resource_ptr, 0),                    handle->scs_instance_array[0]->scs_ptr->rest_process_init_count);
-        EB_SEND_END_OBJ(eb_system_resource_get_producer_fifo(handle->rest_results_resource_ptr, 0),                    handle->scs_instance_array[0]->scs_ptr->entropy_coding_process_init_count);
+        eb_shutdown_process(handle->input_buffer_resource_ptr);
+        eb_shutdown_process(handle->resource_coordination_results_resource_ptr);
+        eb_shutdown_process(handle->picture_analysis_results_resource_ptr);
+        eb_shutdown_process(handle->picture_decision_results_resource_ptr);
+        eb_shutdown_process(handle->motion_estimation_results_resource_ptr);
+        eb_shutdown_process(handle->initial_rate_control_results_resource_ptr);
+        eb_shutdown_process(handle->picture_demux_results_resource_ptr);
+        eb_shutdown_process(handle->rate_control_tasks_resource_ptr);
+        eb_shutdown_process(handle->rate_control_results_resource_ptr);
+        eb_shutdown_process(handle->enc_dec_tasks_resource_ptr);
+        eb_shutdown_process(handle->enc_dec_results_resource_ptr);
+        eb_shutdown_process(handle->entropy_coding_results_resource_ptr);
+        eb_shutdown_process(handle->dlf_results_resource_ptr);
+        eb_shutdown_process(handle->cdef_results_resource_ptr);
+        eb_shutdown_process(handle->rest_results_resource_ptr);
     }
 
     return EB_ErrorNone;


### PR DESCRIPTION
## Description
Avoid using TerminateThread/pthread_cancel which causes issue with multiple continues init/deinit of encoder lib. A customer reported this issue before to SVT-HEVC. This is the fix of it by sending quit signal from main thread to all the kernels. Kernel will break out from the loop once quit signal is set.
Ported from SVT-HEVC. Author: jing.b.li@intel.com

## Results
* BDrate: same
* Speed: same
* Memory: Around 1200(number of fifo object) * EbBool(uint8_t) = ~1200 byte mem increase

Signed-off-by: Jun Tian <jun.tian@intel.com>