### PR TITLE
Use GST_ELEMENT_ERROR macro for GST_FLOW_ERROR

### DIFF
--- a/gstreamer-plugin/gstsvtav1enc.c
+++ b/gstreamer-plugin/gstsvtav1enc.c
@@ -314,7 +314,7 @@ gst_svtav1enc_init (GstSvtAv1Enc * svtav1enc)
   EbErrorType res =
       svt_av1_enc_init_handle(&svtav1enc->svt_encoder, NULL, svtav1enc->svt_config);
   if (res != EB_ErrorNone) {
-    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, INIT, ("svt_av1_enc_init_handle failed with error %d", res), (NULL));
+    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, INIT, (NULL), ("svt_av1_enc_init_handle failed with error %d", res));
     GST_OBJECT_UNLOCK (svtav1enc);
     return;
   }
@@ -583,7 +583,7 @@ gst_svtav1enc_configure_svt (GstSvtAv1Enc * svtav1enc)
   EbErrorType res =
       svt_av1_enc_set_parameter(svtav1enc->svt_encoder, svtav1enc->svt_config);
   if (res != EB_ErrorNone) {
-    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, INIT, ("svt_av1_enc_set_parameter failed with error %d", res), (NULL));
+    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, INIT, (NULL), ("svt_av1_enc_set_parameter failed with error %d", res));
     return FALSE;
   }
   return TRUE;
@@ -597,7 +597,7 @@ gst_svtav1enc_start_svt (GstSvtAv1Enc * svtav1enc)
   G_UNLOCK (init_mutex);
 
   if (res != EB_ErrorNone) {
-    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, INIT, ("svt_av1_enc_init failed with error %d", res), (NULL));
+    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, INIT, (NULL), ("svt_av1_enc_init failed with error %d", res));
     return FALSE;
   }
   return TRUE;
@@ -760,7 +760,7 @@ gst_svtav1enc_encode (GstSvtAv1Enc * svtav1enc, GstVideoCodecFrame * frame)
 
   if (!gst_video_frame_map (&video_frame, &svtav1enc->state->info,
           frame->input_buffer, GST_MAP_READ)) {
-    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, ENCODE, ("couldn't map input frame"), (NULL));
+    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, ENCODE, (NULL), ("couldn't map input frame"));
     return GST_FLOW_ERROR;
   }
 
@@ -792,7 +792,7 @@ gst_svtav1enc_encode (GstSvtAv1Enc * svtav1enc, GstVideoCodecFrame * frame)
 
   res = svt_av1_enc_send_picture(svtav1enc->svt_encoder, input_buffer);
   if (res != EB_ErrorNone) {
-    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, ENCODE, ("error in sending picture to encoder"), (NULL));
+    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, ENCODE, (NULL), ("error in sending picture to encoder"));
     ret = GST_FLOW_ERROR;
   }
   gst_video_frame_unmap (&video_frame);
@@ -816,7 +816,7 @@ gst_svtav1enc_send_eos (GstSvtAv1Enc * svtav1enc)
   ret = svt_av1_enc_send_picture(svtav1enc->svt_encoder, &input_buffer);
 
   if (ret != EB_ErrorNone) {
-    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, ENCODE, ("couldn't send EOS frame."), (NULL));
+    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, ENCODE, (NULL), ("couldn't send EOS frame."));
     return FALSE;
   }
 
@@ -864,7 +864,7 @@ gst_svtav1enc_dequeue_encoded_frames (GstSvtAv1Enc * svtav1enc,
           ((output_buf->flags & EB_BUFFERFLAG_EOS) == EB_BUFFERFLAG_EOS);
 
     if (res == EB_ErrorMax) {
-      GST_ELEMENT_ERROR (svtav1enc, LIBRARY, ENCODE, ("encode failed with error %d", res), (NULL));
+      GST_ELEMENT_ERROR (svtav1enc, LIBRARY, ENCODE, (NULL), ("encode failed"));
       return GST_FLOW_ERROR;
     } else if (res != EB_NoErrorEmptyQueue && output_frames && output_buf) {
       /* if p_app_private is indeed propagated, get the frame through it
@@ -879,7 +879,7 @@ gst_svtav1enc_dequeue_encoded_frames (GstSvtAv1Enc * svtav1enc,
             &output_buf->pts, compare_video_code_frame_and_pts);
 
         if (frame_list_element == NULL) {
-          GST_ELEMENT_ERROR (svtav1enc, LIBRARY, ENCODE, ("failed to get unfinished frame"), (NULL));
+          GST_ELEMENT_ERROR (svtav1enc, LIBRARY, ENCODE, (NULL), ("failed to get unfinished frame"));
           return GST_FLOW_ERROR;
         }
 

--- a/gstreamer-plugin/gstsvtav1enc.c
+++ b/gstreamer-plugin/gstsvtav1enc.c
@@ -314,7 +314,7 @@ gst_svtav1enc_init (GstSvtAv1Enc * svtav1enc)
   EbErrorType res =
       svt_av1_enc_init_handle(&svtav1enc->svt_encoder, NULL, svtav1enc->svt_config);
   if (res != EB_ErrorNone) {
-    GST_ERROR_OBJECT (svtav1enc, "svt_av1_enc_init_handle failed with error %d", res);
+    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, INIT, ("svt_av1_enc_init_handle failed with error %d", res), (NULL));
     GST_OBJECT_UNLOCK (svtav1enc);
     return;
   }
@@ -583,7 +583,7 @@ gst_svtav1enc_configure_svt (GstSvtAv1Enc * svtav1enc)
   EbErrorType res =
       svt_av1_enc_set_parameter(svtav1enc->svt_encoder, svtav1enc->svt_config);
   if (res != EB_ErrorNone) {
-    GST_ERROR_OBJECT (svtav1enc, "svt_av1_enc_set_parameter failed with error %d", res);
+    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, INIT, ("svt_av1_enc_set_parameter failed with error %d", res), (NULL));
     return FALSE;
   }
   return TRUE;
@@ -597,7 +597,7 @@ gst_svtav1enc_start_svt (GstSvtAv1Enc * svtav1enc)
   G_UNLOCK (init_mutex);
 
   if (res != EB_ErrorNone) {
-    GST_ERROR_OBJECT (svtav1enc, "svt_av1_enc_init failed with error %d", res);
+    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, INIT, ("svt_av1_enc_init failed with error %d", res), (NULL));
     return FALSE;
   }
   return TRUE;
@@ -760,7 +760,7 @@ gst_svtav1enc_encode (GstSvtAv1Enc * svtav1enc, GstVideoCodecFrame * frame)
 
   if (!gst_video_frame_map (&video_frame, &svtav1enc->state->info,
           frame->input_buffer, GST_MAP_READ)) {
-    GST_ERROR_OBJECT (svtav1enc, "couldn't map input frame");
+    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, ENCODE, ("couldn't map input frame"), (NULL));
     return GST_FLOW_ERROR;
   }
 
@@ -792,7 +792,7 @@ gst_svtav1enc_encode (GstSvtAv1Enc * svtav1enc, GstVideoCodecFrame * frame)
 
   res = svt_av1_enc_send_picture(svtav1enc->svt_encoder, input_buffer);
   if (res != EB_ErrorNone) {
-    GST_ERROR_OBJECT (svtav1enc, "Issue %d sending picture to SVT-AV1.", res);
+    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, ENCODE, ("error in sending picture to encoder"), (NULL));
     ret = GST_FLOW_ERROR;
   }
   gst_video_frame_unmap (&video_frame);
@@ -816,7 +816,7 @@ gst_svtav1enc_send_eos (GstSvtAv1Enc * svtav1enc)
   ret = svt_av1_enc_send_picture(svtav1enc->svt_encoder, &input_buffer);
 
   if (ret != EB_ErrorNone) {
-    GST_ERROR_OBJECT (svtav1enc, "couldn't send EOS frame.");
+    GST_ELEMENT_ERROR (svtav1enc, LIBRARY, ENCODE, ("couldn't send EOS frame."), (NULL));
     return FALSE;
   }
 
@@ -864,7 +864,7 @@ gst_svtav1enc_dequeue_encoded_frames (GstSvtAv1Enc * svtav1enc,
           ((output_buf->flags & EB_BUFFERFLAG_EOS) == EB_BUFFERFLAG_EOS);
 
     if (res == EB_ErrorMax) {
-      GST_ERROR_OBJECT (svtav1enc, "Error while encoding, return\n");
+      GST_ELEMENT_ERROR (svtav1enc, LIBRARY, ENCODE, ("encode failed with error %d", res), (NULL));
       return GST_FLOW_ERROR;
     } else if (res != EB_NoErrorEmptyQueue && output_frames && output_buf) {
       /* if p_app_private is indeed propagated, get the frame through it
@@ -878,8 +878,10 @@ gst_svtav1enc_dequeue_encoded_frames (GstSvtAv1Enc * svtav1enc,
         frame_list_element = g_list_find_custom (pending_frames,
             &output_buf->pts, compare_video_code_frame_and_pts);
 
-        if (frame_list_element == NULL)
+        if (frame_list_element == NULL) {
+          GST_ELEMENT_ERROR (svtav1enc, LIBRARY, ENCODE, ("failed to get unfinished frame"), (NULL));
           return GST_FLOW_ERROR;
+        }
 
         frame = (GstVideoCodecFrame *) frame_list_element->data;
       }


### PR DESCRIPTION
Signed-off-by: Jun Tian <jun.tian@intel.com>

# Description
use GST_ELEMENT_ERROR message macro for GST_FLOW_ERROR

# Issue
closes #521 
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@tianjunwork 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
