### PR TITLE
EbFileUtils: fix handling of a 0 frame unit size

### DIFF
--- a/Source/App/DecApp/EbFileUtils.c
+++ b/Source/App/DecApp/EbFileUtils.c
@@ -531,7 +531,7 @@ int obudec_read_temporal_unit(DecInputContext *input, uint8_t **buffer, size_t *
             fprintf(stderr, "obudec: Failure reading frame header\n");
             return 0;
         }
-        if (size == 0 && feof(f)) { return 0; }
+        if (size == 0 || feof(f)) { return 0; }
 
         fr_size  = (size_t)size;
         txb_size = fr_size;


### PR DESCRIPTION
When reading Annex-B OBUs in obudec_read_temporal_unit, when reading
a frame unit size of 0, it would call realloc with 0, which has not
well defined behavior.