### PR TITLE
Address valgrind errors that could cause R2R issue and fix print message

### DIFF
--- a/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
@@ -55,12 +55,10 @@ void av1_make_masked_inter_predictor(uint8_t *src_ptr, uint32_t src_stride, uint
                                      InterpFilterParams *filter_params_y, int32_t subpel_x,
                                      int32_t subpel_y, ConvolveParams *conv_params,
                                      InterInterCompoundData *comp_data, uint8_t bitdepth,
-                                     uint8_t plane) {
+                                     uint8_t plane, uint8_t *seg_mask) {
     //We come here when we have a prediction done using regular path for the ref0 stored in conv_param.dst.
     //use regular path to generate a prediction for ref1 into  a temporary buffer,
     //then  blend that temporary buffer with that from  the first reference.
-
-    DECLARE_ALIGNED(16, uint8_t, seg_mask[2 * MAX_SB_SQUARE]);
 
 #define INTER_PRED_BYTES_PER_PIXEL 2
     DECLARE_ALIGNED(32, uint8_t, tmp_buf[INTER_PRED_BYTES_PER_PIXEL * MAX_SB_SQUARE]);
@@ -3870,6 +3868,8 @@ EbErrorType av1_inter_prediction(
         av1_get_convolve_filter_params(
                 interp_filters, &filter_params_x, &filter_params_y, bwidth, bheight);
 
+        DECLARE_ALIGNED(16, uint8_t, seg_mask[2 * MAX_SB_SQUARE]);
+
         //the luma data is applied to chroma below
         av1_dist_wtd_comp_weight_assign(
                 &picture_control_set_ptr->parent_pcs_ptr->scs_ptr->seq_header,
@@ -3902,7 +3902,8 @@ EbErrorType av1_inter_prediction(
                     &conv_params,
                     interinter_comp,
                     bit_depth,
-                    0//plane=Luma  seg_mask is computed based on luma and used for chroma
+                    0,//plane=Luma  seg_mask is computed based on luma and used for chroma
+                    seg_mask
             );
         }
         else
@@ -3995,7 +3996,8 @@ EbErrorType av1_inter_prediction(
                         &conv_params,
                         interinter_comp,
                         bit_depth,
-                        1 //plane=cb  seg_mask is computed based on luma and used for chroma
+                        1, //plane=cb  seg_mask is computed based on luma and used for chroma
+                        seg_mask
                 );
             }
             else
@@ -4081,7 +4083,8 @@ EbErrorType av1_inter_prediction(
                         &conv_params,
                         interinter_comp,
                         bit_depth,
-                        1 //plane=Cr  seg_mask is computed based on luma and used for chroma
+                        1, //plane=Cr  seg_mask is computed based on luma and used for chroma
+                        seg_mask
                 );
             }
             else

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -5083,6 +5083,7 @@ void inject_intra_candidates_ois(PictureControlSet *pcs_ptr, ModeDecisionContext
         if (av1_is_directional_mode((PredictionMode)intra_mode)) {
             int32_t angle_delta                 = ois_blk_ptr[can_total_cnt].angle_delta;
             candidate_array[can_total_cnt].type = INTRA_MODE;
+            candidate_array[can_total_cnt].merge_flag = EB_FALSE;
             candidate_array[can_total_cnt].palette_info.pmi.palette_size[0] = 0;
             candidate_array[can_total_cnt].palette_info.pmi.palette_size[1] = 0;
             candidate_array[can_total_cnt].intra_luma_mode                  = intra_mode;
@@ -5125,6 +5126,7 @@ void inject_intra_candidates_ois(PictureControlSet *pcs_ptr, ModeDecisionContext
             INCRMENT_CAND_TOTAL_COUNT(can_total_cnt);
         } else {
             candidate_array[can_total_cnt].type                             = INTRA_MODE;
+            candidate_array[can_total_cnt].merge_flag                       = EB_FALSE;
             candidate_array[can_total_cnt].palette_info.pmi.palette_size[0] = 0;
             candidate_array[can_total_cnt].palette_info.pmi.palette_size[1] = 0;
             candidate_array[can_total_cnt].intra_luma_mode                  = intra_mode;
@@ -5631,6 +5633,7 @@ void  inject_intra_candidates(
                     int32_t  p_angle = mode_to_angle_map[(PredictionMode)open_loop_intra_candidate] + angle_delta * ANGLE_STEP;
                     if (!disable_z2_prediction || (p_angle <= 90 || p_angle >= 180)) {
                         cand_array[cand_total_cnt].type = INTRA_MODE;
+                        cand_array[cand_total_cnt].merge_flag = EB_FALSE;
                         cand_array[cand_total_cnt].palette_info.pmi.palette_size[0] = 0;
                         cand_array[cand_total_cnt].palette_info.pmi.palette_size[1] = 0;
                         cand_array[cand_total_cnt].intra_luma_mode = open_loop_intra_candidate;
@@ -5692,6 +5695,7 @@ void  inject_intra_candidates(
         }
         else {
             cand_array[cand_total_cnt].type = INTRA_MODE;
+            cand_array[cand_total_cnt].merge_flag = EB_FALSE;
             cand_array[cand_total_cnt].palette_info.pmi.palette_size[0] = 0;
             cand_array[cand_total_cnt].palette_info.pmi.palette_size[1] = 0;
             cand_array[cand_total_cnt].intra_luma_mode = open_loop_intra_candidate;
@@ -5786,6 +5790,7 @@ void  inject_filter_intra_candidates(
                 continue;
 
             cand_array[cand_total_cnt].type = INTRA_MODE;
+            cand_array[cand_total_cnt].merge_flag = EB_FALSE;
             cand_array[cand_total_cnt].intra_luma_mode = DC_PRED;
             cand_array[cand_total_cnt].distortion_ready = 0;
             cand_array[cand_total_cnt].use_intrabc = 0;
@@ -5895,6 +5900,7 @@ void  inject_palette_candidates(
         assert(palette_cand_array[cand_i].pmi.palette_size[0] < 9);
         //to re check these fields
         cand_array[can_total_cnt].type = INTRA_MODE;
+        cand_array[can_total_cnt].merge_flag = EB_FALSE;
         cand_array[can_total_cnt].intra_luma_mode = DC_PRED;
         cand_array[can_total_cnt].distortion_ready = 0;
         cand_array[can_total_cnt].use_intrabc = 0;

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -3094,7 +3094,7 @@ static void print_lib_params(
             config->intra_refresh_type);
     else
         SVT_LOG("\nSVT [config]: FrameRate / Gop Size\t\t\t\t\t\t: %d / %d ", config->frame_rate > 1000 ? config->frame_rate >> 16 : config->frame_rate, config->intra_period_length + 1);
-    SVT_LOG("\nSVT [config]: HierarchicalLevels  / PredStructure\t\t: %d / %d / %d ", config->hierarchical_levels, config->pred_structure);
+    SVT_LOG("\nSVT [config]: HierarchicalLevels  / PredStructure\t\t: %d / %d", config->hierarchical_levels, config->pred_structure);
     if (config->rate_control_mode == 1)
         SVT_LOG("\nSVT [config]: RCMode / TargetBitrate (kbps)/ LookaheadDistance / SceneChange\t\t: VBR / %d / %d / %d ", (int)config->target_bit_rate/1000, config->look_ahead_distance, config->scene_change_detection);
     else if (config->rate_control_mode == 2)


### PR DESCRIPTION
This PR can fix some of the R2R issue that were caused by using uninitialized array in av1_make_masked_inter_predictor() function for chroma compound with COMPOUND_DIFFWTD flag

Github Issue: #733