### PR TITLE
Travis: Re-enable travis-ci for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ addons:
 # Pipeline stages
 stages:
   - name: test
-    if: type != pull_request
 
 # Default scripts
 before_install:


### PR DESCRIPTION
It seems that it was disabled in https://github.com/OpenVisualCloud/SVT-AV1/commit/6bc9f229d21e4803961a63ce469ffb80c29add0a