### PR TITLE
valigrnd fix for mode_decision_update_neighbor_arrays

### DIFF
--- a/Source/Lib/Encoder/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Encoder/Codec/EbEntropyCoding.c
@@ -5147,10 +5147,9 @@ static INLINE int get_vartx_max_txsize(/*const MbModeInfo *xd,*/ BlockSize bsize
 }
 static INLINE int max_block_wide(const MacroBlockD *xd, BlockSize bsize, int plane) {
     int                                   max_blocks_wide = block_size_wide[bsize];
-    const struct macroblockd_plane *const pd              = &xd->plane[plane];
 
     if (xd->mb_to_right_edge < 0)
-        max_blocks_wide += xd->mb_to_right_edge >> (3 + pd->subsampling_x);
+        max_blocks_wide += xd->mb_to_right_edge >> (3 + (plane == 0 ? 0 : 1));
 
     // Scale the width in the transform block unit.
     return max_blocks_wide >> tx_size_wide_log2[0];
@@ -5158,10 +5157,9 @@ static INLINE int max_block_wide(const MacroBlockD *xd, BlockSize bsize, int pla
 
 static INLINE int max_block_high(const MacroBlockD *xd, BlockSize bsize, int plane) {
     int                                   max_blocks_high = block_size_high[bsize];
-    const struct macroblockd_plane *const pd              = &xd->plane[plane];
 
     if (xd->mb_to_bottom_edge < 0)
-        max_blocks_high += xd->mb_to_bottom_edge >> (3 + pd->subsampling_y);
+        max_blocks_high += xd->mb_to_bottom_edge >> (3 + (plane == 0 ? 0 : 1));
 
     // Scale the height in the transform block unit.
     return max_blocks_high >> tx_size_high_log2[0];

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -1265,10 +1265,10 @@ void bipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, PictureC
             const uint8_t      inter_direction      = me_block_results_ptr->direction;
             const uint8_t      list0_ref_index      = me_block_results_ptr->ref_idx_l0;
             const uint8_t      list1_ref_index      = me_block_results_ptr->ref_idx_l1;
-            if (list0_ref_index > context_ptr->md_max_ref_count - 1 ||
-                list1_ref_index > context_ptr->md_max_ref_count - 1)
-                continue;
             if (inter_direction == 2) {
+                if (list0_ref_index > context_ptr->md_max_ref_count - 1 ||
+                    list1_ref_index > context_ptr->md_max_ref_count - 1)
+                    continue;
                 // (Best_L0, 8 Best_L1 neighbors)
                 for (bipred_index = 0; bipred_index < BIPRED_3x3_REFINMENT_POSITIONS;
                      ++bipred_index) {

--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -8552,13 +8552,13 @@ EbErrorType biprediction_compensation(MeContext *context_ptr, uint32_t pu_index,
     return return_error;
 }
 
-uint8_t skip_bi_pred(PictureParentControlSet *pcs_ptr, uint8_t ref_type,
-                     uint8_t ref_type_table[7]) {
+uint8_t skip_bi_pred(PictureParentControlSet *pcs_ptr, uint8_t ref_type, uint8_t ref_type_table[7],
+                     uint8_t size) {
     if (!pcs_ptr->prune_unipred_at_me) return 1;
 
     uint8_t allow_cand = 0;
     uint8_t ref_idx;
-    for (ref_idx = 0; ref_idx < PRUNE_REF_ME_TH; ref_idx++) {
+    for (ref_idx = 0; ref_idx < MIN(PRUNE_REF_ME_TH, size); ref_idx++) {
         if (ref_type == ref_type_table[ref_idx]) allow_cand = 1;
     }
     return allow_cand;
@@ -8622,8 +8622,8 @@ EbErrorType bi_prediction_search(SequenceControlSet *scs_ptr, MeContext *context
                     svt_get_ref_frame_type(REF_LIST_0, first_list_ref_pict_idx);
                 uint8_t to_inject_ref_type_1 =
                     svt_get_ref_frame_type(REF_LIST_1, second_list_ref_pict_idx);
-                uint8_t add_bi = skip_bi_pred(pcs_ptr, to_inject_ref_type_0, ref_type_table);
-                add_bi += skip_bi_pred(pcs_ptr, to_inject_ref_type_1, ref_type_table);
+                uint8_t add_bi = skip_bi_pred(pcs_ptr, to_inject_ref_type_0, ref_type_table, *total_me_candidate_index);
+                add_bi += skip_bi_pred(pcs_ptr, to_inject_ref_type_1, ref_type_table, *total_me_candidate_index);
 #if MUS_ME
                 //if one of the references is skipped at ME, do not consider bi for this cand
                 if (context_ptr->hme_results[REF_LIST_0][first_list_ref_pict_idx].do_ref == 0 ||
@@ -8656,7 +8656,7 @@ EbErrorType bi_prediction_search(SequenceControlSet *scs_ptr, MeContext *context
              first_list_ref_pict_idx++) {
             uint8_t to_inject_ref_type_0 =
                 svt_get_ref_frame_type(REF_LIST_0, first_list_ref_pict_idx);
-            uint8_t add_bi = skip_bi_pred(pcs_ptr, to_inject_ref_type_0, ref_type_table);
+            uint8_t add_bi = skip_bi_pred(pcs_ptr, to_inject_ref_type_0, ref_type_table,*total_me_candidate_index);
 #if MUS_ME
             //if one of the references is skipped at ME, do not consider bi for this cand
             if (context_ptr->hme_results[REF_LIST_0][0].do_ref == 0 ||
@@ -8685,7 +8685,7 @@ EbErrorType bi_prediction_search(SequenceControlSet *scs_ptr, MeContext *context
              second_list_ref_pict_idx++) {
             uint8_t to_inject_ref_type_0 =
                 svt_get_ref_frame_type(REF_LIST_0, first_list_ref_pict_idx);
-            uint8_t add_bi = skip_bi_pred(pcs_ptr, to_inject_ref_type_0, ref_type_table);
+            uint8_t add_bi = skip_bi_pred(pcs_ptr, to_inject_ref_type_0, ref_type_table,*total_me_candidate_index);
 #if MUS_ME
             //if one of the references is skipped at ME, do not consider bi for this cand
             if (context_ptr->hme_results[REF_LIST_1][0].do_ref == 0 ||

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -740,8 +740,10 @@ void md_update_all_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionCont
     context_ptr->blk_ptr = &context_ptr->md_blk_arr_nsq[last_blk_index_mds];
     uint8_t avail_blk_flag = context_ptr->md_local_blk_unit[last_blk_index_mds].avail_blk_flag;
 
-    mode_decision_update_neighbor_arrays(
-        pcs_ptr, context_ptr, last_blk_index_mds, EB_FALSE);
+    if (avail_blk_flag) {
+        mode_decision_update_neighbor_arrays(
+            pcs_ptr, context_ptr, last_blk_index_mds, EB_FALSE);
+    }
 
     update_mi_map(context_ptr,
                   context_ptr->blk_ptr,

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -4925,10 +4925,9 @@ static INLINE int get_vartx_max_txsize(/*const MbModeInfo *xd,*/ BlockSize bsize
 
 static INLINE int max_block_wide(const MacroBlockD *xd, BlockSize bsize, int plane) {
     int                                   max_blocks_wide = block_size_wide[bsize];
-    const struct macroblockd_plane *const pd              = &xd->plane[plane];
 
     if (xd->mb_to_right_edge < 0)
-        max_blocks_wide += xd->mb_to_right_edge >> (3 + pd->subsampling_x);
+        max_blocks_wide += xd->mb_to_right_edge >> (3 + (plane == 0 ? 0 : 1));
 
     // Scale the width in the transform block unit.
     return max_blocks_wide >> tx_size_wide_log2[0];
@@ -4936,10 +4935,9 @@ static INLINE int max_block_wide(const MacroBlockD *xd, BlockSize bsize, int pla
 
 static INLINE int max_block_high(const MacroBlockD *xd, BlockSize bsize, int plane) {
     int                                   max_blocks_high = block_size_high[bsize];
-    const struct macroblockd_plane *const pd              = &xd->plane[plane];
 
     if (xd->mb_to_bottom_edge < 0)
-        max_blocks_high += xd->mb_to_bottom_edge >> (3 + pd->subsampling_y);
+        max_blocks_high += xd->mb_to_bottom_edge >> (3 + (plane == 0 ? 0 : 1));
 
     // Scale the height in the transform block unit.
     return max_blocks_high >> tx_size_high_log2[0];


### PR DESCRIPTION
Issue #733 
This PR fixes:

```
Conditional jump or move depends on uninitialised value(s)
   at 0x504AE27: mode_decision_update_neighbor_arrays (EbProductCodingLoop.c:107)
   by 0x504BD5F: md_update_all_neighbour_arrays (EbProductCodingLoop.c:743)
   by 0x504BDEF: md_update_all_neighbour_arrays_multiple (EbProductCodingLoop.c:762)
   by 0x50590B2: mode_decision_sb (EbProductCodingLoop.c:8433)
   by 0x4FD3D3F: enc_dec_kernel (EbEncDecProcess.c:3104)
   by 0x5EA5DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
   by 0x64B9EAC: clone (in /usr/lib64/libc-2.17.so)

Use of uninitialised value of size 8
   at 0x504AFA5: mode_decision_update_neighbor_arrays (EbProductCodingLoop.c:164)
   by 0x504BD5F: md_update_all_neighbour_arrays (EbProductCodingLoop.c:743)
   by 0x504BDEF: md_update_all_neighbour_arrays_multiple (EbProductCodingLoop.c:762)
   by 0x50590B2: mode_decision_sb (EbProductCodingLoop.c:8433)
   by 0x4FD3D3F: enc_dec_kernel (EbEncDecProcess.c:3104)
   by 0x5EA5DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
   by 0x64B9EAC: clone (in /usr/lib64/libc-2.17.so)

Use of uninitialised value of size 8
   at 0x504B026: mode_decision_update_neighbor_arrays (EbProductCodingLoop.c:182)
   by 0x504BD5F: md_update_all_neighbour_arrays (EbProductCodingLoop.c:743)
   by 0x504BDEF: md_update_all_neighbour_arrays_multiple (EbProductCodingLoop.c:762)
   by 0x50590B2: mode_decision_sb (EbProductCodingLoop.c:8433)
   by 0x4FD3D3F: enc_dec_kernel (EbEncDecProcess.c:3104)
   by 0x5EA5DD4: start_thread (in /usr/lib64/libpthread-2.17.so)
   by 0x64B9EAC: clone (in /usr/lib64/libc-2.17.so)
```