### PR TITLE
Add support for SSIM

### DIFF
--- a/Source/API/EbSvtAv1.h
+++ b/Source/API/EbSvtAv1.h
@@ -78,9 +78,12 @@ typedef struct EbBufferHeaderType {
     uint32_t luma_sse;
     uint32_t cr_sse;
     uint32_t cb_sse;
-
     // pic flags
     uint32_t flags;
+
+    double luma_ssim;
+    double cr_ssim;
+    double cb_ssim;
 } EbBufferHeaderType;
 
 typedef struct EbComponentType {

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -138,6 +138,10 @@ typedef struct EbPerformanceContext {
     double sum_cr_sse;
     double sum_cb_sse;
 
+    double sum_luma_ssim;
+    double sum_cr_ssim;
+    double sum_cb_ssim;
+
     uint64_t sum_qp;
 
 } EbPerformanceContext;

--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -283,16 +283,18 @@ int32_t main(int32_t argc, char *argv[]) {
                                             "------------------------------------------------------"
                                             "---------------\n");
                                     fprintf(configs[inst_cnt]->stat_file,
-                                            "\n\t\t\t\t\t\t\tAverage PSNR (using per-frame "
-                                            "PSNR)\t\t|\tOverall PSNR (using per-frame MSE)\n");
+                                            "\n\t\t\t\tAverage PSNR (using per-frame "
+                                            "PSNR)\t\t|\tOverall PSNR (using per-frame MSE)\t\t|"
+                                            "\tAverage SSIM\n");
                                     fprintf(configs[inst_cnt]->stat_file,
                                             "Total Frames\tAverage QP  \tY-PSNR   \tU-PSNR   "
-                                            "\tV-PSNR\t\t| \tY-PSNR   \tU-PSNR   \tV-PSNR   "
+                                            "\tV-PSNR\t\t| \tY-PSNR   \tU-PSNR   \tV-PSNR   \t|"
+                                            "\tY-SSIM   \tU-SSIM   \tV-SSIM   "
                                             "\t|\tBitrate\n");
                                     fprintf(
                                         configs[inst_cnt]->stat_file,
                                         "%10ld  \t   %2.2f    \t%3.2f dB\t%3.2f dB\t%3.2f dB  "
-                                        "\t|\t%3.2f dB\t%3.2f dB\t%3.2f dB \t|\t%.2f kbps\n",
+                                        "\t|\t%3.2f dB\t%3.2f dB\t%3.2f dB \t|\t%1.5f \t%1.5f \t%1.5f\t\t|\t%.2f kbps\n",
                                         (long int)frame_count,
                                         (float)configs[inst_cnt]->performance_context.sum_qp /
                                             frame_count,
@@ -315,6 +317,9 @@ int32_t main(int32_t argc, char *argv[]) {
                                             (configs[inst_cnt]->performance_context.sum_cr_sse /
                                              frame_count),
                                             max_chroma_sse)),
+                                         (float)configs[inst_cnt]->performance_context.sum_luma_ssim / frame_count,
+                                         (float)configs[inst_cnt]->performance_context.sum_cb_ssim   / frame_count,
+                                         (float)configs[inst_cnt]->performance_context.sum_cr_ssim   / frame_count,
                                         ((double)(configs[inst_cnt]->performance_context.byte_count
                                                   << 3) *
                                          frame_rate / (configs[inst_cnt]->frames_encoded * 1000)));
@@ -340,16 +345,17 @@ int32_t main(int32_t argc, char *argv[]) {
 
                             if (configs[inst_cnt]->stat_report) {
                                 fprintf(stderr,
-                                        "\n\t\t\t\tAverage PSNR (using per-frame "
-                                        "PSNR)\t\t\t|\t\tOverall PSNR (using per-frame MSE)\n");
+                                        "\n\t\tAverage PSNR (using per-frame "
+                                        "PSNR)\t\t|\tOverall PSNR (using per-frame MSE)\t\t|\t"
+                                        "Average SSIM\n");
                                 fprintf(stderr,
                                         "Average "
-                                        "QP\t\tY-PSNR\t\t\tU-PSNR\t\t\tV-PSNR\t\t|\tY-PSNR\t\t\tU-"
-                                        "PSNR\t\t\tV-PSNR\t\n");
+                                        "QP\tY-PSNR\t\tU-PSNR\t\tV-PSNR\t\t|\tY-PSNR\t\tU-"
+                                        "PSNR\t\tV-PSNR\t\t|\tY-SSIM\tU-SSIM\tV-SSIM\n");
                                 fprintf(
                                     stderr,
-                                    "%11.2f\t\t%4.2f dB\t\t%4.2f dB\t\t%4.2f dB\t|\t%4.2f "
-                                    "dB\t\t%4.2f dB\t\t%4.2f dB\n",
+                                    "%11.2f\t%4.2f dB\t%4.2f dB\t%4.2f dB\t|\t%4.2f "
+                                    "dB\t%4.2f dB\t%4.2f dB\t|\t%1.5f\t%1.5f\t%1.5f\n",
                                     (float)configs[inst_cnt]->performance_context.sum_qp /
                                         frame_count,
                                     (float)configs[inst_cnt]->performance_context.sum_luma_psnr /
@@ -369,7 +375,10 @@ int32_t main(int32_t argc, char *argv[]) {
                                     (float)(get_psnr(
                                         (configs[inst_cnt]->performance_context.sum_cr_sse /
                                          frame_count),
-                                        max_chroma_sse)));
+                                        max_chroma_sse)),
+                                    (float)configs[inst_cnt]->performance_context.sum_luma_ssim / frame_count,
+                                    (float)configs[inst_cnt]->performance_context.sum_cb_ssim / frame_count,
+                                    (float)configs[inst_cnt]->performance_context.sum_cr_ssim / frame_count);
                             }
 
                             fflush(stdout);

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -1061,6 +1061,7 @@ double get_psnr(double sse, double max) {
 void process_output_statistics_buffer(EbBufferHeaderType *header_ptr, EbConfig *config) {
     uint32_t max_luma_value = (config->encoder_bit_depth == 8) ? 255 : 1023;
     uint64_t picture_stream_size, luma_sse, cr_sse, cb_sse, picture_number, picture_qp;
+    double   luma_ssim, cr_ssim, cb_ssim;
     double   temp_var, luma_psnr, cb_psnr, cr_psnr;
 
     picture_stream_size = header_ptr->n_filled_len;
@@ -1069,6 +1070,9 @@ void process_output_statistics_buffer(EbBufferHeaderType *header_ptr, EbConfig *
     cb_sse              = header_ptr->cb_sse;
     picture_number      = header_ptr->pts;
     picture_qp          = header_ptr->qp;
+    luma_ssim           = header_ptr->luma_ssim;
+    cr_ssim             = header_ptr->cr_ssim;
+    cb_ssim             = header_ptr->cb_ssim;
 
     temp_var =
         (double)max_luma_value * max_luma_value * (config->source_width * config->source_height);
@@ -1091,12 +1095,18 @@ void process_output_statistics_buffer(EbBufferHeaderType *header_ptr, EbConfig *
     config->performance_context.sum_cb_sse += cb_sse;
 
     config->performance_context.sum_qp += picture_qp;
+    config->performance_context.sum_luma_ssim    += luma_ssim;
+    config->performance_context.sum_cr_ssim      += cr_ssim;
+    config->performance_context.sum_cb_ssim      += cb_ssim;
 
     // Write statistic Data to file
     if (config->stat_file)
         fprintf(config->stat_file,
-                "Picture Number: %4d\t QP: %4d  [ PSNR-Y: %.2f dB,\tPSNR-U: %.2f dB,\tPSNR-V: %.2f "
-                "dB,\tMSE-Y: %.2f,\tMSE-U: %.2f,\tMSE-V: %.2f ]\t %6d bytes\n",
+                "Picture Number: %4d\t QP: %4d  [ "
+                "PSNR-Y: %.2f dB,\tPSNR-U: %.2f dB,\tPSNR-V: %.2f "
+                "dB,\tMSE-Y: %.2f,\tMSE-U: %.2f,\tMSE-V: %.2f,\t"
+                "SSIM-Y: %.5f,\tSSIM-U: %.5f,\tSSIM-V: %.5f"
+                " ]\t %6d bytes\n",
                 (int)picture_number,
                 (int)picture_qp,
                 luma_psnr,
@@ -1105,6 +1115,9 @@ void process_output_statistics_buffer(EbBufferHeaderType *header_ptr, EbConfig *
                 (double)luma_sse / (config->source_width * config->source_height),
                 (double)cb_sse / (config->source_width / 2 * config->source_height / 2),
                 (double)cr_sse / (config->source_width / 2 * config->source_height / 2),
+                luma_ssim,
+                cr_ssim,
+                cb_ssim,
                 (int)picture_stream_size);
 
     return;

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -1535,6 +1535,7 @@ void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr, 
                 EB_FREE_ARRAY(buffer_cr);
                 EB_FREE_ARRAY(buffer_bit_inc_y);
                 EB_FREE_ARRAY(buffer_bit_inc_cb);
+                EB_FREE_ARRAY(buffer_bit_inc_cr);
            }
         }
 

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -1532,6 +1532,7 @@ void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) 
 
             sse_total[2] = residual_distortion;
 
+           // freed in ssim_calculations()
            /* if (pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE) {
                 EB_FREE_ARRAY(buffer_y);
                 EB_FREE_ARRAY(buffer_cb);
@@ -1539,7 +1540,7 @@ void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) 
                 EB_FREE_ARRAY(buffer_bit_inc_y);
                 EB_FREE_ARRAY(buffer_bit_inc_cb);
                 EB_FREE_ARRAY(buffer_bit_inc_cr);
-            } */ // freed in ssim_calculations */
+            } */
         }
 
         pcs_ptr->parent_pcs_ptr->luma_sse = (uint32_t)sse_total[0];

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -613,6 +613,285 @@ void recon_output(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) {
     eb_release_mutex(encode_context_ptr->total_number_of_recon_frame_mutex);
 }
 
+//************************************/
+// Calculate Frame SSIM
+/************************************/
+
+void aom_ssim_parms_8x8_c(const uint8_t *s, int sp, const uint8_t *r, int rp,
+                          uint32_t *sum_s, uint32_t *sum_r, uint32_t *sum_sq_s,
+                          uint32_t *sum_sq_r, uint32_t *sum_sxr) {
+  int i, j;
+  for (i = 0; i < 8; i++, s += sp, r += rp) {
+    for (j = 0; j < 8; j++) {
+      *sum_s += s[j];
+      *sum_r += r[j];
+      *sum_sq_s += s[j] * s[j];
+      *sum_sq_r += r[j] * r[j];
+      *sum_sxr += s[j] * r[j];
+    }
+  }
+}
+
+void aom_highbd_ssim_parms_8x8_c(const uint8_t *s, int sp, const uint8_t *sinc, int spinc, const uint16_t *r,
+                                 int rp, uint32_t *sum_s, uint32_t *sum_r,
+                                 uint32_t *sum_sq_s, uint32_t *sum_sq_r,
+                                 uint32_t *sum_sxr) {
+  int i, j;
+  uint32_t ss;
+  for (i = 0; i < 8; i++, s += sp, sinc += spinc, r += rp) {
+    for (j = 0; j < 8; j++) {
+      ss = (int64_t)(s[j] << 2) + ((sinc[j]>>6)&0x3);
+      *sum_s += ss;
+      *sum_r += r[j];
+      *sum_sq_s += ss * ss;
+      *sum_sq_r += r[j] * r[j];
+      *sum_sxr += ss * r[j];
+    }
+  }
+}
+
+static const int64_t cc1 = 26634;        // (64^2*(.01*255)^2
+static const int64_t cc2 = 239708;       // (64^2*(.03*255)^2
+static const int64_t cc1_10 = 428658;    // (64^2*(.01*1023)^2
+static const int64_t cc2_10 = 3857925;   // (64^2*(.03*1023)^2
+static const int64_t cc1_12 = 6868593;   // (64^2*(.01*4095)^2
+static const int64_t cc2_12 = 61817334;  // (64^2*(.03*4095)^2
+
+static double similarity(uint32_t sum_s, uint32_t sum_r, uint32_t sum_sq_s,
+                         uint32_t sum_sq_r, uint32_t sum_sxr, int count,
+                         uint32_t bd) {
+  int64_t ssim_n, ssim_d;
+  int64_t c1, c2;
+
+  if (bd == 8) {
+    // scale the constants by number of pixels
+    c1 = (cc1 * count * count) >> 12;
+    c2 = (cc2 * count * count) >> 12;
+  } else if (bd == 10) {
+    c1 = (cc1_10 * count * count) >> 12;
+    c2 = (cc2_10 * count * count) >> 12;
+  } else if (bd == 12) {
+    c1 = (cc1_12 * count * count) >> 12;
+    c2 = (cc2_12 * count * count) >> 12;
+  } else {
+    c1 = c2 = 0;
+    assert(0);
+  }
+
+  ssim_n = ((int64_t)2 * sum_s * sum_r + c1) *
+           ((int64_t)2 * count * sum_sxr - (int64_t)2 * sum_s * sum_r + c2);
+
+  ssim_d = ((int64_t)sum_s * sum_s + (int64_t)sum_r * sum_r + c1) *
+           ((int64_t)count * sum_sq_s - (int64_t)sum_s * sum_s +
+            (int64_t)count * sum_sq_r - (int64_t)sum_r * sum_r + c2);
+
+  return ssim_n * 1.0 / ssim_d;
+}
+
+static double ssim_8x8(const uint8_t *s, int sp, const uint8_t *r, int rp) {
+  uint32_t sum_s = 0, sum_r = 0, sum_sq_s = 0, sum_sq_r = 0, sum_sxr = 0;
+  aom_ssim_parms_8x8_c(s, sp, r, rp, &sum_s, &sum_r, &sum_sq_s, &sum_sq_r, &sum_sxr);
+  return similarity(sum_s, sum_r, sum_sq_s, sum_sq_r, sum_sxr, 64, 8);
+}
+
+static double highbd_ssim_8x8(const uint8_t *s, int sp, const uint8_t *sinc, int spinc, const uint16_t *r,
+                              int rp, uint32_t bd, uint32_t shift) {
+  uint32_t sum_s = 0, sum_r = 0, sum_sq_s = 0, sum_sq_r = 0, sum_sxr = 0;
+  aom_highbd_ssim_parms_8x8_c(s, sp, sinc, spinc, r, rp, &sum_s, &sum_r, &sum_sq_s, &sum_sq_r, &sum_sxr);
+  return similarity(sum_s >> shift, sum_r >> shift, sum_sq_s >> (2 * shift),
+                    sum_sq_r >> (2 * shift), sum_sxr >> (2 * shift), 64, bd);
+}
+
+// We are using a 8x8 moving window with starting location of each 8x8 window
+// on the 4x4 pixel grid. Such arrangement allows the windows to overlap
+// block boundaries to penalize blocking artifacts.
+static double aom_ssim2(const uint8_t *img1, int stride_img1,
+                        const uint8_t *img2, int stride_img2,
+                        int width, int height) {
+    int i, j;
+    int samples = 0;
+    double ssim_total = 0;
+
+    // sample point start with each 4x4 location
+    for (i = 0; i <= height - 8;
+        i += 4, img1 += stride_img1 * 4, img2 += stride_img2 * 4) {
+        for (j = 0; j <= width - 8; j += 4) {
+            double v = ssim_8x8(img1 + j, stride_img1, img2 + j, stride_img2);
+            ssim_total += v;
+            samples++;
+        }
+    }
+    ssim_total /= samples;
+    return ssim_total;
+}
+
+static double aom_highbd_ssim2(const uint8_t *img1, int stride_img1,
+                               const uint8_t *img1inc, int stride_img1inc,
+                               const uint16_t *img2, int stride_img2,
+                               int width, int height, uint32_t bd, uint32_t shift) {
+  int i, j;
+  int samples = 0;
+  double ssim_total = 0;
+
+  // sample point start with each 4x4 location
+  for (i = 0; i <= height - 8;
+       i += 4, img1 += stride_img1 * 4, img1inc += stride_img1inc * 4, img2 += stride_img2 * 4) {
+    for (j = 0; j <= width - 8; j += 4) {
+      double v = highbd_ssim_8x8((img1 + j), stride_img1,
+                                 (img1inc + j), stride_img1inc,
+                                 (img2 + j), stride_img2, bd,
+                                 shift);
+      ssim_total += v;
+      samples++;
+    }
+  }
+  ssim_total /= samples;
+  return ssim_total;
+}
+
+void ssim_calculations(
+    PictureControlSet    *pcs_ptr,
+    SequenceControlSet   *scs_ptr){
+    EbBool is16bit = (scs_ptr->static_config.encoder_bit_depth > EB_8BIT);
+
+    if (!is16bit) {
+        EbPictureBufferDesc *recon_ptr;
+
+        if (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE)
+            recon_ptr = ((EbReferenceObject*)pcs_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)->reference_picture;
+        else
+            recon_ptr = pcs_ptr->recon_picture_ptr;
+
+        EbPictureBufferDesc *input_picture_ptr = (EbPictureBufferDesc*)pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
+
+        EbByte  inputBuffer;
+        EbByte  reconCoeffBuffer;
+
+        EbByte buffer_y;
+        EbByte buffer_cb;
+        EbByte buffer_cr;
+
+        double luma_ssim = 0.0;
+        double cb_ssim = 0.0;
+        double cr_ssim = 0.0;
+
+        // if current source picture was temporally filtered, use an alternative buffer which stores
+        // the original source picture
+        if(pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE){
+            buffer_y = pcs_ptr->parent_pcs_ptr->save_enhanced_picture_ptr[0];
+            buffer_cb = pcs_ptr->parent_pcs_ptr->save_enhanced_picture_ptr[1];
+            buffer_cr = pcs_ptr->parent_pcs_ptr->save_enhanced_picture_ptr[2];
+        }
+        else {
+            buffer_y = input_picture_ptr->buffer_y;
+            buffer_cb = input_picture_ptr->buffer_cb;
+            buffer_cr = input_picture_ptr->buffer_cr;
+        }
+
+        reconCoeffBuffer = &((recon_ptr->buffer_y)[recon_ptr->origin_x + recon_ptr->origin_y * recon_ptr->stride_y]);
+        inputBuffer = &(buffer_y[input_picture_ptr->origin_x + input_picture_ptr->origin_y * input_picture_ptr->stride_y]);
+        luma_ssim = aom_ssim2(inputBuffer, input_picture_ptr->stride_y, reconCoeffBuffer, recon_ptr->stride_y, scs_ptr->seq_header.max_frame_width, scs_ptr->seq_header.max_frame_height);
+
+        reconCoeffBuffer = &((recon_ptr->buffer_cb)[recon_ptr->origin_x / 2 + recon_ptr->origin_y / 2 * recon_ptr->stride_cb]);
+        inputBuffer = &(buffer_cb[input_picture_ptr->origin_x / 2 + input_picture_ptr->origin_y / 2 * input_picture_ptr->stride_cb]);
+        cb_ssim = aom_ssim2(inputBuffer, input_picture_ptr->stride_cb, reconCoeffBuffer, recon_ptr->stride_cb, scs_ptr->chroma_width, scs_ptr->chroma_height);
+
+        reconCoeffBuffer = &((recon_ptr->buffer_cr)[recon_ptr->origin_x / 2 + recon_ptr->origin_y / 2 * recon_ptr->stride_cr]);
+        inputBuffer = &(buffer_cr[input_picture_ptr->origin_x / 2 + input_picture_ptr->origin_y / 2 * input_picture_ptr->stride_cr]);
+        cr_ssim = aom_ssim2(inputBuffer, input_picture_ptr->stride_cr, reconCoeffBuffer, recon_ptr->stride_cr, scs_ptr->chroma_width, scs_ptr->chroma_height);
+
+        pcs_ptr->parent_pcs_ptr->luma_ssim = luma_ssim;
+        pcs_ptr->parent_pcs_ptr->cb_ssim = cb_ssim;
+        pcs_ptr->parent_pcs_ptr->cr_ssim = cr_ssim;
+
+        if(pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE) {
+            EB_FREE_ARRAY(buffer_y);
+            EB_FREE_ARRAY(buffer_cb);
+            EB_FREE_ARRAY(buffer_cr);
+        }
+    }
+    else {
+      EbPictureBufferDesc *recon_ptr;
+
+        if (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE)
+            recon_ptr = ((EbReferenceObject*)pcs_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)->reference_picture16bit;
+        else
+            recon_ptr = pcs_ptr->recon_picture16bit_ptr;
+        EbPictureBufferDesc *input_picture_ptr = (EbPictureBufferDesc*)pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
+
+        EbByte  inputBuffer;
+        EbByte  inputBufferBitInc;
+        uint16_t*  reconCoeffBuffer;
+
+        double luma_ssim = 0.0;
+        double cb_ssim = 0.0;
+        double cr_ssim = 0.0;
+
+        if (scs_ptr->static_config.ten_bit_format == 1) {
+            printf("10-bit compressed format not yet supported");
+            assert(1);
+        }
+        else {
+            reconCoeffBuffer = (uint16_t*)(&((recon_ptr->buffer_y)[(recon_ptr->origin_x << is16bit) + (recon_ptr->origin_y << is16bit) * recon_ptr->stride_y]));
+
+            // if current source picture was temporally filtered, use an alternative buffer which stores
+            // the original source picture
+            EbByte buffer_y, buffer_bit_inc_y;
+            EbByte buffer_cb, buffer_bit_inc_cb;
+            EbByte buffer_cr, buffer_bit_inc_cr;
+            int bd, shift;
+
+            if(pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE){
+                buffer_y = pcs_ptr->parent_pcs_ptr->save_enhanced_picture_ptr[0];
+                buffer_bit_inc_y = pcs_ptr->parent_pcs_ptr->save_enhanced_picture_bit_inc_ptr[0];
+                buffer_cb = pcs_ptr->parent_pcs_ptr->save_enhanced_picture_ptr[1];
+                buffer_bit_inc_cb = pcs_ptr->parent_pcs_ptr->save_enhanced_picture_bit_inc_ptr[1];
+                buffer_cr = pcs_ptr->parent_pcs_ptr->save_enhanced_picture_ptr[2];
+                buffer_bit_inc_cr = pcs_ptr->parent_pcs_ptr->save_enhanced_picture_bit_inc_ptr[2];
+            }else{
+                buffer_y = input_picture_ptr->buffer_y;
+                buffer_bit_inc_y = input_picture_ptr->buffer_bit_inc_y;
+                buffer_cb = input_picture_ptr->buffer_cb;
+                buffer_bit_inc_cb = input_picture_ptr->buffer_bit_inc_cb;
+                buffer_cr = input_picture_ptr->buffer_cr;
+                buffer_bit_inc_cr = input_picture_ptr->buffer_bit_inc_cr;
+            }
+
+            bd = 10;
+            shift = 0 ; // both input and output are 10 bit (bitdepth - input_bd)
+
+            inputBuffer = &((buffer_y)[input_picture_ptr->origin_x + input_picture_ptr->origin_y * input_picture_ptr->stride_y]);
+            inputBufferBitInc = &((buffer_bit_inc_y)[input_picture_ptr->origin_x + input_picture_ptr->origin_y * input_picture_ptr->stride_bit_inc_y]);
+            luma_ssim = aom_highbd_ssim2(inputBuffer, input_picture_ptr->stride_y, inputBufferBitInc, input_picture_ptr->stride_bit_inc_y, reconCoeffBuffer, recon_ptr->stride_y, scs_ptr->seq_header.max_frame_width, scs_ptr->seq_header.max_frame_height, bd, shift);
+            if (luma_ssim > 1.0) printf ("luma_ssim: %f ERROR\n", luma_ssim);
+
+            reconCoeffBuffer = (uint16_t*)(&((recon_ptr->buffer_cb)[(recon_ptr->origin_x << is16bit) / 2 + (recon_ptr->origin_y << is16bit) / 2 * recon_ptr->stride_cb]));
+            inputBuffer = &((buffer_cb)[input_picture_ptr->origin_x / 2 + input_picture_ptr->origin_y / 2 * input_picture_ptr->stride_cb]);
+            inputBufferBitInc = &((buffer_bit_inc_cb)[input_picture_ptr->origin_x / 2 + input_picture_ptr->origin_y / 2 * input_picture_ptr->stride_bit_inc_cb]);
+            cb_ssim = aom_highbd_ssim2(inputBuffer, input_picture_ptr->stride_cb, inputBufferBitInc, input_picture_ptr->stride_bit_inc_cb, reconCoeffBuffer, recon_ptr->stride_cb, scs_ptr->chroma_width, scs_ptr->chroma_height, bd, shift);
+
+            reconCoeffBuffer = (uint16_t*)(&((recon_ptr->buffer_cr)[(recon_ptr->origin_x << is16bit) / 2 + (recon_ptr->origin_y << is16bit) / 2 * recon_ptr->stride_cr]));
+            inputBuffer = &((buffer_cr)[input_picture_ptr->origin_x / 2 + input_picture_ptr->origin_y / 2 * input_picture_ptr->stride_cr]);
+            inputBufferBitInc = &((buffer_bit_inc_cr)[input_picture_ptr->origin_x / 2 + input_picture_ptr->origin_y / 2 * input_picture_ptr->stride_bit_inc_cr]);
+            cr_ssim = aom_highbd_ssim2(inputBuffer, input_picture_ptr->stride_cr, inputBufferBitInc, input_picture_ptr->stride_bit_inc_cr, reconCoeffBuffer, recon_ptr->stride_cr, scs_ptr->chroma_width, scs_ptr->chroma_height, bd, shift);
+
+            pcs_ptr->parent_pcs_ptr->luma_ssim = luma_ssim;
+            pcs_ptr->parent_pcs_ptr->cb_ssim = cb_ssim;
+            pcs_ptr->parent_pcs_ptr->cr_ssim = cr_ssim;
+
+            if(pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE) {
+                EB_FREE_ARRAY(buffer_y);
+                EB_FREE_ARRAY(buffer_cb);
+                EB_FREE_ARRAY(buffer_cr);
+                EB_FREE_ARRAY(buffer_bit_inc_y);
+                EB_FREE_ARRAY(buffer_bit_inc_cb);
+                EB_FREE_ARRAY(buffer_bit_inc_cr);
+            }
+        }
+    }
+
+}
+
 void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) {
     EbBool is_16bit = (scs_ptr->static_config.encoder_bit_depth > EB_8BIT);
 
@@ -726,12 +1005,14 @@ void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) 
         pcs_ptr->parent_pcs_ptr->cb_sse   = (uint32_t)sse_total[1];
         pcs_ptr->parent_pcs_ptr->cr_sse   = (uint32_t)sse_total[2];
 
-        if (pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE) {
+        //Freed at SSIM calculation
+        /* if(pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE) {
             EB_FREE_ARRAY(buffer_y);
             EB_FREE_ARRAY(buffer_cb);
             EB_FREE_ARRAY(buffer_cr);
-        }
-    } else {
+        } */
+    }
+    else {
         EbPictureBufferDesc *recon_ptr;
 
         if (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE)
@@ -1085,14 +1366,14 @@ void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) 
 
             sse_total[2] = residual_distortion;
 
-            if (pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE) {
+           /* if (pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE) {
                 EB_FREE_ARRAY(buffer_y);
                 EB_FREE_ARRAY(buffer_cb);
                 EB_FREE_ARRAY(buffer_cr);
                 EB_FREE_ARRAY(buffer_bit_inc_y);
                 EB_FREE_ARRAY(buffer_bit_inc_cb);
                 EB_FREE_ARRAY(buffer_bit_inc_cr);
-            }
+            } */ // freed in ssim_calculations */
         }
 
         pcs_ptr->parent_pcs_ptr->luma_sse = (uint32_t)sse_total[0];

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -916,7 +916,7 @@ void ssim_calculations(
                             four_2bit_pels = input_buffer_bit_inc[k + j * inn_stride];
                             ibu[4*k  ] = (four_2bit_pels     ) & 0xc0;
                             ibu[4*k+1] = (four_2bit_pels << 2) & 0xc0;
-                            ibu[8*k+2] = (four_2bit_pels << 4) & 0xc0;
+                            ibu[4*k+2] = (four_2bit_pels << 4) & 0xc0;
                             ibu[4*k+3] = (four_2bit_pels << 6) & 0xc0;
                         }
                         ibu += 64;
@@ -952,7 +952,7 @@ void ssim_calculations(
                             four_2bit_pels = input_buffer_bit_inc[k + j * inn_stride];
                             ibu[4*k  ] = (four_2bit_pels     ) & 0xc0;
                             ibu[4*k+1] = (four_2bit_pels << 2) & 0xc0;
-                            ibu[8*k+2] = (four_2bit_pels << 4) & 0xc0;
+                            ibu[4*k+2] = (four_2bit_pels << 4) & 0xc0;
                             ibu[4*k+3] = (four_2bit_pels << 6) & 0xc0;
                         }
                         ibu += 64;
@@ -976,7 +976,7 @@ void ssim_calculations(
                             four_2bit_pels = input_buffer_bit_inc[k + j * inn_stride];
                             ibu[4*k  ] = (four_2bit_pels     ) & 0xc0;
                             ibu[4*k+1] = (four_2bit_pels << 2) & 0xc0;
-                            ibu[8*k+2] = (four_2bit_pels << 4) & 0xc0;
+                            ibu[4*k+2] = (four_2bit_pels << 4) & 0xc0;
                             ibu[4*k+3] = (four_2bit_pels << 6) & 0xc0;
                         }
                         ibu += 64;

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -749,9 +749,7 @@ static double aom_highbd_ssim2(const uint8_t *img1, int stride_img1,
   return ssim_total;
 }
 
-void ssim_calculations(
-    PictureControlSet    *pcs_ptr,
-    SequenceControlSet   *scs_ptr){
+void ssim_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr, EbBool free_memory) {
     EbBool is_16bit = (scs_ptr->static_config.encoder_bit_depth > EB_8BIT);
 
     const uint32_t ss_x = scs_ptr->subsampling_x;
@@ -810,7 +808,7 @@ void ssim_calculations(
         pcs_ptr->parent_pcs_ptr->cb_ssim = cb_ssim;
         pcs_ptr->parent_pcs_ptr->cr_ssim = cr_ssim;
 
-        if(pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE) {
+        if (free_memory && pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE) {
             EB_FREE_ARRAY(buffer_y);
             EB_FREE_ARRAY(buffer_cb);
             EB_FREE_ARRAY(buffer_cr);
@@ -1045,7 +1043,7 @@ void ssim_calculations(
             pcs_ptr->parent_pcs_ptr->cb_ssim = cb_ssim;
             pcs_ptr->parent_pcs_ptr->cr_ssim = cr_ssim;
 
-            if(pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE) {
+            if (free_memory && pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE) {
                 EB_FREE_ARRAY(buffer_y);
                 EB_FREE_ARRAY(buffer_cb);
                 EB_FREE_ARRAY(buffer_cr);
@@ -1058,7 +1056,7 @@ void ssim_calculations(
 
 }
 
-void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) {
+void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr, EbBool free_memory) {
     EbBool is_16bit = (scs_ptr->static_config.encoder_bit_depth > EB_8BIT);
 
     const uint32_t ss_x = scs_ptr->subsampling_x;
@@ -1171,12 +1169,11 @@ void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) 
         pcs_ptr->parent_pcs_ptr->cb_sse   = (uint32_t)sse_total[1];
         pcs_ptr->parent_pcs_ptr->cr_sse   = (uint32_t)sse_total[2];
 
-        //Freed at SSIM calculation
-        /* if(pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE) {
+        if(free_memory && pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE) {
             EB_FREE_ARRAY(buffer_y);
             EB_FREE_ARRAY(buffer_cb);
             EB_FREE_ARRAY(buffer_cr);
-        } */
+        }
     }
     else {
         EbPictureBufferDesc *recon_ptr;
@@ -1532,15 +1529,13 @@ void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) 
 
             sse_total[2] = residual_distortion;
 
-           // freed in ssim_calculations()
-           /* if (pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE) {
+            if (free_memory && pcs_ptr->parent_pcs_ptr->temporal_filtering_on == EB_TRUE) {
                 EB_FREE_ARRAY(buffer_y);
                 EB_FREE_ARRAY(buffer_cb);
                 EB_FREE_ARRAY(buffer_cr);
                 EB_FREE_ARRAY(buffer_bit_inc_y);
                 EB_FREE_ARRAY(buffer_bit_inc_cb);
-                EB_FREE_ARRAY(buffer_bit_inc_cr);
-            } */
+           }
         }
 
         pcs_ptr->parent_pcs_ptr->luma_sse = (uint32_t)sse_total[0];

--- a/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
@@ -698,10 +698,16 @@ void *packetization_kernel(void *input_ptr) {
             output_stream_ptr->luma_sse = pcs_ptr->parent_pcs_ptr->luma_sse;
             output_stream_ptr->cr_sse   = pcs_ptr->parent_pcs_ptr->cr_sse;
             output_stream_ptr->cb_sse   = pcs_ptr->parent_pcs_ptr->cb_sse;
+            output_stream_ptr->luma_ssim = pcs_ptr->parent_pcs_ptr->luma_ssim;
+            output_stream_ptr->cr_ssim   = pcs_ptr->parent_pcs_ptr->cr_ssim;
+            output_stream_ptr->cb_ssim   = pcs_ptr->parent_pcs_ptr->cb_ssim;
         } else {
             output_stream_ptr->luma_sse = 0;
             output_stream_ptr->cr_sse   = 0;
             output_stream_ptr->cb_sse   = 0;
+            output_stream_ptr->luma_ssim = 0;
+            output_stream_ptr->cr_ssim   = 0;
+            output_stream_ptr->cb_ssim   = 0;
         }
 
         // Get Empty Rate Control Input Tasks

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -518,6 +518,9 @@ typedef struct PictureParentControlSet {
     uint32_t luma_sse;
     uint32_t cr_sse;
     uint32_t cb_sse;
+    double   luma_ssim;
+    double   cr_ssim;
+    double   cb_ssim;
 
     // Pre Analysis
     EbObjectWrapper *ref_pa_pic_ptr_array[MAX_NUM_OF_REF_PIC_LIST][REF_LIST_MAX_DEPTH];

--- a/Source/Lib/Encoder/Codec/EbRestProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRestProcess.c
@@ -590,8 +590,13 @@ void *rest_kernel(void *input_ptr) {
             }
 
             // PSNR and SSIM Calculation
-            if (scs_ptr->static_config.stat_report) psnr_calculations(pcs_ptr, scs_ptr);
-            if (scs_ptr->static_config.stat_report) ssim_calculations(pcs_ptr, scs_ptr);
+            // (note: memory is freed in ssim_calculations, so this needs to be called last.
+            //  If one wants to skip ssim_calculations, comment back in memory free calls at
+            //  end of psnr_calculations.)
+            if (scs_ptr->static_config.stat_report) {
+                psnr_calculations(pcs_ptr, scs_ptr);
+                ssim_calculations(pcs_ptr, scs_ptr);
+            }
 
             // Pad the reference picture and set ref POC
             if (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE)

--- a/Source/Lib/Encoder/Codec/EbRestProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRestProcess.c
@@ -55,8 +55,8 @@ void recon_output(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr);
 void eb_av1_loop_restoration_filter_frame(Yv12BufferConfig *frame, Av1Common *cm,
                                           int32_t optimized_lr);
 void copy_statistics_to_ref_obj_ect(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr);
-void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr);
-void ssim_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr);
+void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr, EbBool free_memory);
+void ssim_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr, EbBool free_memory);
 void pad_ref_and_set_flags(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr);
 void generate_padding(EbByte src_pic, uint32_t src_stride, uint32_t original_src_width,
                       uint32_t original_src_height, uint32_t padding_width,
@@ -589,13 +589,11 @@ void *rest_kernel(void *input_ptr) {
                 copy_statistics_to_ref_obj_ect(pcs_ptr, scs_ptr);
             }
 
-            // PSNR and SSIM Calculation
-            // (note: memory is freed in ssim_calculations, so this needs to be called last.
-            //  If one wants to skip ssim_calculations, comment back in memory free calls at
-            //  end of psnr_calculations.)
+            // PSNR and SSIM Calculation.
+            // Note: if temporal_filtering is used, memory needs to be freed in the last of these calls
             if (scs_ptr->static_config.stat_report) {
-                psnr_calculations(pcs_ptr, scs_ptr);
-                ssim_calculations(pcs_ptr, scs_ptr);
+                psnr_calculations(pcs_ptr, scs_ptr, EB_FALSE);
+                ssim_calculations(pcs_ptr, scs_ptr, EB_TRUE /* free memory here */);
             }
 
             // Pad the reference picture and set ref POC

--- a/Source/Lib/Encoder/Codec/EbRestProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRestProcess.c
@@ -481,7 +481,6 @@ void eb_av1_superres_upscale_frame(struct Av1Common *cm,
  ******************************************************/
 void *rest_kernel(void *input_ptr) {
     // Context & SCS & PCS
-
     EbThreadContext *   thread_context_ptr = (EbThreadContext *)input_ptr;
     RestContext *       context_ptr        = (RestContext *)thread_context_ptr->priv;
     PictureControlSet * pcs_ptr;

--- a/Source/Lib/Encoder/Codec/EbRestProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRestProcess.c
@@ -56,6 +56,7 @@ void eb_av1_loop_restoration_filter_frame(Yv12BufferConfig *frame, Av1Common *cm
                                           int32_t optimized_lr);
 void copy_statistics_to_ref_obj_ect(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr);
 void psnr_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr);
+void ssim_calculations(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr);
 void pad_ref_and_set_flags(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr);
 void generate_padding(EbByte src_pic, uint32_t src_stride, uint32_t original_src_width,
                       uint32_t original_src_height, uint32_t padding_width,
@@ -480,6 +481,7 @@ void eb_av1_superres_upscale_frame(struct Av1Common *cm,
  ******************************************************/
 void *rest_kernel(void *input_ptr) {
     // Context & SCS & PCS
+
     EbThreadContext *   thread_context_ptr = (EbThreadContext *)input_ptr;
     RestContext *       context_ptr        = (RestContext *)thread_context_ptr->priv;
     PictureControlSet * pcs_ptr;
@@ -587,8 +589,9 @@ void *rest_kernel(void *input_ptr) {
                 copy_statistics_to_ref_obj_ect(pcs_ptr, scs_ptr);
             }
 
-            // PSNR Calculation
+            // PSNR and SSIM Calculation
             if (scs_ptr->static_config.stat_report) psnr_calculations(pcs_ptr, scs_ptr);
+            if (scs_ptr->static_config.stat_report) ssim_calculations(pcs_ptr, scs_ptr);
 
             // Pad the reference picture and set ref POC
             if (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE)


### PR DESCRIPTION
Most other encoders support SSIM along with PSNR as a compression quality metric. For our use of SVT-AV1 we depend on having SSIM readily available, so we have added support for this to SVT-AV1. It supports both 8- and 10-bit bitdepth. However, we do not have any videos in the "compressed 10-bit format" utilized by SVT-AV1, nor any tools to convert to it, and due to SSIM being a little more complex for this format, it has not yet been added. Still, we are submitting this pull request hoping it will generate some interest. 

If someone can share some sample "compressed 10-bit format" test videos, or advice how to convert to this format, we should be able to complete this pull request soon.

We utilize core SSIM calculation functions from 'aom' in this pull request, since other parts of aom are already used and included in SVT-AV1. These functions need to be moved elsewhere with the proper copyright as well.