### PR TITLE
CMake: Add error checking for nasm version, use ENABLE_NASM, don't check for nasm if non-x86

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -22,7 +22,7 @@ jobs:
       # Default depth is 1
       - uses: actions/checkout@v2
       - name: Install dependencies
-        run: sudo apt-get install -y nasm cppcheck
+        run: sudo apt-get install -y yasm cppcheck
       - name: Run CMake
         run: cmake -S . -B Build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
       - name: Run Cppcheck

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,17 +10,8 @@ if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")
                     "Please use the Build folder or create your own.")
 endif()
 
-option(YASM "Use yasm (if present in PATH)" ON)
-if(YASM)
-    find_program(YASM_EXE yasm)
-    if(YASM_EXE AND NOT CMAKE_ASM_NASM_COMPILER MATCHES "yasm")
-        set(CMAKE_ASM_NASM_COMPILER ${YASM_EXE})
-        message(STATUS "Found YASM: ${YASM_EXE}")
-    endif()
-endif()
-
 project(svt-av1 VERSION 0.8.3
-    LANGUAGES C CXX ASM_NASM)
+    LANGUAGES C CXX)
 
 # Default build type to release if the generator does not has its own set of build types
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -33,6 +24,26 @@ endif()
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
     set(X86 TRUE)
+    find_program(YASM_EXE yasm)
+    option(ENABLE_NASM "Use nasm if available (Uses yasm by default if found)" OFF)
+    if(YASM_EXE AND NOT CMAKE_ASM_NASM_COMPILER MATCHES "yasm" AND NOT ENABLE_NASM)
+        set(CMAKE_ASM_NASM_COMPILER "${YASM_EXE}" CACHE FILEPATH "Path to nasm compatible compiler" FORCE)
+    else()
+        set(NASM_VERSION "0.0.0")
+        include(CheckLanguage)
+        check_language(ASM_NASM)
+        execute_process(COMMAND ${CMAKE_ASM_NASM_COMPILER} -v
+            OUTPUT_VARIABLE NASM_VERSION
+            ERROR_QUIET
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+        string(REGEX MATCH "([.0-9])+" NASM_VERSION "${NASM_VERSION}")
+        # NASM_VERSION should now contain something like 2.14.02
+        # Needs to error out on a version less than 2.14
+        if(NASM_VERSION VERSION_LESS "2.14" AND CMAKE_ASM_NASM_COMPILER MATCHES "nasm")
+            message(FATAL_ERROR "Found nasm is too old (requires at least 2.14, found ${NASM_VERSION})!")
+        endif()
+    endif()
+    enable_language(ASM_NASM)
 else()
     set(X86 FALSE)
 endif()


### PR DESCRIPTION
# Description

Modified to only enable `ASM_NASM` language if x86 since nasm is not needed on non-x86 platforms
Add `ENABLE_NASM` variable to forcefully tell cmake to check nasm instead
Add a version check for nasm and error out if nasm is less than 2.14 and yasm is not found.

current flow:

1. find yasm
2. check if (yasm_found && ! CMAKE_ASM_NASM_COMPILER ~= "yasm" && !`ENABLE_NASM`) and sets yasm as the assembler
3. else it will let cmake detect a default assembler (usually nasm) and check the version and compare to 2.14, if it's less and the assembler is nasm, it will error out


# Issue

Closes #1248
Closes #1330 

# Author(s)
@1480c1 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
