### PR TITLE
ffmpeg: fix memory overwrite for complex video content

### DIFF
--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
@@ -1,7 +1,7 @@
-From 6c6b0bccb7899c4637f8d05b4aae279d7661b715 Mon Sep 17 00:00:00 2001
+From f9f92b64daa8b6d4cf5d070d41702da1e6de5ee2 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
-Subject: [PATCH] Add ability for ffmpeg to run svt-av1 with svt-hevc
+Subject: [PATCH 2/2] Add ability for ffmpeg to run svt-av1 with svt-hevc
 
 Change-Id: I37ee5414fdd99e0b3f112a6e5ede166f3e48d819
 Signed-off-by: Daryl Seah <daryl.seah@intel.com>
@@ -13,15 +13,15 @@ Signed-off-by: Xu Guangxin <guangxin.xu@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 528 ++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 534 insertions(+)
+ libavcodec/libsvt_av1.c | 548 ++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 554 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
-index d654be5d72..7aa44c3d10 100755
+index 03427b2bb6..532dd80584 100755
 --- a/configure
 +++ b/configure
-@@ -266,6 +266,7 @@ External library support:
+@@ -268,6 +268,7 @@ External library support:
    --enable-libsrt          enable Haivision SRT protocol via libsrt [no]
    --enable-libssh          enable SFTP protocol via libssh [no]
    --enable-libsvthevc      enable HEVC encoding via svt [no]
@@ -29,7 +29,7 @@ index d654be5d72..7aa44c3d10 100755
    --enable-libtensorflow   enable TensorFlow as a DNN module backend
                             for DNN based filters like sr [no]
    --enable-libtesseract    enable Tesseract, needed for ocr filter [no]
-@@ -1797,6 +1798,7 @@ EXTERNAL_LIBRARY_LIST="
+@@ -1803,6 +1804,7 @@ EXTERNAL_LIBRARY_LIST="
      libsrt
      libssh
      libsvthevc
@@ -37,7 +37,7 @@ index d654be5d72..7aa44c3d10 100755
      libtensorflow
      libtesseract
      libtheora
-@@ -3217,6 +3219,7 @@ libspeex_decoder_deps="libspeex"
+@@ -3233,6 +3235,7 @@ libspeex_decoder_deps="libspeex"
  libspeex_encoder_deps="libspeex"
  libspeex_encoder_select="audio_frame_queue"
  libsvt_hevc_encoder_deps="libsvthevc"
@@ -45,7 +45,7 @@ index d654be5d72..7aa44c3d10 100755
  libtheora_encoder_deps="libtheora"
  libtwolame_encoder_deps="libtwolame"
  libvo_amrwbenc_encoder_deps="libvo_amrwbenc"
-@@ -6311,6 +6314,7 @@ enabled libssh            && require_pkg_config libssh libssh libssh/sftp.h sftp
+@@ -6357,6 +6360,7 @@ enabled libssh            && require_pkg_config libssh libssh libssh/sftp.h sftp
  enabled libspeex          && require_pkg_config libspeex speex speex/speex.h speex_decoder_init
  enabled libsrt            && require_pkg_config libsrt "srt >= 1.3.0" srt/srt.h srt_socket
  enabled libsvthevc        && require_pkg_config libsvthevc SvtHevcEnc EbApi.h EbInitHandle
@@ -54,10 +54,10 @@ index d654be5d72..7aa44c3d10 100755
  enabled libtesseract      && require_pkg_config libtesseract tesseract tesseract/capi.h TessBaseAPICreate
  enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -ltheoraenc -ltheoradec -logg
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 309dd77d3d..0fe1ded6fc 100644
+index fc930e7338..a10b8fb56b 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -998,6 +998,7 @@ OBJS-$(CONFIG_LIBSHINE_ENCODER)           += libshine.o
+@@ -1013,6 +1013,7 @@ OBJS-$(CONFIG_LIBSHINE_ENCODER)           += libshine.o
  OBJS-$(CONFIG_LIBSPEEX_DECODER)           += libspeexdec.o
  OBJS-$(CONFIG_LIBSPEEX_ENCODER)           += libspeexenc.o
  OBJS-$(CONFIG_LIBSVT_HEVC_ENCODER)        += libsvt_hevc.o
@@ -66,10 +66,10 @@ index 309dd77d3d..0fe1ded6fc 100644
  OBJS-$(CONFIG_LIBTWOLAME_ENCODER)         += libtwolame.o
  OBJS-$(CONFIG_LIBVO_AMRWBENC_ENCODER)     += libvo-amrwbenc.o
 diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
-index a8ef8fb3b1..99a6a0b326 100644
+index bf951528d0..309168850d 100644
 --- a/libavcodec/allcodecs.c
 +++ b/libavcodec/allcodecs.c
-@@ -710,6 +710,7 @@ extern AVCodec ff_libshine_encoder;
+@@ -722,6 +722,7 @@ extern AVCodec ff_libshine_encoder;
  extern AVCodec ff_libspeex_encoder;
  extern AVCodec ff_libspeex_decoder;
  extern AVCodec ff_libsvt_hevc_encoder;
@@ -79,10 +79,10 @@ index a8ef8fb3b1..99a6a0b326 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000000..4984816830
+index 0000000000..5f1d8e033f
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,528 @@
+@@ -0,0 +1,548 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -132,6 +132,7 @@ index 0000000000..4984816830
 +
 +    EbBufferHeaderType         *in_buf;
 +    int                         raw_size;
++    int                         max_tu_size;
 +
 +    AVBufferPool* pool;
 +
@@ -232,11 +233,6 @@ index 0000000000..4984816830
 +
 +    svt_enc->in_buf->size        = sizeof(*svt_enc->in_buf);
 +    svt_enc->in_buf->p_app_private  = NULL;
-+
-+    svt_enc->pool = av_buffer_pool_init(svt_enc->raw_size, NULL);
-+    if (!svt_enc->pool) {
-+        return AVERROR(ENOMEM);
-+    }
 +
 +    return 0;
 +
@@ -434,6 +430,30 @@ index 0000000000..4984816830
 +    return 0;
 +}
 +
++static AVBufferRef* get_output_ref(AVCodecContext *avctx, SvtContext  *svt_enc, int filled_len)
++{
++    if (filled_len > svt_enc->max_tu_size) {
++        const int MAX_FRAMES = 8;
++        int max_tu_size;
++        if (filled_len > svt_enc->raw_size * MAX_FRAMES) {
++            av_log(avctx, AV_LOG_ERROR, "something wrong in libsvtav1, the tu size > %d raw frame size.\n", MAX_FRAMES);
++            return NULL;
++        }
++        max_tu_size = 1 << av_ceil_log2(filled_len);
++        av_buffer_pool_uninit(&svt_enc->pool);
++        svt_enc->pool = av_buffer_pool_init(max_tu_size, NULL);
++        if (!svt_enc->pool) {
++            return NULL;
++        }
++        svt_enc->max_tu_size = max_tu_size;
++    }
++    if (!svt_enc->pool) {
++         av_log(avctx, AV_LOG_ERROR, "bug, no buffer pool.\n");
++         return NULL;
++    }
++    return av_buffer_pool_get(svt_enc->pool);
++}
++
 +static int eb_receive_packet(AVCodecContext *avctx, AVPacket *pkt)
 +{
 +    SvtContext  *svt_enc = avctx->priv_data;
@@ -449,7 +469,7 @@ index 0000000000..4984816830
 +    if (svt_ret == EB_NoErrorEmptyQueue)
 +        return AVERROR(EAGAIN);
 +
-+    ref = av_buffer_pool_get(svt_enc->pool);
++    ref = get_output_ref(avctx, svt_enc, headerPtr->n_filled_len);
 +    if (!ref) {
 +        av_log(avctx, AV_LOG_ERROR, "Failed to allocate output packet.\n");
 +        svt_av1_enc_release_out_buffer(&headerPtr);

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -1,4 +1,4 @@
-From c266759a5f107d9ebd618dbf61fa52221b1e5f22 Mon Sep 17 00:00:00 2001
+From 3d1fa971104f88488924fcff03236d0a77e3c049 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1
@@ -13,15 +13,15 @@ Signed-off-by: Xu Guangxin <guangxin.xu@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 528 ++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 534 insertions(+)
+ libavcodec/libsvt_av1.c | 548 ++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 554 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
-index 8f4f2884cf..d2ffecc9f6 100755
+index 6533b43250..7978e0ebdb 100755
 --- a/configure
 +++ b/configure
-@@ -265,6 +265,7 @@ External library support:
+@@ -267,6 +267,7 @@ External library support:
    --enable-libspeex        enable Speex de/encoding via libspeex [no]
    --enable-libsrt          enable Haivision SRT protocol via libsrt [no]
    --enable-libssh          enable SFTP protocol via libssh [no]
@@ -29,7 +29,7 @@ index 8f4f2884cf..d2ffecc9f6 100755
    --enable-libtensorflow   enable TensorFlow as a DNN module backend
                             for DNN based filters like sr [no]
    --enable-libtesseract    enable Tesseract, needed for ocr filter [no]
-@@ -1795,6 +1796,7 @@ EXTERNAL_LIBRARY_LIST="
+@@ -1801,6 +1802,7 @@ EXTERNAL_LIBRARY_LIST="
      libspeex
      libsrt
      libssh
@@ -37,7 +37,7 @@ index 8f4f2884cf..d2ffecc9f6 100755
      libtensorflow
      libtesseract
      libtheora
-@@ -3214,6 +3216,7 @@ libshine_encoder_select="audio_frame_queue"
+@@ -3230,6 +3232,7 @@ libshine_encoder_select="audio_frame_queue"
  libspeex_decoder_deps="libspeex"
  libspeex_encoder_deps="libspeex"
  libspeex_encoder_select="audio_frame_queue"
@@ -45,7 +45,7 @@ index 8f4f2884cf..d2ffecc9f6 100755
  libtheora_encoder_deps="libtheora"
  libtwolame_encoder_deps="libtwolame"
  libvo_amrwbenc_encoder_deps="libvo_amrwbenc"
-@@ -6307,6 +6310,7 @@ enabled libsoxr           && require libsoxr soxr.h soxr_create -lsoxr
+@@ -6353,6 +6356,7 @@ enabled libsoxr           && require libsoxr soxr.h soxr_create -lsoxr
  enabled libssh            && require_pkg_config libssh libssh libssh/sftp.h sftp_init
  enabled libspeex          && require_pkg_config libspeex speex speex/speex.h speex_decoder_init
  enabled libsrt            && require_pkg_config libsrt "srt >= 1.3.0" srt/srt.h srt_socket
@@ -54,10 +54,10 @@ index 8f4f2884cf..d2ffecc9f6 100755
  enabled libtesseract      && require_pkg_config libtesseract tesseract tesseract/capi.h TessBaseAPICreate
  enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -ltheoraenc -ltheoradec -logg
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 006a472a6d..05d8e2e9c0 100644
+index 88944d9a3a..9c54543701 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -997,6 +997,7 @@ OBJS-$(CONFIG_LIBRAV1E_ENCODER)           += librav1e.o
+@@ -1012,6 +1012,7 @@ OBJS-$(CONFIG_LIBRAV1E_ENCODER)           += librav1e.o
  OBJS-$(CONFIG_LIBSHINE_ENCODER)           += libshine.o
  OBJS-$(CONFIG_LIBSPEEX_DECODER)           += libspeexdec.o
  OBJS-$(CONFIG_LIBSPEEX_ENCODER)           += libspeexenc.o
@@ -66,10 +66,10 @@ index 006a472a6d..05d8e2e9c0 100644
  OBJS-$(CONFIG_LIBTWOLAME_ENCODER)         += libtwolame.o
  OBJS-$(CONFIG_LIBVO_AMRWBENC_ENCODER)     += libvo-amrwbenc.o
 diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
-index 0c0741936c..681ae8f67d 100644
+index e7b29426db..c495ea29bc 100644
 --- a/libavcodec/allcodecs.c
 +++ b/libavcodec/allcodecs.c
-@@ -709,6 +709,7 @@ extern AVCodec ff_librsvg_decoder;
+@@ -721,6 +721,7 @@ extern AVCodec ff_librsvg_decoder;
  extern AVCodec ff_libshine_encoder;
  extern AVCodec ff_libspeex_encoder;
  extern AVCodec ff_libspeex_decoder;
@@ -79,10 +79,10 @@ index 0c0741936c..681ae8f67d 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000000..4984816830
+index 0000000000..5f1d8e033f
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,528 @@
+@@ -0,0 +1,548 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -132,6 +132,7 @@ index 0000000000..4984816830
 +
 +    EbBufferHeaderType         *in_buf;
 +    int                         raw_size;
++    int                         max_tu_size;
 +
 +    AVBufferPool* pool;
 +
@@ -232,11 +233,6 @@ index 0000000000..4984816830
 +
 +    svt_enc->in_buf->size        = sizeof(*svt_enc->in_buf);
 +    svt_enc->in_buf->p_app_private  = NULL;
-+
-+    svt_enc->pool = av_buffer_pool_init(svt_enc->raw_size, NULL);
-+    if (!svt_enc->pool) {
-+        return AVERROR(ENOMEM);
-+    }
 +
 +    return 0;
 +
@@ -434,6 +430,30 @@ index 0000000000..4984816830
 +    return 0;
 +}
 +
++static AVBufferRef* get_output_ref(AVCodecContext *avctx, SvtContext  *svt_enc, int filled_len)
++{
++    if (filled_len > svt_enc->max_tu_size) {
++        const int MAX_FRAMES = 8;
++        int max_tu_size;
++        if (filled_len > svt_enc->raw_size * MAX_FRAMES) {
++            av_log(avctx, AV_LOG_ERROR, "something wrong in libsvtav1, the tu size > %d raw frame size.\n", MAX_FRAMES);
++            return NULL;
++        }
++        max_tu_size = 1 << av_ceil_log2(filled_len);
++        av_buffer_pool_uninit(&svt_enc->pool);
++        svt_enc->pool = av_buffer_pool_init(max_tu_size, NULL);
++        if (!svt_enc->pool) {
++            return NULL;
++        }
++        svt_enc->max_tu_size = max_tu_size;
++    }
++    if (!svt_enc->pool) {
++         av_log(avctx, AV_LOG_ERROR, "bug, no buffer pool.\n");
++         return NULL;
++    }
++    return av_buffer_pool_get(svt_enc->pool);
++}
++
 +static int eb_receive_packet(AVCodecContext *avctx, AVPacket *pkt)
 +{
 +    SvtContext  *svt_enc = avctx->priv_data;
@@ -449,7 +469,7 @@ index 0000000000..4984816830
 +    if (svt_ret == EB_NoErrorEmptyQueue)
 +        return AVERROR(EAGAIN);
 +
-+    ref = av_buffer_pool_get(svt_enc->pool);
++    ref = get_output_ref(avctx, svt_enc, headerPtr->n_filled_len);
 +    if (!ref) {
 +        av_log(avctx, AV_LOG_ERROR, "Failed to allocate output packet.\n");
 +        svt_av1_enc_release_out_buffer(&headerPtr);


### PR DESCRIPTION
previous code assumes raw frame size > tu size, it's not true.
A tu may include multiple undisplayable frames + one displayable frame.
So for some complex video pattern, a tu size may > multiple raw frame size.
Instead of using raw frame size as ffmpeg buffer size, This commit will
automatically adjust ffmpeg buffer size based on libsvtav1's output

test:
dd if=/dev/urandom bs=115200 count=30 of=test.yuv
ffmpeg -f rawvideo -vcodec rawvideo -s 320x240 -r 30 -pix_fmt yuv420p -i test.yuv -c:v libsvt_av1 -f ivf -y test.ivf

expected result:
no crash.