### PR TITLE
Travis CI: Move to GCC 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ jobs:
       arch: s390x
     # Valgrind on Linux
     - name: Valgrind
-      env: build_type=debug
+      env: build_type=debug CC=gcc-10 CXX=g++-10
       addons:
         apt:
           update: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ git:
 addons:
   apt:
     update: true
+    sources:
+      - sourceline: "ppa:ubuntu-toolchain-r/test"
     packages:
-      - &native_deps cmake yasm
+      - &native_deps cmake yasm gcc-9 g++-9
   homebrew:
     update: true
     packages:
@@ -94,7 +96,7 @@ jobs:
     - name: Arm64 GCC 9 build
       env: build_type=release CC=gcc-9 CXX=g++-9
       arch: arm64
-    - name: PowerPC GCC 7 build
+    - name: PowerPC GCC 9 build
       env: build_type=release CC=gcc-9 CXX=g++-9
       arch: ppc64le
     - name: IBM Z GCC 9 build

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,14 +91,14 @@ jobs:
         - *base_script
         - *10bit_test
     # Multiple CPU Architectures
-    - name: Arm64 GCC 7 build
-      env: build_type=release CC=gcc-7 CXX=g++-7
+    - name: Arm64 GCC 9 build
+      env: build_type=release CC=gcc-9 CXX=g++-9
       arch: arm64
     - name: PowerPC GCC 7 build
-      env: build_type=release CC=gcc-7 CXX=g++-7
+      env: build_type=release CC=gcc-9 CXX=g++-9
       arch: ppc64le
-    - name: IBM Z GCC 7 build
-      env: build_type=release CC=gcc-7 CXX=g++-7
+    - name: IBM Z GCC 9 build
+      env: build_type=release CC=gcc-9 CXX=g++-9
       arch: s390x
     # Valgrind on Linux
     - name: Valgrind

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
     sources:
       - sourceline: "ppa:ubuntu-toolchain-r/test"
     packages:
-      - &native_deps cmake yasm gcc-9 g++-9
+      - &native_deps cmake yasm gcc-10 g++-10
   homebrew:
     update: true
     packages:
@@ -93,20 +93,23 @@ jobs:
         - *base_script
         - *10bit_test
     # Multiple CPU Architectures
-    - name: Arm64 GCC 9 build
-      env: build_type=release CC=gcc-9 CXX=g++-9
+    - name: Arm64 GCC 10 build
+      env: build_type=release CC=gcc-10 CXX=g++-10
       arch: arm64
-    - name: PowerPC GCC 9 build
-      env: build_type=release CC=gcc-9 CXX=g++-9
+    - name: PowerPC GCC 10 build
+      env: build_type=release CC=gcc-10 CXX=g++-10
       arch: ppc64le
-    - name: IBM Z GCC 9 build
-      env: build_type=release CC=gcc-9 CXX=g++-9
+    - name: IBM Z GCC 10 build
+      env: build_type=release CC=gcc-10 CXX=g++-10
       arch: s390x
     # Valgrind on Linux
     - name: Valgrind
       env: build_type=debug
       addons:
         apt:
+        update: true
+          sources:
+            - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:
             - *native_deps
             - valgrind

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ jobs:
       env: build_type=debug
       addons:
         apt:
-        update: true
+          update: true
           sources:
             - sourceline: "ppa:ubuntu-toolchain-r/test"
           packages:


### PR DESCRIPTION
Yesterday GCC 10.1 was [migrated](https://tracker.debian.org/news/1143538/gcc-10-1010-1-migrated-to-testing/) to [Debian Testing](https://tracker.debian.org/pkg/gcc-10), which makes updating the CI fairly simple.

Use GCC 10 with the build jobs on Arm64, PowerPC and IBM Z, as well as with the Valgrind job.

The PowerPC jobs produces some new notes (light warnings) with GCC 10, other than that all runs pass.
