### PR TITLE
Add unit tests and e2e tests for MacOS CI

### DIFF
--- a/.ci/ci.sh
+++ b/.ci/ci.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 
-[ -d "$HOME/.ccache" ] && sudo chown -R $USER: $HOME/.ccache
+if [[ $NOTROOT != 1 ]]; then
+  SUDO=sudo
+fi
+
+[ -d "$HOME/.ccache" ] && $SUDO chown -R $USER: $HOME/.ccache
 export parent_dir=$PWD
 mkdir -p $parent_dir/Build/linux/${build_type:=Release}
 cmake -S $parent_dir -B $parent_dir/Build/linux/$build_type -G"${generator:-Unix Makefiles}" -DCMAKE_BUILD_TYPE=$build_type -DBUILD_SHARED_LIBS=${shared_libs:-ON} -DBUILD_TESTING=${testing:-OFF} ${CMAKE_EFLAGS}
 cmake -j$(nproc) --build $parent_dir/Build/linux/$build_type
-sudo cmake --build $parent_dir/Build/linux/$build_type --target install
+$SUDO cmake --build $parent_dir/Build/linux/$build_type --target install
 $parent_dir/Bin/$build_type/SvtAv1EncApp -help

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,3 +42,65 @@ jobs:
 
     - name: Install
       run: sudo cmake --build Build --config "${build_type:=Release}" --target install
+
+  unit-tests:
+    runs-on: [self-hosted, macos]
+    env:
+      CC: 'ccache gcc'
+      CXX: 'ccache g++'
+      # Build unit tests
+      testing: 'ON'
+      NOTROOT: 1
+    name: 'Unit Tests (MacOS, GCC)'
+    steps:
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install ${native_deps}
+      - uses: actions/checkout@v2
+      - name: Cache ccache files
+        uses: actions/cache@v1.1.2
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-unit-tests-${{ hashFiles('**/*.c') }}
+          restore-keys: ${{ runner.os }}-unit-tests-
+      - name: Compile SVT-AV1 (Release, Tests)
+        run: |
+          chmod +x .ci/ci.sh
+          .ci/ci.sh
+      - name: Run unit tests
+        run: |
+          export GTEST_TOTAL_SHARDS=10
+          seq 0 $(( $GTEST_TOTAL_SHARDS - 1 )) | xargs -n 1 -P 10 -I{} env GTEST_SHARD_INDEX={} ./Bin/Release/SvtAv1UnitTests
+          unset GTEST_TOTAL_SHARDS
+
+  e2e-tests:
+    runs-on: [self-hosted, macos]
+    env:
+      CC: 'ccache gcc'
+      CXX: 'ccache g++'
+      # Build unit tests
+      testing: 'ON'
+      NOTROOT: 1
+    name: 'E2E Tests (MacOS, GCC)'
+    steps:
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install ${native_deps}
+      - uses: actions/checkout@v2
+      - name: Cache ccache files
+        uses: actions/cache@v1.1.2
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-e2e-${{ hashFiles('**/*.c') }}
+          restore-keys: ${{ runner.os }}-e2e-
+      - name: Compile SVT-AV1 (Release, Tests and TestVectors)
+        run: |
+          chmod +x .ci/ci.sh
+          .ci/ci.sh
+          pushd ./Build/linux/Release
+          make TestVectors
+          popd
+      - name: Run e2e tests
+        run: env SVT_AV1_TEST_VECTOR_PATH="./test/vectors" ./Bin/Release/SvtAv1E2ETests --gtest_filter=-*DummySrcTest*


### PR DESCRIPTION
1. add unit test and e2e tests in MacOS CI
2. modified ci.sh to run without root

For self-hosted runner in GitHub CI workflow, please refer to offical guide:
https://help.github.com/en/actions/hosting-your-own-runners/adding-self-hosted-runners