### PR TITLE
Fix eb_av1_wiener_convolve_add_src_avx2/avx512 for non multiple of 8 resolution

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/wiener_convolve_avx2.c
+++ b/Source/Lib/Common/ASM_AVX2/wiener_convolve_avx2.c
@@ -140,7 +140,6 @@ void eb_av1_wiener_convolve_add_src_avx2(const uint8_t* const src, const ptrdiff
 
     (void)conv_params;
     assert(!(w % 8));
-    assert(!(h % 2));
     assert(conv_params->round_0 == round_0);
     assert(conv_params->round_1 == round_1);
 
@@ -320,8 +319,13 @@ void eb_av1_wiener_convolve_add_src_avx2(const uint8_t* const src, const ptrdiff
                 src_p += 2 * src_stride;
                 const __m256i r0 = wiener_convolve_v8x2_tap7(coeffs_v, round_v, s[0]);
                 const __m256i r1 = wiener_convolve_v8x2_tap7(coeffs_v, round_v, s[1]);
-                pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
-
+                if (y == 1) {
+                    const __m256i d = _mm256_packus_epi16(r0, r1);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storeu_si128((__m128i*)dst_p, d0);
+                } else {
+                    pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                }
                 dst_p += 2 * dst_stride;
                 y -= 2;
             } while (y > 0);
@@ -360,8 +364,13 @@ void eb_av1_wiener_convolve_add_src_avx2(const uint8_t* const src, const ptrdiff
                                          _mm256_castsi256_si128(s[6]));
                 src_p += 2 * src_stride;
                 const __m256i r = wiener_convolve_v8x2_tap7(coeffs_v, round_v, s);
-                pack_store_8x2_avx2(r, dst_ptr, dst_stride);
-
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r, r);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storel_epi64((__m128i*)dst_ptr, d0);
+                } else {
+                    pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                }
                 dst_ptr += 2 * dst_stride;
                 y -= 2;
             } while (y > 0);
@@ -500,8 +509,13 @@ void eb_av1_wiener_convolve_add_src_avx2(const uint8_t* const src, const ptrdiff
                 src_p += 2 * src_stride;
                 const __m256i r0 = wiener_convolve_v8x2_tap5(coeffs_v, round_v, s[0]);
                 const __m256i r1 = wiener_convolve_v8x2_tap5(coeffs_v, round_v, s[1]);
-                pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
-
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r0, r1);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storeu_si128((__m128i*)dst_p, d0);
+                } else {
+                    pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                }
                 dst_p += 2 * dst_stride;
                 y -= 2;
             } while (y > 0);
@@ -535,8 +549,13 @@ void eb_av1_wiener_convolve_add_src_avx2(const uint8_t* const src, const ptrdiff
                                          _mm256_castsi256_si128(s[4]));
                 src_p += 2 * src_stride;
                 const __m256i r = wiener_convolve_v8x2_tap5(coeffs_v, round_v, s);
-                pack_store_8x2_avx2(r, dst_ptr, dst_stride);
-
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r, r);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storel_epi64((__m128i*)dst_ptr, d0);
+                } else {
+                    pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                }
                 dst_ptr += 2 * dst_stride;
                 y -= 2;
             } while (y > 0);
@@ -638,8 +657,13 @@ void eb_av1_wiener_convolve_add_src_avx2(const uint8_t* const src, const ptrdiff
                 src_p += 2 * src_stride;
                 const __m256i r0 = wiener_convolve_v8x2_tap3(coeffs_v, round_v, s[0]);
                 const __m256i r1 = wiener_convolve_v8x2_tap3(coeffs_v, round_v, s[1]);
-                pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
-
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r0, r1);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storeu_si128((__m128i*)dst_p, d0);
+                } else {
+                    pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                }
                 dst_p += 2 * dst_stride;
                 y -= 2;
             } while (y > 0);
@@ -667,8 +691,13 @@ void eb_av1_wiener_convolve_add_src_avx2(const uint8_t* const src, const ptrdiff
                                          _mm256_castsi256_si128(s[2]));
                 src_p += 2 * src_stride;
                 const __m256i r = wiener_convolve_v8x2_tap3(coeffs_v, round_v, s);
-                pack_store_8x2_avx2(r, dst_ptr, dst_stride);
-
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r, r);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storel_epi64((__m128i*)dst_ptr, d0);
+                } else {
+                    pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                }
                 dst_ptr += 2 * dst_stride;
                 y -= 2;
             } while (y > 0);

--- a/Source/Lib/Common/ASM_AVX512/wiener_convolve_avx512.c
+++ b/Source/Lib/Common/ASM_AVX512/wiener_convolve_avx512.c
@@ -334,7 +334,6 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
 
     (void)conv_params;
     assert(!(w % 8));
-    assert(!(h % 2));
     assert(conv_params->round_0 == round_0);
     assert(conv_params->round_1 == round_1);
 
@@ -515,7 +514,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                     src_p += 2 * src_stride;
                     const __m512i r0 = wiener_convolve_v16x2_tap7(coeffs_v_512, round_v_512, s[0]);
                     const __m512i r1 = wiener_convolve_v16x2_tap7(coeffs_v_512, round_v_512, s[1]);
-                    pack_store_32x2_avx512(r0, r1, dst_p, dst_stride);
+                    if (y == 1) {
+                        const __m512i d = _mm512_packus_epi16(r0, r1);
+                        const __m256i d0 = _mm512_castsi512_si256(d);
+                        _mm256_storeu_si256((__m256i*)dst_p, d0);
+                    } else {
+                        pack_store_32x2_avx512(r0, r1, dst_p, dst_stride);
+                    }
 
                     dst_p += 2 * dst_stride;
                     y -= 2;
@@ -605,7 +610,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                 src_p += 2 * src_stride;
                 const __m256i r0 = wiener_convolve_v8x2_tap7(coeffs_v, round_v, s[0]);
                 const __m256i r1 = wiener_convolve_v8x2_tap7(coeffs_v, round_v, s[1]);
-                pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r0, r1);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storeu_si128((__m128i*)dst_p, d0);
+                } else {
+                    pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                }
 
                 dst_p += 2 * dst_stride;
                 y -= 2;
@@ -645,7 +656,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                                          _mm256_castsi256_si128(s[6]));
                 src_p += 2 * src_stride;
                 const __m256i r = wiener_convolve_v8x2_tap7(coeffs_v, round_v, s);
-                pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r, r);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storel_epi64((__m128i*)dst_ptr, d0);
+                } else {
+                    pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                }
 
                 dst_ptr += 2 * dst_stride;
                 y -= 2;
@@ -791,7 +808,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                     src_p += 2 * src_stride;
                     const __m512i r0 = wiener_convolve_v16x2_tap5(coeffs_v_512, round_v_512, s[0]);
                     const __m512i r1 = wiener_convolve_v16x2_tap5(coeffs_v_512, round_v_512, s[1]);
-                    pack_store_32x2_avx512(r0, r1, dst_p, dst_stride);
+                    if (y == 1) {
+                        const __m512i d  = _mm512_packus_epi16(r0, r1);
+                        const __m256i d0 = _mm512_castsi512_si256(d);
+                        _mm256_storeu_si256((__m256i*)dst_p, d0);
+                    } else {
+                        pack_store_32x2_avx512(r0, r1, dst_p, dst_stride);
+                    }
 
                     dst_p += 2 * dst_stride;
                     y -= 2;
@@ -866,7 +889,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                 src_p += 2 * src_stride;
                 const __m256i r0 = wiener_convolve_v8x2_tap5(coeffs_v, round_v, s[0]);
                 const __m256i r1 = wiener_convolve_v8x2_tap5(coeffs_v, round_v, s[1]);
-                pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r0, r1);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storeu_si128((__m128i*)dst_p, d0);
+                } else {
+                    pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                }
 
                 dst_p += 2 * dst_stride;
                 y -= 2;
@@ -901,7 +930,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                                          _mm256_castsi256_si128(s[4]));
                 src_p += 2 * src_stride;
                 const __m256i r = wiener_convolve_v8x2_tap5(coeffs_v, round_v, s);
-                pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r, r);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storel_epi64((__m128i*)dst_ptr, d0);
+                } else {
+                    pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                }
 
                 dst_ptr += 2 * dst_stride;
                 y -= 2;
@@ -1008,7 +1043,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                     src_p += 2 * src_stride;
                     const __m512i r0 = wiener_convolve_v16x2_tap3(coeffs_v_512, round_v_512, s[0]);
                     const __m512i r1 = wiener_convolve_v16x2_tap3(coeffs_v_512, round_v_512, s[1]);
-                    pack_store_32x2_avx512(r0, r1, dst_p, dst_stride);
+                    if (y == 1) {
+                        const __m512i d  = _mm512_packus_epi16(r0, r1);
+                        const __m256i d0 = _mm512_castsi512_si256(d);
+                        _mm256_storeu_si256((__m256i*)dst_p, d0);
+                    } else {
+                        pack_store_32x2_avx512(r0, r1, dst_p, dst_stride);
+                    }
 
                     dst_p += 2 * dst_stride;
                     y -= 2;
@@ -1065,7 +1106,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                 src_p += 2 * src_stride;
                 const __m256i r0 = wiener_convolve_v8x2_tap3(coeffs_v, round_v, s[0]);
                 const __m256i r1 = wiener_convolve_v8x2_tap3(coeffs_v, round_v, s[1]);
-                pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r0, r1);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storeu_si128((__m128i*)dst_p, d0);
+                } else {
+                    pack_store_16x2_avx2(r0, r1, dst_p, dst_stride);
+                }
 
                 dst_p += 2 * dst_stride;
                 y -= 2;
@@ -1094,7 +1141,13 @@ void eb_av1_wiener_convolve_add_src_avx512(const uint8_t* const src, const ptrdi
                                          _mm256_castsi256_si128(s[2]));
                 src_p += 2 * src_stride;
                 const __m256i r = wiener_convolve_v8x2_tap3(coeffs_v, round_v, s);
-                pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                if (y == 1) {
+                    const __m256i d  = _mm256_packus_epi16(r, r);
+                    const __m128i d0 = _mm256_castsi256_si128(d);
+                    _mm_storel_epi64((__m128i*)dst_ptr, d0);
+                } else {
+                    pack_store_8x2_avx2(r, dst_ptr, dst_stride);
+                }
 
                 dst_ptr += 2 * dst_stride;
                 y -= 2;

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
@@ -62,11 +62,6 @@
     } while (0)
 #endif
 
-void setup_rtcd_non8(CPU_FLAGS flags) {
-    (void) flags;
-    eb_av1_compute_stats = eb_av1_compute_stats_c;
-    eb_av1_compute_stats_highbd = eb_av1_compute_stats_highbd_c;
-}
 void setup_rtcd_internal(CPU_FLAGS flags) {
     /** Should be done during library initialization,
         but for safe limiting cpu flags again. */

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
@@ -55,8 +55,6 @@ extern "C" {
 //    CPU_FLAGS get_cpu_flags_to_use();
     void setup_rtcd_internal(CPU_FLAGS flags);
 
-    void setup_rtcd_non8(CPU_FLAGS flags);
-
     //to not include convolve.h, just forward declare what's needed.
     struct ConvolveParams;
     struct InterpFilterParams;

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -967,12 +967,6 @@ EB_API EbErrorType svt_av1_enc_init(EbComponentType *svt_enc_component)
     setup_common_rtcd_internal(enc_handle_ptr->scs_instance_array[0]->scs_ptr->static_config.use_cpu_flags);
     setup_rtcd_internal(enc_handle_ptr->scs_instance_array[0]->scs_ptr->static_config.use_cpu_flags);
 
-#if NON8_FIX_REST
-    if(enc_handle_ptr->scs_instance_array[0]->scs_ptr->max_input_pad_right>0 ||
-       enc_handle_ptr->scs_instance_array[0]->scs_ptr->max_input_pad_bottom>0)
-        setup_rtcd_non8(enc_handle_ptr->scs_instance_array[0]->scs_ptr->static_config.use_cpu_flags);
-#endif
-
     asm_set_convolve_asm_table();
 
     init_intra_dc_predictors_c_internal();

--- a/test/wiener_convolve_test.cc
+++ b/test/wiener_convolve_test.cc
@@ -75,15 +75,26 @@ typedef std::tuple<BlkSize, HbdWienerConvolveFunc, int32_t>
     HbdWienerConvolveParam;
 
 static const BlkSize test_block_size_table[] = {BlkSize(96, 96),
+                                                BlkSize(96, 97),
                                                 BlkSize(88, 88),
+                                                BlkSize(88, 85),
                                                 BlkSize(80, 80),
+                                                BlkSize(80, 79),
                                                 BlkSize(72, 72),
+                                                BlkSize(72, 71),
                                                 BlkSize(64, 64),
+                                                BlkSize(64, 63),
                                                 BlkSize(56, 56),
+                                                BlkSize(56, 57),
                                                 BlkSize(48, 48),
+                                                BlkSize(48, 49),
                                                 BlkSize(32, 32),
+                                                BlkSize(32, 33),
                                                 BlkSize(24, 24),
+                                                BlkSize(24, 23),
                                                 BlkSize(16, 16),
+                                                BlkSize(16, 15),
+                                                BlkSize(8, 9),
                                                 BlkSize(8, 8)};
 
 static const int test_tap_table[] = {7, 5, 3};
@@ -180,7 +191,7 @@ class AV1WienerConvolveTest : public ::testing::TestWithParam<ParamType> {
             hkernel[0] = vkernel[0] = WIENER_FILT_TAP0_MAXV;
             hkernel[1] = vkernel[1] = WIENER_FILT_TAP1_MAXV;
             hkernel[2] = vkernel[2] = WIENER_FILT_TAP2_MAXV;
-        } else {
+        } else if (kernel_type == 2) {
             // Randomly generated values for filter coefficients
             hkernel[0] = WIENER_FILT_TAP0_MINV +
                          pseudo_uniform(WIENER_FILT_TAP0_MAXV + 1 -
@@ -201,6 +212,19 @@ class AV1WienerConvolveTest : public ::testing::TestWithParam<ParamType> {
             vkernel[2] = WIENER_FILT_TAP2_MINV +
                          pseudo_uniform(WIENER_FILT_TAP2_MAXV + 2 -
                                         WIENER_FILT_TAP2_MINV);
+        } else if (kernel_type == 3) {
+            // Check zerocoff path
+            hkernel[0] = vkernel[0] = 0;
+            hkernel[1] = vkernel[1] = 0;
+            hkernel[2] = vkernel[2] = 0;
+        } else if (kernel_type == 4) {
+            hkernel[0] = vkernel[0] = 0;
+            hkernel[1] = vkernel[1] = 0;
+            hkernel[2] = vkernel[2] = WIENER_FILT_TAP2_MAXV;
+        } else if (kernel_type == 5) {
+            hkernel[0] = vkernel[0] = 0;
+            hkernel[1] = vkernel[1] = WIENER_FILT_TAP1_MAXV;
+            hkernel[2] = vkernel[2] = WIENER_FILT_TAP2_MAXV;
         }
 
         if (tap <= 5) {
@@ -244,7 +268,7 @@ class AV1WienerConvolveTest : public ::testing::TestWithParam<ParamType> {
         for (unsigned int tap_idx = 0;
              tap_idx < sizeof(test_tap_table) / sizeof(*test_tap_table);
              tap_idx++) {
-            for (int kernel_type = 0; kernel_type < 3; kernel_type++) {
+            for (int kernel_type = 0; kernel_type < 6; kernel_type++) {
                 generate_kernels(
                     hkernel, vkernel, test_tap_table[tap_idx], kernel_type);
                 for (int i = 0;


### PR DESCRIPTION
Fix for(when height is not multiple of 2):
eb_av1_wiener_convolve_add_src_avx2
eb_av1_wiener_convolve_add_src_avx512

NOTICE: 
Merge this PR to master after PR #1238