### PR TITLE
EbAppConfig: Support double dashes for hme 

### DIFF
--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -69,7 +69,7 @@ A text file that contains encoder parameters such as input file name, quantizati
 
 `-i filename` **[Required]**
 
-A YUV file (e.g. 8 bit 4:2:0 planar) containing the video sequence that will be encoded. The dimensions of each image are specified by `–w` and `–h` as indicated below.
+A YUV file (e.g. 8 bit 4:2:0 planar) containing the video sequence that will be encoded. The dimensions of each image are specified by `-w` and `-h` as indicated below.
 
 `-b filename` **[Optional]**
 
@@ -87,17 +87,17 @@ The height of each input image in units of picture luma pixels, e.g. 1080
 
 The number of frames of the sequence to encode. e.g. 100. If the input frame count is larger than the number of frames in the input video, the encoder will loopback to the first frame when it is done.
 
-`-intra-period integer` **[Optional]**
+`--keyint integer` **[Optional]**
 
 The intra period defines the interval of frames after which you insert an Intra refresh. It is strongly recommended to use (multiple of 8) -1 the closest to 1 second (e.g. 55, 47, 31, 23 should be used for 60, 50, 30, (24 or 25) respectively). When using closed gop (-irefresh-type 2) add 1 to the value above (e.g. 56 instead of 55).
 
-`-rc integer` **[Optional]**
+`--rc integer` **[Optional]**
 
-This token sets the bitrate control encoding mode [1: Variable Bitrate, 0: Constant QP]. When `-rc` is set to 1, it is best to match the `–lad` (lookahead distance described in the next section) parameter to the `-intra-period`. When `–rc` is set to 0, a qp value is expected with the use of the `–q` command line option otherwise a default value is assigned (25).
+This token sets the bitrate control encoding mode [1: Variable Bitrate, 0: Constant QP]. When `--rc` is set to 1, it is best to match the `--lookahead` (lookahead distance described in the next section) parameter to the `--keyint`. When `--rc` is set to 0, a qp value is expected with the use of the `-q` command line option otherwise a default value is assigned (25).
 
 For example, the following command encodes 100 frames of the YUV video sequence into the bin bit stream file. The picture is 1920 luma pixels wide and 1080 pixels high using the `Sample.cfg` configuration. The QP equals 30 and the md5 checksum is not included in the bit stream.
 
-`SvtAv1EncApp.exe -c Sample.cfg -i CrowdRun\_1920x1080.yuv -w 1920 -h 1080 -n 100 -q 30 -intra-period 31 -b CrowdRun\_1920x1080\_qp30.bin`
+`SvtAv1EncApp.exe -c Sample.cfg -i CrowdRun_1920x1080.yuv -w 1920 -h 1080 -n 100 -q 30 --keyint 31 -b CrowdRun_1920x1080_qp30.bin`
 
 It should be noted that not all the encoder parameters present in the `Sample.cfg` can be changed using the command line.
 
@@ -106,14 +106,14 @@ It should be noted that not all the encoder parameters present in the `Sample.cf
 Here are some sample encode command lines
 
 #### 1 pass fixed QP at maximum speed from 24fps yuv 1920x1080 input
-`SvtAv1EncApp -i input.yuv -w 1920 -h 1080 -fps 24 -rc 0 -q 30 -enc-mode 8 -b output.ivf`
+`SvtAv1EncApp -i input.yuv -w 1920 -h 1080 --fps 24 --rc 0 -q 30 --preset 8 -b output.ivf`
 
 #### 1 pass VBR 10000 Kbps at medium speed from 24fps yuv 1920x1080 input
-`SvtAv1EncApp -i input.yuv -w 1920 -h 1080 -fps 24 -rc 2 -tbr 10000 -enc-mode 5 -b output.ivf`
+`SvtAv1EncApp -i input.yuv -w 1920 -h 1080 --fps 24 --rc 2 --tbr 10000 --preset 5 -b output.ivf`
 
 #### 2 pass fixed QP at maximum quality from 24fps yuv 1920x1080 input
-`SvtAv1EncApp -i input.yuv -w 1920 -h 1080 -fps 24 -rc 0 -q 30 -enc-mode 8 -b output.ivf -output-stat-file stat_file.stat`
-`SvtAv1EncApp -i input.yuv -w 1920 -h 1080 -fps 24 -rc 0 -q 30 -enc-mode 0 -b output.ivf -input-stat-file stat_file.stat`
+`SvtAv1EncApp -i input.yuv -w 1920 -h 1080 --fps 24 --rc 0 -q 30 --preset 8 -b output.ivf --output-stat-file stat_file.stat`
+`SvtAv1EncApp -i input.yuv -w 1920 -h 1080 --fps 24 --rc 0 -q 30 --preset 0 -b output.ivf --input-stat-file stat_file.stat`
 
 ### List of all configuration parameters
 
@@ -136,7 +136,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **SourceWidth** | -w | [64 - 4096] | None | Input source width |
 | **SourceHeight** | -h | [0 - 2304] | None | Input source height |
 | **FrameToBeEncoded** | -n | [0 - 2^64 -1] | 0 | Number of frames to be encoded, if number of frames is > number of frames in file, the encoder will loop to the beginning and continue the encode. Use -1 to not buffer. |
-| **BufferedInput** | --nb | [-1, 1 to 2^31 -1] | -1 | number of frames to preload to the RAM before the start of the encode If -nb = 100 and -n 1000 -- > the encoder will encode the first 100 frames of the video 10 times |
+| **BufferedInput** | --nb | [-1, 1 to 2^31 -1] | -1 | number of frames to preload to the RAM before the start of the encode If --nb = 100 and -n 1000 -- > the encoder will encode the first 100 frames of the video 10 times |
 | **EncoderColorFormat** | --color-format | [1 for default] | 1 | Set encoder color format(EB_YUV400, EB_YUV420, EB_YUV422, EB_YUV444) |
 | **Profile** | --profile | [0-2, 0 for default] | 0 | Bitstream profile number to use (0: main profile[default], 1: high profile, 2: professional profile) |
 | **FrameRate** | --fps | [0 - 2^64 -1] | 25 | If the number is less than 1000, the input frame rate is an integer number between 1 and 60, else the input number is in Q16 format (shifted by 16 bits) [Max allowed is 240 fps] |
@@ -225,33 +225,33 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **HMELevel1** | --hme-l1 | [0 - 1] | Depends on input resolution | Enable HME Level 1 , 0 = OFF, 1 = ON |
 | **HMELevel2** | --hme-l2 | [0 - 1] | Depends on input resolution | Enable HME Level 2 , 0 = OFF, 1 = ON |
 | **ExtBlockFlag** | --ext-block | [0 - 1] | Depends on --preset | Enable the non-square block 0=OFF, 1= ON |
-| **SearchAreaWidth** | --search-w | [1 - 256] | Depends on input resolution | Search Area in Width |
-| **SearchAreaHeight** | --search-h | [1 - 256] | Depends on input resolution | Search Area in Height |
+| **SearchAreaWidth** | --search-w | [1 - 480] | Depends on input resolution | Search Area in Width |
+| **SearchAreaHeight** | --search-h | [1 - 480] | Depends on input resolution | Search Area in Height |
 | **NumberHmeSearchRegionInWidth** | --num-hme-w | [1 - 2] | Depends on input resolution | Search Regions in Width |
 | **NumberHmeSearchRegionInHeight** | --num-hme-h | [1 - 2] | Depends on input resolution | Search Regions in Height |
-| **HmeLevel0TotalSearchAreaWidth** | --hme-tot-l0-w | [1 - 256] | Depends on input resolution | Total HME Level 0 Search Area in Width |
-| **HmeLevel0TotalSearchAreaHeight** | --hme-tot-l0-h | [1 - 256] | Depends on input resolution | Total HME Level 1 Search Area in Width |
+| **HmeLevel0TotalSearchAreaWidth** | --hme-tot-l0-w | [1 - 480] | Depends on input resolution | Total HME Level 0 Search Area in Width |
+| **HmeLevel0TotalSearchAreaHeight** | --hme-tot-l0-h | [1 - 480] | Depends on input resolution | Total HME Level 1 Search Area in Width |
 | **ScreenContentMode** | --scm | [0 - 2] | 0 | Enable Screen Content Optimization mode (0: OFF, 1: ON, 2: Content Based Detection) |
 | **IntraBCMode** | --intrabc-mode | [0 - 3], -1 for default] | -1 | IntraBC mode (0 = OFF, 1 = ON slow, 1 = ON faster, 2 = ON fastest, -1 = DEFAULT) |
 | **HighBitDepthModeDecision** | --hbd-md | [0-2, 1 for default] | 1 | Enable high bit depth mode decision(0: OFF, 1: ON partially[default],2: fully ON) |
 | **PaletteMode** | --palette | [0 - 6] | -1 | Enable Palette mode (-1: DEFAULT (ON at level6 when SC is detected), 0: OFF 1: ON Level 1, ...6: ON Level6 ) |
-| **UnrestrictedMotionVector** | --umv | [0-1] | 1 | Enables or disables unrestriced motion vectors, 0 = OFF(motion vectors are constrained within tile boundary), 1 = ON. For MCTS support, set -umv 0 |
+| **UnrestrictedMotionVector** | --umv | [0-1] | 1 | Enables or disables unrestriced motion vectors, 0 = OFF(motion vectors are constrained within tile boundary), 1 = ON. For MCTS support, set --umv 0 |
 | **Injector** | --inj | [0-1, 0 for default] | 0 | Inject pictures at defined frame rate(0: OFF[default],1: ON) |
 | **InjectorFrameRate** | --inj-frm-rt | Null | Null | Set injector frame rate |
 | **SpeedControlFlag** | --speed-ctrl | [0-1, 0 for default] | 0 | Enable speed control(0: OFF[default], 1: ON) |
 | **FilmGrain** | --film-grain | [0-50, 0 for default] | 0 | Enable film grain(0: OFF[default], 1 - 50: Level of denoising for film grain) |
-| **HmeLevel0SearchAreaInWidth** | --hme-l0-w | [1 - 256] | Depends on input resolution | HME Level 0 Search Area in Width for each region, separated in spaces, the number of input search areas must equal to NumberHmeSearchRegionInWidth, and the sum must equal toHmeLevel0TotalSearchAreaWidth |
-| **HmeLevel0SearchAreaInHeight** | --hme-l0-h | [1 - 256] | Depends on input resolution | HME Level 0 Search Area in Height for each region, separated in spaces, the number of input search areas must equal to NumberHmeSearchRegionInHeight, and the sum must equal toHmeLevel0TotalSearchAreaHeight |
-| **HmeLevel1SearchAreaInWidth** | --hme-l1-w | [1 - 256] | Depends on input resolution | HME Level 1 Search Area in Width for each region, separated in spaces, the number of input search areas must equal to NumberHmeSearchRegionInWidth |
-| **HmeLevel1SearchAreaInHeight** | --hme-l1-h | [1 - 256] | Depends on input resolution | HME Level 1 Search Area in Height for each region, separated in spaces, the number of input search areas must equal to NumberHmeSearchRegionInHeight |
-| **HmeLevel2SearchAreaInWidth** | --hme-l2-w | [1 - 256] | Depends on input resolution | HME Level 2 Search Area in Width for each region, separated in spaces, the number of input search areas must equal to NumberHmeSearchRegionInWidth |
-| **HmeLevel2SearchAreaInHeight** | --hme-l2-h | [1 - 256] | Depends on input resolution | HME Level 2 Search Area in Height for each region, separated in spaces, the number of input search areas must equal to NumberHmeSearchRegionInHeight |
+| **HmeLevel0SearchAreaInWidth** | --hme-l0-w | [1 - 480] | Depends on input resolution | HME Level 0 Search Area in Width for each region, separated in spaces, the number of input search areas must equal to NumberHmeSearchRegionInWidth, and the sum must equal toHmeLevel0TotalSearchAreaWidth |
+| **HmeLevel0SearchAreaInHeight** | --hme-l0-h | [1 - 480] | Depends on input resolution | HME Level 0 Search Area in Height for each region, separated in spaces, the number of input search areas must equal to NumberHmeSearchRegionInHeight, and the sum must equal toHmeLevel0TotalSearchAreaHeight |
+| **HmeLevel1SearchAreaInWidth** | --hme-l1-w | [1 - 480] | Depends on input resolution | HME Level 1 Search Area in Width for each region, separated in spaces, the number of input search areas must equal to NumberHmeSearchRegionInWidth |
+| **HmeLevel1SearchAreaInHeight** | --hme-l1-h | [1 - 480] | Depends on input resolution | HME Level 1 Search Area in Height for each region, separated in spaces, the number of input search areas must equal to NumberHmeSearchRegionInHeight |
+| **HmeLevel2SearchAreaInWidth** | --hme-l2-w | [1 - 480] | Depends on input resolution | HME Level 2 Search Area in Width for each region, separated in spaces, the number of input search areas must equal to NumberHmeSearchRegionInWidth |
+| **HmeLevel2SearchAreaInHeight** | --hme-l2-h | [1 - 480] | Depends on input resolution | HME Level 2 Search Area in Height for each region, separated in spaces, the number of input search areas must equal to NumberHmeSearchRegionInHeight |
 | **EnableAltRefs** | --enable-altrefs | [0-1, 1 for default] | 1 | Enable automatic alt reference frames(0: OFF, 1: ON[default]) |
 | **AltRefStrength** | --altref-strength | [0-6, 5 for default] | 5 | AltRef filter strength([0-6], default: 5) |
 | **AltRefNframes** | --altref-nframes | [0-10, 7 for default] | 7 | AltRef max frames([0-10], default: 7) |
 | **EnableOverlays** | --enable-overlays | [0-1, 0 for default] | 0 | Enable the insertion of an extra picture called overlayer picture which will be used as an extra reference frame for the base-layer picture(0: OFF[default], 1: ON) |
 | **SquareWeight** | --sqw | 0 for off and any whole number percentage | 100 | Weighting applied to square/h/v shape costs when deciding if a and b shapes could be skipped. Set to 100 for neutral weighting, lesser than 100 for faster encode and BD-Rate loss, and greater than 100 for slower encode and BD-Rate gain|
-| **ChannelNumber** | -nch | [1 - 6] | 1 | Number of encode instances |
+| **ChannelNumber** | --nch | [1 - 6] | 1 | Number of encode instances |
 | **MDS1PruneClassThreshold** | --mds-1-class-th | 0 for off and any whole number percentage | 100 | Deviation threshold (expressed as a percentage) of an inter-class class pruning mechanism before MD Stage 1 |
 | **MDS1PruneCandThreshold** | --mds-1-cand-th | 0 for off and any whole number percentage | 75 | Deviation threshold (expressed as a percentage) of an intra-class candidate pruning mechanism before MD Stage 1 |
 | **MDS23PruneClassThreshold** | --mds-2-3-class-th | 0 for off and any whole number percentage | 25 | Deviation threshold (expressed as a percentage) of an inter-class class pruning mechanism before MD Stage 2/3 |
@@ -262,21 +262,21 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 
 ### 1. Thread management parameters
 
-LogicalProcessorNumber (`-lp`) and TargetSocket (`-ss`) parameters are used to management thread affinity on Windows and Ubuntu OS. These are some examples how you use them together.
+LogicalProcessorNumber (`--lp`) and TargetSocket (`--ss`) parameters are used to management thread affinity on Windows and Ubuntu OS. These are some examples how you use them together.
 
 If LogicalProcessorNumber and TargetSocket are not set, threads are managed by OS thread scheduler.
 
-`SvtAv1EncApp.exe -i in.yuv -w 3840 -h 2160 –lp 40`
+`SvtAv1EncApp.exe -i in.yuv -w 3840 -h 2160 --lp 40`
 
 If only LogicalProcessorNumber is set, threads run on 40 logical processors. Threads may run on dual sockets if 40 is larger than logical processor number of a socket.
 
 NOTE: On Windows, thread affinity can be set only by group on system with more than 64 logical processors. So, if 40 is larger than logical processor number of a single socket, threads run on all logical processors of both sockets.
 
-`SvtAv1EncApp.exe -i in.yuv -w 3840 -h 2160 –ss 1`
+`SvtAv1EncApp.exe -i in.yuv -w 3840 -h 2160 --ss 1`
 
 If only TargetSocket is set, threads run on all the logical processors of socket 1.
 
-`SvtAv1EncApp.exe -i in.yuv -w 3840 -h 2160 –lp 20 –ss 0`
+`SvtAv1EncApp.exe -i in.yuv -w 3840 -h 2160 --lp 20 --ss 0`
 
 If both LogicalProcessorNumber and TargetSocket are set, threads run on 20 logical processors of socket 0. Threads guaranteed to run only on socket 0 if 20 is larger than logical processor number of socket 0.
 

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -474,7 +474,7 @@ static void set_tile_col(const char *value, EbConfig *cfg) {
 };
 static void set_scene_change_detection(const char *value, EbConfig *cfg) {
     cfg->scene_change_detection = strtoul(value, NULL, 0);
-};
+}
 static void set_look_ahead_distance(const char *value, EbConfig *cfg) {
     cfg->look_ahead_distance = strtoul(value, NULL, 0);
 };
@@ -975,9 +975,9 @@ ConfigEntry config_entry_specific[] = {
      set_edge_skip_angle_intra_flag},
     // INTRA ANGLE DELTA
     {SINGLE_INPUT,
-        INTRA_ANGLE_DELTA_TOKEN,
-        "Enable intra angle delta filtering filtering (0: OFF, 1: ON, -1: DEFAULT)",
-        set_intra_angle_delta_flag},
+     INTRA_ANGLE_DELTA_TOKEN,
+     "Enable intra angle delta filtering filtering (0: OFF, 1: ON, -1: DEFAULT)",
+     set_intra_angle_delta_flag},
     // INTER INTRA COMPOUND
     {SINGLE_INPUT,
      INTER_INTRA_COMPOUND_NEW_TOKEN,
@@ -1128,27 +1128,33 @@ ConfigEntry config_entry_specific[] = {
     // HME
     {ARRAY_INPUT,
      HME_LEVEL0_WIDTH,
-     "Set hierarchical motion estimation level0 search area in Width",
+     "Set hierarchical motion estimation level0 search width (Requires numbers whose sum "
+     "equal the total search width and amount equals the search regions)",
      set_hme_level_0_search_area_in_width_array},
     {ARRAY_INPUT,
      HME_LEVEL0_HEIGHT,
-     "Set hierarchical motion estimation level0 search area in height",
+     "Set hierarchical motion estimation level0 search height (Requires numbers whose sum "
+     "equal the total search height and amount equals the search regions)",
      set_hme_level_0_search_area_in_height_array},
     {ARRAY_INPUT,
      HME_LEVEL1_WIDTH,
-     "Set hierarchical motion estimation level1 search area in Width",
+     "Set hierarchical motion estimation level1 search width (Requires numbers whose sum "
+     "equal the total search width and amount equals the search regions)",
      set_hme_level_1_search_area_in_width_array},
     {ARRAY_INPUT,
      HME_LEVEL1_HEIGHT,
-     "Set hierarchical motion estimation level1 search area in height",
+     "Set hierarchical motion estimation level1 search height (Requires numbers whose sum "
+     "equal the total search height and amount equals the search regions)",
      set_hme_level_1_search_area_in_height_array},
     {ARRAY_INPUT,
      HME_LEVEL2_WIDTH,
-     "Set hierarchical motion estimation level2 search area in Width",
+     "Set hierarchical motion estimation level2 search width (Requires numbers whose sum "
+     "equal the total search width and amount equals the search regions)",
      set_hme_level_2_search_area_in_width_array},
     {ARRAY_INPUT,
      HME_LEVEL2_HEIGHT,
-     "Set hierarchical motion estimation level2 search area in height",
+     "Set hierarchical motion estimation level2 search height (Requires numbers whose sum "
+     "equal the total search height and amount equals the search regions)",
      set_hme_level_2_search_area_in_height_array},
     // --- start: ALTREF_FILTERING_SUPPORT
     {SINGLE_INPUT,
@@ -2647,11 +2653,13 @@ EbErrorType read_command_line(int32_t argc, char *const argv[], EbConfig **confi
     /***********   Find SPECIAL configuration parameter tokens and call respective functions  **********/
     /***************************************************************************************************/
     // Parse command line for search region at level 0 width token
-    if (find_token_multiple_inputs(argc, argv, HME_LEVEL0_WIDTH, config_strings) == 0) {
+    if (!find_token_multiple_inputs(argc, argv, HME_LEVEL0_WIDTH, config_strings) ||
+        !find_token_multiple_inputs(argc, argv, "-" HME_LEVEL0_WIDTH, config_strings)) {
         uint32_t input_index = 0, last_index = 0;
         uint32_t done = 1;
 
         mark_token_as_read(HME_LEVEL0_WIDTH, cmd_copy, &cmd_token_cnt);
+        mark_token_as_read("-" HME_LEVEL0_WIDTH, cmd_copy, &cmd_token_cnt);
 
         for (index = 0; done && (index < num_channels); ++index) {
             configs[index]->hme_level0_column_index = 0;
@@ -2671,11 +2679,13 @@ EbErrorType read_command_line(int32_t argc, char *const argv[], EbConfig **confi
     }
 
     //// Parse command line for search region at level 0 height token
-    if (find_token_multiple_inputs(argc, argv, HME_LEVEL0_HEIGHT, config_strings) == 0) {
+    if (!find_token_multiple_inputs(argc, argv, HME_LEVEL0_HEIGHT, config_strings) ||
+        !find_token_multiple_inputs(argc, argv, "-" HME_LEVEL0_HEIGHT, config_strings)) {
         uint32_t input_index = 0, last_index = 0;
         uint32_t done = 1;
 
         mark_token_as_read(HME_LEVEL0_HEIGHT, cmd_copy, &cmd_token_cnt);
+        mark_token_as_read("-" HME_LEVEL0_HEIGHT, cmd_copy, &cmd_token_cnt);
 
         for (index = 0; done && (index < num_channels); ++index) {
             configs[index]->hme_level0_row_index = 0;
@@ -2695,11 +2705,13 @@ EbErrorType read_command_line(int32_t argc, char *const argv[], EbConfig **confi
     }
 
     // Parse command line for search region at level 1 Height token
-    if (find_token_multiple_inputs(argc, argv, HME_LEVEL1_HEIGHT, config_strings) == 0) {
+    if (!find_token_multiple_inputs(argc, argv, HME_LEVEL1_HEIGHT, config_strings) ||
+        !find_token_multiple_inputs(argc, argv, "-" HME_LEVEL1_HEIGHT, config_strings)) {
         uint32_t input_index = 0, last_index = 0;
         uint32_t done = 1;
 
         mark_token_as_read(HME_LEVEL1_HEIGHT, cmd_copy, &cmd_token_cnt);
+        mark_token_as_read("-" HME_LEVEL1_HEIGHT, cmd_copy, &cmd_token_cnt);
 
         for (index = 0; done && (index < num_channels); ++index) {
             configs[index]->hme_level1_row_index = 0;
@@ -2719,11 +2731,13 @@ EbErrorType read_command_line(int32_t argc, char *const argv[], EbConfig **confi
     }
 
     // Parse command line for search region at level 1 width token
-    if (find_token_multiple_inputs(argc, argv, HME_LEVEL1_WIDTH, config_strings) == 0) {
+    if (!find_token_multiple_inputs(argc, argv, HME_LEVEL1_WIDTH, config_strings) ||
+        !find_token_multiple_inputs(argc, argv, "-" HME_LEVEL1_WIDTH, config_strings)) {
         uint32_t input_index = 0, last_index = 0;
         uint32_t done = 1;
 
         mark_token_as_read(HME_LEVEL1_WIDTH, cmd_copy, &cmd_token_cnt);
+        mark_token_as_read("-" HME_LEVEL1_WIDTH, cmd_copy, &cmd_token_cnt);
 
         for (index = 0; done && (index < num_channels); ++index) {
             configs[index]->hme_level1_column_index = 0;
@@ -2743,11 +2757,13 @@ EbErrorType read_command_line(int32_t argc, char *const argv[], EbConfig **confi
     }
 
     // Parse command line for search region at level 2 width token
-    if (find_token_multiple_inputs(argc, argv, HME_LEVEL2_WIDTH, config_strings) == 0) {
+    if (!find_token_multiple_inputs(argc, argv, HME_LEVEL2_WIDTH, config_strings) ||
+        !find_token_multiple_inputs(argc, argv, "-" HME_LEVEL2_WIDTH, config_strings)) {
         uint32_t input_index = 0, last_index = 0;
         uint32_t done = 1;
 
         mark_token_as_read(HME_LEVEL2_WIDTH, cmd_copy, &cmd_token_cnt);
+        mark_token_as_read("-" HME_LEVEL2_WIDTH, cmd_copy, &cmd_token_cnt);
 
         for (index = 0; done && (index < num_channels); ++index) {
             configs[index]->hme_level2_column_index = 0;
@@ -2767,11 +2783,13 @@ EbErrorType read_command_line(int32_t argc, char *const argv[], EbConfig **confi
     }
 
     // Parse command line for search region at level 2 height token
-    if (find_token_multiple_inputs(argc, argv, HME_LEVEL2_HEIGHT, config_strings) == 0) {
+    if (!find_token_multiple_inputs(argc, argv, HME_LEVEL2_HEIGHT, config_strings) ||
+        !find_token_multiple_inputs(argc, argv, "-" HME_LEVEL2_HEIGHT, config_strings)) {
         uint32_t input_index = 0, last_index = 0;
         uint32_t done = 1;
 
         mark_token_as_read(HME_LEVEL2_HEIGHT, cmd_copy, &cmd_token_cnt);
+        mark_token_as_read("-" HME_LEVEL2_HEIGHT, cmd_copy, &cmd_token_cnt);
 
         for (index = 0; done && (index < num_channels); ++index) {
             configs[index]->hme_level2_row_index = 0;

--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -424,7 +424,7 @@ int32_t main(int32_t argc, char *argv[]) {
             }
         } else {
             fprintf(stderr, "Error in configuration, could not begin encoding! ... \n");
-            fprintf(stderr, "Run %s -help for a list of options\n", argv[0]);
+            fprintf(stderr, "Run %s --help for a list of options\n", argv[0]);
         }
         // Destruct the App memory variables
         for (inst_cnt = 0; inst_cnt < num_channels; ++inst_cnt) {

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2304,7 +2304,7 @@ static int verify_hme_dimension(unsigned int index, unsigned int HmeLevel0Search
     for (i = 0; i < number_hme_search_region_in_width; i++)
         total_search_width += number_hme_search_region_in_width_array[i];
     if ((total_search_width) != (HmeLevel0SearchAreaInWidth)) {
-        SVT_LOG("Error Instance %u: Invalid  HME Total Search Area. \n", index);
+        SVT_LOG("Error Instance %u: Summed values of HME area does not equal the total area. \n", index);
         return_error = -1;
         return return_error;
     }
@@ -2319,8 +2319,8 @@ static int verify_hme_dimension_l1_l2(unsigned int index, uint32_t number_hme_se
 
     for (i = 0; i < number_hme_search_region_in_width; i++)
         total_search_width += number_hme_search_region_in_width_array[i];
-    if ((total_search_width > 256) || (total_search_width == 0)) {
-        SVT_LOG("Error Instance %u: Invalid  HME Total Search Area. Must be [1 - 256].\n", index);
+    if ((total_search_width > 480) || (total_search_width == 0)) {
+        SVT_LOG("Error Instance %u: Invalid HME Total Search Area. Must be [1 - 480].\n", index);
         return_error = -1;
         return return_error;
     }
@@ -2431,13 +2431,13 @@ static EbErrorType verify_settings(
         return_error = EB_ErrorBadParameter;
     }
 
-    if ((config->search_area_width > 256) || (config->search_area_width == 0)) {
-        SVT_LOG("Error Instance %u: Invalid search_area_width. search_area_width must be [1 - 256]\n", channel_number + 1);
+    if ((config->search_area_width > 480) || (config->search_area_width == 0)) {
+        SVT_LOG("Error Instance %u: Invalid search_area_width. search_area_width must be [1 - 480]\n", channel_number + 1);
         return_error = EB_ErrorBadParameter;
     }
 
-    if ((config->search_area_height > 256) || (config->search_area_height == 0)) {
-        SVT_LOG("Error Instance %u: Invalid search_area_height. search_area_height must be [1 - 256]\n", channel_number + 1);
+    if ((config->search_area_height > 480) || (config->search_area_height == 0)) {
+        SVT_LOG("Error Instance %u: Invalid search_area_height. search_area_height must be [1 - 480]\n", channel_number + 1);
         return_error = EB_ErrorBadParameter;
     }
 
@@ -2452,12 +2452,12 @@ static EbErrorType verify_settings(
             return_error = EB_ErrorBadParameter;
         }
 
-        if ((config->hme_level0_total_search_area_height > 256) || (config->hme_level0_total_search_area_height == 0)) {
-            SVT_LOG("Error Instance %u: Invalid hme_level0_total_search_area_height. hme_level0_total_search_area_height must be [1 - 256]\n", channel_number + 1);
+        if ((config->hme_level0_total_search_area_height > 480) || (config->hme_level0_total_search_area_height == 0)) {
+            SVT_LOG("Error Instance %u: Invalid hme_level0_total_search_area_height. hme_level0_total_search_area_height must be [1 - 480]\n", channel_number + 1);
             return_error = EB_ErrorBadParameter;
         }
-        if ((config->hme_level0_total_search_area_width > 256) || (config->hme_level0_total_search_area_width == 0)) {
-            SVT_LOG("Error Instance %u: Invalid hme_level0_total_search_area_width. hme_level0_total_search_area_width must be [1 - 256]\n", channel_number + 1);
+        if ((config->hme_level0_total_search_area_width > 480) || (config->hme_level0_total_search_area_width == 0)) {
+            SVT_LOG("Error Instance %u: Invalid hme_level0_total_search_area_width. hme_level0_total_search_area_width must be [1 - 480]\n", channel_number + 1);
             return_error = EB_ErrorBadParameter;
         }
         if (verify_hme_dimension(channel_number + 1, config->hme_level0_total_search_area_height, config->hme_level0_search_area_in_height_array, config->number_hme_search_region_in_height))
@@ -2520,8 +2520,8 @@ static EbErrorType verify_settings(
         return_error = EB_ErrorBadParameter;
     }
 
-    if (config->scene_change_detection > 1) {
-        SVT_LOG("Error Instance %u: The scene change detection must be [0 - 1] \n", channel_number + 1);
+    if (config->scene_change_detection) {
+        SVT_LOG("Error Instance %u: Scene change detection is currently not supported\n", channel_number + 1);
         return_error = EB_ErrorBadParameter;
     }
     if (config->max_qp_allowed > MAX_QP_VALUE) {


### PR DESCRIPTION
Closes #1271
Closes #441 

Removed `--scd` since it was broken for a long time

Changed printed out help text to double dash
Corrected asm help text in the encoder guide along with replacing single dash long options with their correct ones