### PR TITLE
ConfigureGitVersion: Remove --broken

### DIFF
--- a/Source/Lib/Common/Codec/ConfigureGitVersion.cmake
+++ b/Source/Lib/Common/Codec/ConfigureGitVersion.cmake
@@ -16,11 +16,11 @@
 set(PACKAGE_VERSION_STRING "v${PACKAGE_VERSION_STRING}")
 
 find_package(Git QUIET)
-if((Git_FOUND) AND (EXISTS "${GIT_ROOT_DIR}/.git"))
+if(Git_FOUND AND EXISTS "${GIT_ROOT_DIR}/.git")
     execute_process(COMMAND
         ${GIT_EXECUTABLE}  -C ${GIT_ROOT_DIR}
             describe
-            --tags --dirty --broken --abbrev
+            --tags --dirty --abbrev
             --match "v[0-9].[0-9]*"
         RESULT_VARIABLE git_describe_status
         OUTPUT_VARIABLE git_describe_output


### PR DESCRIPTION
git describe only supports `--broken` if git's version is greater than 2.13.7, else it will print out
```none
  Failure to get version from Git: error: unknown option `broken'
  usage: git describe [<options>] [<commit-ish>...]
     or: git describe [<options>] --dirty
...
<rest of git describe -h>
```