### PR TITLE
Fix for AVX2/AVX512 kernels when non-multiple of 8 resolution is used

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/wiener_convolve_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/wiener_convolve_avx2.c
@@ -140,7 +140,6 @@ void eb_av1_wiener_convolve_add_src_avx2(const uint8_t* const src, const ptrdiff
 
     (void)conv_params;
     assert(!(w % 8));
-    assert(!(h % 2));
     assert(conv_params->round_0 == round_0);
     assert(conv_params->round_1 == round_1);
 
@@ -320,8 +319,13 @@ void eb_av1_wiener_convolve_add_src_avx2(const uint8_t* const src, const ptrdiff
                 src_p += 2 * src_stride;
                 const __m256i r0 = wiener_convolve_v8x2_tap7(coeffs_v, round_v, s[0]);
                 const __m256i r1 = wiener_convolve_v8x2_tap7(coeffs_v, round_v, s[1]);
-                pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
-
+                if (y == 1) {
+                    const __m256i d = _mm256_packus_epi16(r0, r1);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storeu_si128((__m128i*)dst_p, d0);
+                } else {
+                    pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                }
                 dst_p += 2 * dst_stride;
                 y -= 2;
             } while (y > 0);
@@ -360,8 +364,13 @@ void eb_av1_wiener_convolve_add_src_avx2(const uint8_t* const src, const ptrdiff
                                          _mm256_castsi256_si128(s[6]));
                 src_p += 2 * src_stride;
                 const __m256i r = wiener_convolve_v8x2_tap7(coeffs_v, round_v, s);
-                pack_store_8x2_avx2(r, dst_ptr, dst_stride);
-
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r, r);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storel_epi64((__m128i*)dst_ptr, d0);
+                } else {
+                    pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                }
                 dst_ptr += 2 * dst_stride;
                 y -= 2;
             } while (y > 0);
@@ -500,8 +509,13 @@ void eb_av1_wiener_convolve_add_src_avx2(const uint8_t* const src, const ptrdiff
                 src_p += 2 * src_stride;
                 const __m256i r0 = wiener_convolve_v8x2_tap5(coeffs_v, round_v, s[0]);
                 const __m256i r1 = wiener_convolve_v8x2_tap5(coeffs_v, round_v, s[1]);
-                pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
-
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r0, r1);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storeu_si128((__m128i*)dst_p, d0);
+                } else {
+                    pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                }
                 dst_p += 2 * dst_stride;
                 y -= 2;
             } while (y > 0);
@@ -535,8 +549,13 @@ void eb_av1_wiener_convolve_add_src_avx2(const uint8_t* const src, const ptrdiff
                                          _mm256_castsi256_si128(s[4]));
                 src_p += 2 * src_stride;
                 const __m256i r = wiener_convolve_v8x2_tap5(coeffs_v, round_v, s);
-                pack_store_8x2_avx2(r, dst_ptr, dst_stride);
-
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r, r);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storel_epi64((__m128i*)dst_ptr, d0);
+                } else {
+                    pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                }
                 dst_ptr += 2 * dst_stride;
                 y -= 2;
             } while (y > 0);
@@ -638,8 +657,13 @@ void eb_av1_wiener_convolve_add_src_avx2(const uint8_t* const src, const ptrdiff
                 src_p += 2 * src_stride;
                 const __m256i r0 = wiener_convolve_v8x2_tap3(coeffs_v, round_v, s[0]);
                 const __m256i r1 = wiener_convolve_v8x2_tap3(coeffs_v, round_v, s[1]);
-                pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
-
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r0, r1);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storeu_si128((__m128i*)dst_p, d0);
+                } else {
+                    pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                }
                 dst_p += 2 * dst_stride;
                 y -= 2;
             } while (y > 0);
@@ -667,8 +691,13 @@ void eb_av1_wiener_convolve_add_src_avx2(const uint8_t* const src, const ptrdiff
                                          _mm256_castsi256_si128(s[2]));
                 src_p += 2 * src_stride;
                 const __m256i r = wiener_convolve_v8x2_tap3(coeffs_v, round_v, s);
-                pack_store_8x2_avx2(r, dst_ptr, dst_stride);
-
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r, r);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storel_epi64((__m128i*)dst_ptr, d0);
+                } else {
+                    pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                }
                 dst_ptr += 2 * dst_stride;
                 y -= 2;
             } while (y > 0);

--- a/Source/Lib/Common/ASM_AVX512/wiener_convolve_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/wiener_convolve_avx512.c
@@ -334,7 +334,6 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
 
     (void)conv_params;
     assert(!(w % 8));
-    assert(!(h % 2));
     assert(conv_params->round_0 == round_0);
     assert(conv_params->round_1 == round_1);
 
@@ -515,7 +514,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                     src_p += 2 * src_stride;
                     const __m512i r0 = wiener_convolve_v16x2_tap7(coeffs_v_512, round_v_512, s[0]);
                     const __m512i r1 = wiener_convolve_v16x2_tap7(coeffs_v_512, round_v_512, s[1]);
-                    pack_store_32x2_avx512(r0, r1, dst_p, dst_stride);
+                    if (y == 1) {
+                        const __m512i d = _mm512_packus_epi16(r0, r1);
+                        const __m256i d0 = _mm512_castsi512_si256(d);
+                        _mm256_storeu_si256((__m256i*)dst_p, d0);
+                    } else {
+                        pack_store_32x2_avx512(r0, r1, dst_p, dst_stride);
+                    }
 
                     dst_p += 2 * dst_stride;
                     y -= 2;
@@ -605,7 +610,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                 src_p += 2 * src_stride;
                 const __m256i r0 = wiener_convolve_v8x2_tap7(coeffs_v, round_v, s[0]);
                 const __m256i r1 = wiener_convolve_v8x2_tap7(coeffs_v, round_v, s[1]);
-                pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r0, r1);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storeu_si128((__m128i*)dst_p, d0);
+                } else {
+                    pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                }
 
                 dst_p += 2 * dst_stride;
                 y -= 2;
@@ -645,7 +656,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                                          _mm256_castsi256_si128(s[6]));
                 src_p += 2 * src_stride;
                 const __m256i r = wiener_convolve_v8x2_tap7(coeffs_v, round_v, s);
-                pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r, r);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storel_epi64((__m128i*)dst_ptr, d0);
+                } else {
+                    pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                }
 
                 dst_ptr += 2 * dst_stride;
                 y -= 2;
@@ -791,7 +808,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                     src_p += 2 * src_stride;
                     const __m512i r0 = wiener_convolve_v16x2_tap5(coeffs_v_512, round_v_512, s[0]);
                     const __m512i r1 = wiener_convolve_v16x2_tap5(coeffs_v_512, round_v_512, s[1]);
-                    pack_store_32x2_avx512(r0, r1, dst_p, dst_stride);
+                    if (y == 1) {
+                        const __m512i d  = _mm512_packus_epi16(r0, r1);
+                        const __m256i d0 = _mm512_castsi512_si256(d);
+                        _mm256_storeu_si256((__m256i*)dst_p, d0);
+                    } else {
+                        pack_store_32x2_avx512(r0, r1, dst_p, dst_stride);
+                    }
 
                     dst_p += 2 * dst_stride;
                     y -= 2;
@@ -866,7 +889,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                 src_p += 2 * src_stride;
                 const __m256i r0 = wiener_convolve_v8x2_tap5(coeffs_v, round_v, s[0]);
                 const __m256i r1 = wiener_convolve_v8x2_tap5(coeffs_v, round_v, s[1]);
-                pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r0, r1);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storeu_si128((__m128i*)dst_p, d0);
+                } else {
+                    pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                }
 
                 dst_p += 2 * dst_stride;
                 y -= 2;
@@ -901,7 +930,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                                          _mm256_castsi256_si128(s[4]));
                 src_p += 2 * src_stride;
                 const __m256i r = wiener_convolve_v8x2_tap5(coeffs_v, round_v, s);
-                pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r, r);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storel_epi64((__m128i*)dst_ptr, d0);
+                } else {
+                    pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                }
 
                 dst_ptr += 2 * dst_stride;
                 y -= 2;
@@ -1008,7 +1043,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                     src_p += 2 * src_stride;
                     const __m512i r0 = wiener_convolve_v16x2_tap3(coeffs_v_512, round_v_512, s[0]);
                     const __m512i r1 = wiener_convolve_v16x2_tap3(coeffs_v_512, round_v_512, s[1]);
-                    pack_store_32x2_avx512(r0, r1, dst_p, dst_stride);
+                    if (y == 1) {
+                        const __m512i d  = _mm512_packus_epi16(r0, r1);
+                        const __m256i d0 = _mm512_castsi512_si256(d);
+                        _mm256_storeu_si256((__m256i*)dst_p, d0);
+                    } else {
+                        pack_store_32x2_avx512(r0, r1, dst_p, dst_stride);
+                    }
 
                     dst_p += 2 * dst_stride;
                     y -= 2;
@@ -1065,7 +1106,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                 src_p += 2 * src_stride;
                 const __m256i r0 = wiener_convolve_v8x2_tap3(coeffs_v, round_v, s[0]);
                 const __m256i r1 = wiener_convolve_v8x2_tap3(coeffs_v, round_v, s[1]);
-                pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r0, r1);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storeu_si128((__m128i*)dst_p, d0);
+                } else {
+                    pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                }
 
                 dst_p += 2 * dst_stride;
                 y -= 2;
@@ -1094,7 +1141,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                                          _mm256_castsi256_si128(s[2]));
                 src_p += 2 * src_stride;
                 const __m256i r = wiener_convolve_v8x2_tap3(coeffs_v, round_v, s);
-                pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r, r);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storel_epi64((__m128i*)dst_ptr, d0);
+                } else {
+                    pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                }
 
                 dst_ptr += 2 * dst_stride;
                 y -= 2;

--- a/Source/Lib/Encoder/ASM_AVX2/pickrst_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/pickrst_avx2.c
@@ -57,12 +57,12 @@ static INLINE uint8_t find_average_avx2(const uint8_t *src, int32_t h_start, int
 
         do {
             int32_t j = 0;
-            do {
+            while (j < w32) {
                 const __m256i s   = _mm256_loadu_si256((__m256i *)(src_t + j));
                 const __m256i sad = _mm256_sad_epu8(s, _mm256_setzero_si256());
                 ss                = _mm256_add_epi32(ss, sad);
                 j += 32;
-            } while (j < w32);
+            };
 
             const __m256i s   = _mm256_loadu_si256((__m256i *)(src_t + j));
             const __m256i s_t = _mm256_and_si256(s, mask);
@@ -125,11 +125,11 @@ static INLINE uint16_t find_average_highbd_avx2(const uint16_t *src, int32_t h_s
                 __m256i ss = _mm256_setzero_si256();
 
                 int32_t j = 0;
-                do {
+                while (j < w16) {
                     const __m256i s = _mm256_loadu_si256((__m256i *)(src_t + j));
                     ss              = _mm256_add_epi16(ss, s);
                     j += 16;
-                } while (j < w16);
+                };
 
                 const __m256i s   = _mm256_loadu_si256((__m256i *)(src_t + j));
                 const __m256i s_t = _mm256_and_si256(s, mask);
@@ -173,11 +173,11 @@ static INLINE uint16_t find_average_highbd_avx2(const uint16_t *src, int32_t h_s
                 __m256i ss = _mm256_setzero_si256();
 
                 int32_t j = 0;
-                do {
+                while (j < 256){
                     const __m256i s = _mm256_loadu_si256((__m256i *)(src_t + j));
                     ss              = _mm256_add_epi16(ss, s);
                     j += 16;
-                } while (j < 256);
+                };
 
                 add_u16_to_u32_avx2(ss, &sss);
                 ss = _mm256_setzero_si256();
@@ -211,16 +211,16 @@ static INLINE void sub_avg_block_avx2(const uint8_t *src, const int32_t src_stri
                                       int16_t *dst, const int32_t dst_stride) {
     const __m256i a = _mm256_set1_epi16(avg);
 
-    int32_t i = height;
+    int32_t i = height+1;
     do {
         int32_t j = 0;
-        do {
+        while (j < width) {
             const __m128i s  = _mm_loadu_si128((__m128i *)(src + j));
             const __m256i ss = _mm256_cvtepu8_epi16(s);
             const __m256i d  = _mm256_sub_epi16(ss, a);
             _mm256_storeu_si256((__m256i *)(dst + j), d);
             j += 16;
-        } while (j < width);
+        };
 
         src += src_stride;
         dst += dst_stride;
@@ -235,15 +235,15 @@ static INLINE void sub_avg_block_highbd_avx2(const uint16_t *src, const int32_t 
                                              const int32_t dst_stride) {
     const __m256i a = _mm256_set1_epi16(avg);
 
-    int32_t i = height;
+    int32_t i = height+1;
     do {
         int32_t j = 0;
-        do {
+        while (j < width){
             const __m256i s = _mm256_loadu_si256((__m256i *)(src + j));
             const __m256i d = _mm256_sub_epi16(s, a);
             _mm256_storeu_si256((__m256i *)(dst + j), d);
             j += 16;
-        } while (j < width);
+        };
 
         src += src_stride;
         dst += dst_stride;
@@ -898,12 +898,12 @@ static INLINE void compute_stats_win3_avx2(const int16_t *const d, const int32_t
             y = height;
             do {
                 x = 0;
-                do {
+                while (x < w16) {
                     const __m256i src = _mm256_loadu_si256((__m256i *)(s_t + x));
                     const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + x));
                     stats_top_win3_avx2(src, dgd, d_t + j + x, d_stride, sum_m, sum_h);
                     x += 16;
-                } while (x < w16);
+                };
 
                 if (w16 != width) {
                     const __m256i src      = _mm256_loadu_si256((__m256i *)(s_t + w16));
@@ -936,11 +936,11 @@ static INLINE void compute_stats_win3_avx2(const int16_t *const d, const int32_t
             y = height;
             do {
                 x = 0;
-                do {
+                while (x < w16) {
                     const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + j + x));
                     stats_left_win3_avx2(dgd, d_t + x, d_stride, sum_h);
                     x += 16;
-                } while (x < w16);
+                };
 
                 if (w16 != width) {
                     const __m256i dgd      = _mm256_loadu_si256((__m256i *)(d_t + j + x));
@@ -978,12 +978,12 @@ static INLINE void compute_stats_win3_avx2(const int16_t *const d, const int32_t
                 y = h_t;
                 do {
                     x = 0;
-                    do {
+                    while (x < w16) {
                         const __m256i src = _mm256_loadu_si256((__m256i *)(s_t + x));
                         const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + x));
                         stats_top_win3_avx2(src, dgd, d_t + j + x, d_stride, row_m, row_h);
                         x += 16;
-                    } while (x < w16);
+                    } ;
 
                     if (w16 != width) {
                         const __m256i src      = _mm256_loadu_si256((__m256i *)(s_t + w16));
@@ -1033,11 +1033,11 @@ static INLINE void compute_stats_win3_avx2(const int16_t *const d, const int32_t
                 y = h_t;
                 do {
                     x = 0;
-                    do {
+                    while (x < w16) {
                         const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + j + x));
                         stats_left_win3_avx2(dgd, d_t + x, d_stride, row_h);
                         x += 16;
-                    } while (x < w16);
+                    };
 
                     if (w16 != width) {
                         const __m256i dgd      = _mm256_loadu_si256((__m256i *)(d_t + j + x));
@@ -1089,7 +1089,7 @@ static INLINE void compute_stats_win3_avx2(const int16_t *const d, const int32_t
         } else {
             int32_t h4_t = 0;
 
-            do {
+            while (h4_t < h4) {
                 __m256i deltas_t[WIENER_WIN_3TAP] = {0};
 
                 const int32_t h_t = ((h4 - h4_t) < 256) ? (h4 - h4_t) : 256;
@@ -1105,7 +1105,7 @@ static INLINE void compute_stats_win3_avx2(const int16_t *const d, const int32_t
                 deltas[1]   = _mm256_add_epi64(deltas[1], deltas_t[2]);
 
                 h4_t += h_t;
-            } while (h4_t < h4);
+            };
 
             delta = _mm256_setzero_si256();
         }
@@ -1222,7 +1222,7 @@ static INLINE void compute_stats_win3_avx2(const int16_t *const d, const int32_t
         se0 = _mm256_setzero_si256(); // Initialize to avoid warning.
 
         y = 0;
-        do {
+        while (y < h8) {
             // 00s 01s 10s 11s 20s 21s 30s 31s  00e 01e 10e 11e 20e 21e 30e 31e
             se0 = _mm256_insert_epi32(se0, *(int32_t *)(d_t + 0 * d_stride), 0);
             se0 = _mm256_insert_epi32(se0, *(int32_t *)(d_t + 0 * d_stride + width), 4);
@@ -1268,7 +1268,7 @@ static INLINE void compute_stats_win3_avx2(const int16_t *const d, const int32_t
 
             d_t += 8 * d_stride;
             y += 8;
-        } while (y < h8);
+        };
 
         if (bit_depth < AOM_BITS_12) {
             deltas[0] = _mm256_hadd_epi32(deltas[0], deltas[1]); // T0 T0 t1 t1  T0 T0 t1 t1
@@ -1304,7 +1304,7 @@ static INLINE void compute_stats_win3_avx2(const int16_t *const d, const int32_t
             dd[0] = _mm256_insert_epi16(dd[0], d_t[1 * d_stride + width], 9);
             ds[0] = _mm256_insert_epi16(ds[0], d_t[1 * d_stride + 1 + width], 3);
 
-            do {
+           do {
                 dd[0] = _mm256_insert_epi16(dd[0], -d_t[0 * d_stride], 0);
                 dd[0] = _mm256_insert_epi16(dd[0], d_t[0 * d_stride + width], 1);
                 dd[0] = _mm256_unpacklo_epi32(dd[0], dd[0]);
@@ -1326,7 +1326,7 @@ static INLINE void compute_stats_win3_avx2(const int16_t *const d, const int32_t
                 dd[0] = _mm256_permutevar8x32_epi32(dd[0], perm);
                 ds[0] = _mm256_permutevar8x32_epi32(ds[0], perm);
                 d_t += d_stride;
-            } while (++y < height);
+           } while (++y < height);
         }
 
         // Writing one more H on the top edge of a square falls to the next
@@ -1373,12 +1373,12 @@ static INLINE void compute_stats_win3_avx2(const int16_t *const d, const int32_t
             __m256i              d_js[WIENER_WIN_3TAP - 1], d_je[WIENER_WIN_3TAP - 1];
 
             x = 0;
-            do {
+            while (x < w16) {
                 load_square_win3_avx2(di + x, d_j + x, d_stride, height, d_is, d_ie, d_js, d_je);
                 derive_square_win3_avx2(d_is, d_ie, d_js, d_je, deltas);
 
                 x += 16;
-            } while (x < w16);
+            };
 
             if (w16 != width) {
                 load_square_win3_avx2(di + x, d_j + x, d_stride, height, d_is, d_ie, d_js, d_je);
@@ -1417,12 +1417,12 @@ static INLINE void compute_stats_win3_avx2(const int16_t *const d, const int32_t
         __m256i              d_is[WIENER_WIN_3TAP - 1], d_ie[WIENER_WIN_3TAP - 1];
 
         x = 0;
-        do {
+        while (x < w16) {
             load_triangle_win3_avx2(di + x, d_stride, height, d_is, d_ie);
             derive_triangle_win3_avx2(d_is, d_ie, deltas);
 
             x += 16;
-        } while (x < w16);
+        };
 
         if (w16 != width) {
             load_triangle_win3_avx2(di + x, d_stride, height, d_is, d_ie);
@@ -1482,12 +1482,12 @@ static INLINE void compute_stats_win5_avx2(const int16_t *const d, const int32_t
             y = height;
             do {
                 x = 0;
-                do {
+                while (x < w16){
                     const __m256i src = _mm256_loadu_si256((__m256i *)(s_t + x));
                     const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + x));
                     stats_top_win5_avx2(src, dgd, d_t + j + x, d_stride, sum_m, sum_h);
                     x += 16;
-                } while (x < w16);
+                };
 
                 if (w16 != width) {
                     const __m256i src      = _mm256_loadu_si256((__m256i *)(s_t + w16));
@@ -1520,11 +1520,11 @@ static INLINE void compute_stats_win5_avx2(const int16_t *const d, const int32_t
             y = height;
             do {
                 x = 0;
-                do {
+                while (x < w16){
                     const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + j + x));
                     stats_left_win5_avx2(dgd, d_t + x, d_stride, sum_h);
                     x += 16;
-                } while (x < w16);
+                };
 
                 if (w16 != width) {
                     const __m256i dgd      = _mm256_loadu_si256((__m256i *)(d_t + j + x));
@@ -1568,12 +1568,12 @@ static INLINE void compute_stats_win5_avx2(const int16_t *const d, const int32_t
                 y = h_t;
                 do {
                     x = 0;
-                    do {
+                    while (x < w16) {
                         const __m256i src = _mm256_loadu_si256((__m256i *)(s_t + x));
                         const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + x));
                         stats_top_win5_avx2(src, dgd, d_t + j + x, d_stride, row_m, row_h);
                         x += 16;
-                    } while (x < w16);
+                    };
 
                     if (w16 != width) {
                         const __m256i src      = _mm256_loadu_si256((__m256i *)(s_t + w16));
@@ -1627,11 +1627,11 @@ static INLINE void compute_stats_win5_avx2(const int16_t *const d, const int32_t
                 y = h_t;
                 do {
                     x = 0;
-                    do {
+                    while (x < w16) {
                         const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + j + x));
                         stats_left_win5_avx2(dgd, d_t + x, d_stride, row_h);
                         x += 16;
-                    } while (x < w16);
+                    };
 
                     if (w16 != width) {
                         const __m256i dgd      = _mm256_loadu_si256((__m256i *)(d_t + j + x));
@@ -1666,139 +1666,221 @@ static INLINE void compute_stats_win5_avx2(const int16_t *const d, const int32_t
     // triangle in top row.
     {
         const int16_t *d_t = d;
-        // 16-bit idx: 0, 4, 1, 5, 2, 6, 3, 7
-        const __m256i shf                       = _mm256_setr_epi8(0,
-                                             1,
-                                             8,
-                                             9,
-                                             2,
-                                             3,
-                                             10,
-                                             11,
-                                             4,
-                                             5,
-                                             12,
-                                             13,
-                                             6,
-                                             7,
-                                             14,
-                                             15,
-                                             0,
-                                             1,
-                                             8,
-                                             9,
-                                             2,
-                                             3,
-                                             10,
-                                             11,
-                                             4,
-                                             5,
-                                             12,
-                                             13,
-                                             6,
-                                             7,
-                                             14,
-                                             15);
-        __m256i       deltas[WIENER_WIN_CHROMA] = {0};
-        __m256i       dd = _mm256_setzero_si256(); // Initialize to avoid warning.
-        __m256i       ds[WIENER_WIN_CHROMA];
 
-        // 00s 01s 02s 03s 10s 11s 12s 13s  00e 01e 02e 03e 10e 11e 12e 13e
-        dd = _mm256_insert_epi64(dd, *(int64_t *)(d_t + 0 * d_stride), 0);
-        dd = _mm256_insert_epi64(dd, *(int64_t *)(d_t + 0 * d_stride + width), 2);
-        dd = _mm256_insert_epi64(dd, *(int64_t *)(d_t + 1 * d_stride), 1);
-        dd = _mm256_insert_epi64(dd, *(int64_t *)(d_t + 1 * d_stride + width), 3);
-        // 00s 10s 01s 11s 02s 12s 03s 13s  00e 10e 01e 11e 02e 12e 03e 13e
-        ds[0] = _mm256_shuffle_epi8(dd, shf);
+        if (height % 2) {
+            __m256i deltas[WIENER_WIN + 1] = {0};
+            __m256i ds[WIENER_WIN];
 
-        // 10s 11s 12s 13s 20s 21s 22s 23s  10e 11e 12e 13e 20e 21e 22e 23e
-        load_more_64_avx2(d_t + 2 * d_stride, width, &dd);
-        // 10s 20s 11s 21s 12s 22s 13s 23s  10e 20e 11e 21e 12e 22e 13e 23e
-        ds[1] = _mm256_shuffle_epi8(dd, shf);
+            ds[0] = load_win7_avx2(d_t + 0 * d_stride, width);
+            ds[1] = load_win7_avx2(d_t + 1 * d_stride, width);
+            ds[2] = load_win7_avx2(d_t + 2 * d_stride, width);
+            ds[3] = load_win7_avx2(d_t + 3 * d_stride, width);
+            d_t += 4 * d_stride;
 
-        // 20s 21s 22s 23s 30s 31s 32s 33s  20e 21e 22e 23e 30e 31e 32e 33e
-        load_more_64_avx2(d_t + 3 * d_stride, width, &dd);
-        // 20s 30s 21s 31s 22s 32s 23s 33s  20e 30e 21e 31e 22e 32e 23e 33e
-        ds[2] = _mm256_shuffle_epi8(dd, shf);
+            if (bit_depth < AOM_BITS_12) {
+                step3_win5_oneline_avx2(&d_t, d_stride, width, height, ds, deltas);
+                transpose_32bit_8x8_avx2(deltas, deltas);
 
-        if (bit_depth < AOM_BITS_12) {
-            __m128i dlts[WIENER_WIN_CHROMA];
+                update_5_stats_avx2(H + 0 * wiener_win * wiener_win2 + 0 * wiener_win,
+                                    _mm256_extracti128_si256(deltas[0], 0),
+                                    _mm256_extract_epi32(deltas[0], 4),
+                                    H + 1 * wiener_win * wiener_win2 + 1 * wiener_win);
 
-            step3_win5_avx2(&d_t, d_stride, width, height, &dd, ds, deltas);
+                update_5_stats_avx2(H + 1 * wiener_win * wiener_win2 + 1 * wiener_win,
+                                    _mm256_extracti128_si256(deltas[1], 0),
+                                    _mm256_extract_epi32(deltas[1], 4),
+                                    H + 2 * wiener_win * wiener_win2 + 2 * wiener_win);
 
-            dlts[0] = sub_hi_lo_32_avx2(deltas[0]);
-            dlts[1] = sub_hi_lo_32_avx2(deltas[1]);
-            dlts[2] = sub_hi_lo_32_avx2(deltas[2]);
-            dlts[3] = sub_hi_lo_32_avx2(deltas[3]);
-            dlts[4] = sub_hi_lo_32_avx2(deltas[4]);
+                update_5_stats_avx2(H + 2 * wiener_win * wiener_win2 + 2 * wiener_win,
+                                    _mm256_extracti128_si256(deltas[2], 0),
+                                    _mm256_extract_epi32(deltas[2], 4),
+                                    H + 3 * wiener_win * wiener_win2 + 3 * wiener_win);
 
-            transpose_32bit_4x4(dlts, dlts);
-            deltas[4] = _mm256_cvtepi32_epi64(dlts[4]);
+                update_5_stats_avx2(H + 3 * wiener_win * wiener_win2 + 3 * wiener_win,
+                                    _mm256_extracti128_si256(deltas[3], 0),
+                                    _mm256_extract_epi32(deltas[3], 4),
+                                    H + 4 * wiener_win * wiener_win2 + 4 * wiener_win);
+            } else {
+                __m128i deltas128[WIENER_WIN] = {0};
+                int32_t height_t              = 0;
 
-            update_5_stats_avx2(H + 0 * wiener_win * wiener_win2 + 0 * wiener_win,
-                                dlts[0],
-                                _mm256_extract_epi64(deltas[4], 0),
-                                H + 1 * wiener_win * wiener_win2 + 1 * wiener_win);
+                do {
+                    __m256i       deltas_t[WIENER_WIN] = {0};
+                    const int32_t h_t = ((height - height_t) < 128) ? (height - height_t) : 128;
 
-            update_5_stats_avx2(H + 1 * wiener_win * wiener_win2 + 1 * wiener_win,
-                                dlts[1],
-                                _mm256_extract_epi64(deltas[4], 1),
-                                H + 2 * wiener_win * wiener_win2 + 2 * wiener_win);
+                    step3_win5_oneline_avx2(&d_t, d_stride, width, h_t, ds, deltas_t);
+                    add_six_32_to_64_avx2(deltas_t[0], &deltas[0], &deltas128[0]);
+                    add_six_32_to_64_avx2(deltas_t[1], &deltas[1], &deltas128[1]);
+                    add_six_32_to_64_avx2(deltas_t[2], &deltas[2], &deltas128[2]);
+                    add_six_32_to_64_avx2(deltas_t[3], &deltas[3], &deltas128[3]);
+                    add_six_32_to_64_avx2(deltas_t[4], &deltas[4], &deltas128[4]);
+                    add_six_32_to_64_avx2(deltas_t[5], &deltas[5], &deltas128[5]);
+                    add_six_32_to_64_avx2(deltas_t[6], &deltas[6], &deltas128[6]);
 
-            update_5_stats_avx2(H + 2 * wiener_win * wiener_win2 + 2 * wiener_win,
-                                dlts[2],
-                                _mm256_extract_epi64(deltas[4], 2),
-                                H + 3 * wiener_win * wiener_win2 + 3 * wiener_win);
+                    height_t += h_t;
+                } while (height_t < height);
 
-            update_5_stats_avx2(H + 3 * wiener_win * wiener_win2 + 3 * wiener_win,
-                                dlts[3],
-                                _mm256_extract_epi64(deltas[4], 3),
-                                H + 4 * wiener_win * wiener_win2 + 4 * wiener_win);
-        } else {
-            int32_t height_t = 0;
+                transpose_64bit_4x8_avx2(deltas, deltas);
 
-            do {
-                __m256i       deltas_t[WIENER_WIN_CHROMA] = {0};
-                const int32_t h_t = ((height - height_t) < 128) ? (height - height_t) : 128;
+                update_5_stats_highbd_avx2(H + 0 * wiener_win * wiener_win2 + 0 * wiener_win,
+                                           deltas[0],
+                                           _mm256_extract_epi64(deltas[1], 0),
+                                           H + 1 * wiener_win * wiener_win2 + 1 * wiener_win);
 
-                step3_win5_avx2(&d_t, d_stride, width, h_t, &dd, ds, deltas_t);
+                update_5_stats_highbd_avx2(H + 1 * wiener_win * wiener_win2 + 1 * wiener_win,
+                                           deltas[2],
+                                           _mm256_extract_epi64(deltas[3], 0),
+                                           H + 2 * wiener_win * wiener_win2 + 2 * wiener_win);
 
-                deltas_t[0] = hsub_32x8_to_64x4_avx2(deltas_t[0]);
-                deltas_t[1] = hsub_32x8_to_64x4_avx2(deltas_t[1]);
-                deltas_t[2] = hsub_32x8_to_64x4_avx2(deltas_t[2]);
-                deltas_t[3] = hsub_32x8_to_64x4_avx2(deltas_t[3]);
-                deltas_t[4] = hsub_32x8_to_64x4_avx2(deltas_t[4]);
-                deltas[0]   = _mm256_add_epi64(deltas[0], deltas_t[0]);
-                deltas[1]   = _mm256_add_epi64(deltas[1], deltas_t[1]);
-                deltas[2]   = _mm256_add_epi64(deltas[2], deltas_t[2]);
-                deltas[3]   = _mm256_add_epi64(deltas[3], deltas_t[3]);
-                deltas[4]   = _mm256_add_epi64(deltas[4], deltas_t[4]);
+                update_5_stats_highbd_avx2(H + 2 * wiener_win * wiener_win2 + 2 * wiener_win,
+                                           deltas[4],
+                                           _mm256_extract_epi64(deltas[5], 0),
+                                           H + 3 * wiener_win * wiener_win2 + 3 * wiener_win);
 
-                height_t += h_t;
-            } while (height_t < height);
+                update_5_stats_highbd_avx2(H + 3 * wiener_win * wiener_win2 + 3 * wiener_win,
+                                           deltas[6],
+                                           _mm256_extract_epi64(deltas[7], 0),
+                                           H + 4 * wiener_win * wiener_win2 + 4 * wiener_win);
+            }
 
-            transpose_64bit_4x4_avx2(deltas, deltas);
-
-            update_5_stats_highbd_avx2(H + 0 * wiener_win * wiener_win2 + 0 * wiener_win,
-                                       deltas[0],
-                                       _mm256_extract_epi64(deltas[4], 0),
-                                       H + 1 * wiener_win * wiener_win2 + 1 * wiener_win);
-
-            update_5_stats_highbd_avx2(H + 1 * wiener_win * wiener_win2 + 1 * wiener_win,
-                                       deltas[1],
-                                       _mm256_extract_epi64(deltas[4], 1),
-                                       H + 2 * wiener_win * wiener_win2 + 2 * wiener_win);
-
-            update_5_stats_highbd_avx2(H + 2 * wiener_win * wiener_win2 + 2 * wiener_win,
-                                       deltas[2],
-                                       _mm256_extract_epi64(deltas[4], 2),
-                                       H + 3 * wiener_win * wiener_win2 + 3 * wiener_win);
-
-            update_5_stats_highbd_avx2(H + 3 * wiener_win * wiener_win2 + 3 * wiener_win,
-                                       deltas[3],
-                                       _mm256_extract_epi64(deltas[4], 3),
-                                       H + 4 * wiener_win * wiener_win2 + 4 * wiener_win);
         }
+        else {
+            // 16-bit idx: 0, 4, 1, 5, 2, 6, 3, 7
+            const __m256i shf = _mm256_setr_epi8(0,
+                                                 1,
+                                                 8,
+                                                 9,
+                                                 2,
+                                                 3,
+                                                 10,
+                                                 11,
+                                                 4,
+                                                 5,
+                                                 12,
+                                                 13,
+                                                 6,
+                                                 7,
+                                                 14,
+                                                 15,
+                                                 0,
+                                                 1,
+                                                 8,
+                                                 9,
+                                                 2,
+                                                 3,
+                                                 10,
+                                                 11,
+                                                 4,
+                                                 5,
+                                                 12,
+                                                 13,
+                                                 6,
+                                                 7,
+                                                 14,
+                                                 15);
+            __m256i       deltas[WIENER_WIN_CHROMA] = {0};
+            __m256i       dd = _mm256_setzero_si256(); // Initialize to avoid warning.
+            __m256i       ds[WIENER_WIN_CHROMA];
+
+            // 00s 01s 02s 03s 10s 11s 12s 13s  00e 01e 02e 03e 10e 11e 12e 13e
+            dd = _mm256_insert_epi64(dd, *(int64_t *)(d_t + 0 * d_stride), 0);
+            dd = _mm256_insert_epi64(dd, *(int64_t *)(d_t + 0 * d_stride + width), 2);
+            dd = _mm256_insert_epi64(dd, *(int64_t *)(d_t + 1 * d_stride), 1);
+            dd = _mm256_insert_epi64(dd, *(int64_t *)(d_t + 1 * d_stride + width), 3);
+            // 00s 10s 01s 11s 02s 12s 03s 13s  00e 10e 01e 11e 02e 12e 03e 13e
+            ds[0] = _mm256_shuffle_epi8(dd, shf);
+
+            // 10s 11s 12s 13s 20s 21s 22s 23s  10e 11e 12e 13e 20e 21e 22e 23e
+            load_more_64_avx2(d_t + 2 * d_stride, width, &dd);
+            // 10s 20s 11s 21s 12s 22s 13s 23s  10e 20e 11e 21e 12e 22e 13e 23e
+            ds[1] = _mm256_shuffle_epi8(dd, shf);
+
+            // 20s 21s 22s 23s 30s 31s 32s 33s  20e 21e 22e 23e 30e 31e 32e 33e
+            load_more_64_avx2(d_t + 3 * d_stride, width, &dd);
+            // 20s 30s 21s 31s 22s 32s 23s 33s  20e 30e 21e 31e 22e 32e 23e 33e
+            ds[2] = _mm256_shuffle_epi8(dd, shf);
+
+            if (bit_depth < AOM_BITS_12) {
+                __m128i dlts[WIENER_WIN_CHROMA];
+
+                step3_win5_avx2(&d_t, d_stride, width, height, &dd, ds, deltas);
+
+                dlts[0] = sub_hi_lo_32_avx2(deltas[0]);
+                dlts[1] = sub_hi_lo_32_avx2(deltas[1]);
+                dlts[2] = sub_hi_lo_32_avx2(deltas[2]);
+                dlts[3] = sub_hi_lo_32_avx2(deltas[3]);
+                dlts[4] = sub_hi_lo_32_avx2(deltas[4]);
+
+                transpose_32bit_4x4(dlts, dlts);
+                deltas[4] = _mm256_cvtepi32_epi64(dlts[4]);
+
+                update_5_stats_avx2(H + 0 * wiener_win * wiener_win2 + 0 * wiener_win,
+                                    dlts[0],
+                                    _mm256_extract_epi64(deltas[4], 0),
+                                    H + 1 * wiener_win * wiener_win2 + 1 * wiener_win);
+
+                update_5_stats_avx2(H + 1 * wiener_win * wiener_win2 + 1 * wiener_win,
+                                    dlts[1],
+                                    _mm256_extract_epi64(deltas[4], 1),
+                                    H + 2 * wiener_win * wiener_win2 + 2 * wiener_win);
+
+                update_5_stats_avx2(H + 2 * wiener_win * wiener_win2 + 2 * wiener_win,
+                                    dlts[2],
+                                    _mm256_extract_epi64(deltas[4], 2),
+                                    H + 3 * wiener_win * wiener_win2 + 3 * wiener_win);
+
+                update_5_stats_avx2(H + 3 * wiener_win * wiener_win2 + 3 * wiener_win,
+                                    dlts[3],
+                                    _mm256_extract_epi64(deltas[4], 3),
+                                    H + 4 * wiener_win * wiener_win2 + 4 * wiener_win);
+            } else {
+                int32_t height_t = 0;
+
+                do {
+                    __m256i       deltas_t[WIENER_WIN_CHROMA] = {0};
+                    const int32_t h_t = ((height - height_t) < 128) ? (height - height_t) : 128;
+
+                    step3_win5_avx2(&d_t, d_stride, width, h_t, &dd, ds, deltas_t);
+
+                    deltas_t[0] = hsub_32x8_to_64x4_avx2(deltas_t[0]);
+                    deltas_t[1] = hsub_32x8_to_64x4_avx2(deltas_t[1]);
+                    deltas_t[2] = hsub_32x8_to_64x4_avx2(deltas_t[2]);
+                    deltas_t[3] = hsub_32x8_to_64x4_avx2(deltas_t[3]);
+                    deltas_t[4] = hsub_32x8_to_64x4_avx2(deltas_t[4]);
+                    deltas[0]   = _mm256_add_epi64(deltas[0], deltas_t[0]);
+                    deltas[1]   = _mm256_add_epi64(deltas[1], deltas_t[1]);
+                    deltas[2]   = _mm256_add_epi64(deltas[2], deltas_t[2]);
+                    deltas[3]   = _mm256_add_epi64(deltas[3], deltas_t[3]);
+                    deltas[4]   = _mm256_add_epi64(deltas[4], deltas_t[4]);
+
+                    height_t += h_t;
+                } while (height_t < height);
+
+                transpose_64bit_4x4_avx2(deltas, deltas);
+
+                update_5_stats_highbd_avx2(H + 0 * wiener_win * wiener_win2 + 0 * wiener_win,
+                                           deltas[0],
+                                           _mm256_extract_epi64(deltas[4], 0),
+                                           H + 1 * wiener_win * wiener_win2 + 1 * wiener_win);
+
+                update_5_stats_highbd_avx2(H + 1 * wiener_win * wiener_win2 + 1 * wiener_win,
+                                           deltas[1],
+                                           _mm256_extract_epi64(deltas[4], 1),
+                                           H + 2 * wiener_win * wiener_win2 + 2 * wiener_win);
+
+                update_5_stats_highbd_avx2(H + 2 * wiener_win * wiener_win2 + 2 * wiener_win,
+                                           deltas[2],
+                                           _mm256_extract_epi64(deltas[4], 2),
+                                           H + 3 * wiener_win * wiener_win2 + 3 * wiener_win);
+
+                update_5_stats_highbd_avx2(H + 3 * wiener_win * wiener_win2 + 3 * wiener_win,
+                                           deltas[3],
+                                           _mm256_extract_epi64(deltas[4], 3),
+                                           H + 4 * wiener_win * wiener_win2 + 4 * wiener_win);
+            }
+
+        }
+
     }
 
     // Step 4: Derive the top and left edge of each square. No square in top and
@@ -1836,7 +1918,7 @@ static INLINE void compute_stats_win5_avx2(const int16_t *const d, const int32_t
             ds[0] = _mm256_insert_epi16(ds[0], d_j[3 * d_stride + width], 11);
 
             y = 0;
-            do {
+            while (y < h8) {
                 // 00s 10s 20s 30s 40s 50s 60s 70s  00e 10e 20e 30e 40e 50e 60e
                 // 70e
                 dd[0] = _mm256_insert_epi16(dd[0], di[4 * d_stride], 4);
@@ -1883,7 +1965,7 @@ static INLINE void compute_stats_win5_avx2(const int16_t *const d, const int32_t
                 di += 8 * d_stride;
                 d_j += 8 * d_stride;
                 y += 8;
-            } while (y < h8);
+            };
 
             if (bit_depth < AOM_BITS_12) {
                 deltas[0]            = _mm256_hadd_epi32(deltas[0], deltas[1]);
@@ -2038,12 +2120,12 @@ static INLINE void compute_stats_win5_avx2(const int16_t *const d, const int32_t
             __m256i d_js[WIENER_WIN_CHROMA - 1], d_je[WIENER_WIN_CHROMA - 1];
 
             x = 0;
-            do {
+            while (x < w16) {
                 load_square_win5_avx2(di + x, d_j + x, d_stride, height, d_is, d_ie, d_js, d_je);
                 derive_square_win5_avx2(d_is, d_ie, d_js, d_je, deltas);
 
                 x += 16;
-            } while (x < w16);
+            };
 
             if (w16 != width) {
                 load_square_win5_avx2(di + x, d_j + x, d_stride, height, d_is, d_ie, d_js, d_je);
@@ -2106,12 +2188,12 @@ static INLINE void compute_stats_win5_avx2(const int16_t *const d, const int32_t
         __m256i              d_is[WIENER_WIN_CHROMA - 1], d_ie[WIENER_WIN_CHROMA - 1];
 
         x = 0;
-        do {
+        while (x < w16) {
             load_triangle_win5_avx2(di + x, d_stride, height, d_is, d_ie);
             derive_triangle_win5_avx2(d_is, d_ie, deltas);
 
             x += 16;
-        } while (x < w16);
+        };
 
         if (w16 != width) {
             load_triangle_win5_avx2(di + x, d_stride, height, d_is, d_ie);
@@ -2205,12 +2287,12 @@ static INLINE void compute_stats_win7_avx2(const int16_t *const d, const int32_t
             y = height;
             do {
                 x = 0;
-                do {
+                while(x < w16){
                     const __m256i src = _mm256_loadu_si256((__m256i *)(s_t + x));
                     const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + x));
                     stats_top_win7_avx2(src, dgd, d_t + j + x, d_stride, sum_m, sum_h);
                     x += 16;
-                } while (x < w16);
+                };
 
                 if (w16 != width) {
                     const __m256i src      = _mm256_loadu_si256((__m256i *)(s_t + w16));
@@ -2248,11 +2330,11 @@ static INLINE void compute_stats_win7_avx2(const int16_t *const d, const int32_t
             y = height;
             do {
                 x = 0;
-                do {
+                while(x < w16){
                     const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + j + x));
                     stats_left_win7_avx2(dgd, d_t + x, d_stride, sum_h);
                     x += 16;
-                } while (x < w16);
+                };
 
                 if (w16 != width) {
                     const __m256i dgd      = _mm256_loadu_si256((__m256i *)(d_t + j + x));
@@ -2300,12 +2382,12 @@ static INLINE void compute_stats_win7_avx2(const int16_t *const d, const int32_t
                 y = h_t;
                 do {
                     x = 0;
-                    do {
+                    while(x < w16){
                         const __m256i src = _mm256_loadu_si256((__m256i *)(s_t + x));
                         const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + x));
                         stats_top_win7_avx2(src, dgd, d_t + j + x, d_stride, row_m, row_h);
                         x += 16;
-                    } while (x < w16);
+                    };
 
                     if (w16 != width) {
                         const __m256i src      = _mm256_loadu_si256((__m256i *)(s_t + w16));
@@ -2368,11 +2450,11 @@ static INLINE void compute_stats_win7_avx2(const int16_t *const d, const int32_t
                 y = h_t;
                 do {
                     x = 0;
-                    do {
+                    while(x < w16){
                         const __m256i dgd = _mm256_loadu_si256((__m256i *)(d_t + j + x));
                         stats_left_win7_avx2(dgd, d_t + x, d_stride, row_h);
                         x += 16;
-                    } while (x < w16);
+                    };
 
                     if (w16 != width) {
                         const __m256i dgd      = _mm256_loadu_si256((__m256i *)(d_t + j + x));
@@ -2570,7 +2652,7 @@ static INLINE void compute_stats_win7_avx2(const int16_t *const d, const int32_t
             ds[0] = _mm256_insert_epi16(ds[0], d_j[5 * d_stride + width], 13);
 
             y = 0;
-            do {
+            while (y < h8) {
                 // 00s 10s 20s 30s 40s 50s 60s 70s  00e 10e 20e 30e 40e 50e 60e
                 // 70e
                 dd[0] = _mm256_insert_epi16(dd[0], di[6 * d_stride], 6);
@@ -2618,7 +2700,7 @@ static INLINE void compute_stats_win7_avx2(const int16_t *const d, const int32_t
                 di += 8 * d_stride;
                 d_j += 8 * d_stride;
                 y += 8;
-            } while (y < h8);
+            };
 
             if (bit_depth < AOM_BITS_12) {
                 deltas[0]            = _mm256_hadd_epi32(deltas[0], deltas[1]);
@@ -2810,12 +2892,12 @@ static INLINE void compute_stats_win7_avx2(const int16_t *const d, const int32_t
             __m256i              d_js[WIENER_WIN - 1], d_je[WIENER_WIN - 1];
 
             x = 0;
-            do {
+            while (x < w16) {
                 load_square_win7_avx2(di + x, d_j + x, d_stride, height, d_is, d_ie, d_js, d_je);
                 derive_square_win7_avx2(d_is, d_ie, d_js, d_je, deltas);
 
                 x += 16;
-            } while (x < w16);
+            };
 
             if (w16 != width) {
                 load_square_win7_avx2(di + x, d_j + x, d_stride, height, d_is, d_ie, d_js, d_je);
@@ -2898,12 +2980,12 @@ static INLINE void compute_stats_win7_avx2(const int16_t *const d, const int32_t
         __m256i              d_is[WIENER_WIN - 1], d_ie[WIENER_WIN - 1];
 
         x = 0;
-        do {
+        while (x < w16) {
             load_triangle_win7_avx2(di + x, d_stride, height, d_is, d_ie);
             derive_triangle_win7_avx2(d_is, d_ie, deltas);
 
             x += 16;
-        } while (x < w16);
+        };
 
         if (w16 != width) {
             load_triangle_win7_avx2(di + x, d_stride, height, d_is, d_ie);
@@ -3034,8 +3116,6 @@ void eb_av1_compute_stats_avx2(int32_t wiener_win, const uint8_t *dgd, const uin
     d = eb_aom_memalign(32, sizeof(*d) * 6 * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX);
     s = d + 3 * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX;
 
-    assert(!(height % 2));
-
     sub_avg_block_avx2(
         src + v_start * src_stride + h_start, src_stride, avg, width, height, s, s_stride);
     sub_avg_block_avx2(dgd + (v_start - wiener_halfwin) * dgd_stride + h_start - wiener_halfwin,
@@ -3078,8 +3158,6 @@ void eb_av1_compute_stats_highbd_avx2(int32_t wiener_win, const uint8_t *dgd8, c
     const int32_t s_stride = (width + 15) & ~15;
     int32_t       k;
     int16_t *     d, *s;
-
-    assert(!(height % 2));
 
     // The maximum input size is width * height, which is
     // (9 / 4) * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX. Enlarge to

--- a/Source/Lib/Encoder/ASM_AVX512/pickrst_avx512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/pickrst_avx512.c
@@ -82,12 +82,12 @@ static INLINE uint8_t find_average_avx512(const uint8_t *src, int32_t h_start, i
 
         do {
             int32_t j = 0;
-            do {
+            while (j < w64) {
                 const __m512i s   = _mm512_loadu_si512((__m512i *)(src_t + j));
                 const __m512i sad = _mm512_sad_epu8(s, _mm512_setzero_si512());
                 ss                = _mm512_add_epi32(ss, sad);
                 j += 64;
-            } while (j < w64);
+            };
 
             const __m512i s   = _mm512_loadu_si512((__m512i *)(src_t + j));
             const __m512i s_t = _mm512_and_si512(s, mask);
@@ -177,11 +177,11 @@ static INLINE uint16_t find_average_highbd_avx512(const uint16_t *src, int32_t h
             i = h_t;
             do {
                 int32_t j = 0;
-                do {
+                while (j < w32) {
                     const __m512i s = _mm512_loadu_si512((__m512i *)(src_t + j));
                     ss              = _mm512_add_epi16(ss, s);
                     j += 32;
-                } while (j < w32);
+                };
 
                 const __m512i s   = _mm512_loadu_si512((__m512i *)(src_t + j));
                 const __m512i s_t = _mm512_and_si512(s, mask);
@@ -208,16 +208,16 @@ static INLINE void sub_avg_block_avx512(const uint8_t *src, const int32_t src_st
                                         const int32_t dst_stride) {
     const __m512i a = _mm512_set1_epi16(avg);
 
-    int32_t i = height;
+    int32_t i = height +1;
     do {
         int32_t j = 0;
-        do {
+        while (j < width) {
             const __m256i s  = _mm256_loadu_si256((__m256i *)(src + j));
             const __m512i ss = _mm512_cvtepu8_epi16(s);
             const __m512i d  = _mm512_sub_epi16(ss, a);
             zz_store_512(dst + j, d);
             j += 32;
-        } while (j < width);
+        };
 
         src += src_stride;
         dst += dst_stride;
@@ -231,15 +231,15 @@ static INLINE void sub_avg_block_highbd_avx512(const uint16_t *src, const int32_
                                                const int32_t dst_stride) {
     const __m512i a = _mm512_set1_epi16(avg);
 
-    int32_t i = height;
+    int32_t i = height +1;
     do {
         int32_t j = 0;
-        do {
+        while (j < width) {
             const __m512i s = _mm512_loadu_si512((__m512i *)(src + j));
             const __m512i d = _mm512_sub_epi16(s, a);
             zz_store_512(dst + j, d);
             j += 32;
-        } while (j < width);
+        };
 
         src += src_stride;
         dst += dst_stride;
@@ -1046,12 +1046,12 @@ static INLINE void compute_stats_win3_avx512(const int16_t *const d, const int32
             y = height;
             do {
                 x = 0;
-                do {
+                while (x < w32) {
                     const __m512i src = zz_load_512(s_t + x);
                     const __m512i dgd = zz_load_512(d_t + x);
                     stats_top_win3_avx512(src, dgd, d_t + j + x, d_stride, sum_m, sum_h);
                     x += 32;
-                } while (x < w32);
+                } ;
 
                 if (w32 != width) {
                     const __m512i src      = zz_load_512(s_t + w32);
@@ -1084,11 +1084,11 @@ static INLINE void compute_stats_win3_avx512(const int16_t *const d, const int32
             y = height;
             do {
                 x = 0;
-                do {
+                while (x < w32) {
                     const __m512i dgd = _mm512_loadu_si512((__m512i *)(d_t + j + x));
                     stats_left_win3_avx512(dgd, d_t + x, d_stride, sum_h);
                     x += 32;
-                } while (x < w32);
+                };
 
                 if (w32 != width) {
                     const __m512i dgd      = _mm512_loadu_si512((__m512i *)(d_t + j + x));
@@ -1125,12 +1125,12 @@ static INLINE void compute_stats_win3_avx512(const int16_t *const d, const int32
                 y = h_t;
                 do {
                     x = 0;
-                    do {
+                    while (x < w32) {
                         const __m512i src = zz_load_512(s_t + x);
                         const __m512i dgd = zz_load_512(d_t + x);
                         stats_top_win3_avx512(src, dgd, d_t + j + x, d_stride, row_m, row_h);
                         x += 32;
-                    } while (x < w32);
+                    };
 
                     if (w32 != width) {
                         const __m512i src      = zz_load_512(s_t + w32);
@@ -1179,11 +1179,11 @@ static INLINE void compute_stats_win3_avx512(const int16_t *const d, const int32
                 y = h_t;
                 do {
                     x = 0;
-                    do {
+                    while (x < w32) {
                         const __m512i dgd = _mm512_loadu_si512((__m512i *)(d_t + j + x));
                         stats_left_win3_avx512(dgd, d_t + x, d_stride, row_h);
                         x += 32;
-                    } while (x < w32);
+                    };
 
                     if (w32 != width) {
                         const __m512i dgd      = _mm512_loadu_si512((__m512i *)(d_t + j + x));
@@ -1233,7 +1233,7 @@ static INLINE void compute_stats_win3_avx512(const int16_t *const d, const int32
         } else {
             int32_t h4_t = 0;
 
-            do {
+            while (h4_t < h4) {
                 __m256i deltas_t[WIENER_WIN_3TAP] = {0};
 
                 const int32_t h_t = ((h4 - h4_t) < 256) ? (h4 - h4_t) : 256;
@@ -1249,7 +1249,7 @@ static INLINE void compute_stats_win3_avx512(const int16_t *const d, const int32
                 deltas[1]   = _mm256_add_epi64(deltas[1], deltas_t[2]);
 
                 h4_t += h_t;
-            } while (h4_t < h4);
+            };
 
             delta = _mm256_setzero_si256();
         }
@@ -1364,7 +1364,7 @@ static INLINE void compute_stats_win3_avx512(const int16_t *const d, const int32
         se0 = _mm256_setzero_si256(); // Initialize to avoid warning.
 
         y = 0;
-        do {
+        while (y < h8) {
             // 00s 01s 10s 11s 20s 21s 30s 31s  00e 01e 10e 11e 20e 21e 30e 31e
             se0 = _mm256_insert_epi32(se0, *(int32_t *)(d_t + 0 * d_stride), 0);
             se0 = _mm256_insert_epi32(se0, *(int32_t *)(d_t + 0 * d_stride + width), 4);
@@ -1410,7 +1410,7 @@ static INLINE void compute_stats_win3_avx512(const int16_t *const d, const int32
 
             d_t += 8 * d_stride;
             y += 8;
-        } while (y < h8);
+        };
 
         if (bit_depth < AOM_BITS_12) {
             deltas[0] = _mm256_hadd_epi32(deltas[0], deltas[1]); // T0 T0 t1 t1  T0 T0 t1 t1
@@ -1515,12 +1515,12 @@ static INLINE void compute_stats_win3_avx512(const int16_t *const d, const int32
             __m512i              d_js[WIENER_WIN_3TAP - 1], d_je[WIENER_WIN_3TAP - 1];
 
             x = 0;
-            do {
+            while (x < w32) {
                 load_square_win3_avx512(di + x, d_j + x, d_stride, height, d_is, d_ie, d_js, d_je);
                 derive_square_win3_avx512(d_is, d_ie, d_js, d_je, deltas);
 
                 x += 32;
-            } while (x < w32);
+            };
 
             if (w32 != width) {
                 load_square_win3_avx512(di + x, d_j + x, d_stride, height, d_is, d_ie, d_js, d_je);
@@ -1559,12 +1559,12 @@ static INLINE void compute_stats_win3_avx512(const int16_t *const d, const int32
         __m512i              d_is[WIENER_WIN_3TAP - 1], d_ie[WIENER_WIN_3TAP - 1];
 
         x = 0;
-        do {
+        while (x < w32) {
             load_triangle_win3_avx512(di + x, d_stride, height, d_is, d_ie);
             derive_triangle_win3_avx512(d_is, d_ie, deltas);
 
             x += 32;
-        } while (x < w32);
+        };
 
         if (w32 != width) {
             load_triangle_win3_avx512(di + x, d_stride, height, d_is, d_ie);
@@ -1623,12 +1623,12 @@ static INLINE void compute_stats_win5_avx512(const int16_t *const d, const int32
             y = height;
             do {
                 x = 0;
-                do {
+                while (x < w32) {
                     const __m512i src = zz_load_512(s_t + x);
                     const __m512i dgd = zz_load_512(d_t + x);
                     stats_top_win5_avx512(src, dgd, d_t + j + x, d_stride, sum_m, sum_h);
                     x += 32;
-                } while (x < w32);
+                };
 
                 if (w32 != width) {
                     const __m512i src      = zz_load_512(s_t + w32);
@@ -1662,11 +1662,11 @@ static INLINE void compute_stats_win5_avx512(const int16_t *const d, const int32
             y = height;
             do {
                 x = 0;
-                do {
+                while (x < w32) {
                     const __m512i dgd = _mm512_loadu_si512((__m512i *)(d_t + j + x));
                     stats_left_win5_avx512(dgd, d_t + x, d_stride, sum_h);
                     x += 32;
-                } while (x < w32);
+                };
 
                 if (w32 != width) {
                     const __m512i dgd      = _mm512_loadu_si512((__m512i *)(d_t + j + x));
@@ -1709,12 +1709,12 @@ static INLINE void compute_stats_win5_avx512(const int16_t *const d, const int32
                 y = h_t;
                 do {
                     x = 0;
-                    do {
+                    while (x < w32) {
                         const __m512i src = zz_load_512(s_t + x);
                         const __m512i dgd = zz_load_512(d_t + x);
                         stats_top_win5_avx512(src, dgd, d_t + j + x, d_stride, row_m, row_h);
                         x += 32;
-                    } while (x < w32);
+                    };
 
                     if (w32 != width) {
                         const __m512i src      = zz_load_512(s_t + w32);
@@ -1768,11 +1768,11 @@ static INLINE void compute_stats_win5_avx512(const int16_t *const d, const int32
                 y = h_t;
                 do {
                     x = 0;
-                    do {
+                    while (x < w32) {
                         const __m512i dgd = _mm512_loadu_si512((__m512i *)(d_t + j + x));
                         stats_left_win5_avx512(dgd, d_t + x, d_stride, row_h);
                         x += 32;
-                    } while (x < w32);
+                    };
 
                     if (w32 != width) {
                         const __m512i dgd      = _mm512_loadu_si512((__m512i *)(d_t + j + x));
@@ -1806,138 +1806,217 @@ static INLINE void compute_stats_win5_avx512(const int16_t *const d, const int32
     // Step 3: Derive the top edge of each triangle along the diagonal. No triangle in top row.
     {
         const int16_t *d_t = d;
-        // 16-bit idx: 0, 4, 1, 5, 2, 6, 3, 7
-        const __m256i shf                       = _mm256_setr_epi8(0,
-                                             1,
-                                             8,
-                                             9,
-                                             2,
-                                             3,
-                                             10,
-                                             11,
-                                             4,
-                                             5,
-                                             12,
-                                             13,
-                                             6,
-                                             7,
-                                             14,
-                                             15,
-                                             0,
-                                             1,
-                                             8,
-                                             9,
-                                             2,
-                                             3,
-                                             10,
-                                             11,
-                                             4,
-                                             5,
-                                             12,
-                                             13,
-                                             6,
-                                             7,
-                                             14,
-                                             15);
-        __m256i       deltas[WIENER_WIN_CHROMA] = {0};
-        __m256i       dd = _mm256_setzero_si256(); // Initialize to avoid warning.
-        __m256i       ds[WIENER_WIN_CHROMA];
 
-        // 00s 01s 02s 03s 10s 11s 12s 13s  00e 01e 02e 03e 10e 11e 12e 13e
-        dd = _mm256_insert_epi64(dd, *(int64_t *)(d_t + 0 * d_stride), 0);
-        dd = _mm256_insert_epi64(dd, *(int64_t *)(d_t + 0 * d_stride + width), 2);
-        dd = _mm256_insert_epi64(dd, *(int64_t *)(d_t + 1 * d_stride), 1);
-        dd = _mm256_insert_epi64(dd, *(int64_t *)(d_t + 1 * d_stride + width), 3);
-        // 00s 10s 01s 11s 02s 12s 03s 13s  00e 10e 01e 11e 02e 12e 03e 13e
-        ds[0] = _mm256_shuffle_epi8(dd, shf);
+        if (height % 2) {
+            __m256i deltas[WIENER_WIN + 1] = {0};
+            __m256i ds[WIENER_WIN];
 
-        // 10s 11s 12s 13s 20s 21s 22s 23s  10e 11e 12e 13e 20e 21e 22e 23e
-        load_more_64_avx2(d_t + 2 * d_stride, width, &dd);
-        // 10s 20s 11s 21s 12s 22s 13s 23s  10e 20e 11e 21e 12e 22e 13e 23e
-        ds[1] = _mm256_shuffle_epi8(dd, shf);
+            ds[0] = load_win7_avx2(d_t + 0 * d_stride, width);
+            ds[1] = load_win7_avx2(d_t + 1 * d_stride, width);
+            ds[2] = load_win7_avx2(d_t + 2 * d_stride, width);
+            ds[3] = load_win7_avx2(d_t + 3 * d_stride, width);
+            d_t += 4 * d_stride;
 
-        // 20s 21s 22s 23s 30s 31s 32s 33s  20e 21e 22e 23e 30e 31e 32e 33e
-        load_more_64_avx2(d_t + 3 * d_stride, width, &dd);
-        // 20s 30s 21s 31s 22s 32s 23s 33s  20e 30e 21e 31e 22e 32e 23e 33e
-        ds[2] = _mm256_shuffle_epi8(dd, shf);
+            if (bit_depth < AOM_BITS_12) {
+                step3_win5_oneline_avx2(&d_t, d_stride, width, height, ds, deltas);
+                transpose_32bit_8x8_avx2(deltas, deltas);
 
-        if (bit_depth < AOM_BITS_12) {
-            __m128i dlts[WIENER_WIN_CHROMA];
+                update_5_stats_avx2(H + 0 * wiener_win * wiener_win2 + 0 * wiener_win,
+                                    _mm256_extracti128_si256(deltas[0], 0),
+                                    _mm256_extract_epi32(deltas[0], 4),
+                                    H + 1 * wiener_win * wiener_win2 + 1 * wiener_win);
 
-            step3_win5_avx2(&d_t, d_stride, width, height, &dd, ds, deltas);
+                update_5_stats_avx2(H + 1 * wiener_win * wiener_win2 + 1 * wiener_win,
+                                    _mm256_extracti128_si256(deltas[1], 0),
+                                    _mm256_extract_epi32(deltas[1], 4),
+                                    H + 2 * wiener_win * wiener_win2 + 2 * wiener_win);
 
-            dlts[0] = sub_hi_lo_32_avx2(deltas[0]);
-            dlts[1] = sub_hi_lo_32_avx2(deltas[1]);
-            dlts[2] = sub_hi_lo_32_avx2(deltas[2]);
-            dlts[3] = sub_hi_lo_32_avx2(deltas[3]);
-            dlts[4] = sub_hi_lo_32_avx2(deltas[4]);
+                update_5_stats_avx2(H + 2 * wiener_win * wiener_win2 + 2 * wiener_win,
+                                    _mm256_extracti128_si256(deltas[2], 0),
+                                    _mm256_extract_epi32(deltas[2], 4),
+                                    H + 3 * wiener_win * wiener_win2 + 3 * wiener_win);
 
-            transpose_32bit_4x4(dlts, dlts);
-            deltas[4] = _mm256_cvtepi32_epi64(dlts[4]);
+                update_5_stats_avx2(H + 3 * wiener_win * wiener_win2 + 3 * wiener_win,
+                                    _mm256_extracti128_si256(deltas[3], 0),
+                                    _mm256_extract_epi32(deltas[3], 4),
+                                    H + 4 * wiener_win * wiener_win2 + 4 * wiener_win);
+            } else {
+                __m128i deltas128[WIENER_WIN] = {0};
+                int32_t height_t              = 0;
 
-            update_5_stats_avx2(H + 0 * wiener_win * wiener_win2 + 0 * wiener_win,
-                                dlts[0],
-                                _mm256_extract_epi64(deltas[4], 0),
-                                H + 1 * wiener_win * wiener_win2 + 1 * wiener_win);
+                do {
+                    __m256i       deltas_t[WIENER_WIN] = {0};
+                    const int32_t h_t = ((height - height_t) < 128) ? (height - height_t) : 128;
 
-            update_5_stats_avx2(H + 1 * wiener_win * wiener_win2 + 1 * wiener_win,
-                                dlts[1],
-                                _mm256_extract_epi64(deltas[4], 1),
-                                H + 2 * wiener_win * wiener_win2 + 2 * wiener_win);
+                    step3_win5_oneline_avx2(&d_t, d_stride, width, h_t, ds, deltas_t);
+                    add_six_32_to_64_avx2(deltas_t[0], &deltas[0], &deltas128[0]);
+                    add_six_32_to_64_avx2(deltas_t[1], &deltas[1], &deltas128[1]);
+                    add_six_32_to_64_avx2(deltas_t[2], &deltas[2], &deltas128[2]);
+                    add_six_32_to_64_avx2(deltas_t[3], &deltas[3], &deltas128[3]);
+                    add_six_32_to_64_avx2(deltas_t[4], &deltas[4], &deltas128[4]);
+                    add_six_32_to_64_avx2(deltas_t[5], &deltas[5], &deltas128[5]);
+                    add_six_32_to_64_avx2(deltas_t[6], &deltas[6], &deltas128[6]);
 
-            update_5_stats_avx2(H + 2 * wiener_win * wiener_win2 + 2 * wiener_win,
-                                dlts[2],
-                                _mm256_extract_epi64(deltas[4], 2),
-                                H + 3 * wiener_win * wiener_win2 + 3 * wiener_win);
+                    height_t += h_t;
+                } while (height_t < height);
 
-            update_5_stats_avx2(H + 3 * wiener_win * wiener_win2 + 3 * wiener_win,
-                                dlts[3],
-                                _mm256_extract_epi64(deltas[4], 3),
-                                H + 4 * wiener_win * wiener_win2 + 4 * wiener_win);
+                transpose_64bit_4x8_avx2(deltas, deltas);
+
+                update_5_stats_highbd_avx2(H + 0 * wiener_win * wiener_win2 + 0 * wiener_win,
+                                           deltas[0],
+                                           _mm256_extract_epi64(deltas[1], 0),
+                                           H + 1 * wiener_win * wiener_win2 + 1 * wiener_win);
+
+                update_5_stats_highbd_avx2(H + 1 * wiener_win * wiener_win2 + 1 * wiener_win,
+                                           deltas[2],
+                                           _mm256_extract_epi64(deltas[3], 0),
+                                           H + 2 * wiener_win * wiener_win2 + 2 * wiener_win);
+
+                update_5_stats_highbd_avx2(H + 2 * wiener_win * wiener_win2 + 2 * wiener_win,
+                                           deltas[4],
+                                           _mm256_extract_epi64(deltas[5], 0),
+                                           H + 3 * wiener_win * wiener_win2 + 3 * wiener_win);
+
+                update_5_stats_highbd_avx2(H + 3 * wiener_win * wiener_win2 + 3 * wiener_win,
+                                           deltas[6],
+                                           _mm256_extract_epi64(deltas[7], 0),
+                                           H + 4 * wiener_win * wiener_win2 + 4 * wiener_win);
+            }
+
         } else {
-            int32_t height_t = 0;
+            // 16-bit idx: 0, 4, 1, 5, 2, 6, 3, 7
+            const __m256i shf = _mm256_setr_epi8(0,
+                                                 1,
+                                                 8,
+                                                 9,
+                                                 2,
+                                                 3,
+                                                 10,
+                                                 11,
+                                                 4,
+                                                 5,
+                                                 12,
+                                                 13,
+                                                 6,
+                                                 7,
+                                                 14,
+                                                 15,
+                                                 0,
+                                                 1,
+                                                 8,
+                                                 9,
+                                                 2,
+                                                 3,
+                                                 10,
+                                                 11,
+                                                 4,
+                                                 5,
+                                                 12,
+                                                 13,
+                                                 6,
+                                                 7,
+                                                 14,
+                                                 15);
+            __m256i       deltas[WIENER_WIN_CHROMA] = {0};
+            __m256i       dd = _mm256_setzero_si256(); // Initialize to avoid warning.
+            __m256i       ds[WIENER_WIN_CHROMA];
 
-            do {
-                __m256i       deltas_t[WIENER_WIN_CHROMA] = {0};
-                const int32_t h_t = ((height - height_t) < 128) ? (height - height_t) : 128;
+            // 00s 01s 02s 03s 10s 11s 12s 13s  00e 01e 02e 03e 10e 11e 12e 13e
+            dd = _mm256_insert_epi64(dd, *(int64_t *)(d_t + 0 * d_stride), 0);
+            dd = _mm256_insert_epi64(dd, *(int64_t *)(d_t + 0 * d_stride + width), 2);
+            dd = _mm256_insert_epi64(dd, *(int64_t *)(d_t + 1 * d_stride), 1);
+            dd = _mm256_insert_epi64(dd, *(int64_t *)(d_t + 1 * d_stride + width), 3);
+            // 00s 10s 01s 11s 02s 12s 03s 13s  00e 10e 01e 11e 02e 12e 03e 13e
+            ds[0] = _mm256_shuffle_epi8(dd, shf);
 
-                step3_win5_avx2(&d_t, d_stride, width, h_t, &dd, ds, deltas_t);
+            // 10s 11s 12s 13s 20s 21s 22s 23s  10e 11e 12e 13e 20e 21e 22e 23e
+            load_more_64_avx2(d_t + 2 * d_stride, width, &dd);
+            // 10s 20s 11s 21s 12s 22s 13s 23s  10e 20e 11e 21e 12e 22e 13e 23e
+            ds[1] = _mm256_shuffle_epi8(dd, shf);
 
-                deltas_t[0] = hsub_32x8_to_64x4_avx2(deltas_t[0]);
-                deltas_t[1] = hsub_32x8_to_64x4_avx2(deltas_t[1]);
-                deltas_t[2] = hsub_32x8_to_64x4_avx2(deltas_t[2]);
-                deltas_t[3] = hsub_32x8_to_64x4_avx2(deltas_t[3]);
-                deltas_t[4] = hsub_32x8_to_64x4_avx2(deltas_t[4]);
-                deltas[0]   = _mm256_add_epi64(deltas[0], deltas_t[0]);
-                deltas[1]   = _mm256_add_epi64(deltas[1], deltas_t[1]);
-                deltas[2]   = _mm256_add_epi64(deltas[2], deltas_t[2]);
-                deltas[3]   = _mm256_add_epi64(deltas[3], deltas_t[3]);
-                deltas[4]   = _mm256_add_epi64(deltas[4], deltas_t[4]);
+            // 20s 21s 22s 23s 30s 31s 32s 33s  20e 21e 22e 23e 30e 31e 32e 33e
+            load_more_64_avx2(d_t + 3 * d_stride, width, &dd);
+            // 20s 30s 21s 31s 22s 32s 23s 33s  20e 30e 21e 31e 22e 32e 23e 33e
+            ds[2] = _mm256_shuffle_epi8(dd, shf);
 
-                height_t += h_t;
-            } while (height_t < height);
+            if (bit_depth < AOM_BITS_12) {
+                __m128i dlts[WIENER_WIN_CHROMA];
 
-            transpose_64bit_4x4_avx2(deltas, deltas);
+                step3_win5_avx2(&d_t, d_stride, width, height, &dd, ds, deltas);
 
-            update_5_stats_highbd_avx2(H + 0 * wiener_win * wiener_win2 + 0 * wiener_win,
-                                       deltas[0],
-                                       _mm256_extract_epi64(deltas[4], 0),
-                                       H + 1 * wiener_win * wiener_win2 + 1 * wiener_win);
+                dlts[0] = sub_hi_lo_32_avx2(deltas[0]);
+                dlts[1] = sub_hi_lo_32_avx2(deltas[1]);
+                dlts[2] = sub_hi_lo_32_avx2(deltas[2]);
+                dlts[3] = sub_hi_lo_32_avx2(deltas[3]);
+                dlts[4] = sub_hi_lo_32_avx2(deltas[4]);
 
-            update_5_stats_highbd_avx2(H + 1 * wiener_win * wiener_win2 + 1 * wiener_win,
-                                       deltas[1],
-                                       _mm256_extract_epi64(deltas[4], 1),
-                                       H + 2 * wiener_win * wiener_win2 + 2 * wiener_win);
+                transpose_32bit_4x4(dlts, dlts);
+                deltas[4] = _mm256_cvtepi32_epi64(dlts[4]);
 
-            update_5_stats_highbd_avx2(H + 2 * wiener_win * wiener_win2 + 2 * wiener_win,
-                                       deltas[2],
-                                       _mm256_extract_epi64(deltas[4], 2),
-                                       H + 3 * wiener_win * wiener_win2 + 3 * wiener_win);
+                update_5_stats_avx2(H + 0 * wiener_win * wiener_win2 + 0 * wiener_win,
+                                    dlts[0],
+                                    _mm256_extract_epi64(deltas[4], 0),
+                                    H + 1 * wiener_win * wiener_win2 + 1 * wiener_win);
 
-            update_5_stats_highbd_avx2(H + 3 * wiener_win * wiener_win2 + 3 * wiener_win,
-                                       deltas[3],
-                                       _mm256_extract_epi64(deltas[4], 3),
-                                       H + 4 * wiener_win * wiener_win2 + 4 * wiener_win);
+                update_5_stats_avx2(H + 1 * wiener_win * wiener_win2 + 1 * wiener_win,
+                                    dlts[1],
+                                    _mm256_extract_epi64(deltas[4], 1),
+                                    H + 2 * wiener_win * wiener_win2 + 2 * wiener_win);
+
+                update_5_stats_avx2(H + 2 * wiener_win * wiener_win2 + 2 * wiener_win,
+                                    dlts[2],
+                                    _mm256_extract_epi64(deltas[4], 2),
+                                    H + 3 * wiener_win * wiener_win2 + 3 * wiener_win);
+
+                update_5_stats_avx2(H + 3 * wiener_win * wiener_win2 + 3 * wiener_win,
+                                    dlts[3],
+                                    _mm256_extract_epi64(deltas[4], 3),
+                                    H + 4 * wiener_win * wiener_win2 + 4 * wiener_win);
+            } else {
+                int32_t height_t = 0;
+
+                do {
+                    __m256i       deltas_t[WIENER_WIN_CHROMA] = {0};
+                    const int32_t h_t = ((height - height_t) < 128) ? (height - height_t) : 128;
+
+                    step3_win5_avx2(&d_t, d_stride, width, h_t, &dd, ds, deltas_t);
+
+                    deltas_t[0] = hsub_32x8_to_64x4_avx2(deltas_t[0]);
+                    deltas_t[1] = hsub_32x8_to_64x4_avx2(deltas_t[1]);
+                    deltas_t[2] = hsub_32x8_to_64x4_avx2(deltas_t[2]);
+                    deltas_t[3] = hsub_32x8_to_64x4_avx2(deltas_t[3]);
+                    deltas_t[4] = hsub_32x8_to_64x4_avx2(deltas_t[4]);
+                    deltas[0]   = _mm256_add_epi64(deltas[0], deltas_t[0]);
+                    deltas[1]   = _mm256_add_epi64(deltas[1], deltas_t[1]);
+                    deltas[2]   = _mm256_add_epi64(deltas[2], deltas_t[2]);
+                    deltas[3]   = _mm256_add_epi64(deltas[3], deltas_t[3]);
+                    deltas[4]   = _mm256_add_epi64(deltas[4], deltas_t[4]);
+
+                    height_t += h_t;
+                } while (height_t < height);
+
+                transpose_64bit_4x4_avx2(deltas, deltas);
+
+                update_5_stats_highbd_avx2(H + 0 * wiener_win * wiener_win2 + 0 * wiener_win,
+                                           deltas[0],
+                                           _mm256_extract_epi64(deltas[4], 0),
+                                           H + 1 * wiener_win * wiener_win2 + 1 * wiener_win);
+
+                update_5_stats_highbd_avx2(H + 1 * wiener_win * wiener_win2 + 1 * wiener_win,
+                                           deltas[1],
+                                           _mm256_extract_epi64(deltas[4], 1),
+                                           H + 2 * wiener_win * wiener_win2 + 2 * wiener_win);
+
+                update_5_stats_highbd_avx2(H + 2 * wiener_win * wiener_win2 + 2 * wiener_win,
+                                           deltas[2],
+                                           _mm256_extract_epi64(deltas[4], 2),
+                                           H + 3 * wiener_win * wiener_win2 + 3 * wiener_win);
+
+                update_5_stats_highbd_avx2(H + 3 * wiener_win * wiener_win2 + 3 * wiener_win,
+                                           deltas[3],
+                                           _mm256_extract_epi64(deltas[4], 3),
+                                           H + 4 * wiener_win * wiener_win2 + 4 * wiener_win);
+            }
         }
     }
 
@@ -1975,7 +2054,7 @@ static INLINE void compute_stats_win5_avx512(const int16_t *const d, const int32
             ds[0] = _mm256_insert_epi16(ds[0], d_j[3 * d_stride + width], 11);
 
             y = 0;
-            do {
+            while (y < h8) {
                 // 00s 10s 20s 30s 40s 50s 60s 70s  00e 10e 20e 30e 40e 50e 60e 70e
                 dd[0] = _mm256_insert_epi16(dd[0], di[4 * d_stride], 4);
                 dd[0] = _mm256_insert_epi16(dd[0], di[4 * d_stride + width], 12);
@@ -2020,7 +2099,7 @@ static INLINE void compute_stats_win5_avx512(const int16_t *const d, const int32
                 di += 8 * d_stride;
                 d_j += 8 * d_stride;
                 y += 8;
-            } while (y < h8);
+            };
 
             if (bit_depth < AOM_BITS_12) {
                 deltas[0]            = _mm256_hadd_epi32(deltas[0], deltas[1]);
@@ -2175,12 +2254,12 @@ static INLINE void compute_stats_win5_avx512(const int16_t *const d, const int32
             __m512i d_js[WIENER_WIN_CHROMA - 1], d_je[WIENER_WIN_CHROMA - 1];
 
             x = 0;
-            do {
+            while (x < w32) {
                 load_square_win5_avx512(di + x, d_j + x, d_stride, height, d_is, d_ie, d_js, d_je);
                 derive_square_win5_avx512(d_is, d_ie, d_js, d_je, deltas);
 
                 x += 32;
-            } while (x < w32);
+            };
 
             if (w32 != width) {
                 load_square_win5_avx512(di + x, d_j + x, d_stride, height, d_is, d_ie, d_js, d_je);
@@ -2243,12 +2322,12 @@ static INLINE void compute_stats_win5_avx512(const int16_t *const d, const int32
         __m512i              d_is[WIENER_WIN_CHROMA - 1], d_ie[WIENER_WIN_CHROMA - 1];
 
         x = 0;
-        do {
+        while (x < w32) {
             load_triangle_win5_avx512(di + x, d_stride, height, d_is, d_ie);
             derive_triangle_win5_avx512(d_is, d_ie, deltas);
 
             x += 32;
-        } while (x < w32);
+        };
 
         if (w32 != width) {
             load_triangle_win5_avx512(di + x, d_stride, height, d_is, d_ie);
@@ -2341,12 +2420,12 @@ static INLINE void compute_stats_win7_avx512(const int16_t *const d, const int32
             y = height;
             do {
                 x = 0;
-                do {
+                while (x < w32) {
                     const __m512i src = zz_load_512(s_t + x);
                     const __m512i dgd = zz_load_512(d_t + x);
                     stats_top_win7_avx512(src, dgd, d_t + j + x, d_stride, sum_m, sum_h);
                     x += 32;
-                } while (x < w32);
+                };
 
                 if (w32 != width) {
                     const __m512i src      = zz_load_512(s_t + w32);
@@ -2384,11 +2463,11 @@ static INLINE void compute_stats_win7_avx512(const int16_t *const d, const int32
             y = height;
             do {
                 x = 0;
-                do {
+                while (x < w32) {
                     const __m512i dgd = _mm512_loadu_si512((__m512i *)(d_t + j + x));
                     stats_left_win7_avx512(dgd, d_t + x, d_stride, sum_h);
                     x += 32;
-                } while (x < w32);
+                };
 
                 if (w32 != width) {
                     const __m512i dgd      = _mm512_loadu_si512((__m512i *)(d_t + j + x));
@@ -2436,12 +2515,12 @@ static INLINE void compute_stats_win7_avx512(const int16_t *const d, const int32
                 y = h_t;
                 do {
                     x = 0;
-                    do {
+                    while (x < w32) {
                         const __m512i src = zz_load_512(s_t + x);
                         const __m512i dgd = zz_load_512(d_t + x);
                         stats_top_win7_avx512(src, dgd, d_t + j + x, d_stride, row_m, row_h);
                         x += 32;
-                    } while (x < w32);
+                    };
 
                     if (w32 != width) {
                         const __m512i src      = zz_load_512(s_t + w32);
@@ -2503,11 +2582,11 @@ static INLINE void compute_stats_win7_avx512(const int16_t *const d, const int32
                 y = h_t;
                 do {
                     x = 0;
-                    do {
+                    while (x < w32) {
                         const __m512i dgd = _mm512_loadu_si512((__m512i *)(d_t + j + x));
                         stats_left_win7_avx512(dgd, d_t + x, d_stride, row_h);
                         x += 32;
-                    } while (x < w32);
+                    };
 
                     if (w32 != width) {
                         const __m512i dgd      = _mm512_loadu_si512((__m512i *)(d_t + j + x));
@@ -2703,7 +2782,7 @@ static INLINE void compute_stats_win7_avx512(const int16_t *const d, const int32
             ds[0] = _mm256_insert_epi16(ds[0], d_j[5 * d_stride + width], 13);
 
             y = 0;
-            do {
+            while (y < h8) {
                 // 00s 10s 20s 30s 40s 50s 60s 70s  00e 10e 20e 30e 40e 50e 60e 70e
                 dd[0] = _mm256_insert_epi16(dd[0], di[6 * d_stride], 6);
                 dd[0] = _mm256_insert_epi16(dd[0], di[6 * d_stride + width], 14);
@@ -2749,7 +2828,7 @@ static INLINE void compute_stats_win7_avx512(const int16_t *const d, const int32
                 di += 8 * d_stride;
                 d_j += 8 * d_stride;
                 y += 8;
-            } while (y < h8);
+            };
 
             if (bit_depth < AOM_BITS_12) {
                 deltas[0]            = _mm256_hadd_epi32(deltas[0], deltas[1]);
@@ -2941,12 +3020,12 @@ static INLINE void compute_stats_win7_avx512(const int16_t *const d, const int32
             __m512i              d_js[WIENER_WIN - 1], d_je[WIENER_WIN - 1];
 
             x = 0;
-            do {
+            while (x < w32) {
                 load_square_win7_avx512(di + x, d_j + x, d_stride, height, d_is, d_ie, d_js, d_je);
                 derive_square_win7_avx512(d_is, d_ie, d_js, d_je, deltas);
 
                 x += 32;
-            } while (x < w32);
+            };
 
             if (w32 != width) {
                 load_square_win7_avx512(di + x, d_j + x, d_stride, height, d_is, d_ie, d_js, d_je);
@@ -3029,12 +3108,12 @@ static INLINE void compute_stats_win7_avx512(const int16_t *const d, const int32
         __m512i              d_is[WIENER_WIN - 1], d_ie[WIENER_WIN - 1];
 
         x = 0;
-        do {
+        while (x < w32) {
             load_triangle_win7_avx512(di + x, d_stride, height, d_is, d_ie);
             derive_triangle_win7_avx512(d_is, d_ie, deltas);
 
             x += 32;
-        } while (x < w32);
+        };
 
         if (w32 != width) {
             load_triangle_win7_avx512(di + x, d_stride, height, d_is, d_ie);
@@ -3165,8 +3244,6 @@ void eb_av1_compute_stats_avx512(int32_t wiener_win, const uint8_t *dgd, const u
     d = eb_aom_memalign(64, sizeof(*d) * 6 * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX);
     s = d + 3 * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX;
 
-    assert(!(height % 2));
-
     sub_avg_block_avx512(
         src + v_start * src_stride + h_start, src_stride, avg, width, height, s, s_stride);
     sub_avg_block_avx512(dgd + (v_start - wiener_halfwin) * dgd_stride + h_start - wiener_halfwin,
@@ -3217,8 +3294,6 @@ void eb_av1_compute_stats_highbd_avx512(int32_t wiener_win, const uint8_t *dgd8,
     // paddings.
     d = eb_aom_memalign(64, sizeof(*d) * 6 * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX);
     s = d + 3 * RESTORATION_UNITSIZE_MAX * RESTORATION_UNITSIZE_MAX;
-
-    assert(!(height % 2));
 
     sub_avg_block_highbd_avx512(
         src + v_start * src_stride + h_start, src_stride, avg, width, height, s, s_stride);

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
@@ -62,10 +62,6 @@
     } while (0)
 #endif
 
-void setup_rtcd_non8(CPU_FLAGS flags) {
-    (void) flags;
-    eb_av1_wiener_convolve_add_src = eb_av1_wiener_convolve_add_src_c;
-}
 void setup_rtcd_internal(CPU_FLAGS flags) {
     /** Should be done during library initialization,
         but for safe limiting cpu flags again. */

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
@@ -64,8 +64,7 @@
 
 void setup_rtcd_non8(CPU_FLAGS flags) {
     (void) flags;
-    eb_av1_compute_stats = eb_av1_compute_stats_c;
-    eb_av1_compute_stats_highbd = eb_av1_compute_stats_highbd_c;
+    eb_av1_wiener_convolve_add_src = eb_av1_wiener_convolve_add_src_c;
 }
 void setup_rtcd_internal(CPU_FLAGS flags) {
     /** Should be done during library initialization,

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
@@ -55,8 +55,6 @@ extern "C" {
 //    CPU_FLAGS get_cpu_flags_to_use();
     void setup_rtcd_internal(CPU_FLAGS flags);
 
-    void setup_rtcd_non8(CPU_FLAGS flags);
-
     //to not include convolve.h, just forward declare what's needed.
     struct ConvolveParams;
     struct InterpFilterParams;

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -967,12 +967,6 @@ EB_API EbErrorType svt_av1_enc_init(EbComponentType *svt_enc_component)
     setup_common_rtcd_internal(enc_handle_ptr->scs_instance_array[0]->scs_ptr->static_config.use_cpu_flags);
     setup_rtcd_internal(enc_handle_ptr->scs_instance_array[0]->scs_ptr->static_config.use_cpu_flags);
 
-#if NON8_FIX_REST
-    if(enc_handle_ptr->scs_instance_array[0]->scs_ptr->max_input_pad_right>0 ||
-       enc_handle_ptr->scs_instance_array[0]->scs_ptr->max_input_pad_bottom>0)
-        setup_rtcd_non8(enc_handle_ptr->scs_instance_array[0]->scs_ptr->static_config.use_cpu_flags);
-#endif
-
     asm_set_convolve_asm_table();
 
     init_intra_dc_predictors_c_internal();

--- a/test/RestorationPickTest.cc
+++ b/test/RestorationPickTest.cc
@@ -8,6 +8,7 @@
 #include "EbDefinitions.h"
 #include "EbRestoration.h"
 #include "EbUnitTestUtility.h"
+#include "util.h"
 
 #include <immintrin.h>  // AVX2
 #include "synonyms.h"
@@ -27,389 +28,129 @@ typedef void (*av1_compute_stats_highbd_func)(
     int32_t dgd_stride, int32_t src_stride, int64_t *M, int64_t *H,
     AomBitDepth bit_depth);
 
-static const int32_t sizes[2] = {RESTORATION_UNITSIZE_MAX,
-                                 RESTORATION_UNITSIZE_MAX * 3 / 2};
+typedef ::testing::tuple<BlockSize, av1_compute_stats_func, int, int>
+    av1_compute_stats_params;
 
-static const int32_t wins[3] = {WIENER_WIN_3TAP, WIENER_WIN_CHROMA, WIENER_WIN};
-
-static void init_data(uint8_t **dgd, int32_t *dgd_stride, uint8_t **src,
-                      int32_t *src_stride, const int idx) {
-    *dgd_stride =
-        eb_create_random_aligned_stride(2 * RESTORATION_UNITSIZE_MAX, 64);
-    *src_stride =
-        eb_create_random_aligned_stride(2 * RESTORATION_UNITSIZE_MAX, 64);
-    *dgd = (uint8_t *)malloc(sizeof(**dgd) * 2 * RESTORATION_UNITSIZE_MAX *
-                             *dgd_stride);
-    *src = (uint8_t *)malloc(sizeof(**src) * 2 * RESTORATION_UNITSIZE_MAX *
-                             *src_stride);
-
-    if (!idx) {
-        memset(*dgd,
-               0,
-               sizeof(**dgd) * 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride);
-        memset(*src,
-               0,
-               sizeof(**src) * 2 * RESTORATION_UNITSIZE_MAX * *src_stride);
-    } else if (1 == idx) {
-        eb_buf_random_u8_to_255(*dgd,
-                                2 * RESTORATION_UNITSIZE_MAX * *dgd_stride);
-        eb_buf_random_u8_to_255(*src,
-                                2 * RESTORATION_UNITSIZE_MAX * *src_stride);
-    } else if (2 == idx) {
-        eb_buf_random_u8_to_255(*dgd,
-                                2 * RESTORATION_UNITSIZE_MAX * *dgd_stride);
-        memset(*src,
-               0,
-               sizeof(**src) * 2 * RESTORATION_UNITSIZE_MAX * *src_stride);
-    } else if (3 == idx) {
-        memset(*dgd,
-               0,
-               sizeof(**dgd) * 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride);
-        eb_buf_random_u8_to_255(*src,
-                                2 * RESTORATION_UNITSIZE_MAX * *src_stride);
-    } else if (4 == idx) {
-        eb_buf_random_u8_to_0_or_255(
-            *dgd, 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride);
-        eb_buf_random_u8_to_0_or_255(
-            *src, 2 * RESTORATION_UNITSIZE_MAX * *src_stride);
-    } else {
-        eb_buf_random_u8(*dgd, 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride);
-        eb_buf_random_u8(*src, 2 * RESTORATION_UNITSIZE_MAX * *src_stride);
-    }
-}
-
-static void init_data_highbd(uint16_t **dgd, int32_t *dgd_stride,
-                             uint16_t **src, int32_t *src_stride,
-                             const AomBitDepth bd, const int idx) {
-    *dgd_stride =
-        eb_create_random_aligned_stride(2 * RESTORATION_UNITSIZE_MAX, 64);
-    *src_stride =
-        eb_create_random_aligned_stride(2 * RESTORATION_UNITSIZE_MAX, 64);
-    *dgd = (uint16_t *)malloc(sizeof(**dgd) * 2 * RESTORATION_UNITSIZE_MAX *
-                              *dgd_stride);
-    *src = (uint16_t *)malloc(sizeof(**src) * 2 * RESTORATION_UNITSIZE_MAX *
-                              *src_stride);
-
-    if (!idx) {
-        memset(*dgd,
-               0,
-               sizeof(**dgd) * 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride);
-        memset(*src,
-               0,
-               sizeof(**src) * 2 * RESTORATION_UNITSIZE_MAX * *src_stride);
-    } else if (1 == idx) {
-        eb_buf_random_u16_to_bd(
-            *dgd, 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride, bd);
-        eb_buf_random_u16_to_bd(
-            *src, 2 * RESTORATION_UNITSIZE_MAX * *src_stride, bd);
-    } else if (2 == idx) {
-        eb_buf_random_u16_to_bd(
-            *dgd, 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride, bd);
-        memset(*src,
-               0,
-               sizeof(**src) * 2 * RESTORATION_UNITSIZE_MAX * *src_stride);
-    } else if (3 == idx) {
-        memset(*dgd,
-               0,
-               sizeof(**dgd) * 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride);
-        eb_buf_random_u16_to_bd(
-            *src, 2 * RESTORATION_UNITSIZE_MAX * *src_stride, bd);
-    } else if (4 == idx) {
-        eb_buf_random_u16_to_0_or_bd(
-            *dgd, 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride, bd);
-        eb_buf_random_u16_to_0_or_bd(
-            *src, 2 * RESTORATION_UNITSIZE_MAX * *src_stride, bd);
-    } else if (5 == idx) {
-        // Trigger the 32-bit overflow in Step 3 and 4 for AOM_BITS_12.
-        eb_buf_random_u16_to_bd(
-            *dgd, 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride, bd);
-        for (int i = 0; i < 2 * RESTORATION_UNITSIZE_MAX; i++) {
-            memset(*dgd + i * *dgd_stride, 0, sizeof(**dgd) * 20);
-        }
-        memset(*src,
-               0,
-               sizeof(**src) * 2 * RESTORATION_UNITSIZE_MAX * *src_stride);
-    } else if (6 == idx) {
-        // Trigger the 32-bit overflow in Step 5 and 6 for AOM_BITS_12.
-        eb_buf_random_u16_to_bd(
-            *dgd, 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride, bd);
-        memset(*dgd, 0, sizeof(**dgd) * 2 * RESTORATION_UNITSIZE_MAX * 20);
-        memset(*src,
-               0,
-               sizeof(**src) * 2 * RESTORATION_UNITSIZE_MAX * *src_stride);
-    } else {
-        eb_buf_random_u16_with_bd(
-            *dgd, 2 * RESTORATION_UNITSIZE_MAX * *dgd_stride, bd);
-        eb_buf_random_u16_with_bd(
-            *src, 2 * RESTORATION_UNITSIZE_MAX * *src_stride, bd);
-    }
-}
-
-static void uninit_data(uint8_t *dgd, uint8_t *src) {
-    free(dgd);
-    free(src);
-}
-
-static void uninit_data_highbd(uint16_t *dgd, uint16_t *src) {
-    free(dgd);
-    free(src);
-}
-
-static void init_output(int64_t M_org[WIENER_WIN2], int64_t M_opt[WIENER_WIN2],
-                        int64_t H_org[WIENER_WIN2 * WIENER_WIN2],
-                        int64_t H_opt[WIENER_WIN2 * WIENER_WIN2]) {
-    eb_buf_random_s64(M_org, WIENER_WIN2);
-    eb_buf_random_s64(M_opt, WIENER_WIN2);
-    eb_buf_random_s64(H_org, WIENER_WIN2 * WIENER_WIN2);
-    eb_buf_random_s64(H_opt, WIENER_WIN2 * WIENER_WIN2);
-    memcpy(M_opt, M_org, sizeof(*M_org) * WIENER_WIN2);
-    memcpy(H_opt, H_org, sizeof(*H_org) * WIENER_WIN2 * WIENER_WIN2);
-}
-
-void match_test(av1_compute_stats_func func) {
+class av1_compute_stats_test
+    : public ::testing::TestWithParam<av1_compute_stats_params> {
     uint8_t *dgd, *src;
     int32_t dgd_stride, src_stride;
     int64_t M_org[WIENER_WIN2], M_opt[WIENER_WIN2];
     int64_t H_org[WIENER_WIN2 * WIENER_WIN2], H_opt[WIENER_WIN2 * WIENER_WIN2];
 
-    init_output(M_org, M_opt, H_org, H_opt);
 
-    for (int i = 0; i < 2; i++) {
-        for (int j = 0; j < 6; j++) {
-            init_data(&dgd, &dgd_stride, &src, &src_stride, j);
+    void init_data(const int idx) {
+        if (!idx) {
+            memset(dgd, 0, sizeof(*dgd) * 2 * RESTORATION_UNITSIZE_MAX * dgd_stride);
+            memset(src, 0, sizeof(*src) * 2 * RESTORATION_UNITSIZE_MAX * src_stride);
+        } else if (1 == idx) {
+            eb_buf_random_u8_to_255(dgd, 2 * RESTORATION_UNITSIZE_MAX * dgd_stride);
+            eb_buf_random_u8_to_255(src, 2 * RESTORATION_UNITSIZE_MAX * src_stride);
+        } else if (2 == idx) {
+            eb_buf_random_u8_to_255(dgd, 2 * RESTORATION_UNITSIZE_MAX * dgd_stride);
+            memset(src, 0, sizeof(*src) * 2 * RESTORATION_UNITSIZE_MAX * src_stride);
+        } else if (3 == idx) {
+            memset(dgd, 0, sizeof(*dgd) * 2 * RESTORATION_UNITSIZE_MAX * dgd_stride);
+            eb_buf_random_u8_to_255(src, 2 * RESTORATION_UNITSIZE_MAX * src_stride);
+        } else if (4 == idx) {
+            eb_buf_random_u8_to_0_or_255(dgd, 2 * RESTORATION_UNITSIZE_MAX * dgd_stride);
+            eb_buf_random_u8_to_0_or_255(src, 2 * RESTORATION_UNITSIZE_MAX * src_stride);
+        } else {
+            eb_buf_random_u8(dgd, 2 * RESTORATION_UNITSIZE_MAX * dgd_stride);
+            eb_buf_random_u8(src, 2 * RESTORATION_UNITSIZE_MAX * src_stride);
+        }
+    }
+
+    void init_output() {
+        eb_buf_random_s64(M_org, WIENER_WIN2);
+        eb_buf_random_s64(H_org, WIENER_WIN2 * WIENER_WIN2);
+        memcpy(M_opt, M_org, sizeof(*M_org) * WIENER_WIN2);
+        memcpy(H_opt, H_org, sizeof(*H_org) * WIENER_WIN2 * WIENER_WIN2);
+    }
+
+  public:
+    void match_test() {
+        const int block_size = TEST_GET_PARAM(0);
+        int width = block_size_wide[block_size];
+        int height = block_size_high[block_size];
+        av1_compute_stats_func func = TEST_GET_PARAM(1);
+        int test_idx = TEST_GET_PARAM(2);
+        int wiener_win = TEST_GET_PARAM(3);
+        init_output();
+
+        dgd_stride =
+            eb_create_random_aligned_stride(2 * RESTORATION_UNITSIZE_MAX, 64);
+        src_stride =
+            eb_create_random_aligned_stride(2 * RESTORATION_UNITSIZE_MAX, 64);
+        dgd = (uint8_t *)malloc(sizeof(*dgd) * 2 * RESTORATION_UNITSIZE_MAX *
+                                dgd_stride);
+        src = (uint8_t *)malloc(sizeof(*src) * 2 * RESTORATION_UNITSIZE_MAX *
+                                src_stride);
+
+        int test_times = test_idx == 0 ? 1 : 10;
+        for (int i = 0; i < test_times; i++) {
+            width += i % 2 == 0 ? 0 : 1;
+            height += i % 2 == 0 ? 1 : 0;
+            init_data(test_idx);
             uint8_t *const d = dgd + WIENER_WIN * dgd_stride;
             uint8_t *const s = src + WIENER_WIN * src_stride;
 
-            for (int wn_filter_mode = 0; wn_filter_mode <= 2;
-                 wn_filter_mode++) {
-                for (int plane = 0; plane <= 1; plane++) {
-                    const int32_t wn_luma = wn_filter_mode == 1
-                                                ? WIENER_WIN_3TAP
-                                                : wn_filter_mode == 2
-                                                      ? WIENER_WIN_CHROMA
-                                                      : WIENER_WIN;
-                    const int32_t wiener_win = wn_filter_mode == 1
-                                                   ? WIENER_WIN_3TAP
-                                                   : (plane == AOM_PLANE_Y)
-                                                         ? wn_luma
-                                                         : WIENER_WIN_CHROMA;
+            eb_av1_compute_stats_c(wiener_win,
+                                   d,
+                                   s,
+                                   0,
+                                   width,
+                                   0,
+                                   height,
+                                   dgd_stride,
+                                   src_stride,
+                                   M_org,
+                                   H_org);
 
-                    for (int start = 0; start <= 2; start += 2) {
-                        const int32_t h_start = start;
-                        const int32_t v_start = start;
+            func(wiener_win,
+                 d,
+                 s,
+                 0,
+                 width,
+                 0,
+                 height,
+                 dgd_stride,
+                 src_stride,
+                 M_opt,
+                 H_opt);
 
-                        for (int end = 0; end < 32; end += 2) {
-                            const int32_t h_end =
-                                RESTORATION_UNITSIZE_MAX * 3 / 2 + end;
-                            const int32_t v_end =
-                                RESTORATION_UNITSIZE_MAX * 3 / 2 + end;
-
-                            eb_av1_compute_stats_c(wiener_win,
-                                                   d,
-                                                   s,
-                                                   h_start,
-                                                   h_end,
-                                                   v_start,
-                                                   v_end,
-                                                   dgd_stride,
-                                                   src_stride,
-                                                   M_org,
-                                                   H_org);
-
-                            func(wiener_win,
-                                 d,
-                                 s,
-                                 h_start,
-                                 h_end,
-                                 v_start,
-                                 v_end,
-                                 dgd_stride,
-                                 src_stride,
-                                 M_opt,
-                                 H_opt);
-
-                            for (int idx = 0; idx < WIENER_WIN2; idx++) {
-                                if (M_org[idx] != M_opt[idx]) {
-                                    printf(
-                                        "\n M: width = %d, height = %d, "
-                                        "wiener_win=%d, idx=%d, [%d, %d]",
-                                        h_end - h_start,
-                                        v_end - v_start,
-                                        wiener_win,
-                                        idx,
-                                        idx / (wiener_win * wiener_win),
-                                        idx % (wiener_win * wiener_win));
-                                }
-                                EXPECT_EQ(M_org[idx], M_opt[idx]);
-                            }
-                            for (int idx = 0; idx < WIENER_WIN2 * WIENER_WIN2;
-                                 idx++) {
-                                if (H_org[idx] != H_opt[idx]) {
-                                    printf(
-                                        "\n H: width = %d, height = %d, "
-                                        "wiener_win=%d, idx=%d, [%d, %d]",
-                                        h_end - h_start,
-                                        v_end - v_start,
-                                        wiener_win,
-                                        idx,
-                                        idx / (wiener_win * wiener_win),
-                                        idx % (wiener_win * wiener_win));
-                                }
-                                EXPECT_EQ(H_org[idx], H_opt[idx]);
-                            }
-                        }
-                    }
-                }
-            }
-
-            uninit_data(dgd, src);
+            ASSERT_EQ(0, memcmp(M_org, M_opt, sizeof(M_org)));
+            ASSERT_EQ(0, memcmp(H_org, H_opt, sizeof(H_org)));
         }
+        free(dgd);
+        free(src);
     }
-}
 
-void highbd_match_test(av1_compute_stats_highbd_func func) {
-    uint16_t *dgd, *src;
-    int32_t dgd_stride, src_stride;
-    int64_t M_org[WIENER_WIN2], M_opt[WIENER_WIN2];
-    int64_t H_org[WIENER_WIN2 * WIENER_WIN2], H_opt[WIENER_WIN2 * WIENER_WIN2];
+    void speed_test() {
+        double time_c, time_o;
+        uint64_t start_time_seconds, start_time_useconds;
+        uint64_t middle_time_seconds, middle_time_useconds;
+        uint64_t finish_time_seconds, finish_time_useconds;
+        av1_compute_stats_func func = TEST_GET_PARAM(1);
+        int wiener_win = TEST_GET_PARAM(3);
 
-    init_output(M_org, M_opt, H_org, H_opt);
+        init_output();
+        dgd_stride =
+            eb_create_random_aligned_stride(2 * RESTORATION_UNITSIZE_MAX, 64);
+        src_stride =
+            eb_create_random_aligned_stride(2 * RESTORATION_UNITSIZE_MAX, 64);
+        dgd = (uint8_t *)malloc(sizeof(*dgd) * 2 * RESTORATION_UNITSIZE_MAX *
+                                dgd_stride);
+        src = (uint8_t *)malloc(sizeof(*src) * 2 * RESTORATION_UNITSIZE_MAX *
+                                src_stride);
+        init_data(5);
+        uint8_t *const d = dgd + WIENER_WIN * dgd_stride;
+        uint8_t *const s = src + WIENER_WIN * src_stride;
+        const int32_t h_start = 0;
+        const int32_t v_start = 0;
+        const int32_t h_end = RESTORATION_UNITSIZE_MAX;
+        const int32_t v_end = RESTORATION_UNITSIZE_MAX;
 
-    for (int bd = AOM_BITS_8; bd <= AOM_BITS_12; bd += 2) {
-        const AomBitDepth bit_depth = (AomBitDepth)bd;
-
-        for (int i = 0; i < 2; i++) {
-            for (int j = 0; j < 8; j++) {
-                init_data_highbd(
-                    &dgd, &dgd_stride, &src, &src_stride, bit_depth, j);
-                const uint16_t *const d =
-                    dgd + WIENER_WIN * dgd_stride + WIENER_WIN;
-                const uint16_t *const s =
-                    src + WIENER_WIN * src_stride + WIENER_WIN;
-                const uint8_t *const dgd8 = CONVERT_TO_BYTEPTR(d);
-                const uint8_t *const src8 = CONVERT_TO_BYTEPTR(s);
-
-                for (int wn_filter_mode = 0; wn_filter_mode <= 2;
-                     wn_filter_mode++) {
-                    for (int plane = 0; plane <= 1; plane++) {
-                        const int32_t wn_luma = wn_filter_mode == 1
-                                                    ? WIENER_WIN_3TAP
-                                                    : wn_filter_mode == 2
-                                                          ? WIENER_WIN_CHROMA
-                                                          : WIENER_WIN;
-                        const int32_t wiener_win =
-                            wn_filter_mode == 1
-                                ? WIENER_WIN_3TAP
-                                : (plane == AOM_PLANE_Y) ? wn_luma
-                                                         : WIENER_WIN_CHROMA;
-
-                        for (int size_mode = 0; size_mode < 2; size_mode++) {
-                            for (int start = 0; start <= 2; start += 2) {
-                                const int32_t h_start = start;
-                                const int32_t v_start = start;
-
-                                for (int end = 0; end <= 2; end += 2) {
-                                    const int32_t h_end =
-                                        sizes[size_mode] + end;
-                                    const int32_t v_end =
-                                        sizes[size_mode] + end;
-
-                                    eb_av1_compute_stats_highbd_c(wiener_win,
-                                                                  dgd8,
-                                                                  src8,
-                                                                  h_start,
-                                                                  h_end,
-                                                                  v_start,
-                                                                  v_end,
-                                                                  dgd_stride,
-                                                                  src_stride,
-                                                                  M_org,
-                                                                  H_org,
-                                                                  bit_depth);
-
-                                    func(wiener_win,
-                                         dgd8,
-                                         src8,
-                                         h_start,
-                                         h_end,
-                                         v_start,
-                                         v_end,
-                                         dgd_stride,
-                                         src_stride,
-                                         M_opt,
-                                         H_opt,
-                                         bit_depth);
-
-                                    for (int idx = 0; idx < WIENER_WIN2;
-                                         idx++) {
-                                        if (M_org[idx] != M_opt[idx]) {
-                                            printf(
-                                                "\n M: bd=%d, width = %d, "
-                                                "height = %d, wiener_win=%d, "
-                                                "idx=%d, [%d, %d]",
-                                                bd,
-                                                h_end - h_start,
-                                                v_end - v_start,
-                                                wiener_win,
-                                                idx,
-                                                idx / (wiener_win * wiener_win),
-                                                idx %
-                                                    (wiener_win * wiener_win));
-                                        }
-                                        EXPECT_EQ(M_org[idx], M_opt[idx]);
-                                    }
-                                    for (int idx = 0;
-                                         idx < WIENER_WIN2 * WIENER_WIN2;
-                                         idx++) {
-                                        if (H_org[idx] != H_opt[idx]) {
-                                            printf(
-                                                "\n H: bd=%d, width = %d, "
-                                                "height = %d, wiener_win=%d, "
-                                                "idx=%d, [%d, %d]",
-                                                bd,
-                                                h_end - h_start,
-                                                v_end - v_start,
-                                                wiener_win,
-                                                idx,
-                                                idx / (wiener_win * wiener_win),
-                                                idx %
-                                                    (wiener_win * wiener_win));
-                                        }
-                                        EXPECT_EQ(H_org[idx], H_opt[idx]);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                uninit_data_highbd(dgd, src);
-            }
-        }
-    }
-}
-
-void speed_test(av1_compute_stats_func func) {
-    uint8_t *dgd, *src;
-    int32_t dgd_stride, src_stride;
-    int64_t M_org[WIENER_WIN2], M_opt[WIENER_WIN2];
-    int64_t H_org[WIENER_WIN2 * WIENER_WIN2], H_opt[WIENER_WIN2 * WIENER_WIN2];
-    double time_c, time_o;
-    uint64_t start_time_seconds, start_time_useconds;
-    uint64_t middle_time_seconds, middle_time_useconds;
-    uint64_t finish_time_seconds, finish_time_useconds;
-
-    init_output(M_org, M_opt, H_org, H_opt);
-    init_data(&dgd, &dgd_stride, &src, &src_stride, 5);
-    uint8_t *const d = dgd + WIENER_WIN * dgd_stride;
-    uint8_t *const s = src + WIENER_WIN * src_stride;
-    const int32_t h_start = 0;
-    const int32_t v_start = 0;
-    const int32_t h_end = RESTORATION_UNITSIZE_MAX;
-    const int32_t v_end = RESTORATION_UNITSIZE_MAX;
-
-    for (int j = 0; j < 3; j++) {
-        const int32_t wiener_win = wins[j];
         const uint64_t num_loop = 100000 / (wiener_win * wiener_win);
 
         eb_start_time(&start_time_seconds, &start_time_useconds);
@@ -446,171 +187,305 @@ void speed_test(av1_compute_stats_func func) {
 
         eb_start_time(&finish_time_seconds, &finish_time_useconds);
         eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                      start_time_useconds,
-                                      middle_time_seconds,
-                                      middle_time_useconds,
-                                      &time_c);
+                                            start_time_useconds,
+                                            middle_time_seconds,
+                                            middle_time_useconds,
+                                            &time_c);
         eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                      middle_time_useconds,
-                                      finish_time_seconds,
-                                      finish_time_useconds,
-                                      &time_o);
+                                            middle_time_useconds,
+                                            finish_time_seconds,
+                                            finish_time_useconds,
+                                            &time_o);
 
-        for (int idx = 0; idx < WIENER_WIN2; idx++) {
-            EXPECT_EQ(M_org[idx], M_opt[idx]);
-        }
-        for (int idx = 0; idx < WIENER_WIN2 * WIENER_WIN2; idx++) {
-            EXPECT_EQ(H_org[idx], H_opt[idx]);
-        }
+        ASSERT_EQ(0, memcmp(M_org, M_opt, sizeof(M_org)));
+        ASSERT_EQ(0, memcmp(H_org, H_opt, sizeof(H_org)));
 
         printf("Average Nanoseconds per Function Call\n");
         printf("    eb_av1_compute_stats_c(%d)   : %6.2f\n",
-               wiener_win,
-               1000000 * time_c / num_loop);
+                wiener_win,
+                1000000 * time_c / num_loop);
         printf(
-            "    eb_av1_compute_stats_opt(%d) : %6.2f   (Comparison: %5.2fx)\n",
+            "    eb_av1_compute_stats_opt(%d) : %6.2f   (Comparison: "
+            "%5.2fx)\n",
             wiener_win,
             1000000 * time_o / num_loop,
             time_c / time_o);
     }
+
+};
+
+TEST_P(av1_compute_stats_test, match) {
+    match_test();
+}
+TEST_P(av1_compute_stats_test, DISABLED_speed) {
+    speed_test();
 }
 
-void highbd_speed_test(av1_compute_stats_highbd_func func) {
+INSTANTIATE_TEST_CASE_P(
+    AV1_COMPUTE_STATS_AVX2, av1_compute_stats_test,
+    ::testing::Combine(::testing::Range(BLOCK_4X4, BlockSizeS_ALL),
+                       ::testing::Values(eb_av1_compute_stats_avx2),
+                       ::testing::Range(0, 6),
+                       ::testing::Values(WIENER_WIN_CHROMA, WIENER_WIN,
+                                         WIENER_WIN_3TAP)));
+
+#ifndef NON_AVX512_SUPPORT
+INSTANTIATE_TEST_CASE_P(
+    AV1_COMPUTE_STATS_AVX512, av1_compute_stats_test,
+    ::testing::Combine(::testing::Range(BLOCK_4X4, BlockSizeS_ALL),
+                       ::testing::Values(eb_av1_compute_stats_avx512),
+                       ::testing::Range(0, 6),
+                       ::testing::Values(WIENER_WIN_CHROMA, WIENER_WIN,
+                                         WIENER_WIN_3TAP)));
+#endif
+
+typedef ::testing::tuple<BlockSize, av1_compute_stats_highbd_func, int, int, AomBitDepth>
+    av1_compute_stats_hbd_params;
+
+class av1_compute_stats_test_hbd
+    : public ::testing::TestWithParam<av1_compute_stats_hbd_params> {
     uint16_t *dgd, *src;
     int32_t dgd_stride, src_stride;
     int64_t M_org[WIENER_WIN2], M_opt[WIENER_WIN2];
     int64_t H_org[WIENER_WIN2 * WIENER_WIN2], H_opt[WIENER_WIN2 * WIENER_WIN2];
-    double time_c, time_o;
-    uint64_t start_time_seconds, start_time_useconds;
-    uint64_t middle_time_seconds, middle_time_useconds;
-    uint64_t finish_time_seconds, finish_time_useconds;
 
-    init_output(M_org, M_opt, H_org, H_opt);
-    const int32_t h_start = 0;
-    const int32_t v_start = 0;
-    const int32_t h_end = RESTORATION_UNITSIZE_MAX;
-    const int32_t v_end = RESTORATION_UNITSIZE_MAX;
+    void init_data_highbd(AomBitDepth bd, const int idx) {
+        if (!idx) {
+            memset(dgd, 0, sizeof(*dgd) * 2 * RESTORATION_UNITSIZE_MAX * dgd_stride);
+            memset(src, 0, sizeof(*src) * 2 * RESTORATION_UNITSIZE_MAX * src_stride);
+        } else if (1 == idx) {
+            eb_buf_random_u16_to_bd(
+                dgd, 2 * RESTORATION_UNITSIZE_MAX * dgd_stride, bd);
+            eb_buf_random_u16_to_bd(
+                src, 2 * RESTORATION_UNITSIZE_MAX * src_stride, bd);
+        } else if (2 == idx) {
+            eb_buf_random_u16_to_bd(
+                dgd, 2 * RESTORATION_UNITSIZE_MAX * dgd_stride, bd);
+            memset(src, 0, sizeof(*src) * 2 * RESTORATION_UNITSIZE_MAX * src_stride);
+        } else if (3 == idx) {
+            memset(dgd, 0, sizeof(*dgd) * 2 * RESTORATION_UNITSIZE_MAX * dgd_stride);
+            eb_buf_random_u16_to_bd(
+                src, 2 * RESTORATION_UNITSIZE_MAX * src_stride, bd);
+        } else if (4 == idx) {
+            eb_buf_random_u16_to_0_or_bd(
+                dgd, 2 * RESTORATION_UNITSIZE_MAX * dgd_stride, bd);
+            eb_buf_random_u16_to_0_or_bd(
+                src, 2 * RESTORATION_UNITSIZE_MAX * src_stride, bd);
+        } else if (5 == idx) {
+            // Trigger the 32-bit overflow in Step 3 and 4 for AOM_BITS_12.
+            eb_buf_random_u16_to_bd(
+                dgd, 2 * RESTORATION_UNITSIZE_MAX * dgd_stride, bd);
+            for (int i = 0; i < 2 * RESTORATION_UNITSIZE_MAX; i++) {
+                memset(dgd + i * dgd_stride, 0, sizeof(*dgd) * 20);
+            }
+            memset(src, 0, sizeof(*src) * 2 * RESTORATION_UNITSIZE_MAX * src_stride);
+        } else if (6 == idx) {
+            // Trigger the 32-bit overflow in Step 5 and 6 for AOM_BITS_12.
+            eb_buf_random_u16_to_bd(
+                dgd, 2 * RESTORATION_UNITSIZE_MAX * dgd_stride, bd);
+            memset(dgd, 0, sizeof(*dgd) * 2 * RESTORATION_UNITSIZE_MAX * 20);
+            memset(src, 0, sizeof(*src) * 2 * RESTORATION_UNITSIZE_MAX * src_stride);
+        } else {
+            eb_buf_random_u16_with_bd(
+                dgd, 2 * RESTORATION_UNITSIZE_MAX * dgd_stride, bd);
+            eb_buf_random_u16_with_bd(
+                src, 2 * RESTORATION_UNITSIZE_MAX * src_stride, bd);
+        }
+    }
 
-    for (int bd = AOM_BITS_8; bd <= AOM_BITS_12; bd += 2) {
-        const AomBitDepth bit_depth = (AomBitDepth)bd;
-        init_data_highbd(&dgd, &dgd_stride, &src, &src_stride, bit_depth, 7);
+    void init_output() {
+        eb_buf_random_s64(M_org, WIENER_WIN2);
+        eb_buf_random_s64(H_org, WIENER_WIN2 * WIENER_WIN2);
+        memcpy(M_opt, M_org, sizeof(*M_org) * WIENER_WIN2);
+        memcpy(H_opt, H_org, sizeof(*H_org) * WIENER_WIN2 * WIENER_WIN2);
+    }
+
+  public:
+    void highbd_match_test() {
+        const int block_size = TEST_GET_PARAM(0);
+        int width = block_size_wide[block_size];
+        int height = block_size_high[block_size];
+        av1_compute_stats_highbd_func func = TEST_GET_PARAM(1);
+        int test_idx = TEST_GET_PARAM(2);
+        int wiener_win = TEST_GET_PARAM(3);
+        const AomBitDepth bit_depth = TEST_GET_PARAM(4);
+        init_output();
+
+        dgd_stride =
+            eb_create_random_aligned_stride(2 * RESTORATION_UNITSIZE_MAX, 64);
+        src_stride =
+            eb_create_random_aligned_stride(2 * RESTORATION_UNITSIZE_MAX, 64);
+        dgd = (uint16_t *)malloc(sizeof(*dgd) * 2 * RESTORATION_UNITSIZE_MAX *
+                                  dgd_stride);
+        src = (uint16_t *)malloc(sizeof(*src) * 2 * RESTORATION_UNITSIZE_MAX *
+                                  src_stride);
+
+        int test_times = test_idx == 0 ? 1 : 10;
+        for (int i = 0; i < test_times; i++) {
+            width += i % 2 == 0 ? 0 : 1;
+            height +=  i % 2 == 0 ? 1 : 0;
+            init_data_highbd(bit_depth, test_idx);
+
+            const uint16_t *const d =
+                dgd + WIENER_WIN * dgd_stride + WIENER_WIN;
+            const uint16_t *const s =
+                src + WIENER_WIN * src_stride + WIENER_WIN;
+            const uint8_t *const dgd8 = CONVERT_TO_BYTEPTR(d);
+            const uint8_t *const src8 = CONVERT_TO_BYTEPTR(s);
+
+            eb_av1_compute_stats_highbd_c(wiener_win,
+                                          dgd8,
+                                          src8,
+                                          0,
+                                          width,
+                                          0,
+                                          height,
+                                          dgd_stride,
+                                          src_stride,
+                                          M_org,
+                                          H_org,
+                                          bit_depth);
+
+            func(wiener_win,
+                 dgd8,
+                 src8,
+                 0,
+                 width,
+                 0,
+                 height,
+                 dgd_stride,
+                 src_stride,
+                 M_opt,
+                 H_opt,
+                 bit_depth);
+
+                ASSERT_EQ(0, memcmp(M_org, M_opt, sizeof(M_org)));
+                ASSERT_EQ(0, memcmp(H_org, H_opt, sizeof(H_org)));
+        }
+        free(dgd);
+        free(src);
+    }
+
+    void highbd_speed_test() {
+        double time_c, time_o;
+        uint64_t start_time_seconds, start_time_useconds;
+        uint64_t middle_time_seconds, middle_time_useconds;
+        uint64_t finish_time_seconds, finish_time_useconds;
+
+        av1_compute_stats_highbd_func func = TEST_GET_PARAM(1);
+        int wiener_win = TEST_GET_PARAM(3);
+        const AomBitDepth bit_depth = TEST_GET_PARAM(4);
+        init_output();
+
+        dgd_stride =
+            eb_create_random_aligned_stride(2 * RESTORATION_UNITSIZE_MAX, 64);
+        src_stride =
+            eb_create_random_aligned_stride(2 * RESTORATION_UNITSIZE_MAX, 64);
+        dgd = (uint16_t *)malloc(sizeof(*dgd) * 2 * RESTORATION_UNITSIZE_MAX *
+                                 dgd_stride);
+        src = (uint16_t *)malloc(sizeof(*src) * 2 * RESTORATION_UNITSIZE_MAX *
+                                 src_stride);
+
+        const int32_t h_start = 0;
+        const int32_t v_start = 0;
+        const int32_t h_end = RESTORATION_UNITSIZE_MAX;
+        const int32_t v_end = RESTORATION_UNITSIZE_MAX;
+
+        init_data_highbd(bit_depth, 7);
         uint16_t *const d = dgd + WIENER_WIN * dgd_stride;
         uint16_t *const s = src + WIENER_WIN * src_stride;
         const uint8_t *const dgd8 = CONVERT_TO_BYTEPTR(d);
         const uint8_t *const src8 = CONVERT_TO_BYTEPTR(s);
 
-        for (int j = 0; j < 3; j++) {
-            const int32_t wiener_win = wins[j];
-            const uint64_t num_loop = 1000000 / (wiener_win * wiener_win);
+        const uint64_t num_loop = 1000000 / (wiener_win * wiener_win);
 
-            eb_start_time(&start_time_seconds, &start_time_useconds);
+        eb_start_time(&start_time_seconds, &start_time_useconds);
 
-            for (uint64_t i = 0; i < num_loop; i++) {
-                eb_av1_compute_stats_highbd_c(wiener_win,
-                                              dgd8,
-                                              src8,
-                                              h_start,
-                                              h_end,
-                                              v_start,
-                                              v_end,
-                                              dgd_stride,
-                                              src_stride,
-                                              M_org,
-                                              H_org,
-                                              bit_depth);
-            }
-
-            eb_start_time(&middle_time_seconds, &middle_time_useconds);
-
-            for (uint64_t i = 0; i < num_loop; i++) {
-                func(wiener_win,
-                     dgd8,
-                     src8,
-                     h_start,
-                     h_end,
-                     v_start,
-                     v_end,
-                     dgd_stride,
-                     src_stride,
-                     M_opt,
-                     H_opt,
-                     bit_depth);
-            }
-
-            eb_start_time(&finish_time_seconds, &finish_time_useconds);
-            eb_compute_overall_elapsed_time_ms(start_time_seconds,
-                                          start_time_useconds,
-                                          middle_time_seconds,
-                                          middle_time_useconds,
-                                          &time_c);
-            eb_compute_overall_elapsed_time_ms(middle_time_seconds,
-                                          middle_time_useconds,
-                                          finish_time_seconds,
-                                          finish_time_useconds,
-                                          &time_o);
-
-            for (int idx = 0; idx < WIENER_WIN2; idx++) {
-                EXPECT_EQ(M_org[idx], M_opt[idx]);
-            }
-            for (int idx = 0; idx < WIENER_WIN2 * WIENER_WIN2; idx++) {
-                EXPECT_EQ(H_org[idx], H_opt[idx]);
-            }
-
-            printf("Average Nanoseconds per Function Call\n");
-            printf("    eb_av1_compute_stats_highbd_c(%d)   : %6.2f\n",
-                   wiener_win,
-                   1000000 * time_c / num_loop);
-            printf(
-                "    av1_compute_stats_highbd_opt(%d) : %6.2f   "
-                "(Comparison: "
-                "%5.2fx)\n",
-                wiener_win,
-                1000000 * time_o / num_loop,
-                time_c / time_o);
+        for (uint64_t i = 0; i < num_loop; i++) {
+            eb_av1_compute_stats_highbd_c(wiener_win,
+                                            dgd8,
+                                            src8,
+                                            h_start,
+                                            h_end,
+                                            v_start,
+                                            v_end,
+                                            dgd_stride,
+                                            src_stride,
+                                            M_org,
+                                            H_org,
+                                            bit_depth);
         }
+
+        eb_start_time(&middle_time_seconds, &middle_time_useconds);
+
+        for (uint64_t i = 0; i < num_loop; i++) {
+            func(wiener_win,
+                    dgd8,
+                    src8,
+                    h_start,
+                    h_end,
+                    v_start,
+                    v_end,
+                    dgd_stride,
+                    src_stride,
+                    M_opt,
+                    H_opt,
+                    bit_depth);
+        }
+
+        eb_start_time(&finish_time_seconds, &finish_time_useconds);
+        eb_compute_overall_elapsed_time_ms(start_time_seconds,
+                                            start_time_useconds,
+                                            middle_time_seconds,
+                                            middle_time_useconds,
+                                            &time_c);
+        eb_compute_overall_elapsed_time_ms(middle_time_seconds,
+                                            middle_time_useconds,
+                                            finish_time_seconds,
+                                            finish_time_useconds,
+                                            &time_o);
+
+        ASSERT_EQ(0, memcmp(M_org, M_opt, sizeof(M_org)));
+        ASSERT_EQ(0, memcmp(H_org, H_opt, sizeof(H_org)));
+
+        printf("Average Nanoseconds per Function Call\n");
+        printf("    eb_av1_compute_stats_highbd_c(%d)   : %6.2f\n",
+                wiener_win,
+                1000000 * time_c / num_loop);
+        printf(
+            "    av1_compute_stats_highbd_opt(%d) : %6.2f   "
+            "(Comparison: "
+            "%5.2fx)\n",
+            wiener_win,
+            1000000 * time_o / num_loop,
+            time_c / time_o);
     }
+
+};
+
+TEST_P(av1_compute_stats_test_hbd, match) {
+    highbd_match_test();
+}
+TEST_P(av1_compute_stats_test_hbd, DISABLED_speed) {
+    highbd_speed_test();
 }
 
-TEST(EbRestorationPick_avx2, match) {
-    match_test(eb_av1_compute_stats_avx2);
-}
-
-TEST(EbRestorationPick_avx2, match_highbd) {
-    highbd_match_test(eb_av1_compute_stats_highbd_avx2);
-}
-
-TEST(EbRestorationPick_avx2, DISABLED_speed) {
-    speed_test(eb_av1_compute_stats_avx2);
-}
-
-TEST(EbRestorationPick_avx2, DISABLED_speed_highbd) {
-    highbd_speed_test(eb_av1_compute_stats_highbd_avx2);
-}
+INSTANTIATE_TEST_CASE_P(
+    AV1_COMPUTE_STATS_HBD_AVX2, av1_compute_stats_test_hbd,
+    ::testing::Combine(
+        ::testing::Range(BLOCK_4X4, BlockSizeS_ALL),
+        ::testing::Values(eb_av1_compute_stats_highbd_avx2),
+        ::testing::Range(0, 8),
+        ::testing::Values(WIENER_WIN_CHROMA, WIENER_WIN, WIENER_WIN_3TAP),
+        ::testing::Values(AOM_BITS_8, AOM_BITS_10, AOM_BITS_12)));
 
 #ifndef NON_AVX512_SUPPORT
-
-TEST(EbRestorationPick_avx512, match) {
-    if (get_cpu_flags_to_use() & CPU_FLAGS_AVX512F) {
-        match_test(eb_av1_compute_stats_avx512);
-    }
-}
-
-TEST(EbRestorationPick_avx512, match_highbd) {
-    if (get_cpu_flags_to_use() & CPU_FLAGS_AVX512F) {
-        highbd_match_test(eb_av1_compute_stats_highbd_avx512);
-    }
-}
-
-TEST(EbRestorationPick_avx512, DISABLED_speed) {
-    if (get_cpu_flags_to_use() & CPU_FLAGS_AVX512F) {
-        speed_test(eb_av1_compute_stats_avx512);
-    }
-}
-
-TEST(EbRestorationPick_avx512, DISABLED_speed_highbd) {
-    if (get_cpu_flags_to_use() & CPU_FLAGS_AVX512F) {
-        highbd_speed_test(eb_av1_compute_stats_highbd_avx512);
-    }
-}
-
+INSTANTIATE_TEST_CASE_P(
+    AV1_COMPUTE_STATS_HBD_AVX512, av1_compute_stats_test_hbd,
+    ::testing::Combine(
+        ::testing::Range(BLOCK_4X4, BlockSizeS_ALL),
+        ::testing::Values(eb_av1_compute_stats_highbd_avx512),
+        ::testing::Range(0, 8),
+        ::testing::Values(WIENER_WIN_CHROMA, WIENER_WIN, WIENER_WIN_3TAP),
+        ::testing::Values(AOM_BITS_8, AOM_BITS_10, AOM_BITS_12)));
 #endif

--- a/test/wiener_convolve_test.cc
+++ b/test/wiener_convolve_test.cc
@@ -75,15 +75,26 @@ typedef std::tuple<BlkSize, HbdWienerConvolveFunc, int32_t>
     HbdWienerConvolveParam;
 
 static const BlkSize test_block_size_table[] = {BlkSize(96, 96),
+                                                BlkSize(96, 97),
                                                 BlkSize(88, 88),
+                                                BlkSize(88, 85),
                                                 BlkSize(80, 80),
+                                                BlkSize(80, 79),
                                                 BlkSize(72, 72),
+                                                BlkSize(72, 71),
                                                 BlkSize(64, 64),
+                                                BlkSize(64, 63),
                                                 BlkSize(56, 56),
+                                                BlkSize(56, 57),
                                                 BlkSize(48, 48),
+                                                BlkSize(48, 49),
                                                 BlkSize(32, 32),
+                                                BlkSize(32, 33),
                                                 BlkSize(24, 24),
+                                                BlkSize(24, 23),
                                                 BlkSize(16, 16),
+                                                BlkSize(16, 15),
+                                                BlkSize(8, 9),
                                                 BlkSize(8, 8)};
 
 static const int test_tap_table[] = {7, 5, 3};
@@ -180,7 +191,7 @@ class AV1WienerConvolveTest : public ::testing::TestWithParam<ParamType> {
             hkernel[0] = vkernel[0] = WIENER_FILT_TAP0_MAXV;
             hkernel[1] = vkernel[1] = WIENER_FILT_TAP1_MAXV;
             hkernel[2] = vkernel[2] = WIENER_FILT_TAP2_MAXV;
-        } else {
+        } else if (kernel_type == 2) {
             // Randomly generated values for filter coefficients
             hkernel[0] = WIENER_FILT_TAP0_MINV +
                          pseudo_uniform(WIENER_FILT_TAP0_MAXV + 1 -
@@ -201,6 +212,19 @@ class AV1WienerConvolveTest : public ::testing::TestWithParam<ParamType> {
             vkernel[2] = WIENER_FILT_TAP2_MINV +
                          pseudo_uniform(WIENER_FILT_TAP2_MAXV + 2 -
                                         WIENER_FILT_TAP2_MINV);
+        } else if (kernel_type == 3) {
+            // Check zerocoff path
+            hkernel[0] = vkernel[0] = 0;
+            hkernel[1] = vkernel[1] = 0;
+            hkernel[2] = vkernel[2] = 0;
+        } else if (kernel_type == 4) {
+            hkernel[0] = vkernel[0] = 0;
+            hkernel[1] = vkernel[1] = 0;
+            hkernel[2] = vkernel[2] = WIENER_FILT_TAP2_MAXV;
+        } else if (kernel_type == 5) {
+            hkernel[0] = vkernel[0] = 0;
+            hkernel[1] = vkernel[1] = WIENER_FILT_TAP1_MAXV;
+            hkernel[2] = vkernel[2] = WIENER_FILT_TAP2_MAXV;
         }
 
         if (tap <= 5) {
@@ -244,7 +268,7 @@ class AV1WienerConvolveTest : public ::testing::TestWithParam<ParamType> {
         for (unsigned int tap_idx = 0;
              tap_idx < sizeof(test_tap_table) / sizeof(*test_tap_table);
              tap_idx++) {
-            for (int kernel_type = 0; kernel_type < 3; kernel_type++) {
+            for (int kernel_type = 0; kernel_type < 6; kernel_type++) {
                 generate_kernels(
                     hkernel, vkernel, test_tap_table[tap_idx], kernel_type);
                 for (int i = 0;


### PR DESCRIPTION
Fixed kernels:
-eb_av1_compute_stats_avx2
-eb_av1_compute_stats_highbd_avx2
-eb_av1_compute_stats_avx512
-eb_av1_compute_stats_highbd_avx512
 -eb_av1_wiener_convolve_add_src_avx2
 -eb_av1_wiener_convolve_add_src_avx512