### PR TITLE
Fix calling NULL pointer

### DIFF
--- a/Source/Lib/Encoder/Codec/EbPredictionStructure.c
+++ b/Source/Lib/Encoder/Codec/EbPredictionStructure.c
@@ -2150,11 +2150,11 @@ EbErrorType prediction_structure_group_ctor(PredictionStructureGroup *pred_struc
     // Insert manual prediction structure into array
     if (config->enable_manual_pred_struct) {
         prediction_structure_config_array[config->hierarchical_levels].entry_count = config->manual_pred_struct_entry_num;
-        eb_memcpy(prediction_structure_config_array[config->hierarchical_levels].entry_array,
+        EB_MEMCPY(prediction_structure_config_array[config->hierarchical_levels].entry_array,
           &config->pred_struct[config->manual_pred_struct_entry_num - 1],
           sizeof(PredictionStructureConfigEntry));
         if (config->manual_pred_struct_entry_num > 1) {
-            eb_memcpy(prediction_structure_config_array[config->hierarchical_levels].entry_array + 1,
+            EB_MEMCPY(prediction_structure_config_array[config->hierarchical_levels].entry_array + 1,
               &config->pred_struct[0],
               (config->manual_pred_struct_entry_num - 1) * sizeof(PredictionStructureConfigEntry));
         }


### PR DESCRIPTION
The eb_memcpy is a function pointer to NULL which is only initialized
after a call to setup_common_rtcd_internal, which is not done yet
when this is called.

Fix #1216

This issues might be present in other cases, this code is a bit messy and the way those pointer are initialized being done in `setup_common_rtcd_internal` is really weird…
Even more confusing that there is `EB_MEMCPY` which does not do the same as `eb_memcpy` with regard to which implementation is called…
(It was introduced in #1155 where some `EB_MEMCPY` were replaced with `eb_memcpy`)