### PR TITLE
CI: Extend binary identical test to checkout target branch for pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,15 @@ jobs:
         tar xf video.tar.gz
         mv -t $HOME akiyo_cif.y4m
         mv -t $HOME Chimera-Aerial_480x264_2997fps_10bit_420_150frames.y4m
-    - name: Checkout SVT-AV1 (master)
+    - name: Checkout SVT-AV1 on pull request (master)
+      if: github.event_name == 'pull_request'
       uses: actions/checkout@v2
       with:
-        repository: 'OpenVisualCloud/SVT-AV1'
+        ref: ${{ github.base_ref }}
+    - name: Checkout SVT-AV1 on push (master)
+      if: github.event_name == 'push'
+      uses: actions/checkout@v2
+      with:
         ref: 'master'
     - name: Prepare cache hash
       id: cache_hash


### PR DESCRIPTION
Extended binary identical test behavior to checkout the target branch upon pull request. Previously, CI compares against the official repository's master independent of the target branch. The change will behave as follows now:
- On pull request event, checkout the target branch
- On push event, checkout master. I removed the option that checks out the official repository's master. For forked projects, users may not want to compare against the official repo's master. It would be better to keep the behavior this way. Open for discussion if there are disagreements on this.

Sanity checks:
Push: https://github.com/ultrawide/SVT-AV1/pull/4/checks?check_run_id=496160708 
Pull Request: https://github.com/ultrawide/SVT-AV1/pull/4/checks?check_run_id=496172549 

Closes #1098 