### PR TITLE
Fix wrong parameter for assert, 0 is valid

### DIFF
--- a/Source/Lib/Encoder/Codec/EbMdRateEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMdRateEstimation.c
@@ -828,7 +828,7 @@ static AOM_INLINE void sum_intra_stats(PictureControlSet *pcs_ptr, BlkStruct *bl
     }
     if (av1_is_directional_mode(get_uv_mode(uv_mode)) && av1_use_angle_delta(bsize, pcs_ptr->parent_pcs_ptr->scs_ptr->static_config.intra_angle_delta)) {
         assert((uv_mode - UV_V_PRED) < DIRECTIONAL_MODES);
-        assert((uv_mode - UV_V_PRED) > 0);
+        assert((uv_mode - UV_V_PRED) >= 0);
         update_cdf(fc->angle_delta_cdf[uv_mode - UV_V_PRED],
                    mbmi->block_mi.angle_delta[PLANE_TYPE_UV] + MAX_ANGLE_DELTA,
                    2 * MAX_ANGLE_DELTA + 1);


### PR DESCRIPTION
For Debug build with command line below assert is called
cmdline: 176x144.yuv -w 176 -h 144 -bit-depth 8 -enc-mode 0 -n 40 -b out.av1

@ePirat could you confirm that this is fixed correctly? (assert is introduced in PR #1260 )