### PR TITLE
Init encoder_color_format and enable_manual_pred_struct (#1245)

### DIFF
--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -3013,6 +3013,8 @@ EbErrorType eb_svt_enc_init_parameter(
     config_ptr->hme_level2_search_area_in_height_array[1] = 1;
     config_ptr->enable_hbd_mode_decision = 1;
     config_ptr->enable_palette = -1;
+    config_ptr->enable_manual_pred_struct = EB_FALSE;
+    config_ptr->encoder_color_format = 1;
     // Bitstream options
     //config_ptr->codeVpsSpsPps = 0;
     //config_ptr->codeEosNal = 0;


### PR DESCRIPTION
Set EbSvtAv1EncConfiguration.encoder_color_format to 1 and EbSvtAv1EncConfiguration.enable_manual_pred_struct to EB_FALSE, otherwise build will fail due to random value in memory.
Opened a new PR since I cleaned the git log and pulled the newest master code.