### PR TITLE
Fix log2f, and revert "Revert log2f changes due to rate loss

### DIFF
--- a/Source/Lib/Common/ASM_SSE2/EbPictureOperators_SSE2.asm
+++ b/Source/Lib/Common/ASM_SSE2/EbPictureOperators_SSE2.asm
@@ -480,6 +480,8 @@ Label_PictureAverageKernel_SSE2_WIDTH16:
     ret
 
 ; ----------------------------------------------------------------------------------------
-    cglobal Log2f_SSE2
+    cglobal Log2f_ASM
+;   If (r0 == 0) then bsr return undefined behavior. For 0 return 0
+    or r0, 1
     bsr rax, r0
     ret

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -1945,11 +1945,7 @@ static const EbWarpedMotionParams default_warp_params = {
 
 #define MAX_NUM_TOKENS          200
 
-#ifdef ARCH_X86
-#define    Log2f                              Log2f_SSE2
-#else
-#define    Log2f                              log2f_32
-#endif
+
 #define INPUT_SIZE_576p_TH                  0x90000        // 0.58 Million
 #define INPUT_SIZE_1080i_TH                 0xB71B0        // 0.75 Million
 #define INPUT_SIZE_1080p_TH                 0x1AB3F0    // 1.75 Million

--- a/Source/Lib/Common/Codec/EbUtility.c
+++ b/Source/Lib/Common/Codec/EbUtility.c
@@ -470,8 +470,8 @@ void md_scan_all_blks(uint32_t* idx_mds, uint32_t sq_size, uint32_t x, uint32_t 
 
             blk_geom_mds[*idx_mds].bwidth  = quartsize * ns_quarter_size_mult[part_it][0][nsq_it];
             blk_geom_mds[*idx_mds].bheight = quartsize * ns_quarter_size_mult[part_it][1][nsq_it];
-            blk_geom_mds[*idx_mds].bwidth_log2  = Log2f(blk_geom_mds[*idx_mds].bwidth);
-            blk_geom_mds[*idx_mds].bheight_log2 = Log2f(blk_geom_mds[*idx_mds].bheight);
+            blk_geom_mds[*idx_mds].bwidth_log2  = eb_log2f(blk_geom_mds[*idx_mds].bwidth);
+            blk_geom_mds[*idx_mds].bheight_log2 = eb_log2f(blk_geom_mds[*idx_mds].bheight);
             blk_geom_mds[*idx_mds].bsize = hvsize_to_bsize[blk_geom_mds[*idx_mds].bwidth_log2 - 2]
                                                           [blk_geom_mds[*idx_mds].bheight_log2 - 2];
             blk_geom_mds[*idx_mds].bwidth_uv  = MAX(4, blk_geom_mds[*idx_mds].bwidth >> 1);

--- a/Source/Lib/Common/Codec/EbUtility.h
+++ b/Source/Lib/Common/Codec/EbUtility.h
@@ -138,12 +138,7 @@ extern const CodedBlockStats* get_coded_blk_stats(const uint32_t cu_idx);
 
 #define TU_ORIGIN_ADJUST(cu_origin, cu_size, offset) ((((cu_size) * (offset)) >> 2) + (cu_origin))
 #define TU_SIZE_ADJUST(cu_size, tuDepth) ((cu_size) >> (tuDepth))
-#ifdef ARCH_X86
-extern uint32_t log2f_32(uint32_t x);
-#else
-extern uint32_t log2f_32(uint32_t x);
-#endif
-extern uint32_t Log2f(uint32_t x);
+
 extern uint64_t log2f_64(uint64_t x);
 
 /****************************
@@ -216,11 +211,7 @@ extern uint64_t log2f_64(uint64_t x);
     (x) |= ((x) >> 16);             \
     (x) += 1;                       \
     MULTI_LINE_MACRO_END
-#ifdef ARCH_X86
-#define LOG2F Log2f_SSE2
-#else
-#define LOG2F log2f_32
-#endif
+
 
 #define LOG2F_8(x)               \
     (((x) < 0x0002u)             \

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.c
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.c
@@ -790,6 +790,7 @@ void setup_common_rtcd_internal(CPU_FLAGS flags) {
     eb_aom_highbd_h_predictor_8x8 = eb_aom_highbd_h_predictor_8x8_c;
     eb_aom_highbd_h_predictor_16x16 = eb_aom_highbd_h_predictor_16x16_c;
     eb_aom_highbd_h_predictor_16x32 = eb_aom_highbd_h_predictor_16x32_c;
+    eb_log2f = log2f_32;
     eb_memcpy = eb_memcpy_c;
 #ifdef ARCH_X86
     flags &= get_cpu_flags_to_use();
@@ -1461,6 +1462,7 @@ void setup_common_rtcd_internal(CPU_FLAGS flags) {
         if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_64x16 = eb_aom_highbd_h_predictor_64x16_avx2;
         if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_64x32 = eb_aom_highbd_h_predictor_64x32_avx2;
         if (flags & HAS_AVX2) eb_aom_highbd_h_predictor_64x64 = eb_aom_highbd_h_predictor_64x64_avx2;
+        if (flags & HAS_SSE2) eb_log2f = Log2f_ASM;
         if (flags & HAS_SSE2) eb_memcpy = eb_memcpy_intrin_sse;
 #ifndef NON_AVX512_SUPPORT
         if (flags & HAS_AVX512F) {

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.h
@@ -1086,6 +1086,8 @@ extern "C" {
     RTCD_EXTERN void(*aom_lpf_vertical_6)(uint8_t *s, int32_t pitch, const uint8_t *blimit, const uint8_t *limit, const uint8_t *thresh);
     void aom_lpf_vertical_8_c(uint8_t *s, int32_t pitch, const uint8_t *blimit, const uint8_t *limit, const uint8_t *thresh);
     RTCD_EXTERN void(*aom_lpf_vertical_8)(uint8_t *s, int32_t pitch, const uint8_t *blimit, const uint8_t *limit, const uint8_t *thresh);
+    uint32_t log2f_32(uint32_t x);
+    RTCD_EXTERN uint32_t(*eb_log2f)(uint32_t x);
     void eb_memcpy_c(void  *dst_ptr, void  *src_ptr, size_t size);
     RTCD_EXTERN void (*eb_memcpy)(void  *dst_ptr, void  *src_ptr, size_t size);
 #ifdef ARCH_X86
@@ -2209,6 +2211,8 @@ extern "C" {
             void aom_lpf_vertical_6_sse2(uint8_t *s, int32_t pitch, const uint8_t *blimit, const uint8_t *limit, const uint8_t *thresh);
 
             void aom_lpf_vertical_8_sse2(uint8_t *s, int32_t pitch, const uint8_t *blimit, const uint8_t *limit, const uint8_t *thresh);
+
+            uint32_t Log2f_ASM(uint32_t x);
 
             extern void eb_memcpy_intrin_sse (void  *dst_ptr, void  *src_ptr, size_t size);
 #endif

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -499,8 +499,8 @@ static void av1_encode_loop(PictureControlSet *pcs_ptr, EncDecContext *context_p
                 context_ptr->blk_geom->tx_width_uv[blk_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height_uv[blk_ptr->tx_depth][context_ptr->txb_itr],
                 round_offset,
-                LOG2F(context_ptr->blk_geom->tx_width_uv[blk_ptr->tx_depth][context_ptr->txb_itr]) +
-                LOG2F(context_ptr->blk_geom
+                eb_log2f(context_ptr->blk_geom->tx_width_uv[blk_ptr->tx_depth][context_ptr->txb_itr]) +
+                eb_log2f(context_ptr->blk_geom
                               ->tx_height_uv[blk_ptr->tx_depth][context_ptr->txb_itr]));
 
             if (context_ptr->evaluate_cfl_ep) {
@@ -992,8 +992,8 @@ static void av1_encode_loop_16bit(PictureControlSet *pcs_ptr, EncDecContext *con
                 context_ptr->blk_geom->tx_width_uv[blk_ptr->tx_depth][context_ptr->txb_itr],
                 context_ptr->blk_geom->tx_height_uv[blk_ptr->tx_depth][context_ptr->txb_itr],
                 round_offset,
-                LOG2F(context_ptr->blk_geom->tx_width_uv[blk_ptr->tx_depth][context_ptr->txb_itr]) +
-                LOG2F(context_ptr->blk_geom
+                eb_log2f(context_ptr->blk_geom->tx_width_uv[blk_ptr->tx_depth][context_ptr->txb_itr]) +
+                eb_log2f(context_ptr->blk_geom
                               ->tx_height_uv[blk_ptr->tx_depth][context_ptr->txb_itr]));
 
             int32_t alpha_q3 = cfl_idx_to_alpha(blk_ptr->prediction_unit_array->cfl_alpha_idx,

--- a/Source/Lib/Encoder/Codec/EbDeblockingFilter.c
+++ b/Source/Lib/Encoder/Codec/EbDeblockingFilter.c
@@ -677,7 +677,7 @@ void eb_av1_loop_filter_frame(EbPictureBufferDesc *frame_buffer, PictureControlS
         (SequenceControlSet *)pcs_ptr->parent_pcs_ptr->scs_wrapper_ptr->object_ptr;
     //SuperBlock                     *sb_ptr;
     //uint16_t                                   sb_index;
-    uint8_t  sb_size_log2 = (uint8_t)Log2f(scs_ptr->sb_size_pix);
+    uint8_t  sb_size_log2 = (uint8_t)eb_log2f(scs_ptr->sb_size_pix);
     uint32_t x_sb_index;
     uint32_t y_sb_index;
     uint32_t sb_origin_x;

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -3120,7 +3120,7 @@ void *enc_dec_kernel(void *input_ptr) {
         (void)end_of_row_flag;
         // SB Constants
         sb_sz              = (uint8_t)scs_ptr->sb_size_pix;
-        sb_size_log2       = (uint8_t)Log2f(sb_sz);
+        sb_size_log2       = (uint8_t)eb_log2f(sb_sz);
         context_ptr->sb_sz = sb_sz;
         pic_width_in_sb    = (pcs_ptr->parent_pcs_ptr->aligned_width + sb_sz - 1) >> sb_size_log2;
 #if TILES_PARALLEL

--- a/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
@@ -290,7 +290,7 @@ static void model_rd_with_curvfit(PictureControlSet *picture_control_set_ptr, Bl
     aom_clear_system_state();
 #endif
     const double sse_norm = (double)sse / num_samples;
-    const double xqr      = (double)LOG2F((uint32_t)sse_norm / (qstep * qstep));
+    const double xqr      = (double)eb_log2f((uint32_t)sse_norm / (qstep * qstep));
 
     double rate_f, dist_by_sse_norm_f;
     av1_model_rd_curvfit(plane_bsize, sse_norm, xqr, &rate_f, &dist_by_sse_norm_f);

--- a/Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c
@@ -568,7 +568,7 @@ void *entropy_coding_kernel(void *input_ptr) {
 
         sb_sz = (uint8_t)scs_ptr->sb_size_pix;
 
-        sb_size_log2       = (uint8_t)Log2f(sb_sz);
+        sb_size_log2       = (uint8_t)eb_log2f(sb_sz);
         context_ptr->sb_sz = sb_sz;
         pic_width_in_sb    = (pcs_ptr->parent_pcs_ptr->aligned_width + sb_sz - 1) >> sb_size_log2;
 #if TILES_PARALLEL

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -5931,7 +5931,7 @@ EbErrorType generate_md_stage_0_cand(
     context_ptr->injected_mv_count_l0 = 0;
     context_ptr->injected_mv_count_l1 = 0;
     context_ptr->injected_mv_count_bipred = 0;
-    uint8_t sq_index = LOG2F(context_ptr->blk_geom->sq_size) - 2;
+    uint8_t sq_index = eb_log2f(context_ptr->blk_geom->sq_size) - 2;
     EbBool coeff_based_nsq_cand_reduction = EB_FALSE;
     if (slice_type != I_SLICE) {
         if (context_ptr->coeff_based_nsq_cand_reduction) {

--- a/Source/Lib/Encoder/Codec/EbNeighborArrays.c
+++ b/Source/Lib/Encoder/Codec/EbNeighborArrays.c
@@ -28,9 +28,9 @@ EbErrorType neighbor_array_unit_ctor32(NeighborArrayUnit32 *na_unit_ptr, uint32_
     na_unit_ptr->dctor                     = neighbor_array_unit_dctor32;
     na_unit_ptr->unit_size                 = (uint8_t)(unit_size);
     na_unit_ptr->granularity_normal        = (uint8_t)(granularity_normal);
-    na_unit_ptr->granularity_normal_log2   = (uint8_t)(Log2f(na_unit_ptr->granularity_normal));
+    na_unit_ptr->granularity_normal_log2   = (uint8_t)(eb_log2f(na_unit_ptr->granularity_normal));
     na_unit_ptr->granularity_top_left      = (uint8_t)(granularity_top_left);
-    na_unit_ptr->granularity_top_left_log2 = (uint8_t)(Log2f(na_unit_ptr->granularity_top_left));
+    na_unit_ptr->granularity_top_left_log2 = (uint8_t)(eb_log2f(na_unit_ptr->granularity_top_left));
     na_unit_ptr->left_array_size =
         (uint16_t)((type_mask & NEIGHBOR_ARRAY_UNIT_LEFT_MASK)
                        ? max_picture_height >> na_unit_ptr->granularity_normal_log2
@@ -73,9 +73,9 @@ EbErrorType neighbor_array_unit_ctor(NeighborArrayUnit *na_unit_ptr, uint32_t ma
     na_unit_ptr->dctor                     = neighbor_array_unit_dctor;
     na_unit_ptr->unit_size                 = (uint8_t)(unit_size);
     na_unit_ptr->granularity_normal        = (uint8_t)(granularity_normal);
-    na_unit_ptr->granularity_normal_log2   = (uint8_t)(Log2f(na_unit_ptr->granularity_normal));
+    na_unit_ptr->granularity_normal_log2   = (uint8_t)(eb_log2f(na_unit_ptr->granularity_normal));
     na_unit_ptr->granularity_top_left      = (uint8_t)(granularity_top_left);
-    na_unit_ptr->granularity_top_left_log2 = (uint8_t)(Log2f(na_unit_ptr->granularity_top_left));
+    na_unit_ptr->granularity_top_left_log2 = (uint8_t)(eb_log2f(na_unit_ptr->granularity_top_left));
     na_unit_ptr->left_array_size =
         (uint16_t)((type_mask & NEIGHBOR_ARRAY_UNIT_LEFT_MASK)
                        ? max_picture_height >> na_unit_ptr->granularity_normal_log2

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -252,7 +252,7 @@ uint8_t  circ_inc(uint8_t max, uint8_t off, uint8_t input)
 #define SCENE_TH                            3000
 #define NOISY_SCENE_TH                      4500    // SCD TH in presence of noise
 #define HIGH_PICTURE_VARIANCE_TH            1500
-#define NUM64x64INPIC(w,h)          ((w*h)>> (LOG2F(BLOCK_SIZE_64)<<1))
+#define NUM64x64INPIC(w,h)          ((w*h)>> (eb_log2f(BLOCK_SIZE_64)<<1))
 #define QUEUE_GET_PREVIOUS_SPOT(h)  ((h == 0) ? PICTURE_DECISION_REORDER_QUEUE_MAX_DEPTH - 1 : h - 1)
 #define QUEUE_GET_NEXT_SPOT(h,off)  (( (h+off) >= PICTURE_DECISION_REORDER_QUEUE_MAX_DEPTH) ? h+off - PICTURE_DECISION_REORDER_QUEUE_MAX_DEPTH  : h + off)
 

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -3932,7 +3932,7 @@ static void cfl_prediction(PictureControlSet *          pcs_ptr,
                             chroma_width,
                             chroma_height,
                             round_offset,
-                            LOG2F(chroma_width) + LOG2F(chroma_height));
+                            eb_log2f(chroma_width) + eb_log2f(chroma_height));
 
         // 3: Loop over alphas and find the best or choose DC
         cfl_rd_pick_alpha(pcs_ptr,
@@ -7690,7 +7690,7 @@ void md_encode_block(PictureControlSet *pcs_ptr, ModeDecisionContext *context_pt
     candidate_buffer = candidate_buffer_ptr_array[candidate_index];
 
     bestcandidate_buffers[0] = candidate_buffer;
-    uint8_t sq_index         = LOG2F(context_ptr->blk_geom->sq_size) - 2;
+    uint8_t sq_index         = eb_log2f(context_ptr->blk_geom->sq_size) - 2;
     if (context_ptr->blk_geom->shape == PART_N) {
         context_ptr->parent_sq_type[sq_index] = candidate_buffer->candidate_ptr->type;
 
@@ -8507,7 +8507,7 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
                    sizeof(MdEncPassCuData));
 
             if (context_ptr->blk_geom->shape == PART_N) {
-                uint8_t sq_index                      = LOG2F(context_ptr->blk_geom->sq_size) - 2;
+                uint8_t sq_index                      = eb_log2f(context_ptr->blk_geom->sq_size) - 2;
                 context_ptr->parent_sq_type[sq_index] = src_cu->prediction_mode_flag;
                 context_ptr->parent_sq_has_coeff[sq_index] = src_cu->block_has_coeff;
                 context_ptr->parent_sq_pred_mode[sq_index] = src_cu->pred_mode;

--- a/Source/Lib/Encoder/Codec/EbRestProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRestProcess.c
@@ -491,7 +491,7 @@ void *rest_kernel(void *input_ptr) {
         scs_ptr          = (SequenceControlSet *)pcs_ptr->scs_wrapper_ptr->object_ptr;
         frm_hdr          = &pcs_ptr->parent_pcs_ptr->frm_hdr;
 #if !TILES_PARALLEL
-        uint8_t sb_size_log2 = (uint8_t)Log2f(scs_ptr->sb_size_pix);
+        uint8_t sb_size_log2 = (uint8_t)eb_log2f(scs_ptr->sb_size_pix);
 #endif
         EbBool     is_16bit = (EbBool)(scs_ptr->static_config.encoder_bit_depth > EB_8BIT);
         Av1Common *cm       = pcs_ptr->parent_pcs_ptr->av1_cm;

--- a/Source/Lib/Encoder/Codec/EbSegmentation.c
+++ b/Source/Lib/Encoder/Codec/EbSegmentation.c
@@ -167,11 +167,11 @@ void find_segment_qps(SegmentationParams *segmentation_params,
         avg_var += (local_avg >> 6);
     }
     avg_var /= pcs_ptr->sb_total_count;
-    avg_var = Log2f(avg_var);
+    avg_var = eb_log2f(avg_var);
 
     //get variance bin edges & QPs
-    uint16_t min_var_log = Log2f(MAX(1, min_var));
-    uint16_t max_var_log = Log2f(MAX(1, max_var));
+    uint16_t min_var_log = eb_log2f(MAX(1, min_var));
+    uint16_t max_var_log = eb_log2f(MAX(1, max_var));
     uint16_t step_size   = (uint16_t)(max_var_log - min_var_log) <= MAX_SEGMENTS
                              ? 1
                              : ROUND(((max_var_log - min_var_log)) / MAX_SEGMENTS);


### PR DESCRIPTION
in M1 kirkland (#1257)"

uint Log2 should return 0 for arg 0.

Fixes #1261 
Protecting kernel Log2f_ASM() will return 0 when argument is 0.
In argument always sets first bit, to not get undefined behavior from asm bsr.
Results not changes for values different that 0.