### PR TITLE
fixed run2run issue caused by uint32_t recon_offset

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/EbPictureOperators_AVX2.h
+++ b/Source/Lib/Common/ASM_AVX2/EbPictureOperators_AVX2.h
@@ -47,37 +47,37 @@ void full_distortion_kernel32_bits_avx2(int32_t *coeff, uint32_t coeff_stride, i
 
 uint64_t spatial_full_distortion_kernel4x_n_avx2_intrin(uint8_t *input, uint32_t input_offset,
                                                         uint32_t input_stride, uint8_t *recon,
-                                                        uint32_t recon_offset,
+                                                        int32_t recon_offset,
                                                         uint32_t recon_stride, uint32_t area_width,
                                                         uint32_t area_height);
 
 uint64_t spatial_full_distortion_kernel8x_n_avx2_intrin(uint8_t *input, uint32_t input_offset,
                                                         uint32_t input_stride, uint8_t *recon,
-                                                        uint32_t recon_offset,
+                                                        int32_t recon_offset,
                                                         uint32_t recon_stride, uint32_t area_width,
                                                         uint32_t area_height);
 
 uint64_t spatial_full_distortion_kernel16x_n_avx2_intrin(uint8_t *input, uint32_t input_offset,
                                                          uint32_t input_stride, uint8_t *recon,
-                                                         uint32_t recon_offset,
+                                                         int32_t recon_offset,
                                                          uint32_t recon_stride, uint32_t area_width,
                                                          uint32_t area_height);
 
 uint64_t spatial_full_distortion_kernel32x_n_avx2_intrin(uint8_t *input, uint32_t input_offset,
                                                          uint32_t input_stride, uint8_t *recon,
-                                                         uint32_t recon_offset,
+                                                         int32_t recon_offset,
                                                          uint32_t recon_stride, uint32_t area_width,
                                                          uint32_t area_height);
 
 uint64_t spatial_full_distortion_kernel64x_n_avx2_intrin(uint8_t *input, uint32_t input_offset,
                                                          uint32_t input_stride, uint8_t *recon,
-                                                         uint32_t recon_offset,
+                                                         int32_t recon_offset,
                                                          uint32_t recon_stride, uint32_t area_width,
                                                          uint32_t area_height);
 
 uint64_t spatial_full_distortion_kernel128x_n_avx2_intrin(
     uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon,
-    uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
+    int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Common/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
@@ -1423,7 +1423,7 @@ void residual_kernel8bit_avx2(uint8_t *input, uint32_t input_stride, uint8_t *pr
 
 uint64_t spatial_full_distortion_kernel4x_n_avx2_intrin(uint8_t *input, uint32_t input_offset,
                                                         uint32_t input_stride, uint8_t *recon,
-                                                        uint32_t recon_offset,
+                                                        int32_t recon_offset,
                                                         uint32_t recon_stride, uint32_t area_width,
                                                         uint32_t area_height) {
     int32_t row_count = area_height;
@@ -1456,7 +1456,7 @@ uint64_t spatial_full_distortion_kernel4x_n_avx2_intrin(uint8_t *input, uint32_t
 
 uint64_t spatial_full_distortion_kernel8x_n_avx2_intrin(uint8_t *input, uint32_t input_offset,
                                                         uint32_t input_stride, uint8_t *recon,
-                                                        uint32_t recon_offset,
+                                                        int32_t recon_offset,
                                                         uint32_t recon_stride, uint32_t area_width,
                                                         uint32_t area_height) {
     int32_t row_count = area_height;
@@ -1483,7 +1483,7 @@ uint64_t spatial_full_distortion_kernel8x_n_avx2_intrin(uint8_t *input, uint32_t
 
 uint64_t spatial_full_distortion_kernel16x_n_avx2_intrin(uint8_t *input, uint32_t input_offset,
                                                          uint32_t input_stride, uint8_t *recon,
-                                                         uint32_t recon_offset,
+                                                         int32_t recon_offset,
                                                          uint32_t recon_stride, uint32_t area_width,
                                                          uint32_t area_height) {
     int32_t row_count = area_height;
@@ -1510,7 +1510,7 @@ static INLINE void spatial_full_distortion_kernel_64_avx2_intrin(const uint8_t *
 
 uint64_t spatial_full_distortion_kernel32x_n_avx2_intrin(uint8_t *input, uint32_t input_offset,
                                                          uint32_t input_stride, uint8_t *recon,
-                                                         uint32_t recon_offset,
+                                                         int32_t recon_offset,
                                                          uint32_t recon_stride, uint32_t area_width,
                                                          uint32_t area_height) {
     int32_t row_count = area_height;
@@ -1530,7 +1530,7 @@ uint64_t spatial_full_distortion_kernel32x_n_avx2_intrin(uint8_t *input, uint32_
 
 uint64_t spatial_full_distortion_kernel64x_n_avx2_intrin(uint8_t *input, uint32_t input_offset,
                                                          uint32_t input_stride, uint8_t *recon,
-                                                         uint32_t recon_offset,
+                                                         int32_t recon_offset,
                                                          uint32_t recon_stride, uint32_t area_width,
                                                          uint32_t area_height) {
     int32_t row_count = area_height;
@@ -1550,7 +1550,7 @@ uint64_t spatial_full_distortion_kernel64x_n_avx2_intrin(uint8_t *input, uint32_
 
 uint64_t spatial_full_distortion_kernel128x_n_avx2_intrin(
     uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon,
-    uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height) {
+    int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height) {
     int32_t row_count = area_height;
     __m256i sum       = _mm256_setzero_si256();
     input += input_offset;
@@ -1569,7 +1569,7 @@ uint64_t spatial_full_distortion_kernel128x_n_avx2_intrin(
 
 uint64_t spatial_full_distortion_kernel_avx2(uint8_t *input, uint32_t input_offset,
                                              uint32_t input_stride, uint8_t *recon,
-                                             uint32_t recon_offset, uint32_t recon_stride,
+                                             int32_t recon_offset, uint32_t recon_stride,
                                              uint32_t area_width, uint32_t area_height) {
     const uint32_t leftover = area_width & 31;
     int32_t        h;
@@ -1708,7 +1708,7 @@ uint64_t spatial_full_distortion_kernel_avx2(uint8_t *input, uint32_t input_offs
  ************************************************/
 uint64_t full_distortion_kernel16_bits_avx2(uint8_t *input, uint32_t input_offset,
                                             uint32_t input_stride, uint8_t *recon,
-                                            uint32_t recon_offset, uint32_t recon_stride,
+                                            int32_t recon_offset, uint32_t recon_stride,
                                             uint32_t area_width, uint32_t area_height) {
     const uint32_t leftover = area_width & 15;
     uint32_t       w, h;

--- a/Source/Lib/Common/ASM_AVX512/EbPictureOperators_AVX512.h
+++ b/Source/Lib/Common/ASM_AVX512/EbPictureOperators_AVX512.h
@@ -14,15 +14,15 @@ extern "C" {
 
 uint64_t spatial_full_distortion_kernel32x_n_avx512_intrin(
     uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon,
-    uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
+    int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
 
 uint64_t spatial_full_distortion_kernel64x_n_avx512_intrin(
     uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon,
-    uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
+    int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
 
 uint64_t spatial_full_distortion_kernel128x_n_avx512_intrin(
     uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon,
-    uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
+    int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Common/ASM_AVX512/EbPictureOperators_Intrinsic_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/EbPictureOperators_Intrinsic_AVX512.c
@@ -209,7 +209,7 @@ static INLINE void SpatialFullDistortionKernel64_AVX512_INTRIN(const uint8_t *co
 
 uint64_t spatial_full_distortion_kernel32x_n_avx512_intrin(
     uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon,
-    uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height) {
+    int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height) {
     int32_t row_count = area_height;
     __m512i sum       = _mm512_setzero_si512();
 
@@ -231,7 +231,7 @@ uint64_t spatial_full_distortion_kernel32x_n_avx512_intrin(
 
 uint64_t spatial_full_distortion_kernel64x_n_avx512_intrin(
     uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon,
-    uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height) {
+    int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height) {
     int32_t row_count = area_height;
     __m512i sum       = _mm512_setzero_si512();
 
@@ -251,7 +251,7 @@ uint64_t spatial_full_distortion_kernel64x_n_avx512_intrin(
 
 uint64_t spatial_full_distortion_kernel128x_n_avx512_intrin(
     uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon,
-    uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height) {
+    int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height) {
     int32_t row_count = area_height;
     __m512i sum       = _mm512_setzero_si512();
 
@@ -272,7 +272,7 @@ uint64_t spatial_full_distortion_kernel128x_n_avx512_intrin(
 
 uint64_t spatial_full_distortion_kernel_avx512(uint8_t *input, uint32_t input_offset,
                                                uint32_t input_stride, uint8_t *recon,
-                                               uint32_t recon_offset, uint32_t recon_stride,
+                                               int32_t recon_offset, uint32_t recon_stride,
                                                uint32_t area_width, uint32_t area_height) {
     const uint32_t leftover = area_width & 31;
     int32_t        h;

--- a/Source/Lib/Common/ASM_SSE2/EbPictureOperators_Intrinsic_SSE2.c
+++ b/Source/Lib/Common/ASM_SSE2/EbPictureOperators_Intrinsic_SSE2.c
@@ -221,7 +221,7 @@ static INLINE __m128i distortion_sse2_intrin(const __m128i input, const __m128i 
 
 uint64_t spatial_full_distortion_kernel4x_n_sse2_intrin(uint8_t *input, uint32_t input_offset,
                                                         uint32_t input_stride, uint8_t *recon,
-                                                        uint32_t recon_offset,
+                                                        int32_t recon_offset,
                                                         uint32_t recon_stride, uint32_t area_width,
                                                         uint32_t area_height) {
     int32_t row_count = area_height;
@@ -245,7 +245,7 @@ uint64_t spatial_full_distortion_kernel4x_n_sse2_intrin(uint8_t *input, uint32_t
 
 uint64_t spatial_full_distortion_kernel8x_n_sse2_intrin(uint8_t *input, uint32_t input_offset,
                                                         uint32_t input_stride, uint8_t *recon,
-                                                        uint32_t recon_offset,
+                                                        int32_t recon_offset,
                                                         uint32_t recon_stride, uint32_t area_width,
                                                         uint32_t area_height) {
     int32_t row_count = area_height;
@@ -297,7 +297,7 @@ static INLINE void spatial_full_distortion_kernel_64_sse2_intrin(const uint8_t *
 
 uint64_t spatial_full_distortion_kernel16x_n_sse2_intrin(uint8_t *input, uint32_t input_offset,
                                                          uint32_t input_stride, uint8_t *recon,
-                                                         uint32_t recon_offset,
+                                                         int32_t recon_offset,
                                                          uint32_t recon_stride, uint32_t area_width,
                                                          uint32_t area_height) {
     int32_t row_count = area_height;
@@ -317,7 +317,7 @@ uint64_t spatial_full_distortion_kernel16x_n_sse2_intrin(uint8_t *input, uint32_
 
 uint64_t spatial_full_distortion_kernel32x_n_sse2_intrin(uint8_t *input, uint32_t input_offset,
                                                          uint32_t input_stride, uint8_t *recon,
-                                                         uint32_t recon_offset,
+                                                         int32_t recon_offset,
                                                          uint32_t recon_stride, uint32_t area_width,
                                                          uint32_t area_height) {
     int32_t row_count = area_height;
@@ -337,7 +337,7 @@ uint64_t spatial_full_distortion_kernel32x_n_sse2_intrin(uint8_t *input, uint32_
 
 uint64_t spatial_full_distortion_kernel64x_n_sse2_intrin(uint8_t *input, uint32_t input_offset,
                                                          uint32_t input_stride, uint8_t *recon,
-                                                         uint32_t recon_offset,
+                                                         int32_t recon_offset,
                                                          uint32_t recon_stride, uint32_t area_width,
                                                          uint32_t area_height) {
     int32_t row_count = area_height;
@@ -357,7 +357,7 @@ uint64_t spatial_full_distortion_kernel64x_n_sse2_intrin(uint8_t *input, uint32_
 
 uint64_t spatial_full_distortion_kernel128x_n_sse2_intrin(
     uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon,
-    uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height) {
+    int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height) {
     int32_t row_count = area_height;
     __m128i sum       = _mm_setzero_si128();
     input += input_offset;

--- a/Source/Lib/Common/ASM_SSE2/EbPictureOperators_SSE2.h
+++ b/Source/Lib/Common/ASM_SSE2/EbPictureOperators_SSE2.h
@@ -44,37 +44,37 @@ static INLINE int32_t hadd32_sse2_intrin(const __m128i src) {
 
 uint64_t spatial_full_distortion_kernel4x_n_sse2_intrin(uint8_t *input, uint32_t input_offset,
                                                         uint32_t input_stride, uint8_t *recon,
-                                                        uint32_t recon_offset,
+                                                        int32_t recon_offset,
                                                         uint32_t recon_stride, uint32_t area_width,
                                                         uint32_t area_height);
 
 uint64_t spatial_full_distortion_kernel8x_n_sse2_intrin(uint8_t *input, uint32_t input_offset,
                                                         uint32_t input_stride, uint8_t *recon,
-                                                        uint32_t recon_offset,
+                                                        int32_t recon_offset,
                                                         uint32_t recon_stride, uint32_t area_width,
                                                         uint32_t area_height);
 
 uint64_t spatial_full_distortion_kernel16x_n_sse2_intrin(uint8_t *input, uint32_t input_offset,
                                                          uint32_t input_stride, uint8_t *recon,
-                                                         uint32_t recon_offset,
+                                                         int32_t recon_offset,
                                                          uint32_t recon_stride, uint32_t area_width,
                                                          uint32_t area_height);
 
 uint64_t spatial_full_distortion_kernel32x_n_sse2_intrin(uint8_t *input, uint32_t input_offset,
                                                          uint32_t input_stride, uint8_t *recon,
-                                                         uint32_t recon_offset,
+                                                         int32_t recon_offset,
                                                          uint32_t recon_stride, uint32_t area_width,
                                                          uint32_t area_height);
 
 uint64_t spatial_full_distortion_kernel64x_n_sse2_intrin(uint8_t *input, uint32_t input_offset,
                                                          uint32_t input_stride, uint8_t *recon,
-                                                         uint32_t recon_offset,
+                                                         int32_t recon_offset,
                                                          uint32_t recon_stride, uint32_t area_width,
                                                          uint32_t area_height);
 
 uint64_t spatial_full_distortion_kernel128x_n_sse2_intrin(
     uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon,
-    uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
+    int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Common/C_DEFAULT/EbPictureOperators_C.c
+++ b/Source/Lib/Common/C_DEFAULT/EbPictureOperators_C.c
@@ -55,7 +55,7 @@ void picture_copy_kernel(EbByte src, uint32_t src_stride, EbByte dst, uint32_t d
 
 uint64_t spatial_full_distortion_kernel_c(uint8_t *input, uint32_t input_offset,
                                           uint32_t input_stride, uint8_t *recon,
-                                          uint32_t recon_offset, uint32_t recon_stride,
+                                          int32_t recon_offset, uint32_t recon_stride,
                                           uint32_t area_width, uint32_t area_height) {
     uint32_t column_index;
     uint32_t row_index          = 0;

--- a/Source/Lib/Common/Codec/EbPictureOperators.c
+++ b/Source/Lib/Common/Codec/EbPictureOperators.c
@@ -187,7 +187,7 @@ void full_distortion_kernel32_bits_c(int32_t *coeff, uint32_t coeff_stride, int3
 }
 
 uint64_t full_distortion_kernel16_bits_c(uint8_t *input, uint32_t input_offset,
-                                         uint32_t input_stride, uint8_t *pred, uint32_t pred_offset,
+                                         uint32_t input_stride, uint8_t *pred, int32_t pred_offset,
                                          uint32_t pred_stride, uint32_t area_width,
                                          uint32_t area_height) {
     uint32_t column_index;

--- a/Source/Lib/Common/Codec/EbPictureOperators.h
+++ b/Source/Lib/Common/Codec/EbPictureOperators.h
@@ -62,7 +62,7 @@ void full_distortion_kernel32_bits_c(int32_t *coeff, uint32_t coeff_stride, int3
                                      uint32_t area_width, uint32_t area_height);
 
 uint64_t full_distortion_kernel16_bits_c(uint8_t *input, uint32_t input_offset,
-                                         uint32_t input_stride, uint8_t *pred, uint32_t pred_offset,
+                                         uint32_t input_stride, uint8_t *pred, int32_t pred_offset,
                                          uint32_t pred_stride, uint32_t area_width,
                                          uint32_t area_height);
 

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.h
@@ -266,14 +266,14 @@ extern "C" {
     RTCD_EXTERN void(*picture_average_kernel)(EbByte src0, uint32_t src0_stride, EbByte src1, uint32_t src1_stride, EbByte dst, uint32_t dst_stride, uint32_t area_width, uint32_t area_height);
     RTCD_EXTERN void(*picture_average_kernel1_line)(EbByte src0, EbByte src1, EbByte dst, uint32_t area_width);
 
-    uint64_t spatial_full_distortion_kernel_c(uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon, uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
-    uint64_t spatial_full_distortion_kernel_avx2(uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon, uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
-    uint64_t spatial_full_distortion_kernel_avx512(uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon, uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
-    RTCD_EXTERN uint64_t(*spatial_full_distortion_kernel)(uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon, uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
+    uint64_t spatial_full_distortion_kernel_c(uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon, int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
+    uint64_t spatial_full_distortion_kernel_avx2(uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon, int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
+    uint64_t spatial_full_distortion_kernel_avx512(uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon, int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
+    RTCD_EXTERN uint64_t(*spatial_full_distortion_kernel)(uint8_t *input, uint32_t input_offset, uint32_t input_stride, uint8_t *recon, int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
 
-    uint64_t full_distortion_kernel16_bits_c(uint8_t* input, uint32_t input_offset, uint32_t input_stride, uint8_t* recon, uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
-    uint64_t full_distortion_kernel16_bits_avx2(uint8_t* input, uint32_t input_offset, uint32_t input_stride, uint8_t* recon, uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
-    RTCD_EXTERN uint64_t(*full_distortion_kernel16_bits)(uint8_t* input, uint32_t input_offset, uint32_t input_stride, uint8_t* recon, uint32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
+    uint64_t full_distortion_kernel16_bits_c(uint8_t* input, uint32_t input_offset, uint32_t input_stride, uint8_t* recon, int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
+    uint64_t full_distortion_kernel16_bits_avx2(uint8_t* input, uint32_t input_offset, uint32_t input_stride, uint8_t* recon, int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
+    RTCD_EXTERN uint64_t(*full_distortion_kernel16_bits)(uint8_t* input, uint32_t input_offset, uint32_t input_stride, uint8_t* recon, int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
     RTCD_EXTERN void(*residual_kernel16bit)(uint16_t *input, uint32_t input_stride, uint16_t *pred, uint32_t pred_stride, int16_t *residual, uint32_t residual_stride, uint32_t area_width, uint32_t area_height);
 
     void avc_style_luma_interpolation_filter_ssse3_helper(EbByte ref_pic, uint32_t src_stride, EbByte dst, uint32_t dst_stride, uint32_t pu_width, uint32_t pu_height, EbByte temp_buf, EbBool skip, uint32_t frac_pos, uint8_t choice);

--- a/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
@@ -2547,10 +2547,10 @@ extern void model_rd_for_sb(PictureControlSet *  picture_control_set_ptr,
              input_picture_ptr->stride_cb +
              (md_context_ptr->blk_origin_x + input_picture_ptr->origin_x)) /
             2;
-    const uint32_t prediction_offset =
+    const int32_t prediction_offset =
             prediction_ptr->origin_x + md_context_ptr->blk_geom->origin_x +
             (prediction_ptr->origin_y + md_context_ptr->blk_geom->origin_y) * prediction_ptr->stride_y;
-    const uint32_t prediction_chroma_offset =
+    const int32_t prediction_chroma_offset =
             (prediction_ptr->origin_x + md_context_ptr->blk_geom->origin_x +
              (prediction_ptr->origin_y + md_context_ptr->blk_geom->origin_y) *
              prediction_ptr->stride_cb) /

--- a/Source/Lib/Encoder/Codec/EbFullLoop.c
+++ b/Source/Lib/Encoder/Codec/EbFullLoop.c
@@ -2127,7 +2127,7 @@ void product_full_loop(ModeDecisionCandidateBuffer *candidate_buffer,
                                        input_txb_origin_index,
                                        input_picture_ptr->stride_y,
                                        candidate_buffer->prediction_ptr->buffer_y,
-                                       txb_origin_index,
+                                       (int32_t)txb_origin_index,
                                        candidate_buffer->prediction_ptr->stride_y,
                                        cropped_tx_width,
                                        cropped_tx_height);
@@ -2137,7 +2137,7 @@ void product_full_loop(ModeDecisionCandidateBuffer *candidate_buffer,
                                        input_txb_origin_index,
                                        input_picture_ptr->stride_y,
                                        candidate_buffer->recon_ptr->buffer_y,
-                                       txb_origin_index,
+                                       (int32_t)txb_origin_index,
                                        candidate_buffer->recon_ptr->stride_y,
                                        cropped_tx_width,
                                        cropped_tx_height);
@@ -3023,7 +3023,7 @@ void cu_full_distortion_fast_txb_mode_r(
                         input_picture_ptr->stride_cb +
                     (((context_ptr->sb_origin_x + ((txb_origin_x >> 3) << 3)) >> 1) +
                      (input_picture_ptr->origin_x >> 1));
-                uint32_t txb_uv_origin_index =
+                int32_t txb_uv_origin_index =
                     (((txb_origin_x >> 3) << 3) +
                      (((txb_origin_y >> 3) << 3) *
                       candidate_buffer->residual_quant_coeff_ptr->stride_cb)) >>

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -1200,7 +1200,7 @@ void fast_loop_core(ModeDecisionCandidateBuffer *candidate_buffer, PictureContro
                                                               input_origin_index,
                                                               input_picture_ptr->stride_y,
                                                               prediction_ptr->buffer_y,
-                                                              cu_origin_index,
+                                                              (int32_t)cu_origin_index,
                                                               prediction_ptr->stride_y,
                                                               context_ptr->blk_geom->bwidth,
                                                               context_ptr->blk_geom->bheight));
@@ -1239,7 +1239,7 @@ void fast_loop_core(ModeDecisionCandidateBuffer *candidate_buffer, PictureContro
                                            input_cb_origin_in_index,
                                            input_picture_ptr->stride_cb,
                                            candidate_buffer->prediction_ptr->buffer_cb,
-                                           cu_chroma_origin_index,
+                                           (int32_t)cu_chroma_origin_index,
                                            prediction_ptr->stride_cb,
                                            context_ptr->blk_geom->bwidth_uv,
                                            context_ptr->blk_geom->bheight_uv);
@@ -1249,7 +1249,7 @@ void fast_loop_core(ModeDecisionCandidateBuffer *candidate_buffer, PictureContro
                                            input_cr_origin_in_index,
                                            input_picture_ptr->stride_cb,
                                            candidate_buffer->prediction_ptr->buffer_cr,
-                                           cu_chroma_origin_index,
+                                           (int32_t)cu_chroma_origin_index,
                                            prediction_ptr->stride_cr,
                                            context_ptr->blk_geom->bwidth_uv,
                                            context_ptr->blk_geom->bheight_uv);
@@ -2373,7 +2373,7 @@ void md_full_pel_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                  refinement_pos_y <= search_position_end_y;
                  ++refinement_pos_y) {
 #endif
-                uint32_t ref_origin_index =
+                int32_t ref_origin_index =
                     ref_pic->origin_x +
                     (context_ptr->blk_origin_x + (mvx >> 3) + refinement_pos_x) +
                     (context_ptr->blk_origin_y + (mvy >> 3) + ref_pic->origin_y +
@@ -2490,7 +2490,7 @@ void md_full_pel_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context
              refinement_pos_y <= search_position_end_y;
              ++refinement_pos_y) {
 #endif
-            uint32_t ref_origin_index =
+            int32_t ref_origin_index =
                 ref_pic->origin_x + (context_ptr->blk_origin_x + (mvx >> 3) + refinement_pos_x) +
                 (context_ptr->blk_origin_y + (mvy >> 3) + ref_pic->origin_y + refinement_pos_y) *
                     ref_pic->stride_y;
@@ -2626,7 +2626,7 @@ void md_sub_pel_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context_
                                                                   input_origin_index,
                                                                   input_picture_ptr->stride_y,
                                                                   prediction_ptr->buffer_y,
-                                                                  blk_origin_index,
+                                                                  (int32_t)blk_origin_index,
                                                                   prediction_ptr->stride_y,
                                                                   context_ptr->blk_geom->bwidth,
                                                                   context_ptr->blk_geom->bheight);
@@ -2929,7 +2929,7 @@ void    predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *co
                 EbPictureBufferDesc *ref_pic =
                     hbd_mode_decision ? ref_obj->reference_picture16bit : ref_obj->reference_picture;
 
-                uint32_t ref_origin_index =
+                int32_t ref_origin_index =
                     ref_pic->origin_x + (context_ptr->blk_origin_x + (me_mv_x >> 3)) +
                     (context_ptr->blk_origin_y + (me_mv_y >> 3) + ref_pic->origin_y) *
                     ref_pic->stride_y;
@@ -3015,7 +3015,7 @@ void    predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *co
                                                        ? ref_obj->reference_picture16bit
                                                        : ref_obj->reference_picture;
 
-                    uint32_t ref_origin_index =
+                    int32_t ref_origin_index =
                         ref_pic->origin_x +
                         (context_ptr->blk_origin_x + (mvp_x_array[mvp_index] >> 3)) +
                         (context_ptr->blk_origin_y + (mvp_y_array[mvp_index] >> 3) +
@@ -4773,7 +4773,7 @@ void tx_type_search(PictureControlSet *pcs_ptr,
             input_txb_origin_index,
             input_picture_ptr->stride_y,
             candidate_buffer->prediction_ptr->buffer_y,
-            txb_origin_index,
+            (int32_t)txb_origin_index,
             candidate_buffer->prediction_ptr->stride_y,
             context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
             context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);
@@ -4783,7 +4783,7 @@ void tx_type_search(PictureControlSet *pcs_ptr,
             input_txb_origin_index,
             input_picture_ptr->stride_y,
             candidate_buffer->recon_ptr->buffer_y,
-            txb_origin_index,
+            (int32_t)txb_origin_index,
             candidate_buffer->recon_ptr->stride_y,
             context_ptr->blk_geom->tx_width[context_ptr->tx_depth][context_ptr->txb_itr],
             context_ptr->blk_geom->tx_height[context_ptr->tx_depth][context_ptr->txb_itr]);

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
@@ -101,7 +101,7 @@ extern "C" {
         uint32_t   input_offset,
         uint32_t   input_stride,
         uint8_t   *recon,
-        uint32_t   recon_offset,
+        int32_t    recon_offset,
         uint32_t   recon_stride,
         uint32_t   area_width,
         uint32_t   area_height);

--- a/test/SpatialFullDistortionTest.cc
+++ b/test/SpatialFullDistortionTest.cc
@@ -31,7 +31,7 @@ namespace {
 
 typedef uint64_t (*SpatialFullDistortionKernelFunc)(
     uint8_t *input, uint32_t input_offset, uint32_t input_stride,
-    uint8_t *recon, uint32_t recon_offset, uint32_t recon_stride,
+    uint8_t *recon, int32_t recon_offset, uint32_t recon_stride,
     uint32_t area_width, uint32_t area_height);
 
 class SpatialFullDistortionTest


### PR DESCRIPTION
The MV offset recon_offset is taken as unsigned value in function spatial_full_distortion_kernel_avx2(), then minus value MV like (-36, -10) generate very big recon_offset for forcing to be unsigned int type, it causes the recon buffer points to far away invalid memory, it should change to  signed value int32_t type.
Quality and speed are impacted only when functions spatial_full_distortion_kernel and full_distortion_kernel16bit are called, very slight impact.


Speed Deviation | BD-Rate Deviation
-- | --
-- | 0.00%

