### PR TITLE
Documentation fix: keyint -> intra-period

### DIFF
--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -173,7 +173,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 #### Keyframe Placement Options
 | **Configuration file parameter** | **Command line** | **Range** | **Default** | **Description** |
 | --- | --- | --- | --- | --- |
-| **IntraPeriod** | --keyint | [-2 - 255] | -1 | Intra period interval(frames) -2: No intra update, -1: default intra period or [0-255] |
+| **IntraPeriod** | --intra-period | [-2 - 255] | -1 | Intra period interval(frames) -2: No intra update, -1: default intra period or [0-255] |
 | **IntraRefreshType** | --irefresh-type | [1 - 2] | 1 | 1: CRA (Open GOP)2: IDR (Closed GOP) |
 
 #### AV1 Specific Options


### PR DESCRIPTION
The documentation says --keyint but in reality it seems that the name of the parameter is --intra-period (at least in the latest available release)