### PR TITLE
Update .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,64 +1,45 @@
 ---
 Language: Cpp
 # BasedOnStyle:  Google
-AccessModifierOffset: -1
 AlignAfterOpenBracket: Align
+AlignEscapedNewlines: Left
 AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: true
 AlignEscapedNewlines: Left
-AlignOperands: true
+AlignOperands: false
 AlignTrailingComments: false
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: true
 AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
-AlwaysBreakTemplateDeclarations: true
 BinPackArguments: false
 BinPackParameters: true
 BraceWrapping:
-  AfterClass: false
   AfterControlStatement: false
   AfterEnum: false
   AfterFunction: false
-  AfterNamespace: false
-  AfterObjCDeclaration: false
   AfterStruct: false
   AfterUnion: false
   AfterExternBlock: false
-  BeforeCatch: false
   BeforeElse: false
   IndentBraces: false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
-  SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
-BreakBeforeBraces: Attach
+BreakBeforeBraces: Custom
 BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
-BreakConstructorInitializers: BeforeColon
-BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit: 100
 CommentPragmas: "^ IWYU pragma:"
-CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
-Cpp11BracedListStyle: true
 DerivePointerAlignment: true
 DisableFormat: false
 ExperimentalAutoDetectBinPacking: false
-FixNamespaceComments: true
-ForEachMacros:
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
 IncludeBlocks: Preserve
 IncludeCategories:
   - Regex: '^<ext/.*\.h>'
@@ -74,17 +55,11 @@ IndentCaseLabels: false
 IndentPPDirectives: None
 IndentWidth: 4
 IndentWrappedFunctionNames: false
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
 MacroBlockBegin: ""
 MacroBlockEnd: ""
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBlockIndentWidth: 4
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: false
-PenaltyBreakAssignment: 2
+PenaltyBreakAssignment: 100
 PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
@@ -101,12 +76,10 @@ SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles: false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard: Cpp11
 TabWidth: 4
 UseTab: Never
 ---


### PR DESCRIPTION
Hi,

This PR updates the existing `.clang-format` file in order to be closer to the coding style described in `STYLE.md`
Additionally, it removes the C++ specific directives, since they are not used by this project.

Ideally, this would be used to validate the coding styles during the CI, but there are 2 main issues:
* Clang's format understanding of `AllowShortBlocksOnASingleLine` or `AllowShortFunctionsOnASingleLine` is not (AFAICS) exactly what one would expect by "Allow". If set to true, it will force all small blocks/functions on a single line, provided it doesn't conflict with the maximum number of columns
* `STYLE.md` says that multi line `if`s should have their opening braces wrapped to a new line. This is only doable using clang-format 10, which is not widely distributed yet (debian testing ships version 9, the version 10 is only in experimental for now). Using version 9 and before, only "always" and "never" options are available for wrapping braces after a control statement

Given that this would cause quite a lot of changes, I'm not sure it's a good idea to clang-format the entire tree for now, meaning it's not viable to check if a commit breaks the coding style using that tool yet.

The current clang format will transform this sample:
```
int supersupersupersupersupersupersupersupersupersupersupersupersupersuperfunc()
{
    return 1;
}

int main()
{
    int a = 0, b = 0, c = 0;
    const int my_var = a +supersupersupersupersupersupersupersupersupersupersupersupersupersuperfunc()
                                        + b + c;

    const int abc = (a + supersupersupersupersupersupersupersupersupersupersupersupersupersuperfunc() +
                            c -b);

    if ( a &&
         b) {
        return 1;
    }
    if ( a && b ) return 1;

    switch ( a )
    {
                case 1:
{
return 1;
            }
    case 2222222: supersupersupersupersupersupersupersupersupersupersupersupersupersuperfunc(); break;
    case 3: foobar(); break;
                        default: break;
    }

}
```

into this:
```
int supersupersupersupersupersupersupersupersupersupersupersupersupersuperfunc() { return 1; }

int main() {
    int       a = 0, b = 0, c = 0;
    const int my_var = a +
        supersupersupersupersupersupersupersupersupersupersupersupersupersuperfunc() + b + c;

    const int abc = (a +
                     supersupersupersupersupersupersupersupersupersupersupersupersupersuperfunc() +
                     c - b);

    if (a && b) {
        return 1;
    }
    if (a && b)
        return 1;

    switch (a) {
    case 1: {
        return 1;
    }
    case 2222222:
        supersupersupersupersupersupersupersupersupersupersupersupersupersuperfunc();
        break;
    case 3: foobar(); break;
    default: break;
    }
}
```