### PR TITLE
Add print CLI of SvtAv1EncApp when E2E test case failure

### DIFF
--- a/test/e2e_test/ConfigEncoder.cc
+++ b/test/e2e_test/ConfigEncoder.cc
@@ -3,6 +3,8 @@
  * SPDX - License - Identifier: BSD - 2 - Clause - Patent
  */
 
+#include <string>
+
 extern "C" {
 #include "EbAppConfig.c"
 #include "EbAppContext.c"
@@ -44,4 +46,18 @@ int copy_enc_param(EbSvtAv1EncConfiguration *dst_enc_config, void *config_ptr) {
            &app_ctx.eb_enc_parameters,
            sizeof(EbSvtAv1EncConfiguration));
     return 0;
+}
+
+extern ConfigEntry config_entry[];
+std::string get_enc_token(const char *name) {
+    std::string str;
+    int index = 0;
+    while (config_entry[index].name != NULL) {
+        if (EB_STRCMP(name, config_entry[index].name) == 0) {
+            str = config_entry[index].token;
+            break;
+        }
+        index++;
+    }
+    return str;
 }

--- a/test/e2e_test/ConfigEncoder.h
+++ b/test/e2e_test/ConfigEncoder.h
@@ -11,5 +11,6 @@ void *create_enc_config();
 void release_enc_config(void *config_ptr);
 void set_enc_config(void *config, const char *name, const char *value);
 int copy_enc_param(EbSvtAv1EncConfiguration *dst_enc_config, void *config_ptr);
+std::string get_enc_token(const char* name);
 
 #endif

--- a/test/e2e_test/E2eTestVectors.h
+++ b/test/e2e_test/E2eTestVectors.h
@@ -18,6 +18,7 @@
 #include <map>
 #include "VideoSource.h"
 #include "EbDefinitions.h"
+#include "ConfigEncoder.h"
 
 /** @defgroup svt_av1_e2e_test_vector Test vectors for E2E test
  *  Defines the test vectors of E2E test, with file-type, width, height and
@@ -110,6 +111,14 @@ typedef struct EncTestSetting {
         return str;
     }
 
+    std::string to_cli(TestVideoVector& vector) const {
+        std::string str = "SvtAv1EncApp";
+        str += get_vector_cli(vector);
+        str += get_setting_cli();
+        str += " -b output.ivf -o recon.yuv";
+        return str;
+    }
+
     std::string get_setting_str() const {
         std::string str(name);
         str += ": ";
@@ -118,6 +127,45 @@ typedef struct EncTestSetting {
             str += "=";
             str += x.second;
             str += ", ";
+        }
+        return str;
+    }
+
+    int color_fmt(VideoColorFormat fmt) const {
+        switch (fmt) {
+        case IMG_FMT_420:
+        case IMG_FMT_420P10_PACKED: return 420;
+        case IMG_FMT_422:
+        case IMG_FMT_422P10_PACKED: return 422;
+        case IMG_FMT_444:
+        case IMG_FMT_444P10_PACKED: return 444;
+        default: break;
+        }
+        return -1;
+    }
+
+    std::string get_vector_cli(TestVideoVector& vector) const {
+        std::string str(" -i " + std::get<0>(vector));
+        if (std::get<1>(vector) != Y4M_VIDEO_FILE) {
+            str += " -w ";
+            str += std::to_string(std::get<3>(vector));
+            str += " -h ";
+            str += std::to_string(std::get<4>(vector));
+            str += " -bit-depth ";
+            str += std::to_string(std::get<5>(vector));
+            str += " -colour-space ";
+            str += std::to_string(color_fmt(std::get<2>(vector)));
+        }
+        return str;
+    }
+
+    std::string get_setting_cli() const {
+        std::string str;
+        for (auto x : setting) {
+            str += " ";
+            str += get_enc_token(x.first.c_str());
+            str += " ";
+            str += x.second;
         }
         return str;
     }

--- a/test/e2e_test/SvtAv1E2EFramework.cc
+++ b/test/e2e_test/SvtAv1E2EFramework.cc
@@ -525,7 +525,8 @@ void SvtAv1E2ETestFramework::run_death_test() {
             },
             ::testing::ExitedWithCode(0),
             ".*")
-            << "Fatal Error on running test case " << enc_setting.to_string(fn);
+            << "Fatal Error on running test case " << enc_setting.to_string(fn)
+            << "\ncli command: " << enc_setting.to_cli(test_vector);
     }
 }
 
@@ -582,13 +583,8 @@ static void write_ivf_frame_header(
 
 void SvtAv1E2ETestFramework::write_compress_data(
     const EbBufferHeaderType *output) {
-    write_ivf_frame_header(
-        output_file_,
-        output->n_filled_len);
-    fwrite(output->p_buffer,
-        1,
-        output->n_filled_len,
-        output_file_->file);
+    write_ivf_frame_header(output_file_, output->n_filled_len);
+    fwrite(output->p_buffer, 1, output->n_filled_len, output_file_->file);
 }
 
 void SvtAv1E2ETestFramework::process_compress_data(


### PR DESCRIPTION
1. add print cli string when e2e test case failure, to help re-produce issue in SvtAv1EncApp

e.g. RcTest6 failed! to print:
cli command: SvtAv1EncApp -i kirland_640_480_30.yuv -w 640 -h 480 -bit-depth 8 -colour-space 420 -rc 1 -tbr 500000 -b output.ivf -o recon.yuv