### PR TITLE
EbAppMain, Ebthreads: use lowercase windows.h for case sensitive systems

### DIFF
--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -24,7 +24,7 @@
 #include "EbTime.h"
 #include "EbAppString.h"
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #include <io.h> /* _setmode() */
 #include <fcntl.h> /* _O_BINARY */
 #else

--- a/Source/Lib/Common/Codec/EbThreads.h
+++ b/Source/Lib/Common/Codec/EbThreads.h
@@ -9,7 +9,7 @@
 #include "EbDefinitions.h"
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
On nix systems with mingw-w64, gcc will error out on `Windows.h` since they do not do case insensitive include search