### PR TITLE
Cleanup: Remove always false skip arguments

### DIFF
--- a/Source/Lib/Common/ASM_SSE2/EbAvcStyleMcp_Intrinsic_SSE2.c
+++ b/Source/Lib/Common/ASM_SSE2/EbAvcStyleMcp_Intrinsic_SSE2.c
@@ -8,19 +8,10 @@
 #include "emmintrin.h"
 #include "common_dsp_rtcd.h"
 void avc_style_copy_sse2(EbByte ref_pic, uint32_t src_stride, EbByte dst, uint32_t dst_stride,
-                         uint32_t pu_width, uint32_t pu_height, EbByte temp_buf, EbBool skip,
+                         uint32_t pu_width, uint32_t pu_height, EbByte temp_buf,
                          uint32_t frac_pos) {
     (void)temp_buf;
     (void)frac_pos;
-    if (skip) {
-        //do the last row too.
-        eb_memcpy(
-            dst + (pu_height - 1) * dst_stride, ref_pic + (pu_height - 1) * src_stride, pu_width);
-
-        src_stride <<= 1;
-        dst_stride <<= 1;
-        pu_height >>= 1;
-    }
 
     picture_copy_kernel_sse2(ref_pic, src_stride, dst, dst_stride, pu_width, pu_height);
 }

--- a/Source/Lib/Common/ASM_SSE2/EbAvcStyleMcp_SSE2.h
+++ b/Source/Lib/Common/ASM_SSE2/EbAvcStyleMcp_SSE2.h
@@ -12,7 +12,7 @@ extern "C" {
 #endif
 
 void avc_style_copy_sse2(EbByte ref_pic, uint32_t src_stride, EbByte dst, uint32_t dst_stride,
-                         uint32_t pu_width, uint32_t pu_height, EbByte temp_buf, EbBool skip,
+                         uint32_t pu_width, uint32_t pu_height, EbByte temp_buf,
                          uint32_t frac_pos);
 
 #ifdef __cplusplus

--- a/Source/Lib/Common/ASM_SSSE3/EbAvcStyleMcp_Intrinsic_SSSE3.c
+++ b/Source/Lib/Common/ASM_SSSE3/EbAvcStyleMcp_Intrinsic_SSSE3.c
@@ -21,13 +21,13 @@ EB_EXTERN EB_ALIGN(16) const int8_t avc_style_luma_if_coeff8_ssse3[] = {
 void avc_style_luma_interpolation_filter_pose_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos) {
+                                                    uint32_t frac_pos) {
     uint32_t temp_buf_size = pu_width * pu_height;
     (void)frac_pos;
     avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(
-        ref_pic, src_stride, temp_buf, pu_width, pu_width, pu_height, 0, skip, 2);
+        ref_pic, src_stride, temp_buf, pu_width, pu_width, pu_height, 0, 2);
     avc_style_luma_interpolation_filter_vertical_ssse3_intrin(
-        ref_pic, src_stride, temp_buf + temp_buf_size, pu_width, pu_width, pu_height, 0, skip, 2);
+        ref_pic, src_stride, temp_buf + temp_buf_size, pu_width, pu_width, pu_height, 0, 2);
     picture_average_kernel_sse2_intrin(temp_buf,
                                        pu_width,
                                        temp_buf + temp_buf_size,
@@ -41,7 +41,7 @@ void avc_style_luma_interpolation_filter_pose_ssse3(EbByte ref_pic, uint32_t src
 void avc_style_luma_interpolation_filter_posf_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos) {
+                                                    uint32_t frac_pos) {
     uint32_t temp_buf_size = pu_width * pu_height;
     (void)frac_pos;
     avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(
@@ -50,9 +50,8 @@ void avc_style_luma_interpolation_filter_posf_ssse3(EbByte ref_pic, uint32_t src
         temp_buf + temp_buf_size,
         pu_width,
         pu_width,
-        skip ? (2 * pu_height + 3) : (pu_height + 3),
+        (pu_height + 3),
         0,
-        EB_FALSE,
         2);
     avc_style_luma_interpolation_filter_vertical_ssse3_intrin(temp_buf + temp_buf_size + pu_width,
                                                               pu_width,
@@ -61,10 +60,9 @@ void avc_style_luma_interpolation_filter_posf_ssse3(EbByte ref_pic, uint32_t src
                                                               pu_width,
                                                               pu_height,
                                                               0,
-                                                              skip,
                                                               2);
     picture_average_kernel_sse2_intrin(temp_buf + temp_buf_size + pu_width,
-                                       skip ? 2 * pu_width : pu_width,
+                                       pu_width,
                                        temp_buf,
                                        pu_width,
                                        dst,
@@ -76,11 +74,11 @@ void avc_style_luma_interpolation_filter_posf_ssse3(EbByte ref_pic, uint32_t src
 void avc_style_luma_interpolation_filter_posg_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos) {
+                                                    uint32_t frac_pos) {
     uint32_t temp_buf_size = pu_width * pu_height;
     (void)frac_pos;
     avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(
-        ref_pic, src_stride, temp_buf, pu_width, pu_width, pu_height, 0, skip, 2);
+        ref_pic, src_stride, temp_buf, pu_width, pu_width, pu_height, 0, 2);
     avc_style_luma_interpolation_filter_vertical_ssse3_intrin(ref_pic + 1,
                                                               src_stride,
                                                               temp_buf + temp_buf_size,
@@ -88,7 +86,6 @@ void avc_style_luma_interpolation_filter_posg_ssse3(EbByte ref_pic, uint32_t src
                                                               pu_width,
                                                               pu_height,
                                                               0,
-                                                              skip,
                                                               2);
     picture_average_kernel_sse2_intrin(temp_buf,
                                        pu_width,
@@ -103,11 +100,11 @@ void avc_style_luma_interpolation_filter_posg_ssse3(EbByte ref_pic, uint32_t src
 void avc_style_luma_interpolation_filter_posi_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos) {
+                                                    uint32_t frac_pos) {
     uint32_t temp_buf_size = pu_width * pu_height;
     (void)frac_pos;
     avc_style_luma_interpolation_filter_vertical_ssse3_intrin(
-        ref_pic, src_stride, temp_buf, pu_width, pu_width, pu_height, 0, skip, 2);
+        ref_pic, src_stride, temp_buf, pu_width, pu_width, pu_height, 0, 2);
     avc_style_luma_interpolation_filter_posj_ssse3(ref_pic,
                                                    src_stride,
                                                    temp_buf + temp_buf_size,
@@ -115,7 +112,6 @@ void avc_style_luma_interpolation_filter_posi_ssse3(EbByte ref_pic, uint32_t src
                                                    pu_width,
                                                    pu_height,
                                                    temp_buf + 2 * temp_buf_size,
-                                                   skip,
                                                    2);
     picture_average_kernel_sse2_intrin(temp_buf,
                                        pu_width,
@@ -130,42 +126,30 @@ void avc_style_luma_interpolation_filter_posi_ssse3(EbByte ref_pic, uint32_t src
 void avc_style_luma_interpolation_filter_posj_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos) {
+                                                    uint32_t frac_pos) {
     (void)frac_pos;
-    if (skip)
-        avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(ref_pic - src_stride,
-                                                                    src_stride,
-                                                                    temp_buf,
-                                                                    pu_width,
-                                                                    pu_width,
-                                                                    (pu_height + 3),
-                                                                    0,
-                                                                    EB_FALSE,
-                                                                    2);
-    else
-        avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(
-            ref_pic - src_stride,
-            src_stride,
-            temp_buf,
-            pu_width,
-            pu_width,
-            skip ? (2 * pu_height + 3) : (pu_height + 3),
-            0,
-            EB_FALSE,
-            2);
+    avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(
+        ref_pic - src_stride,
+        src_stride,
+        temp_buf,
+        pu_width,
+        pu_width,
+        (pu_height + 3),
+        0,
+        2);
 
     avc_style_luma_interpolation_filter_vertical_ssse3_intrin(
-        temp_buf + pu_width, pu_width, dst, dst_stride, pu_width, pu_height, 0, skip, 2);
+        temp_buf + pu_width, pu_width, dst, dst_stride, pu_width, pu_height, 0, 2);
 }
 
 void avc_style_luma_interpolation_filter_posk_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos) {
+                                                    uint32_t frac_pos) {
     uint32_t temp_buf_size = pu_width * pu_height;
     (void)frac_pos;
     avc_style_luma_interpolation_filter_vertical_ssse3_intrin(
-        ref_pic + 1, src_stride, temp_buf, pu_width, pu_width, pu_height, 0, skip, 2);
+        ref_pic + 1, src_stride, temp_buf, pu_width, pu_width, pu_height, 0, 2);
     avc_style_luma_interpolation_filter_posj_ssse3(ref_pic,
                                                    src_stride,
                                                    temp_buf + temp_buf_size,
@@ -173,7 +157,6 @@ void avc_style_luma_interpolation_filter_posk_ssse3(EbByte ref_pic, uint32_t src
                                                    pu_width,
                                                    pu_height,
                                                    temp_buf + 2 * temp_buf_size,
-                                                   skip,
                                                    2);
     picture_average_kernel_sse2_intrin(temp_buf,
                                        pu_width,
@@ -188,11 +171,11 @@ void avc_style_luma_interpolation_filter_posk_ssse3(EbByte ref_pic, uint32_t src
 void avc_style_luma_interpolation_filter_posp_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos) {
+                                                    uint32_t frac_pos) {
     uint32_t temp_buf_size = pu_width * pu_height;
     (void)frac_pos;
     avc_style_luma_interpolation_filter_vertical_ssse3_intrin(
-        ref_pic, src_stride, temp_buf, pu_width, pu_width, pu_height, 0, skip, 2);
+        ref_pic, src_stride, temp_buf, pu_width, pu_width, pu_height, 0, 2);
     avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(ref_pic + src_stride,
                                                                 src_stride,
                                                                 temp_buf + temp_buf_size,
@@ -200,7 +183,6 @@ void avc_style_luma_interpolation_filter_posp_ssse3(EbByte ref_pic, uint32_t src
                                                                 pu_width,
                                                                 pu_height,
                                                                 0,
-                                                                skip,
                                                                 2);
     picture_average_kernel_sse2_intrin(temp_buf,
                                        pu_width,
@@ -215,7 +197,7 @@ void avc_style_luma_interpolation_filter_posp_ssse3(EbByte ref_pic, uint32_t src
 void avc_style_luma_interpolation_filter_posq_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos) {
+                                                    uint32_t frac_pos) {
     uint32_t temp_buf_size = pu_width * pu_height;
     (void)frac_pos;
     avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(
@@ -224,9 +206,8 @@ void avc_style_luma_interpolation_filter_posq_ssse3(EbByte ref_pic, uint32_t src
         temp_buf + temp_buf_size,
         pu_width,
         pu_width,
-        skip ? (2 * pu_height + 3) : (pu_height + 3),
+        (pu_height + 3),
         0,
-        EB_FALSE,
         2);
     avc_style_luma_interpolation_filter_vertical_ssse3_intrin(temp_buf + temp_buf_size + pu_width,
                                                               pu_width,
@@ -235,10 +216,9 @@ void avc_style_luma_interpolation_filter_posq_ssse3(EbByte ref_pic, uint32_t src
                                                               pu_width,
                                                               pu_height,
                                                               0,
-                                                              skip,
                                                               2);
     picture_average_kernel_sse2_intrin(temp_buf + temp_buf_size + 2 * pu_width,
-                                       skip ? 2 * pu_width : pu_width,
+                                       pu_width,
                                        temp_buf,
                                        pu_width,
                                        dst,
@@ -250,11 +230,11 @@ void avc_style_luma_interpolation_filter_posq_ssse3(EbByte ref_pic, uint32_t src
 void avc_style_luma_interpolation_filter_posr_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos) {
+                                                    uint32_t frac_pos) {
     uint32_t temp_buf_size = pu_width * pu_height;
     (void)frac_pos;
     avc_style_luma_interpolation_filter_vertical_ssse3_intrin(
-        ref_pic + 1, src_stride, temp_buf, pu_width, pu_width, pu_height, 0, skip, 2);
+        ref_pic + 1, src_stride, temp_buf, pu_width, pu_width, pu_height, 0, 2);
     avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(ref_pic + src_stride,
                                                                 src_stride,
                                                                 temp_buf + temp_buf_size,
@@ -262,7 +242,6 @@ void avc_style_luma_interpolation_filter_posr_ssse3(EbByte ref_pic, uint32_t src
                                                                 pu_width,
                                                                 pu_height,
                                                                 0,
-                                                                skip,
                                                                 2);
     picture_average_kernel_sse2_intrin(temp_buf,
                                        pu_width,
@@ -276,15 +255,12 @@ void avc_style_luma_interpolation_filter_posr_ssse3(EbByte ref_pic, uint32_t src
 
 void avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(
     EbByte ref_pic, uint32_t src_stride, EbByte dst, uint32_t dst_stride, uint32_t pu_width,
-    uint32_t pu_height, EbByte temp_buf, EbBool skip, uint32_t frac_pos) {
+    uint32_t pu_height, EbByte temp_buf, uint32_t frac_pos) {
     (void)temp_buf;
     __m128i  if_offset, if_coeff_1_0, if_coeff_3_2, sum_clip_u8;
     uint32_t width_cnt, height_cnt;
     uint32_t if_shift = 5;
 
-    src_stride <<= skip;
-    dst_stride <<= skip;
-    pu_height >>= skip;
     frac_pos <<= 5;
     if_offset    = _mm_set1_epi16(0x0010);
     if_coeff_1_0 = _mm_loadu_si128((__m128i *)(avc_style_luma_if_coeff8_ssse3 + frac_pos - 32));
@@ -321,35 +297,6 @@ void avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(
             ref_pic += src_stride;
             dst += dst_stride;
         }
-        //do the last row if sub-pred ON.
-        if (skip) {
-            ref_pic -= (src_stride >> 1);
-            dst -= (dst_stride >> 1);
-            for (width_cnt = 0; width_cnt < pu_width; width_cnt += 16) {
-                ref0 = _mm_loadu_si128((__m128i *)(ref_pic + width_cnt - 1));
-                ref1 = _mm_loadu_si128((__m128i *)(ref_pic + width_cnt));
-                ref2 = _mm_loadu_si128((__m128i *)(ref_pic + width_cnt + 1));
-                ref3 = _mm_loadu_si128((__m128i *)(ref_pic + width_cnt + 2));
-
-                ref01_lo = _mm_unpacklo_epi8(ref0, ref1);
-                ref01_hi = _mm_unpackhi_epi8(ref0, ref1);
-                ref23_lo = _mm_unpacklo_epi8(ref2, ref3);
-                ref23_hi = _mm_unpackhi_epi8(ref2, ref3);
-
-                sum_lo = _mm_srai_epi16(
-                    _mm_add_epi16(_mm_add_epi16(_mm_maddubs_epi16(ref01_lo, if_coeff_1_0),
-                                                _mm_maddubs_epi16(ref23_lo, if_coeff_3_2)),
-                                  if_offset),
-                    if_shift);
-                sum_hi = _mm_srai_epi16(
-                    _mm_add_epi16(_mm_add_epi16(_mm_maddubs_epi16(ref01_hi, if_coeff_1_0),
-                                                _mm_maddubs_epi16(ref23_hi, if_coeff_3_2)),
-                                  if_offset),
-                    if_shift);
-                sum_clip_u8 = _mm_packus_epi16(sum_lo, sum_hi);
-                _mm_storeu_si128((__m128i *)(dst + width_cnt), sum_clip_u8);
-            }
-        }
     } else { //8x
         __m128i sum01, sum23, sum;
 
@@ -374,29 +321,6 @@ void avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(
             ref_pic += src_stride;
             dst += dst_stride;
         }
-
-        //do the last row if sub-pred ON.
-        if (skip) {
-            ref_pic -= (src_stride >> 1);
-            dst -= (dst_stride >> 1);
-            for (width_cnt = 0; width_cnt < pu_width; width_cnt += 8) {
-                sum01 = _mm_maddubs_epi16(
-                    _mm_unpacklo_epi8(_mm_loadl_epi64((__m128i *)(ref_pic + width_cnt - 1)),
-                                      _mm_loadl_epi64((__m128i *)(ref_pic + width_cnt))),
-                    if_coeff_1_0);
-
-                sum23 = _mm_maddubs_epi16(
-                    _mm_unpacklo_epi8(_mm_loadl_epi64((__m128i *)(ref_pic + width_cnt + 1)),
-                                      _mm_loadl_epi64((__m128i *)(ref_pic + width_cnt + 2))),
-                    if_coeff_3_2);
-
-                sum =
-                    _mm_srai_epi16(_mm_add_epi16(_mm_add_epi16(sum01, sum23), if_offset), if_shift);
-                sum_clip_u8 = _mm_packus_epi16(sum, sum);
-
-                _mm_storel_epi64((__m128i *)(dst + width_cnt), sum_clip_u8);
-            }
-        }
     }
 }
 
@@ -404,12 +328,12 @@ void avc_style_luma_interpolation_filter_vertical_ssse3_intrin(EbByte ref_pic, u
                                                                EbByte dst, uint32_t dst_stride,
                                                                uint32_t pu_width,
                                                                uint32_t pu_height, EbByte temp_buf,
-                                                               EbBool skip, uint32_t frac_pos) {
+                                                               uint32_t frac_pos) {
     (void)temp_buf;
     __m128i  if_offset, if_coeff_1_0, if_coeff_3_2, sum_clip_u8;
     uint32_t width_cnt, height_cnt;
     uint32_t if_shift        = 5;
-    uint32_t src_stride_skip = src_stride << (skip ? 1 : 0);
+
     EbByte   ref_pic_temp, dst_temp;
 
     frac_pos <<= 5;
@@ -417,8 +341,7 @@ void avc_style_luma_interpolation_filter_vertical_ssse3_intrin(EbByte ref_pic, u
     if_offset    = _mm_set1_epi16(0x0010);
     if_coeff_1_0 = _mm_loadu_si128((__m128i *)(avc_style_luma_if_coeff8_ssse3 + frac_pos - 32));
     if_coeff_3_2 = _mm_loadu_si128((__m128i *)(avc_style_luma_if_coeff8_ssse3 + frac_pos - 16));
-    dst_stride <<= skip;
-    pu_height >>= skip;
+
     if (!(pu_width & 15)) { //16x
 
         __m128i sum_lo, sum_hi, ref0, refs, ref2s, ref3s;
@@ -446,31 +369,7 @@ void avc_style_luma_interpolation_filter_vertical_ssse3_intrin(EbByte ref_pic, u
                 sum_clip_u8 = _mm_packus_epi16(sum_lo, sum_hi);
                 _mm_storeu_si128((__m128i *)(dst_temp), sum_clip_u8);
                 dst_temp += dst_stride;
-                ref_pic_temp += src_stride_skip;
-            }
-            //do the last row if sub-pred is ON.
-            if (skip) {
-                dst_temp -= (dst_stride >> 1);
-                ref_pic_temp -= (src_stride_skip >> 1);
-                {
-                    ref0  = _mm_loadu_si128((__m128i *)(ref_pic_temp));
-                    refs  = _mm_loadu_si128((__m128i *)(ref_pic_temp + src_stride));
-                    ref2s = _mm_loadu_si128((__m128i *)(ref_pic_temp + 2 * src_stride));
-                    ref3s = _mm_loadu_si128((__m128i *)(ref_pic_temp + 3 * src_stride));
-
-                    sum_lo = _mm_add_epi16(
-                        _mm_maddubs_epi16(_mm_unpacklo_epi8(ref0, refs), if_coeff_1_0),
-                        _mm_maddubs_epi16(_mm_unpacklo_epi8(ref2s, ref3s), if_coeff_3_2));
-
-                    sum_hi = _mm_add_epi16(
-                        _mm_maddubs_epi16(_mm_unpackhi_epi8(ref0, refs), if_coeff_1_0),
-                        _mm_maddubs_epi16(_mm_unpackhi_epi8(ref2s, ref3s), if_coeff_3_2));
-
-                    sum_lo      = _mm_srai_epi16(_mm_add_epi16(sum_lo, if_offset), if_shift);
-                    sum_hi      = _mm_srai_epi16(_mm_add_epi16(sum_hi, if_offset), if_shift);
-                    sum_clip_u8 = _mm_packus_epi16(sum_lo, sum_hi);
-                    _mm_storeu_si128((__m128i *)(dst_temp), sum_clip_u8);
-                }
+                ref_pic_temp += src_stride;
             }
             ref_pic += 16;
             dst += 16;
@@ -499,29 +398,7 @@ void avc_style_luma_interpolation_filter_vertical_ssse3_intrin(EbByte ref_pic, u
                 _mm_storel_epi64((__m128i *)(dst_temp), sum_clip_u8);
 
                 dst_temp += dst_stride;
-                ref_pic_temp += src_stride_skip;
-            }
-            //do the last row if sub-pred is ON.
-            if (skip) {
-                dst_temp -= (dst_stride >> 1);
-                ref_pic_temp -= (src_stride_skip >> 1);
-                {
-                    sum01 = _mm_maddubs_epi16(
-                        _mm_unpacklo_epi8(_mm_loadl_epi64((__m128i *)(ref_pic_temp)),
-                                          _mm_loadl_epi64((__m128i *)(ref_pic_temp + src_stride))),
-                        if_coeff_1_0);
-
-                    sum23 = _mm_maddubs_epi16(
-                        _mm_unpacklo_epi8(
-                            _mm_loadl_epi64((__m128i *)(ref_pic_temp + 2 * src_stride)),
-                            _mm_loadl_epi64((__m128i *)(ref_pic_temp + 3 * src_stride))),
-                        if_coeff_3_2);
-
-                    sum = _mm_srai_epi16(_mm_add_epi16(_mm_add_epi16(sum01, sum23), if_offset),
-                                         if_shift);
-                    sum_clip_u8 = _mm_packus_epi16(sum, sum);
-                    _mm_storel_epi64((__m128i *)(dst_temp), sum_clip_u8);
-                }
+                ref_pic_temp += src_stride;
             }
             ref_pic += 8;
             dst += 8;
@@ -535,70 +412,71 @@ void avc_style_luma_interpolation_filter_helper_ssse3(EbByte ref_pic, uint32_t s
                                                       EbByte temp_buf, EbBool skip,
                                                       uint32_t frac_pos,
                                                       uint8_t  fractional_position) {
+    assert(skip == EB_FALSE);
     switch (fractional_position) {
     case 0:
         avc_style_copy_sse2(
-            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, skip, frac_pos);
+            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, frac_pos);
         break;
     case 1:
         avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(
-            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, skip, frac_pos);
+            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, frac_pos);
         break;
     case 2:
         avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(
-            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, skip, frac_pos);
+            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, frac_pos);
         break;
     case 3:
         avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(
-            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, skip, frac_pos);
+            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, frac_pos);
         break;
     case 4:
         avc_style_luma_interpolation_filter_vertical_ssse3_intrin(
-            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, skip, frac_pos);
+            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, frac_pos);
         break;
     case 5:
         avc_style_luma_interpolation_filter_pose_ssse3(
-            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, skip, frac_pos);
+            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, frac_pos);
         break;
     case 6:
         avc_style_luma_interpolation_filter_posf_ssse3(
-            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, skip, frac_pos);
+            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, frac_pos);
         break;
     case 7:
         avc_style_luma_interpolation_filter_posg_ssse3(
-            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, skip, frac_pos);
+            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, frac_pos);
         break;
     case 8:
         avc_style_luma_interpolation_filter_vertical_ssse3_intrin(
-            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, skip, frac_pos);
+            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, frac_pos);
         break;
     case 9:
         avc_style_luma_interpolation_filter_posi_ssse3(
-            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, skip, frac_pos);
+            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, frac_pos);
         break;
     case 10:
         avc_style_luma_interpolation_filter_posj_ssse3(
-            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, skip, frac_pos);
+            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, frac_pos);
         break;
     case 11:
         avc_style_luma_interpolation_filter_posk_ssse3(
-            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, skip, frac_pos);
+            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, frac_pos);
         break;
     case 12:
         avc_style_luma_interpolation_filter_vertical_ssse3_intrin(
-            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, skip, frac_pos);
+            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, frac_pos);
         break;
     case 13:
         avc_style_luma_interpolation_filter_posp_ssse3(
-            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, skip, frac_pos);
+            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, frac_pos);
         break;
     case 14:
         avc_style_luma_interpolation_filter_posq_ssse3(
-            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, skip, frac_pos);
+            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, frac_pos);
         break;
     case 15:
         avc_style_luma_interpolation_filter_posr_ssse3(
-            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, skip, frac_pos);
+            ref_pic, src_stride, dst, dst_stride, pu_width, pu_height, temp_buf, frac_pos);
         break;
     default: assert(0);
     }

--- a/Source/Lib/Common/ASM_SSSE3/EbAvcStyleMcp_Intrinsic_SSSE3.c
+++ b/Source/Lib/Common/ASM_SSSE3/EbAvcStyleMcp_Intrinsic_SSSE3.c
@@ -409,10 +409,9 @@ void avc_style_luma_interpolation_filter_vertical_ssse3_intrin(EbByte ref_pic, u
 void avc_style_luma_interpolation_filter_helper_ssse3(EbByte ref_pic, uint32_t src_stride,
                                                       EbByte dst, uint32_t dst_stride,
                                                       uint32_t pu_width, uint32_t pu_height,
-                                                      EbByte temp_buf, EbBool skip,
+                                                      EbByte temp_buf,
                                                       uint32_t frac_pos,
                                                       uint8_t  fractional_position) {
-    assert(skip == EB_FALSE);
     switch (fractional_position) {
     case 0:
         avc_style_copy_sse2(

--- a/Source/Lib/Common/ASM_SSSE3/EbAvcStyleMcp_SSSE3.h
+++ b/Source/Lib/Common/ASM_SSSE3/EbAvcStyleMcp_SSSE3.h
@@ -15,57 +15,57 @@ extern "C" {
 void avc_style_luma_interpolation_filter_pose_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos);
+                                                    uint32_t frac_pos);
 
 void avc_style_luma_interpolation_filter_posf_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos);
+                                                    uint32_t frac_pos);
 
 void avc_style_luma_interpolation_filter_posg_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos);
+                                                    uint32_t frac_pos);
 
 void avc_style_luma_interpolation_filter_posi_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos);
+                                                    uint32_t frac_pos);
 
 void avc_style_luma_interpolation_filter_posj_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos);
+                                                    uint32_t frac_pos);
 
 void avc_style_luma_interpolation_filter_posk_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos);
+                                                    uint32_t frac_pos);
 
 void avc_style_luma_interpolation_filter_posp_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos);
+                                                    uint32_t frac_pos);
 
 void avc_style_luma_interpolation_filter_posq_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos);
+                                                    uint32_t frac_pos);
 
 void avc_style_luma_interpolation_filter_posr_ssse3(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                     uint32_t dst_stride, uint32_t pu_width,
                                                     uint32_t pu_height, EbByte temp_buf,
-                                                    EbBool skip, uint32_t frac_pos);
+                                                    uint32_t frac_pos);
 
 void avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(
     EbByte ref_pic, uint32_t src_stride, EbByte dst, uint32_t dst_stride, uint32_t pu_width,
-    uint32_t pu_height, EbByte temp_buf, EbBool skip, uint32_t frac_pos);
+    uint32_t pu_height, EbByte temp_buf, uint32_t frac_pos);
 
 void avc_style_luma_interpolation_filter_vertical_ssse3_intrin(EbByte ref_pic, uint32_t src_stride,
                                                                EbByte dst, uint32_t dst_stride,
                                                                uint32_t pu_width,
                                                                uint32_t pu_height, EbByte temp_buf,
-                                                               EbBool skip, uint32_t frac_pos);
+                                                               uint32_t frac_pos);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Common/Codec/EbAvcStyleMcp.c
+++ b/Source/Lib/Common/Codec/EbAvcStyleMcp.c
@@ -284,12 +284,9 @@ void avc_style_luma_interpolation_filter_posr_c(EbByte ref_pic, uint32_t src_str
 
 void avc_style_luma_interpolation_filter_helper_c(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                   uint32_t dst_stride, uint32_t pu_width,
-                                                  uint32_t pu_height, EbByte temp_buf, EbBool skip,
+                                                  uint32_t pu_height, EbByte temp_buf,
                                                   uint32_t frac_pos, uint8_t fractional_position) {
-    /* Code with 'skip' true are not used. Cleanup should remove 'skip' parameter. */
-    /* frac_pos and fractional_position are redundant as well, cleanup should also unify the two*/
-    (void)skip;
-    assert(!skip);
+    /* TODO: frac_pos and fractional_position are redundant, a cleanup should unify the two*/
 
     switch (fractional_position) {
     case 0:

--- a/Source/Lib/Common/Codec/EbAvcStyleMcp.h
+++ b/Source/Lib/Common/Codec/EbAvcStyleMcp.h
@@ -61,7 +61,7 @@ void avc_style_luma_interpolation_filter_posr_c(EbByte ref_pic, uint32_t src_str
 
 void avc_style_luma_interpolation_filter_helper_c(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                                                   uint32_t dst_stride, uint32_t pu_width,
-                                                  uint32_t pu_height, EbByte temp_buf, EbBool skip,
+                                                  uint32_t pu_height, EbByte temp_buf,
                                                   uint32_t frac_pos, uint8_t fractional_position);
 
 #ifdef __cplusplus

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.h
@@ -194,7 +194,7 @@ extern "C" {
     uint64_t full_distortion_kernel16_bits_c(uint8_t* input, uint32_t input_offset, uint32_t input_stride, uint8_t* recon, int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
     RTCD_EXTERN uint64_t(*full_distortion_kernel16_bits)(uint8_t* input, uint32_t input_offset, uint32_t input_stride, uint8_t* recon, int32_t recon_offset, uint32_t recon_stride, uint32_t area_width, uint32_t area_height);
     RTCD_EXTERN void(*residual_kernel16bit)(uint16_t *input, uint32_t input_stride, uint16_t *pred, uint32_t pred_stride, int16_t *residual, uint32_t residual_stride, uint32_t area_width, uint32_t area_height);
-    RTCD_EXTERN void(*avc_style_luma_interpolation_filter)(EbByte ref_pic, uint32_t src_stride, EbByte dst, uint32_t dst_stride, uint32_t pu_width, uint32_t pu_height, EbByte temp_buf, EbBool skip, uint32_t frac_pos, uint8_t choice);
+    RTCD_EXTERN void(*avc_style_luma_interpolation_filter)(EbByte ref_pic, uint32_t src_stride, EbByte dst, uint32_t dst_stride, uint32_t pu_width, uint32_t pu_height, EbByte temp_buf, uint32_t frac_pos, uint8_t choice);
     void eb_av1_wiener_convolve_add_src_c(const uint8_t *const src, const ptrdiff_t src_stride, uint8_t *const dst, const ptrdiff_t dst_stride, const int16_t *const filter_x, const int16_t *const filter_y, const int32_t w, const int32_t h, const ConvolveParams *const conv_params);
     RTCD_EXTERN void(*eb_av1_wiener_convolve_add_src)(const uint8_t *const src, const ptrdiff_t src_stride, uint8_t *const dst, const ptrdiff_t dst_stride, const int16_t *const filter_x, const int16_t *const filter_y, const int32_t w, const int32_t h, const ConvolveParams *const conv_params);
     void eb_av1_highbd_wiener_convolve_add_src_c(const uint8_t *const src, const ptrdiff_t src_stride, uint8_t *const dst, const ptrdiff_t dst_stride, const int16_t *const filter_x, const int16_t *const filter_y, const int32_t w, const int32_t h, const ConvolveParams *const conv_params, const int32_t bd);
@@ -1234,7 +1234,7 @@ extern "C" {
     void avc_style_luma_interpolation_filter_helper_ssse3(EbByte ref_pic, uint32_t src_stride,
         EbByte dst, uint32_t dst_stride,
         uint32_t pu_width, uint32_t pu_height,
-        EbByte temp_buf, EbBool skip,
+        EbByte temp_buf,
         uint32_t frac_pos,
         uint8_t  fractional_position);
     void eb_av1_wiener_convolve_add_src_avx2(const uint8_t *const src, const ptrdiff_t src_stride, uint8_t *const dst, const ptrdiff_t dst_stride, const int16_t *const filter_x, const int16_t *const filter_y, const int32_t w, const int32_t h, const ConvolveParams *const conv_params);

--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -4742,7 +4742,6 @@ void interpolate_search_region_avc(
             search_area_width_for_asm,
             search_area_height + ME_FILTER_TAP,
             context_ptr->avctemp_buffer,
-            EB_FALSE,
             2,
             2);
     }
@@ -4757,7 +4756,6 @@ void interpolate_search_region_avc(
             search_area_width_for_asm,
             search_area_height + 1,
             context_ptr->avctemp_buffer,
-            EB_FALSE,
             2,
             8);
     }
@@ -4772,7 +4770,6 @@ void interpolate_search_region_avc(
             search_area_width_for_asm,
             search_area_height + 1,
             context_ptr->avctemp_buffer,
-            EB_FALSE,
             2,
             8);
     }

--- a/test/AVCStyleMcpTest.cc
+++ b/test/AVCStyleMcpTest.cc
@@ -278,7 +278,6 @@ class AVCStyleMcpTestBase : public ::testing::Test {
                                                 block_width_,
                                                 block_height_,
                                                 tmp_buf_,
-                                                EB_FALSE,
                                                 2,
                                                 i);
 
@@ -290,7 +289,6 @@ class AVCStyleMcpTestBase : public ::testing::Test {
                                                 block_width_,
                                                 block_height_,
                                                 tmp_buf_,
-                                                EB_FALSE,
                                                 2,
                                                 i);
 

--- a/test/AVCStyleMcpTest.cc
+++ b/test/AVCStyleMcpTest.cc
@@ -96,7 +96,7 @@ typedef void (*MCP_REF_FUNC)(EbByte refPic, uint32_t srcStride, EbByte dst,
                              uint32_t fracPos);
 typedef void (*MCP_TEST_FUNC)(EbByte ref_pic, uint32_t src_stride, EbByte dst,
                               uint32_t dst_stride, uint32_t pu_width,
-                              uint32_t pu_height, EbByte temp_buf, EbBool skip,
+                              uint32_t pu_height, EbByte temp_buf,
                               uint32_t frac_pos);
 
 typedef struct {
@@ -245,7 +245,6 @@ class AVCStyleMcpTestBase : public ::testing::Test {
                                                      block_width_,
                                                      block_height_,
                                                      tmp_buf_,
-                                                     EB_FALSE,
                                                      2);
 
             int fail_pixel_Count = 0;

--- a/test/AVCStyleMcpTest.cc
+++ b/test/AVCStyleMcpTest.cc
@@ -90,19 +90,15 @@ SearchArea TEST_AREAS[] = {SearchArea(64, 64),
 
 PUSize TEST_PU_HELPER[] = {PUSize(64, 64)};
 
-typedef void (*MCP_REF_FUNC)(EbByte refPic, uint32_t srcStride, EbByte dst,
+typedef void (*MCP_FUNC)(EbByte refPic, uint32_t srcStride, EbByte dst,
                              uint32_t dstStride, uint32_t puWidth,
                              uint32_t puHeight, EbByte tempBuf,
                              uint32_t fracPos);
-typedef void (*MCP_TEST_FUNC)(EbByte ref_pic, uint32_t src_stride, EbByte dst,
-                              uint32_t dst_stride, uint32_t pu_width,
-                              uint32_t pu_height, EbByte temp_buf,
-                              uint32_t frac_pos);
 
 typedef struct {
     const char *name;
-    MCP_REF_FUNC ref_func;
-    MCP_TEST_FUNC test_func;
+    MCP_FUNC ref_func;
+    MCP_FUNC test_func;
 } AVCStyleMcpFuncPair;
 static const AVCStyleMcpFuncPair AVC_style_c_sse3_func_pairs[] = {
     {"posA", avc_style_copy_c, avc_style_copy_sse2},


### PR DESCRIPTION
**UPDATE**: This PR was updated to remove the skip parameter, see discussion. This makes the issue detailed below obsolete.

There is a tautology in the `avc_style_luma_interpolation_filter_posj_ssse3` function:

```
    if (skip)
        avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(ref_pic - src_stride,
                                                                    src_stride,
                                                                    temp_buf,
                                                                    pu_width,
                                                                    pu_width,
                                                                    (pu_height + 3),
                                                                    0,
                                                                    EB_FALSE,
                                                                    2);
    else
        avc_style_luma_interpolation_filter_horizontal_ssse3_intrin(
            ref_pic - src_stride,
            src_stride,
            temp_buf,
            pu_width,
            pu_width,
            skip ? (2 * pu_height + 3) : (pu_height + 3),
            0,
            EB_FALSE,
            2);
```

If `skip` is true, the first branch is taken, calls `avc_style_luma_interpolation_filter_horizontal_ssse3_intrin` with `(pu_height + 3)`.

If `skip` is false, the second branch is taken, calls
`avc_style_luma_interpolation_filter_horizontal_ssse3_intrin` with `(pu_height + 3)`.

So there is no difference between the two branches, making them useless.
Additionally `avc_style_luma_interpolation_filter_horizontal_ssse3_intrin` has a skip parameter, why is that not used here? Is it not applicable?
Which variant of the code is correct? Maybe it was actually supposed to do what was done in the second branch and call `avc_style_luma_interpolation_filter_horizontal_ssse3_intrin` with `(2 * pu_height + 3)` when `skip` is true?