### PR TITLE
ffmpeg: Adapt with new libavcodec internal encode api changes

### DIFF
--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
@@ -1,4 +1,4 @@
-From 7a23b1f57b9e32103b03c7858e30c2fa0f3a39fe Mon Sep 17 00:00:00 2001
+From f2f4c3bc1df02e3e3daaafa276f1a26f232101ef Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1 with svt-hevc
@@ -13,15 +13,15 @@ Signed-off-by: Xu Guangxin <guangxin.xu@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 551 ++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 557 insertions(+)
+ libavcodec/libsvt_av1.c | 577 ++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 583 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
-index dc5f74f4a9..20717c77a4 100755
+index 4af7170b53..8188f83660 100755
 --- a/configure
 +++ b/configure
-@@ -265,6 +265,7 @@ External library support:
+@@ -268,6 +268,7 @@ External library support:
    --enable-libsrt          enable Haivision SRT protocol via libsrt [no]
    --enable-libssh          enable SFTP protocol via libssh [no]
    --enable-libsvthevc      enable HEVC encoding via svt [no]
@@ -29,7 +29,7 @@ index dc5f74f4a9..20717c77a4 100755
    --enable-libtensorflow   enable TensorFlow as a DNN module backend
                             for DNN based filters like sr [no]
    --enable-libtesseract    enable Tesseract, needed for ocr filter [no]
-@@ -1795,6 +1796,7 @@ EXTERNAL_LIBRARY_LIST="
+@@ -1805,6 +1806,7 @@ EXTERNAL_LIBRARY_LIST="
      libsrt
      libssh
      libsvthevc
@@ -37,7 +37,7 @@ index dc5f74f4a9..20717c77a4 100755
      libtensorflow
      libtesseract
      libtheora
-@@ -3194,6 +3196,7 @@ libspeex_decoder_deps="libspeex"
+@@ -3243,6 +3245,7 @@ libspeex_decoder_deps="libspeex"
  libspeex_encoder_deps="libspeex"
  libspeex_encoder_select="audio_frame_queue"
  libsvt_hevc_encoder_deps="libsvthevc"
@@ -45,7 +45,7 @@ index dc5f74f4a9..20717c77a4 100755
  libtheora_encoder_deps="libtheora"
  libtwolame_encoder_deps="libtwolame"
  libvo_amrwbenc_encoder_deps="libvo_amrwbenc"
-@@ -6267,6 +6270,7 @@ enabled libssh            && require_pkg_config libssh libssh libssh/sftp.h sftp
+@@ -6376,6 +6379,7 @@ enabled libssh            && require_pkg_config libssh libssh libssh/sftp.h sftp
  enabled libspeex          && require_pkg_config libspeex speex speex/speex.h speex_decoder_init
  enabled libsrt            && require_pkg_config libsrt "srt >= 1.3.0" srt/srt.h srt_socket
  enabled libsvthevc        && require_pkg_config libsvthevc SvtHevcEnc EbApi.h EbInitHandle
@@ -54,10 +54,10 @@ index dc5f74f4a9..20717c77a4 100755
  enabled libtesseract      && require_pkg_config libtesseract tesseract tesseract/capi.h TessBaseAPICreate
  enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -ltheoraenc -ltheoradec -logg
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index d39f568585..c500f3d274 100644
+index 8cc0cfe890..0dedc8a19c 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -992,6 +992,7 @@ OBJS-$(CONFIG_LIBSHINE_ENCODER)           += libshine.o
+@@ -1025,6 +1025,7 @@ OBJS-$(CONFIG_LIBSHINE_ENCODER)           += libshine.o
  OBJS-$(CONFIG_LIBSPEEX_DECODER)           += libspeexdec.o
  OBJS-$(CONFIG_LIBSPEEX_ENCODER)           += libspeexenc.o
  OBJS-$(CONFIG_LIBSVT_HEVC_ENCODER)        += libsvt_hevc.o
@@ -66,10 +66,10 @@ index d39f568585..c500f3d274 100644
  OBJS-$(CONFIG_LIBTWOLAME_ENCODER)         += libtwolame.o
  OBJS-$(CONFIG_LIBVO_AMRWBENC_ENCODER)     += libvo-amrwbenc.o
 diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
-index d8788a7954..db1b1b2188 100644
+index 58888189c7..7a6bd449fd 100644
 --- a/libavcodec/allcodecs.c
 +++ b/libavcodec/allcodecs.c
-@@ -708,6 +708,7 @@ extern AVCodec ff_libshine_encoder;
+@@ -729,6 +729,7 @@ extern AVCodec ff_libshine_encoder;
  extern AVCodec ff_libspeex_encoder;
  extern AVCodec ff_libspeex_decoder;
  extern AVCodec ff_libsvt_hevc_encoder;
@@ -79,10 +79,10 @@ index d8788a7954..db1b1b2188 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000000..edf69b69b2
+index 0000000000..a84a45c56c
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,551 @@
+@@ -0,0 +1,577 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -116,6 +116,9 @@ index 0000000000..edf69b69b2
 +#include "libavutil/avassert.h"
 +
 +#include "internal.h"
++#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 93, 100)
++#include "encode.h"
++#endif
 +#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 90, 100)
 +#include "packet_internal.h"
 +#endif
@@ -136,6 +139,8 @@ index 0000000000..edf69b69b2
 +    EbBufferHeaderType         *in_buf;
 +    int                         raw_size;
 +    int                         max_tu_size;
++
++    AVFrame *frame;
 +
 +    AVBufferPool* pool;
 +
@@ -395,6 +400,10 @@ index 0000000000..edf69b69b2
 +        }
 +    }
 +
++    svt_enc->frame = av_frame_alloc();
++    if (!svt_enc->frame)
++        return AVERROR(ENOMEM);
++
 +    ret = alloc_buffer(&svt_enc->enc_params, svt_enc);
 +    if (ret < 0)
 +        return ret;
@@ -409,6 +418,10 @@ index 0000000000..edf69b69b2
 +
 +    if (!frame) {
 +        EbBufferHeaderType headerPtrLast;
++
++        if (svt_enc->eos_flag == EOS_SENT)
++            return 0;
++
 +        headerPtrLast.n_alloc_len   = 0;
 +        headerPtrLast.n_filled_len  = 0;
 +        headerPtrLast.n_tick_count  = 0;
@@ -461,12 +474,24 @@ index 0000000000..edf69b69b2
 +{
 +    SvtContext  *svt_enc = avctx->priv_data;
 +    EbBufferHeaderType *headerPtr;
++    AVFrame *frame = svt_enc->frame;
 +    EbErrorType svt_ret;
 +    int ret = 0, pict_type;
 +    AVBufferRef* ref;
 +
 +    if (svt_enc->eos_flag == EOS_RECEIVED)
 +        return AVERROR_EOF;
++
++#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 93, 100)
++    ret = ff_encode_get_frame(avctx, frame);
++    if (ret < 0 && ret != AVERROR_EOF)
++        return ret;
++    if (ret == AVERROR_EOF)
++        frame = NULL;
++
++    eb_send_frame(avctx, frame);
++    av_frame_unref(svt_enc->frame);
++#endif
 +
 +    svt_ret = svt_av1_enc_get_packet(svt_enc->svt_handle, &headerPtr, svt_enc->eos_flag);
 +    if (svt_ret == EB_NoErrorEmptyQueue)
@@ -505,7 +530,7 @@ index 0000000000..edf69b69b2
 +
 +    svt_av1_enc_release_out_buffer(&headerPtr);
 +
-+    return ret;
++    return 0;
 +}
 +
 +static av_cold int eb_enc_close(AVCodecContext *avctx)
@@ -517,6 +542,8 @@ index 0000000000..edf69b69b2
 +            svt_av1_enc_deinit(svt_enc->svt_handle);
 +            svt_av1_enc_deinit_handle(svt_enc->svt_handle);
 +        }
++
++        av_frame_free(&svt_enc->frame);
 +
 +        free_buffer(svt_enc);
 +        svt_enc = NULL;
@@ -622,7 +649,6 @@ index 0000000000..edf69b69b2
 +    .type           = AVMEDIA_TYPE_VIDEO,
 +    .id             = AV_CODEC_ID_AV1,
 +    .init           = eb_enc_init,
-+    .send_frame     = eb_send_frame,
 +    .receive_packet = eb_receive_packet,
 +    .close          = eb_enc_close,
 +    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS,

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1-with-svt-hevc.patch
@@ -1,4 +1,4 @@
-From f2f4c3bc1df02e3e3daaafa276f1a26f232101ef Mon Sep 17 00:00:00 2001
+From 0fc7f3504857ea1c8c31b52934db2a9fdf39f992 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1 with svt-hevc
@@ -13,8 +13,8 @@ Signed-off-by: Xu Guangxin <guangxin.xu@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 577 ++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 583 insertions(+)
+ libavcodec/libsvt_av1.c | 580 ++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 586 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index 58888189c7..7a6bd449fd 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000000..a84a45c56c
+index 0000000000..bb46f898a8
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,577 @@
+@@ -0,0 +1,580 @@
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
 +*
@@ -649,6 +649,9 @@ index 0000000000..a84a45c56c
 +    .type           = AVMEDIA_TYPE_VIDEO,
 +    .id             = AV_CODEC_ID_AV1,
 +    .init           = eb_enc_init,
++#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 93, 100)
++    .send_frame     = eb_send_frame,
++#endif
 +    .receive_packet = eb_receive_packet,
 +    .close          = eb_enc_close,
 +    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS,

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -1,4 +1,4 @@
-From af9d3a2f718843777bdd7820e91a71fb5aa3da6b Mon Sep 17 00:00:00 2001
+From 982420395aa469fb7a0530c18f1c0a8423937f95 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1
@@ -13,12 +13,12 @@ Signed-off-by: Xu Guangxin <guangxin.xu@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 552 ++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 558 insertions(+)
+ libavcodec/libsvt_av1.c | 578 ++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 584 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
-index 8569a60bf8..60d92052cb 100755
+index 7495f35faa..95a0e6229a 100755
 --- a/configure
 +++ b/configure
 @@ -267,6 +267,7 @@ External library support:
@@ -45,7 +45,7 @@ index 8569a60bf8..60d92052cb 100755
  libtheora_encoder_deps="libtheora"
  libtwolame_encoder_deps="libtwolame"
  libvo_amrwbenc_encoder_deps="libvo_amrwbenc"
-@@ -6369,6 +6372,7 @@ enabled libsoxr           && require libsoxr soxr.h soxr_create -lsoxr
+@@ -6372,6 +6375,7 @@ enabled libsoxr           && require libsoxr soxr.h soxr_create -lsoxr
  enabled libssh            && require_pkg_config libssh libssh libssh/sftp.h sftp_init
  enabled libspeex          && require_pkg_config libspeex speex speex/speex.h speex_decoder_init
  enabled libsrt            && require_pkg_config libsrt "srt >= 1.3.0" srt/srt.h srt_socket
@@ -54,7 +54,7 @@ index 8569a60bf8..60d92052cb 100755
  enabled libtesseract      && require_pkg_config libtesseract tesseract tesseract/capi.h TessBaseAPICreate
  enabled libtheora         && require libtheora theora/theoraenc.h th_info_init -ltheoraenc -ltheoradec -logg
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 0a3bbc7128..d4e767c7b4 100644
+index 5a6ea59715..67d5da04d6 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
 @@ -1024,6 +1024,7 @@ OBJS-$(CONFIG_LIBRAV1E_ENCODER)           += librav1e.o
@@ -66,7 +66,7 @@ index 0a3bbc7128..d4e767c7b4 100644
  OBJS-$(CONFIG_LIBTWOLAME_ENCODER)         += libtwolame.o
  OBJS-$(CONFIG_LIBVO_AMRWBENC_ENCODER)     += libvo-amrwbenc.o
 diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
-index 5240d0afdf..7554c0fa2d 100644
+index 80f128cade..a79758f0ca 100644
 --- a/libavcodec/allcodecs.c
 +++ b/libavcodec/allcodecs.c
 @@ -728,6 +728,7 @@ extern AVCodec ff_librsvg_decoder;
@@ -79,10 +79,10 @@ index 5240d0afdf..7554c0fa2d 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000000..42dfea1b80
+index 0000000000..a2705bcc1c
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,552 @@
+@@ -0,0 +1,578 @@
 +
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
@@ -117,6 +117,9 @@ index 0000000000..42dfea1b80
 +#include "libavutil/avassert.h"
 +
 +#include "internal.h"
++#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 93, 100)
++#include "encode.h"
++#endif
 +#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 90, 100)
 +#include "packet_internal.h"
 +#endif
@@ -137,6 +140,8 @@ index 0000000000..42dfea1b80
 +    EbBufferHeaderType         *in_buf;
 +    int                         raw_size;
 +    int                         max_tu_size;
++
++    AVFrame *frame;
 +
 +    AVBufferPool* pool;
 +
@@ -396,6 +401,10 @@ index 0000000000..42dfea1b80
 +        }
 +    }
 +
++    svt_enc->frame = av_frame_alloc();
++    if (!svt_enc->frame)
++        return AVERROR(ENOMEM);
++
 +    ret = alloc_buffer(&svt_enc->enc_params, svt_enc);
 +    if (ret < 0)
 +        return ret;
@@ -410,6 +419,10 @@ index 0000000000..42dfea1b80
 +
 +    if (!frame) {
 +        EbBufferHeaderType headerPtrLast;
++
++        if (svt_enc->eos_flag == EOS_SENT)
++            return 0;
++
 +        headerPtrLast.n_alloc_len   = 0;
 +        headerPtrLast.n_filled_len  = 0;
 +        headerPtrLast.n_tick_count  = 0;
@@ -462,12 +475,24 @@ index 0000000000..42dfea1b80
 +{
 +    SvtContext  *svt_enc = avctx->priv_data;
 +    EbBufferHeaderType *headerPtr;
++    AVFrame *frame = svt_enc->frame;
 +    EbErrorType svt_ret;
 +    int ret = 0, pict_type;
 +    AVBufferRef* ref;
 +
 +    if (svt_enc->eos_flag == EOS_RECEIVED)
 +        return AVERROR_EOF;
++
++#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 93, 100)
++    ret = ff_encode_get_frame(avctx, frame);
++    if (ret < 0 && ret != AVERROR_EOF)
++        return ret;
++    if (ret == AVERROR_EOF)
++        frame = NULL;
++
++    eb_send_frame(avctx, frame);
++    av_frame_unref(svt_enc->frame);
++#endif
 +
 +    svt_ret = svt_av1_enc_get_packet(svt_enc->svt_handle, &headerPtr, svt_enc->eos_flag);
 +    if (svt_ret == EB_NoErrorEmptyQueue)
@@ -506,7 +531,7 @@ index 0000000000..42dfea1b80
 +
 +    svt_av1_enc_release_out_buffer(&headerPtr);
 +
-+    return ret;
++    return 0;
 +}
 +
 +static av_cold int eb_enc_close(AVCodecContext *avctx)
@@ -518,6 +543,8 @@ index 0000000000..42dfea1b80
 +            svt_av1_enc_deinit(svt_enc->svt_handle);
 +            svt_av1_enc_deinit_handle(svt_enc->svt_handle);
 +        }
++
++        av_frame_free(&svt_enc->frame);
 +
 +        free_buffer(svt_enc);
 +        svt_enc = NULL;
@@ -623,7 +650,6 @@ index 0000000000..42dfea1b80
 +    .type           = AVMEDIA_TYPE_VIDEO,
 +    .id             = AV_CODEC_ID_AV1,
 +    .init           = eb_enc_init,
-+    .send_frame     = eb_send_frame,
 +    .receive_packet = eb_receive_packet,
 +    .close          = eb_enc_close,
 +    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS,

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -1,4 +1,4 @@
-From 982420395aa469fb7a0530c18f1c0a8423937f95 Mon Sep 17 00:00:00 2001
+From f2614046d711bab7803981dc53511699b569b351 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1
@@ -13,8 +13,8 @@ Signed-off-by: Xu Guangxin <guangxin.xu@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 578 ++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 584 insertions(+)
+ libavcodec/libsvt_av1.c | 581 ++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 587 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index 80f128cade..a79758f0ca 100644
  extern AVCodec ff_libvo_amrwbenc_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000000..a2705bcc1c
+index 0000000000..ffb8861af4
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,578 @@
+@@ -0,0 +1,581 @@
 +
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
@@ -650,6 +650,9 @@ index 0000000000..a2705bcc1c
 +    .type           = AVMEDIA_TYPE_VIDEO,
 +    .id             = AV_CODEC_ID_AV1,
 +    .init           = eb_enc_init,
++#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 93, 100)
++    .send_frame     = eb_send_frame,
++#endif
 +    .receive_packet = eb_receive_packet,
 +    .close          = eb_enc_close,
 +    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS,


### PR DESCRIPTION
# Description
https://git.videolan.org/?p=ffmpeg.git;a=commitdiff;h=827d6fe73d2f5472c1c2128eb14fab6a4db29032 changed the internal encode API, as as such the ffmpeg plugin needs to be adapted.

# Issue
Without this change, the plugin will fail to build starting with lavc version 58.93.100

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
James Almer

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
