### PR TITLE
fixes symbols conflict with libaom. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 project(svt-av1 VERSION 0.8.3
     LANGUAGES C CXX)
 
+set(CMAKE_C_VISIBILITY_PRESET hidden)
 # Default build type to release if the generator does not has its own set of build types
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE Release)

--- a/Source/API/EbSvtAv1.h
+++ b/Source/API/EbSvtAv1.h
@@ -21,7 +21,7 @@ extern "C" {
 #ifdef _WIN32
 #define EB_API __declspec(dllexport)
 #else
-#define EB_API
+#define EB_API __attribute__ ((visibility ("default")))
 #endif
 
 #define EB_MAX_NUM_OPERATING_POINTS 32

--- a/Source/Lib/Common/Codec/EbBitstreamUnit.c
+++ b/Source/Lib/Common/Codec/EbBitstreamUnit.c
@@ -19,6 +19,7 @@
 #include "EbBitstreamUnit.h"
 #include "EbDefinitions.h"
 #include "EbUtility.h"
+#include "EbLog.h"
 
 #if OD_MEASURE_EC_OVERHEAD
 #include <stdio.h>
@@ -71,12 +72,16 @@ void eb_aom_daala_start_encode(DaalaWriter *br, uint8_t *source) {
 }
 
 int32_t eb_aom_daala_stop_encode(DaalaWriter *br) {
-    int32_t  nb_bits;
-    uint32_t daala_bytes;
+    int32_t  nb_bits = -1;
+    uint32_t daala_bytes = 0;
     uint8_t *daala_data;
     daala_data = eb_od_ec_enc_done(&br->ec, &daala_bytes);
-    nb_bits    = eb_od_ec_enc_tell(&br->ec);
-    memcpy(br->buffer, daala_data, daala_bytes);
+    if (daala_data) {
+        nb_bits    = eb_od_ec_enc_tell(&br->ec);
+        memcpy(br->buffer, daala_data, daala_bytes);
+    } else {
+        SVT_ERROR("eb_od_ec_enc_done returns null ptr");
+    }
     br->pos = daala_bytes;
     eb_od_ec_enc_clear(&br->ec);
     return nb_bits;

--- a/Source/Lib/Decoder/Codec/EbDecHandle.c
+++ b/Source/Lib/Decoder/Codec/EbDecHandle.c
@@ -473,9 +473,6 @@ static EbErrorType init_svt_av1_decoder_handle(EbComponentType *hComponent) {
     return return_error;
 }
 
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType
 svt_av1_dec_init_handle(EbComponentType **p_handle, void *p_app_data,
                    EbSvtAv1DecConfiguration *config_ptr) {
@@ -509,9 +506,6 @@ svt_av1_dec_init_handle(EbComponentType **p_handle, void *p_app_data,
     return return_error;
 }
 
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType
 svt_av1_dec_set_parameter(EbComponentType *         svt_dec_component,
                          EbSvtAv1DecConfiguration *config_struct) {
@@ -525,9 +519,6 @@ svt_av1_dec_set_parameter(EbComponentType *         svt_dec_component,
     return EB_ErrorNone;
 }
 
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType
 svt_av1_dec_init(EbComponentType *svt_dec_component) {
     EbErrorType return_error = EB_ErrorNone;
@@ -573,9 +564,6 @@ svt_av1_dec_init(EbComponentType *svt_dec_component) {
     return return_error;
 }
 
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType
 svt_av1_dec_frame(EbComponentType *svt_dec_component, const uint8_t *data, const size_t data_size,
                     uint32_t is_annexb) {
@@ -619,9 +607,6 @@ svt_av1_dec_frame(EbComponentType *svt_dec_component, const uint8_t *data, const
     return return_error;
 }
 
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType
 svt_av1_dec_get_picture(EbComponentType *svt_dec_component, EbBufferHeaderType *p_buffer,
                        EbAV1StreamInfo *stream_info, EbAV1FrameInfo *frame_info) {
@@ -637,9 +622,6 @@ svt_av1_dec_get_picture(EbComponentType *svt_dec_component, EbBufferHeaderType *
     return return_error;
 }
 
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType
 svt_av1_dec_deinit(EbComponentType *svt_dec_component) {
     if (svt_dec_component == NULL) return EB_ErrorBadParameter;
@@ -692,9 +674,6 @@ EbErrorType eb_dec_component_de_init(EbComponentType *svt_dec_component) {
     return return_error;
 }
 
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType
 svt_av1_dec_deinit_handle(EbComponentType *svt_dec_component) {
     EbErrorType return_error = EB_ErrorNone;

--- a/Source/Lib/Decoder/Codec/EbDecParseObu.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseObu.c
@@ -2659,6 +2659,9 @@ EbErrorType decode_multiple_obu(EbDecHandle *dec_handle_ptr, uint8_t **data, siz
     return status;
 }
 
+#ifdef __GNUC__
+__attribute__((visibility("default")))
+#endif
 EB_API EbErrorType eb_get_sequence_info(const uint8_t *obu_data, size_t size,
                                         SeqHeader *sequence_info) {
     if (obu_data == NULL || size == 0 || sequence_info == NULL) return EB_ErrorBadParameter;

--- a/Source/Lib/Decoder/Codec/EbDecParseObu.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseObu.c
@@ -2659,9 +2659,6 @@ EbErrorType decode_multiple_obu(EbDecHandle *dec_handle_ptr, uint8_t **data, siz
     return status;
 }
 
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType eb_get_sequence_info(const uint8_t *obu_data, size_t size,
                                         SeqHeader *sequence_info) {
     if (obu_data == NULL || size == 0 || sequence_info == NULL) return EB_ErrorBadParameter;

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -950,9 +950,6 @@ void av1_init_wedge_masks(void);
 /**********************************
 * Initialize Encoder Library
 **********************************/
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType svt_av1_enc_init(EbComponentType *svt_enc_component)
 {
     if(svt_enc_component == NULL)
@@ -1744,9 +1741,6 @@ EB_API EbErrorType svt_av1_enc_init(EbComponentType *svt_enc_component)
 /**********************************
 * DeInitialize Encoder Library
 **********************************/
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType svt_av1_enc_deinit(EbComponentType *svt_enc_component){
     if(svt_enc_component == NULL)
         return EB_ErrorBadParameter;
@@ -1781,9 +1775,6 @@ EbErrorType init_svt_av1_encoder_handle(
 /**********************************
 * GetHandle
 **********************************/
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType svt_av1_enc_init_handle(
     EbComponentType** p_handle,               // Function to be called in the future for manipulating the component
     void*              p_app_data,
@@ -1845,9 +1836,6 @@ EbErrorType eb_av1_enc_component_de_init(EbComponentType  *svt_enc_component)
 /**********************************
 * svt_av1_enc_deinit_handle
 **********************************/
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType svt_av1_enc_deinit_handle(
     EbComponentType  *svt_enc_component)
 {
@@ -3155,9 +3143,6 @@ static void print_lib_params(
 
 * Set Parameter
 **********************************/
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType svt_av1_enc_set_parameter(
     EbComponentType              *svt_enc_component,
     EbSvtAv1EncConfiguration     *config_struct)
@@ -3215,9 +3200,6 @@ EB_API EbErrorType svt_av1_enc_set_parameter(
 
     return return_error;
 }
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType svt_av1_enc_stream_header(
     EbComponentType           *svt_enc_component,
     EbBufferHeaderType        **output_stream_ptr)
@@ -3267,9 +3249,6 @@ EB_API EbErrorType svt_av1_enc_stream_header(
 
     return return_error;
 }
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType svt_av1_enc_stream_header_release(
     EbBufferHeaderType        *stream_header_ptr)
 {
@@ -3285,9 +3264,6 @@ EB_API EbErrorType svt_av1_enc_stream_header_release(
     return return_error;
 }
 //
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType svt_av1_enc_eos_nal(
     EbComponentType           *svt_enc_component,
     EbBufferHeaderType       **output_stream_ptr
@@ -3486,9 +3462,6 @@ static void copy_input_buffer(
 /**********************************
 * Empty This Buffer
 **********************************/
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType svt_av1_enc_send_picture(
     EbComponentType      *svt_enc_component,
     EbBufferHeaderType   *p_buffer)
@@ -3536,9 +3509,6 @@ static void copy_output_recon_buffer(
 /**********************************
 * svt_av1_enc_get_packet sends out packet
 **********************************/
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType svt_av1_enc_get_packet(
     EbComponentType      *svt_enc_component,
     EbBufferHeaderType  **p_buffer,
@@ -3572,9 +3542,6 @@ EB_API EbErrorType svt_av1_enc_get_packet(
     return return_error;
 }
 
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API void svt_av1_enc_release_out_buffer(
     EbBufferHeaderType  **p_buffer)
 {
@@ -3591,9 +3558,6 @@ EB_API void svt_av1_enc_release_out_buffer(
 /**********************************
 * Fill This Buffer
 **********************************/
-#ifdef __GNUC__
-__attribute__((visibility("default")))
-#endif
 EB_API EbErrorType svt_av1_get_recon(
     EbComponentType      *svt_enc_component,
     EbBufferHeaderType   *p_buffer)


### PR DESCRIPTION
# Description


if we enable libaom and libsvtav1 at same time in ffmpeg like this
`./configure --enable-libsvtav1 --enable-libaom`


it will report error:


```
    libSvtAv1Enc.so: warning: multiple common of `aom_obmc_variance32x32'
    libaom.a(aom_dsp_rtcd.c.o): warning: previous common is here
    libSvtAv1Enc.so: warning: multiple common of `av1_build_compound_diffwtd_mask'
    libaom.a(av1_rtcd.c.o): warning: previous common is here

```
The root cause is we reuse some functions in libaom. Make it hidden by default will fix the issue


# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999 
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
Guangxin.Xu@intel.com

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch


