### PR TITLE
EbDefinitions: Do not disable all assertions

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stddef.h>
+#include <assert.h>
 #include "EbSvtAv1.h"
 #include "EbSvtAv1Enc.h"
 #ifdef _WIN32
@@ -1146,18 +1147,6 @@ typedef enum ATTRIBUTE_PACKED {
 #define SUPERRES_SCALE_DENOMINATOR_MIN (SCALE_NUMERATOR + 1)
 #define NUM_SCALES 8
 
-//*********************************************************************************************************************//
-// assert.h
-#undef assert
-
-#ifdef NDEBUG
-
-#define assert(expression) ((void)0)
-
-#else
-#define assert(expression) ((void)0)
-
-#endif
 //**********************************************************************************************************************//
 // onyxc_int.h
 #define CDEF_MAX_STRENGTHS 16


### PR DESCRIPTION
# Description
EbDefinitions has a weird redefinition of asserts that cause asserts
to not work at all when EbDefinitions was included after assert.h
or if only EbDefinitions was included but no assert.h, without
any warning.

This removes the code completely as it is completely unnecessary and
highly misleading to mess with C library provided macros.

# Author(s)
Marvin Scholz

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
