### PR TITLE
Fix inconsistent code

### DIFF
--- a/Source/Lib/Common/Codec/EbMcp.c
+++ b/Source/Lib/Common/Codec/EbMcp.c
@@ -266,3 +266,51 @@ void pad_input_picture(
 
     return;
 }
+
+/** pad_input_picture_16bit()
+is used to pad the input picture in order to get . The horizontal padding happens first and then the vertical padding.
+*/
+void pad_input_picture_16bit(
+    uint16_t* src_pic, //output paramter, pointer to the source picture to be padded.
+    uint32_t src_stride, //input paramter, the stride of the source picture to be padded.
+    uint32_t
+        original_src_width, //input paramter, the width of the source picture which excludes the padding.
+    uint32_t
+             original_src_height, //input paramter, the height of the source picture which excludes the padding.
+    uint32_t pad_right, //input paramter, the padding right.
+    uint32_t pad_bottom) //input paramter, the padding bottom.
+{
+    uint32_t vertical_idx;
+    uint16_t* temp_src_pic0;
+
+    if (pad_right) {
+        // Add padding @ the right
+        vertical_idx  = original_src_height;
+        temp_src_pic0 = src_pic;
+
+        while (vertical_idx) {
+            memset16bit(temp_src_pic0 + original_src_width,
+                        *(temp_src_pic0 + original_src_width - 1),
+                        pad_right);
+            temp_src_pic0 += src_stride;
+            --vertical_idx;
+        }
+    }
+
+    if (pad_bottom) {
+        uint16_t* temp_src_pic1;
+        // Add padding @ the bottom
+        vertical_idx  = pad_bottom;
+        temp_src_pic0 = (uint16_t*)(src_pic + (original_src_height - 1) * src_stride);
+        temp_src_pic1 = temp_src_pic0;
+
+        while (vertical_idx) {
+            temp_src_pic1 += src_stride;
+            eb_memcpy(
+                temp_src_pic1, temp_src_pic0, sizeof(uint16_t) * (original_src_width + pad_right));
+            --vertical_idx;
+        }
+    }
+
+    return;
+}

--- a/Source/Lib/Common/Codec/EbMcp.h
+++ b/Source/Lib/Common/Codec/EbMcp.h
@@ -60,6 +60,10 @@ extern void pad_input_picture(EbByte src_pic, uint32_t src_stride, uint32_t orig
                               uint32_t original_src_height, uint32_t pad_right,
                               uint32_t pad_bottom);
 
+extern void pad_input_picture_16bit(uint16_t* src_pic, uint32_t src_stride,
+                                    uint32_t original_src_width, uint32_t original_src_height,
+                                    uint32_t pad_right, uint32_t pad_bottom);
+
     void generate_padding_l(EbByte src_pic, uint32_t src_stride,
         uint32_t row_height, uint32_t padding_width);
     void generate_padding_r(EbByte src_pic, uint32_t src_stride,

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -687,7 +687,7 @@ void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) 
         row_index           = 0;
         while (row_index < (uint32_t)((input_picture_ptr->height - scs_ptr->max_input_pad_bottom) >> ss_y)) {
             column_index = 0;
-            while (column_index < (uint32_t)((input_picture_ptr->width - scs_ptr->max_input_pad_bottom) >> ss_x)) {
+            while (column_index < (uint32_t)((input_picture_ptr->width - scs_ptr->max_input_pad_right) >> ss_x)) {
                 residual_distortion += (int64_t)SQR((int64_t)(input_buffer[column_index]) -
                                                     (recon_coeff_buffer[column_index]));
                 ++column_index;
@@ -710,7 +710,7 @@ void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) 
 
         while (row_index < (uint32_t)((input_picture_ptr->height - scs_ptr->max_input_pad_bottom) >> ss_y)) {
             column_index = 0;
-            while (column_index < (uint32_t)((input_picture_ptr->width - scs_ptr->max_input_pad_bottom) >> ss_x)) {
+            while (column_index < (uint32_t)((input_picture_ptr->width - scs_ptr->max_input_pad_right) >> ss_x)) {
                 residual_distortion += (int64_t)SQR((int64_t)(input_buffer[column_index]) -
                                                     (recon_coeff_buffer[column_index]));
                 ++column_index;

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -1138,6 +1138,7 @@ void pad_ref_and_set_flags(PictureControlSet *pcs_ptr, SequenceControlSet *scs_p
 
     //We need this for MCP
     if (is_16bit) {
+        pad_picture_to_multiple_of_min_blk_size_dimensions_16bit(scs_ptr, ref_pic_16bit_ptr);
         // Y samples
         generate_padding16_bit(ref_pic_16bit_ptr->buffer_y,
                                ref_pic_16bit_ptr->stride_y << 1,

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.h
@@ -25,6 +25,8 @@ void downsample_decimation_input_picture(PictureParentControlSet *pcs_ptr,
 
 void pad_picture_to_multiple_of_min_blk_size_dimensions(SequenceControlSet * scs_ptr,
                                                         EbPictureBufferDesc *input_picture_ptr);
+void pad_picture_to_multiple_of_min_blk_size_dimensions_16bit(
+    SequenceControlSet * scs_ptr, EbPictureBufferDesc *input_picture_ptr);
 void picture_pre_processing_operations(PictureParentControlSet *pcs_ptr,
                                        SequenceControlSet *scs_ptr, uint32_t sb_total_count);
 void pad_picture_to_multiple_of_sb_dimensions(EbPictureBufferDesc *input_padded_picture_ptr);

--- a/Source/Lib/Encoder/Codec/EbPsnr.c
+++ b/Source/Lib/Encoder/Codec/EbPsnr.c
@@ -171,8 +171,8 @@ static int64_t highbd_get_sse(const uint8_t *a, int32_t a_stride, const uint8_t 
 static void highbd_variance64(const uint8_t *a8, int a_stride,
                               const uint8_t *b8, int b_stride, int w, int h,
                               uint64_t *sse, int64_t *sum) {
-  const uint16_t *a = (uint16_t *)a8;
-  const uint16_t *b = (uint16_t *)b8;
+  const uint16_t *a = CONVERT_TO_SHORTPTR(a8);
+  const uint16_t *b = CONVERT_TO_SHORTPTR(b8);
   int64_t tsum = 0;
   uint64_t tsse = 0;
   for (int i = 0; i < h; ++i) {


### PR DESCRIPTION
This PR fixes three inconsistent implementation.
1. Fix column range in psnr_calculations. It does not make sense to use `input_picture_ptr->width - scs_ptr->max_input_pad_bottom`
2. Fix ptr in highbd_variance64. This function is fed with `CONVERT_TO_BYTEPTR(uint16_t*)` pointers. The highbd_variance64 function uses `(uint16_t*)` cast, while the corresponding avx2 implementation uses`CONVERT_TO_SHORTPTR(uint8_t*)`.
3. Fix rec/dec mismatch when encoding hbd non 8-aligned video, which was caused by the improper padding when hbd