### PR TITLE
Fix parameter name "AsmType" to "Asm" in Encoder User Guide.

### DIFF
--- a/Config/Sample.cfg
+++ b/Config/Sample.cfg
@@ -30,7 +30,7 @@ Tier                            : 0                         # Tier
 HierarchicalLevels              : 4                         # Set hierarchical levels
 PredStructure                   : 2                         # Set prediction structure( 0: low delay P, 1: low delay B, 2: random access [default] )
 PredStructFile                  : Config/PredStruct_level4.cfg        # Prediction structure file
-Asm                             : 0                         # Assembly instruction set (0: Automatically select lowest assembly instruction set supported, 1: Automatically select highest assembly instruction set supported)
+Asm                             : 0                         # Limit assembly instruction set ("0" is equivalent to "c", "1" is "mmx" etc, max value is "11" or "max"), by default select highest assembly instruction that is supported by CPU
 LogicalProcessors               : 1                         # Number of logical processors to be used
 UnpinSingleCoreExecution        : 1                         # Allows the execution of multiple encodes on the CPU without having to pin them to a specific( 0: OFF ,1: ON[default]) mask
 TargetSocket                    : 0                         # Specify  which socket the encoder runs on

--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -147,7 +147,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **HierarchicalLevels** | --hierarchical-levels | [3 - 4] | 4 | 0 : Flat4: 5-Level HierarchyMinigop Size = (2^HierarchicalLevels) (e.g. 3 == > 7B pyramid, 4 == > 15B Pyramid) |
 | **PredStructure** | --pred-struct | [0-2, 2 for default] | 2 | Set prediction structure( 0: low delay P, 1: low delay B, 2: random access [default]) |
 | **HighDynamicRangeInput** | --enable-hdr | [0-1, 0 for default] | 0 | Enable high dynamic range(0: OFF[default], ON: 1) |
-| **AsmType** | --asm | [0 - 1] | 1 | Assembly instruction set (0: Automatically select lowest assembly instruction set supported, 1: Automatically select highest assembly instruction set supported,) |
+| **Asm** | --asm |  [0 - 11] or [c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512, max] | 11 or max | Limit assembly instruction set ("0" is equivalent to "c", "1" is "mmx" etc, max value is "11" or "max"), by default select highest assembly instruction that is supported by CPU |
 | **LogicalProcessorNumber** | --lp | [0, total number of logical processor] | 0 | The number of logical processor which encoder threads run on.Refer to Appendix A.1 |
 | **UnpinSingleCoreExecution** | --unpin-lp1 | [0, 1] | 1 | Unpin the execution . If logical_processors is set to 1, this option does not set the execution to be pinned to core #0 when set to 1. this allows the execution of multiple encodes on the CPU without having to pin them to a specific mask  0=OFF, 1= ON |
 | **TargetSocket** | --ss | [-1,1] | -1 | For dual socket systems, this can specify which socket the encoder runs on.Refer to Appendix A.1 |

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -793,8 +793,8 @@ ConfigEntry config_entry_global_options[] = {
     // Asm Type
     {SINGLE_INPUT,
      ASM_TYPE_TOKEN,
-     "Assembly instruction set (0: Automatically select lowest assembly instruction set supported, "
-     "1: Automatically select highest assembly instruction set supported)",
+     "Limit assembly instruction set [0 - 11] or [c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2,"
+     " avx, avx2, avx512, max], by default highest level supported by CPU",
      set_asm_type},
     {SINGLE_INPUT, THREAD_MGMNT, "number of logical processors to be used", set_logical_processors},
     {SINGLE_INPUT,

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2607,8 +2607,8 @@ static EbErrorType verify_settings(
     }
 
     if (config->use_cpu_flags & CPU_FLAGS_INVALID) {
-        SVT_LOG("Error Instance %u: param '-asm' have invalid value.\n"
-            "Value should be [0 - 11, c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512, max]\n", channel_number + 1);
+        SVT_LOG("Error Instance %u: param '--asm' have invalid value.\n"
+            "Value should be [0 - 11] or [c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512, max]\n", channel_number + 1);
         return_error = EB_ErrorBadParameter;
     }
 


### PR DESCRIPTION
And fix wrong description of "Asm" parameter.
 
