### PR TITLE
Update PR template and the PR contributing guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,30 @@
-## Description
+# Description
 
 
-## Issue #
+# Issue
+
+<!--
+Mention if the PR fixes or address an issue in this section
+https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
+Example
+Fixes #999
+--->
+
+# Author(s)
 
 
-## Author(s)
+# Performance impact
+- [ ] quality
+- [ ] memory
+- [ ] speed
+- [ ] 8 bit
+- [ ] 10 bit
+- [ ] N/A
 
+# Test set
+- [ ] obj-1-fast
+- [ ] other
 
-## Test set and performance impact
-
-
-## Squash and merge (Allow maintainer to squash and merge when PR is ready)
-[yes / no]
+# Squash and merge (Allow maintainer to squash and merge when PR is ready)
+[ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
+[ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,11 @@ Fixes #999
 
 
 # Performance impact
+<!--
+Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
+Example
+- [x] memory
+--->
 - [ ] quality
 - [ ] memory
 - [ ] speed
@@ -24,7 +29,8 @@ Fixes #999
 # Test set
 - [ ] obj-1-fast
 - [ ] other
+- [ ] N/A
 
 # Squash and merge (Allow maintainer to squash and merge when PR is ready)
-[ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
-[ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
+- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
+- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@ Mention if the PR fixes or address an issue in this section
 https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
 Example
 Fixes #999
+If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
 --->
 
 # Author(s)
@@ -27,10 +28,10 @@ Example
 - [ ] N/A
 
 # Test set
-- [ ] obj-1-fast
+- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
 - [ ] other
 - [ ] N/A
 
-# Squash and merge (Allow maintainer to squash and merge when PR is ready)
+# Merge method
 - [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
 - [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Description
+
+
+## Issue #
+
+
+## Author(s)
+
+
+## Test set and performance impact
+
+
+## Squash and merge (Allow maintainer to squash and merge when PR is ready)
+[yes / no]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,14 @@ We welcome community contributions to the SVT-AV1 Encoder. Thank you for your ti
 ## Contribution process
 
 - Follow the [coding guidelines](STYLE.md)
-
 - Validate that your changes do not break a build
   - either locally or through travis-ci and appveyor. Preferably all of them.
-
 - Perform smoke tests and ensure they pass
-
 - Submit a pull request for review to the maintainer
+
+## Pull request process:
+
+- Make commits concise and to the point (1 feature / issue = 1 commit )
+- Authors would be responsible for breaking down the PR into commits that make sense (with proper commit messages)
+- Use rebase and merge for all PRs to make sure that all commits are carried over to the master
+- Maintainers would only use squash and merge with the permission of the authors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,9 @@ We welcome community contributions to the SVT-AV1 Encoder. Thank you for your ti
 - Submit a pull request for review to the maintainer
 
 ## Pull request process:
-
-- Make commits concise and to the point (1 feature / issue = 1 commit )
-- Authors would be responsible for breaking down the PR into commits that make sense (with proper commit messages)
-- Use rebase and merge for all PRs to make sure that all commits are carried over to the master
-- Maintainers would only use squash and merge with the permission of the authors.
+- Authors should use a valid email account when committing.
+- Make clear and concise commits (1 commit per 1 feature or issue)
+- Authors are responsible for breaking down the PR into sensible commits (with proper commit messages)
+- Avoid using force push when addressing comments and review items.
+- Maintainers shall use 'rebase and merge' to make sure all commits can apply cleanly onto the master branch
+- Maintainers shall only use 'squash and merge' with the permission of the authors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,8 @@ We welcome community contributions to the SVT-AV1 Encoder. Thank you for your ti
 - Perform smoke tests and ensure they pass
 - Submit a pull request for review to the maintainer
 
-## Pull request process:
+## Pull request process
+
 - Authors should use a valid email account when committing.
 - Make clear and concise commits (1 commit per 1 feature or issue)
 - Authors are responsible for breaking down the PR into sensible commits (with proper commit messages)


### PR DESCRIPTION
# Description
- Update the PR template to standardize the PR description
- Add PR guidelines to the Contributing.md doc

# Issue
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
--->

As discussed in #1283 

## Author(s)
@hassount 
@1480c1 

# Performance impact
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast
- [ ] other
- [x] N/A


# Squash and merge (Allow maintainer to squash and merge when PR is ready)
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch