### PR TITLE
mrp and inter-intra clean ups

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -46,6 +46,8 @@ extern "C" {
 #define QUANT_CLEANUP               1
 #define QUANT_HBD0_FIX              1
 #define NEW_MD_LAMBDA               1
+#define CLEANUP_INTER_INTRA  1  //shutting inter intra could be done via 2 ways.at the seq level(in ress coord), or at the pic level (in pic decision)
+#define MRP_CTRL             1  //add control to inject smaller number of references.
 
 
 // Added plane wise TF

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -2014,6 +2014,9 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
         context_ptr->md_pic_obmc_mode = pcs_ptr->parent_pcs_ptr->pic_obmc_mode;
 
     // Set enable_inter_intra @ MD
+#if  CLEANUP_INTER_INTRA
+    //Block level switch, has to follow the picture level
+#endif
     if (context_ptr->pd_pass == PD_PASS_0)
         context_ptr->md_enable_inter_intra = 0;
     else if (context_ptr->pd_pass == PD_PASS_1)

--- a/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.c
@@ -49,10 +49,17 @@ void global_motion_estimation(PictureParentControlSet *pcs_ptr, MeContext *conte
         if (context_ptr->me_alt_ref == EB_TRUE)
             num_of_ref_pic_to_search = 1;
         else
+#if MRP_CTRL
+            num_of_ref_pic_to_search = pcs_ptr->slice_type == P_SLICE
+                                          ? pcs_ptr->ref_list0_count_try
+                                          : list_index == REF_LIST_0 ? pcs_ptr->ref_list0_count_try
+                                          : pcs_ptr->ref_list1_count_try;
+#else
             num_of_ref_pic_to_search = pcs_ptr->slice_type == P_SLICE
                                            ? pcs_ptr->ref_list0_count
                                            : list_index == REF_LIST_0 ? pcs_ptr->ref_list0_count
                                                                       : pcs_ptr->ref_list1_count;
+#endif
 
         // Limit the global motion search to the first frame types of ref lists
         num_of_ref_pic_to_search = MIN(num_of_ref_pic_to_search, 1);

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -4785,8 +4785,13 @@ void inject_inter_candidates(PictureControlSet *pcs_ptr, ModeDecisionContext *co
                 rf[1] = -1;
 
                 uint8_t inter_type;
+#if CLEANUP_INTER_INTRA
+                uint8_t is_ii_allowed = svt_is_interintra_allowed(
+                    context_ptr->md_enable_inter_intra, bsize, GLOBALMV, rf);
+#else
                 uint8_t is_ii_allowed = svt_is_interintra_allowed(
                     pcs_ptr->parent_pcs_ptr->enable_inter_intra, bsize, GLOBALMV, rf);
+#endif
                 uint8_t tot_inter_types = is_ii_allowed ? II_COUNT : 1;
                 //uint8_t is_obmc_allowed =  obmc_motion_mode_allowed(pcs_ptr, context_ptr->blk_ptr, bsize, rf[0], rf[1], NEWMV) == OBMC_CAUSAL;
                 //tot_inter_types = is_obmc_allowed ? tot_inter_types+1 : tot_inter_types;

--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -9552,10 +9552,17 @@ void integer_search_sb(
         if (context_ptr->me_alt_ref == EB_TRUE) {
             num_of_ref_pic_to_search = 1;
         } else {
+#if MRP_CTRL
+            num_of_ref_pic_to_search = (pcs_ptr->slice_type == P_SLICE)
+                ? pcs_ptr->ref_list0_count_try
+                : (list_index == REF_LIST_0) ? pcs_ptr->ref_list0_count_try
+                : pcs_ptr->ref_list1_count_try;
+#else
             num_of_ref_pic_to_search = (pcs_ptr->slice_type == P_SLICE)
                                            ? pcs_ptr->ref_list0_count
                                            : (list_index == REF_LIST_0) ? pcs_ptr->ref_list0_count
                                                                         : pcs_ptr->ref_list1_count;
+#endif
 
             reference_object =
                 (EbPaReferenceObject *)pcs_ptr->ref_pa_pic_ptr_array[0][0]->object_ptr;
@@ -10037,12 +10044,21 @@ void prune_references_fp(
             num_of_ref_pic_to_search = 1;
         }
         else {
+#if MRP_CTRL
+            num_of_ref_pic_to_search =
+                (pcs_ptr->slice_type == P_SLICE)
+                ? pcs_ptr->ref_list0_count_try
+                : (list_index == REF_LIST_0)
+                ? pcs_ptr->ref_list0_count_try
+                : pcs_ptr->ref_list1_count_try;
+#else
             num_of_ref_pic_to_search =
                 (pcs_ptr->slice_type == P_SLICE)
                 ? pcs_ptr->ref_list0_count
                 : (list_index == REF_LIST_0)
                 ? pcs_ptr->ref_list0_count
                 : pcs_ptr->ref_list1_count;
+#endif
         }
         // Ref Picture Loop
         for (ref_pic_index = 0; ref_pic_index < num_of_ref_pic_to_search; ++ref_pic_index) {
@@ -10173,10 +10189,17 @@ void hme_sb(
         if (context_ptr->me_alt_ref == EB_TRUE)
             num_of_ref_pic_to_search = 1;
         else {
+#if MRP_CTRL
+            num_of_ref_pic_to_search = (pcs_ptr->slice_type == P_SLICE)
+                ? pcs_ptr->ref_list0_count_try
+                : (list_index == REF_LIST_0) ? pcs_ptr->ref_list0_count_try
+                : pcs_ptr->ref_list1_count_try;
+#else
             num_of_ref_pic_to_search = (pcs_ptr->slice_type == P_SLICE)
                                            ? pcs_ptr->ref_list0_count
                                            : (list_index == REF_LIST_0) ? pcs_ptr->ref_list0_count
                                                                         : pcs_ptr->ref_list1_count;
+#endif
             reference_object =
                 (EbPaReferenceObject *)pcs_ptr->ref_pa_pic_ptr_array[0][0]->object_ptr;
             ref_0_poc = pcs_ptr->ref_pic_poc_array[0][0];
@@ -10842,10 +10865,17 @@ EbErrorType motion_estimate_sb(
         if (context_ptr->me_alt_ref == EB_TRUE) {
             num_of_ref_pic_to_search = 1;
         } else {
+#if MRP_CTRL
+            num_of_ref_pic_to_search = (pcs_ptr->slice_type == P_SLICE)
+                ? pcs_ptr->ref_list0_count_try
+                : (list_index == REF_LIST_0) ? pcs_ptr->ref_list0_count_try
+                : pcs_ptr->ref_list1_count_try;
+#else
             num_of_ref_pic_to_search = (pcs_ptr->slice_type == P_SLICE)
                                            ? pcs_ptr->ref_list0_count
                                            : (list_index == REF_LIST_0) ? pcs_ptr->ref_list0_count
                                                                         : pcs_ptr->ref_list1_count;
+#endif
 
             reference_object =
                 (EbPaReferenceObject *)pcs_ptr->ref_pa_pic_ptr_array[0][0]->object_ptr;
@@ -11983,11 +12013,19 @@ EbErrorType motion_estimate_sb(
             else
                 n_idx = pu_index;
             for (list_index = REF_LIST_0; list_index <= num_of_list_to_search; ++list_index) {
+#if MRP_CTRL
+                num_of_ref_pic_to_search = (pcs_ptr->slice_type == P_SLICE)
+                    ? pcs_ptr->ref_list0_count_try
+                    : (list_index == REF_LIST_0)
+                    ? pcs_ptr->ref_list0_count_try
+                    : pcs_ptr->ref_list1_count_try;
+#else
                 num_of_ref_pic_to_search = (pcs_ptr->slice_type == P_SLICE)
                                                ? pcs_ptr->ref_list0_count
                                                : (list_index == REF_LIST_0)
                                                      ? pcs_ptr->ref_list0_count
                                                      : pcs_ptr->ref_list1_count;
+#endif
 
                 // Ref Picture Loop
                 for (ref_pic_index = 0; ref_pic_index < num_of_ref_pic_to_search; ++ref_pic_index) {
@@ -12045,8 +12083,13 @@ EbErrorType motion_estimate_sb(
                                         context_ptr,
                                         pu_index,
                                         cand_index,
+#if MRP_CTRL
+                                        pcs_ptr->ref_list0_count_try,
+                                        pcs_ptr->ref_list1_count_try,
+#else
                                         pcs_ptr->ref_list0_count,
                                         pcs_ptr->ref_list1_count,
+#endif
                                         &total_me_candidate_index,
                                         ref_type_table,
                                         pcs_ptr);
@@ -12089,11 +12132,19 @@ EbErrorType motion_estimate_sb(
             }
 
             for (list_index = REF_LIST_0; list_index <= num_of_list_to_search; ++list_index) {
+#if MRP_CTRL
+                num_of_ref_pic_to_search = (pcs_ptr->slice_type == P_SLICE)
+                    ? pcs_ptr->ref_list0_count_try
+                    : (list_index == REF_LIST_0)
+                    ? pcs_ptr->ref_list0_count_try
+                    : pcs_ptr->ref_list1_count_try;
+#else
                 num_of_ref_pic_to_search = (pcs_ptr->slice_type == P_SLICE)
                                                ? pcs_ptr->ref_list0_count
                                                : (list_index == REF_LIST_0)
                                                      ? pcs_ptr->ref_list0_count
                                                      : pcs_ptr->ref_list1_count;
+#endif
 
                 // Ref Picture Loop
                 for (ref_pic_index = 0; ref_pic_index < num_of_ref_pic_to_search; ++ref_pic_index) {

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -603,8 +603,8 @@ typedef struct PictureParentControlSet {
     uint8_t          ref_list0_count;
     uint8_t          ref_list1_count;
 #if MRP_CTRL
-    uint8_t          ref_list0_count_try;  //the number of references to try (in ME/MD) in list0. should be <= ref_list0_count
-    uint8_t          ref_list1_count_try;  //the number of references to try (in ME/MD) in list1. should be <= ref_list1_count
+    uint8_t          ref_list0_count_try;  //The number of references to try (in ME / MD) in list0.Should be <= ref_list0_count.
+    uint8_t          ref_list1_count_try;  // The number of references to try (in ME/MD) in list1. Should be <= ref_list1_count.
 #endif
     MvReferenceFrame ref_frame_type_arr[MODE_CTX_REF_FRAMES];
     uint8_t          tot_ref_frame_types;

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -602,6 +602,10 @@ typedef struct PictureParentControlSet {
     EbBool           is_used_as_reference_flag;
     uint8_t          ref_list0_count;
     uint8_t          ref_list1_count;
+#if MRP_CTRL
+    uint8_t          ref_list0_count_try;  //the number of references to try (in ME/MD) in list0. should be <= ref_list0_count
+    uint8_t          ref_list1_count_try;  //the number of references to try (in ME/MD) in list1. should be <= ref_list1_count
+#endif
     MvReferenceFrame ref_frame_type_arr[MODE_CTX_REF_FRAMES];
     uint8_t          tot_ref_frame_types;
     // Rate Control

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -5047,7 +5047,7 @@ void* picture_decision_kernel(void *input_ptr)
                                 pcs_ptr->ref_list1_count = (picture_type == I_SLICE || pcs_ptr->is_overlay) ? 0 : (uint8_t)pred_position_ptr->ref_list1.reference_list_count;
 
 #if MRP_CTRL
-                                //set the number of references to try in ME/MD.Note: PicMgr/Rps will still use the original values to sync the references.
+                                // Set the number of references to try in ME/MD. Note: PicMgr/RPS will still use the original values to sync the references.
                                 if (pcs_ptr->sc_content_detected) {
                                     pcs_ptr->ref_list0_count_try = MIN(pcs_ptr->ref_list0_count, 4);
                                     pcs_ptr->ref_list1_count_try = MIN(pcs_ptr->ref_list1_count, 3);

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -1128,11 +1128,20 @@ EbErrorType signal_derivation_multi_processes_oq(
         // inter intra pred                      Settings
         // 0                                     OFF
         // 1                                     ON
+#if  CLEANUP_INTER_INTRA
+        //picture level switch,  has to follow the sequence level.
+        if (pcs_ptr->slice_type != I_SLICE && scs_ptr->seq_header.enable_interintra_compound) {
+            pcs_ptr->enable_inter_intra = 1;//shut for sc , if needed.
+        }
+        else {
+            pcs_ptr->enable_inter_intra = 0;
+        }
+#else
         if (scs_ptr->static_config.inter_intra_compound == DEFAULT)
             pcs_ptr->enable_inter_intra = pcs_ptr->slice_type != I_SLICE ? scs_ptr->seq_header.enable_interintra_compound : 0;
         else
             pcs_ptr->enable_inter_intra = scs_ptr->static_config.inter_intra_compound;
-
+#endif
         // Set compound mode      Settings
         // 0                 OFF: No compond mode search : AVG only
         // 1                 ON: compond mode search: AVG/DIST/DIFF
@@ -1206,6 +1215,53 @@ static void set_all_ref_frame_type(SequenceControlSet *scs_ptr, PictureParentCon
 
     //SVT_LOG("POC %i  totRef L0:%i   totRef L1: %i\n", parent_pcs_ptr->picture_number, parent_pcs_ptr->ref_list0_count, parent_pcs_ptr->ref_list1_count);
 
+#if MRP_CTRL
+     //single ref - List0
+    for (uint8_t ref_idx0 = 0; ref_idx0 < parent_pcs_ptr->ref_list0_count_try; ++ref_idx0) {
+        rf[0] = svt_get_ref_frame_type(REF_LIST_0, ref_idx0);
+        ref_frame_arr[(*tot_ref_frames)++] = rf[0];
+    }
+
+    //single ref - List1
+    for (uint8_t ref_idx1 = 0; ref_idx1 < parent_pcs_ptr->ref_list1_count_try; ++ref_idx1) {
+        rf[1] = svt_get_ref_frame_type(REF_LIST_1, ref_idx1);
+        ref_frame_arr[(*tot_ref_frames)++] = rf[1];
+    }
+
+    //compound Bi-Dir
+    for (uint8_t ref_idx0 = 0; ref_idx0 < parent_pcs_ptr->ref_list0_count_try; ++ref_idx0) {
+        for (uint8_t ref_idx1 = 0; ref_idx1 < parent_pcs_ptr->ref_list1_count_try; ++ref_idx1) {
+            rf[0] = svt_get_ref_frame_type(REF_LIST_0, ref_idx0);
+            rf[1] = svt_get_ref_frame_type(REF_LIST_1, ref_idx1);
+            ref_frame_arr[(*tot_ref_frames)++] = av1_ref_frame_type(rf);
+        }
+    }
+
+    if (scs_ptr->mrp_mode == 0 && parent_pcs_ptr->slice_type == B_SLICE)
+    {
+
+        //compound Uni-Dir
+        if (parent_pcs_ptr->ref_list0_count_try > 1) {
+            rf[0] = LAST_FRAME;
+            rf[1] = LAST2_FRAME;
+            ref_frame_arr[(*tot_ref_frames)++] = av1_ref_frame_type(rf);
+            if (parent_pcs_ptr->ref_list0_count_try > 2) {
+                rf[1] = LAST3_FRAME;
+                ref_frame_arr[(*tot_ref_frames)++] = av1_ref_frame_type(rf);
+                if (parent_pcs_ptr->ref_list0_count_try > 3) {
+                    rf[1] = GOLDEN_FRAME;
+                    ref_frame_arr[(*tot_ref_frames)++] = av1_ref_frame_type(rf);
+                }
+            }
+        }
+        if (parent_pcs_ptr->ref_list1_count_try > 2) {
+            rf[0] = BWDREF_FRAME;
+            rf[1] = ALTREF_FRAME;
+            ref_frame_arr[(*tot_ref_frames)++] = av1_ref_frame_type(rf);
+        }
+    }
+
+#else
     //single ref - List0
     for (uint8_t ref_idx0 = 0; ref_idx0 < parent_pcs_ptr->ref_list0_count; ++ref_idx0) {
         rf[0] = svt_get_ref_frame_type(REF_LIST_0, ref_idx0);
@@ -1250,6 +1306,7 @@ static void set_all_ref_frame_type(SequenceControlSet *scs_ptr, PictureParentCon
             ref_frame_arr[(*tot_ref_frames)++] = av1_ref_frame_type(rf);
         }
     }
+#endif
 }
 
 static void prune_refs(PredictionStructureEntry *pred_position_ptr, Av1RpsNode *av1_rps)
@@ -4988,6 +5045,21 @@ void* picture_decision_kernel(void *input_ptr)
                                 pcs_ptr->ref_list0_count = (picture_type == I_SLICE) ? 0 :
                                                                             (pcs_ptr->is_overlay) ? 1 : (uint8_t)pred_position_ptr->ref_list0.reference_list_count;
                                 pcs_ptr->ref_list1_count = (picture_type == I_SLICE || pcs_ptr->is_overlay) ? 0 : (uint8_t)pred_position_ptr->ref_list1.reference_list_count;
+
+#if MRP_CTRL
+                                //set the number of references to try in ME/MD.Note: PicMgr/Rps will still use the original values to sync the references.
+                                if (pcs_ptr->sc_content_detected) {
+                                    pcs_ptr->ref_list0_count_try = MIN(pcs_ptr->ref_list0_count, 4);
+                                    pcs_ptr->ref_list1_count_try = MIN(pcs_ptr->ref_list1_count, 3);
+                                }
+                                else {
+                                    pcs_ptr->ref_list0_count_try = MIN(pcs_ptr->ref_list0_count, 4);
+                                    pcs_ptr->ref_list1_count_try = MIN(pcs_ptr->ref_list1_count, 3);
+                                }
+                                assert(pcs_ptr->ref_list0_count_try <= pcs_ptr->ref_list0_count);
+                                assert(pcs_ptr->ref_list1_count_try <= pcs_ptr->ref_list1_count);
+#endif
+
                                 if (!pcs_ptr->is_overlay) {
                                     input_entry_ptr->list0_ptr = &pred_position_ptr->ref_list0;
                                     input_entry_ptr->list1_ptr = &pred_position_ptr->ref_list1;


### PR DESCRIPTION
## Description
 
- clean up the  inter intra compound control signals. turning on/off  could be done via 2 ways: at the seq level(in ressource coordination), or at the picture level (in picture decision)
- add control to search smaller number of references i both ME and MD. 

