### PR TITLE
SvtAv1EncApp: Remove .exe suffix from usage

### DIFF
--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -2013,7 +2013,7 @@ uint32_t get_help(int32_t argc, char *const argv[]) {
         const char *empty_string         = "";
         fprintf(stderr,
                 "\n%-25s\n",
-                "Usage: SvtAv1EncApp.exe <options> -b dst_filename -i src_filename");
+                "Usage: SvtAv1EncApp <options> -b dst_filename -i src_filename");
         fprintf(stderr, "\n%-25s\n", "Options:");
         while (config_entry_options[++options_token_index].token != NULL) {
             uint32_t check = check_long(


### PR DESCRIPTION
Even on Windows in the terminal a binary can be run without
the .exe suffix