### PR TITLE
nsq_weight : skip NSQ partitions based on H vs V costs

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 #define QPS_CHANGE_II            1 // Change the QP assignment for I
+#define NSQ_HV                      1 // skip NSQ partitions based on H vs V costs
 #define OMARK_LAMBDA                1 // 2. fix lambda calculation for HBD0
 #define OMARK_HBD1_CDEF             1 // 3. fix CDEF lambda for hbd1/2
 #define OMARK_HBD0_ED               1 // 4. fix ED lambda for hbd0

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -1931,9 +1931,11 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
 
 #if NSQ_HV
     // nsq_hv_level  needs sq_weight to be ON
-        // 0: OFF
-        // 1: ON 10% + skip HA/HB/H4  or skip VA/VB/V4
-        // 2: ON 10% + skip HA/HB  or skip VA/VB   ,  5% + skip H4  or skip V4
+    // 0: OFF
+    // 1: ON
+    //        if H > V + TH1% then skip HA / HB / H4
+    //        if V > H + TH1% then skip VA / VB / V4
+    // 2: ON  for  H4 / V4 use more agressive TH2% for faster mode
     if (MR_MODE || context_ptr->pd_pass < PD_PASS_2)
         context_ptr->nsq_hv_level = 0;
     else if (pcs_ptr->enc_mode <= ENC_M3) {

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -1929,6 +1929,22 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
         context_ptr->sq_weight = scs_ptr->static_config.sq_weight;
 #endif
 
+#if NSQ_HV
+    // nsq_hv_level  needs sq_weight to be ON
+        // 0: OFF
+        // 1: ON 10% + skip HA/HB/H4  or skip VA/VB/V4
+        // 2: ON 10% + skip HA/HB  or skip VA/VB   ,  5% + skip H4  or skip V4
+    if (MR_MODE || context_ptr->pd_pass < PD_PASS_2)
+        context_ptr->nsq_hv_level = 0;
+    else if (pcs_ptr->enc_mode <= ENC_M3) {
+        context_ptr->nsq_hv_level = 1;
+        assert(context_ptr->sq_weight != (uint32_t)~0);
+    }
+    else {
+        context_ptr->nsq_hv_level = 2;
+        assert(context_ptr->sq_weight != (uint32_t)~0);
+    }
+#endif
     // Set pred ME full search area
     if (context_ptr->pd_pass == PD_PASS_0) {
         context_ptr->pred_me_full_pel_search_width  = PRED_ME_FULL_PEL_SEARCH_WIDTH;

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
@@ -376,7 +376,9 @@ typedef struct ModeDecisionContext {
     uint8_t *    left_txfm_context;
     // square cost weighting for deciding if a/b shapes could be skipped
     uint32_t sq_weight;
-
+#if NSQ_HV
+    uint32_t nsq_hv_level;
+#endif
     // signal for enabling shortcut to skip search depths
     MD_COMP_TYPE compound_types_to_try;
     uint8_t      best_me_cand_only_flag;

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -7600,6 +7600,11 @@ uint8_t update_skip_nsq_shapes(SequenceControlSet *scs_ptr, PictureControlSet *p
     if (context_ptr->blk_geom->shape == PART_H4 || context_ptr->blk_geom->shape == PART_V4)
         sq_weight += CONSERVATIVE_OFFSET_0;
 
+#if NSQ_HV
+    uint32_t sqi = context_ptr->blk_geom->sqi_mds;
+    MdBlkStruct *local_cu_unit = context_ptr->md_local_blk_unit;
+#endif
+
     if (context_ptr->blk_geom->shape == PART_HA || context_ptr->blk_geom->shape == PART_HB || context_ptr->blk_geom->shape == PART_H4) {
         if (context_ptr->md_local_blk_unit[context_ptr->blk_geom->sqi_mds].avail_blk_flag &&
             context_ptr->md_local_blk_unit[context_ptr->blk_geom->sqi_mds + 1].avail_blk_flag &&
@@ -7636,6 +7641,21 @@ uint8_t update_skip_nsq_shapes(SequenceControlSet *scs_ptr, PictureControlSet *p
 
             // Determine if nsq shapes can be skipped based on the relative cost of SQ and H blocks
             skip_nsq = (h_cost > ((sq_cost * sq_weight) / 100));
+
+#if NSQ_HV
+            if (!skip_nsq && context_ptr->nsq_hv_level > 0) {
+                if (local_cu_unit[sqi + 3].avail_blk_flag && local_cu_unit[sqi + 4].avail_blk_flag) {
+                    uint64_t v_cost = local_cu_unit[sqi + 3].default_cost + local_cu_unit[sqi + 4].default_cost;
+                    uint32_t offset = 10;
+                    if (context_ptr->nsq_hv_level == 2 && context_ptr->blk_geom->shape == PART_H4)
+                        offset = 5;
+                    if (offset >= 5 && scs_ptr->static_config.qp <= 20)
+                        offset -= 5;
+                    uint32_t v_weight = 100 + offset;
+                    skip_nsq = (h_cost > ((v_cost * v_weight) / 100));
+                }
+            }
+#endif
         }
     }
     if (context_ptr->blk_geom->shape == PART_VA || context_ptr->blk_geom->shape == PART_VB || context_ptr->blk_geom->shape == PART_V4) {
@@ -7674,6 +7694,22 @@ uint8_t update_skip_nsq_shapes(SequenceControlSet *scs_ptr, PictureControlSet *p
 
             // Determine if nsq shapes can be skipped based on the relative cost of SQ and V blocks
             skip_nsq = (v_cost > ((sq_cost * sq_weight) / 100));
+#if NSQ_HV
+            if (!skip_nsq  && context_ptr->nsq_hv_level > 0) {
+                if (local_cu_unit[sqi + 1].avail_blk_flag && local_cu_unit[sqi + 2].avail_blk_flag) {
+                    uint64_t h_cost = local_cu_unit[sqi + 1].default_cost + local_cu_unit[sqi + 2].default_cost;
+                    uint32_t offset = 10;
+
+                    if (context_ptr->nsq_hv_level == 2 && context_ptr->blk_geom->shape == PART_V4)
+                        offset = 5;
+                    if (offset >= 5 && scs_ptr->static_config.qp <= 20)
+                        offset -= 5;
+
+                    uint32_t h_weight = 100 + offset;
+                    skip_nsq = (v_cost > ((h_cost * h_weight) / 100));
+                }
+            }
+#endif
         }
     }
 

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -7645,6 +7645,8 @@ uint8_t update_skip_nsq_shapes(SequenceControlSet *scs_ptr, PictureControlSet *p
 #if NSQ_HV
             if (!skip_nsq && context_ptr->nsq_hv_level > 0) {
                 if (local_cu_unit[sqi + 3].avail_blk_flag && local_cu_unit[sqi + 4].avail_blk_flag) {
+
+                    //compute the cost of V partition
                     uint64_t v_cost = local_cu_unit[sqi + 3].default_cost + local_cu_unit[sqi + 4].default_cost;
                     uint32_t offset = 10;
                     if (context_ptr->nsq_hv_level == 2 && context_ptr->blk_geom->shape == PART_H4)
@@ -7652,6 +7654,9 @@ uint8_t update_skip_nsq_shapes(SequenceControlSet *scs_ptr, PictureControlSet *p
                     if (offset >= 5 && scs_ptr->static_config.qp <= 20)
                         offset -= 5;
                     uint32_t v_weight = 100 + offset;
+
+                    //if the cost of H partition is bigger than the V partition by a certain percentage, skip HA/HB
+                    //use 10% to skip HA/HB, use 5% to skip H4, also for very low QP be more aggressive to skip
                     skip_nsq = (h_cost > ((v_cost * v_weight) / 100));
                 }
             }


### PR DESCRIPTION
## Description
 nsq_hv_level :
        0:  OFF
        1: ON  if H>V + TH1% then  skip HA/HB/H4  
                       if V>H+ TH1% then   skip VA/VB/V4  
      
## Testing and Performance
 in context of cs2 branch / enc-mode 0. 

| Speed Deviation| BD-Rate Deviation|
| -- | --
| ~+1.95% | -0.02%|

