### PR TITLE
Remove EB_NULL

### DIFF
--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -35,10 +35,6 @@ API.  This is a 32 bit pointer and is aligned on a 32 bit word boundary.
 */
 typedef void *EbPtr;
 
-/** The EB_NULL type is used to define the C style NULL pointer.
-*/
-#define EB_NULL ((void *)0)
-
 #define WARNING_LENGTH 100
 
 // memory map to be removed and replaced by malloc / free
@@ -63,7 +59,7 @@ extern uint32_t          app_malloc_count;
 
 #define EB_APP_MALLOC(type, pointer, n_elements, pointer_class, return_type) \
     pointer = (type)malloc(n_elements);                                      \
-    if (pointer == (type)EB_NULL) {                                          \
+    if (pointer == (type)NULL) {                                             \
         return return_type;                                                  \
     } else {                                                                 \
         app_memory_map[*(app_memory_map_index)].ptr_type = pointer_class;    \
@@ -80,7 +76,7 @@ extern uint32_t          app_malloc_count;
 #define EB_APP_MALLOC_NR(type, pointer, n_elements, pointer_class, return_type) \
     (void)return_type;                                                          \
     pointer = (type)malloc(n_elements);                                         \
-    if (pointer == (type)EB_NULL) {                                             \
+    if (pointer == (type)NULL) {                                                \
         return_type = EB_ErrorInsufficientResources;                            \
         fprintf(stderr, "Malloc has failed due to insuffucient resources");     \
         return;                                                                 \

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -936,7 +936,7 @@ AppExitConditionType process_input_buffer(EbConfig *config, EbAppContext *app_ca
         if (header_ptr->n_filled_len) {
             // Update the context parameters
             config->processed_byte_count += header_ptr->n_filled_len;
-            header_ptr->p_app_private = (EbPtr)EB_NULL;
+            header_ptr->p_app_private = (EbPtr)NULL;
             config->frames_encoded    = (int32_t)(++config->processed_frame_count);
 
             // Configuration parameters changed on the fly

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -2259,10 +2259,6 @@ typedef struct {
     uint8_t  *color_idx_map;
 } PaletteInfo;
 
-/** The EB_NULL type is used to define the C style NULL pointer.
-*/
-#define EB_NULL ((void*) 0)
-
 /** The EbHandle type is used to define OS object handles for threads,
 semaphores, mutexs, etc.
 */

--- a/Source/Lib/Common/Codec/EbSystemResourceManager.c
+++ b/Source/Lib/Common/Codec/EbSystemResourceManager.c
@@ -44,7 +44,7 @@ static EbErrorType eb_fifo_push_back(EbFifo *fifoPtr, EbObjectWrapper *wrapper_p
     EbErrorType return_error = EB_ErrorNone;
 
     // If FIFO is empty
-    if (fifoPtr->first_ptr == (EbObjectWrapper *)EB_NULL) {
+    if (fifoPtr->first_ptr == (EbObjectWrapper *)NULL) {
         fifoPtr->first_ptr = wrapper_ptr;
         fifoPtr->last_ptr  = wrapper_ptr;
     } else {
@@ -52,7 +52,7 @@ static EbErrorType eb_fifo_push_back(EbFifo *fifoPtr, EbObjectWrapper *wrapper_p
         fifoPtr->last_ptr           = wrapper_ptr;
     }
 
-    fifoPtr->last_ptr->next_ptr = (EbObjectWrapper *)EB_NULL;
+    fifoPtr->last_ptr->next_ptr = (EbObjectWrapper *)NULL;
 
     return return_error;
 }
@@ -68,7 +68,7 @@ static EbErrorType eb_fifo_pop_front(EbFifo *fifoPtr, EbObjectWrapper **wrapper_
 
     // Update tail of BufferPool if the BufferPool is now empty
     fifoPtr->last_ptr =
-        (fifoPtr->first_ptr == fifoPtr->last_ptr) ? (EbObjectWrapper *)EB_NULL : fifoPtr->last_ptr;
+        (fifoPtr->first_ptr == fifoPtr->last_ptr) ? (EbObjectWrapper *)NULL : fifoPtr->last_ptr;
 
     // Update head of BufferPool
     fifoPtr->first_ptr = fifoPtr->first_ptr->next_ptr;
@@ -115,7 +115,7 @@ static EbErrorType eb_circular_buffer_ctor(EbCircularBuffer *bufferPtr,
  **************************************/
 static EbBool eb_circular_buffer_empty_check(EbCircularBuffer *bufferPtr) {
     return ((bufferPtr->head_index == bufferPtr->tail_index) &&
-            (bufferPtr->array_ptr[bufferPtr->head_index] == EB_NULL))
+            (bufferPtr->array_ptr[bufferPtr->head_index] == NULL))
                ? EB_TRUE
                : EB_FALSE;
 }
@@ -128,7 +128,7 @@ static EbErrorType eb_circular_buffer_pop_front(EbCircularBuffer *bufferPtr, EbP
 
     // Copy the head of the buffer into the object_ptr
     *object_ptr                                 = bufferPtr->array_ptr[bufferPtr->head_index];
-    bufferPtr->array_ptr[bufferPtr->head_index] = EB_NULL;
+    bufferPtr->array_ptr[bufferPtr->head_index] = NULL;
 
     // Increment the head & check for rollover
     bufferPtr->head_index = (bufferPtr->head_index == bufferPtr->buffer_total_count - 1)
@@ -214,8 +214,8 @@ static EbErrorType eb_muxing_queue_ctor(EbMuxingQueue *queue_ptr, uint32_t objec
                eb_fifo_ctor,
                0,
                object_total_count,
-               (EbObjectWrapper *)EB_NULL,
-               (EbObjectWrapper *)EB_NULL,
+               (EbObjectWrapper *)NULL,
+               (EbObjectWrapper *)NULL,
                queue_ptr);
     }
 
@@ -470,7 +470,7 @@ EbErrorType eb_system_resource_ctor(EbSystemResource *resource_ptr, uint32_t obj
                resource_ptr->object_total_count,
                consumer_process_total_count);
     } else {
-        resource_ptr->full_queue = (EbMuxingQueue *)EB_NULL;
+        resource_ptr->full_queue = (EbMuxingQueue *)NULL;
     }
 
     return return_error;
@@ -654,7 +654,7 @@ EbErrorType eb_get_full_object(EbFifo *full_fifo_ptr, EbObjectWrapper **wrapper_
 **************************************/
 static EbBool eb_fifo_peak_front(EbFifo *fifoPtr) {
     // Set wrapper_ptr to head of BufferPool
-    if (fifoPtr->first_ptr == (EbObjectWrapper *)EB_NULL)
+    if (fifoPtr->first_ptr == (EbObjectWrapper *)NULL)
         return EB_TRUE;
     else
         return EB_FALSE;
@@ -684,7 +684,7 @@ EbErrorType eb_get_full_object_non_blocking(
     if (fifo_empty == EB_FALSE)
         eb_get_full_object(full_fifo_ptr, wrapper_dbl_ptr);
     else
-        *wrapper_dbl_ptr = (EbObjectWrapper *)EB_NULL;
+        *wrapper_dbl_ptr = (EbObjectWrapper *)NULL;
 
     return return_error;
 }

--- a/Source/Lib/Common/Codec/EbThreads.c
+++ b/Source/Lib/Common/Codec/EbThreads.c
@@ -82,7 +82,7 @@ EbHandle eb_create_thread(void *thread_function(void *), void *thread_context) {
                 thread_handle = (pthread_t *)malloc(sizeof(pthread_t));
                 if (thread_handle != NULL) {
                     pthread_create((pthread_t *)thread_handle, // Thread handle
-                                   (const pthread_attr_t *)EB_NULL, // attributes
+                                   (const pthread_attr_t *)NULL, // attributes
                                    thread_function, // function to be run by new thread
                                    thread_context);
                 }

--- a/Source/Lib/Common/Codec/EbUtility.c
+++ b/Source/Lib/Common/Codec/EbUtility.c
@@ -259,13 +259,13 @@ EbLinkedListNode* concat_eb_linked_list(EbLinkedListNode* a, EbLinkedListNode* b
 EbLinkedListNode* split_eb_linked_list(EbLinkedListNode* input, EbLinkedListNode** restLL,
                                        EbBool (*predicate_func)(EbLinkedListNode*)) {
     EbLinkedListNode* ll_true_ptr =
-        (EbLinkedListNode*)EB_NULL; // list of nodes satifying predicate_func(node) == TRUE
+        (EbLinkedListNode*)NULL; // list of nodes satifying predicate_func(node) == TRUE
     EbLinkedListNode* ll_rest_ptr =
-        (EbLinkedListNode*)EB_NULL; // list of nodes satifying predicate_func(node) != TRUE
+        (EbLinkedListNode*)NULL; // list of nodes satifying predicate_func(node) != TRUE
 
     while (input) {
         EbLinkedListNode* next = input->next;
-        input->next            = (EbLinkedListNode*)EB_NULL;
+        input->next            = (EbLinkedListNode*)NULL;
         if (predicate_func(input))
             ll_true_ptr = concat_eb_linked_list(input, ll_true_ptr);
         else

--- a/Source/Lib/Decoder/Codec/EbDecHandle.c
+++ b/Source/Lib/Decoder/Codec/EbDecHandle.c
@@ -102,7 +102,7 @@ static EbErrorType eb_dec_handle_ctor(EbDecHandle **decHandleDblPtr, EbComponent
     // Allocate Memory
     EbDecHandle *dec_handle_ptr = (EbDecHandle *)malloc(sizeof(EbDecHandle));
     *decHandleDblPtr            = dec_handle_ptr;
-    if (dec_handle_ptr == (EbDecHandle *)EB_NULL) return EB_ErrorInsufficientResources;
+    if (dec_handle_ptr == (EbDecHandle *)NULL) return EB_ErrorInsufficientResources;
     dec_handle_ptr->memory_map       = (EbMemoryMapEntry *)malloc(sizeof(EbMemoryMapEntry));
     dec_handle_ptr->memory_map_index = 0;
     dec_handle_ptr->total_lib_memory =

--- a/Source/Lib/Decoder/Codec/EbDecMemInit.h
+++ b/Source/Lib/Decoder/Codec/EbDecMemInit.h
@@ -21,11 +21,11 @@ extern EbMemoryMapEntry                 *memory_map_end_address;
 #ifdef _WIN32
 #define EB_ALLIGN_MALLOC_DEC(type, pointer, n_elements, pointer_class)                  \
     pointer = (type)_aligned_malloc(n_elements, ALVALUE);                               \
-    if (pointer == (type)EB_NULL)                                                       \
+    if (pointer == (type)NULL)                                                       \
         return EB_ErrorInsufficientResources;                                           \
     else {                                                                              \
         EbMemoryMapEntry *node = malloc(sizeof(EbMemoryMapEntry));                      \
-        if (node == (EbMemoryMapEntry *)EB_NULL) return EB_ErrorInsufficientResources;  \
+        if (node == (EbMemoryMapEntry *)NULL) return EB_ErrorInsufficientResources;  \
         node->ptr_type     = pointer_class;                                             \
         node->ptr          = (EbPtr)pointer;                                            \
         node->prev_entry   = (EbPtr)svt_dec_memory_map;                                 \
@@ -45,7 +45,7 @@ extern EbMemoryMapEntry                 *memory_map_end_address;
     else {                                                                              \
         pointer                = (type)pointer;                                         \
         EbMemoryMapEntry *node = malloc(sizeof(EbMemoryMapEntry));                      \
-        if (node == (EbMemoryMapEntry *)EB_NULL) return EB_ErrorInsufficientResources;  \
+        if (node == (EbMemoryMapEntry *)NULL) return EB_ErrorInsufficientResources;  \
         node->ptr_type     = pointer_class;                                             \
         node->ptr          = (EbPtr)pointer;                                            \
         node->prev_entry   = (EbPtr)svt_dec_memory_map;                                 \
@@ -61,11 +61,11 @@ extern EbMemoryMapEntry                 *memory_map_end_address;
 #endif
 #define EB_MALLOC_DEC(type, pointer, n_elements, pointer_class)                         \
     pointer = (type)malloc(n_elements);                                                 \
-    if (pointer == (type)EB_NULL)                                                       \
+    if (pointer == (type)NULL)                                                       \
         return EB_ErrorInsufficientResources;                                           \
     else {                                                                              \
         EbMemoryMapEntry *node = malloc(sizeof(EbMemoryMapEntry));                      \
-        if (node == (EbMemoryMapEntry *)EB_NULL) return EB_ErrorInsufficientResources;  \
+        if (node == (EbMemoryMapEntry *)NULL) return EB_ErrorInsufficientResources;  \
         node->ptr_type     = pointer_class;                                             \
         node->ptr          = (EbPtr)pointer;                                            \
         node->prev_entry   = (EbPtr)svt_dec_memory_map;                                 \

--- a/Source/Lib/Decoder/Codec/EbDecProcess.c
+++ b/Source/Lib/Decoder/Codec/EbDecProcess.c
@@ -1366,7 +1366,7 @@ void *dec_all_stage_kernel(void *input_ptr) {
             break;
         }
     }
-    return EB_NULL;
+    return NULL;
 }
 
 void dec_sync_all_threads(EbDecHandle *dec_handle_ptr) {

--- a/Source/Lib/Encoder/Codec/EbCdefProcess.c
+++ b/Source/Lib/Encoder/Codec/EbCdefProcess.c
@@ -606,5 +606,5 @@ void *cdef_kernel(void *input_ptr) {
         eb_release_object(dlf_results_wrapper_ptr);
     }
 
-    return EB_NULL;
+    return NULL;
 }

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -2505,7 +2505,7 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                 const BlockGeom *blk_geom = context_ptr->blk_geom = get_blk_geom_mds(d1_itr);
 
                 // PU Stack variables
-                PredictionUnit *     pu_ptr           = (PredictionUnit *)EB_NULL; //  done
+                PredictionUnit *     pu_ptr           = (PredictionUnit *)NULL; //  done
                 EbPictureBufferDesc *residual_buffer  = context_ptr->residual_buffer;
                 EbPictureBufferDesc *transform_buffer = context_ptr->transform_buffer;
 
@@ -3185,12 +3185,12 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                         ref_idx_l0 >= 0
                             ? (EbReferenceObject *)pcs_ptr->ref_pic_ptr_array[list_idx0][ref_idx_l0]
                                   ->object_ptr
-                            : (EbReferenceObject *)EB_NULL;
+                            : (EbReferenceObject *)NULL;
                     EbReferenceObject *ref_obj_1 =
                         ref_idx_l1 >= 0
                             ? (EbReferenceObject *)pcs_ptr->ref_pic_ptr_array[list_idx1][ref_idx_l1]
                                   ->object_ptr
-                            : (EbReferenceObject *)EB_NULL;
+                            : (EbReferenceObject *)NULL;
                     uint16_t txb_origin_x;
                     uint16_t txb_origin_y;
                     EbBool   is_blk_skip = EB_FALSE;
@@ -3250,21 +3250,21 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 ref_pic_list0 =
                                     context_ptr->md_context->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds].ref_frame_index_l0 >= 0
                                     ? ref_obj_0->reference_picture
-                                    : (EbPictureBufferDesc *)EB_NULL;
+                                    : (EbPictureBufferDesc *)NULL;
                                 ref_pic_list1 =
                                     context_ptr->md_context->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds].ref_frame_index_l1 >= 0
                                     ? ref_obj_1->reference_picture
-                                    : (EbPictureBufferDesc *)EB_NULL;
+                                    : (EbPictureBufferDesc *)NULL;
                             }
                             else {
                                 ref_pic_list0 =
                                     context_ptr->md_context->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds].ref_frame_index_l0 >= 0
                                     ? ref_obj_0->reference_picture16bit
-                                    : (EbPictureBufferDesc *)EB_NULL;
+                                    : (EbPictureBufferDesc *)NULL;
                                 ref_pic_list1 =
                                     context_ptr->md_context->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds].ref_frame_index_l1 >= 0
                                     ? ref_obj_1->reference_picture16bit
-                                    : (EbPictureBufferDesc *)EB_NULL;
+                                    : (EbPictureBufferDesc *)NULL;
                             }
 #endif
                                 warped_motion_prediction(
@@ -3305,20 +3305,20 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 ref_pic_list0 =
                                     context_ptr->md_context->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds].ref_frame_index_l0 >= 0
                                     ? ref_obj_0->reference_picture
-                                    : (EbPictureBufferDesc *)EB_NULL;
+                                    : (EbPictureBufferDesc *)NULL;
                                 ref_pic_list1 =
                                     context_ptr->md_context->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds].ref_frame_index_l1 >= 0
                                     ? ref_obj_1->reference_picture
-                                    : (EbPictureBufferDesc *)EB_NULL;
+                                    : (EbPictureBufferDesc *)NULL;
                             } else {
                                 ref_pic_list0 =
                                     context_ptr->md_context->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds].ref_frame_index_l0 >= 0
                                     ? ref_obj_0->reference_picture16bit
-                                    : (EbPictureBufferDesc *)EB_NULL;
+                                    : (EbPictureBufferDesc *)NULL;
                                 ref_pic_list1 =
                                     context_ptr->md_context->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds].ref_frame_index_l1 >= 0
                                     ? ref_obj_1->reference_picture16bit
-                                    : (EbPictureBufferDesc *)EB_NULL;
+                                    : (EbPictureBufferDesc *)NULL;
                             }
 
                                     if (is_16bit) {

--- a/Source/Lib/Encoder/Codec/EbDlfProcess.c
+++ b/Source/Lib/Encoder/Codec/EbDlfProcess.c
@@ -55,8 +55,8 @@ EbErrorType dlf_context_ctor(EbThreadContext *thread_context_ptr, const EbEncHan
     context_ptr->dlf_output_fifo_ptr =
         eb_system_resource_get_producer_fifo(enc_handle_ptr->dlf_results_resource_ptr, index);
 
-    context_ptr->temp_lf_recon_picture16bit_ptr = (EbPictureBufferDesc *)EB_NULL;
-    context_ptr->temp_lf_recon_picture_ptr      = (EbPictureBufferDesc *)EB_NULL;
+    context_ptr->temp_lf_recon_picture16bit_ptr = (EbPictureBufferDesc *)NULL;
+    context_ptr->temp_lf_recon_picture_ptr      = (EbPictureBufferDesc *)NULL;
     EbPictureBufferDescInitData temp_lf_recon_desc_init_data;
     temp_lf_recon_desc_init_data.max_width          = (uint16_t)scs_ptr->max_input_luma_width;
     temp_lf_recon_desc_init_data.max_height         = (uint16_t)scs_ptr->max_input_luma_height;
@@ -357,5 +357,5 @@ void *dlf_kernel(void *input_ptr) {
         eb_release_object(enc_dec_results_wrapper_ptr);
     }
 
-    return EB_NULL;
+    return NULL;
 }

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -104,7 +104,7 @@ EbErrorType enc_dec_context_ctor(EbThreadContext *  thread_context_ptr,
         init_data.split_mode         = EB_FALSE;
         init_data.color_format       = color_format;
 
-        context_ptr->input_sample16bit_buffer = (EbPictureBufferDesc *)EB_NULL;
+        context_ptr->input_sample16bit_buffer = (EbPictureBufferDesc *)NULL;
         if (is_16bit || static_config->is_16bit_pipeline) {
             init_data.bit_depth = EB_16BIT;
 
@@ -3254,7 +3254,7 @@ void *enc_dec_kernel(void *input_ptr) {
         // Release Mode Decision Results
         eb_release_object(enc_dec_tasks_wrapper_ptr);
     }
-    return EB_NULL;
+    return NULL;
 }
 
 void eb_av1_add_film_grain(EbPictureBufferDesc *src, EbPictureBufferDesc *dst,

--- a/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
@@ -6108,7 +6108,7 @@ void search_compound_diff_wedge(PictureControlSet *    picture_control_set_ptr,
                             ->object_ptr)
                                     ->reference_picture;
         else
-            ref_pic_list0 = (EbPictureBufferDesc *)EB_NULL;
+            ref_pic_list0 = (EbPictureBufferDesc *)NULL;
 
         if (ref_idx_l1 >= 0)
             ref_pic_list1 = hbd_mode_decision ? ((EbReferenceObject *)picture_control_set_ptr
@@ -6120,7 +6120,7 @@ void search_compound_diff_wedge(PictureControlSet *    picture_control_set_ptr,
                             ->object_ptr)
                                     ->reference_picture;
         else
-            ref_pic_list1 = (EbPictureBufferDesc *)EB_NULL;
+            ref_pic_list1 = (EbPictureBufferDesc *)NULL;
 
         //CHKN get seperate prediction of each ref(Luma only)
         //ref0 prediction
@@ -6270,8 +6270,8 @@ EbErrorType inter_pu_prediction_av1(uint8_t hbd_mode_decision, ModeDecisionConte
                                     PictureControlSet *          picture_control_set_ptr,
                                     ModeDecisionCandidateBuffer *candidate_buffer_ptr) {
     EbErrorType                  return_error  = EB_ErrorNone;
-    EbPictureBufferDesc *        ref_pic_list0 = (EbPictureBufferDesc *)EB_NULL;
-    EbPictureBufferDesc *        ref_pic_list1 = (EbPictureBufferDesc *)EB_NULL;
+    EbPictureBufferDesc *        ref_pic_list0 = (EbPictureBufferDesc *)NULL;
+    EbPictureBufferDesc *        ref_pic_list1 = (EbPictureBufferDesc *)NULL;
     ModeDecisionCandidate *const candidate_ptr = candidate_buffer_ptr->candidate_ptr;
     SequenceControlSet *         scs_ptr =
             ((SequenceControlSet *)(picture_control_set_ptr->scs_wrapper_ptr->object_ptr));

--- a/Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c
@@ -707,7 +707,7 @@ void *entropy_coding_kernel(void *input_ptr) {
                             for (ref_idx = 0; ref_idx < pcs_ptr->parent_pcs_ptr->ref_list0_count;
                                  ++ref_idx) {
                                 if (scs_ptr->use_output_stat_file && tile_cnt == 1 &&
-                                    pcs_ptr->ref_pic_ptr_array[0][ref_idx] != EB_NULL &&
+                                    pcs_ptr->ref_pic_ptr_array[0][ref_idx] != NULL &&
                                     pcs_ptr->ref_pic_ptr_array[0][ref_idx]->live_count == 1)
                                     write_stat_to_file(
                                         scs_ptr,
@@ -717,7 +717,7 @@ void *entropy_coding_kernel(void *input_ptr) {
                                         ((EbReferenceObject *)pcs_ptr->ref_pic_ptr_array[0][ref_idx]
                                              ->object_ptr)
                                             ->ref_poc);
-                                if (pcs_ptr->ref_pic_ptr_array[0][ref_idx] != EB_NULL) {
+                                if (pcs_ptr->ref_pic_ptr_array[0][ref_idx] != NULL) {
                                     eb_release_object(pcs_ptr->ref_pic_ptr_array[0][ref_idx]);
                                 }
                             }
@@ -726,7 +726,7 @@ void *entropy_coding_kernel(void *input_ptr) {
                             for (ref_idx = 0; ref_idx < pcs_ptr->parent_pcs_ptr->ref_list1_count;
                                  ++ref_idx) {
                                 if (scs_ptr->use_output_stat_file && tile_cnt == 1 &&
-                                    pcs_ptr->ref_pic_ptr_array[1][ref_idx] != EB_NULL &&
+                                    pcs_ptr->ref_pic_ptr_array[1][ref_idx] != NULL &&
                                     pcs_ptr->ref_pic_ptr_array[1][ref_idx]->live_count == 1)
                                     write_stat_to_file(
                                         scs_ptr,
@@ -736,7 +736,7 @@ void *entropy_coding_kernel(void *input_ptr) {
                                         ((EbReferenceObject *)pcs_ptr->ref_pic_ptr_array[1][ref_idx]
                                              ->object_ptr)
                                             ->ref_poc);
-                                if (pcs_ptr->ref_pic_ptr_array[1][ref_idx] != EB_NULL)
+                                if (pcs_ptr->ref_pic_ptr_array[1][ref_idx] != NULL)
                                     eb_release_object(pcs_ptr->ref_pic_ptr_array[1][ref_idx]);
                             }
 
@@ -842,7 +842,7 @@ void *entropy_coding_kernel(void *input_ptr) {
                         for (ref_idx = 0; ref_idx < pcs_ptr->parent_pcs_ptr->ref_list0_count;
                              ++ref_idx) {
                             if (scs_ptr->use_output_stat_file &&
-                                pcs_ptr->ref_pic_ptr_array[0][ref_idx] != EB_NULL &&
+                                pcs_ptr->ref_pic_ptr_array[0][ref_idx] != NULL &&
                                 pcs_ptr->ref_pic_ptr_array[0][ref_idx]->live_count == 1)
                                 write_stat_to_file(
                                     scs_ptr,
@@ -852,7 +852,7 @@ void *entropy_coding_kernel(void *input_ptr) {
                                     ((EbReferenceObject *)pcs_ptr->ref_pic_ptr_array[0][ref_idx]
                                          ->object_ptr)
                                         ->ref_poc);
-                            if (pcs_ptr->ref_pic_ptr_array[0][ref_idx] != EB_NULL) {
+                            if (pcs_ptr->ref_pic_ptr_array[0][ref_idx] != NULL) {
                                 eb_release_object(pcs_ptr->ref_pic_ptr_array[0][ref_idx]);
                             }
                         }
@@ -861,7 +861,7 @@ void *entropy_coding_kernel(void *input_ptr) {
                         for (ref_idx = 0; ref_idx < pcs_ptr->parent_pcs_ptr->ref_list1_count;
                              ++ref_idx) {
                             if (scs_ptr->use_output_stat_file &&
-                                pcs_ptr->ref_pic_ptr_array[1][ref_idx] != EB_NULL &&
+                                pcs_ptr->ref_pic_ptr_array[1][ref_idx] != NULL &&
                                 pcs_ptr->ref_pic_ptr_array[1][ref_idx]->live_count == 1)
                                 write_stat_to_file(
                                     scs_ptr,
@@ -871,7 +871,7 @@ void *entropy_coding_kernel(void *input_ptr) {
                                     ((EbReferenceObject *)pcs_ptr->ref_pic_ptr_array[1][ref_idx]
                                          ->object_ptr)
                                         ->ref_poc);
-                            if (pcs_ptr->ref_pic_ptr_array[1][ref_idx] != EB_NULL)
+                            if (pcs_ptr->ref_pic_ptr_array[1][ref_idx] != NULL)
                                 eb_release_object(pcs_ptr->ref_pic_ptr_array[1][ref_idx]);
                         }
 
@@ -974,13 +974,13 @@ void *entropy_coding_kernel(void *input_ptr) {
 
                 // Release the List 0 Reference Pictures
                 for (ref_idx = 0; ref_idx < pcs_ptr->parent_pcs_ptr->ref_list0_count; ++ref_idx) {
-                    if (pcs_ptr->ref_pic_ptr_array[0][ref_idx] != EB_NULL)
+                    if (pcs_ptr->ref_pic_ptr_array[0][ref_idx] != NULL)
                         eb_release_object(pcs_ptr->ref_pic_ptr_array[0][ref_idx]);
                 }
 
                 // Release the List 1 Reference Pictures
                 for (ref_idx = 0; ref_idx < pcs_ptr->parent_pcs_ptr->ref_list1_count; ++ref_idx) {
-                    if (pcs_ptr->ref_pic_ptr_array[1][ref_idx] != EB_NULL)
+                    if (pcs_ptr->ref_pic_ptr_array[1][ref_idx] != NULL)
                         eb_release_object(pcs_ptr->ref_pic_ptr_array[1][ref_idx]);
                 }
 
@@ -1004,5 +1004,5 @@ void *entropy_coding_kernel(void *input_ptr) {
 #endif
     }
 
-    return EB_NULL;
+    return NULL;
 }

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -475,14 +475,14 @@ void release_pa_reference_objects(SequenceControlSet *scs_ptr, PictureParentCont
                           : MIN(pcs_ptr->ref_list1_count, scs_ptr->reference_count);
 
             for (ref_pic_index = 0; ref_pic_index < num_of_ref_pic_to_search; ++ref_pic_index) {
-                if (pcs_ptr->ref_pa_pic_ptr_array[list_index][ref_pic_index] != EB_NULL) {
+                if (pcs_ptr->ref_pa_pic_ptr_array[list_index][ref_pic_index] != NULL) {
                     eb_release_object(pcs_ptr->ref_pa_pic_ptr_array[list_index][ref_pic_index]);
                 }
             }
         }
     }
 
-    if (pcs_ptr->pa_reference_picture_wrapper_ptr != EB_NULL) {
+    if (pcs_ptr->pa_reference_picture_wrapper_ptr != NULL) {
         eb_release_object(pcs_ptr->pa_reference_picture_wrapper_ptr);
     }
 
@@ -924,7 +924,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                 queue_entry_index_temp =
                     encode_context_ptr->initial_rate_control_reorder_queue_head_index;
                 if (encode_context_ptr->initial_rate_control_reorder_queue[queue_entry_index_temp]
-                        ->parent_pcs_wrapper_ptr != EB_NULL)
+                        ->parent_pcs_wrapper_ptr != NULL)
                     end_of_sequence_flag =
                         (((PictureParentControlSet
                                *)(encode_context_ptr
@@ -951,10 +951,10 @@ void *initial_rate_control_kernel(void *input_ptr) {
                         (EbBool)(move_slide_window_flag &&
                                  (encode_context_ptr
                                       ->initial_rate_control_reorder_queue[queue_entry_index_temp2]
-                                      ->parent_pcs_wrapper_ptr != EB_NULL));
+                                      ->parent_pcs_wrapper_ptr != NULL));
                     if (encode_context_ptr
                             ->initial_rate_control_reorder_queue[queue_entry_index_temp2]
-                            ->parent_pcs_wrapper_ptr != EB_NULL) {
+                            ->parent_pcs_wrapper_ptr != NULL) {
                         // check if it is the last frame. If we have reached the last frame, we would output the buffered frames in the Queue.
                         end_of_sequence_flag =
                             ((PictureParentControlSet *)(encode_context_ptr
@@ -1106,7 +1106,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                     }
                     // Reset the Reorder Queue Entry
                     queue_entry_ptr->picture_number += INITIAL_RATE_CONTROL_REORDER_QUEUE_MAX_DEPTH;
-                    queue_entry_ptr->parent_pcs_wrapper_ptr = (EbObjectWrapper *)EB_NULL;
+                    queue_entry_ptr->parent_pcs_wrapper_ptr = (EbObjectWrapper *)NULL;
 
                     // Increment the Reorder Queue head Ptr
                     encode_context_ptr->initial_rate_control_reorder_queue_head_index =
@@ -1125,5 +1125,5 @@ void *initial_rate_control_kernel(void *input_ptr) {
         // Release the Input Results
         eb_release_object(in_results_wrapper_ptr);
     }
-    return EB_NULL;
+    return NULL;
 }

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlReorderQueue.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlReorderQueue.c
@@ -9,7 +9,7 @@
 EbErrorType initial_rate_control_reorder_entry_ctor(InitialRateControlReorderEntry *entry_ptr,
                                                     uint32_t picture_number) {
     entry_ptr->picture_number         = picture_number;
-    entry_ptr->parent_pcs_wrapper_ptr = (EbObjectWrapper *)EB_NULL;
+    entry_ptr->parent_pcs_wrapper_ptr = (EbObjectWrapper *)NULL;
 
     return EB_ErrorNone;
 }

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -322,7 +322,7 @@ void inter_intra_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                        ->object_ptr)
                       ->reference_picture;
     else
-        ref_pic_list0 = (EbPictureBufferDesc *)EB_NULL;
+        ref_pic_list0 = (EbPictureBufferDesc *)NULL;
 
     if (ref_idx_l1 >= 0)
         ref_pic_list1 =
@@ -334,7 +334,7 @@ void inter_intra_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                        ->object_ptr)
                       ->reference_picture;
     else
-        ref_pic_list1 = (EbPictureBufferDesc *)EB_NULL;
+        ref_pic_list1 = (EbPictureBufferDesc *)NULL;
 
     mv_unit.pred_direction = candidate_ptr->prediction_direction[0];
 
@@ -673,7 +673,7 @@ EbErrorType mode_decision_candidate_buffer_ctor(ModeDecisionCandidateBuffer *buf
     thirty_two_width_picture_buffer_desc_init_data.split_mode    = EB_FALSE;
 
     // Candidate Ptr
-    buffer_ptr->candidate_ptr = (ModeDecisionCandidate *)EB_NULL;
+    buffer_ptr->candidate_ptr = (ModeDecisionCandidate *)NULL;
 
     // Video Buffers
     EB_NEW(buffer_ptr->prediction_ptr,
@@ -753,7 +753,7 @@ EbErrorType mode_decision_scratch_candidate_buffer_ctor(ModeDecisionCandidateBuf
     thirty_two_width_picture_buffer_desc_init_data.split_mode    = EB_FALSE;
 
     // Candidate Ptr
-    buffer_ptr->candidate_ptr = (ModeDecisionCandidate *)EB_NULL;
+    buffer_ptr->candidate_ptr = (ModeDecisionCandidate *)NULL;
 
     // Video Buffers
     EB_NEW(buffer_ptr->prediction_ptr,

--- a/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
@@ -853,10 +853,10 @@ void set_target_budget_oq(PictureControlSet *pcs_ptr,
             ref_obj__l1 =
                 (pcs_ptr->parent_pcs_ptr->slice_type == B_SLICE)
                     ? (EbReferenceObject *)pcs_ptr->ref_pic_ptr_array[REF_LIST_1][0]->object_ptr
-                    : (EbReferenceObject *)EB_NULL;
+                    : (EbReferenceObject *)NULL;
             luminosity_change_boost =
                 ABS(pcs_ptr->parent_pcs_ptr->average_intensity[0] - ref_obj__l0->average_intensity);
-            luminosity_change_boost += (ref_obj__l1 != EB_NULL)
+            luminosity_change_boost += (ref_obj__l1 != NULL)
                                            ? ABS(pcs_ptr->parent_pcs_ptr->average_intensity[0] -
                                                  ref_obj__l1->average_intensity)
                                            : 0;
@@ -1715,5 +1715,5 @@ void *mode_decision_configuration_kernel(void *input_ptr) {
         eb_release_object(rate_control_results_wrapper_ptr);
     }
 
-    return EB_NULL;
+    return NULL;
 }

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -93,7 +93,7 @@ void *set_me_hme_params_from_config(SequenceControlSet *scs_ptr, MeContext *me_c
                 scs_ptr->static_config.hme_level2_search_area_in_height_array[hme_region_index];
     }
 
-    return EB_NULL;
+    return NULL;
 }
 
 /************************************************
@@ -188,7 +188,7 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
     if (input_resolution <= INPUT_SIZE_576p_RANGE_OR_LOWER)
         me_context_ptr->update_hme_search_center_flag = 0;
 
-    return EB_NULL;
+    return NULL;
 };
 
 /******************************************************
@@ -396,7 +396,7 @@ void *tf_set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet
     if (input_resolution <= INPUT_SIZE_576p_RANGE_OR_LOWER)
         me_context_ptr->update_hme_search_center_flag = 0;
 
-    return EB_NULL;
+    return NULL;
 };
 
 /******************************************************
@@ -1077,5 +1077,5 @@ void *motion_estimation_kernel(void *input_ptr) {
         }
     }
 
-    return EB_NULL;
+    return NULL;
 }

--- a/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
@@ -615,10 +615,10 @@ static void encode_show_existing(EncodeContext *encode_context_ptr,
 static void release_frames(EncodeContext *encode_context_ptr, int frames) {
     for (int i = 0; i < frames; i++) {
         PacketizationReorderEntry *queue_entry_ptr = get_reorder_queue_entry(encode_context_ptr, i);
-        queue_entry_ptr->out_meta_data = (EbLinkedListNode *)EB_NULL;
+        queue_entry_ptr->out_meta_data = (EbLinkedListNode *)NULL;
         // Reset the Reorder Queue Entry
         queue_entry_ptr->picture_number += PACKETIZATION_REORDER_QUEUE_MAX_DEPTH;
-        queue_entry_ptr->output_stream_wrapper_ptr = (EbObjectWrapper *)EB_NULL;
+        queue_entry_ptr->output_stream_wrapper_ptr = (EbObjectWrapper *)NULL;
     }
     encode_context_ptr->packetization_reorder_queue_head_index = get_reorder_queue_pos(encode_context_ptr, frames);
 }
@@ -766,7 +766,7 @@ void *packetization_kernel(void *input_ptr) {
             picture_manager_results_ptr->picture_type    = EB_PIC_FEEDBACK;
             picture_manager_results_ptr->scs_wrapper_ptr = pcs_ptr->scs_wrapper_ptr;
         } else {
-            picture_manager_results_wrapper_ptr = EB_NULL;
+            picture_manager_results_wrapper_ptr = NULL;
             (void)picture_manager_results_ptr;
             (void)picture_manager_results_wrapper_ptr;
         }
@@ -820,12 +820,12 @@ void *packetization_kernel(void *input_ptr) {
         queue_entry_ptr->out_meta_data = concat_eb_linked_list(
             extract_passthrough_data(&(pcs_ptr->parent_pcs_ptr->data_ll_head_ptr)),
             pcs_ptr->parent_pcs_ptr->app_out_data_ll_head_ptr);
-        pcs_ptr->parent_pcs_ptr->app_out_data_ll_head_ptr = (EbLinkedListNode *)EB_NULL;
+        pcs_ptr->parent_pcs_ptr->app_out_data_ll_head_ptr = (EbLinkedListNode *)NULL;
 
         // Calling callback functions to release the memory allocated for data linked list in the application
-        while (pcs_ptr->parent_pcs_ptr->data_ll_head_ptr != EB_NULL) {
+        while (pcs_ptr->parent_pcs_ptr->data_ll_head_ptr != NULL) {
             app_data_ll_head_temp_ptr = pcs_ptr->parent_pcs_ptr->data_ll_head_ptr->next;
-            if (pcs_ptr->parent_pcs_ptr->data_ll_head_ptr->release_cb_fnc_ptr != EB_NULL)
+            if (pcs_ptr->parent_pcs_ptr->data_ll_head_ptr->release_cb_fnc_ptr != NULL)
                 pcs_ptr->parent_pcs_ptr->data_ll_head_ptr->release_cb_fnc_ptr(
                     pcs_ptr->parent_pcs_ptr->data_ll_head_ptr);
             pcs_ptr->parent_pcs_ptr->data_ll_head_ptr = app_data_ll_head_temp_ptr;
@@ -886,6 +886,6 @@ void *packetization_kernel(void *input_ptr) {
             release_frames(encode_context_ptr, frames);
         }
     }
-    return EB_NULL;
+    return NULL;
 
 }

--- a/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
@@ -3635,5 +3635,5 @@ void *picture_analysis_kernel(void *input_ptr) {
         // Post the Full Results Object
         eb_post_full_object(out_results_wrapper_ptr);
     }
-    return EB_NULL;
+    return NULL;
 }

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.c
@@ -421,10 +421,10 @@ EbErrorType picture_control_set_ctor(PictureControlSet *object_ptr, EbPtr object
     coeff_buffer_desc_init_data.split_mode = EB_FALSE;
     coeff_buffer_desc_init_data.is_16bit_pipeline = init_data_ptr->is_16bit_pipeline;
 
-    object_ptr->scs_wrapper_ptr = (EbObjectWrapper *)EB_NULL;
+    object_ptr->scs_wrapper_ptr = (EbObjectWrapper *)NULL;
 
-    object_ptr->recon_picture16bit_ptr = (EbPictureBufferDesc *)EB_NULL;
-    object_ptr->recon_picture_ptr      = (EbPictureBufferDesc *)EB_NULL;
+    object_ptr->recon_picture16bit_ptr = (EbPictureBufferDesc *)NULL;
+    object_ptr->recon_picture_ptr      = (EbPictureBufferDesc *)NULL;
     object_ptr->color_format           = init_data_ptr->color_format;
 
     EbPictureBufferDescInitData coeff_buffer_desc_32bit_init_data;
@@ -439,7 +439,7 @@ EbErrorType picture_control_set_ctor(PictureControlSet *object_ptr, EbPtr object
     coeff_buffer_desc_32bit_init_data.bot_padding        = 0;
     coeff_buffer_desc_32bit_init_data.split_mode         = EB_FALSE;
 
-    object_ptr->recon_picture32bit_ptr = (EbPictureBufferDesc *)EB_NULL;
+    object_ptr->recon_picture32bit_ptr = (EbPictureBufferDesc *)NULL;
     EB_NEW(object_ptr->recon_picture32bit_ptr,
            eb_recon_picture_buffer_desc_ctor,
            (EbPtr)&coeff_buffer_desc_32bit_init_data);
@@ -1895,12 +1895,12 @@ EbErrorType picture_parent_control_set_ctor(PictureParentControlSet *object_ptr,
 
     object_ptr->dctor = picture_parent_control_set_dctor;
 
-    object_ptr->scs_wrapper_ptr               = (EbObjectWrapper *)EB_NULL;
-    object_ptr->input_picture_wrapper_ptr     = (EbObjectWrapper *)EB_NULL;
-    object_ptr->reference_picture_wrapper_ptr = (EbObjectWrapper *)EB_NULL;
-    object_ptr->enhanced_picture_ptr          = (EbPictureBufferDesc *)EB_NULL;
-    object_ptr->enhanced_downscaled_picture_ptr = (EbPictureBufferDesc *)EB_NULL;
-    object_ptr->enhanced_unscaled_picture_ptr   = (EbPictureBufferDesc *)EB_NULL;
+    object_ptr->scs_wrapper_ptr               = (EbObjectWrapper *)NULL;
+    object_ptr->input_picture_wrapper_ptr     = (EbObjectWrapper *)NULL;
+    object_ptr->reference_picture_wrapper_ptr = (EbObjectWrapper *)NULL;
+    object_ptr->enhanced_picture_ptr          = (EbPictureBufferDesc *)NULL;
+    object_ptr->enhanced_downscaled_picture_ptr = (EbPictureBufferDesc *)NULL;
+    object_ptr->enhanced_unscaled_picture_ptr   = (EbPictureBufferDesc *)NULL;
 
     if (init_data_ptr->color_format >= EB_YUV422) {
         EbPictureBufferDescInitData input_pic_buf_desc_init_data;
@@ -1932,8 +1932,8 @@ EbErrorType picture_parent_control_set_ctor(PictureParentControlSet *object_ptr,
     object_ptr->sb_total_count       = picture_sb_width * picture_sb_height;
     object_ptr->sb_total_count_unscaled = object_ptr->sb_total_count;
 
-    object_ptr->data_ll_head_ptr         = (EbLinkedListNode *)EB_NULL;
-    object_ptr->app_out_data_ll_head_ptr = (EbLinkedListNode *)EB_NULL;
+    object_ptr->data_ll_head_ptr         = (EbLinkedListNode *)NULL;
+    object_ptr->app_out_data_ll_head_ptr = (EbLinkedListNode *)NULL;
     EB_MALLOC_2D(object_ptr->variance, object_ptr->sb_total_count, MAX_ME_PU_COUNT);
     EB_MALLOC_2D(object_ptr->y_mean, object_ptr->sb_total_count, MAX_ME_PU_COUNT);
     EB_MALLOC_2D(object_ptr->cb_mean, object_ptr->sb_total_count, 21);

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -496,7 +496,7 @@ EbErrorType release_prev_picture_from_reorder_queue(
         // Reset the Picture Decision Reordering Queue Entry
         // P.S. The reset of the Picture Decision Reordering Queue Entry could not be done before running the Scene Change Detector
         queue_previous_entry_ptr->picture_number += PICTURE_DECISION_REORDER_QUEUE_MAX_DEPTH;
-        queue_previous_entry_ptr->parent_pcs_wrapper_ptr = (EbObjectWrapper *)EB_NULL;
+        queue_previous_entry_ptr->parent_pcs_wrapper_ptr = (EbObjectWrapper *)NULL;
     }
 
     return return_error;
@@ -3797,7 +3797,7 @@ static EbErrorType av1_generate_minigop_rps_info_from_user_config(
     uint32_t                       mini_gop_index
 )
 {
-    PictureParentControlSet       *picture_control_set_ptr = EB_NULL;
+    PictureParentControlSet       *picture_control_set_ptr = NULL;
     if (encode_context_ptr->is_mini_gop_changed) {
         PredictionStructure          *next_pred_struct_ptr;
         PredictionStructureEntry     *next_base_layer_pred_position_ptr;
@@ -4411,7 +4411,7 @@ void* picture_decision_kernel(void *input_ptr)
 
     int32_t                           previous_entry_index;
 
-    PaReferenceQueueEntry         *input_entry_ptr = (PaReferenceQueueEntry*)EB_NULL;;
+    PaReferenceQueueEntry         *input_entry_ptr = (PaReferenceQueueEntry*)NULL;;
     uint32_t                           input_queue_index;
 
     PaReferenceQueueEntry         *pa_reference_entry_ptr;
@@ -4474,7 +4474,7 @@ void* picture_decision_kernel(void *input_ptr)
         // P.S. The Picture Decision Reordering Queue should be parsed in the display order to be able to construct a pred structure
         queue_entry_ptr = encode_context_ptr->picture_decision_reorder_queue[encode_context_ptr->picture_decision_reorder_queue_head_index];
 
-        while (queue_entry_ptr->parent_pcs_wrapper_ptr != EB_NULL) {
+        while (queue_entry_ptr->parent_pcs_wrapper_ptr != NULL) {
             if (((PictureParentControlSet *)(queue_entry_ptr->parent_pcs_wrapper_ptr->object_ptr))->end_of_sequence_flag == EB_TRUE) {
                 frame_passthrough = EB_TRUE;
             }
@@ -4770,7 +4770,7 @@ void* picture_decision_kernel(void *input_ptr)
                                     eb_release_object(pcs_ptr->overlay_ppcs_ptr->pa_reference_picture_wrapper_ptr);
                                     // release the parent pcs
                                     eb_release_object(pcs_ptr->overlay_ppcs_ptr->p_pcs_wrapper_ptr);
-                                    pcs_ptr->overlay_ppcs_ptr = EB_NULL;
+                                    pcs_ptr->overlay_ppcs_ptr = NULL;
                                 }
                             }
                             PictureParentControlSet       *cur_picture_control_set_ptr = pcs_ptr;
@@ -5006,7 +5006,7 @@ void* picture_decision_kernel(void *input_ptr)
                                 }
                                 else if (pcs_ptr->idr_flag == EB_TRUE) {
                                     // Set the Picture Decision PA Reference Entry pointer
-                                    input_entry_ptr = (PaReferenceQueueEntry*)EB_NULL;
+                                    input_entry_ptr = (PaReferenceQueueEntry*)NULL;
                                 }
 
                                 // Place Picture in Picture Decision PA Reference Queue
@@ -5024,7 +5024,7 @@ void* picture_decision_kernel(void *input_ptr)
                                     // Check if the Picture Decision PA Reference is full
                                     CHECK_REPORT_ERROR(
                                         (((encode_context_ptr->picture_decision_pa_reference_queue_head_index != encode_context_ptr->picture_decision_pa_reference_queue_tail_index) ||
-                                        (encode_context_ptr->picture_decision_pa_reference_queue[encode_context_ptr->picture_decision_pa_reference_queue_head_index]->input_object_ptr == EB_NULL))),
+                                        (encode_context_ptr->picture_decision_pa_reference_queue[encode_context_ptr->picture_decision_pa_reference_queue_head_index]->input_object_ptr == NULL))),
                                         encode_context_ptr->app_callback_ptr,
                                         EB_ENC_PD_ERROR4);
                                 }
@@ -5484,7 +5484,7 @@ void* picture_decision_kernel(void *input_ptr)
                         (input_entry_ptr->input_object_ptr)) {
                         // Release the nominal live_count value
                         eb_release_object(input_entry_ptr->input_object_ptr);
-                        input_entry_ptr->input_object_ptr = (EbObjectWrapper*)EB_NULL;
+                        input_entry_ptr->input_object_ptr = (EbObjectWrapper*)NULL;
                     }
 
                     // Increment the head_index if the head is null
@@ -5495,7 +5495,7 @@ void* picture_decision_kernel(void *input_ptr)
 
                     CHECK_REPORT_ERROR(
                         (((encode_context_ptr->picture_decision_pa_reference_queue_head_index != encode_context_ptr->picture_decision_pa_reference_queue_tail_index) ||
-                        (encode_context_ptr->picture_decision_pa_reference_queue[encode_context_ptr->picture_decision_pa_reference_queue_head_index]->input_object_ptr == EB_NULL))),
+                        (encode_context_ptr->picture_decision_pa_reference_queue[encode_context_ptr->picture_decision_pa_reference_queue_head_index]->input_object_ptr == NULL))),
                         encode_context_ptr->app_callback_ptr,
                         EB_ENC_PD_ERROR4);
 
@@ -5517,6 +5517,6 @@ void* picture_decision_kernel(void *input_ptr)
         eb_release_object(in_results_wrapper_ptr);
     }
 
-    return EB_NULL;
+    return NULL;
 }
 // clang-format on

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -233,7 +233,7 @@ void *picture_manager_kernel(void *input_ptr) {
             queue_entry_ptr = encode_context_ptr->picture_manager_reorder_queue
                                   [encode_context_ptr->picture_manager_reorder_queue_head_index];
 
-            while (queue_entry_ptr->parent_pcs_wrapper_ptr != EB_NULL) {
+            while (queue_entry_ptr->parent_pcs_wrapper_ptr != NULL) {
                 pcs_ptr =
                     (PictureParentControlSet *)queue_entry_ptr->parent_pcs_wrapper_ptr->object_ptr;
 
@@ -457,7 +457,7 @@ void *picture_manager_kernel(void *input_ptr) {
                     }
                 } else if (pcs_ptr->idr_flag == EB_TRUE) {
                     // Set Reference Entry pointer
-                    reference_entry_ptr = (ReferenceQueueEntry *)EB_NULL;
+                    reference_entry_ptr = (ReferenceQueueEntry *)NULL;
                 }
 
                 // Check if the EnhancedPictureQueue is full.
@@ -468,7 +468,7 @@ void *picture_manager_kernel(void *input_ptr) {
                        encode_context_ptr->input_picture_queue_tail_index) ||
                       (encode_context_ptr
                            ->input_picture_queue[encode_context_ptr->input_picture_queue_head_index]
-                           ->input_object_ptr == EB_NULL))),
+                           ->input_object_ptr == NULL))),
                     encode_context_ptr->app_callback_ptr,
                     EB_ENC_PM_ERROR4);
 
@@ -502,7 +502,7 @@ void *picture_manager_kernel(void *input_ptr) {
                           (encode_context_ptr
                                ->reference_picture_queue[encode_context_ptr
                                                              ->reference_picture_queue_head_index]
-                               ->reference_object_ptr == EB_NULL))),
+                               ->reference_object_ptr == NULL))),
                         encode_context_ptr->app_callback_ptr,
                         EB_ENC_PM_ERROR5);
 
@@ -511,7 +511,7 @@ void *picture_manager_kernel(void *input_ptr) {
                         encode_context_ptr->reference_picture_queue
                             [encode_context_ptr->reference_picture_queue_tail_index];
                     reference_entry_ptr->picture_number        = pcs_ptr->picture_number;
-                    reference_entry_ptr->reference_object_ptr  = (EbObjectWrapper *)EB_NULL;
+                    reference_entry_ptr->reference_object_ptr  = (EbObjectWrapper *)NULL;
                     reference_entry_ptr->release_enable        = EB_TRUE;
                     reference_entry_ptr->reference_available   = EB_FALSE;
                     reference_entry_ptr->slice_type            = pcs_ptr->slice_type;
@@ -560,11 +560,11 @@ void *picture_manager_kernel(void *input_ptr) {
                 if (pcs_ptr->is_used_as_reference_flag == EB_FALSE) {
                     // Release the nominal live_count value
                     eb_release_object(pcs_ptr->reference_picture_wrapper_ptr);
-                    pcs_ptr->reference_picture_wrapper_ptr = (EbObjectWrapper *)EB_NULL;
+                    pcs_ptr->reference_picture_wrapper_ptr = (EbObjectWrapper *)NULL;
                 }
 
                 // Release the Picture Manager Reorder Queue
-                queue_entry_ptr->parent_pcs_wrapper_ptr = (EbObjectWrapper *)EB_NULL;
+                queue_entry_ptr->parent_pcs_wrapper_ptr = (EbObjectWrapper *)NULL;
                 queue_entry_ptr->picture_number += PICTURE_MANAGER_REORDER_QUEUE_MAX_DEPTH;
 
                 // Increment the Picture Manager Reorder Queue
@@ -662,8 +662,8 @@ void *picture_manager_kernel(void *input_ptr) {
 
             CHECK_REPORT_ERROR_NC(encode_context_ptr->app_callback_ptr, EB_ENC_PM_ERROR9);
 
-            pcs_ptr            = (PictureParentControlSet *)EB_NULL;
-            encode_context_ptr = (EncodeContext *)EB_NULL;
+            pcs_ptr            = (PictureParentControlSet *)NULL;
+            encode_context_ptr = (EncodeContext *)NULL;
 
             break;
         }
@@ -673,12 +673,12 @@ void *picture_manager_kernel(void *input_ptr) {
         // *************************************
 
         // Walk the input queue and start all ready pictures.  Mark entry as null after started.  Increment the head as you go.
-        if (encode_context_ptr != (EncodeContext *)EB_NULL) {
+        if (encode_context_ptr != (EncodeContext *)NULL) {
             input_queue_index = encode_context_ptr->input_picture_queue_head_index;
             while (input_queue_index != encode_context_ptr->input_picture_queue_tail_index) {
                 input_entry_ptr = encode_context_ptr->input_picture_queue[input_queue_index];
 
-                if (input_entry_ptr->input_object_ptr != EB_NULL) {
+                if (input_entry_ptr->input_object_ptr != NULL) {
                     entry_pcs_ptr =
                         (PictureParentControlSet *)input_entry_ptr->input_object_ptr->object_ptr;
                     entry_scs_ptr =
@@ -1385,7 +1385,7 @@ void *picture_manager_kernel(void *input_ptr) {
                         eb_post_full_object(output_wrapper_ptr);
 
                         // Remove the Input Entry from the Input Queue
-                        input_entry_ptr->input_object_ptr = (EbObjectWrapper *)EB_NULL;
+                        input_entry_ptr->input_object_ptr = (EbObjectWrapper *)NULL;
                     }
                 }
 
@@ -1429,7 +1429,7 @@ void *picture_manager_kernel(void *input_ptr) {
                                  reference_entry_ptr->reference_object_ptr->object_ptr)
                                 ->ref_poc);
                     eb_release_object(reference_entry_ptr->reference_object_ptr);
-                    reference_entry_ptr->reference_object_ptr      = (EbObjectWrapper *)EB_NULL;
+                    reference_entry_ptr->reference_object_ptr      = (EbObjectWrapper *)NULL;
                     reference_entry_ptr->reference_available       = EB_FALSE;
                     reference_entry_ptr->is_used_as_reference_flag = EB_FALSE;
                 }
@@ -1470,5 +1470,5 @@ void *picture_manager_kernel(void *input_ptr) {
         // Release the Input Picture Demux Results
         eb_release_object(input_picture_demux_wrapper_ptr);
     }
-    return EB_NULL;
+    return NULL;
 }

--- a/Source/Lib/Encoder/Codec/EbPredictionStructure.c
+++ b/Source/Lib/Encoder/Codec/EbPredictionStructure.c
@@ -737,7 +737,7 @@ static PredictionStructureConfig prediction_structure_config_array[] = {
     {8, four_level_hierarchical_pred_struct},
     {16, five_level_hierarchical_pred_struct},
     {32, six_level_hierarchical_pred_struct},
-    {0, (PredictionStructureConfigEntry *)EB_NULL} // Terminating Code, must always come last!
+    {0, (PredictionStructureConfigEntry *)NULL} // Terminating Code, must always come last!
 };
 
 /************************************************
@@ -1100,7 +1100,7 @@ static EbErrorType prediction_structure_ctor(
                                     ->ref_list0.reference_list_count);
             } else
                 predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
-                    ->ref_list0.reference_list = (int32_t *)EB_NULL;
+                    ->ref_list0.reference_list = (int32_t *)NULL;
             // Copy Config List1 => LeadingPic Reference List 0
             for (ref_index = 0;
                  ref_index < predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
@@ -1114,7 +1114,7 @@ static EbErrorType prediction_structure_ctor(
             predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
                 ->ref_list1.reference_list_count = 0;
             predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
-                ->ref_list1.reference_list = (int32_t *)EB_NULL;
+                ->ref_list1.reference_list = (int32_t *)NULL;
 
             // Set the Temporal Layer Index
             predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]->temporal_layer_index =
@@ -1169,7 +1169,7 @@ static EbErrorType prediction_structure_ctor(
                                     ->ref_list0.reference_list_count);
             } else
                 predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
-                    ->ref_list0.reference_list = (int32_t *)EB_NULL;
+                    ->ref_list0.reference_list = (int32_t *)NULL;
             // Copy Reference List 0
             for (ref_index = 0;
                  ref_index < predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
@@ -1187,7 +1187,7 @@ static EbErrorType prediction_structure_ctor(
                 predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
                     ->ref_list1.reference_list_count = 0;
                 predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
-                    ->ref_list1.reference_list = (int32_t *)EB_NULL;
+                    ->ref_list1.reference_list = (int32_t *)NULL;
 
                 break;
 
@@ -1210,7 +1210,7 @@ static EbErrorType prediction_structure_ctor(
                                         ->ref_list1.reference_list_count);
                 } else
                     predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
-                        ->ref_list1.reference_list = (int32_t *)EB_NULL;
+                        ->ref_list1.reference_list = (int32_t *)NULL;
                 // Copy Reference List 1
                 for (ref_index = 0;
                      ref_index < predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
@@ -1249,7 +1249,7 @@ static EbErrorType prediction_structure_ctor(
                                         ->ref_list1.reference_list_count);
                 } else
                     predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
-                        ->ref_list1.reference_list = (int32_t *)EB_NULL;
+                        ->ref_list1.reference_list = (int32_t *)NULL;
                 // Copy Reference List 1
                 for (ref_index = 0;
                      ref_index < predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
@@ -1324,7 +1324,7 @@ static EbErrorType prediction_structure_ctor(
                 predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
                     ->ref_list1.reference_list_count = 0;
                 predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
-                    ->ref_list1.reference_list = (int32_t *)EB_NULL;
+                    ->ref_list1.reference_list = (int32_t *)NULL;
 
                 break;
 
@@ -1347,7 +1347,7 @@ static EbErrorType prediction_structure_ctor(
                                         ->ref_list1.reference_list_count);
                 } else
                     predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
-                        ->ref_list1.reference_list = (int32_t *)EB_NULL;
+                        ->ref_list1.reference_list = (int32_t *)NULL;
                 // Copy Reference List 1
                 for (ref_index = 0;
                      ref_index < predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
@@ -1380,7 +1380,7 @@ static EbErrorType prediction_structure_ctor(
                                         ->ref_list1.reference_list_count);
                 } else
                     predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
-                        ->ref_list1.reference_list = (int32_t *)EB_NULL;
+                        ->ref_list1.reference_list = (int32_t *)NULL;
                 // Copy Reference List 1
                 for (ref_index = 0;
                      ref_index < predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]
@@ -1437,7 +1437,7 @@ static EbErrorType prediction_structure_ctor(
     //
     //        // Null out List 1
     //        predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]->ref_list1.reference_list_count = 0;
-    //        predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]->ref_list1.reference_list = (int32_t*) EB_NULL;
+    //        predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]->ref_list1.reference_list = (int32_t*) NULL;
     //
     //        // Set the Temporal Layer Index
     //        predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]->temporal_layer_index = predictionStructureConfigPtr->entry_array[config_entry_index].temporal_layer_index;
@@ -1523,7 +1523,7 @@ static EbErrorType prediction_structure_ctor(
                                     ->dep_list0.list_count);
             } else
                 predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]->dep_list0.list =
-                    (int32_t *)EB_NULL;
+                    (int32_t *)NULL;
         }
 
         // Third, reset the Dependent List Length (they are re-derived)
@@ -1671,7 +1671,7 @@ static EbErrorType prediction_structure_ctor(
                                     ->dep_list1.list_count);
             } else
                 predictionStructurePtr->pred_struct_entry_ptr_array[entry_index]->dep_list1.list =
-                    (int32_t *)EB_NULL;
+                    (int32_t *)NULL;
         }
 
         // Third, reset the Dependent List Length (they are re-derived)

--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -6043,5 +6043,5 @@ void *rate_control_kernel(void *input_ptr) {
         }
     }
 
-    return EB_NULL;
+    return NULL;
 }

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -802,7 +802,7 @@ void *resource_coordination_kernel(void *input_ptr) {
             eb_object_release_disable(
                 context_ptr->sequence_control_set_active_array[instance_index]);
 
-            if (prev_scs_wrapper_ptr != EB_NULL) {
+            if (prev_scs_wrapper_ptr != NULL) {
                 // Enable releaseFlag of old SequenceControlSet
                 eb_object_release_enable(prev_scs_wrapper_ptr);
 
@@ -1112,5 +1112,5 @@ void *resource_coordination_kernel(void *input_ptr) {
         }
     }
 
-    return EB_NULL;
+    return NULL;
 }

--- a/Source/Lib/Encoder/Codec/EbRestProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRestProcess.c
@@ -640,5 +640,5 @@ void *rest_kernel(void *input_ptr) {
         eb_release_object(cdef_results_wrapper_ptr);
     }
 
-    return EB_NULL;
+    return NULL;
 }

--- a/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
@@ -59,7 +59,7 @@ EbErrorType eb_sequence_control_set_ctor(SequenceControlSet *scs_ptr, EbPtr obje
     }
 
     // Encode Context
-    if (scs_init_data != EB_NULL) scs_ptr->encode_context_ptr = scs_init_data->encode_context_ptr;
+    if (scs_init_data != NULL) scs_ptr->encode_context_ptr = scs_init_data->encode_context_ptr;
 
     // Profile & ID
     scs_ptr->chroma_format_idc   = EB_YUV420;
@@ -395,7 +395,7 @@ EbErrorType eb_sequence_control_set_instance_ctor(EbSequenceControlSetInstance *
 
     object_ptr->dctor = eb_sequence_control_set_instance_dctor;
 
-    EB_NEW(object_ptr->encode_context_ptr, encode_context_ctor, EB_NULL);
+    EB_NEW(object_ptr->encode_context_ptr, encode_context_ctor, NULL);
     scs_init_data.encode_context_ptr = object_ptr->encode_context_ptr;
 
     scs_init_data.sb_size = 64;

--- a/Source/Lib/Encoder/Codec/EbSourceBasedOperationsProcess.c
+++ b/Source/Lib/Encoder/Codec/EbSourceBasedOperationsProcess.c
@@ -161,5 +161,5 @@ void *source_based_operations_kernel(void *input_ptr) {
         // Post the Full Results Object
         eb_post_full_object(out_results_wrapper_ptr);
     }
-    return EB_NULL;
+    return NULL;
 }


### PR DESCRIPTION
There is no good reason to have an own definition that is essentially
the same as `NULL`, it just makes the code more confusing to read.