### PR TITLE
fix 2 16bits memory leaks 

### DIFF
--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.c
@@ -453,9 +453,6 @@ EbErrorType picture_control_set_ctor(PictureControlSet *object_ptr, EbPtr object
                eb_recon_picture_buffer_desc_ctor,
                (EbPtr)&input_pic_buf_desc_init_data);
     }
-    EB_NEW(object_ptr->recon_picture16bit_ptr,
-           eb_recon_picture_buffer_desc_ctor,
-           (EbPtr)&coeff_buffer_desc_init_data);
     // Film Grain Picture Buffer
     if (init_data_ptr->film_grain_noise_level) {
         if (is_16bit) {

--- a/Source/Lib/Encoder/Codec/EbReferenceObject.c
+++ b/Source/Lib/Encoder/Codec/EbReferenceObject.c
@@ -174,11 +174,6 @@ EbErrorType eb_reference_object_ctor(EbReferenceObject *reference_object,
             picture_buffer_desc_init_data_ptr,
             picture_buffer_desc_init_data_16bit_ptr.bit_depth);
     }
-    picture_buffer_desc_init_data_16bit_ptr.split_mode = EB_FALSE;
-    picture_buffer_desc_init_data_16bit_ptr.bit_depth  = EB_10BIT;
-    EB_NEW(reference_object->reference_picture16bit,
-           eb_picture_buffer_desc_ctor,
-           (EbPtr)&picture_buffer_desc_init_data_16bit_ptr);
     picture_buffer_desc_init_data_16bit_ptr.bit_depth = EB_8BIT;
     if (picture_buffer_desc_init_data_ptr->mfmv) {
         //MFMV map is 8x8 based.


### PR DESCRIPTION
**Test command:**
../Bin/Debug/SvtAv1EncApp -i /bits/480x264.y4m  -n 1 -b test.ivf

**No fps or quality impact.**

Hi @hassount ,
is it possible to add some memory leak check for ci? else we always can get some memory leak.

thanks