### PR TITLE
appveyor: run pacman update along with installing packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,9 @@ install:
   - set "PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%"
   - ps: (New-Object System.Net.WebClient).DownloadFile('https://raw.githubusercontent.com/OpenVisualCloud/SVT-AV1-Resources/master/video.tar.gz', "$PWD\video.tar.gz")
   - tar xf video.tar.gz
+  - pacman -Syyuu --ask=20 --noconfirm --noprogressbar --needed
   - ps: if ("$env:generator" -match "Unix") { $env:packages = "mingw-w64-x86_64-ccache mingw-w64-x86_64-gcc pkg-config make" }
-  - pacman -Sy --ask=20 --noconfirm --noprogressbar --needed mingw-w64-x86_64-yasm %packages%
+  - pacman -Suu --ask=20 --noconfirm --noprogressbar --needed mingw-w64-x86_64-yasm %packages%
   - ps: |
       if ("$env:generator" -match "Visual*") {
         cmake -S . -B Build -G "Visual Studio 16 2019" -A x64 -DCMAKE_INSTALL_PREFIX=C:/msys64/mingw64 -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=ON


### PR DESCRIPTION
Fixes appveyor failing due to pacman not installing gcc