### PR TITLE
EbPacketizationProcess: do not push alt ref frame to undisplayed queue

### DIFF
--- a/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
@@ -568,10 +568,10 @@ static void encode_tu(EncodeContext *encode_context_ptr, int frames, int total_b
         uint32_t size = src_stream_ptr->n_filled_len;
         dst -= size;
         memmove(dst, src_stream_ptr->p_buffer, size);
-        if (i != last) {
-            //lost frame is displayable frame, other are unsidplayed
+        //1. The last frame is a displayable frame, others are undisplayed.
+        //2. We do not push alt ref frame since the overlay frame will carry the pts.
+        if (i != last && !queue_entry_ptr->is_alt_ref)
             push_undisplayed_frame(encode_context_ptr, wrapper);
-        }
     }
     if (frames > 1)
         sort_undisplayed_frame(encode_context_ptr);


### PR DESCRIPTION
Test command:
SvtAv1EncApp -i test.y4m -intra-period 31  -b test.ivf  -n 200

It will print out:
"Bug, too many frames in undisplayed queue"

Root cause:
The overlay frame is not a show_existing frame, it will carry a pts.
So we do not need to push it's counterpart(alt ref frame) to undisplayed queue.