### PR TITLE
Add protection when tile is enbaled and enc_dec segment number is reduced

### DIFF
--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -881,8 +881,11 @@ void *picture_manager_kernel(void *input_ptr) {
                                 ->tile_group_row_count_array[entry_pcs_ptr->temporal_layer_index]);
 
                         if (tile_group_cols * tile_group_rows > 1) {
-                            enc_dec_seg_col_cnt = pic_width_in_sb / tile_group_cols;
-                            enc_dec_seg_row_cnt = picture_height_in_sb / tile_group_rows;
+                            enc_dec_seg_col_cnt = MIN(enc_dec_seg_col_cnt,
+                                                      (uint8_t)(pic_width_in_sb / tile_group_cols));
+                            enc_dec_seg_row_cnt = MIN(
+                                enc_dec_seg_row_cnt,
+                                (uint8_t)(picture_height_in_sb / tile_group_rows));
                         }
 
                         ppcs_ptr->tile_group_cols = tile_group_cols;

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -415,12 +415,8 @@ EbErrorType load_default_buffer_configuration_settings(
         (((scs_ptr->max_input_luma_width + 32) / BLOCK_SIZE_64) < 10) ? 1 : 10;
     if ((core_count != SINGLE_CORE_COUNT) && (core_count < (CONS_CORE_COUNT >> 2)))
     {
-        //check on tiles to be removed when crash is fixed
-        if ((scs_ptr->static_config.tile_rows == 0) && (scs_ptr->static_config.tile_columns == 0))
-        {
-            enc_dec_seg_h = MAX(1, enc_dec_seg_h / 2);
-            enc_dec_seg_w = MAX(1, enc_dec_seg_w / 2);
-        }
+        enc_dec_seg_h = MAX(1, enc_dec_seg_h / 2);
+        enc_dec_seg_w = MAX(1, enc_dec_seg_w / 2);
         me_seg_h = MAX(1, me_seg_h / 2);
         me_seg_w = MAX(1, me_seg_w / 2);
     }

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2136,8 +2136,11 @@ void copy_api_from_app(
     // Intra Edge Filter
     scs_ptr->static_config.enable_intra_edge_filter = ((EbSvtAv1EncConfiguration*)config_struct)->enable_intra_edge_filter;
 
-    // Picture based rate estimation
-    scs_ptr->static_config.pic_based_rate_est = ((EbSvtAv1EncConfiguration*)config_struct)->pic_based_rate_est;
+    // Picture based rate estimation, only active with lp 1
+    if(((EbSvtAv1EncConfiguration*)config_struct)->logical_processors > 1)
+        scs_ptr->static_config.pic_based_rate_est = 0;
+    else
+        scs_ptr->static_config.pic_based_rate_est = ((EbSvtAv1EncConfiguration*)config_struct)->pic_based_rate_est;
 
     // ME Tools
     scs_ptr->static_config.use_default_me_hme = ((EbSvtAv1EncConfiguration*)config_struct)->use_default_me_hme;


### PR DESCRIPTION
# Description
Add protection when tile is enbaled and enc_dec segment number is reduced
# Issue
Fixes #1276
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)

@tszumski
# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
