### PR TITLE
fix a bug of altref_strength calculation

### DIFF
--- a/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
@@ -2512,15 +2512,14 @@ static void adjust_filter_strength(PictureParentControlSet *picture_control_set_
         }
         adj_strength += noiselevel_adj;
     }
-
+    // Decrease the filter strength for low QPs
+    if (picture_control_set_ptr_central->scs_ptr->static_config.qp <= ALT_REF_QP_THRESH){
+        adj_strength = adj_strength - 1;
+    }
     if (adj_strength > 0)
         strength = adj_strength;
     else
         strength = 0;
-    // Decrease the filter strength for low QPs
-    if (picture_control_set_ptr_central->scs_ptr->static_config.qp <= ALT_REF_QP_THRESH){
-        strength = strength - 1;
-    }
     // if highbd, adjust filter strength strength = strength + 2*(bit depth - 8)
     if (is_highbd) strength = strength + 2 * (encoder_bit_depth - 8);
 


### PR DESCRIPTION
altref_strength is defined as unsigned integer, but it can be calculated as negative (-1) if in the case that low QP (<=20) and --altref-strength is set to 1 or 0