### PR TITLE
Update the Y sample buffer indexing for position A in Motion Estimation.

### DIFF
--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -9308,6 +9308,10 @@ static void hme_mv_center_check(EbPictureBufferDesc *ref_pic_ptr, MeContext *con
             ? search_center_y - ((origin_y + search_center_y) - ((int16_t)ref_pic_ptr->height - 1))
             : search_center_y;
 
+    search_region_index =
+        (int16_t)(ref_pic_ptr->origin_x + origin_x) + search_center_x +
+        ((int16_t)(ref_pic_ptr->origin_y + origin_y) + search_center_y) * ref_pic_ptr->stride_y;
+
     uint64_t mv_a_sad = nxm_sad_kernel(context_ptr->sb_src_ptr,
                                        context_ptr->sb_src_stride << sub_sampled_sad,
                                        &(ref_pic_ptr->buffer_y[search_region_index]),


### PR DESCRIPTION
NxM SAD is calculated between the current super block buffer and its
corresponding referenced one (in reconstructed picture) for O/A/B/C/D
positions.

Ported from SVT-HEVC PR #530.

Signed-off-by: Austin Hu <austin.hu@intel.com>