### PR TITLE
Remove the macro for 31B

### DIFF
--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -546,12 +546,12 @@ EbErrorType load_default_buffer_configuration_settings(
 
         //Pa-References.Min to sustain flow (RA-5L-MRP-ON) -->TODO: derive numbers for other GOP Structures.
         min_paref = 25 +  scs_ptr->scd_delay + eos_delay;
-#if MRP_31B_SUPPORT
+
         if (scs_ptr->static_config.hierarchical_levels == 5 &&
             core_count == SINGLE_CORE_COUNT) {
             min_paref += 8;
         }
-#endif
+
         if (scs_ptr->static_config.enable_overlays)
             min_paref *= 2;
 


### PR DESCRIPTION
The macro "MRP_31B_SUPPORT" is removed in EbDefinition.h (enabled by default), so remove it here.

When I submit the previous PR #1265 (31B hang related) for review, the macro is there.
When merging the PR #1265, the macro is removed by some other PR , so it will still hang for 31B

Signed-off-by: Jing Li <jing.b.li@intel.com>