### PR TITLE
Fix r2r for -enable-overlays cases

### DIFF
--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -4733,7 +4733,7 @@ void interpolate_search_region_avc(
             context_ptr->pos_b_buffer[list_index][ref_pic_index],
             context_ptr->interpolated_stride,
             search_area_width_for_asm,
-            search_area_height + ME_FILTER_TAP,
+            search_area_height + ME_FILTER_TAP + 1,
             context_ptr->avctemp_buffer,
             EB_FALSE,
             2,
@@ -4748,7 +4748,7 @@ void interpolate_search_region_avc(
             context_ptr->pos_h_buffer[list_index][ref_pic_index],
             context_ptr->interpolated_stride,
             search_area_width_for_asm,
-            search_area_height + 1,
+            search_area_height + 2,
             context_ptr->avctemp_buffer,
             EB_FALSE,
             2,
@@ -4763,7 +4763,7 @@ void interpolate_search_region_avc(
             context_ptr->pos_j_buffer[list_index][ref_pic_index],
             context_ptr->interpolated_stride,
             search_area_width_for_asm,
-            search_area_height + 1,
+            search_area_height + 2,
             context_ptr->avctemp_buffer,
             EB_FALSE,
             2,
@@ -4851,8 +4851,8 @@ static void pu_half_pel_refinement(
 
     int16_t x_mv           = _MVXT(*p_best_MV);
     int16_t y_mv           = _MVYT(*p_best_MV);
-    int16_t x_search_index = (x_mv >> 2) - x_search_area_origin;
-    int16_t y_search_index = (y_mv >> 2) - y_search_area_origin;
+    int32_t x_search_index = (x_mv >> 2) - x_search_area_origin;
+    int32_t y_search_index = (y_mv >> 2) - y_search_area_origin;
 
     (void)scs_ptr;
     (void)encode_context_ptr;
@@ -4884,7 +4884,7 @@ static void pu_half_pel_refinement(
                                                      blk_sb_buffer_index,
                                                      context_ptr->sb_src_stride,
                                                      refBuffer,
-                                                     y_search_index * ref_stride + x_search_index,
+                                                     y_search_index * (int32_t)ref_stride + x_search_index,
                                                      ref_stride,
                                                      pu_width,
                                                      pu_height);
@@ -4896,7 +4896,7 @@ static void pu_half_pel_refinement(
     {
         // L position
         search_region_index =
-            x_search_index + (int16_t)context_ptr->interpolated_stride * y_search_index;
+            x_search_index + (int32_t)context_ptr->interpolated_stride * y_search_index;
         distortion_left_pos =
             (context_ptr->fractional_search_method == SSD_SEARCH)
                 ? spatial_full_distortion_kernel(context_ptr->sb_src_ptr,
@@ -4985,7 +4985,7 @@ static void pu_half_pel_refinement(
         }
         // T position
         search_region_index =
-            x_search_index + (int16_t)context_ptr->interpolated_stride * y_search_index;
+            x_search_index + (int32_t)context_ptr->interpolated_stride * y_search_index;
         distortion_top_pos =
             (context_ptr->fractional_search_method == SSD_SEARCH)
                 ? spatial_full_distortion_kernel(context_ptr->sb_src_ptr,
@@ -5030,7 +5030,7 @@ static void pu_half_pel_refinement(
         }
 
         // b position
-        search_region_index += (int16_t)context_ptr->interpolated_stride;
+        search_region_index += (int32_t)context_ptr->interpolated_stride;
         distortion_bottom_pos =
             (context_ptr->fractional_search_method == SSD_SEARCH)
                 ? spatial_full_distortion_kernel(context_ptr->sb_src_ptr,
@@ -5076,7 +5076,7 @@ static void pu_half_pel_refinement(
 
         // TL position
         search_region_index =
-            x_search_index + (int16_t)context_ptr->interpolated_stride * y_search_index;
+            x_search_index + (int32_t)context_ptr->interpolated_stride * y_search_index;
         distortion_top_left_pos =
             (context_ptr->fractional_search_method == SSD_SEARCH)
                 ? spatial_full_distortion_kernel(context_ptr->sb_src_ptr,
@@ -5167,7 +5167,7 @@ static void pu_half_pel_refinement(
         }
 
         // BR position
-        search_region_index += (int16_t)context_ptr->interpolated_stride;
+        search_region_index += (int32_t)context_ptr->interpolated_stride;
         distortion_bottom_right_pos =
             (context_ptr->fractional_search_method == SSD_SEARCH)
                 ? spatial_full_distortion_kernel(context_ptr->sb_src_ptr,
@@ -10825,6 +10825,10 @@ EbErrorType motion_estimate_sb(
                 context_ptr->half_pel_mode == SWITCHABLE_HP_MODE ? EX_HP_MODE :
                 context_ptr->half_pel_mode;
 #endif
+            // R2R FIX: no winner integer MV is set in special case like initial p_sb_best_mv for overlay case,
+            // then it sends dirty p_sb_best_mv to MD, initializing it is necessary
+            for(uint32_t pi = 0; pi < MAX_ME_PU_COUNT; pi++)
+                context_ptr->p_sb_best_mv[li][ri][pi] = 0;
         }
     }
     // HME: Perform Hierachical Motion Estimation for all refrence frames.

--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -4733,7 +4733,7 @@ void interpolate_search_region_avc(
             context_ptr->pos_b_buffer[list_index][ref_pic_index],
             context_ptr->interpolated_stride,
             search_area_width_for_asm,
-            search_area_height + ME_FILTER_TAP + 1,
+            search_area_height + ME_FILTER_TAP,
             context_ptr->avctemp_buffer,
             EB_FALSE,
             2,
@@ -4748,7 +4748,7 @@ void interpolate_search_region_avc(
             context_ptr->pos_h_buffer[list_index][ref_pic_index],
             context_ptr->interpolated_stride,
             search_area_width_for_asm,
-            search_area_height + 2,
+            search_area_height + 1,
             context_ptr->avctemp_buffer,
             EB_FALSE,
             2,
@@ -4763,7 +4763,7 @@ void interpolate_search_region_avc(
             context_ptr->pos_j_buffer[list_index][ref_pic_index],
             context_ptr->interpolated_stride,
             search_area_width_for_asm,
-            search_area_height + 2,
+            search_area_height + 1,
             context_ptr->avctemp_buffer,
             EB_FALSE,
             2,
@@ -11713,11 +11713,11 @@ EbErrorType motion_estimate_sb(
                                          ->interpolated_full_stride[list_index][ref_pic_index]),
                                 context_ptr->interpolated_full_stride[list_index][ref_pic_index],
 #if MUS_ME_FP
-                                (uint32_t)context_ptr->sa_width[list_index][ref_pic_index] + (BLOCK_SIZE_64 - 1),
-                                (uint32_t)context_ptr->sa_height[list_index][ref_pic_index] + (BLOCK_SIZE_64 - 1),
+                                MAX(1, (uint32_t)context_ptr->sa_width[list_index][ref_pic_index]) + (BLOCK_SIZE_64 - 1),
+                                MAX(1, (uint32_t)context_ptr->sa_height[list_index][ref_pic_index]) + (BLOCK_SIZE_64 - 1),
 #else
-                                (uint32_t)search_area_width + (BLOCK_SIZE_64 - 1),
-                                (uint32_t)search_area_height + (BLOCK_SIZE_64 - 1),
+                                MAX(1, (uint32_t)search_area_width) + (BLOCK_SIZE_64 - 1),
+                                MAX(1, (uint32_t)search_area_height) + (BLOCK_SIZE_64 - 1),
 #endif
                                 8);
 
@@ -11909,11 +11909,11 @@ EbErrorType motion_estimate_sb(
                                  context_ptr->interpolated_full_stride[list_index][ref_pic_index]),
                             context_ptr->interpolated_full_stride[list_index][ref_pic_index],
 #if MUS_ME_FP
-                            (uint32_t)context_ptr->sa_width[list_index][ref_pic_index] + (BLOCK_SIZE_64 - 1),
-                            (uint32_t)context_ptr->sa_height[list_index][ref_pic_index] + (BLOCK_SIZE_64 - 1),
+                            MAX(1, (uint32_t)context_ptr->sa_width[list_index][ref_pic_index]) + (BLOCK_SIZE_64 - 1),
+                            MAX(1, (uint32_t)context_ptr->sa_height[list_index][ref_pic_index]) + (BLOCK_SIZE_64 - 1),
 #else
-                            (uint32_t)search_area_width + (BLOCK_SIZE_64 - 1),
-                            (uint32_t)search_area_height + (BLOCK_SIZE_64 - 1),
+                            MAX(1, (uint32_t)search_area_width) + (BLOCK_SIZE_64 - 1),
+                            MAX(1, (uint32_t)search_area_height) + (BLOCK_SIZE_64 - 1),
 #endif
                             8);
 

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -4058,6 +4058,16 @@ void perform_simple_picture_analysis_for_overlay(PictureParentControlSet     *pc
     else
         pcs_ptr->chroma_downsampled_picture_ptr = input_picture_ptr;
 
+    // R2R FIX: copying input_picture_ptr to input_padded_picture_ptr for motion_estimate_sb needs it
+    {
+        uint8_t *pa = input_padded_picture_ptr->buffer_y + input_padded_picture_ptr->origin_x +
+                      input_padded_picture_ptr->origin_y * input_padded_picture_ptr->stride_y;
+        uint8_t *in = input_picture_ptr->buffer_y + input_picture_ptr->origin_x +
+                      input_picture_ptr->origin_y * input_picture_ptr->stride_y;
+        for (uint32_t row = 0; row < input_picture_ptr->height; row++)
+            EB_MEMCPY(pa + row * input_padded_picture_ptr->stride_y, in + row * input_picture_ptr->stride_y, sizeof(uint8_t) * input_picture_ptr->width);
+    }
+
     // Pad input picture to complete border SBs
     pad_picture_to_multiple_of_sb_dimensions(
         input_padded_picture_ptr);


### PR DESCRIPTION
## Description

In includes 4 part changes below:
1, to set int32_t recon_offset in half pixel spatial_full_distortion_kernel()
Found it gets crash in a special case  for invalid memory access in function spatial_full_distortion_kernel() function, and root cause the input big recon_offset value does not reasonable, actually it’s a minus value and converted to be unsigned int, which makes it taken as very big value, this error is not fatal for it does not always access invalid memory;
2, to initialized context_ptr->p_sb_best_mv[] in beginning of function motion_estimate_sb()
Found the ME output MVs always get r2r and something the MV value could be very big, then checked the ME module and found this overlay test is very special, it generates search_window size 0x0 of one block in full pixels searching part, then the context_ptr->p_sb_best_mv[] array is not updated at all, which is used to output MVs to MD, then I memset it to 0 and found output MVs do not that much “r2r” as before.
3, copying input_padded_picture_ptr in perform_simple_picture_analysis_for_overlay()
to avoid motion_estimate_sb use dirty input_padded_picture_ptr data
Found distortion value calculated in function nxm_sad_kernel() function is always gets r2r, double checked the input pixels data, it is from input_padded_picture_ptr, which is also gets r2r, then root caused the function perform_simple_picture_analysis_for_overlay() only updates pixels data in input_picture_ptr and forget updates input_padded_picture_ptr’s. 
4, increase interpolate height by 1 in interpolate_search_region_avc() to
avoid r2r in last line pixels data in pos_h_buffer and pos_j_buffer
After above 3 changes, the full pixels test(setting -subpel 0 in cmdline) does not get r2r now, then focused on sub_pixel searching code in ME for ME output MVs still get r2r, sa_width and sa_height are 0 for overlay picture, it results in only 63x63 pixels are interpolated in interpolate_search_region_avc(), while distortion calculating r2r needs 64x64 interpolated pixels, fixing it by limit interpolate win to be min 64x64 for fixing overlay r2r, this change does not impact non-overlay pictures for sa_width and sa_height is 0 for only overlay picture.


## Issue:
Fixes #929 
