### PR TITLE
ffmpeg: add tile support

### DIFF
--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -877,7 +877,7 @@ ConfigEntry config_entry_specific[] = {
      "Offline packing of the 2bits: requires two bits packed input (0: OFF[default], 1: ON)",
      set_compressed_ten_bit_format},
     {SINGLE_INPUT, TILE_ROW_TOKEN, "Number of tile rows to use, log2[0-6]", set_tile_row},
-    {SINGLE_INPUT, TILE_COL_TOKEN, "Number of tile columns to use, log2[0-6]", set_tile_col},
+    {SINGLE_INPUT, TILE_COL_TOKEN, "Number of tile columns to use, log2[0-4]", set_tile_col},
     {SINGLE_INPUT, QP_TOKEN, "Constant/Constrained Quality level", set_cfg_qp},
     {SINGLE_INPUT, QP_LONG_TOKEN, "Constant/Constrained Quality level", set_cfg_qp},
 

--- a/Source/Lib/Common/Codec/EbSystemResourceManager.c
+++ b/Source/Lib/Common/Codec/EbSystemResourceManager.c
@@ -485,6 +485,10 @@ EbFifo *eb_system_resource_get_consumer_fifo(const EbSystemResource *resource_pt
 }
 
 EbErrorType eb_shutdown_process(const EbSystemResource *resource_ptr) {
+    //not fully constructed
+    if (!resource_ptr || !resource_ptr->full_queue)
+        return EB_ErrorNone;
+
     //notify all consumers we are shutting down
     for (unsigned int i = 0; i < resource_ptr->full_queue->process_total_count; i++) {
         EbFifo *fifo_ptr = eb_system_resource_get_consumer_fifo(resource_ptr, i);

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -1,4 +1,4 @@
-From 51534a68b6ad6ebf797ddc8b8ffd29401b5a698f Mon Sep 17 00:00:00 2001
+From 070621ebf5c3bc41e2563d9544d2acfcbe1eac87 Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1
@@ -66,10 +66,10 @@ index 5a6ea59715..b4dbca54d5 100644
  OBJS-$(CONFIG_AC3_AT_DECODER)             += audiotoolboxdec.o
  OBJS-$(CONFIG_ADPCM_IMA_QT_AT_DECODER)    += audiotoolboxdec.o
 diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
-index 80f128cade..2e45683b38 100644
+index fa0c08d42e..ec1e0d48ba 100644
 --- a/libavcodec/allcodecs.c
 +++ b/libavcodec/allcodecs.c
-@@ -719,6 +719,7 @@ extern AVCodec ff_libmp3lame_encoder;
+@@ -716,6 +716,7 @@ extern AVCodec ff_libmp3lame_encoder;
  extern AVCodec ff_libopencore_amrnb_encoder;
  extern AVCodec ff_libopencore_amrnb_decoder;
  extern AVCodec ff_libopencore_amrwb_decoder;
@@ -79,7 +79,7 @@ index 80f128cade..2e45683b38 100644
  extern AVCodec ff_libopus_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000000..6e0b9da832
+index 0000000000..882f711339
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
 @@ -0,0 +1,577 @@
@@ -608,9 +608,9 @@ index 0000000000..6e0b9da832
 +
 +    { "rc", "Bit rate control mode", OFFSET(rc_mode),
 +      AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 3, VE , "rc"},
-+        { "cqp", "Const QP", 0, AV_OPT_TYPE_CONST, { .i64 = 0 },  INT_MIN, INT_MAX, VE, "rc" },
-+        { "vbr", "Variable bit rate, achieve the target bitrate at entire stream", 0, AV_OPT_TYPE_CONST, { .i64 = 1 },  INT_MIN, INT_MAX, VE, "rc" },
-+        { "cvbr", "Constrained variable bit rate, achieve the target bitrate at each gop", 0, AV_OPT_TYPE_CONST,{ .i64 = 2 },  INT_MIN, INT_MAX, VE, "rc" },
++        { "cqp", "Const Quantization Parameter", 0, AV_OPT_TYPE_CONST, { .i64 = 0 },  INT_MIN, INT_MAX, VE, "rc" },
++        { "vbr", "Variable Bit Rate, use a target bitrate for the entire stream", 0, AV_OPT_TYPE_CONST, { .i64 = 1 },  INT_MIN, INT_MAX, VE, "rc" },
++        { "cvbr", "Constrained Variable Bit Rate, use a target bitrate for each GOP", 0, AV_OPT_TYPE_CONST,{ .i64 = 2 },  INT_MIN, INT_MAX, VE, "rc" },
 +
 +    { "qp", "QP value for intra frames", OFFSET(qp),
 +      AV_OPT_TYPE_INT, { .i64 = 50 }, 0, 63, VE },

--- a/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
+++ b/ffmpeg_plugin/0001-Add-ability-for-ffmpeg-to-run-svt-av1.patch
@@ -1,4 +1,4 @@
-From 070621ebf5c3bc41e2563d9544d2acfcbe1eac87 Mon Sep 17 00:00:00 2001
+From 726a9def395d40aa0d8a4b8fe5ebc1af13015dbb Mon Sep 17 00:00:00 2001
 From: Daryl Seah <daryl.seah@intel.com>
 Date: Fri, 18 Jan 2019 02:11:38 +0000
 Subject: [PATCH] Add ability for ffmpeg to run svt-av1
@@ -13,8 +13,8 @@ Signed-off-by: Xu Guangxin <guangxin.xu@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/libsvt_av1.c | 577 ++++++++++++++++++++++++++++++++++++++++
- 4 files changed, 583 insertions(+)
+ libavcodec/libsvt_av1.c | 583 ++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 589 insertions(+)
  create mode 100644 libavcodec/libsvt_av1.c
 
 diff --git a/configure b/configure
@@ -79,10 +79,10 @@ index fa0c08d42e..ec1e0d48ba 100644
  extern AVCodec ff_libopus_encoder;
 diff --git a/libavcodec/libsvt_av1.c b/libavcodec/libsvt_av1.c
 new file mode 100644
-index 0000000000..882f711339
+index 0000000000..541ba228fa
 --- /dev/null
 +++ b/libavcodec/libsvt_av1.c
-@@ -0,0 +1,577 @@
+@@ -0,0 +1,583 @@
 +
 +/*
 +* Scalable Video Technology for AV1 encoder library plugin
@@ -161,7 +161,8 @@ index 0000000000..882f711339
 +    int level;
 +    int profile;
 +
-+
++    int tile_columns;
++    int tile_rows;
 +} SvtContext;
 +
 +static const struct {
@@ -315,6 +316,9 @@ index 0000000000..882f711339
 +
 +    if (svt_enc->la_depth != -1)
 +        param->look_ahead_distance  = svt_enc->la_depth;
++
++    param->tile_columns = svt_enc->tile_columns;
++    param->tile_rows = svt_enc->tile_rows;
 +
 +    return 0;
 +}
@@ -620,6 +624,8 @@ index 0000000000..882f711339
 +
 +    { "forced-idr", "If forcing keyframes, force them as IDR frames.", OFFSET(forced_idr),
 +      AV_OPT_TYPE_BOOL,   { .i64 = 1 }, 0, 1, VE },
++    { "tile-columns",     "Log2 of number of tile columns to use", OFFSET(tile_columns), AV_OPT_TYPE_INT, {.i64 = 0}, 0, 4, VE},
++    { "tile-rows",        "Log2 of number of tile rows to use",    OFFSET(tile_rows), AV_OPT_TYPE_INT, {.i64 = 0}, 0, 6, VE},
 +
 +    {NULL},
 +};


### PR DESCRIPTION
# Description
enable tile in ffmpeg plugin 

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->
 fixes https://github.com/OpenVisualCloud/SVT-AV1/issues/482

# Author(s)
Guangxin.Xu@intel.com

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Test command
 ffmpeg -i input.264 -c:v libsvt_av1  -tile-columns 2 -tile-rows 2 out.ivf -y

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
