### PR TITLE
ffmpeg: fix build for missing packet_internal.h

### DIFF
--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
@@ -1,7 +1,7 @@
-From f9f92b64daa8b6d4cf5d070d41702da1e6de5ee2 Mon Sep 17 00:00:00 2001
+From 7a23b1f57b9e32103b03c7858e30c2fa0f3a39fe Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
-Subject: [PATCH 2/2] Add ability for ffmpeg to run svt-av1 with svt-hevc
+Subject: [PATCH] Add ability for ffmpeg to run svt-av1 with svt-hevc
 
 Change-Id: I37ee5414fdd99e0b3f112a6e5ede166f3e48d819
 Signed-off-by: Daryl Seah <daryl.seah@intel.com>
@@ -13,15 +13,15 @@ Signed-off-by: Xu Guangxin <guangxin.xu@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 548 ++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 554 insertions(+)
+ libavcodec/libsvt_av1.c | 551 ++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 557 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
-index 03427b2bb6..532dd80584 100755
+index dc5f74f4a9..20717c77a4 100755
 --- a/configure
 +++ b/configure
-@@ -268,6 +268,7 @@ External library support:
+@@ -265,6 +265,7 @@ External library support:
    --enable-libsrt          enable Haivision SRT protocol via libsrt [no]
    --enable-libssh          enable SFTP protocol via libssh [no]
    --enable-libsvthevc      enable HEVC encoding via svt [no]
@@ -29,7 +29,7 @@ index 03427b2bb6..532dd80584 100755
    --enable-libtensorflow   enable TensorFlow as a DNN module backend
                             for DNN based filters like sr [no]
    --enable-libtesseract    enable Tesseract, needed for ocr filter [no]
-@@ -1803,6 +1804,7 @@ EXTERNAL_LIBRARY_LIST="
+@@ -1795,6 +1796,7 @@ EXTERNAL_LIBRARY_LIST="
      libsrt
      libssh
      libsvthevc
@@ -37,7 +37,7 @@ index 03427b2bb6..532dd80584 100755
      libtensorflow
      libtesseract
      libtheora
-@@ -3233,6 +3235,7 @@ libspeex_decoder_deps="libspeex"
+@@ -3194,6 +3196,7 @@ libspeex_decoder_deps="libspeex"
  libspeex_encoder_deps="libspeex"
  libspeex_encoder_select="audio_frame_queue"
  libsvt_hevc_encoder_deps="libsvthevc"
@@ -45,7 +45,7 @@ index 03427b2bb6..532dd80584 100755
  libtheora_encoder_deps="libtheora"
  libtwolame_encoder_deps="libtwolame"
  libvo_amrwbenc_encoder_deps="libvo_amrwbenc"
-@@ -6357,6 +6360,7 @@ enabled libssh            && require_pkg_config libssh libssh libssh/sftp.h sftp
+@@ -6267,6 +6270,7 @@ enabled libssh            && require_pkg_config libssh libssh libssh/sftp.h sftp
  enabled libspeex          && require_pkg_config libspeex speex speex/speex.h speex_decoder_init
  enabled libsrt            && require_pkg_config libsrt "srt >= 1.3.0" srt/srt.h srt_socket
  enabled libsvthevc        && require_pkg_config libsvthevc SvtHevcEnc EbApi.h EbInitHandle
@@ -54,10 +54,10 @@ index 03427b2bb6..532dd80584 100755
  enabled libtesseract      && require_pkg_config libtesseract tesseract tesseract/capi.h TessBaseAPICreate
  enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -ltheoraenc -ltheoradec -logg
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index fc930e7338..a10b8fb56b 100644
+index d39f568585..c500f3d274 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -1013,6 +1013,7 @@ OBJS-$(CONFIG_LIBSHINE_ENCODER)           += libshine.o
+@@ -992,6 +992,7 @@ OBJS-$(CONFIG_LIBSHINE_ENCODER)           += libshine.o
  OBJS-$(CONFIG_LIBSPEEX_DECODER)           += libspeexdec.o
  OBJS-$(CONFIG_LIBSPEEX_ENCODER)           += libspeexenc.o
  OBJS-$(CONFIG_LIBSVT_HEVC_ENCODER)        += libsvt_hevc.o
@@ -66,10 +66,10 @@ index fc930e7338..a10b8fb56b 100644
  OBJS-$(CONFIG_LIBTWOLAME_ENCODER)         += libtwolame.o
  OBJS-$(CONFIG_LIBVO_AMRWBENC_ENCODER)     += libvo-amrwbenc.o
 diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
-index bf951528d0..309168850d 100644
+index d8788a7954..db1b1b2188 100644
 --- a/libavcodec/allcodecs.c
 +++ b/libavcodec/allcodecs.c
-@@ -722,6 +722,7 @@ extern AVCodec ff_libshine_encoder;
+@@ -708,6 +708,7 @@ extern AVCodec ff_libshine_encoder;
  extern AVCodec ff_libspeex_encoder;
  extern AVCodec ff_libspeex_decoder;
  extern AVCodec ff_libsvt_hevc_encoder;
@@ -79,10 +79,10 @@ index bf951528d0..309168850d 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000000..5f1d8e033f
+index 0000000000..edf69b69b2
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,548 @@
+@@ -0,0 +1,551 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -116,6 +116,9 @@ index 0000000000..5f1d8e033f
 +#include "libavutil/avassert.h"
 +
 +#include "internal.h"
++#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 90, 100)
++#include "packet_internal.h"
++#endif
 +#include "avcodec.h"
 +
 +typedef enum eos_status {
@@ -633,3 +636,4 @@ index 0000000000..5f1d8e033f
 +};
 --
 2.17.1
+

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -1,4 +1,4 @@
-From 3d1fa971104f88488924fcff03236d0a77e3c049 Mon Sep 17 00:00:00 2001
+From af9d3a2f718843777bdd7820e91a71fb5aa3da6b Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1
@@ -13,12 +13,12 @@ Signed-off-by: Xu Guangxin <guangxin.xu@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 548 ++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 554 insertions(+)
+ libavcodec/libsvt_av1.c | 552 ++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 558 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
-index 6533b43250..7978e0ebdb 100755
+index 8569a60bf8..60d92052cb 100755
 --- a/configure
 +++ b/configure
 @@ -267,6 +267,7 @@ External library support:
@@ -29,7 +29,7 @@ index 6533b43250..7978e0ebdb 100755
    --enable-libtensorflow   enable TensorFlow as a DNN module backend
                             for DNN based filters like sr [no]
    --enable-libtesseract    enable Tesseract, needed for ocr filter [no]
-@@ -1801,6 +1802,7 @@ EXTERNAL_LIBRARY_LIST="
+@@ -1803,6 +1804,7 @@ EXTERNAL_LIBRARY_LIST="
      libspeex
      libsrt
      libssh
@@ -37,7 +37,7 @@ index 6533b43250..7978e0ebdb 100755
      libtensorflow
      libtesseract
      libtheora
-@@ -3230,6 +3232,7 @@ libshine_encoder_select="audio_frame_queue"
+@@ -3240,6 +3242,7 @@ libshine_encoder_select="audio_frame_queue"
  libspeex_decoder_deps="libspeex"
  libspeex_encoder_deps="libspeex"
  libspeex_encoder_select="audio_frame_queue"
@@ -45,7 +45,7 @@ index 6533b43250..7978e0ebdb 100755
  libtheora_encoder_deps="libtheora"
  libtwolame_encoder_deps="libtwolame"
  libvo_amrwbenc_encoder_deps="libvo_amrwbenc"
-@@ -6353,6 +6356,7 @@ enabled libsoxr           && require libsoxr soxr.h soxr_create -lsoxr
+@@ -6369,6 +6372,7 @@ enabled libsoxr           && require libsoxr soxr.h soxr_create -lsoxr
  enabled libssh            && require_pkg_config libssh libssh libssh/sftp.h sftp_init
  enabled libspeex          && require_pkg_config libspeex speex speex/speex.h speex_decoder_init
  enabled libsrt            && require_pkg_config libsrt "srt >= 1.3.0" srt/srt.h srt_socket
@@ -54,10 +54,10 @@ index 6533b43250..7978e0ebdb 100755
  enabled libtesseract      && require_pkg_config libtesseract tesseract tesseract/capi.h TessBaseAPICreate
  enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -ltheoraenc -ltheoradec -logg
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 88944d9a3a..9c54543701 100644
+index 0a3bbc7128..d4e767c7b4 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -1012,6 +1012,7 @@ OBJS-$(CONFIG_LIBRAV1E_ENCODER)           += librav1e.o
+@@ -1024,6 +1024,7 @@ OBJS-$(CONFIG_LIBRAV1E_ENCODER)           += librav1e.o
  OBJS-$(CONFIG_LIBSHINE_ENCODER)           += libshine.o
  OBJS-$(CONFIG_LIBSPEEX_DECODER)           += libspeexdec.o
  OBJS-$(CONFIG_LIBSPEEX_ENCODER)           += libspeexenc.o
@@ -66,10 +66,10 @@ index 88944d9a3a..9c54543701 100644
  OBJS-$(CONFIG_LIBTWOLAME_ENCODER)         += libtwolame.o
  OBJS-$(CONFIG_LIBVO_AMRWBENC_ENCODER)     += libvo-amrwbenc.o
 diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
-index e7b29426db..c495ea29bc 100644
+index 5240d0afdf..7554c0fa2d 100644
 --- a/libavcodec/allcodecs.c
 +++ b/libavcodec/allcodecs.c
-@@ -721,6 +721,7 @@ extern AVCodec ff_librsvg_decoder;
+@@ -728,6 +728,7 @@ extern AVCodec ff_librsvg_decoder;
  extern AVCodec ff_libshine_encoder;
  extern AVCodec ff_libspeex_encoder;
  extern AVCodec ff_libspeex_decoder;
@@ -79,10 +79,11 @@ index e7b29426db..c495ea29bc 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000000..5f1d8e033f
+index 0000000000..42dfea1b80
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,548 @@
+@@ -0,0 +1,552 @@
++
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -116,6 +117,9 @@ index 0000000000..5f1d8e033f
 +#include "libavutil/avassert.h"
 +
 +#include "internal.h"
++#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 90, 100)
++#include "packet_internal.h"
++#endif
 +#include "avcodec.h"
 +
 +typedef enum eos_status {
@@ -633,3 +637,4 @@ index 0000000000..5f1d8e033f
 +};
 --
 2.17.1
+


### PR DESCRIPTION

# Description
fix build for the latest ffmpeg code.

the build is broken by the following commit in ffmpeg

    build failed since following commit in ffmpeg

    commit 6e1903938befc0bce2f64e01770af2f65d625cfc
    Author: James Almer <jamrial@gmail.com>
    Date:   Tue Jun 2 18:38:33 2020 -0300

        avcodec/internal: move packet related functions to their own header

        Signed-off-by: James Almer <jamrial@gmail.com>
    commit 6e1903938befc0bce2f64e01770af2f65d625cfc
    Author: James Almer <jamrial@gmail.com>
    Date:   Tue Jun 2 18:38:33 2020 -0300

        avcodec/internal: move packet related functions to their own header

        Signed-off-by: James Almer <jamrial@gmail.com>


# Issue
NO

# Author(s)
 Xu Guangxin <guangxin.xu@intel.com>


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
