### PR TITLE
Fix valgrind issue for: -w 640 -h 480 -enc-mode 8 -scm 1 -palette 3

### DIFF
--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -3852,10 +3852,10 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
                NEW_NEWMV
             ************* */
             if (allow_bipred) {
-                if (list0_ref_index > context_ptr->md_max_ref_count - 1 ||
-                    list1_ref_index > context_ptr->md_max_ref_count - 1)
-                    continue;
                 if (inter_direction == 2) {
+                    if (list0_ref_index > context_ptr->md_max_ref_count - 1 ||
+                        list1_ref_index > context_ptr->md_max_ref_count - 1)
+                        continue;
 #if ENHANCED_ME_MV
                     int16_t to_inject_mv_x_l0 =
                         context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
@@ -5837,7 +5837,7 @@ void  inject_palette_candidates(
         &tot_palette_cands);
 
     for (cand_i = 0; cand_i < tot_palette_cands; ++cand_i) {
-
+        cand_array[can_total_cnt].is_interintra_used = 0;
         palette_cand_array[cand_i].pmi.palette_size[1] = 0;
         memcpy(cand_array[can_total_cnt].palette_info.color_idx_map, palette_cand_array[cand_i].color_idx_map, 64 * 64);
         memcpy(&cand_array[can_total_cnt].palette_info.pmi, &palette_cand_array[cand_i].pmi, sizeof(PaletteModeInfo));

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -743,15 +743,16 @@ void md_update_all_neighbour_arrays(PictureControlSet *pcs_ptr, ModeDecisionCont
     if (avail_blk_flag) {
         mode_decision_update_neighbor_arrays(
             pcs_ptr, context_ptr, last_blk_index_mds, EB_FALSE);
-    }
 
-    update_mi_map(context_ptr,
+        update_mi_map(context_ptr,
                   context_ptr->blk_ptr,
                   context_ptr->blk_origin_x,
                   context_ptr->blk_origin_y,
                   context_ptr->blk_geom,
                   avail_blk_flag,
                   pcs_ptr);
+    }
+
 }
 
 void md_update_all_neighbour_arrays_multiple(PictureControlSet *  pcs_ptr,


### PR DESCRIPTION
Conditional jump or move depends on uninitialised value(s)
update_mi_map (EbAdaptiveMotionVectorPrediction.c:1517)
md_update_all_neighbour_arrays (EbProductCodingLoop.c:748)
md_update_all_neighbour_arrays_multiple (EbProductCodingLoop.c:764)
mode_decision_sb (EbProductCodingLoop.c:8726)
enc_dec_kernel (EbEncDecProcess.c:3436)

Conditional jump or move depends on uninitialised value(s)
inject_new_candidates (EbModeDecision.c:3855)
inject_inter_candidates (EbModeDecision.c:4429)
generate_md_stage_0_cand (EbModeDecision.c:5998)
md_encode_block (EbProductCodingLoop.c:7470)
mode_decision_sb (EbProductCodingLoop.c:8584)
enc_dec_kernel (EbEncDecProcess.c:3436)