### PR TITLE
App: Add option to print a bit more verbose or none as alternatives

### DIFF
--- a/Docs/svt-av1_encoder_user_guide.md
+++ b/Docs/svt-av1_encoder_user_guide.md
@@ -128,7 +128,8 @@ The encoder parameters present in the `Sample.cfg` file are listed in this table
 | **ErrorFile** | --errlog | any string | stderr | error log displaying configuration or encode errors |
 | **ReconFile** | -o | any string | null | Recon file path. Optional output of recon. |
 | **StatFile** | --stat-file | any string | Null | Path to statistics file if specified and StatReport is set to 1, per picture statistics are outputted in the file|
-| **NoProgress** | --no-progress | [0,1] | 0 | Use `--no-progress 1` to disable printing of frame processed when encoding |
+| **Progress** | --progress | [0,1,2] | 1 | Use `--progress 0` to disable printing of frame processed when encoding, `--progress 1` for default printing, and `--progress 2` for aomenc style printing |
+| **NoProgress** | --no-progress | [0,1] | 0 | `--no-progress 1` is equivalent to `--progress 0` and `--no-progress 0` is equivalent to `--progress 1` |
 
 #### Encoder Global Options
 | **Configuration file parameter** | **Command line** | **Range** | **Default** | **Description** |

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -185,7 +185,7 @@ typedef struct EbConfig {
     EbBool        y4m_input;
     unsigned char y4m_buf[9];
     EbBool        use_qp_file;
-    EbBool        no_progress;
+    uint8_t       progress; // 0 = no progress output, 1 = normal, 2 = aomenc style verbose progress
     uint8_t       stat_report;
     uint32_t      frame_rate;
     uint32_t      frame_rate_numerator;

--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -221,7 +221,6 @@ static EbErrorType encode(int32_t argc, char *argv[], EncodePass pass) {
                 free(warning[warning_id]);
 
             fprintf(stderr, "%sEncoding          ", get_pass_name(pass));
-            fflush(stdout);
 
             int32_t total_frames = 0;
 

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -1162,29 +1162,34 @@ AppExitConditionType process_output_stream_buffer(EbConfig *config, EbAppContext
             svt_av1_enc_release_out_buffer(&header_ptr);
 
             ++*frame_count;
-            if (!config->no_progress && !(header_ptr->flags & EB_BUFFERFLAG_IS_ALT_REF))
-                fprintf(stderr, "\b\b\b\b\b\b\b\b\b%9d", *frame_count);
-
-            //++frame_count;
-            fflush(stdout);
-
-            {
-                config->performance_context.average_speed =
-                    (config->performance_context.frame_count) /
-                    config->performance_context.total_encode_time;
-                config->performance_context.average_latency =
-                    config->performance_context.total_latency /
-                    (double)(config->performance_context.frame_count);
+            const double fps = (double)*frame_count / config->performance_context.total_encode_time;
+            switch (config->progress) {
+            case 0: break;
+            case 1:
+                if (!(header_ptr->flags & EB_BUFFERFLAG_IS_ALT_REF))
+                    fprintf(stderr, "\b\b\b\b\b\b\b\b\b%9d", *frame_count);
+                break;
+            case 2:
+                fprintf(stderr,
+                        "\rEncoding frame %4d %.2f fp%c  ",
+                        *frame_count,
+                        fps >= 1.0 ? fps : fps * 60,
+                        fps >= 1.0 ? 's' : 'm');
+            default: break;
             }
+            fflush(stderr);
 
-            if (!(*frame_count % SPEED_MEASUREMENT_INTERVAL)) {
-                {
-                    fprintf(stderr, "\n");
-                    fprintf(stderr,
-                            "Average System Encoding Speed:        %.2f\n",
-                            (double)(*frame_count) / config->performance_context.total_encode_time);
-                }
-            }
+            config->performance_context.average_speed =
+                (double)config->performance_context.frame_count /
+                config->performance_context.total_encode_time;
+            config->performance_context.average_latency =
+                (double)config->performance_context.total_latency /
+                config->performance_context.frame_count;
+
+            if (config->progress == 1 && !(*frame_count % SPEED_MEASUREMENT_INTERVAL))
+                fprintf(stderr,
+                        "\nAverage System Encoding Speed:        %.2f\n",
+                        (double)*frame_count / config->performance_context.total_encode_time);
         }
     }
     return return_value;


### PR DESCRIPTION
# Description

Changes the output from using `\b` to `\r` since using `\b` can be quite ugly when logging to a file or trying to parse the output.

Perhaps an ideal would be to do something like ?
```none
[85.1%] 9323/10961, 24.96 fps, 993.49 kbps, eta 0:01:08
```

# Issue

Closes #1348
Related to #1237, #1178, and #945


# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
