### PR TITLE
Super-resolution support for inter pictures

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -1264,6 +1264,7 @@ typedef enum ATTRIBUTE_PACKED {
 #define SCALE_NUMERATOR 8
 #define SUPERRES_SCALE_BITS 3
 #define SUPERRES_SCALE_DENOMINATOR_MIN (SCALE_NUMERATOR + 1)
+#define NUM_SCALES 8
 
 //*********************************************************************************************************************//
 // assert.h

--- a/Source/Lib/Common/Codec/EbMcp.c
+++ b/Source/Lib/Common/Codec/EbMcp.c
@@ -166,6 +166,7 @@ void generate_padding(
 /** generate_padding16_bit()
 is used to pad the target picture. The horizontal padding happens first and then the vertical padding.
 */
+// TODO: generate_padding() and generate_padding16() functions are not aligned, inputs according to comments are wrong
 void generate_padding16_bit(
     EbByte   src_pic, //output paramter, pointer to the source picture to be padded.
     uint32_t src_stride, //input paramter, the stride of the source picture to be padded.

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -2719,12 +2719,13 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                          ->reference_picture_wrapper_ptr->object_ptr)
                                         ->reference_picture;
 
-                                if (is_16bit) {
+                                if (is_16bit)
                                     ref_pic_list0 =
                                         ((EbReferenceObject *)pcs_ptr->parent_pcs_ptr
                                              ->reference_picture_wrapper_ptr->object_ptr)
                                             ->reference_picture16bit;
 
+                                if (is_16bit && !(scs_ptr->static_config.superres_mode > SUPERRES_NONE)) {
                                     av1_inter_prediction_16bit_pipeline(
                                         pcs_ptr,
                                         blk_ptr->interp_filters,
@@ -3316,74 +3317,75 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                     : (EbPictureBufferDesc *)NULL;
                             }
 
-                                    if (is_16bit) {
-                                        av1_inter_prediction_16bit_pipeline(
-                                            pcs_ptr,
-                                            blk_ptr->interp_filters,
-                                            blk_ptr,
-                                            blk_ptr->prediction_unit_array->ref_frame_type,
-                                            &context_ptr->mv_unit,
-                                            0, //use_intrabc,
-                                            blk_ptr->prediction_unit_array->motion_mode,
-                                            0, //use_precomputed_obmc,
-                                            0,
-                                            blk_ptr->compound_idx,
-                                            &blk_ptr->interinter_comp,
-                                            &sb_ptr->tile_info,
-                                            ep_luma_recon_neighbor_array,
-                                            ep_cb_recon_neighbor_array,
-                                            ep_cr_recon_neighbor_array,
-                                            blk_ptr->is_interintra_used,
-                                            blk_ptr->interintra_mode,
-                                            blk_ptr->use_wedge_interintra,
-                                            blk_ptr->interintra_wedge_index,
-                                            context_ptr->blk_origin_x,
-                                            context_ptr->blk_origin_y,
-                                            blk_geom->bwidth,
-                                            blk_geom->bheight,
-                                            ref_pic_list0,
-                                            ref_pic_list1,
-                                            recon_buffer,
-                                            context_ptr->blk_origin_x,
-                                            context_ptr->blk_origin_y,
-                                            EB_TRUE,
-                                            (uint8_t)scs_ptr->static_config.encoder_bit_depth);
-                                    } else {
-                            av1_inter_prediction(
-                                pcs_ptr,
-                                blk_ptr->interp_filters,
-                                blk_ptr,
-                                blk_ptr->prediction_unit_array->ref_frame_type,
-                                &context_ptr->mv_unit,
-                                0, //use_intrabc,
-                                blk_ptr->prediction_unit_array->motion_mode,
-                                0, //use_precomputed_obmc,
-                                0,
-                                blk_ptr->compound_idx,
-                                &blk_ptr->interinter_comp,
-                                &sb_ptr->tile_info,
-                                ep_luma_recon_neighbor_array,
-                                ep_cb_recon_neighbor_array,
-                                ep_cr_recon_neighbor_array,
-                                blk_ptr->is_interintra_used,
-                                blk_ptr->interintra_mode,
-                                blk_ptr->use_wedge_interintra,
-                                blk_ptr->interintra_wedge_index,
 
-                                context_ptr->blk_origin_x,
-                                context_ptr->blk_origin_y,
-                                blk_geom->bwidth,
-                                blk_geom->bheight,
-                                ref_pic_list0,
-                                ref_pic_list1,
-                                recon_buffer,
-                                context_ptr->blk_origin_x,
-                                context_ptr->blk_origin_y,
-                                EB_TRUE,
-                                (uint8_t)scs_ptr->static_config.encoder_bit_depth);
+                            if (is_16bit && !(scs_ptr->static_config.superres_mode > SUPERRES_NONE)) {
+                                av1_inter_prediction_16bit_pipeline(
+                                    pcs_ptr,
+                                    blk_ptr->interp_filters,
+                                    blk_ptr,
+                                    blk_ptr->prediction_unit_array->ref_frame_type,
+                                    &context_ptr->mv_unit,
+                                    0, //use_intrabc,
+                                    blk_ptr->prediction_unit_array->motion_mode,
+                                    0, //use_precomputed_obmc,
+                                    0,
+                                    blk_ptr->compound_idx,
+                                    &blk_ptr->interinter_comp,
+                                    &sb_ptr->tile_info,
+                                    ep_luma_recon_neighbor_array,
+                                    ep_cb_recon_neighbor_array,
+                                    ep_cr_recon_neighbor_array,
+                                    blk_ptr->is_interintra_used,
+                                    blk_ptr->interintra_mode,
+                                    blk_ptr->use_wedge_interintra,
+                                    blk_ptr->interintra_wedge_index,
+                                    context_ptr->blk_origin_x,
+                                    context_ptr->blk_origin_y,
+                                    blk_geom->bwidth,
+                                    blk_geom->bheight,
+                                    ref_pic_list0,
+                                    ref_pic_list1,
+                                    recon_buffer,
+                                    context_ptr->blk_origin_x,
+                                    context_ptr->blk_origin_y,
+                                    EB_TRUE,
+                                    (uint8_t)scs_ptr->static_config.encoder_bit_depth);
+                            } else {
+                                av1_inter_prediction(
+                                    pcs_ptr,
+                                    blk_ptr->interp_filters,
+                                    blk_ptr,
+                                    blk_ptr->prediction_unit_array->ref_frame_type,
+                                    &context_ptr->mv_unit,
+                                    0, //use_intrabc,
+                                    blk_ptr->prediction_unit_array->motion_mode,
+                                    0, //use_precomputed_obmc,
+                                    0,
+                                    blk_ptr->compound_idx,
+                                    &blk_ptr->interinter_comp,
+                                    &sb_ptr->tile_info,
+                                    ep_luma_recon_neighbor_array,
+                                    ep_cb_recon_neighbor_array,
+                                    ep_cr_recon_neighbor_array,
+                                    blk_ptr->is_interintra_used,
+                                    blk_ptr->interintra_mode,
+                                    blk_ptr->use_wedge_interintra,
+                                    blk_ptr->interintra_wedge_index,
+
+                                    context_ptr->blk_origin_x,
+                                    context_ptr->blk_origin_y,
+                                    blk_geom->bwidth,
+                                    blk_geom->bheight,
+                                    ref_pic_list0,
+                                    ref_pic_list1,
+                                    recon_buffer,
+                                    context_ptr->blk_origin_x,
+                                    context_ptr->blk_origin_y,
+                                    EB_TRUE,
+                                    (uint8_t)scs_ptr->static_config.encoder_bit_depth);
+                            }
                         }
                     }
-                            }
                     context_ptr->txb_itr = 0;
                     // Transform Loop
                     context_ptr->md_context->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds].y_has_coeff[0] = EB_FALSE;

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -1547,8 +1547,10 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(SequenceControlSet * scs_ptr,
         // Level                Settings
         // 0                    Injection off (Hsan: but not derivation as used by MV ref derivation)
         // 1                    On
+        // Note: global motion is off for frames with super-res enabled
 #if GLOBAL_WARPED_MOTION
-    if (scs_ptr->static_config.enable_global_motion == EB_TRUE) {
+    if (scs_ptr->static_config.enable_global_motion == EB_TRUE &&
+        pcs_ptr->parent_pcs_ptr->frame_superres_enabled == EB_FALSE) {
         if (context_ptr->pd_pass == PD_PASS_0)
             context_ptr->global_mv_injection = 0;
         else if (context_ptr->pd_pass == PD_PASS_1)

--- a/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.c
@@ -35,14 +35,14 @@ void global_motion_estimation(PictureParentControlSet *pcs_ptr, MeContext *conte
     EbPictureBufferDesc *ref_picture_ptr;
     SequenceControlSet * scs_ptr = (SequenceControlSet *)pcs_ptr->scs_wrapper_ptr->object_ptr;
     pa_reference_object =
-        (EbPaReferenceObject *)pcs_ptr->pa_reference_picture_wrapper_ptr->object_ptr;
+            (EbPaReferenceObject *)pcs_ptr->pa_reference_picture_wrapper_ptr->object_ptr;
     quarter_picture_ptr =
-        (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED)
+            (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED)
             ? (EbPictureBufferDesc *)pa_reference_object->quarter_filtered_picture_ptr
             : (EbPictureBufferDesc *)pa_reference_object->quarter_decimated_picture_ptr;
 #endif
     uint32_t num_of_list_to_search =
-        (pcs_ptr->slice_type == P_SLICE) ? (uint32_t)REF_LIST_0 : (uint32_t)REF_LIST_1;
+            (pcs_ptr->slice_type == P_SLICE) ? (uint32_t)REF_LIST_0 : (uint32_t)REF_LIST_1;
 
     for (uint32_t list_index = REF_LIST_0; list_index <= num_of_list_to_search; ++list_index) {
         uint32_t num_of_ref_pic_to_search;
@@ -73,15 +73,15 @@ void global_motion_estimation(PictureParentControlSet *pcs_ptr, MeContext *conte
                 reference_object = (EbPaReferenceObject *)context_ptr->alt_ref_reference_ptr;
             else
                 reference_object =
-                    (EbPaReferenceObject *)pcs_ptr->ref_pa_pic_ptr_array[list_index][ref_pic_index]
-                        ->object_ptr;
+                        (EbPaReferenceObject *)pcs_ptr->ref_pa_pic_ptr_array[list_index][ref_pic_index]
+                                ->object_ptr;
 
 #if GLOBAL_WARPED_MOTION
             // Set the source and the reference picture to be used by the global motion search
             // based on the input search mode
             if (pcs_ptr->gm_level == GM_DOWN) {
                 quarter_ref_pic_ptr =
-                    (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED)
+                        (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED)
                         ? (EbPictureBufferDesc *)reference_object->quarter_filtered_picture_ptr
                         : (EbPictureBufferDesc *)reference_object->quarter_decimated_picture_ptr;
                 ref_picture_ptr   = quarter_ref_pic_ptr;

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -887,16 +887,6 @@ void *initial_rate_control_kernel(void *input_ptr) {
             release_pa_reference_objects(scs_ptr, pcs_ptr);
 
             //****************************************************
-            // Picture resizing for super-res tool
-            //****************************************************
-
-            // Scale picture if super-res is used
-            if(scs_ptr->static_config.superres_mode > SUPERRES_NONE){
-                init_resize_picture(pcs_ptr->scs_ptr,
-                                    pcs_ptr);
-            }
-
-            //****************************************************
             // Input Motion Analysis Results into Reordering Queue
             //****************************************************
 

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -32,6 +32,8 @@
 #include "EbRateDistortionCost.h"
 #include "aom_dsp_rtcd.h"
 #include "EbLog.h"
+#include "EbResize.h"
+
 #if INFR_OPT
 #define INCRMENT_CAND_TOTAL_COUNT(cnt)                                                     \
     MULTI_LINE_MACRO_BEGIN cnt++;                                                          \
@@ -45,6 +47,7 @@
         SVT_LOG(" ERROR: reaching limit for MODE_DECISION_CANDIDATE_MAX_COUNT %i\n", cnt); \
     MULTI_LINE_MACRO_END
 #endif
+
 int8_t av1_ref_frame_type(const MvReferenceFrame *const rf);
 int    av1_filter_intra_allowed_bsize(uint8_t enable_filter_intra, BlockSize bs);
 #define INT_MAX 2147483647 // maximum (signed) int value
@@ -335,6 +338,18 @@ void inter_intra_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                       ->reference_picture;
     else
         ref_pic_list1 = (EbPictureBufferDesc *)NULL;
+
+    // Use scaled references if resolution of the reference is different from that of the input
+    if(ref_pic_list0 != NULL)
+        use_scaled_rec_refs_if_needed(pcs_ptr,
+                                      pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr,
+                                      (EbReferenceObject *)pcs_ptr->ref_pic_ptr_array[list_idx0][list_idx0]->object_ptr,
+                                      &ref_pic_list0);
+    if(ref_pic_list1 != NULL)
+        use_scaled_rec_refs_if_needed(pcs_ptr,
+                                      pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr,
+                                      (EbReferenceObject *)pcs_ptr->ref_pic_ptr_array[list_idx1][ref_idx_l1]->object_ptr,
+                                      &ref_pic_list1);
 
     mv_unit.pred_direction = candidate_ptr->prediction_direction[0];
 
@@ -3463,9 +3478,16 @@ void obmc_motion_refinement(PictureControlSet *pcs_ptr, struct ModeDecisionConte
     {
         uint8_t              ref_idx  = get_ref_frame_idx(candidate->ref_frame_type);
         uint8_t              list_idx = get_list_idx(candidate->ref_frame_type);
+
         EbPictureBufferDesc *reference_picture =
             ((EbReferenceObject *)pcs_ptr->ref_pic_ptr_array[list_idx][ref_idx]->object_ptr)
                 ->reference_picture;
+
+        use_scaled_rec_refs_if_needed(pcs_ptr,
+                                      pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr,
+                                      (EbReferenceObject *)pcs_ptr->ref_pic_ptr_array[list_idx][ref_idx]->object_ptr,
+                                      &reference_picture);
+
         Yv12BufferConfig ref_buf;
         link_eb_to_aom_buffer_desc_8bit(reference_picture, &ref_buf);
 

--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -24,6 +24,7 @@
 #include "EbLambdaRateTables.h"
 
 #include "EbLog.h"
+#include "EbResize.h"
 
 #define AVCCODEL
 /********************************************
@@ -10246,6 +10247,17 @@ void hme_sb(
                 (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED)
                     ? (EbPictureBufferDesc *)reference_object->sixteenth_filtered_picture_ptr
                     : (EbPictureBufferDesc *)reference_object->sixteenth_decimated_picture_ptr;
+
+            EbPictureBufferDesc *input_picture_ptr = pcs_ptr->enhanced_picture_ptr;
+
+            // Use scaled source references if resolution of the reference is different that of the input
+            use_scaled_source_refs_if_needed(pcs_ptr,
+                                             input_picture_ptr,
+                                             reference_object,
+                                             &ref_pic_ptr,
+                                             &quarter_ref_pic_ptr,
+                                             &sixteenth_ref_pic_ptr);
+
             if (pcs_ptr->temporal_layer_index > 0 || list_index == 0) {
                 if (context_ptr->update_hme_search_center_flag)
                     hme_mv_center_check(ref_pic_ptr,
@@ -10960,14 +10972,28 @@ EbErrorType motion_estimate_sb(
 #else
             // Set 1/4 and 1/16 ME reference buffer(s); filtered or decimated
             quarter_ref_pic_ptr =
-                (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED)
+                    (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED)
                     ? (EbPictureBufferDesc *)reference_object->quarter_filtered_picture_ptr
                     : (EbPictureBufferDesc *)reference_object->quarter_decimated_picture_ptr;
 
             sixteenth_ref_pic_ptr =
-                (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED)
+                    (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED)
                     ? (EbPictureBufferDesc *)reference_object->sixteenth_filtered_picture_ptr
                     : (EbPictureBufferDesc *)reference_object->sixteenth_decimated_picture_ptr;
+
+            uint16_t ref_picture_number = (uint16_t)pcs_ptr->ref_pic_poc_array[list_index][ref_pic_index];
+            UNUSED(ref_picture_number);
+
+            // Use scaled source references if resolution of the reference is different that of the input
+            use_scaled_source_refs_if_needed(pcs_ptr,
+                                             input_picture_ptr,
+                                             reference_object,
+                                             &ref_pic_ptr,
+                                             &quarter_ref_pic_ptr,
+                                             &sixteenth_ref_pic_ptr);
+
+            //printf("frame #%d, width=%d, ref pic=%d, ALT-REF %d\n", (int)pcs_ptr->picture_number, input_picture_ptr->width, ref_picture_number, (int)context_ptr->me_alt_ref);
+
             if (pcs_ptr->temporal_layer_index > 0 || list_index == 0) {
                 // A - The MV center for Tier0 search could be either (0,0), or
                 // HME A - Set HME MV Center

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.c
@@ -2093,6 +2093,8 @@ EbErrorType picture_parent_control_set_ctor(PictureParentControlSet *object_ptr,
     object_ptr->frame_width = init_data_ptr->picture_width;
     object_ptr->frame_height = init_data_ptr->picture_height;
 
+    object_ptr->superres_denom = SCALE_NUMERATOR;
+
     return return_error;
 }
 

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -873,6 +873,7 @@ typedef struct PictureParentControlSet {
     uint16_t frame_height;
 
     EbBool frame_superres_enabled;
+    uint8_t superres_denom;
 #if MUS_ME
     uint8_t prune_ref_based_me;
 #endif

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -27,6 +27,8 @@
 #include "EbUtility.h"
 #include "EbLog.h"
 #include "common_dsp_rtcd.h"
+#include "EbResize.h"
+
 /************************************************
  * Defines
  ************************************************/
@@ -83,6 +85,8 @@ typedef struct PictureDecisionContext
     uint8_t       last_i_picture_sc_detection;
     uint64_t      key_poc;
 } PictureDecisionContext;
+
+void init_resize_picture(SequenceControlSet* scs_ptr, PictureParentControlSet* pcs_ptr);
 
 uint64_t  get_ref_poc(PictureDecisionContext *context, uint64_t curr_picture_number, int32_t delta_poc)
 {
@@ -5551,6 +5555,18 @@ void* picture_decision_kernel(void *input_ptr)
                             pcs_ptr->me_segments_row_count = (uint8_t)(scs_ptr->me_segment_row_count_array[pcs_ptr->temporal_layer_index]);
                             pcs_ptr->me_segments_total_count = (uint16_t)(pcs_ptr->me_segments_column_count  * pcs_ptr->me_segments_row_count);
                             pcs_ptr->me_segments_completion_mask = 0;
+
+                            //****************************************************
+                            // Picture resizing for super-res tool
+                            //****************************************************
+
+                            // Scale picture if super-res is used
+                            if(scs_ptr->static_config.superres_mode > SUPERRES_NONE){
+                                init_resize_picture(pcs_ptr->scs_ptr,
+                                                    pcs_ptr);
+                            }
+
+                            //****************************************************
 
                             // Post the results to the ME processes
                             {

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -1010,7 +1010,6 @@ void *picture_manager_kernel(void *input_ptr) {
 
                         // Update pcs_ptr->mi_stride
                         child_pcs_ptr->mi_stride = pic_width_in_sb * (scs_ptr->sb_size_pix >> MI_SIZE_LOG2);
-                        assert(child_pcs_ptr->mi_stride == entry_pcs_ptr->av1_cm->mi_stride);
 
                         // copy buffer info from the downsampled picture to the input frame 16 bit buffer
                         if(entry_pcs_ptr->frame_superres_enabled && scs_ptr->static_config.encoder_bit_depth > EB_8BIT){
@@ -1041,7 +1040,6 @@ void *picture_manager_kernel(void *input_ptr) {
 
                         // Update pcs_ptr->mi_stride
                         child_pcs_ptr->mi_stride = pic_width_in_sb * (scs_ptr->sb_size_pix >> MI_SIZE_LOG2);
-                        assert(child_pcs_ptr->mi_stride == entry_pcs_ptr->av1_cm->mi_stride);
 
                         // copy buffer info from the downsampled picture to the input frame 16 bit buffer
                         if(entry_pcs_ptr->frame_superres_enabled && scs_ptr->static_config.encoder_bit_depth > EB_8BIT){

--- a/Source/Lib/Encoder/Codec/EbReferenceObject.h
+++ b/Source/Lib/Encoder/Codec/EbReferenceObject.h
@@ -15,6 +15,8 @@ typedef struct EbReferenceObject {
     EbDctor              dctor;
     EbPictureBufferDesc *reference_picture;
     EbPictureBufferDesc *reference_picture16bit;
+    EbPictureBufferDesc *downscaled_reference_picture[NUM_SCALES];
+    EbPictureBufferDesc *downscaled_reference_picture16bit[NUM_SCALES];
     uint64_t             ref_poc;
     uint16_t             qp;
     EB_SLICE             slice_type;
@@ -39,6 +41,8 @@ typedef struct EbReferenceObject {
     StatStruct           stat_struct;
     EbHandle             referenced_area_mutex;
     uint64_t             referenced_area_avg;
+    int32_t              mi_cols;
+    int32_t              mi_rows;
 } EbReferenceObject;
 
 typedef struct EbReferenceObjectDescInitData {
@@ -52,11 +56,16 @@ typedef struct EbPaReferenceObject {
     EbPictureBufferDesc *sixteenth_decimated_picture_ptr;
     EbPictureBufferDesc *quarter_filtered_picture_ptr;
     EbPictureBufferDesc *sixteenth_filtered_picture_ptr;
+    // downscaled reference pointers
+    EbPictureBufferDesc *downscaled_input_padded_picture_ptr[NUM_SCALES];
+    EbPictureBufferDesc *downscaled_quarter_decimated_picture_ptr[NUM_SCALES];
+    EbPictureBufferDesc *downscaled_sixteenth_decimated_picture_ptr[NUM_SCALES];
+    EbPictureBufferDesc *downscaled_quarter_filtered_picture_ptr[NUM_SCALES];
+    EbPictureBufferDesc *downscaled_sixteenth_filtered_picture_ptr[NUM_SCALES];
     uint16_t             variance[MAX_NUMBER_OF_TREEBLOCKS_PER_PICTURE];
     uint8_t              y_mean[MAX_NUMBER_OF_TREEBLOCKS_PER_PICTURE];
     EB_SLICE             slice_type;
     uint32_t             dependent_pictures_count; //number of pic using this reference frame
-
 } EbPaReferenceObject;
 
 typedef struct EbPaReferenceObjectDescInitData {

--- a/Source/Lib/Encoder/Codec/EbResize.c
+++ b/Source/Lib/Encoder/Codec/EbResize.c
@@ -1049,7 +1049,6 @@ EbErrorType sb_params_init_pcs(SequenceControlSet *scs_ptr, PictureParentControl
 
 static uint8_t get_denom_idx(uint8_t superres_denom){
     uint8_t denom_idx = (uint8_t)(superres_denom - SCALE_NUMERATOR - 1);
-    assert(denom_idx >= 0);
     return denom_idx;
 }
 

--- a/Source/Lib/Encoder/Codec/EbResize.c
+++ b/Source/Lib/Encoder/Codec/EbResize.c
@@ -172,7 +172,20 @@ static const InterpKernel filteredinterp_filters875[(1 << RS_SUBPEL_BITS)] = {
         {-1, 3, -9, 17, 112, 10, -7, 3},  {-1, 3, -8, 15, 112, 12, -7, 2},
 };
 
+void downsample_decimation_input_picture(PictureParentControlSet *pcs_ptr,
+                                         EbPictureBufferDesc *input_padded_picture_ptr,
+                                         EbPictureBufferDesc *quarter_decimated_picture_ptr,
+                                         EbPictureBufferDesc *sixteenth_decimated_picture_ptr);
+
+void downsample_filtering_input_picture(PictureParentControlSet *pcs_ptr,
+                                        EbPictureBufferDesc *input_padded_picture_ptr,
+                                        EbPictureBufferDesc *quarter_picture_ptr,
+                                        EbPictureBufferDesc *sixteenth_picture_ptr);
+
 void calculate_scaled_size_helper(uint16_t *dim, uint8_t denom);
+
+void pad_and_decimate_filtered_pic(
+        PictureParentControlSet *picture_control_set_ptr_central);
 
 static int get_down2_length(int length, int steps) {
     for (int s = 0; s < steps; ++s) length = (length + 1) >> 1;
@@ -301,8 +314,8 @@ static void down2_symodd(const uint8_t *const input, int length, uint8_t *output
 
 static const InterpKernel *choose_interp_filter(int in_length, int out_length) {
     int out_length16 = out_length * 16;
-    // TODO: use original filter in libaom
-    if (out_length16 >= in_length * 16) return filteredinterp_filters1000;
+    if (out_length16 >= in_length * 16)
+        return filteredinterp_filters1000;
     if (out_length16 >= in_length * 16)
         return filteredinterp_filters875; // wrong
     else if (out_length16 >= in_length * 13)
@@ -718,9 +731,9 @@ static void highbd_fill_arr_to_col(uint16_t *img, int stride, int len, uint16_t 
     for (i = 0; i < len; ++i, iptr += stride) { *iptr = *aptr++; }
 }
 
-EbErrorType av1_highbd_resize_plane(const uint16_t *const input, int height, int width,
-                                    int in_stride, uint16_t *output, int height2, int width2,
-                                    int out_stride, int bd) {
+static EbErrorType av1_highbd_resize_plane(const uint16_t *const input, int height, int width,
+                                           int in_stride, uint16_t *output, int height2, int width2,
+                                           int out_stride, int bd) {
     int       i;
     uint16_t *intbuf;
     uint16_t *tmpbuf;
@@ -772,13 +785,17 @@ void save_YUV_to_file_highbd(char *filename, uint16_t *buffer_y, uint16_t *buffe
                              uint16_t stride_u, uint16_t stride_v, uint16_t origin_y,
                              uint16_t origin_x, uint32_t ss_x, uint32_t ss_y);
 
-EbErrorType av1_resize_and_extend_frame(const EbPictureBufferDesc *src, EbPictureBufferDesc *dst,
-                                        int bd, const int num_planes, const uint32_t ss_x,
-                                        const uint32_t ss_y) {
+/*
+ * Resize frame according to dst resolution.
+ * Supports 8-bit / 10-bit and either packed or unpacked buffers
+ */
+static EbErrorType av1_resize_frame(const EbPictureBufferDesc *src, EbPictureBufferDesc *dst,
+                                    int bd, const int num_planes, const uint32_t ss_x,
+                                    const uint32_t ss_y, uint8_t is_packed) {
     uint16_t *src_buffer_highbd[MAX_MB_PLANE];
     uint16_t *dst_buffer_highbd[MAX_MB_PLANE];
 
-    if (bd > 8) {
+    if (bd > 8 && !is_packed) {
         EB_MALLOC_ARRAY(src_buffer_highbd[0], src->luma_size);
         EB_MALLOC_ARRAY(src_buffer_highbd[1], src->chroma_size);
         EB_MALLOC_ARRAY(src_buffer_highbd[2], src->chroma_size);
@@ -786,6 +803,13 @@ EbErrorType av1_resize_and_extend_frame(const EbPictureBufferDesc *src, EbPictur
         EB_MALLOC_ARRAY(dst_buffer_highbd[1], dst->chroma_size);
         EB_MALLOC_ARRAY(dst_buffer_highbd[2], dst->chroma_size);
         pack_highbd_pic(src, src_buffer_highbd, ss_x, ss_y, EB_TRUE);
+    }else{
+        src_buffer_highbd[0] = (uint16_t*)src->buffer_y;
+        src_buffer_highbd[1] = (uint16_t*)src->buffer_cb;
+        src_buffer_highbd[2] = (uint16_t*)src->buffer_cr;
+        dst_buffer_highbd[0] = (uint16_t*)dst->buffer_y;
+        dst_buffer_highbd[1] = (uint16_t*)dst->buffer_cb;
+        dst_buffer_highbd[2] = (uint16_t*)dst->buffer_cr;
     }
 
 #if DEBUG_SCALING
@@ -819,7 +843,7 @@ EbErrorType av1_resize_and_extend_frame(const EbPictureBufferDesc *src, EbPictur
                          1);
 #endif
 
-    for (int plane = 0; plane < AOMMIN(num_planes, MAX_MB_PLANE); ++plane) {
+    for (int plane = 0; plane <= AOMMIN(num_planes, MAX_MB_PLANE-1); ++plane) {
         if (bd > 8) {
             switch (plane) {
             case 0:
@@ -936,7 +960,7 @@ EbErrorType av1_resize_and_extend_frame(const EbPictureBufferDesc *src, EbPictur
                          1);
 #endif
 
-    if (bd > 8) {
+    if (bd > 8 && !is_packed) {
         unpack_highbd_pic(dst_buffer_highbd, dst, ss_x, ss_y, EB_TRUE);
 
         EB_FREE(src_buffer_highbd[0]);
@@ -947,10 +971,6 @@ EbErrorType av1_resize_and_extend_frame(const EbPictureBufferDesc *src, EbPictur
         EB_FREE(dst_buffer_highbd[2]);
     }
 
-    // TODO: extend frame borders
-    // use eb_extend_frame() instead
-    // aom_extend_frame_borders(dst, num_planes);
-
     return EB_ErrorNone;
 }
 
@@ -960,10 +980,12 @@ static INLINE unsigned int lcg_rand16(unsigned int *state) {
     return *state / 65536 % 32768;
 }
 
-// Given the superres configurations and the frame type, determine the denominator and
-// encoding resolution
-void calc_superres_params(superres_params_type *spr_params, SequenceControlSet *scs_ptr,
-                          PictureParentControlSet *pcs_ptr) {
+/*
+ * Given the superres configurations and the frame type, determine the denominator and
+ * encoding resolution
+ */
+static void calc_superres_params(superres_params_type *spr_params, SequenceControlSet *scs_ptr,
+                                 PictureParentControlSet *pcs_ptr) {
     spr_params->superres_denom = SCALE_NUMERATOR;
     static unsigned int seed = 34567;
     FrameHeader *frm_hdr = &pcs_ptr->frm_hdr;
@@ -973,12 +995,9 @@ void calc_superres_params(superres_params_type *spr_params, SequenceControlSet *
     uint8_t cfg_kf_denom  = scs_ptr->static_config.superres_kf_denom;
     //uint8_t superres_qthres = scs_ptr->static_config.superres_qthres;
 
-    // For now, super-resolution can only be enabled for key frames or intra only frames
-    // In addition, it can only be enabled in case allow_intrabc is disabled and
+    // super-res can only be enabled in case allow_intrabc is disabled and
     // loop restoration is enabled
-    if ((frm_hdr->frame_type != KEY_FRAME &&
-        frm_hdr->frame_type != INTRA_ONLY_FRAME) ||
-        frm_hdr->allow_intrabc ||
+    if (frm_hdr->allow_intrabc ||
         !scs_ptr->seq_header.enable_restoration) { return; }
 
     // remove assertion when rest of the modes are implemented
@@ -1003,9 +1022,9 @@ void calc_superres_params(superres_params_type *spr_params, SequenceControlSet *
     calculate_scaled_size_helper(&spr_params->encoding_width, spr_params->superres_denom);
 }
 
-EbErrorType downscaled_source_buffer_desc_ctor(EbPictureBufferDesc **picture_ptr,
-                                               EbPictureBufferDesc * picture_ptr_for_reference,
-                                               superres_params_type  spr_params) {
+static EbErrorType downscaled_source_buffer_desc_ctor(EbPictureBufferDesc **picture_ptr,
+                                                      EbPictureBufferDesc * picture_ptr_for_reference,
+                                                      superres_params_type  spr_params) {
     EbPictureBufferDescInitData initData;
 
     initData.buffer_enable_mask = PICTURE_BUFFER_DESC_FULL_MASK;
@@ -1028,9 +1047,19 @@ EbErrorType sb_geom_init_pcs(SequenceControlSet *scs_ptr, PictureParentControlSe
 
 EbErrorType sb_params_init_pcs(SequenceControlSet *scs_ptr, PictureParentControlSet *pcs_ptr);
 
-EbErrorType scale_pcs_params(SequenceControlSet *scs_ptr, PictureParentControlSet *pcs_ptr,
-                             superres_params_type spr_params, uint16_t source_width,
-                             uint16_t source_height) {
+static uint8_t get_denom_idx(uint8_t superres_denom){
+    uint8_t denom_idx = (uint8_t)(superres_denom - SCALE_NUMERATOR - 1);
+    assert(denom_idx >= 0);
+    return denom_idx;
+}
+
+/*
+ * Modify encoder parameters and structures that depend on picture resolution
+ * Performed after a source picture has been scaled
+ */
+static EbErrorType scale_pcs_params(SequenceControlSet *scs_ptr, PictureParentControlSet *pcs_ptr,
+                                    superres_params_type spr_params, uint16_t source_width,
+                                    uint16_t source_height) {
     Av1Common *cm = pcs_ptr->av1_cm;
 
     // frame sizes
@@ -1067,29 +1096,492 @@ EbErrorType scale_pcs_params(SequenceControlSet *scs_ptr, PictureParentControlSe
     pcs_ptr->sb_total_count = picture_sb_width * picture_sb_height;
 
     // mi params
-    cm->mi_stride = picture_sb_width * (BLOCK_SIZE_64 / 4);
+    const uint16_t picture_sb_pix_width =
+            (uint16_t)((aligned_width + scs_ptr->sb_size_pix - 1) / scs_ptr->sb_size_pix);
+
+    cm->mi_stride = picture_sb_pix_width * (scs_ptr->sb_size_pix >> MI_SIZE_LOG2);
     cm->mi_cols   = aligned_width >> MI_SIZE_LOG2;
     cm->mi_rows   = aligned_height >> MI_SIZE_LOG2;
 
-    if (cm->frm_size.superres_denominator != SCALE_NUMERATOR) {
-        derive_input_resolution(&pcs_ptr->input_resolution,
-                                spr_params.encoding_width * spr_params.encoding_height);
+    derive_input_resolution(&pcs_ptr->input_resolution,
+                            spr_params.encoding_width * spr_params.encoding_height);
 
-        // create new picture level sb_params and sb_geom
-        sb_params_init_pcs(scs_ptr, pcs_ptr);
+    // create new picture level sb_params and sb_geom
+    sb_params_init_pcs(scs_ptr, pcs_ptr);
 
-        sb_geom_init_pcs(scs_ptr, pcs_ptr);
+    sb_geom_init_pcs(scs_ptr, pcs_ptr);
+
+    pcs_ptr->frm_hdr.use_ref_frame_mvs = 0;
+
+    return EB_ErrorNone;
+}
+
+/*
+ * Memory allocation for donwscaled reconstructed reference pictures
+ */
+static EbErrorType allocate_downscaled_reference_pics(EbPictureBufferDesc **downscaled_reference_picture_ptr,
+                                                      EbPictureBufferDesc **downscaled_reference_picture16bit,
+                                                      EbPictureBufferDesc *picture_ptr_for_reference,
+                                                      PictureParentControlSet *pcs_ptr) {
+
+    EbPictureBufferDescInitData ref_pic_buf_desc_init_data;
+
+    // Initialize the various Picture types
+    ref_pic_buf_desc_init_data.max_width = pcs_ptr->aligned_width;
+    ref_pic_buf_desc_init_data.max_height = pcs_ptr->aligned_height;
+    ref_pic_buf_desc_init_data.bit_depth = picture_ptr_for_reference->bit_depth;
+    ref_pic_buf_desc_init_data.color_format = picture_ptr_for_reference->color_format;
+    ref_pic_buf_desc_init_data.buffer_enable_mask = PICTURE_BUFFER_DESC_FULL_MASK;
+
+    ref_pic_buf_desc_init_data.left_padding = PAD_VALUE;
+    ref_pic_buf_desc_init_data.right_padding = PAD_VALUE;
+    ref_pic_buf_desc_init_data.top_padding = PAD_VALUE;
+    ref_pic_buf_desc_init_data.bot_padding = PAD_VALUE;
+    ref_pic_buf_desc_init_data.mfmv = pcs_ptr->scs_ptr->mfmv_enabled;
+
+    if (ref_pic_buf_desc_init_data.bit_depth == EB_10BIT) {
+        // Hsan: set split_mode to 0 to construct the packed reference buffer (used @ EP)
+        ref_pic_buf_desc_init_data.split_mode = EB_FALSE;
+        EB_NEW(*downscaled_reference_picture16bit,
+               eb_picture_buffer_desc_ctor,
+               (EbPtr)&ref_pic_buf_desc_init_data);
+
+        // Hsan: set split_mode to 1 to construct the unpacked reference buffer (used @ MD)
+        ref_pic_buf_desc_init_data.split_mode = EB_TRUE;
+        EB_NEW(*downscaled_reference_picture_ptr,
+               eb_picture_buffer_desc_ctor,
+               (EbPtr)&ref_pic_buf_desc_init_data);
+    } else {
+        // Hsan: set split_mode to 0 to as 8BIT input
+        ref_pic_buf_desc_init_data.split_mode = EB_FALSE;
+        EB_NEW(*downscaled_reference_picture_ptr,
+               eb_picture_buffer_desc_ctor,
+               (EbPtr)&ref_pic_buf_desc_init_data);
     }
 
     return EB_ErrorNone;
 }
 
+/*
+ * Memory allocation for donwscaled source reference pictures
+ */
+static EbErrorType allocate_downscaled_source_reference_pics(EbPictureBufferDesc **input_padded_picture_ptr,
+                                                             EbPictureBufferDesc **quarter_decimated_picture_ptr,
+                                                             EbPictureBufferDesc **quarter_filtered_picture_ptr,
+                                                             EbPictureBufferDesc **sixteenth_decimated_picture_ptr,
+                                                             EbPictureBufferDesc **sixteenth_filtered_picture_ptr,
+                                                             EbPictureBufferDesc *picture_ptr_for_reference,
+                                                             superres_params_type spr_params,
+                                                             uint8_t down_sampling_method_me_search){
+
+    EbPictureBufferDescInitData initData;
+
+    initData.buffer_enable_mask = PICTURE_BUFFER_DESC_LUMA_MASK;
+    initData.max_width          = spr_params.encoding_width;
+    initData.max_height         = spr_params.encoding_height;
+    initData.bit_depth          = picture_ptr_for_reference->bit_depth;
+    initData.color_format       = picture_ptr_for_reference->color_format;
+    initData.split_mode         = EB_TRUE;
+    initData.left_padding       = picture_ptr_for_reference->origin_x;
+    initData.right_padding      = picture_ptr_for_reference->origin_x;
+    initData.top_padding        = picture_ptr_for_reference->origin_y;
+    initData.bot_padding        = picture_ptr_for_reference->origin_y;
+
+    EB_NEW(*input_padded_picture_ptr, eb_picture_buffer_desc_ctor, (EbPtr)&initData);
+
+    initData.buffer_enable_mask = PICTURE_BUFFER_DESC_LUMA_MASK;
+    initData.max_width          = spr_params.encoding_width >> 1;
+    initData.max_height         = spr_params.encoding_height >> 1;
+    initData.bit_depth          = picture_ptr_for_reference->bit_depth;
+    initData.color_format       = picture_ptr_for_reference->color_format;
+    initData.split_mode         = EB_TRUE;
+    initData.left_padding       = picture_ptr_for_reference->origin_x >> 1;
+    initData.right_padding      = picture_ptr_for_reference->origin_x >> 1;
+    initData.top_padding        = picture_ptr_for_reference->origin_y >> 1;
+    initData.bot_padding        = picture_ptr_for_reference->origin_y >> 1;
+
+    EB_NEW(*quarter_decimated_picture_ptr, eb_picture_buffer_desc_ctor, (EbPtr)&initData);
+
+    initData.buffer_enable_mask = PICTURE_BUFFER_DESC_LUMA_MASK;
+    initData.max_width          = spr_params.encoding_width >> 2;
+    initData.max_height         = spr_params.encoding_height >> 2;
+    initData.bit_depth          = picture_ptr_for_reference->bit_depth;
+    initData.color_format       = picture_ptr_for_reference->color_format;
+    initData.split_mode         = EB_TRUE;
+    initData.left_padding       = picture_ptr_for_reference->origin_x >> 2;
+    initData.right_padding      = picture_ptr_for_reference->origin_x >> 2;
+    initData.top_padding        = picture_ptr_for_reference->origin_y >> 2;
+    initData.bot_padding        = picture_ptr_for_reference->origin_y >> 2;
+
+    EB_NEW(*sixteenth_decimated_picture_ptr, eb_picture_buffer_desc_ctor, (EbPtr)&initData);
+
+    if(down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED){
+
+        initData.buffer_enable_mask = PICTURE_BUFFER_DESC_LUMA_MASK;
+        initData.max_width          = spr_params.encoding_width >> 1;
+        initData.max_height         = spr_params.encoding_height >> 1;
+        initData.bit_depth          = picture_ptr_for_reference->bit_depth;
+        initData.color_format       = picture_ptr_for_reference->color_format;
+        initData.split_mode         = EB_TRUE;
+        initData.left_padding       = picture_ptr_for_reference->origin_x >> 1;
+        initData.right_padding      = picture_ptr_for_reference->origin_x >> 1;
+        initData.top_padding        = picture_ptr_for_reference->origin_y >> 1;
+        initData.bot_padding        = picture_ptr_for_reference->origin_y >> 1;
+
+        EB_NEW(*quarter_filtered_picture_ptr, eb_picture_buffer_desc_ctor, (EbPtr)&initData);
+
+        initData.buffer_enable_mask = PICTURE_BUFFER_DESC_LUMA_MASK;
+        initData.max_width          = spr_params.encoding_width >> 2;
+        initData.max_height         = spr_params.encoding_height >> 2;
+        initData.bit_depth          = picture_ptr_for_reference->bit_depth;
+        initData.color_format       = picture_ptr_for_reference->color_format;
+        initData.split_mode         = EB_TRUE;
+        initData.left_padding       = picture_ptr_for_reference->origin_x >> 2;
+        initData.right_padding      = picture_ptr_for_reference->origin_x >> 2;
+        initData.top_padding        = picture_ptr_for_reference->origin_y >> 2;
+        initData.bot_padding        = picture_ptr_for_reference->origin_y >> 2;
+
+        EB_NEW(*sixteenth_filtered_picture_ptr, eb_picture_buffer_desc_ctor, (EbPtr)&initData);
+
+    }
+
+    return EB_ErrorNone;
+}
+
+/*
+ * Allocate memory and perform scaling of the source reference picture (references to the current picture)
+ * and its decimated/filtered versions to match with the input picture resolution
+ * This is used in the open-loop stage.
+ */
+void scale_source_references(SequenceControlSet *scs_ptr,
+                             PictureParentControlSet *pcs_ptr,
+                             EbPictureBufferDesc *input_picture_ptr){
+
+    EbPaReferenceObject *reference_object;
+
+    uint8_t denom_idx = get_denom_idx(pcs_ptr->superres_denom);
+    const int32_t  num_planes = 0; // Y only
+    const uint32_t ss_x       = scs_ptr->subsampling_x;
+    const uint32_t ss_y       = scs_ptr->subsampling_y;
+
+    uint32_t num_of_list_to_search =
+            (pcs_ptr->slice_type == P_SLICE) ? (uint32_t)REF_LIST_0 : (uint32_t)REF_LIST_1;
+
+    for (uint8_t list_index = REF_LIST_0; list_index <= num_of_list_to_search; ++list_index) {
+        uint8_t ref_pic_index;
+
+        uint8_t num_of_ref_pic_to_search = (pcs_ptr->slice_type == P_SLICE)
+                                           ? pcs_ptr->ref_list0_count
+                                           : (list_index == REF_LIST_0) ? pcs_ptr->ref_list0_count
+                                                                        : pcs_ptr->ref_list1_count;
+
+        for (ref_pic_index = 0; ref_pic_index < num_of_ref_pic_to_search; ++ref_pic_index) {
+
+            reference_object = (EbPaReferenceObject *) pcs_ptr->ref_pa_pic_ptr_array[list_index][ref_pic_index]
+                    ->object_ptr;
+
+            uint64_t ref_picture_number = pcs_ptr->ref_pic_poc_array[list_index][ref_pic_index];
+            UNUSED(ref_picture_number);
+
+            EbPictureBufferDesc *ref_pic_ptr = reference_object->input_padded_picture_ptr;
+
+            // if the size of the reference pic is different than the size of the input pic, then scale references
+            if (ref_pic_ptr->width != input_picture_ptr->width){
+
+                if (reference_object->downscaled_input_padded_picture_ptr[denom_idx] == NULL){
+
+                    superres_params_type spr_params = {pcs_ptr->aligned_width, // encoding_width
+                                                       pcs_ptr->aligned_height, // encoding_height
+                                                       scs_ptr->static_config.superres_mode};
+
+                    // Allocate downsampled reference picture buffer descriptors
+                    allocate_downscaled_source_reference_pics(&reference_object->downscaled_input_padded_picture_ptr[denom_idx],
+                                                       &reference_object->downscaled_quarter_decimated_picture_ptr[denom_idx],
+                                                       &reference_object->downscaled_quarter_filtered_picture_ptr[denom_idx],
+                                                       &reference_object->downscaled_sixteenth_decimated_picture_ptr[denom_idx],
+                                                       &reference_object->downscaled_sixteenth_filtered_picture_ptr[denom_idx],
+                                                       ref_pic_ptr,
+                                                       spr_params,
+                                                       scs_ptr->down_sampling_method_me_search);
+
+                    EbPictureBufferDesc *down_ref_pic_ptr = reference_object->downscaled_input_padded_picture_ptr[denom_idx];
+
+                    // downsample input padded picture buffer
+                    av1_resize_frame(ref_pic_ptr,
+                                     down_ref_pic_ptr,
+                                     8, // only 8-bit buffer needed for open-loop processing
+                                     num_planes,
+                                     ss_x,
+                                     ss_y,
+                                     0 // is_packed
+                                     );
+
+                    generate_padding(down_ref_pic_ptr->buffer_y,
+                                     down_ref_pic_ptr->stride_y,
+                                     down_ref_pic_ptr->width,
+                                     down_ref_pic_ptr->height,
+                                     down_ref_pic_ptr->origin_x,
+                                     down_ref_pic_ptr->origin_y);
+
+                    downsample_decimation_input_picture(
+                            pcs_ptr,
+                            down_ref_pic_ptr,
+                            reference_object->downscaled_quarter_decimated_picture_ptr[denom_idx],
+                            reference_object->downscaled_sixteenth_decimated_picture_ptr[denom_idx]);
+
+                    // 1/4 & 1/16 input picture downsampling through filtering
+                    if (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) {
+                        downsample_filtering_input_picture(
+                                pcs_ptr,
+                                down_ref_pic_ptr,
+                                reference_object->downscaled_quarter_filtered_picture_ptr[denom_idx],
+                                reference_object->downscaled_sixteenth_filtered_picture_ptr[denom_idx]);
+                    }
+                }
+            }
+        }
+    }
+
+}
+
+/*
+ * Allocate memory and perform scaling of the input reference picture (current picture)
+ * and its decimated/filtered versions to match with the input picture resolution
+ * This is used in the open-loop stage.
+ */
+static void scale_input_references(PictureParentControlSet *pcs_ptr,
+                            superres_params_type superres_params) {
+
+    uint8_t denom_idx = get_denom_idx(superres_params.superres_denom);
+
+    // reference structures (padded pictures + downsampled versions)
+    EbPaReferenceObject *src_object = (EbPaReferenceObject *)pcs_ptr->pa_reference_picture_wrapper_ptr->object_ptr;
+    EbPictureBufferDesc *padded_pic_ptr = src_object->input_padded_picture_ptr;
+
+    if(src_object->downscaled_input_padded_picture_ptr[denom_idx] == NULL){
+        // Allocate downsampled reference picture buffer descriptors
+        allocate_downscaled_source_reference_pics(&src_object->downscaled_input_padded_picture_ptr[denom_idx],
+                                                  &src_object->downscaled_quarter_decimated_picture_ptr[denom_idx],
+                                                  &src_object->downscaled_quarter_filtered_picture_ptr[denom_idx],
+                                                  &src_object->downscaled_sixteenth_decimated_picture_ptr[denom_idx],
+                                                  &src_object->downscaled_sixteenth_filtered_picture_ptr[denom_idx],
+                                                  padded_pic_ptr,
+                                                  superres_params,
+                                                  pcs_ptr->scs_ptr->down_sampling_method_me_search);
+    }
+
+    padded_pic_ptr = src_object->downscaled_input_padded_picture_ptr[denom_idx];
+    EbPictureBufferDesc *input_picture_ptr = pcs_ptr->enhanced_picture_ptr;
+
+    generate_padding(input_picture_ptr->buffer_y,
+                     input_picture_ptr->stride_y,
+                     input_picture_ptr->width,
+                     input_picture_ptr->height,
+                     input_picture_ptr->origin_x,
+                     input_picture_ptr->origin_y);
+
+    for (uint32_t row = 0; row < (uint32_t)(input_picture_ptr->height + 2*input_picture_ptr->origin_y); row++)
+        EB_MEMCPY(padded_pic_ptr->buffer_y + row * padded_pic_ptr->stride_y,
+                  input_picture_ptr->buffer_y + row * input_picture_ptr->stride_y,
+                  sizeof(uint8_t) * input_picture_ptr->stride_y);
+
+    // 1/4 & 1/16 input picture decimation
+    downsample_decimation_input_picture(pcs_ptr,
+                                        padded_pic_ptr,
+                                        src_object->downscaled_quarter_decimated_picture_ptr[denom_idx],
+                                        src_object->downscaled_sixteenth_decimated_picture_ptr[denom_idx]);
+
+    // 1/4 & 1/16 input filtered picture
+    if (pcs_ptr->scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED)
+        downsample_filtering_input_picture(pcs_ptr,
+                                           padded_pic_ptr,
+                                           src_object->downscaled_quarter_filtered_picture_ptr[denom_idx],
+                                           src_object->downscaled_sixteenth_filtered_picture_ptr[denom_idx]);
+}
+
+/*
+ * Allocate memory and perform scaling of the reconstructed reference pictures
+ * to match with the input picture resolution
+ */
+void scale_rec_references(PictureControlSet *pcs_ptr,
+                          EbPictureBufferDesc *input_picture_ptr,
+                          uint8_t hbd_mode_decision){
+
+    EbReferenceObject *reference_object;
+
+    PictureParentControlSet *ppcs_ptr = pcs_ptr->parent_pcs_ptr;
+    SequenceControlSet *scs_ptr = ppcs_ptr->scs_ptr;
+
+    uint8_t denom_idx = get_denom_idx(ppcs_ptr->superres_denom);
+    const int32_t num_planes = av1_num_planes(&scs_ptr->seq_header.color_config);
+    const uint32_t ss_x = scs_ptr->subsampling_x;
+    const uint32_t ss_y = scs_ptr->subsampling_y;
+
+    uint32_t num_of_list_to_search =
+            (ppcs_ptr->slice_type == P_SLICE) ? (uint32_t)REF_LIST_0 : (uint32_t)REF_LIST_1;
+
+    for (uint8_t list_index = REF_LIST_0; list_index <= num_of_list_to_search; ++list_index) {
+        uint8_t ref_pic_index;
+
+        uint8_t num_of_ref_pic_to_search = (ppcs_ptr->slice_type == P_SLICE)
+                                           ? ppcs_ptr->ref_list0_count
+                                           : (list_index == REF_LIST_0) ? ppcs_ptr->ref_list0_count
+                                                                        : ppcs_ptr->ref_list1_count;
+
+        for (ref_pic_index = 0; ref_pic_index < num_of_ref_pic_to_search; ++ref_pic_index) {
+
+            reference_object = (EbReferenceObject *) pcs_ptr->ref_pic_ptr_array[list_index][ref_pic_index]
+                    ->object_ptr;
+
+            uint64_t ref_picture_number = ppcs_ptr->ref_pic_poc_array[list_index][ref_pic_index];
+            UNUSED(ref_picture_number);
+
+            EbPictureBufferDesc *ref_pic_ptr = hbd_mode_decision ? reference_object->reference_picture16bit : reference_object->reference_picture;
+
+            // if the size of the reference pic is different than the size of the input pic, then scale references
+            if (ref_pic_ptr->width != input_picture_ptr->width) {
+
+                EbPictureBufferDesc *down_ref_pic_ptr = hbd_mode_decision
+                                                        ? reference_object->downscaled_reference_picture16bit[denom_idx]
+                                                        : reference_object->downscaled_reference_picture[denom_idx];
+
+                if (down_ref_pic_ptr == NULL) {
+                    // Allocate downsampled reference picture buffer descriptors
+                    allocate_downscaled_reference_pics(&reference_object->downscaled_reference_picture[denom_idx],
+                                                       &reference_object->downscaled_reference_picture16bit[denom_idx],
+                                                       ref_pic_ptr,
+                                                       ppcs_ptr);
+
+                    down_ref_pic_ptr = hbd_mode_decision
+                                       ? reference_object->downscaled_reference_picture16bit[denom_idx]
+                                       : reference_object->downscaled_reference_picture[denom_idx];
+
+                    // downsample input padded picture buffer
+                    av1_resize_frame(ref_pic_ptr,
+                                     down_ref_pic_ptr,
+                                     down_ref_pic_ptr->bit_depth,
+                                     num_planes,
+                                     ss_x,
+                                     ss_y,
+                                     1 // is_packed
+                                     );
+
+                    if(down_ref_pic_ptr->bit_depth > EB_8BIT){
+                        generate_padding16_bit(down_ref_pic_ptr->buffer_y,
+                                         down_ref_pic_ptr->stride_y << 1,
+                                         down_ref_pic_ptr->width << 1,
+                                         down_ref_pic_ptr->height,
+                                         down_ref_pic_ptr->origin_x << 1,
+                                         down_ref_pic_ptr->origin_y);
+
+                        generate_padding16_bit(down_ref_pic_ptr->buffer_cb,
+                                         down_ref_pic_ptr->stride_cb << 1,
+                                         down_ref_pic_ptr->width,
+                                         down_ref_pic_ptr->height >> ss_y,
+                                         down_ref_pic_ptr->origin_x,
+                                         down_ref_pic_ptr->origin_y >> ss_y);
+
+                        generate_padding16_bit(down_ref_pic_ptr->buffer_cr,
+                                         down_ref_pic_ptr->stride_cr << 1,
+                                         down_ref_pic_ptr->width,
+                                         down_ref_pic_ptr->height >> ss_y,
+                                         down_ref_pic_ptr->origin_x,
+                                         down_ref_pic_ptr->origin_y >> ss_y);
+                    }else{
+                        generate_padding(down_ref_pic_ptr->buffer_y,
+                                         down_ref_pic_ptr->stride_y,
+                                         down_ref_pic_ptr->width,
+                                         down_ref_pic_ptr->height,
+                                         down_ref_pic_ptr->origin_x,
+                                         down_ref_pic_ptr->origin_y);
+
+                        generate_padding(down_ref_pic_ptr->buffer_cb,
+                                         down_ref_pic_ptr->stride_cb,
+                                         down_ref_pic_ptr->width >> ss_x,
+                                         down_ref_pic_ptr->height >> ss_y,
+                                         down_ref_pic_ptr->origin_x >> ss_x,
+                                         down_ref_pic_ptr->origin_y >> ss_y);
+
+                        generate_padding(down_ref_pic_ptr->buffer_cr,
+                                         down_ref_pic_ptr->stride_cr,
+                                         down_ref_pic_ptr->width >> ss_x,
+                                         down_ref_pic_ptr->height >> ss_y,
+                                         down_ref_pic_ptr->origin_x >> ss_x,
+                                         down_ref_pic_ptr->origin_y >> ss_y);
+                    }
+
+                    //printf("rescaled reference picture %d\n", (int)ref_picture_number);
+
+                }
+            }
+        }
+    }
+
+}
+
+/*
+ * Check if width of input and reference <reconstructed> pictures match.
+ * if not, return pointers to downscaled reference picture of the correct resolution
+ */
+void use_scaled_rec_refs_if_needed(PictureControlSet *pcs_ptr,
+                                   EbPictureBufferDesc *input_picture_ptr,
+                                   EbReferenceObject *ref_obj,
+                                   EbPictureBufferDesc **ref_pic){
+
+    if((*ref_pic)->width != input_picture_ptr->width){
+        uint8_t denom_idx = get_denom_idx(pcs_ptr->parent_pcs_ptr->superres_denom);
+
+        if(pcs_ptr->hbd_mode_decision){
+            assert(ref_obj->downscaled_reference_picture16bit[denom_idx] != NULL);
+            *ref_pic = ref_obj->downscaled_reference_picture16bit[denom_idx];
+        }else{
+            assert(ref_obj->downscaled_reference_picture[denom_idx] != NULL);
+            *ref_pic = ref_obj->downscaled_reference_picture[denom_idx];
+        }
+    }
+    assert((*ref_pic)->width == input_picture_ptr->width);
+
+}
+
+/*
+ * Check if width of input and reference <source> pictures match.
+ * if not, return pointers to downscaled reference picture of the correct resolution.
+ * These are used in the open-loop stage.
+ */
+void use_scaled_source_refs_if_needed(PictureParentControlSet *pcs_ptr,
+                                      EbPictureBufferDesc *input_picture_ptr,
+                                      EbPaReferenceObject *ref_obj,
+                                      EbPictureBufferDesc **ref_pic_ptr,
+                                      EbPictureBufferDesc **quarter_ref_pic_ptr,
+                                      EbPictureBufferDesc **sixteenth_ref_pic_ptr){
+
+    if ((*ref_pic_ptr)->width != input_picture_ptr->width) {
+        uint8_t denom_idx = get_denom_idx(pcs_ptr->superres_denom);
+
+        assert(ref_obj->downscaled_input_padded_picture_ptr[denom_idx] != NULL);
+
+        *ref_pic_ptr = ref_obj->downscaled_input_padded_picture_ptr[denom_idx];
+        *quarter_ref_pic_ptr = (pcs_ptr->scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) ?
+                               ref_obj->downscaled_quarter_filtered_picture_ptr[denom_idx] :
+                               ref_obj->downscaled_quarter_decimated_picture_ptr[denom_idx];
+        *sixteenth_ref_pic_ptr = (pcs_ptr->scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED) ?
+                                 ref_obj->downscaled_sixteenth_filtered_picture_ptr[denom_idx] :
+                                 ref_obj->downscaled_sixteenth_decimated_picture_ptr[denom_idx];
+    }
+    assert((*ref_pic_ptr)->width == input_picture_ptr->width);
+}
+
+/*
+ * If super-res is ON, determine super-res denominator for current picture,
+ * perform resizing of source picture and
+ * adjust resolution related parameters
+ */
 void init_resize_picture(SequenceControlSet *scs_ptr, PictureParentControlSet *pcs_ptr) {
     EbPictureBufferDesc *input_picture_ptr = pcs_ptr->enhanced_picture_ptr;
 
     superres_params_type spr_params = {input_picture_ptr->width, // encoding_width
                                        input_picture_ptr->height, // encoding_height
-                                       scs_ptr->static_config.superres_mode};
+                                       scs_ptr->static_config.superres_denom};
 
     // determine super-resolution parameters - encoding resolution
     // given configs and frame type
@@ -1100,6 +1592,8 @@ void init_resize_picture(SequenceControlSet *scs_ptr, PictureParentControlSet *p
         scs_ptr->seq_header.enable_superres = 1; // enable sequence level super-res flag
                                                  // if super-res is ON for any frame
 
+        pcs_ptr->superres_denom = spr_params.superres_denom;
+
         // Allocate downsampled picture buffer descriptor
         downscaled_source_buffer_desc_ctor(
             &pcs_ptr->enhanced_downscaled_picture_ptr, input_picture_ptr, spr_params);
@@ -1109,12 +1603,16 @@ void init_resize_picture(SequenceControlSet *scs_ptr, PictureParentControlSet *p
         const uint32_t ss_y       = scs_ptr->subsampling_y;
 
         // downsample picture buffer
-        av1_resize_and_extend_frame(input_picture_ptr,
-                                    pcs_ptr->enhanced_downscaled_picture_ptr,
-                                    pcs_ptr->enhanced_downscaled_picture_ptr->bit_depth,
-                                    num_planes,
-                                    ss_x,
-                                    ss_y);
+        av1_resize_frame(input_picture_ptr,
+                         pcs_ptr->enhanced_downscaled_picture_ptr,
+                         pcs_ptr->enhanced_downscaled_picture_ptr->bit_depth,
+                         num_planes,
+                         ss_x,
+                         ss_y,
+                         0 // is_packed
+                         );
+
+        // TODO: apply padding to enchanced picture ptr? The original one is padded
 
         // use downscaled picture instead of original res for mode decision, encoding loop etc
         // after temporal filtering and motion estimation
@@ -1124,5 +1622,12 @@ void init_resize_picture(SequenceControlSet *scs_ptr, PictureParentControlSet *p
 
         scale_pcs_params(
             scs_ptr, pcs_ptr, spr_params, input_picture_ptr->width, input_picture_ptr->height);
+
+        scale_input_references(pcs_ptr, spr_params);
+
+        if(pcs_ptr->slice_type != I_SLICE){
+            scale_source_references(scs_ptr, pcs_ptr, pcs_ptr->enhanced_picture_ptr);
+        }
+
     }
 }

--- a/Source/Lib/Encoder/Codec/EbResize.h
+++ b/Source/Lib/Encoder/Codec/EbResize.h
@@ -21,6 +21,7 @@
 #include "EbInterPrediction.h"
 #include "EbSequenceControlSet.h"
 #include "EbSuperRes.h"
+#include "EbReferenceObject.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -32,9 +33,25 @@ typedef struct {
     uint8_t  superres_denom;
 } superres_params_type;
 
-EbErrorType av1_resize_and_extend_frame(const EbPictureBufferDesc* src, EbPictureBufferDesc* dst,
-                                        int bd, const int num_planes, const uint32_t ss_x,
-                                        const uint32_t ss_y);
+void scale_source_references(SequenceControlSet *scs_ptr,
+                             PictureParentControlSet *pcs_ptr,
+                             EbPictureBufferDesc *input_picture_ptr);
+
+void scale_rec_references(PictureControlSet *pcs_ptr,
+                          EbPictureBufferDesc *input_picture_ptr,
+                          uint8_t hbd_mode_decision);
+
+void use_scaled_rec_refs_if_needed(PictureControlSet *pcs_ptr,
+                                   EbPictureBufferDesc *input_picture_ptr,
+                                   EbReferenceObject *ref_obj,
+                                   EbPictureBufferDesc **ref_pic);
+
+void use_scaled_source_refs_if_needed(PictureParentControlSet *pcs_ptr,
+                                      EbPictureBufferDesc *input_picture_ptr,
+                                      EbPaReferenceObject *ref_obj,
+                                      EbPictureBufferDesc **ref_pic_ptr,
+                                      EbPictureBufferDesc **quarter_ref_pic_ptr,
+                                      EbPictureBufferDesc **sixteenth_ref_pic_ptr);
 
 void init_resize_picture(SequenceControlSet* scs_ptr, PictureParentControlSet* pcs_ptr);
 

--- a/Source/Lib/Encoder/Codec/EbRestProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRestProcess.c
@@ -49,6 +49,9 @@ typedef struct RestContext {
     int32_t *rst_tmpbuf;
 } RestContext;
 
+void pack_highbd_pic(const EbPictureBufferDesc *pic_ptr, uint16_t *buffer_16bit[3], uint32_t ss_x,
+                     uint32_t ss_y, EbBool include_padding);
+void copy_buffer_info(EbPictureBufferDesc *src_ptr, EbPictureBufferDesc *dst_ptr);
 void recon_output(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr);
 void eb_av1_loop_restoration_filter_frame(Yv12BufferConfig *frame, Av1Common *cm,
                                           int32_t optimized_lr);
@@ -255,6 +258,16 @@ void get_own_recon(SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
     }
 }
 
+void set_unscaled_input_16bit(PictureControlSet *pcs_ptr){
+    uint16_t *unscaled_input_frame16bit[MAX_MB_PLANE];
+    unscaled_input_frame16bit[0] = (uint16_t *)pcs_ptr->input_frame16bit->buffer_y;
+    unscaled_input_frame16bit[1] = (uint16_t *)pcs_ptr->input_frame16bit->buffer_cb;
+    unscaled_input_frame16bit[2] = (uint16_t *)pcs_ptr->input_frame16bit->buffer_cr;
+
+    pack_highbd_pic(pcs_ptr->parent_pcs_ptr->enhanced_unscaled_picture_ptr, unscaled_input_frame16bit, 1, 1, EB_TRUE);
+    copy_buffer_info(pcs_ptr->parent_pcs_ptr->enhanced_unscaled_picture_ptr, pcs_ptr->input_frame16bit);
+}
+
 void derive_blk_pointers_enc(EbPictureBufferDesc *recon_picture_buf, int32_t plane,
                              int32_t blk_col_px, int32_t blk_row_px,
                              void **pp_blk_recon_buf, int32_t *recon_stride,
@@ -437,6 +450,9 @@ void eb_av1_superres_upscale_frame(struct Av1Common *cm,
     EbPictureBufferDesc *src = ps_recon_pic_temp;
     EbPictureBufferDesc *dst = recon_ptr;
 
+    // get the bit-depth from the encoder config instead of from the recon ptr
+    int bit_depth = scs_ptr->static_config.encoder_bit_depth;
+
     for (int plane = 0; plane < num_planes; ++plane) {
         uint8_t *src_buf, *dst_buf;
         int32_t src_stride, dst_stride;
@@ -450,7 +466,7 @@ void eb_av1_superres_upscale_frame(struct Av1Common *cm,
 
         av1_upscale_normative_rows(cm, (const uint8_t *) src_buf, src_stride, dst_buf,
                                    dst_stride, src->height >> sub_x,
-                                   sub_x, src->bit_depth, is_16bit);
+                                   sub_x, bit_depth, is_16bit);
     }
 
     // free the memory
@@ -500,15 +516,13 @@ void *rest_kernel(void *input_ptr) {
 
             // ------- start: Normative upscaling - super-resolution tool
             if(!av1_superres_unscaled(&cm->frm_size)) {
-
                 eb_av1_superres_upscale_frame(cm,
                                               pcs_ptr,
                                               scs_ptr);
 
-                uint16_t picture_sb_width = (uint16_t)(
-                        (cm->frm_size.superres_upscaled_width + scs_ptr->sb_sz - 1) / scs_ptr->sb_sz);
-                cm->mi_stride = picture_sb_width * (BLOCK_SIZE_64 / 4);
-                cm->mi_cols = cm->frm_size.superres_upscaled_width >> MI_SIZE_LOG2;
+                if(scs_ptr->static_config.is_16bit_pipeline || is_16bit){
+                    set_unscaled_input_16bit(pcs_ptr);
+                }
             }
             // ------- end: Normative upscaling - super-resolution tool
             get_own_recon(scs_ptr, pcs_ptr, context_ptr,

--- a/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
@@ -2990,7 +2990,7 @@ static void adjust_filter_strength(PictureParentControlSet *picture_control_set_
     // TODO: apply further refinements to the filter parameters according to 1st pass statistics
 }
 
-static void pad_and_decimate_filtered_pic(
+void pad_and_decimate_filtered_pic(
     PictureParentControlSet *picture_control_set_ptr_central) {
     // reference structures (padded pictures + downsampled versions)
     EbPaReferenceObject *src_object =

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2892,9 +2892,9 @@ static EbErrorType verify_settings(
                 "only SUPERRES_NONE (0), SUPERRES_FIXED (1) and SUPERRES_RANDOM (2) are currently implemented \n", channel_number + 1, config->superres_mode, 0, 2);
         return_error = EB_ErrorBadParameter;
     }
-
-    if (config->superres_mode > 0 && (config->input_stat_file || config->output_stat_file)){
-        SVT_LOG("Error instance %u: superres cannot be enabled in 2-pass mode yet \n", channel_number + 1);
+    
+    if (config->superres_mode > 0 && ((config->input_stat_file || config->output_stat_file))){
+        SVT_LOG("Error instance %u: superres is not supported for 2-pass\n", channel_number + 1);
         return_error = EB_ErrorBadParameter;
     }
 

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2892,7 +2892,7 @@ static EbErrorType verify_settings(
                 "only SUPERRES_NONE (0), SUPERRES_FIXED (1) and SUPERRES_RANDOM (2) are currently implemented \n", channel_number + 1, config->superres_mode, 0, 2);
         return_error = EB_ErrorBadParameter;
     }
-    
+
     if (config->superres_mode > 0 && ((config->input_stat_file || config->output_stat_file))){
         SVT_LOG("Error instance %u: superres is not supported for 2-pass\n", channel_number + 1);
         return_error = EB_ErrorBadParameter;


### PR DESCRIPTION
Implementation of the following features at the encoder side:
- Scaling and super-resolution of inter pictures (intra was already supported)
- Reference scaling
- Clean-up of av1_inter_prediction() to align scaled and unscaled reference path

If -superres-mode 0 (default), bitstreams should match the master branch.