### PR TITLE
EbPictureAnalysisProcess: assert sizes larger than 0

### DIFF
--- a/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
@@ -285,6 +285,8 @@ uint64_t compute_mean_c(uint8_t *input_samples, /**< input parameter, input samp
 {
     uint32_t hi, vi;
     uint64_t block_mean = 0;
+    assert(input_area_width > 0);
+    assert(input_area_height > 0);
 
     for (vi = 0; vi < input_area_height; vi++) {
         for (hi = 0; hi < input_area_width; hi++) { block_mean += input_samples[hi]; }
@@ -308,6 +310,8 @@ uint64_t compute_mean_squared_values_c(
 {
     uint32_t hi, vi;
     uint64_t block_mean = 0;
+    assert(input_area_width > 0);
+    assert(input_area_height > 0);
 
     for (vi = 0; vi < input_area_height; vi++) {
         for (hi = 0; hi < input_area_width; hi++) {


### PR DESCRIPTION
Helps to catch bugs in debug builds, as those would cause div by
0 further in the code.

Additionally helps guide the static analyzer to know those are not
supposed to be 0 and silences the div by 0 warnings.