### PR TITLE
App: Add --no-progress option 

### DIFF
--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -128,6 +128,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **ErrorFile** | --errlog | any string | stderr | error log displaying configuration or encode errors |
 | **ReconFile** | -o | any string | null | Recon file path. Optional output of recon. |
 | **StatFile** | --stat-file | any string | Null | Path to statistics file if specified and StatReport is set to 1, per picture statistics are outputted in the file|
+| **NoProgress** | --no-progress | [0,1] | 0 | Use `--no-progress 1` to disable printing of frame processed when encoding |
 
 #### Encoder Global Options
 | **Configuration file parameter** | **Command line** | **Range** | **Default** | **Description** |

--- a/Source/App/DecApp/EbDecAppMain.c
+++ b/Source/App/DecApp/EbDecAppMain.c
@@ -160,10 +160,6 @@ int32_t main(int32_t argc, char *argv[]) {
     uint8_t *buf             = NULL;
     size_t   bytes_in_buffer = 0, buffer_size = 0;
 
-    // Print Decoder Info
-    fprintf(stderr, "-------------------------------------\n");
-    fprintf(stderr, "SVT-AV1 Decoder\n");
-
     // Initialize config
     if (!config_ptr) return EB_ErrorInsufficientResources;
     EbComponentType *p_handle;

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -41,6 +41,7 @@
 #define HEIGHT_TOKEN "-h"
 #define NUMBER_OF_PICTURES_TOKEN "-n"
 #define BUFFERED_INPUT_TOKEN "-nb"
+#define NO_PROGRESS_TOKEN "--no-progress"
 #define BASE_LAYER_SWITCH_MODE_TOKEN "-base-layer-switch-mode" // no Eval
 #define QP_TOKEN "-q"
 #define USE_QP_FILE_TOKEN "-use-q-file"
@@ -309,6 +310,9 @@ static void set_cfg_frames_to_be_encoded(const char *value, EbConfig *cfg) {
 static void set_buffered_input(const char *value, EbConfig *cfg) {
     cfg->buffered_input = strtol(value, NULL, 0);
 };
+static void set_no_progress(const char*value, EbConfig *cfg) {
+    cfg->no_progress = (EbBool)strtoul(value, NULL, 0);
+}
 static void set_frame_rate(const char *value, EbConfig *cfg) {
     cfg->frame_rate = strtoul(value, NULL, 0);
     if (cfg->frame_rate > 1000)
@@ -747,6 +751,7 @@ ConfigEntry config_entry_global_options[] = {
      set_cfg_frames_to_be_encoded},
 
     {SINGLE_INPUT, BUFFERED_INPUT_TOKEN, "Buffer n input frames", set_buffered_input},
+    {SINGLE_INPUT, NO_PROGRESS_TOKEN, "Do not print out progress", set_no_progress},
     {SINGLE_INPUT,
      ENCODER_COLOR_FORMAT,
      "Set encoder color format(EB_YUV400, EB_YUV420, EB_YUV422, EB_YUV444)",
@@ -1215,6 +1220,7 @@ ConfigEntry config_entry[] = {
     // Prediction Structure
     {SINGLE_INPUT, NUMBER_OF_PICTURES_TOKEN, "FrameToBeEncoded", set_cfg_frames_to_be_encoded},
     {SINGLE_INPUT, BUFFERED_INPUT_TOKEN, "BufferedInput", set_buffered_input},
+    {SINGLE_INPUT, NO_PROGRESS_TOKEN, "NoProgress", set_no_progress},
     {SINGLE_INPUT, ENCMODE_TOKEN, "EncoderMode", set_enc_mode},
     {SINGLE_INPUT, ENCMODE2P_TOKEN, "EncoderMode2p", set_snd_pass_enc_mode},
     {SINGLE_INPUT, INTRA_PERIOD_TOKEN, "IntraPeriod", set_cfg_intra_period},
@@ -1536,6 +1542,7 @@ void eb_config_ctor(EbConfig *config_ptr) {
     config_ptr->hierarchical_levels                       = 4;
     config_ptr->pred_structure                            = 2;
     config_ptr->enable_global_motion                      = EB_TRUE;
+    config_ptr->no_progress                               = EB_FALSE;
     config_ptr->enable_warped_motion                      = DEFAULT;
     config_ptr->cdef_mode                                 = DEFAULT;
     config_ptr->enable_restoration_filtering              = DEFAULT;

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -2017,8 +2017,7 @@ uint32_t get_help(int32_t argc, char *const argv[]) {
         char *      token_options_format = "\t%-5s\t%-25s\t%-25s\n";
         const char *empty_string         = "";
         fprintf(stderr,
-                "\n%-25s\n",
-                "Usage: SvtAv1EncApp <options> -b dst_filename -i src_filename");
+                "Usage: SvtAv1EncApp <options> -b dst_filename -i src_filename\n");
         fprintf(stderr, "\n%-25s\n", "Options:");
         while (config_entry_options[++options_token_index].token != NULL) {
             uint32_t check = check_long(

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -164,6 +164,7 @@ typedef struct EbConfig {
     EbBool        y4m_input;
     unsigned char y4m_buf[9];
     EbBool        use_qp_file;
+    EbBool        no_progress;
     uint8_t       stat_report;
     uint32_t      frame_rate;
     uint32_t      frame_rate_numerator;

--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -98,8 +98,6 @@ int32_t main(int32_t argc, char *argv[]) {
     uint32_t      inst_cnt     = 0;
     EbAppContext *app_callbacks[MAX_CHANNEL_NUMBER]; // Instances App callback data
     signal(SIGINT, event_handler);
-    fprintf(stderr, "-------------------------------------------\n");
-    fprintf(stderr, "SVT-AV1 Encoder\n");
     if (!get_help(argc, argv)) {
         // Get num_channels
         num_channels = get_number_of_channels(argc, argv);

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -1186,13 +1186,9 @@ AppExitConditionType process_output_stream_buffer(EbConfig *config, EbAppContext
             // Release the output buffer
             svt_av1_enc_release_out_buffer(&header_ptr);
 
-#if DEADLOCK_DEBUG
             ++frame_count;
-#else
-            //++frame_count;
-            if (!(header_ptr->flags & EB_BUFFERFLAG_IS_ALT_REF))
-                fprintf(stderr, "\b\b\b\b\b\b\b\b\b%9d", ++frame_count);
-#endif
+            if (!config->no_progress && !(header_ptr->flags & EB_BUFFERFLAG_IS_ALT_REF))
+                fprintf(stderr, "\b\b\b\b\b\b\b\b\b%9d", frame_count);
 
             //++frame_count;
             fflush(stdout);

--- a/Source/Lib/Decoder/Codec/EbDecHandle.c
+++ b/Source/Lib/Decoder/Codec/EbDecHandle.c
@@ -448,22 +448,22 @@ EbErrorType eb_svt_dec_set_default_parameter(EbSvtAv1DecConfiguration *config_pt
 static EbErrorType init_svt_av1_decoder_handle(EbComponentType *hComponent) {
     EbErrorType      return_error      = EB_ErrorNone;
     EbComponentType *svt_dec_component = (EbComponentType *)hComponent;
-
+    SVT_LOG("-------------------------------------------\n");
     SVT_LOG("SVT [version]:\tSVT-AV1 Decoder Lib %s\n", SVT_AV1_CVS_VERSION);
-#if ( defined( _MSC_VER ) && (_MSC_VER >= 1920) )
+#if defined(_MSC_VER) && (_MSC_VER >= 1920)
     SVT_LOG("SVT [build]  :\tVisual Studio 2019");
-#elif ( defined( _MSC_VER ) && (_MSC_VER >= 1910) )
+#elif defined(_MSC_VER) && (_MSC_VER >= 1910)
     SVT_LOG("SVT [build]  :\tVisual Studio 2017");
-#elif ( defined( _MSC_VER ) && (_MSC_VER >= 1900) )
+#elif defined(_MSC_VER) && (_MSC_VER >= 1900)
     SVT_LOG("SVT [build]  :\tVisual Studio 2015");
-#elif ( defined( _MSC_VER ) && (_MSC_VER < 1900) )
+#elif defined(_MSC_VER)
     SVT_LOG("SVT [build]  :\tVisual Studio (old)");
 #elif defined(__GNUC__)
     SVT_LOG("SVT [build]  :\tGCC %d.%d.%d\t", __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
 #else
     SVT_LOG("SVT [build]  :\tunknown compiler");
 #endif
-    SVT_LOG(" %u bit\n", (unsigned)sizeof(void *) * 8);
+    SVT_LOG(" %zu bit\n", sizeof(void *) * 8);
     SVT_LOG("LIB Build date: %s %s\n", __DATE__, __TIME__);
     SVT_LOG("-------------------------------------------\n");
 

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -3665,22 +3665,22 @@ EbErrorType init_svt_av1_encoder_handle(
     EbErrorType       return_error = EB_ErrorNone;
     EbComponentType  *svt_enc_component = (EbComponentType*)hComponent;
     EbEncHandle      *handle;
-
+    SVT_LOG("-------------------------------------------\n");
     SVT_LOG("SVT [version]:\tSVT-AV1 Encoder Lib %s\n", SVT_AV1_CVS_VERSION);
-#if ( defined( _MSC_VER ) && (_MSC_VER >= 1920) )
+#if defined( _MSC_VER ) && (_MSC_VER >= 1920)
     SVT_LOG("SVT [build]  :\tVisual Studio 2019");
-#elif ( defined( _MSC_VER ) && (_MSC_VER >= 1910) )
+#elif defined( _MSC_VER ) && (_MSC_VER >= 1910)
     SVT_LOG("SVT [build]  :\tVisual Studio 2017");
-#elif ( defined( _MSC_VER ) && (_MSC_VER >= 1900) )
+#elif defined( _MSC_VER ) && (_MSC_VER >= 1900)
     SVT_LOG("SVT [build]  :\tVisual Studio 2015");
-#elif ( defined( _MSC_VER ) && (_MSC_VER < 1900) )
+#elif defined( _MSC_VER )
     SVT_LOG("SVT [build]  :\tVisual Studio (old)");
 #elif defined(__GNUC__)
     SVT_LOG("SVT [build]  :\tGCC %s\t", __VERSION__);
 #else
     SVT_LOG("SVT [build]  :\tunknown compiler");
 #endif
-    SVT_LOG(" %u bit\n", (unsigned) sizeof(void*) * 8);
+    SVT_LOG(" %zu bit\n", sizeof(void*) * 8);
     SVT_LOG("LIB Build date: %s %s\n", __DATE__, __TIME__);
     SVT_LOG("-------------------------------------------\n");
 


### PR DESCRIPTION
Suppresses the backspaces and frame count printing that sucks when trying to parse the output

Currently needs to be enabled by way of `--no-progress <anything>`  due to the limitation of the current arg parsing system

Semi Closes #1237