### PR TITLE
GCC10: Fix issues related to common symbols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: ['gcc-7', 'gcc-8', 'gcc-9', 'clang-6', 'clang-10']
+        compiler: ['gcc-7', 'gcc-8', 'gcc-9', 'gcc-10', 'clang-6', 'clang-10']
         include:
           - compiler: gcc-7
             packages: gcc-7 g++-7
@@ -27,6 +27,13 @@ jobs:
             env:
               CC: 'ccache gcc-9'
               CXX: 'ccache g++-9'
+          - compiler: gcc-10
+            packages: gcc
+            env:
+              CC: ccache gcc
+              CXX: ccache g++
+              CFLAGS: -fno-common
+              CXXFLAGS: -fno-common
           - compiler: clang-6
             packages: ''
             env:

--- a/Source/Lib/Common/Codec/EbThreads.h
+++ b/Source/Lib/Common/Codec/EbThreads.h
@@ -52,9 +52,6 @@ extern EbMemoryMapEntry *memory_map; // library Memory table
 extern uint32_t *        memory_map_index; // library memory index
 extern uint64_t *        total_lib_memory; // library Memory malloc'd
 #ifdef _WIN32
-extern GROUP_AFFINITY group_affinity;
-extern uint8_t        num_groups;
-extern EbBool         alternate_groups;
 
 #define EB_CREATE_THREAD(pointer, thread_function, thread_context)   \
     do {                                                             \
@@ -78,7 +75,6 @@ extern EbBool         alternate_groups;
 #endif
 #include <sched.h>
 #include <pthread.h>
-extern cpu_set_t group_affinity;
 #define EB_CREATE_THREAD(pointer, thread_function, thread_context)                           \
     do {                                                                                     \
         pointer = eb_create_thread(thread_function, thread_context);                         \

--- a/Source/Lib/Common/Codec/common_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/common_dsp_rtcd.h
@@ -178,7 +178,8 @@ extern "C" {
     RTCD_EXTERN void(*convert_8bit_to_16bit)(uint8_t *src, uint32_t src_stride, uint16_t *dst, uint32_t dst_stride, uint32_t width, uint32_t height);
     void convert_8bit_to_16bit_avx2(uint8_t* src, uint32_t src_stride, uint16_t* dst,uint32_t dst_stride, uint32_t width, uint32_t height);
     RTCD_EXTERN void(*convert_16bit_to_8bit)(uint16_t *src, uint32_t src_stride, uint8_t *dst, uint32_t dst_stride, uint32_t width, uint32_t height);
-    void convert_16bit_to_8bit_avx2(uint16_t *src, uint32_t src_stride, uint8_t *dst, uint32_t dst_stride, uint32_t width, uint32_t height);    RTCD_EXTERN void(*pack2d_16_bit_src_mul4)(uint8_t *in8_bit_buffer, uint32_t in8_stride, uint8_t *inn_bit_buffer, uint16_t *out16_bit_buffer, uint32_t inn_stride, uint32_t out_stride, uint32_t width, uint32_t height);
+    void convert_16bit_to_8bit_avx2(uint16_t *src, uint32_t src_stride, uint8_t *dst, uint32_t dst_stride, uint32_t width, uint32_t height);
+    RTCD_EXTERN void(*pack2d_16_bit_src_mul4)(uint8_t *in8_bit_buffer, uint32_t in8_stride, uint8_t *inn_bit_buffer, uint16_t *out16_bit_buffer, uint32_t inn_stride, uint32_t out_stride, uint32_t width, uint32_t height);
     RTCD_EXTERN void(*un_pack2d_16_bit_src_mul4)(uint16_t *in16_bit_buffer, uint32_t in_stride, uint8_t *out8_bit_buffer, uint8_t *outn_bit_buffer, uint32_t out8_stride, uint32_t outn_stride, uint32_t width, uint32_t height);
     void residual_kernel8bit_c(uint8_t *input, uint32_t input_stride, uint8_t *pred, uint32_t pred_stride, int16_t *residual, uint32_t residual_stride, uint32_t area_width, uint32_t area_height);
     RTCD_EXTERN void(*residual_kernel8bit)(uint8_t *input, uint32_t input_stride, uint8_t *pred, uint32_t pred_stride, int16_t *residual, uint32_t residual_stride, uint32_t area_width, uint32_t area_height);

--- a/Source/Lib/Decoder/Codec/EbDecHandle.c
+++ b/Source/Lib/Decoder/Codec/EbDecHandle.c
@@ -82,7 +82,7 @@ void        dec_sync_all_threads(EbDecHandle *dec_handle_ptr);
 EbErrorType decode_multiple_obu(EbDecHandle *dec_handle_ptr, uint8_t **data, size_t data_size,
                                 uint32_t is_annexb);
 
-void switch_to_real_time() {
+static void dec_switch_to_real_time() {
 #ifndef _WIN32
 
     struct sched_param schedParam = {.sched_priority = 99};
@@ -467,7 +467,7 @@ static EbErrorType init_svt_av1_decoder_handle(EbComponentType *hComponent) {
     SVT_LOG("LIB Build date: %s %s\n", __DATE__, __TIME__);
     SVT_LOG("-------------------------------------------\n");
 
-    switch_to_real_time();
+    dec_switch_to_real_time();
 
     // Set Component Size & Version
     svt_dec_component->size = sizeof(EbComponentType);

--- a/Source/Lib/Decoder/Codec/EbDecHandle.c
+++ b/Source/Lib/Decoder/Codec/EbDecHandle.c
@@ -39,18 +39,12 @@
 /**************************************
 * Globals
 **************************************/
-uint8_t num_groups = 0;
 #ifdef _WIN32
+uint8_t        num_groups = 0;
 GROUP_AFFINITY group_affinity;
 EbBool         alternate_groups = 0;
 #elif defined(__linux__)
 cpu_set_t group_affinity;
-typedef struct logicalProcessorGroup {
-    uint32_t num;
-    uint32_t group[1024];
-} processorGroup;
-#define INITIAL_PROCESSOR_GROUP 16
-processorGroup *lp_group = NULL;
 #endif
 
 EbMemoryMapEntry *svt_dec_memory_map;

--- a/Source/Lib/Decoder/Codec/EbDecParseObu.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseObu.c
@@ -15,6 +15,7 @@
 */
 
 #include <stdlib.h>
+#include <limits.h>
 
 #include "EbDefinitions.h"
 #include "EbUtility.h"
@@ -64,8 +65,6 @@ void dec_av1_loop_restoration_filter_frame_mt(EbDecHandle *dec_handle,
                                               DecThreadCtxt *thread_ctxt);
 
 #define CONFIG_MAX_DECODE_PROFILE 2
-
-#define INT_MAX 2147483647 // maximum (signed) int value
 
 void dec_init_intra_predictors_12b_internal(void);
 

--- a/Source/Lib/Decoder/Codec/EbDecProcess.c
+++ b/Source/Lib/Decoder/Codec/EbDecProcess.c
@@ -34,6 +34,13 @@
 
 #include <stdlib.h>
 
+#ifdef _WIN32
+extern uint8_t        num_groups;
+extern GROUP_AFFINITY group_affinity;
+extern EbBool         alternate_groups;
+#elif defined(__linux__)
+extern cpu_set_t      group_affinity;
+#endif
 void *dec_all_stage_kernel(void *input_ptr);
 /*ToDo : Remove all these replications */
 void eb_av1_loop_filter_frame_init(FrameHeader *frm_hdr, LoopFilterInfoN *lfi, int32_t plane_start,

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -18,6 +18,7 @@
 * Includes
 ***************************************/
 #include <stdlib.h>
+#include <limits.h>
 
 #include "EbCommonUtils.h"
 #include "EbSequenceControlSet.h"
@@ -42,7 +43,6 @@
 
 int8_t av1_ref_frame_type(const MvReferenceFrame *const rf);
 int    av1_filter_intra_allowed_bsize(uint8_t enable_filter_intra, BlockSize bs);
-#define INT_MAX 2147483647 // maximum (signed) int value
 
 void av1_set_ref_frame(MvReferenceFrame *rf, int8_t ref_frame_type);
 

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -3806,7 +3806,7 @@ uint8_t get_end_tx_depth(BlockSize bsize) {
     return tx_depth;
 }
 
-uint8_t allowed_tx_set_a[TX_SIZES_ALL][TX_TYPES];
+extern uint8_t allowed_tx_set_a[TX_SIZES_ALL][TX_TYPES];
 
 void tx_initialize_neighbor_arrays(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
                                    EbBool is_inter) {

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
@@ -14,7 +14,7 @@
 * PATENTS file, you can obtain it at www.aomedia.org/license/patent.
 */
 
-#define RTCD_C
+#define AOM_RTCD_C
 #include "aom_dsp_rtcd.h"
 #include "EbComputeSAD_C.h"
 #include "EbPictureAnalysisProcess.h"

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
@@ -23,7 +23,8 @@
 #include "EbDefinitions.h"
 #include "EbCodingUnit.h"
 
-#ifdef RTCD_C
+#undef RTCD_EXTERN
+#ifdef AOM_RTCD_C
 #define RTCD_EXTERN                //CHKN RTCD call in effect. declare the function pointers in  encHandle.
 #else
 #define RTCD_EXTERN extern         //CHKN run time externing the fucntion pointers.
@@ -509,8 +510,6 @@ extern "C" {
     RTCD_EXTERN void(*eb_aom_fft8x8_float)(const float *input, float *temp, float *output);
     void eb_av1_get_nz_map_contexts_c(const uint8_t *const levels, const int16_t *const scan, const uint16_t eob, const TxSize tx_size, const TxClass tx_class, int8_t *const coeff_contexts);
     RTCD_EXTERN void(*eb_av1_get_nz_map_contexts)(const uint8_t *const levels, const int16_t *const scan, const uint16_t eob, const TxSize tx_size, const TxClass tx_class, int8_t *const coeff_contexts);
-    void residual_kernel8bit_c(uint8_t *input, uint32_t input_stride, uint8_t *pred, uint32_t pred_stride, int16_t *residual, uint32_t residual_stride, uint32_t area_width, uint32_t area_height);
-    RTCD_EXTERN void(*residual_kernel8bit)(uint8_t *input, uint32_t input_stride, uint8_t *pred, uint32_t pred_stride, int16_t *residual, uint32_t residual_stride, uint32_t area_width, uint32_t area_height);
     RTCD_EXTERN void(*sad_loop_kernel)(uint8_t *src, uint32_t src_stride, uint8_t *ref, uint32_t ref_stride, uint32_t block_height, uint32_t block_width, uint64_t *best_sad, int16_t *x_search_center, int16_t *y_search_center, uint32_t src_stride_raw, int16_t search_area_width, int16_t search_area_height);
     RTCD_EXTERN void(*sad_loop_kernel_sparse)(uint8_t *src, uint32_t src_stride, uint8_t *ref, uint32_t ref_stride, uint32_t block_height, uint32_t block_width, uint64_t *best_sad, int16_t *x_search_center, int16_t *y_search_center, uint32_t src_stride_raw, int16_t search_area_width, int16_t search_area_height);
     RTCD_EXTERN void(*sad_loop_kernel_hme_l0)(uint8_t *src, uint32_t src_stride, uint8_t *ref, uint32_t ref_stride, uint32_t block_height, uint32_t block_width, uint64_t *best_sad, int16_t *x_search_center, int16_t *y_search_center, uint32_t src_stride_raw, int16_t search_area_width, int16_t search_area_height);
@@ -559,7 +558,6 @@ extern "C" {
     RTCD_EXTERN uint32_t(*nxm_sad_kernel_sub_sampled)(const uint8_t *src, uint32_t src_stride, const uint8_t *ref, uint32_t ref_stride, uint32_t height, uint32_t width);
     RTCD_EXTERN uint32_t(*nxm_sad_kernel)(const uint8_t *src, uint32_t src_stride, const uint8_t *ref, uint32_t ref_stride, uint32_t height, uint32_t width);
     RTCD_EXTERN uint32_t(*nxm_sad_avg_kernel)(uint8_t *src, uint32_t src_stride, uint8_t *ref1, uint32_t ref1_stride, uint8_t *ref2, uint32_t ref2_stride, uint32_t height, uint32_t width);
-    RTCD_EXTERN void(*avc_style_luma_interpolation_filter)(EbByte ref_pic, uint32_t src_stride, EbByte dst, uint32_t dst_stride, uint32_t pu_width, uint32_t pu_height, EbByte temp_buf, EbBool skip, uint32_t frac_pos, uint8_t fractional_position);
     RTCD_EXTERN uint64_t(*compute_mean_8x8)(uint8_t *input_samples, uint32_t input_stride, uint32_t input_area_width, uint32_t input_area_height);
     RTCD_EXTERN uint64_t(*compute_mean_square_values_8x8)(uint8_t *input_samples, uint32_t input_stride, uint32_t input_area_width, uint32_t input_area_height);
     RTCD_EXTERN uint64_t(*compute_sub_mean_8x8)(uint8_t* input_samples, uint16_t input_stride);

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -97,19 +97,18 @@
 /**************************************
  * Globals
  **************************************/
-
-uint8_t                          num_groups = 0;
+static uint8_t                   num_groups = 0;
 #ifdef _WIN32
-GROUP_AFFINITY                   group_affinity;
-EbBool                           alternate_groups = 0;
+static GROUP_AFFINITY            group_affinity;
+static EbBool                    alternate_groups = 0;
 #elif defined(__linux__)
-cpu_set_t                        group_affinity;
+static cpu_set_t                 group_affinity;
 typedef struct logicalProcessorGroup {
     uint32_t num;
     uint32_t group[1024];
-}processorGroup;
+} processorGroup;
 #define INITIAL_PROCESSOR_GROUP 16
-processorGroup                  *lp_group = NULL;
+static processorGroup           *lp_group = NULL;
 #endif
 
 static const char *get_asm_level_name_str(CPU_FLAGS cpu_flags) {

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -309,7 +309,7 @@ void init_intra_dc_predictors_c_internal(void);
 void init_intra_predictors_internal(void);
 void eb_av1_init_me_luts(void);
 
-void switch_to_real_time(){
+static void enc_switch_to_real_time(){
 #ifndef _WIN32
 
     struct sched_param schedParam = {
@@ -3657,7 +3657,7 @@ EbErrorType init_svt_av1_encoder_handle(
     SVT_LOG("LIB Build date: %s %s\n", __DATE__, __TIME__);
     SVT_LOG("-------------------------------------------\n");
 
-    switch_to_real_time();
+    enc_switch_to_real_time();
 
     // Set Component Size & Version
     svt_enc_component->size = sizeof(EbComponentType);


### PR DESCRIPTION
Closes #999

The issue is caused by the fact that `aom_dsp_rtcd.h` includes `common_dsp_rtcd.h`, and use the same define to trigger using `extern`, causing `aom_dsp_rtcd.o` to have the same function pointers as `common_dsp_rtcd.o`