### PR TITLE
Fix lambda for HBD

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -34,6 +34,18 @@
 extern "C" {
 #endif
 
+#define OMARK_LAMBDA                1 // 2. fix lambda calculation for HBD0
+#define OMARK_HBD1_CDEF             1 // 3. fix CDEF lambda for hbd1/2
+#define OMARK_HBD0_ED               1 // 4. fix ED lambda for hbd0
+#define OMARK_HBD0_IFS              1 // 5. fix IFS lambda for hbd0
+#define OMARK_HBD0_MD               1 // 5. fix MD lambda for hbd0
+#define OMARK_HBD0_RDOQ             1 // 6. fix RDOQ lambda for hbd0
+#define RDQO_ON_HBD0                1 // 6. turn ON RDOQ for hbd0
+#define PICT_SWITCH                 1  // Fix picture switching
+#define QUANT_CLEANUP               1
+#define QUANT_HBD0_FIX              1
+#define NEW_MD_LAMBDA               1
+
 #define CHROMA_SEARCH_OPT        1 // Move chroma search to be done on the best intra candidate survived from MD stage 2
 #if CHROMA_SEARCH_OPT
 #define INFR_OPT                 1 // Lossless: Infrastructure work to allow the protability of the chroma search

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -499,6 +499,13 @@ static void av1_encode_loop(PictureControlSet *pcs_ptr, EncDecContext *context_p
             context_ptr->md_context->luma_dc_sign_context,
             blk_ptr->pred_mode,
             blk_ptr->av1xd->use_intrabc,
+#if OMARK_HBD0_RDOQ
+#if NEW_MD_LAMBDA
+            context_ptr->md_context->full_lambda_md[EB_8_BIT_MD],
+#else
+            context_ptr->full_lambda,
+#endif
+#endif
             EB_TRUE);
 
         if (context_ptr->md_skip_blk) {
@@ -708,6 +715,13 @@ static void av1_encode_loop(PictureControlSet *pcs_ptr, EncDecContext *context_p
             context_ptr->md_context->cb_dc_sign_context,
             blk_ptr->pred_mode,
             blk_ptr->av1xd->use_intrabc,
+#if OMARK_HBD0_RDOQ
+#if NEW_MD_LAMBDA
+            context_ptr->md_context->full_lambda_md[EB_8_BIT_MD],
+#else
+            context_ptr->md_context->full_lambda,
+#endif
+#endif
             EB_TRUE);
 
         if (context_ptr->md_skip_blk) {
@@ -753,6 +767,13 @@ static void av1_encode_loop(PictureControlSet *pcs_ptr, EncDecContext *context_p
             context_ptr->md_context->cr_dc_sign_context,
             blk_ptr->pred_mode,
             blk_ptr->av1xd->use_intrabc,
+#if OMARK_HBD0_RDOQ
+#if NEW_MD_LAMBDA
+            context_ptr->md_context->full_lambda_md[EB_8_BIT_MD],
+#else
+            context_ptr->md_context->full_lambda,
+#endif
+#endif
             EB_TRUE);
         if (context_ptr->md_skip_blk) {
             count_non_zero_coeffs[2] = 0;
@@ -929,6 +950,13 @@ static void av1_encode_loop_16bit(PictureControlSet *pcs_ptr, EncDecContext *con
                 context_ptr->md_context->luma_dc_sign_context,
                 blk_ptr->pred_mode,
                 blk_ptr->av1xd->use_intrabc,
+#if OMARK_HBD0_RDOQ
+#if NEW_MD_LAMBDA
+                context_ptr->md_context->full_lambda_md[EB_10_BIT_MD],
+#else
+                context_ptr->md_context->full_lambda,
+#endif
+#endif
                 EB_TRUE);
             if (context_ptr->md_skip_blk) {
                 count_non_zero_coeffs[0] = 0;
@@ -1080,6 +1108,13 @@ static void av1_encode_loop_16bit(PictureControlSet *pcs_ptr, EncDecContext *con
                 context_ptr->md_context->cb_dc_sign_context,
                 blk_ptr->pred_mode,
                 blk_ptr->av1xd->use_intrabc,
+#if OMARK_HBD0_RDOQ
+#if NEW_MD_LAMBDA
+                context_ptr->md_context->full_lambda_md[EB_10_BIT_MD],
+#else
+                context_ptr->md_context->full_lambda,
+#endif
+#endif
                 EB_TRUE);
 
             if (context_ptr->md_skip_blk) {
@@ -1126,6 +1161,13 @@ static void av1_encode_loop_16bit(PictureControlSet *pcs_ptr, EncDecContext *con
                 context_ptr->md_context->cr_dc_sign_context,
                 blk_ptr->pred_mode,
                 blk_ptr->av1xd->use_intrabc,
+#if OMARK_HBD0_RDOQ
+#if NEW_MD_LAMBDA
+                context_ptr->md_context->full_lambda_md[EB_10_BIT_MD],
+#else
+                context_ptr->md_context->full_lambda,
+#endif
+#endif
                 EB_TRUE);
             if (context_ptr->md_skip_blk) {
                 count_non_zero_coeffs[2] = 0;

--- a/Source/Lib/Encoder/Codec/EbEncCdef.c
+++ b/Source/Lib/Encoder/Codec/EbEncCdef.c
@@ -1225,15 +1225,25 @@ void finish_cdef_search(EncDecContext *context_ptr, PictureControlSet *pcs_ptr,
     uint64_t      lambda;
     const int32_t num_planes = 3; // av1_num_planes(cm);
     uint16_t qp_index = (uint8_t)pcs_ptr->parent_pcs_ptr->frm_hdr.quantization_params.base_q_idx;
+#if NEW_MD_LAMBDA
+    uint32_t fast_lambda, full_lambda;
+#else
     uint32_t fast_lambda, full_lambda, fast_chroma_lambda, full_chroma_lambda;
+#endif
     (*av1_lambda_assignment_function_table[pcs_ptr->parent_pcs_ptr->pred_structure])(
         &fast_lambda,
         &full_lambda,
+#if !NEW_MD_LAMBDA
         &fast_chroma_lambda,
         &full_chroma_lambda,
+#endif
         (uint8_t)pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
         qp_index,
+#if OMARK_HBD1_CDEF && OMARK_LAMBDA
+        EB_FALSE);
+#else
         pcs_ptr->hbd_mode_decision);
+#endif
     lambda = full_lambda;
 
     mse[0] = (uint64_t(*)[64])malloc(sizeof(**mse) * nvfb * nhfb);

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -249,11 +249,17 @@ static void reset_enc_dec(EncDecContext *context_ptr, PictureControlSet *pcs_ptr
     (*av1_lambda_assignment_function_table[pcs_ptr->parent_pcs_ptr->pred_structure])(
         &context_ptr->fast_lambda,
         &context_ptr->full_lambda,
+#if !NEW_MD_LAMBDA
         &context_ptr->fast_chroma_lambda,
         &context_ptr->full_chroma_lambda,
+#endif
         (uint8_t)pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
         context_ptr->qp_index,
+#if OMARK_HBD0_ED && OMARK_LAMBDA
+        EB_TRUE);
+#else
         context_ptr->md_context->hbd_mode_decision);
+#endif
     // Reset MD rate Estimation table to initial values by copying from md_rate_estimation_array
     if (context_ptr->is_md_rate_estimation_ptr_owner) {
         EB_FREE(context_ptr->md_rate_estimation_ptr);
@@ -303,11 +309,17 @@ static void enc_dec_configure_sb(EncDecContext *context_ptr, SuperBlock *sb_ptr,
     (*av1_lambda_assignment_function_table[pcs_ptr->parent_pcs_ptr->pred_structure])(
         &context_ptr->fast_lambda,
         &context_ptr->full_lambda,
+#if !NEW_MD_LAMBDA
         &context_ptr->fast_chroma_lambda,
         &context_ptr->full_chroma_lambda,
+#endif
         (uint8_t)pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
         context_ptr->qp_index,
+#if OMARK_HBD0_ED && OMARK_LAMBDA
+        EB_TRUE);
+#else
         context_ptr->md_context->hbd_mode_decision);
+#endif
 
     return;
 }

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.h
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.h
@@ -54,8 +54,10 @@ typedef struct EncDecContext {
     uint8_t  chroma_qp;
     uint32_t fast_lambda;
     uint32_t full_lambda;
+#if !NEW_MD_LAMBDA
     uint32_t fast_chroma_lambda;
     uint32_t full_chroma_lambda;
+#endif
     uint32_t full_chroma_lambda_sao;
 
     //  Context Variables---------------------------------

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -276,6 +276,11 @@ void inter_intra_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                        (context_ptr->blk_origin_y + src_pic->origin_y) * src_pic->stride_y;
 
     uint8_t bit_depth = context_ptr->hbd_mode_decision ? EB_10BIT : EB_8BIT;
+#if NEW_MD_LAMBDA
+    uint32_t full_lambda =  context_ptr->hbd_mode_decision ?
+        context_ptr->full_lambda_md[EB_10_BIT_MD] :
+        context_ptr->full_lambda_md[EB_8_BIT_MD];
+#endif
 
     uint32_t            bwidth  = context_ptr->blk_geom->bwidth;
     uint32_t            bheight = context_ptr->blk_geom->bheight;
@@ -471,7 +476,11 @@ void inter_intra_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                                                  NULL);
                 }
                 // rd = RDCOST(x->rdmult, tmp_rate_mv + rate_sum + rmode, dist_sum);
+#if NEW_MD_LAMBDA
+                rd = RDCOST(full_lambda, tmp_rate_mv + rate_sum + rmode, dist_sum);
+#else
                 rd = RDCOST(context_ptr->full_lambda, tmp_rate_mv + rate_sum + rmode, dist_sum);
+#endif
 
                 if (rd < best_interintra_rd) {
                     best_interintra_rd             = rd;
@@ -3387,6 +3396,10 @@ static void single_motion_search(PictureControlSet *pcs, ModeDecisionContext *co
     (void)ref_idx;
     const Av1Common *const cm      = pcs->parent_pcs_ptr->av1_cm;
     FrameHeader *          frm_hdr = &pcs->parent_pcs_ptr->frm_hdr;
+#if NEW_MD_LAMBDA
+// single_motion_search supports 8bit path only
+    uint32_t full_lambda = context_ptr->full_lambda_md[EB_8_BIT_MD];
+#endif
 
     x->xd            = context_ptr->blk_ptr->av1xd;
     const int mi_row = -x->xd->mb_to_top_edge / (8 * MI_SIZE);
@@ -3404,7 +3417,12 @@ static void single_motion_search(PictureControlSet *pcs, ModeDecisionContext *co
     x->mv_limits.col_max = (cm->mi_cols - mi_col) * MI_SIZE + AOM_INTERP_EXTEND;
     //set search paramters
     x->sadperbit16 = sad_per_bit16lut_8[frm_hdr->quantization_params.base_q_idx];
+    x->sadperbit16 = sad_per_bit16lut_8[frm_hdr->quantization_params.base_q_idx];
+#if NEW_MD_LAMBDA
+    x->errorperbit = full_lambda >> RD_EPB_SHIFT;
+#else
     x->errorperbit = context_ptr->full_lambda >> RD_EPB_SHIFT;
+#endif
     x->errorperbit += (x->errorperbit == 0);
 
     int bestsme = INT_MAX;
@@ -5186,6 +5204,11 @@ void intra_bc_search(PictureControlSet *pcs, ModeDecisionContext *context_ptr,
                      uint8_t *num_dv_cand) {
     IntraBcContext  x_st;
     IntraBcContext *x = &x_st;
+#if NEW_MD_LAMBDA
+    uint32_t full_lambda =  context_ptr->hbd_mode_decision ?
+        context_ptr->full_lambda_md[EB_10_BIT_MD] :
+        context_ptr->full_lambda_md[EB_8_BIT_MD];
+#endif
     //fill x with what needed.
     x->is_exhaustive_allowed =
         context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4 ? 1 : 0;
@@ -5221,7 +5244,11 @@ void intra_bc_search(PictureControlSet *pcs, ModeDecisionContext *context_ptr,
     x->mv_limits.col_max = (cm->mi_cols - mi_col) * MI_SIZE + AOM_INTERP_EXTEND;
     //set search paramters
     x->sadperbit16 = sad_per_bit16lut_8[frm_hdr->quantization_params.base_q_idx];
+#if NEW_MD_LAMBDA
+    x->errorperbit = full_lambda >> RD_EPB_SHIFT;
+#else
     x->errorperbit = context_ptr->full_lambda >> RD_EPB_SHIFT;
+#endif
     x->errorperbit += (x->errorperbit == 0);
     //temp buffer for hash me
     for (int xi = 0; xi < 2; xi++)

--- a/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
@@ -1107,6 +1107,9 @@ EbErrorType signal_derivation_mode_decision_config_kernel_oq(
     frm_hdr->is_motion_mode_switchable =
         frm_hdr->is_motion_mode_switchable || pcs_ptr->parent_pcs_ptr->pic_obmc_mode;
 
+#if PICT_SWITCH
+    pcs_ptr->hbd_mode_decision = scs_ptr->static_config.enable_hbd_mode_decision;
+#endif
     return return_error;
 }
 
@@ -1520,7 +1523,34 @@ void *mode_decision_configuration_kernel(void *input_ptr) {
         set_global_motion_field(pcs_ptr);
 
         eb_av1_qm_init(pcs_ptr->parent_pcs_ptr);
+#if QUANT_CLEANUP
+        Quants *const quants_bd = &pcs_ptr->parent_pcs_ptr->quants_bd;
+        Dequants *const deq_bd = &pcs_ptr->parent_pcs_ptr->deq_bd;
+        eb_av1_set_quantizer(
+            pcs_ptr->parent_pcs_ptr,
+            frm_hdr->quantization_params.base_q_idx);
+        eb_av1_build_quantizer(
+            (AomBitDepth)scs_ptr->static_config.encoder_bit_depth,
+            frm_hdr->quantization_params.delta_q_dc[AOM_PLANE_Y],
+            frm_hdr->quantization_params.delta_q_dc[AOM_PLANE_U],
+            frm_hdr->quantization_params.delta_q_ac[AOM_PLANE_U],
+            frm_hdr->quantization_params.delta_q_dc[AOM_PLANE_V],
+            frm_hdr->quantization_params.delta_q_ac[AOM_PLANE_V],
+            quants_bd,
+            deq_bd);
 
+        Quants *const quants_8bit = &pcs_ptr->parent_pcs_ptr->quants_8bit;
+        Dequants *const deq_8bit = &pcs_ptr->parent_pcs_ptr->deq_8bit;
+        eb_av1_build_quantizer(
+            AOM_BITS_8,
+            frm_hdr->quantization_params.delta_q_dc[AOM_PLANE_Y],
+            frm_hdr->quantization_params.delta_q_dc[AOM_PLANE_U],
+            frm_hdr->quantization_params.delta_q_ac[AOM_PLANE_U],
+            frm_hdr->quantization_params.delta_q_dc[AOM_PLANE_V],
+            frm_hdr->quantization_params.delta_q_ac[AOM_PLANE_V],
+            quants_8bit,
+            deq_8bit);
+#else
         Quants *const   quants   = &pcs_ptr->parent_pcs_ptr->quants;
         Dequants *const dequants = &pcs_ptr->parent_pcs_ptr->deq;
 
@@ -1545,6 +1575,7 @@ void *mode_decision_configuration_kernel(void *input_ptr) {
                                frm_hdr->quantization_params.delta_q_ac[AOM_PLANE_V],
                                quants_md,
                                dequants_md);
+#endif
 
         // Hsan: collapse spare code
         MdRateEstimationContext *md_rate_estimation_array;
@@ -1562,11 +1593,17 @@ void *mode_decision_configuration_kernel(void *input_ptr) {
         (*av1_lambda_assignment_function_table[pcs_ptr->parent_pcs_ptr->pred_structure])(
             &lambdasad_,
             &lambda_sse,
+#if !NEW_MD_LAMBDA
             &lambdasad_,
             &lambda_sse,
+#endif
             (uint8_t)pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
             context_ptr->qp_index,
+#if OMARK_LAMBDA
+            EB_TRUE);
+#else
             pcs_ptr->hbd_mode_decision);
+#endif
         context_ptr->lambda      = (uint64_t)lambdasad_;
         md_rate_estimation_array = pcs_ptr->md_rate_estimation_array;
         // Reset MD rate Estimation table to initial values by copying from md_rate_estimation_array

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.c
@@ -422,16 +422,43 @@ const EbLambdaAssignFunc lambda_assignment_function_table[4] = {
     lambda_assign_i_slice // I_SLICE
 };
 
+#if NEW_MD_LAMBDA
+void av1_lambda_assign_md(
+    ModeDecisionContext   *context_ptr)
+{
+        context_ptr->full_lambda_md[0] = av1_lambda_mode_decision8_bit_sse[context_ptr->qp_index];
+        context_ptr->fast_lambda_md[0] = av1_lambda_mode_decision8_bit_sad[context_ptr->qp_index];
+
+        context_ptr->full_lambda_md[1] = av1lambda_mode_decision10_bit_sse[context_ptr->qp_index];
+        context_ptr->fast_lambda_md[1] = av1lambda_mode_decision10_bit_sad[context_ptr->qp_index];
+
+        context_ptr->full_lambda_md[1] *= 16;
+        context_ptr->fast_lambda_md[1] *= 4;
+}
+#endif
+#if NEW_MD_LAMBDA
+void av1_lambda_assign(uint32_t *fast_lambda, uint32_t *full_lambda, uint8_t bit_depth, uint16_t qp_index,
+#if OMARK_LAMBDA
+                       EbBool multiply_lambda) {
+#else
+                       EbBool hbd_mode_decision) {
+#endif
+#else
 void av1_lambda_assign(uint32_t *fast_lambda, uint32_t *full_lambda, uint32_t *fast_chroma_lambda,
                        uint32_t *full_chroma_lambda, uint8_t bit_depth, uint16_t qp_index,
                        EbBool hbd_mode_decision) {
+#endif
     if (bit_depth == 8) {
         *full_lambda = av1_lambda_mode_decision8_bit_sse[qp_index];
         *fast_lambda = av1_lambda_mode_decision8_bit_sad[qp_index];
     } else if (bit_depth == 10) {
         *full_lambda = av1lambda_mode_decision10_bit_sse[qp_index];
         *fast_lambda = av1lambda_mode_decision10_bit_sad[qp_index];
+#if OMARK_LAMBDA
+        if (multiply_lambda) {
+#else
         if (hbd_mode_decision) {
+#endif
             *full_lambda *= 16;
             *fast_lambda *= 4;
         }
@@ -443,10 +470,12 @@ void av1_lambda_assign(uint32_t *fast_lambda, uint32_t *full_lambda, uint32_t *f
         assert(bit_depth <= 12);
     }
 
+#if !NEW_MD_LAMBDA
     //*full_lambda = 0; //-------------Nader
     //*fast_lambda = 0;
     *fast_chroma_lambda = *fast_lambda;
     *full_chroma_lambda = *full_lambda;
+#endif
 
     // NM: To be done: tune lambda based on the picture type and layer.
 }
@@ -466,6 +495,9 @@ void reset_mode_decision(SequenceControlSet *scs_ptr, ModeDecisionContext *conte
                          PictureControlSet *pcs_ptr, uint32_t segment_index) {
 #endif
     FrameHeader *frm_hdr = &pcs_ptr->parent_pcs_ptr->frm_hdr;
+#if PICT_SWITCH
+    context_ptr->hbd_mode_decision = pcs_ptr->hbd_mode_decision;
+#endif
     // QP
     uint16_t picture_qp   = pcs_ptr->parent_pcs_ptr->frm_hdr.quantization_params.base_q_idx;
     context_ptr->qp       = picture_qp;
@@ -473,14 +505,26 @@ void reset_mode_decision(SequenceControlSet *scs_ptr, ModeDecisionContext *conte
     // Asuming cb and cr offset to be the same for chroma QP in both slice and pps for lambda computation
     context_ptr->chroma_qp = (uint8_t)context_ptr->qp;
     context_ptr->qp_index  = (uint8_t)frm_hdr->quantization_params.base_q_idx;
+#if NEW_MD_LAMBDA
+    av1_lambda_assign_md(context_ptr);
+#else
     (*av1_lambda_assignment_function_table[pcs_ptr->parent_pcs_ptr->pred_structure])(
         &context_ptr->fast_lambda,
         &context_ptr->full_lambda,
         &context_ptr->fast_chroma_lambda,
         &context_ptr->full_chroma_lambda,
+#if OMARK_HBD0_MD
+        context_ptr->hbd_mode_decision? EB_10BIT : EB_8BIT,
+#else
         (uint8_t)pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
+#endif
         context_ptr->qp_index,
+#if OMARK_LAMBDA && OMARK_HBD0_MD
+        EB_TRUE);
+#else
         context_ptr->hbd_mode_decision);
+#endif
+#endif
     // Reset MD rate Estimation table to initial values by copying from md_rate_estimation_array
     if (context_ptr->is_md_rate_estimation_ptr_owner) {
         context_ptr->is_md_rate_estimation_ptr_owner = EB_FALSE;
@@ -537,15 +581,28 @@ void mode_decision_configure_sb(ModeDecisionContext *context_ptr, PictureControl
         pcs_ptr->parent_pcs_ptr->frm_hdr.delta_q_params.delta_q_present
             ? (uint8_t)quantizer_to_qindex[sb_qp]
             : (uint8_t)pcs_ptr->parent_pcs_ptr->frm_hdr.quantization_params.base_q_idx;
+#if NEW_MD_LAMBDA
 
+    av1_lambda_assign_md(context_ptr);
+
+#else
     (*av1_lambda_assignment_function_table[pcs_ptr->parent_pcs_ptr->pred_structure])(
         &context_ptr->fast_lambda,
         &context_ptr->full_lambda,
         &context_ptr->fast_chroma_lambda,
         &context_ptr->full_chroma_lambda,
+#if OMARK_HBD0_MD
+        context_ptr->hbd_mode_decision? EB_10BIT : EB_8BIT,
+#else
         (uint8_t)pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,
+#endif
         context_ptr->qp_index,
+#if OMARK_LAMBDA && OMARK_HBD0_MD
+        EB_TRUE);
+#else
         context_ptr->hbd_mode_decision);
+#endif
+#endif
 
     return;
 }

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
@@ -165,11 +165,16 @@ typedef struct ModeDecisionContext {
     // Lambda
     uint16_t qp;
     uint8_t  chroma_qp;
+#if NEW_MD_LAMBDA
+    uint32_t fast_lambda_md[2];
+    uint32_t full_lambda_md[2];
+#else
     uint32_t fast_lambda;
     uint32_t full_lambda;
     uint32_t fast_chroma_lambda;
     uint32_t full_chroma_lambda;
     uint32_t full_chroma_lambda_sao;
+#endif
 
     //  Context Variables---------------------------------
     SuperBlock *     sb_ptr;
@@ -398,9 +403,15 @@ typedef struct ModeDecisionContext {
 } ModeDecisionContext;
 
 typedef void (*EbAv1LambdaAssignFunc)(uint32_t *fast_lambda, uint32_t *full_lambda,
+#if !NEW_MD_LAMBDA
                                       uint32_t *fast_chroma_lambda, uint32_t *full_chroma_lambda,
+#endif
                                       uint8_t bit_depth, uint16_t qp_index,
+#if OMARK_LAMBDA
+                                      EbBool multiply_lambda);
+#else
                                       EbBool hbd_mode_decision);
+#endif
 
 typedef void (*EbLambdaAssignFunc)(uint32_t *fast_lambda, uint32_t *full_lambda,
                                    uint32_t *fast_chroma_lambda, uint32_t *full_chroma_lambda,

--- a/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
@@ -122,9 +122,15 @@ void update_rc_rate_tables(PictureControlSet *pcs_ptr, SequenceControlSet *scs_p
         {
             eb_block_on_mutex(encode_context_ptr->rate_table_update_mutex);
 
+#if QUANT_CLEANUP
+            uint64_t ref_qindex_dequant =
+                (uint64_t)pcs_ptr->parent_pcs_ptr->deq_bd
+                    .y_dequant_qtx[frm_hdr->quantization_params.base_q_idx][1];
+#else
             uint64_t ref_qindex_dequant =
                 (uint64_t)pcs_ptr->parent_pcs_ptr->deq
                     .y_dequant_qtx[frm_hdr->quantization_params.base_q_idx][1];
+#endif
             uint64_t sad_bits_ref_dequant = 0;
             uint64_t weight               = 0;
             {
@@ -150,7 +156,11 @@ void update_rc_rate_tables(PictureControlSet *pcs_ptr, SequenceControlSet *scs_p
                                         .intra_sad_bits_array[pcs_ptr->temporal_layer_index]
                                                              [sad_interval_index] = (EbBitNumber)(
                                         ((weight * sad_bits_ref_dequant /
+#if QUANT_CLEANUP
+                                          pcs_ptr->parent_pcs_ptr->deq_bd
+#else
                                           pcs_ptr->parent_pcs_ptr->deq
+#endif
                                               .y_dequant_qtx[quantizer_to_qindex[qp_index]][1]) +
                                          (10 - weight) *
                                              (uint32_t)encode_context_ptr
@@ -193,7 +203,11 @@ void update_rc_rate_tables(PictureControlSet *pcs_ptr, SequenceControlSet *scs_p
                                         .intra_sad_bits_array[pcs_ptr->temporal_layer_index]
                                                              [sad_interval_index] = (EbBitNumber)(
                                         ((weight * sad_bits_ref_dequant /
+#if QUANT_CLEANUP
+                                          pcs_ptr->parent_pcs_ptr->deq_bd
+#else
                                           pcs_ptr->parent_pcs_ptr->deq
+#endif
                                               .y_dequant_qtx[quantizer_to_qindex[qp_index]][1]) +
                                          (10 - weight) *
                                              (uint32_t)encode_context_ptr
@@ -237,7 +251,11 @@ void update_rc_rate_tables(PictureControlSet *pcs_ptr, SequenceControlSet *scs_p
                                         .sad_bits_array[pcs_ptr->temporal_layer_index]
                                                        [sad_interval_index] = (EbBitNumber)(
                                         ((weight * sad_bits_ref_dequant /
+#if QUANT_CLEANUP
+                                          pcs_ptr->parent_pcs_ptr->deq_bd
+#else
                                           pcs_ptr->parent_pcs_ptr->deq
+#endif
                                               .y_dequant_qtx[quantizer_to_qindex[qp_index]][1]) +
                                          (10 - weight) *
                                              (uint32_t)encode_context_ptr
@@ -278,7 +296,11 @@ void update_rc_rate_tables(PictureControlSet *pcs_ptr, SequenceControlSet *scs_p
                                         .sad_bits_array[pcs_ptr->temporal_layer_index]
                                                        [sad_interval_index] = (EbBitNumber)(
                                         ((weight * sad_bits_ref_dequant /
+#if QUANT_CLEANUP
+                                          pcs_ptr->parent_pcs_ptr->deq_bd
+#else
                                           pcs_ptr->parent_pcs_ptr->deq
+#endif
                                               .y_dequant_qtx[quantizer_to_qindex[qp_index]][1]) +
                                          (10 - weight) *
                                              (uint32_t)encode_context_ptr

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -766,10 +766,17 @@ typedef struct PictureParentControlSet {
     // Global quant matrix tables
     const QmVal *giqmatrix[NUM_QM_LEVELS][3][TX_SIZES_ALL];
     const QmVal *gqmatrix[NUM_QM_LEVELS][3][TX_SIZES_ALL];
+#if QUANT_CLEANUP
+    Quants quants_bd; // follows input bit depth
+    Dequants deq_bd;  // follows input bit depth
+    Quants quants_8bit;  // 8bit
+    Dequants deq_8bit; // 8bit
+#else
     Quants       quants;
     Dequants     deq;
     Quants       quants_md;
     Dequants     deq_md;
+#endif
     int32_t      min_qmlevel;
     int32_t      max_qmlevel;
     // Encoder

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -1167,6 +1167,14 @@ void fast_loop_core(ModeDecisionCandidateBuffer *candidate_buffer, PictureContro
                     uint32_t cu_origin_index, uint32_t cu_chroma_origin_index, EbBool use_ssd) {
     uint64_t luma_fast_distortion;
     uint64_t chroma_fast_distortion;
+#if NEW_MD_LAMBDA
+    uint32_t full_lambda =  context_ptr->hbd_mode_decision ?
+        context_ptr->full_lambda_md[EB_10_BIT_MD] :
+        context_ptr->full_lambda_md[EB_8_BIT_MD];
+    uint32_t fast_lambda =  context_ptr->hbd_mode_decision ?
+        context_ptr->fast_lambda_md[EB_10_BIT_MD] :
+        context_ptr->fast_lambda_md[EB_8_BIT_MD];
+#endif
 
     ModeDecisionCandidate *candidate_ptr  = candidate_buffer->candidate_ptr;
     EbPictureBufferDesc *  prediction_ptr = candidate_buffer->prediction_ptr;
@@ -1293,7 +1301,11 @@ void fast_loop_core(ModeDecisionCandidateBuffer *candidate_buffer, PictureContro
         blk_ptr->qp,
         luma_fast_distortion,
         chroma_fast_distortion,
+#if NEW_MD_LAMBDA
+        use_ssd ? full_lambda : fast_lambda,
+#else
         use_ssd ? context_ptr->full_lambda : context_ptr->fast_lambda,
+#endif
         use_ssd,
         pcs_ptr,
         &(context_ptr->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds]
@@ -2169,6 +2181,11 @@ void md_stage_0(
     uint64_t best_first_fast_cost_search_candidate_cost  = MAX_CU_COST;
     int32_t  best_first_fast_cost_search_candidate_index = INVALID_FAST_CANDIDATE_INDEX;
     EbBool   use_ssd = EB_FALSE;
+#if NEW_MD_LAMBDA
+    uint32_t fast_lambda =  context_ptr->hbd_mode_decision ?
+        context_ptr->fast_lambda_md[EB_10_BIT_MD] :
+        context_ptr->fast_lambda_md[EB_8_BIT_MD];
+#endif
     // Set MD Staging fast_loop_core settings
     context_ptr->md_staging_skip_interpolation_search =
         (context_ptr->md_staging_mode == MD_STAGING_MODE_1 ||
@@ -2213,7 +2230,11 @@ void md_stage_0(
                         blk_ptr->qp,
                         luma_fast_distortion,
                         0,
+#if NEW_MD_LAMBDA
+                        fast_lambda,
+#else
                         context_ptr->fast_lambda,
+#endif
                         0,
                         pcs_ptr,
                         &(context_ptr->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds]
@@ -3452,13 +3473,27 @@ void cfl_rd_pick_alpha(PictureControlSet *pcs_ptr, ModeDecisionCandidateBuffer *
     int64_t  best_rd = INT64_MAX;
     uint64_t full_distortion[DIST_CALC_TOTAL];
     uint64_t coeff_bits;
+#if NEW_MD_LAMBDA
+    uint32_t full_lambda =  context_ptr->hbd_mode_decision ?
+        context_ptr->full_lambda_md[EB_10_BIT_MD] :
+        context_ptr->full_lambda_md[EB_8_BIT_MD];
+#endif
 
+#if NEW_MD_LAMBDA
+    const int64_t mode_rd = RDCOST(
+         full_lambda,
+        (uint64_t)candidate_buffer->candidate_ptr->md_rate_estimation_ptr
+            ->intra_uv_mode_fac_bits[CFL_ALLOWED][candidate_buffer->candidate_ptr->intra_luma_mode]
+                                    [UV_CFL_PRED],
+        0);
+#else
     const int64_t mode_rd = RDCOST(
         context_ptr->full_lambda,
         (uint64_t)candidate_buffer->candidate_ptr->md_rate_estimation_ptr
             ->intra_uv_mode_fac_bits[CFL_ALLOWED][candidate_buffer->candidate_ptr->intra_luma_mode]
                                     [UV_CFL_PRED],
         0);
+#endif
 
     int64_t best_rd_uv[CFL_JOINT_SIGNS][CFL_PRED_PLANES];
     int32_t best_c[CFL_JOINT_SIGNS][CFL_PRED_PLANES];
@@ -3496,9 +3531,15 @@ void cfl_rd_pick_alpha(PictureControlSet *pcs_ptr, ModeDecisionCandidateBuffer *
             const int32_t alpha_rate = candidate_buffer->candidate_ptr->md_rate_estimation_ptr
                                            ->cfl_alpha_fac_bits[joint_sign][plane][0];
 
+#if NEW_MD_LAMBDA
+            best_rd_uv[joint_sign][plane] = RDCOST(full_lambda,
+                                                   coeff_bits + alpha_rate,
+                                                   full_distortion[DIST_CALC_RESIDUAL]);
+#else
             best_rd_uv[joint_sign][plane] = RDCOST(context_ptr->full_lambda,
                                                    coeff_bits + alpha_rate,
                                                    full_distortion[DIST_CALC_RESIDUAL]);
+#endif
         }
     }
 
@@ -3538,9 +3579,15 @@ void cfl_rd_pick_alpha(PictureControlSet *pcs_ptr, ModeDecisionCandidateBuffer *
                         candidate_buffer->candidate_ptr->md_rate_estimation_ptr
                             ->cfl_alpha_fac_bits[joint_sign][plane][c];
 
+#if NEW_MD_LAMBDA
+                    int64_t this_rd = RDCOST(full_lambda,
+                                             coeff_bits + alpha_rate,
+                                             full_distortion[DIST_CALC_RESIDUAL]);
+#else
                     int64_t this_rd = RDCOST(context_ptr->full_lambda,
                                              coeff_bits + alpha_rate,
                                              full_distortion[DIST_CALC_RESIDUAL]);
+#endif
                     if (this_rd >= best_rd_uv[joint_sign][plane]) continue;
                     best_rd_uv[joint_sign][plane] = this_rd;
                     best_c[joint_sign][plane]     = c;
@@ -3564,12 +3611,21 @@ void cfl_rd_pick_alpha(PictureControlSet *pcs_ptr, ModeDecisionCandidateBuffer *
     candidate_buffer->candidate_ptr->cfl_alpha_idx   = 0;
     candidate_buffer->candidate_ptr->cfl_alpha_signs = 0;
 
+#if NEW_MD_LAMBDA
+    const int64_t dc_mode_rd = RDCOST(
+        full_lambda,
+        candidate_buffer->candidate_ptr->md_rate_estimation_ptr
+            ->intra_uv_mode_fac_bits[CFL_ALLOWED][candidate_buffer->candidate_ptr->intra_luma_mode]
+                                    [UV_DC_PRED],
+        0);
+#else
     const int64_t dc_mode_rd = RDCOST(
         context_ptr->full_lambda,
         candidate_buffer->candidate_ptr->md_rate_estimation_ptr
             ->intra_uv_mode_fac_bits[CFL_ALLOWED][candidate_buffer->candidate_ptr->intra_luma_mode]
                                     [UV_DC_PRED],
         0);
+#endif
 
     av1_cost_calc_cfl(pcs_ptr,
                       candidate_buffer,
@@ -3584,7 +3640,11 @@ void cfl_rd_pick_alpha(PictureControlSet *pcs_ptr, ModeDecisionCandidateBuffer *
                       1);
 
     int64_t dc_rd =
+#if NEW_MD_LAMBDA
+        RDCOST(full_lambda, coeff_bits, full_distortion[DIST_CALC_RESIDUAL]);
+#else
         RDCOST(context_ptr->full_lambda, coeff_bits, full_distortion[DIST_CALC_RESIDUAL]);
+#endif
 
     dc_rd += dc_mode_rd;
     if (dc_rd <= best_rd) {
@@ -3820,6 +3880,11 @@ void check_best_indepedant_cfl(PictureControlSet *pcs_ptr, EbPictureBufferDesc *
                                uint8_t cr_qp, uint64_t *cb_full_distortion,
                                uint64_t *cr_full_distortion, uint64_t *cb_coeff_bits,
                                uint64_t *cr_coeff_bits) {
+#if NEW_MD_LAMBDA
+    uint32_t full_lambda =  context_ptr->hbd_mode_decision ?
+        context_ptr->full_lambda_md[EB_10_BIT_MD] :
+        context_ptr->full_lambda_md[EB_8_BIT_MD];
+#endif
     if (candidate_buffer->candidate_ptr->filter_intra_mode != FILTER_INTRA_MODES)
         assert(candidate_buffer->candidate_ptr->intra_luma_mode == DC_PRED);
     FrameHeader *frm_hdr = &pcs_ptr->parent_pcs_ptr->frm_hdr;
@@ -3849,7 +3914,11 @@ void check_best_indepedant_cfl(PictureControlSet *pcs_ptr, EbPictureBufferDesc *
     int distortion =
         (int)(cb_full_distortion[DIST_CALC_RESIDUAL] + cr_full_distortion[DIST_CALC_RESIDUAL]);
     int rate = (int)(coeff_rate + chroma_rate + candidate_buffer->candidate_ptr->fast_luma_rate);
+#if NEW_MD_LAMBDA
+    uint64_t cfl_uv_cost = RDCOST(full_lambda, rate, distortion);
+#else
     uint64_t cfl_uv_cost = RDCOST(context_ptr->full_lambda, rate, distortion);
+#endif
 
     // cfl vs. best independant
     if (context_ptr->best_uv_cost[candidate_buffer->candidate_ptr->intra_luma_mode]
@@ -4512,6 +4581,11 @@ void tx_type_search(PictureControlSet *pcs_ptr,
                                .feature_data[context_ptr->blk_ptr->segment_id][SEG_LVL_ALT_Q]
                          : 0;
 
+#if NEW_MD_LAMBDA
+    uint32_t full_lambda =  context_ptr->hbd_mode_decision ?
+        context_ptr->full_lambda_md[EB_10_BIT_MD] :
+        context_ptr->full_lambda_md[EB_8_BIT_MD];
+#endif
     TxType   txk_start           = DCT_DCT;
     TxType   txk_end             = TX_TYPES;
     uint64_t best_cost_tx_search = (uint64_t)~0;
@@ -4642,6 +4716,13 @@ void tx_type_search(PictureControlSet *pcs_ptr,
             context_ptr->luma_dc_sign_context,
             candidate_buffer->candidate_ptr->pred_mode,
             candidate_buffer->candidate_ptr->use_intrabc,
+#if OMARK_HBD0_RDOQ
+#if NEW_MD_LAMBDA
+            full_lambda,
+#else
+            context_ptr->full_lambda,
+#endif
+#endif
             EB_FALSE);
 
         candidate_buffer->candidate_ptr->quantized_dc[0][context_ptr->txb_itr] =
@@ -4765,8 +4846,13 @@ void tx_type_search(PictureControlSet *pcs_ptr,
             candidate_buffer->candidate_ptr->transform_type_uv,
             COMPONENT_LUMA);
 
+#if NEW_MD_LAMBDA
+        uint64_t cost = RDCOST(
+            full_lambda, y_txb_coeff_bits, txb_full_distortion[0][DIST_CALC_RESIDUAL]);
+#else
         uint64_t cost = RDCOST(
             context_ptr->full_lambda, y_txb_coeff_bits, txb_full_distortion[0][DIST_CALC_RESIDUAL]);
+#endif
         if (cost < best_cost_tx_search) {
             best_cost_tx_search = cost;
             best_tx_type        = tx_type;
@@ -5306,6 +5392,11 @@ void perform_tx_partitioning(ModeDecisionCandidateBuffer *candidate_buffer,
 #if !TXS_DEPTH_2
     UNUSED(start_tx_depth); // TODO: start_tx_depth will be used for future features; this commit is adding the infrastructure for that
 #endif
+#if NEW_MD_LAMBDA
+    uint32_t full_lambda =  context_ptr->hbd_mode_decision ?
+        context_ptr->full_lambda_md[EB_10_BIT_MD] :
+        context_ptr->full_lambda_md[EB_8_BIT_MD];
+#endif
     EbPictureBufferDesc *input_picture_ptr = context_ptr->hbd_mode_decision
                                                  ? pcs_ptr->input_frame16bit
                                                  : pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
@@ -5510,9 +5601,16 @@ void perform_tx_partitioning(ModeDecisionCandidateBuffer *candidate_buffer,
 
             if (y_has_coeff) block_has_coeff = EB_TRUE;
 
+
+#if NEW_MD_LAMBDA
+            current_tx_cost = RDCOST(full_lambda,
+                                     tx_y_coeff_bits,
+                                     tx_y_full_distortion[DIST_CALC_RESIDUAL]);
+#else
             current_tx_cost = RDCOST(context_ptr->full_lambda,
                                      tx_y_coeff_bits,
                                      tx_y_full_distortion[DIST_CALC_RESIDUAL]);
+#endif
             if (current_tx_cost > best_cost_search) break;
 
         } // Transform Loop
@@ -5526,9 +5624,15 @@ void perform_tx_partitioning(ModeDecisionCandidateBuffer *candidate_buffer,
                                                 context_ptr->tx_depth,
                                                 block_has_coeff);
 
+#if NEW_MD_LAMBDA
+        uint64_t cost = RDCOST(full_lambda,
+                               (tx_y_coeff_bits + tx_size_bits),
+                               tx_y_full_distortion[DIST_CALC_RESIDUAL]);
+#else
         uint64_t cost = RDCOST(context_ptr->full_lambda,
                                (tx_y_coeff_bits + tx_size_bits),
                                tx_y_full_distortion[DIST_CALC_RESIDUAL]);
+#endif
 
             if (cost < best_cost_search) {
                 best_cost_search                      = cost;
@@ -5617,6 +5721,11 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
     uint64_t y_coeff_bits;
     uint64_t cb_coeff_bits = 0;
     uint64_t cr_coeff_bits = 0;
+#if NEW_MD_LAMBDA
+    uint32_t full_lambda = context_ptr->hbd_mode_decision ?
+        context_ptr->full_lambda_md[EB_10_BIT_MD] :
+        context_ptr->full_lambda_md[EB_8_BIT_MD];
+#endif
 
     // initialize TU Split
     y_full_distortion[DIST_CALC_RESIDUAL]   = 0;
@@ -5837,7 +5946,11 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
                                                               y_full_distortion,
                                                               cb_full_distortion,
                                                               cr_full_distortion,
+#if NEW_MD_LAMBDA
+                                                              full_lambda,
+#else
                                                               context_ptr->full_lambda,
+#endif
                                                               &y_coeff_bits,
                                                               &cb_coeff_bits,
                                                               &cr_coeff_bits,
@@ -6412,6 +6525,11 @@ void search_best_independent_uv_mode(PictureControlSet *  pcs_ptr,
                                      uint32_t             cu_chroma_origin_index,
                                      ModeDecisionContext *context_ptr) {
     FrameHeader *frm_hdr = &pcs_ptr->parent_pcs_ptr->frm_hdr;
+#if NEW_MD_LAMBDA
+    uint32_t full_lambda =  context_ptr->hbd_mode_decision ?
+        context_ptr->full_lambda_md[EB_10_BIT_MD] :
+        context_ptr->full_lambda_md[EB_8_BIT_MD];
+#endif
     // Start uv search path
     context_ptr->uv_search_path = EB_TRUE;
 
@@ -6724,10 +6842,17 @@ void search_best_independent_uv_mode(PictureControlSet *  pcs_ptr,
                               [MAX_ANGLE_DELTA + candidate_ptr->angle_delta[PLANE_TYPE_UV]] +
                     candidate_ptr->fast_luma_rate + candidate_ptr->fast_chroma_rate;
                 uint64_t uv_cost =
+#if NEW_MD_LAMBDA
+                    RDCOST(full_lambda,
+                           rate,
+                           distortion[candidate_ptr->intra_chroma_mode]
+                                     [MAX_ANGLE_DELTA + candidate_ptr->angle_delta[PLANE_TYPE_UV]]);
+#else
                     RDCOST(context_ptr->full_lambda,
                            rate,
                            distortion[candidate_ptr->intra_chroma_mode]
                                      [MAX_ANGLE_DELTA + candidate_ptr->angle_delta[PLANE_TYPE_UV]]);
+#endif
 
                 if (uv_cost <
                     context_ptr->best_uv_cost[intra_mode][MAX_ANGLE_DELTA + angle_delta]) {
@@ -7613,6 +7738,11 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
     EbBool all_blk_init = (pcs_ptr->parent_pcs_ptr->pic_depth_mode <= PIC_SQ_DEPTH_MODE);
     init_sq_nsq_block(scs_ptr, context_ptr);
 
+#if NEW_MD_LAMBDA
+    uint32_t full_lambda =  context_ptr->hbd_mode_decision ?
+        context_ptr->full_lambda_md[EB_10_BIT_MD] :
+        context_ptr->full_lambda_md[EB_8_BIT_MD];
+#endif
     // Mode Decision Neighbor Arrays
 #if TILES_PARALLEL
     context_ptr->intra_luma_mode_neighbor_array =
@@ -8085,7 +8215,11 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
                                               sb_addr,
                                               sb_origin_x,
                                               sb_origin_y,
+#if NEW_MD_LAMBDA
+                                              full_lambda,
+#else
                                               context_ptr->full_lambda,
+#endif
                                               context_ptr->md_rate_estimation_ptr,
                                               pcs_ptr);
             d1_block_itr   = 0;

--- a/Source/Lib/Encoder/Codec/EbRateDistortionCost.c
+++ b/Source/Lib/Encoder/Codec/EbRateDistortionCost.c
@@ -805,8 +805,11 @@ uint64_t av1_intra_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidat
 
         if (use_ssd) {
             int32_t         current_q_index = frm_hdr->quantization_params.base_q_idx;
+#if QUANT_CLEANUP
+            Dequants *const dequants = &pcs_ptr->parent_pcs_ptr->deq_bd;
+#else
             Dequants *const dequants        = &pcs_ptr->parent_pcs_ptr->deq;
-
+#endif
             int16_t quantizer = dequants->y_dequant_q3[current_q_index][1];
             rate              = 0;
             model_rd_from_sse(blk_geom->bsize, quantizer, luma_distortion, &rate, &luma_sad);
@@ -1698,7 +1701,11 @@ uint64_t av1_inter_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidat
     candidate_ptr->fast_chroma_rate = (full_cost_shut_fast_rate_flag) ? 0 : chroma_rate;
     if (use_ssd) {
         int32_t         current_q_index = frm_hdr->quantization_params.base_q_idx;
+#if QUANT_CLEANUP
+        Dequants *const dequants = &pcs_ptr->parent_pcs_ptr->deq_bd;
+#else
         Dequants *const dequants        = &pcs_ptr->parent_pcs_ptr->deq;
+#endif
 
         int16_t quantizer = dequants->y_dequant_q3[current_q_index][1];
         rate              = 0;

--- a/Source/Lib/Encoder/Codec/EbTransforms.h
+++ b/Source/Lib/Encoder/Codec/EbTransforms.h
@@ -140,7 +140,11 @@ extern int32_t av1_quantize_inv_quantize(
         int32_t segmentation_qp_offset, uint32_t width, uint32_t height, TxSize txsize, uint16_t *eob,
         uint32_t *y_count_non_zero_coeffs, uint32_t component_type, uint32_t bit_increment,
         TxType tx_type, ModeDecisionCandidateBuffer *candidate_buffer, int16_t txb_skip_context,
+#if OMARK_HBD0_RDOQ
+        int16_t dc_sign_context, PredictionMode pred_mode, EbBool is_intra_bc, uint32_t lambda,EbBool is_encode_pass);
+#else
         int16_t dc_sign_context, PredictionMode pred_mode, EbBool is_intra_bc, EbBool is_encode_pass);
+#endif
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Description
_________________________________________________________________________________

- Fix lambda for HBD (hbd mode 0, 1 and 2)
- Fix the mismatch of using 10bit vs 8bit lambda depending on the hbd-mode and/or the kernel.
### Author(s)
_________________________________________________________________________________
@okhlif 


### Type of change
_________________________________________________________________________________
Enhancement.
### Tests and performance
_________________________________________________________________________________
Data generated on the 14 720p true 10bit in context in enc-mode 0.

Speed Deviation | BD-Rate Deviation
-- | --
no speed diff | -0.45%






