### PR TITLE
Snap: Use 'git' as version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: svt-av1-enc
 base: core18
-version: '0.8.1+dev'
+version: 'git'
 summary: Scalable Video Technology implementation of AV1 encoder
 description: |
   An AV1-compliant cpu-based encoder library and sample application


### PR DESCRIPTION
The magic version 'git' will be replaced with the git describe string
as per the snapcraft.yaml documentation:
https://snapcraft.io/docs/snapcraft-yaml-reference