### PR TITLE
AVX2 kernel implementation

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/cfl_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/cfl_avx2.c
@@ -277,3 +277,109 @@ static INLINE __m256i _mm256_addl_epi16(__m256i a) {
         } while (src < end);
     }
 }
+
+void cfl_luma_subsampling_420_hbd_avx2(const uint16_t *input, int32_t input_stride,
+                                       int16_t *output_q3, int32_t width, int32_t height) {
+    const int      luma_stride = input_stride << 1;
+    __m256i *      row         = (__m256i *)output_q3;
+    const __m256i *row_end     = row + (height >> 1) * CFL_BUF_LINE_I256;
+    do {
+        if (width == 4) {
+            const __m128i top     = _mm_loadl_epi64((__m128i *)input);
+            const __m128i bot     = _mm_loadl_epi64((__m128i *)(input + input_stride));
+            __m128i       sum     = _mm_add_epi16(top, bot);
+            sum                   = _mm_hadd_epi16(sum, sum);
+            *((int *)row)         = _mm_cvtsi128_si32(_mm_add_epi16(sum, sum));
+        } else if (width == 8) {
+            const __m128i top = _mm_loadu_si128((__m128i *)input);
+            const __m128i bot = _mm_loadu_si128((__m128i *)(input + input_stride));
+            __m128i       sum = _mm_add_epi16(top, bot);
+            sum               = _mm_hadd_epi16(sum, sum);
+            _mm_storel_epi64((__m128i *)row, _mm_add_epi16(sum, sum));
+        } else if (width == 16) {
+            __m256i top = _mm256_loadu_si256((__m256i *)input);
+            __m256i bot = _mm256_loadu_si256((__m256i *)(input + input_stride));
+            __m256i sum = _mm256_add_epi16(top, bot);
+            sum         = _mm256_hadd_epi16(sum, sum);
+            sum         = _mm256_add_epi16(sum, sum);
+            _mm_storel_epi64((__m128i *)row, _mm256_castsi256_si128(sum));
+            int16_t *ptr = (int16_t *)row;
+            _mm_storel_epi64((__m128i *)(ptr+4), _mm256_extracti128_si256(sum,1));
+        } else {
+            __m256i top   = _mm256_loadu_si256((__m256i *)input);
+            __m256i bot   = _mm256_loadu_si256((__m256i *)(input + input_stride));
+            __m256i sum   = _mm256_add_epi16(top, bot);
+            __m256i top_1 = _mm256_loadu_si256((__m256i *)(input + 16));
+            __m256i bot_1 = _mm256_loadu_si256((__m256i *)(input + 16 + input_stride));
+            __m256i sum_1 = _mm256_add_epi16(top_1, bot_1);
+            __m256i hsum  = _mm256_hadd_epi16(sum, sum_1);
+            hsum          = _mm256_permute4x64_epi64(hsum, _MM_SHUFFLE(3, 1, 2, 0));
+            hsum          = _mm256_add_epi16(hsum, hsum);
+            _mm256_storeu_si256(row, hsum);
+            if (width == 64) {
+                top           = _mm256_loadu_si256((__m256i *)(input + 32));
+                bot           = _mm256_loadu_si256((__m256i *)(input + 32 +input_stride));
+                sum           = _mm256_add_epi16(top, bot);
+                top_1         = _mm256_loadu_si256((__m256i *)(input + 48));
+                bot_1         = _mm256_loadu_si256((__m256i *)(input + 48 + input_stride));
+                sum_1         = _mm256_add_epi16(top_1, bot_1);
+                hsum          = _mm256_hadd_epi16(sum, sum_1);
+                hsum          = _mm256_permute4x64_epi64(hsum, _MM_SHUFFLE(3, 1, 2, 0));
+                hsum          = _mm256_add_epi16(hsum, hsum);
+                _mm256_storeu_si256(row + 1, hsum);
+            }
+        }
+        input += luma_stride;
+    } while ((row += CFL_BUF_LINE_I256) < row_end);
+}
+
+void cfl_luma_subsampling_420_lbd_avx2(const uint8_t *input, int32_t input_stride,
+                                       int16_t *output_q3, int32_t width, int32_t height) {
+    const __m128i  twos_128    = _mm_set1_epi8(2);
+    const __m256i  twos_256    = _mm256_set1_epi8(2); // Thirty two twos
+    const int      luma_stride = input_stride << 1;
+    __m256i *      row         = (__m256i *)output_q3;
+    const __m256i *row_end     = row + (height >> 1) * CFL_BUF_LINE_I256;
+    do {
+        if (width == 4) {
+            __m128i top       = _mm_cvtsi32_si128(*((int *)input));
+            top               = _mm_maddubs_epi16(top, twos_128);
+            __m128i bot       = _mm_cvtsi32_si128(*((int *)(input + input_stride)));
+            bot               = _mm_maddubs_epi16(bot, twos_128);
+            const __m128i sum = _mm_add_epi16(top, bot);
+            _mm_storeh_epi32((__m128i *)row, sum);
+        } else if (width == 8) {
+            __m128i top       = _mm_loadl_epi64((__m128i *)input);
+            top               = _mm_maddubs_epi16(top, twos_128);
+            __m128i bot       = _mm_loadl_epi64((__m128i *)(input + input_stride));
+            bot               = _mm_maddubs_epi16(bot, twos_128);
+            const __m128i sum = _mm_add_epi16(top, bot);
+            _mm_storel_epi64((__m128i *)row, sum);
+        } else if (width == 16) {
+            __m128i top       = _mm_loadu_si128((__m128i *)input);
+            top               = _mm_maddubs_epi16(top, twos_128);
+            __m128i bot       = _mm_loadu_si128((__m128i *)(input + input_stride));
+            bot               = _mm_maddubs_epi16(bot, twos_128);
+            const __m128i sum = _mm_add_epi16(top, bot);
+            _mm_storeu_si128((__m128i *)row, sum);
+        } else {
+            __m256i top = _mm256_loadu_si256((__m256i *)input);
+            __m256i bot = _mm256_loadu_si256((__m256i *)(input + input_stride));
+
+            __m256i top_16x16 = _mm256_maddubs_epi16(top, twos_256);
+            __m256i bot_16x16 = _mm256_maddubs_epi16(bot, twos_256);
+            __m256i sum_16x16 = _mm256_add_epi16(top_16x16, bot_16x16);
+
+            _mm256_storeu_si256(row, sum_16x16);
+            if (width == 64) {
+                top       = _mm256_loadu_si256(((__m256i *)input) + 1);
+                bot       = _mm256_loadu_si256(((__m256i *)(input + input_stride)) + 1);
+                top_16x16 = _mm256_maddubs_epi16(top, twos_256);
+                bot_16x16 = _mm256_maddubs_epi16(bot, twos_256);
+                sum_16x16 = _mm256_add_epi16(top_16x16, bot_16x16);
+                _mm256_storeu_si256(row + 1, sum_16x16);
+            }
+        }
+        input += luma_stride;
+    } while ((row += CFL_BUF_LINE_I256) < row_end);
+}

--- a/Source/Lib/Common/Codec/EbCabacContextModel.h
+++ b/Source/Lib/Common/Codec/EbCabacContextModel.h
@@ -903,6 +903,10 @@ static INLINE void partition_gather_vert_alike(AomCdfProb *out, const AomCdfProb
 /**********************************************************************************************************************/
 int av1_get_palette_color_index_context(const uint8_t *color_map, int stride, int r, int c,
                                         int palette_size, uint8_t *color_order, int *color_idx);
+#if PALETTE_SPEEDUP
+int av1_get_palette_color_index_context_optimized(const uint8_t *color_map, int stride, int r,
+                                                  int c, int palette_size, int *color_idx);
+#endif
 /**********************************************************************************************************************/
 /**********************************************************************************************************************/
 

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -133,6 +133,8 @@ extern "C" {
 #define RESTRUCTURE_SAD 1
 #endif
 
+#define PALETTE_SPEEDUP 1 //Flag to use optimized version of av1_get_palette_color_index_context()
+
 typedef enum MeHpMode {
     EX_HP_MODE        = 0, // Exhaustive  1/2-pel serach mode.
     REFINEMENT_HP_MODE = 1 // Refinement 1/2-pel serach mode.

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.c
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.c
@@ -1547,6 +1547,11 @@ void setup_common_rtcd_internal(CPU_FLAGS flags) {
     }
 #endif
 
-
+    SET_AVX2(cfl_luma_subsampling_420_lbd,
+             cfl_luma_subsampling_420_lbd_c,
+             cfl_luma_subsampling_420_lbd_avx2);
+    SET_AVX2(cfl_luma_subsampling_420_hbd,
+             cfl_luma_subsampling_420_hbd_c,
+             cfl_luma_subsampling_420_hbd_avx2);
 
 }

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.h
@@ -130,6 +130,14 @@ extern "C" {
     void eb_cfl_predict_hbd_avx2(const int16_t *pred_buf_q3, uint16_t *pred, int32_t pred_stride, uint16_t *dst, int32_t dst_stride, int32_t alpha_q3, int32_t bit_depth, int32_t width, int32_t height);
     RTCD_EXTERN void(*eb_cfl_predict_hbd)(const int16_t *pred_buf_q3, uint16_t *pred, int32_t pred_stride, uint16_t *dst, int32_t dst_stride, int32_t alpha_q3, int32_t bit_depth, int32_t width, int32_t height);
 
+    void cfl_luma_subsampling_420_lbd_c(const uint8_t *input, int32_t input_stride, int16_t *output_q3, int32_t width, int32_t height);
+    void cfl_luma_subsampling_420_lbd_avx2(const uint8_t *input, int32_t input_stride, int16_t *output_q3, int32_t width, int32_t height);
+    RTCD_EXTERN void(*cfl_luma_subsampling_420_lbd)(const uint8_t *input, int32_t input_stride, int16_t *output_q3, int32_t width, int32_t height);
+
+    void cfl_luma_subsampling_420_hbd_c(const uint16_t *input, int32_t input_stride, int16_t *output_q3, int32_t width, int32_t height);
+    void cfl_luma_subsampling_420_hbd_avx2(const uint16_t *input, int32_t input_stride, int16_t *output_q3, int32_t width, int32_t height);
+    RTCD_EXTERN void(*cfl_luma_subsampling_420_hbd)(const uint16_t *input, int32_t input_stride, int16_t *output_q3, int32_t width, int32_t height);
+
     void eb_av1_filter_intra_predictor_c(uint8_t *dst, ptrdiff_t stride, TxSize tx_size, const uint8_t *above, const uint8_t *left, int32_t mode);
     void eb_av1_filter_intra_predictor_sse4_1(uint8_t *dst, ptrdiff_t stride, TxSize tx_size, const uint8_t *above, const uint8_t *left, int mode);
     RTCD_EXTERN void (*eb_av1_filter_intra_predictor) (uint8_t *dst, ptrdiff_t stride, TxSize tx_size, const uint8_t *above, const uint8_t *left, int32_t mode);

--- a/Source/Lib/Decoder/Codec/EbDecIntraPrediction.c
+++ b/Source/Lib/Decoder/Codec/EbDecIntraPrediction.c
@@ -138,7 +138,7 @@ static void cfl_subsampling_highbd(TxSize tx_size, int32_t sub_x, int32_t sub_y,
     int32_t height = tx_size_high[tx_size];
     assert(width != 64 || height != 64);
     if (sub_x == 1 && sub_y == 1) {
-        cfl_luma_subsampling_420_hbd_c(input, input_stride, recon_buf_q3,
+        cfl_luma_subsampling_420_hbd(input, input_stride, recon_buf_q3,
             width, height);
     }
     else if (sub_x == 1 && sub_y == 0) {
@@ -159,7 +159,7 @@ static void cfl_subsampling_lowbd(TxSize tx_size, int32_t sub_x, int32_t sub_y,
     int32_t height = tx_size_high[tx_size];
     assert(width != 64 || height != 64);
     if (sub_x == 1 && sub_y == 1) {
-        cfl_luma_subsampling_420_lbd_c(input, input_stride, recon_buf_q3,
+        cfl_luma_subsampling_420_lbd(input, input_stride, recon_buf_q3,
             width, height);
     }
     else if (sub_x == 1 && sub_y == 0) {

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -479,7 +479,7 @@ static void av1_encode_loop(PictureControlSet *pcs_ptr, EncDecContext *context_p
                 (recon_samples->origin_x + round_origin_x);
 
             // Down sample Luma
-            cfl_luma_subsampling_420_lbd_c(
+            cfl_luma_subsampling_420_lbd(
                 recon_samples->buffer_y + recon_luma_offset,
                 recon_samples->stride_y,
                 context_ptr->md_context->pred_buf_q3,
@@ -928,7 +928,7 @@ static void av1_encode_loop_16bit(PictureControlSet *pcs_ptr, EncDecContext *con
                 (recon_samples->origin_x + round_origin_x);
 
             // Down sample Luma
-            cfl_luma_subsampling_420_hbd_c(
+            cfl_luma_subsampling_420_hbd(
                 ((uint16_t *)recon_samples->buffer_y) + recon_luma_offset,
                 recon_samples->stride_y,
                 context_ptr->md_context->pred_buf_q3,

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -3698,7 +3698,7 @@ static void cfl_prediction(PictureControlSet *          pcs_ptr,
 
         // Down sample Luma
         if (!context_ptr->hbd_mode_decision) {
-            cfl_luma_subsampling_420_lbd_c(
+            cfl_luma_subsampling_420_lbd(
                 &(context_ptr->cfl_temp_luma_recon[rec_luma_offset]),
                 candidate_buffer->recon_ptr->stride_y,
                 context_ptr->pred_buf_q3,
@@ -3709,7 +3709,7 @@ static void cfl_prediction(PictureControlSet *          pcs_ptr,
                     ? (context_ptr->blk_geom->bheight_uv << 1)
                     : context_ptr->blk_geom->bheight);
         } else {
-            cfl_luma_subsampling_420_hbd_c(
+            cfl_luma_subsampling_420_hbd(
                 context_ptr->cfl_temp_luma_recon16bit + rec_luma_offset,
                 candidate_buffer->recon_ptr->stride_y,
                 context_ptr->pred_buf_q3,

--- a/test/intrapred_cfl_test.cc
+++ b/test/intrapred_cfl_test.cc
@@ -9,6 +9,8 @@
  * @brief Unit test for chroma from luma prediction:
  * - eb_cfl_predict_hbd_avx2
  * - eb_cfl_predict_lbd_avx2
+ * - cfl_luma_subsampling_420_lbd_avx2
+ * - cfl_luma_subsampling_420_hbd_avx2
  *
  * @author Cidana-Wenyao
  *
@@ -263,5 +265,137 @@ INSTANTIATE_TEST_CASE_P(
                        ::testing::Values(USE_2_TAPS, USE_4_TAPS, USE_8_TAPS),
                        ::testing::Values(0, 1, 2),
                        ::testing::Values(0, 1, 2)));
+
+
+typedef void (*CflLumaSubsamplingLbdFunc)(const uint8_t *, int32_t, int16_t *, int32_t,
+                                   int32_t);
+typedef ::testing::tuple<BlockSize, CflLumaSubsamplingLbdFunc>
+    CflLumaSubsamplingLbdParam;
+
+class CflLumaSubsamplingLbdTest
+    : public ::testing::TestWithParam<CflLumaSubsamplingLbdParam> {
+  public:
+    CflLumaSubsamplingLbdTest() : rnd_(0, 255){};
+    virtual ~CflLumaSubsamplingLbdTest() {
+    }
+
+    void TearDown() override {
+        aom_clear_system_state();
+    }
+
+    void run_test() {
+        const int block_size = TEST_GET_PARAM(0);
+        CflLumaSubsamplingLbdFunc test_impl = TEST_GET_PARAM(1);
+        const int width = block_size_wide[block_size];
+        // Output width is defined by CFL_BUF_LINE(32),
+        // it lead to assumption that input width cannot be larger than 64,
+        // otherwise computation will overwrite line "n" by line "n+1"
+        if (width > 64)
+            return;
+        const int height = block_size_high[block_size];
+        DECLARE_ALIGNED(16, uint8_t, input[MAX_SB_SQUARE]);
+        DECLARE_ALIGNED(16, int16_t, output_q3_ref_[MAX_SB_SQUARE]);
+        DECLARE_ALIGNED(16, int16_t, output_q3_tst_[MAX_SB_SQUARE]);
+
+        memset(output_q3_ref_, 1, sizeof(output_q3_ref_));
+        memset(output_q3_tst_, 1, sizeof(output_q3_tst_));
+
+        const int run_times = 100;
+        for (int i = 0; i < run_times; ++i) {
+
+            memset(input, 1, sizeof(input));
+            for (int j = 0; j < MAX_SB_SQUARE; j++) {
+                input[j] = rnd_.random();
+            }
+
+            cfl_luma_subsampling_420_lbd_c(
+                input, width, output_q3_ref_, width, height);
+
+            test_impl(input, width, output_q3_tst_, width, height);
+
+            ASSERT_EQ(
+                0,
+                memcmp(output_q3_ref_, output_q3_tst_, sizeof(output_q3_ref_)));
+
+        }
+    }
+
+  private:
+    SVTRandom rnd_;
+};
+
+TEST_P(CflLumaSubsamplingLbdTest, MatchTest) {
+    run_test();
+}
+
+INSTANTIATE_TEST_CASE_P(
+    CFL_LUMA_SUBSAMPLING_LBD, CflLumaSubsamplingLbdTest,
+    ::testing::Combine(::testing::Range(BLOCK_4X4, BlockSizeS_ALL),
+                       ::testing::Values(cfl_luma_subsampling_420_lbd_avx2)));
+
+
+typedef void (*CflLumaSubsamplingHbdFunc)(const uint16_t *, int32_t, int16_t *,
+                                          int32_t, int32_t);
+typedef ::testing::tuple<BlockSize, CflLumaSubsamplingHbdFunc>
+    CflLumaSubsamplingHbdParam;
+
+class CflLumaSubsamplingHbdTest
+    : public ::testing::TestWithParam<CflLumaSubsamplingHbdParam> {
+  public:
+    CflLumaSubsamplingHbdTest() : rnd_(0, 1023){};
+    virtual ~CflLumaSubsamplingHbdTest() {
+    }
+
+    void TearDown() override {
+        aom_clear_system_state();
+    }
+
+    void run_test() {
+        const int block_size = TEST_GET_PARAM(0);
+        CflLumaSubsamplingHbdFunc test_impl = TEST_GET_PARAM(1);
+        const int width = block_size_wide[block_size];
+        // Output width is defined by CFL_BUF_LINE(32),
+        // it lead to assumption that input width cannot be larger than 64,
+        // otherwise computation will overwrite line "n" by line "n+1"
+        if (width > 64)
+            return;
+        const int height = block_size_high[block_size];
+        DECLARE_ALIGNED(16, uint16_t, input[MAX_SB_SQUARE]);
+        DECLARE_ALIGNED(16, int16_t, output_q3_ref_[MAX_SB_SQUARE]);
+        DECLARE_ALIGNED(16, int16_t, output_q3_tst_[MAX_SB_SQUARE]);
+
+        memset(output_q3_ref_, 1, sizeof(output_q3_ref_));
+        memset(output_q3_tst_, 1, sizeof(output_q3_tst_));
+
+        const int run_times = 100;
+        for (int i = 0; i < run_times; ++i) {
+            memset(input, 1, sizeof(input));
+            for (int j = 0; j < MAX_SB_SQUARE; j++) {
+                input[j] = rnd_.random();
+            }
+
+            cfl_luma_subsampling_420_hbd_c(
+                input, width, output_q3_ref_, width, height);
+
+            test_impl(input, width, output_q3_tst_, width, height);
+
+            ASSERT_EQ(
+                0,
+                memcmp(output_q3_ref_, output_q3_tst_, sizeof(output_q3_ref_)));
+        }
+    }
+
+  private:
+    SVTRandom rnd_;
+};
+
+TEST_P(CflLumaSubsamplingHbdTest, MatchTest) {
+    run_test();
+}
+
+INSTANTIATE_TEST_CASE_P(
+    CFL_LUMA_SUBSAMPLING_HBD, CflLumaSubsamplingHbdTest,
+    ::testing::Combine(::testing::Range(BLOCK_4X4, BlockSizeS_ALL),
+                       ::testing::Values(cfl_luma_subsampling_420_hbd_avx2)));
 
 }  // namespace


### PR DESCRIPTION
1. kernel implementation with UT for:
- cfl_luma_subsampling_420_hbd_avx2 speedup ~3.4x comapred to C
- cfl_luma_subsampling_420_lbd_avx2 speedup ~3.1x comapred to C

2. Modification of:
- av1_get_palette_color_index_context (speedup ~10% compared to previous implementation)
