### PR TITLE
Releases: pack releases using zip

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -23,35 +23,39 @@ jobs:
         run: cmake --build Build-static --parallel 4 --config Release
       - name: Build shared SVT-AV1
         run: cmake --build Build-shared --parallel 4 --config Release
-      - name: Zip shared build
-        run: 7z.exe a SvtAv1Enc-shared.zip ./shared/Release/SvtAv1Enc.dll ./shared/Release/SvtAv1Enc.lib ./shared/Release/SvtAv1EncApp.exe
+      - name: Pack artifacts
+        run: |
+          7z.exe a SvtAv1Enc-shared.zip ./shared/Release/SvtAv1Enc.dll ./shared/Release/SvtAv1Enc.lib ./shared/Release/SvtAv1EncApp.exe
+          7z.exe a SvtAv1EncApp.zip ./static/Release/SvtAv1EncApp.exe
+          7z.exe a SvtAv1DecApp.zip ./static/Release/SvtAv1DecApp.exe
+          7z.exe a SvtAv1Enclib.zip ./static/Release/SvtAv1Enc.lib
 
       - name: Get Current Release
         id: get_release
         shell: bash
         run: echo "::set-output name=upload_url::$(curl -L https://api.github.com/repos/${{ github.repository }}/releases/tags/$(cut -d/ -f3 <<< ${{ github.ref }}) | jq -r ."upload_url")"
 
-      - name: Upload static SvtAv1EncApp.exe
+      - name: Upload static SvtAv1EncApp.zip
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: static/Release/SvtAv1EncApp.exe
-          asset_name: SvtAv1EncApp.exe
-          asset_content_type: application/vnd.microsoft.portable-executable
-      - name: Upload static SvtAv1DecApp.exe
+          asset_path: SvtAv1EncApp.zip
+          asset_name: SvtAv1EncApp.zip
+          asset_content_type: application/zip
+      - name: Upload static SvtAv1DecApp.zip
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: static/Release/SvtAv1DecApp.exe
-          asset_name: SvtAv1DecApp.exe
-          asset_content_type: application/vnd.microsoft.portable-executable
-      - name: Upload static SvtAv1Enc.lib
+          asset_path: SvtAv1DecApp.zip
+          asset_name: SvtAv1DecApp.zip
+          asset_content_type: application/zip
+      - name: Upload static SvtAv1Enclib.zip
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: static/Release/SvtAv1Enc.lib
-          asset_name: SvtAv1Enc.lib
-          asset_content_type: application/octet-stream
+          asset_path: SvtAv1Enclib.zip
+          asset_name: SvtAv1Enclib.zip
+          asset_content_type: application/zip
 
       - name: Upload SvtAv1Enc-shared.zip
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
# Description

Packs `SvtAv1DecApp.exe`, `SvtAv1EncApp.exe`, and `SvtAv1Enc.lib` into their own zip files, which should be okay to do since windows has some native ways to unzip

# Issue

Closes #1346

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
