### PR TITLE
Fix UT, read outside of allocated memory

### DIFF
--- a/test/PackUnPackTest.cc
+++ b/test/PackUnPackTest.cc
@@ -187,7 +187,7 @@ class PackMsbTest : public ::testing::Test,
 
     void SetUp() override {
         inn_bit_buffer_ =
-            reinterpret_cast<uint8_t *>(eb_aom_memalign(32, test_size_ >> 4));
+            reinterpret_cast<uint8_t *>(eb_aom_memalign(32, test_size_ >> 2));
         in_8bit_buffer_ =
             reinterpret_cast<uint8_t *>(eb_aom_memalign(32, test_size_));
         out_16bit_buffer1_ = reinterpret_cast<uint16_t *>(
@@ -228,7 +228,7 @@ class PackMsbTest : public ::testing::Test,
 
     void run_test() {
         for (int i = 0; i < RANDOM_TIME; i++) {
-            eb_buf_random_u8(inn_bit_buffer_, test_size_ >> 4);
+            eb_buf_random_u8(inn_bit_buffer_, test_size_ >> 2);
             eb_buf_random_u8(in_8bit_buffer_, test_size_);
             compressed_packmsb_avx2_intrin(in_8bit_buffer_,
                                            in8_stride_,


### PR DESCRIPTION
UT is failing for example here: https://github.com/OpenVisualCloud/SVT-AV1/pull/1154/checks?check_run_id=566794496

I can reproduce it on windows, visual studio 2019 Debug build with error:
```
unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.
```
Root cause is that test allocate too small input buffer