### PR TITLE
fix crash on Ctrl+C [WIP]

### DIFF
--- a/Source/Lib/Common/Codec/EbThreads.c
+++ b/Source/Lib/Common/Codec/EbThreads.c
@@ -244,8 +244,11 @@ EbErrorType eb_block_on_semaphore(EbHandle semaphore_handle)
             ? EB_ErrorSemaphoreUnresponsive
             : EB_ErrorNone;
 #else
-    return_error =
-        sem_wait((sem_t *)semaphore_handle) ? EB_ErrorSemaphoreUnresponsive : EB_ErrorNone;
+    int ret;
+    do {
+        ret = sem_wait((sem_t *)semaphore_handle);
+    } while(ret == -1 && errno == EINTR);
+    return_error = ret ? EB_ErrorSemaphoreUnresponsive : EB_ErrorNone;
 #endif
 
     return return_error;


### PR DESCRIPTION
# Description

sem_wait will interrupted by singals, like Ctrl-C.
In this case, eb_get_full_object/eb_get_empty_object wakeup with zero object in queue.
It will crash the application

    Test steps:
    1. run ./ffmpeg -i input.264 test.ivf -y
    2. wait sometime to make sure encode is started.
    3. press Ctrl+C

    Expected:
    No crash


# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->


# Author(s)
Guangxin.Xu@intel.com

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
