### PR TITLE
CMake: Default build type to Release if needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,8 @@ endif()
 
 project(svt-av1 C CXX ASM_NASM)
 
-if(NOT CMAKE_BUILD_TYPE AND NOT (MSVC OR CMAKE_GENERATOR STREQUAL "Xcode"))
+# Default build type to release if the generator does not has its own set of build types
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 


### PR DESCRIPTION
Instead of special-casing some generators here, instead check the
CMAKE_CONFIGURATION_TYPES variable, if that is set it means the
generator has its own choices for build types and does not need the
CMAKE_BUILD_TYPE. Else default the build type to release, like before.

See https://blog.kitware.com/cmake-and-the-default-build-type/