### PR TITLE
Set unpin to 1 by default

### DIFF
--- a/Config/Sample.cfg
+++ b/Config/Sample.cfg
@@ -32,7 +32,7 @@ PredStructure                   : 2                         # Set prediction str
 PredStructFile                  : Config/PredStruct_level4.cfg        # Prediction structure file
 Asm                             : 0                         # Limit assembly instruction set ("0" is equivalent to "c", "1" is "mmx" etc, max value is "11" or "max"), by default select highest assembly instruction that is supported by CPU
 LogicalProcessors               : 1                         # Number of logical processors to be used
-UnpinExecution                  : 1                         # Allows the execution to be pined/unpined to/from a specific number of cores. --unpin is overwritten to 0 when --ss is set to 0 or 1. ( 0: OFF [default] ,1: ON)
+UnpinExecution                  : 1                         # Allows the execution to be pined/unpined to/from a specific number of cores. --unpin is overwritten to 0 when --ss is set to 0 or 1. ( 0: OFF ,1: ON [default])
 TargetSocket                    : 0                         # Specify  which socket the encoder runs on.--unpin is overwritten to 0 when --ss is set to 0 or 1
 HighDynamicRangeInput           : 0                         # Enable high dynamic range(0: OFF[default], ON: 1)
 

--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -149,7 +149,7 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **HighDynamicRangeInput** | --enable-hdr | [0-1, 0 for default] | 0 | Enable high dynamic range(0: OFF[default], ON: 1) |
 | **Asm** | --asm |  [0 - 11] or [c, mmx, sse, sse2, sse3, ssse3, sse4_1, sse4_2, avx, avx2, avx512, max] | 11 or max | Limit assembly instruction set ("0" is equivalent to "c", "1" is "mmx" etc, max value is "11" or "max"), by default select highest assembly instruction that is supported by CPU |
 | **LogicalProcessorNumber** | --lp | [0, total number of logical processor] | 0 | The number of logical processor which encoder threads run on.Refer to Appendix A.1 |
-| **UnpinExecution** | --unpin | [0, 1] | 0 | Allows the execution to be pined/unpined to/from a specific number of cores.--unpin is overwritten to 0 when --ss is set to 0 or 1. 0=OFF, 1= ON |
+| **UnpinExecution** | --unpin | [0, 1] | 1 | Allows the execution to be pined/unpined to/from a specific number of cores.--unpin is overwritten to 0 when --ss is set to 0 or 1. 0=OFF, 1= ON |
 | **TargetSocket** | --ss | [-1,1] | -1 | For dual socket systems, this can specify which socket the encoder runs on.Refer to Appendix A.1 |
 
 #### Rate Control Options

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -557,8 +557,7 @@ typedef struct EbSvtAv1EncConfiguration {
     * of multiple encodes on the CPU wihtout having to pin them to a specific mask
     * 1: unpinned
     * 0: pinned
-    *
-    * If logical_processors is set to 1 default is 1 otherwise it is 0. */
+    * default 1 */
     uint32_t unpin;
 
     /* Target socket to run on. For dual socket systems, this can specify which

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -801,7 +801,7 @@ ConfigEntry config_entry_global_options[] = {
      UNPIN_TOKEN,
     "Allows the execution to be pined/unpined to/from a specific number of cores \n"
     "The combinational use of --unpin with --lp results in memory reduction while allowing the execution to work on any of the cores and not restrict it to specific cores \n"
-    "--unpin is overwritten to 0 when --ss is set to 0 or 1. ( 0: OFF [default] ,1: ON) \n"
+    "--unpin is overwritten to 0 when --ss is set to 0 or 1. ( 0: OFF ,1: ON [default]) \n"
     "Example: 72 core machine: \n"
     "72 jobs x -- lp 1 -- unpin 1 \n"
     "36 jobs x -- lp 2 -- unpin 1 \n"
@@ -1617,7 +1617,7 @@ void eb_config_ctor(EbConfig *config_ptr) {
     // ASM Type
     config_ptr->cpu_flags_limit = CPU_FLAGS_ALL;
 
-    config_ptr->unpin     = 0;
+    config_ptr->unpin     = 1;
     config_ptr->target_socket = -1;
 
     config_ptr->unrestricted_motion_vector = EB_TRUE;

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -3037,7 +3037,7 @@ EbErrorType eb_svt_enc_init_parameter(
 
     // Channel info
     config_ptr->logical_processors = 0;
-    config_ptr->unpin = 0;
+    config_ptr->unpin = 1;
     config_ptr->target_socket = -1;
     config_ptr->channel_id = 0;
     config_ptr->active_channel_count = 1;


### PR DESCRIPTION
# Description
set unpin to 1 by default to not restrict the execution in 1 core when -lp1 and update documentation accordingly
