### PR TITLE
Fix the r2r

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -87,6 +87,7 @@ extern "C" {
 
 #define MRP_31B_SUPPORT 1
 #define TILES_PARALLEL 1
+#define R2R_FIX 1
 
 #if TILES_PARALLEL
 #define MAX_TILE_CNTS 128 // Annex A.3

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -2418,6 +2418,13 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
     while (blk_it < scs_ptr->max_block_cnt) {
         BlkStruct *blk_ptr = context_ptr->blk_ptr =
             &context_ptr->md_context->md_blk_arr_nsq[blk_it];
+#if R2R_FIX
+        //At the boundary when it's not a complete super block.
+        //We may only use part of the blocks in MD.
+        //And the mds_idx of the parent block is not set properly
+        //And it will generate the wrong cdf ctx and influence the MD for the next SB
+        blk_ptr->mds_idx = blk_it;
+#endif
         PartitionType part = blk_ptr->part;
 
         const BlockGeom *blk_geom = context_ptr->blk_geom = get_blk_geom_mds(blk_it);

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -1318,6 +1318,12 @@ void fast_loop_core(ModeDecisionCandidateBuffer *candidate_buffer, PictureContro
         1,
         context_ptr->intra_luma_left_mode,
         context_ptr->intra_luma_top_mode);
+
+#if R2R_FIX
+    // Init full cost in case we by pass stage1/stage2
+    if (context_ptr->md_staging_mode == MD_STAGING_MODE_0)
+        *(candidate_buffer->full_cost_ptr) = *(candidate_buffer->fast_cost_ptr);
+#endif
 }
 #if NICS_CLEANUP
 static const int32_t pd0_nic[MD_STAGE_TOTAL-1][MAX_FRAME_TYPE][CAND_CLASS_TOTAL] = {


### PR DESCRIPTION
Contains 2 cases
    - When skiping stage1/2, the full cost is used directly without been
    initialized
    - At the boundary when it's not a complete super block. We may only
    use part of the blocks in MD and didn't set its parent blocks
    properly. it will generate the wrong CDF context for the next SB

Signed-off-by: Jing Li <jing.b.li@intel.com>