### PR TITLE
CI: Add simple cppcheck job

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,26 @@
+name: Cppcheck
+on: [push, pull_request]
+
+jobs:
+  check:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y nasm cppcheck
+      - name: Run CMake
+        run: |
+          cd Build
+          cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+      - name: Run Cppcheck
+        run: |
+          cd Build
+          cppcheck \
+            --project=compile_commands.json \
+            --error-exitcode=0 \
+            --enable=all \
+            --template="::error file={file},line={line},col={column}::{severity}: {message} ({id})" \
+            -ithird_party


### PR DESCRIPTION
This adds static analysis using [cppcheck](http://cppcheck.sourceforge.net) and creates annotations that show up in the job information. Additionally if a PR introduces new errors, those should show up inline in the diff.

Fix #1161