### PR TITLE
cppcheck5: variableScope & unreadVariable

### DIFF
--- a/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -5715,7 +5715,6 @@ void pme_sad_loop_kernel_avx2(uint8_t * src, // input parameter, source samples 
                     ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
                     ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
                     ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
-                    p_ref += ref_stride << 2;
                     ss3 =
                         _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4), _mm256_adds_epu16(ss5, ss6));
                     s3      = _mm_adds_epu16(_mm256_castsi256_si128(ss3),

--- a/Source/Lib/Encoder/ASM_AVX2/EbRestorationPick_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbRestorationPick_AVX2.c
@@ -25,7 +25,6 @@ void get_proj_subspace_avx2(const uint8_t *src8, int width, int height, int src_
                             const uint8_t *dat8, int dat_stride, int use_highbitdepth,
                             int32_t *flt0, int flt0_stride, int32_t *flt1, int flt1_stride, int *xq,
                             const SgrParamsType *params) {
-    int       i, j;
     double    H[2][2] = {{0, 0}, {0, 0}};
     double    C[2]    = {0, 0};
     double    det;
@@ -50,13 +49,13 @@ void get_proj_subspace_avx2(const uint8_t *src8, int width, int height, int src_
     __m256i u_256, s_256, f1_256, f2_256;
     __m256i f1_256_tmp, f2_256_tmp;
     __m256i out[2];
-    int     avx2_cnt = 0;
 
     if (!use_highbitdepth) {
         const uint8_t *src = src8;
         const uint8_t *dat = dat8;
-        for (i = 0; i < height; ++i) {
-            for (j = 0, avx2_cnt = 0; avx2_cnt < width / 16; j += 16, ++avx2_cnt) {
+        for (int i = 0; i < height; ++i) {
+            int j=0, avx2_cnt =0;
+            for (; avx2_cnt < width / 16; j += 16, ++avx2_cnt) {
                 u_256 = _mm256_cvtepu8_epi16(
                     _mm_loadu_si128((const __m128i *)(dat + i * dat_stride + j)));
                 u_256 = _mm256_slli_epi16(u_256, SGRPROJ_RST_BITS);
@@ -155,8 +154,9 @@ void get_proj_subspace_avx2(const uint8_t *src8, int width, int height, int src_
         const uint16_t *src = CONVERT_TO_SHORTPTR(src8);
         const uint16_t *dat = CONVERT_TO_SHORTPTR(dat8);
 
-        for (i = 0; i < height; ++i) {
-            for (j = 0, avx2_cnt = 0; avx2_cnt < width / 16; j += 16, ++avx2_cnt) {
+        for (int i = 0; i < height; ++i) {
+            int j = 0, avx2_cnt = 0;
+            for (; avx2_cnt < width / 16; j += 16, ++avx2_cnt) {
                 u_256 = _mm256_loadu_si256((const __m256i *)(dat + i * dat_stride + j));
                 u_256 = _mm256_slli_epi16(u_256, SGRPROJ_RST_BITS);
 

--- a/Source/Lib/Encoder/ASM_AVX2/highbd_fwd_txfm_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/highbd_fwd_txfm_avx2.c
@@ -4193,11 +4193,9 @@ static INLINE void load_buffer_16_avx2(const int16_t *input, __m256i *in, int32_
 static INLINE void load_buffer_32x8n(const int16_t *input, __m256i *out, int32_t stride,
                                      int32_t flipud, int32_t fliplr, int32_t shift,
                                      const int32_t height) {
-    const int16_t *in     = input;
-    __m256i *      output = out;
     for (int32_t col = 0; col < height; col++) {
-        in     = input + col * stride;
-        output = out + col * 4;
+        const int16_t *in     = input + col * stride;
+        __m256i *      output = out + col * 4;
         load_buffer_32_avx2(in, output, 8, flipud, fliplr, shift);
     }
 }

--- a/Source/Lib/Encoder/ASM_SSE4_1/EbTemporalFiltering_highbd_sse4.c
+++ b/Source/Lib/Encoder/ASM_SSE4_1/EbTemporalFiltering_highbd_sse4.c
@@ -179,9 +179,7 @@ static INLINE void highbd_read_chroma_dist_row_8(int ss_x, const uint32_t *u_dis
 }
 
 static void highbd_apply_temporal_filter_luma_8(
-    const uint16_t *y_src, int y_src_stride, const uint16_t *y_pre, int y_pre_stride,
-    const uint16_t *u_src, const uint16_t *v_src, int uv_src_stride, const uint16_t *u_pre,
-    const uint16_t *v_pre, int uv_pre_stride, unsigned int block_width, unsigned int block_height,
+    const uint16_t *y_pre, int y_pre_stride, unsigned int block_width, unsigned int block_height,
     int ss_x, int ss_y, int strength, int use_whole_blk, uint32_t *y_accum, uint16_t *y_count,
     const uint32_t *y_dist, const uint32_t *u_dist, const uint32_t *v_dist,
     const uint32_t *const *neighbors_first, const uint32_t *const *neighbors_second, int top_weight,
@@ -245,17 +243,12 @@ static void highbd_apply_temporal_filter_luma_8(
 
     highbd_accumulate_and_store_8(sum_row_first, sum_row_second, y_pre, y_count, y_accum);
 
-    y_src += y_src_stride;
     y_pre += y_pre_stride;
     y_count += y_pre_stride;
     y_accum += y_pre_stride;
     y_dist += DIST_STRIDE;
 
-    u_src += uv_src_stride;
-    u_pre += uv_pre_stride;
     u_dist += DIST_STRIDE;
-    v_src += uv_src_stride;
-    v_pre += uv_pre_stride;
     v_dist += DIST_STRIDE;
 
     // Then all the rows except the last one
@@ -287,11 +280,7 @@ static void highbd_apply_temporal_filter_luma_8(
             highbd_read_chroma_dist_row_8(
                 ss_x, u_dist, v_dist, &u_first, &u_second, &v_first, &v_second);
 
-            u_src += uv_src_stride;
-            u_pre += uv_pre_stride;
             u_dist += DIST_STRIDE;
-            v_src += uv_src_stride;
-            v_pre += uv_pre_stride;
             v_dist += DIST_STRIDE;
         }
 
@@ -312,7 +301,6 @@ static void highbd_apply_temporal_filter_luma_8(
                          weight);
         highbd_accumulate_and_store_8(sum_row_first, sum_row_second, y_pre, y_count, y_accum);
 
-        y_src += y_src_stride;
         y_pre += y_pre_stride;
         y_count += y_pre_stride;
         y_accum += y_pre_stride;
@@ -361,9 +349,8 @@ static void highbd_apply_temporal_filter_luma_8(
 
 // Perform temporal filter for the luma component.
 static void highbd_apply_temporal_filter_luma(
-    const uint16_t *y_src, int y_src_stride, const uint16_t *y_pre, int y_pre_stride,
-    const uint16_t *u_src, const uint16_t *v_src, int uv_src_stride, const uint16_t *u_pre,
-    const uint16_t *v_pre, int uv_pre_stride, unsigned int block_width, unsigned int block_height,
+    const uint16_t *y_pre, int y_pre_stride,
+    unsigned int block_width, unsigned int block_height,
     int ss_x, int ss_y, int strength, const int *blk_fw, int use_whole_blk, uint32_t *y_accum,
     uint16_t *y_count, const uint32_t *y_dist, const uint32_t *u_dist, const uint32_t *v_dist) {
     unsigned int       blk_col = 0, uv_blk_col = 0;
@@ -376,16 +363,8 @@ static void highbd_apply_temporal_filter_luma(
     // Left
     neighbors_first  = highbd_luma_left_column_neighbors;
     neighbors_second = highbd_luma_middle_column_neighbors;
-    highbd_apply_temporal_filter_luma_8(y_src + blk_col,
-                                        y_src_stride,
-                                        y_pre + blk_col,
+    highbd_apply_temporal_filter_luma_8(y_pre + blk_col,
                                         y_pre_stride,
-                                        u_src + uv_blk_col,
-                                        v_src + uv_blk_col,
-                                        uv_src_stride,
-                                        u_pre + uv_blk_col,
-                                        v_pre + uv_blk_col,
-                                        uv_pre_stride,
                                         blk_col_step,
                                         block_height,
                                         ss_x,
@@ -408,16 +387,8 @@ static void highbd_apply_temporal_filter_luma(
     // Middle First
     neighbors_first = highbd_luma_middle_column_neighbors;
     for (; blk_col < mid_width; blk_col += blk_col_step, uv_blk_col += uv_blk_col_step) {
-        highbd_apply_temporal_filter_luma_8(y_src + blk_col,
-                                            y_src_stride,
-                                            y_pre + blk_col,
+        highbd_apply_temporal_filter_luma_8(y_pre + blk_col,
                                             y_pre_stride,
-                                            u_src + uv_blk_col,
-                                            v_src + uv_blk_col,
-                                            uv_src_stride,
-                                            u_pre + uv_blk_col,
-                                            v_pre + uv_blk_col,
-                                            uv_pre_stride,
                                             blk_col_step,
                                             block_height,
                                             ss_x,
@@ -442,16 +413,8 @@ static void highbd_apply_temporal_filter_luma(
 
     // Middle Second
     for (; blk_col < last_width; blk_col += blk_col_step, uv_blk_col += uv_blk_col_step) {
-        highbd_apply_temporal_filter_luma_8(y_src + blk_col,
-                                            y_src_stride,
-                                            y_pre + blk_col,
+        highbd_apply_temporal_filter_luma_8(y_pre + blk_col,
                                             y_pre_stride,
-                                            u_src + uv_blk_col,
-                                            v_src + uv_blk_col,
-                                            uv_src_stride,
-                                            u_pre + uv_blk_col,
-                                            v_pre + uv_blk_col,
-                                            uv_pre_stride,
                                             blk_col_step,
                                             block_height,
                                             ss_x,
@@ -471,16 +434,8 @@ static void highbd_apply_temporal_filter_luma(
 
     // Right
     neighbors_second = highbd_luma_right_column_neighbors;
-    highbd_apply_temporal_filter_luma_8(y_src + blk_col,
-                                        y_src_stride,
-                                        y_pre + blk_col,
+    highbd_apply_temporal_filter_luma_8(y_pre + blk_col,
                                         y_pre_stride,
-                                        u_src + uv_blk_col,
-                                        v_src + uv_blk_col,
-                                        uv_src_stride,
-                                        u_pre + uv_blk_col,
-                                        v_pre + uv_blk_col,
-                                        uv_pre_stride,
                                         blk_col_step,
                                         block_height,
                                         ss_x,
@@ -552,9 +507,7 @@ static INLINE void highbd_add_luma_dist_to_8_chroma_mod(const uint32_t *y_dist, 
 // blk_fw as an array of size 4 for the weights for each of the 4 subblocks,
 // else use top_weight for top half, and bottom weight for bottom half.
 static void highbd_apply_temporal_filter_chroma_8(
-    const uint16_t *y_src, int y_src_stride, const uint16_t *y_pre, int y_pre_stride,
-    const uint16_t *u_src, const uint16_t *v_src, int uv_src_stride, const uint16_t *u_pre,
-    const uint16_t *v_pre, int uv_pre_stride, unsigned int uv_block_width,
+    const uint16_t *u_pre, const uint16_t *v_pre, int uv_pre_stride, unsigned int uv_block_width,
     unsigned int uv_block_height, int ss_x, int ss_y, int strength, uint32_t *u_accum,
     uint16_t *u_count, uint32_t *v_accum, uint16_t *v_count, const uint32_t *y_dist,
     const uint32_t *u_dist, const uint32_t *v_dist, const uint32_t *const *neighbors_fst,
@@ -629,10 +582,8 @@ static void highbd_apply_temporal_filter_chroma_8(
     highbd_accumulate_and_store_8(u_sum_row_fst, u_sum_row_snd, u_pre, u_count, u_accum);
     highbd_accumulate_and_store_8(v_sum_row_fst, v_sum_row_snd, v_pre, v_count, v_accum);
 
-    u_src += uv_src_stride;
     u_pre += uv_pre_stride;
     u_dist += DIST_STRIDE;
-    v_src += uv_src_stride;
     v_pre += uv_pre_stride;
     v_dist += DIST_STRIDE;
     u_count += uv_pre_stride;
@@ -640,8 +591,6 @@ static void highbd_apply_temporal_filter_chroma_8(
     v_count += uv_pre_stride;
     v_accum += uv_pre_stride;
 
-    y_src += y_src_stride * (1 + ss_y);
-    y_pre += y_pre_stride * (1 + ss_y);
     y_dist += DIST_STRIDE * (1 + ss_y);
 
     // Then all the rows except the last one
@@ -722,10 +671,8 @@ static void highbd_apply_temporal_filter_chroma_8(
         highbd_accumulate_and_store_8(u_sum_row_fst, u_sum_row_snd, u_pre, u_count, u_accum);
         highbd_accumulate_and_store_8(v_sum_row_fst, v_sum_row_snd, v_pre, v_count, v_accum);
 
-        u_src += uv_src_stride;
         u_pre += uv_pre_stride;
         u_dist += DIST_STRIDE;
-        v_src += uv_src_stride;
         v_pre += uv_pre_stride;
         v_dist += DIST_STRIDE;
         u_count += uv_pre_stride;
@@ -733,8 +680,6 @@ static void highbd_apply_temporal_filter_chroma_8(
         v_count += uv_pre_stride;
         v_accum += uv_pre_stride;
 
-        y_src += y_src_stride * (1 + ss_y);
-        y_pre += y_pre_stride * (1 + ss_y);
         y_dist += DIST_STRIDE * (1 + ss_y);
     }
 
@@ -798,12 +743,10 @@ static void highbd_apply_temporal_filter_chroma_8(
 
 // Perform temporal filter for the chroma components.
 static void highbd_apply_temporal_filter_chroma(
-    const uint16_t *y_src, int y_src_stride, const uint16_t *y_pre, int y_pre_stride,
-    const uint16_t *u_src, const uint16_t *v_src, int uv_src_stride, const uint16_t *u_pre,
-    const uint16_t *v_pre, int uv_pre_stride, unsigned int block_width, unsigned int block_height,
-    int ss_x, int ss_y, int strength, const int *blk_fw, int use_whole_blk, uint32_t *u_accum,
-    uint16_t *u_count, uint32_t *v_accum, uint16_t *v_count, const uint32_t *y_dist,
-    const uint32_t *u_dist, const uint32_t *v_dist) {
+    const uint16_t *u_pre, const uint16_t *v_pre, int uv_pre_stride, unsigned int block_width,
+    unsigned int block_height, int ss_x, int ss_y, int strength, const int *blk_fw,
+    int use_whole_blk, uint32_t *u_accum, uint16_t *u_count, uint32_t *v_accum, uint16_t *v_count,
+    const uint32_t *y_dist, const uint32_t *u_dist, const uint32_t *v_dist) {
     const unsigned int uv_width = block_width >> ss_x, uv_height = block_height >> ss_y;
 
     unsigned int       blk_col = 0, uv_blk_col = 0;
@@ -828,14 +771,7 @@ static void highbd_apply_temporal_filter_chroma(
         }
 
         if (use_whole_blk) {
-            highbd_apply_temporal_filter_chroma_8(y_src + blk_col,
-                                                  y_src_stride,
-                                                  y_pre + blk_col,
-                                                  y_pre_stride,
-                                                  u_src + uv_blk_col,
-                                                  v_src + uv_blk_col,
-                                                  uv_src_stride,
-                                                  u_pre + uv_blk_col,
+            highbd_apply_temporal_filter_chroma_8(u_pre + uv_blk_col,
                                                   v_pre + uv_blk_col,
                                                   uv_pre_stride,
                                                   uv_width,
@@ -856,14 +792,7 @@ static void highbd_apply_temporal_filter_chroma(
                                                   bottom_weight,
                                                   NULL);
         } else {
-            highbd_apply_temporal_filter_chroma_8(y_src + blk_col,
-                                                  y_src_stride,
-                                                  y_pre + blk_col,
-                                                  y_pre_stride,
-                                                  u_src + uv_blk_col,
-                                                  v_src + uv_blk_col,
-                                                  uv_src_stride,
-                                                  u_pre + uv_blk_col,
+            highbd_apply_temporal_filter_chroma_8(u_pre + uv_blk_col,
                                                   v_pre + uv_blk_col,
                                                   uv_pre_stride,
                                                   uv_width,
@@ -900,14 +829,7 @@ static void highbd_apply_temporal_filter_chroma(
         neighbors_snd = highbd_chroma_no_ss_middle_column_neighbors;
     }
 
-    highbd_apply_temporal_filter_chroma_8(y_src + blk_col,
-                                          y_src_stride,
-                                          y_pre + blk_col,
-                                          y_pre_stride,
-                                          u_src + uv_blk_col,
-                                          v_src + uv_blk_col,
-                                          uv_src_stride,
-                                          u_pre + uv_blk_col,
+    highbd_apply_temporal_filter_chroma_8(u_pre + uv_blk_col,
                                           v_pre + uv_blk_col,
                                           uv_pre_stride,
                                           uv_width,
@@ -941,14 +863,7 @@ static void highbd_apply_temporal_filter_chroma(
     }
 
     for (; uv_blk_col < uv_mid_width; blk_col += blk_col_step, uv_blk_col += uv_blk_col_step) {
-        highbd_apply_temporal_filter_chroma_8(y_src + blk_col,
-                                              y_src_stride,
-                                              y_pre + blk_col,
-                                              y_pre_stride,
-                                              u_src + uv_blk_col,
-                                              v_src + uv_blk_col,
-                                              uv_src_stride,
-                                              u_pre + uv_blk_col,
+        highbd_apply_temporal_filter_chroma_8(u_pre + uv_blk_col,
                                               v_pre + uv_blk_col,
                                               uv_pre_stride,
                                               uv_width,
@@ -977,14 +892,7 @@ static void highbd_apply_temporal_filter_chroma(
 
     // Middle Second
     for (; uv_blk_col < uv_last_width; blk_col += blk_col_step, uv_blk_col += uv_blk_col_step) {
-        highbd_apply_temporal_filter_chroma_8(y_src + blk_col,
-                                              y_src_stride,
-                                              y_pre + blk_col,
-                                              y_pre_stride,
-                                              u_src + uv_blk_col,
-                                              v_src + uv_blk_col,
-                                              uv_src_stride,
-                                              u_pre + uv_blk_col,
+        highbd_apply_temporal_filter_chroma_8(u_pre + uv_blk_col,
                                               v_pre + uv_blk_col,
                                               uv_pre_stride,
                                               uv_width,
@@ -1015,14 +923,7 @@ static void highbd_apply_temporal_filter_chroma(
         neighbors_snd = highbd_chroma_no_ss_right_column_neighbors;
     }
 
-    highbd_apply_temporal_filter_chroma_8(y_src + blk_col,
-                                          y_src_stride,
-                                          y_pre + blk_col,
-                                          y_pre_stride,
-                                          u_src + uv_blk_col,
-                                          v_src + uv_blk_col,
-                                          uv_src_stride,
-                                          u_pre + uv_blk_col,
+    highbd_apply_temporal_filter_chroma_8(u_pre + uv_blk_col,
                                           v_pre + uv_blk_col,
                                           uv_pre_stride,
                                           uv_width,
@@ -1100,9 +1001,6 @@ void svt_av1_highbd_apply_temporal_filter_sse4_1(
         v_dist_ptr += DIST_STRIDE;
     }
 
-    y_src_ptr = y_src;
-    u_src_ptr = u_src;
-    v_src_ptr = v_src;
     y_pre_ptr = y_pre;
     u_pre_ptr = u_pre;
     v_pre_ptr = v_pre;
@@ -1111,16 +1009,8 @@ void svt_av1_highbd_apply_temporal_filter_sse4_1(
     u_dist_ptr = u_dist + 1;
     v_dist_ptr = v_dist + 1;
 
-    highbd_apply_temporal_filter_luma(y_src_ptr,
-                                      y_src_stride,
-                                      y_pre_ptr,
+    highbd_apply_temporal_filter_luma(y_pre_ptr,
                                       y_pre_stride,
-                                      u_src_ptr,
-                                      v_src_ptr,
-                                      uv_src_stride,
-                                      u_pre_ptr,
-                                      v_pre_ptr,
-                                      uv_pre_stride,
                                       block_width,
                                       block_height,
                                       ss_x,
@@ -1134,14 +1024,7 @@ void svt_av1_highbd_apply_temporal_filter_sse4_1(
                                       u_dist_ptr,
                                       v_dist_ptr);
 
-    highbd_apply_temporal_filter_chroma(y_src_ptr,
-                                        y_src_stride,
-                                        y_pre_ptr,
-                                        y_pre_stride,
-                                        u_src_ptr,
-                                        v_src_ptr,
-                                        uv_src_stride,
-                                        u_pre_ptr,
+    highbd_apply_temporal_filter_chroma(u_pre_ptr,
                                         v_pre_ptr,
                                         uv_pre_stride,
                                         block_width,

--- a/Source/Lib/Encoder/ASM_SSE4_1/EbTemporalFiltering_sse4.c
+++ b/Source/Lib/Encoder/ASM_SSE4_1/EbTemporalFiltering_sse4.c
@@ -308,13 +308,11 @@ static INLINE void add_luma_dist_to_8_chroma_mod(const uint16_t *y_dist, int ss_
 // size 4 for the weights for each of the 4 subblocks if blk_fw is not NULL,
 // else use top_weight for top half, and bottom weight for bottom half.
 static void av1_apply_temporal_filter_luma_16(
-    const uint8_t *y_src, int y_src_stride, const uint8_t *y_pre, int y_pre_stride,
-    const uint8_t *u_src, const uint8_t *v_src, int uv_src_stride, const uint8_t *u_pre,
-    const uint8_t *v_pre, int uv_pre_stride, unsigned int block_width, unsigned int block_height,
-    int ss_x, int ss_y, int strength, int use_whole_blk, uint32_t *y_accum, uint16_t *y_count,
-    const uint16_t *y_dist, const uint16_t *u_dist, const uint16_t *v_dist,
-    const int16_t *const *neighbors_first, const int16_t *const *neighbors_second, int top_weight,
-    int bottom_weight, const int *blk_fw) {
+    const uint8_t *y_pre, int y_pre_stride, unsigned int block_width,
+    unsigned int block_height, int ss_x, int ss_y, int strength, int use_whole_blk,
+    uint32_t *y_accum, uint16_t *y_count, const uint16_t *y_dist, const uint16_t *u_dist,
+    const uint16_t *v_dist, const int16_t *const *neighbors_first,
+    const int16_t *const *neighbors_second, int top_weight, int bottom_weight, const int *blk_fw) {
     const int rounding = (1 << strength) >> 1;
     int       weight   = top_weight;
 
@@ -370,17 +368,12 @@ static void av1_apply_temporal_filter_luma_16(
     }
     accumulate_and_store_16(sum_row_first, sum_row_second, y_pre, y_count, y_accum);
 
-    y_src += y_src_stride;
     y_pre += y_pre_stride;
     y_count += y_pre_stride;
     y_accum += y_pre_stride;
     y_dist += DIST_STRIDE;
 
-    u_src += uv_src_stride;
-    u_pre += uv_pre_stride;
     u_dist += DIST_STRIDE;
-    v_src += uv_src_stride;
-    v_pre += uv_pre_stride;
     v_dist += DIST_STRIDE;
 
     // Then all the rows except the last one
@@ -416,11 +409,7 @@ static void av1_apply_temporal_filter_luma_16(
             // corresponds to a new chroma row
             read_chroma_dist_row_16(ss_x, u_dist, v_dist, &u_first, &u_second, &v_first, &v_second);
 
-            u_src += uv_src_stride;
-            u_pre += uv_pre_stride;
             u_dist += DIST_STRIDE;
-            v_src += uv_src_stride;
-            v_pre += uv_pre_stride;
             v_dist += DIST_STRIDE;
         }
 
@@ -444,7 +433,6 @@ static void av1_apply_temporal_filter_luma_16(
         }
         accumulate_and_store_16(sum_row_first, sum_row_second, y_pre, y_count, y_accum);
 
-        y_src += y_src_stride;
         y_pre += y_pre_stride;
         y_count += y_pre_stride;
         y_accum += y_pre_stride;
@@ -489,12 +477,12 @@ static void av1_apply_temporal_filter_luma_16(
 }
 
 // Perform temporal filter for the luma component.
-static void av1_apply_temporal_filter_luma(
-    const uint8_t *y_src, int y_src_stride, const uint8_t *y_pre, int y_pre_stride,
-    const uint8_t *u_src, const uint8_t *v_src, int uv_src_stride, const uint8_t *u_pre,
-    const uint8_t *v_pre, int uv_pre_stride, unsigned int block_width, unsigned int block_height,
-    int ss_x, int ss_y, int strength, const int *blk_fw, int use_whole_blk, uint32_t *y_accum,
-    uint16_t *y_count, const uint16_t *y_dist, const uint16_t *u_dist, const uint16_t *v_dist) {
+static void av1_apply_temporal_filter_luma(const uint8_t *y_pre, int y_pre_stride,
+                                           unsigned int block_width, unsigned int block_height,
+                                           int ss_x, int ss_y, int strength, const int *blk_fw,
+                                           int use_whole_blk, uint32_t *y_accum, uint16_t *y_count,
+                                           const uint16_t *y_dist, const uint16_t *u_dist,
+                                           const uint16_t *v_dist) {
     unsigned int       blk_col = 0, uv_blk_col = 0;
     const unsigned int blk_col_step = 16, uv_blk_col_step = 16 >> ss_x;
     const unsigned int mid_width = block_width >> 1, last_width = block_width - blk_col_step;
@@ -509,16 +497,8 @@ static void av1_apply_temporal_filter_luma(
         neighbors_first  = luma_left_column_neighbors;
         neighbors_second = luma_right_column_neighbors;
         if (use_whole_blk) {
-            av1_apply_temporal_filter_luma_16(y_src + blk_col,
-                                              y_src_stride,
-                                              y_pre + blk_col,
+            av1_apply_temporal_filter_luma_16(y_pre + blk_col,
                                               y_pre_stride,
-                                              u_src + uv_blk_col,
-                                              v_src + uv_blk_col,
-                                              uv_src_stride,
-                                              u_pre + uv_blk_col,
-                                              v_pre + uv_blk_col,
-                                              uv_pre_stride,
                                               16,
                                               block_height,
                                               ss_x,
@@ -536,16 +516,8 @@ static void av1_apply_temporal_filter_luma(
                                               bottom_weight,
                                               NULL);
         } else {
-            av1_apply_temporal_filter_luma_16(y_src + blk_col,
-                                              y_src_stride,
-                                              y_pre + blk_col,
+            av1_apply_temporal_filter_luma_16(y_pre + blk_col,
                                               y_pre_stride,
-                                              u_src + uv_blk_col,
-                                              v_src + uv_blk_col,
-                                              uv_src_stride,
-                                              u_pre + uv_blk_col,
-                                              v_pre + uv_blk_col,
-                                              uv_pre_stride,
                                               16,
                                               block_height,
                                               ss_x,
@@ -570,16 +542,8 @@ static void av1_apply_temporal_filter_luma(
     // Left
     neighbors_first  = luma_left_column_neighbors;
     neighbors_second = luma_middle_column_neighbors;
-    av1_apply_temporal_filter_luma_16(y_src + blk_col,
-                                      y_src_stride,
-                                      y_pre + blk_col,
+    av1_apply_temporal_filter_luma_16(y_pre + blk_col,
                                       y_pre_stride,
-                                      u_src + uv_blk_col,
-                                      v_src + uv_blk_col,
-                                      uv_src_stride,
-                                      u_pre + uv_blk_col,
-                                      v_pre + uv_blk_col,
-                                      uv_pre_stride,
                                       16,
                                       block_height,
                                       ss_x,
@@ -603,16 +567,8 @@ static void av1_apply_temporal_filter_luma(
     // Middle First
     neighbors_first = luma_middle_column_neighbors;
     for (; blk_col < mid_width; blk_col += blk_col_step, uv_blk_col += uv_blk_col_step) {
-        av1_apply_temporal_filter_luma_16(y_src + blk_col,
-                                          y_src_stride,
-                                          y_pre + blk_col,
+        av1_apply_temporal_filter_luma_16(y_pre + blk_col,
                                           y_pre_stride,
-                                          u_src + uv_blk_col,
-                                          v_src + uv_blk_col,
-                                          uv_src_stride,
-                                          u_pre + uv_blk_col,
-                                          v_pre + uv_blk_col,
-                                          uv_pre_stride,
                                           16,
                                           block_height,
                                           ss_x,
@@ -638,16 +594,8 @@ static void av1_apply_temporal_filter_luma(
 
     // Middle Second
     for (; blk_col < last_width; blk_col += blk_col_step, uv_blk_col += uv_blk_col_step) {
-        av1_apply_temporal_filter_luma_16(y_src + blk_col,
-                                          y_src_stride,
-                                          y_pre + blk_col,
+        av1_apply_temporal_filter_luma_16(y_pre + blk_col,
                                           y_pre_stride,
-                                          u_src + uv_blk_col,
-                                          v_src + uv_blk_col,
-                                          uv_src_stride,
-                                          u_pre + uv_blk_col,
-                                          v_pre + uv_blk_col,
-                                          uv_pre_stride,
                                           16,
                                           block_height,
                                           ss_x,
@@ -668,16 +616,8 @@ static void av1_apply_temporal_filter_luma(
 
     // Right
     neighbors_second = luma_right_column_neighbors;
-    av1_apply_temporal_filter_luma_16(y_src + blk_col,
-                                      y_src_stride,
-                                      y_pre + blk_col,
+    av1_apply_temporal_filter_luma_16(y_pre + blk_col,
                                       y_pre_stride,
-                                      u_src + uv_blk_col,
-                                      v_src + uv_blk_col,
-                                      uv_src_stride,
-                                      u_pre + uv_blk_col,
-                                      v_pre + uv_blk_col,
-                                      uv_pre_stride,
                                       16,
                                       block_height,
                                       ss_x,
@@ -701,9 +641,7 @@ static void av1_apply_temporal_filter_luma(
 // blk_fw as an array of size 4 for the weights for each of the 4 subblocks,
 // else use top_weight for top half, and bottom weight for bottom half.
 static void av1_apply_temporal_filter_chroma_8(
-    const uint8_t *y_src, int y_src_stride, const uint8_t *y_pre, int y_pre_stride,
-    const uint8_t *u_src, const uint8_t *v_src, int uv_src_stride, const uint8_t *u_pre,
-    const uint8_t *v_pre, int uv_pre_stride, unsigned int uv_block_width,
+    const uint8_t *u_pre, const uint8_t *v_pre, int uv_pre_stride, unsigned int uv_block_width,
     unsigned int uv_block_height, int ss_x, int ss_y, int strength, uint32_t *u_accum,
     uint16_t *u_count, uint32_t *v_accum, uint16_t *v_count, const uint16_t *y_dist,
     const uint16_t *u_dist, const uint16_t *v_dist, const int16_t *const *neighbors, int top_weight,
@@ -751,10 +689,8 @@ static void av1_apply_temporal_filter_chroma_8(
     accumulate_and_store_8(u_sum_row, u_pre, u_count, u_accum);
     accumulate_and_store_8(v_sum_row, v_pre, v_count, v_accum);
 
-    u_src += uv_src_stride;
     u_pre += uv_pre_stride;
     u_dist += DIST_STRIDE;
-    v_src += uv_src_stride;
     v_pre += uv_pre_stride;
     v_dist += DIST_STRIDE;
     u_count += uv_pre_stride;
@@ -762,8 +698,6 @@ static void av1_apply_temporal_filter_chroma_8(
     v_count += uv_pre_stride;
     v_accum += uv_pre_stride;
 
-    y_src += y_src_stride * (1 + ss_y);
-    y_pre += y_pre_stride * (1 + ss_y);
     y_dist += DIST_STRIDE * (1 + ss_y);
 
     // Then all the rows except the last one
@@ -809,10 +743,8 @@ static void av1_apply_temporal_filter_chroma_8(
         accumulate_and_store_8(u_sum_row, u_pre, u_count, u_accum);
         accumulate_and_store_8(v_sum_row, v_pre, v_count, v_accum);
 
-        u_src += uv_src_stride;
         u_pre += uv_pre_stride;
         u_dist += DIST_STRIDE;
-        v_src += uv_src_stride;
         v_pre += uv_pre_stride;
         v_dist += DIST_STRIDE;
         u_count += uv_pre_stride;
@@ -820,8 +752,6 @@ static void av1_apply_temporal_filter_chroma_8(
         v_count += uv_pre_stride;
         v_accum += uv_pre_stride;
 
-        y_src += y_src_stride * (1 + ss_y);
-        y_pre += y_pre_stride * (1 + ss_y);
         y_dist += DIST_STRIDE * (1 + ss_y);
     }
 
@@ -857,12 +787,10 @@ static void av1_apply_temporal_filter_chroma_8(
 
 // Perform temporal filter for the chroma components.
 static void av1_apply_temporal_filter_chroma(
-    const uint8_t *y_src, int y_src_stride, const uint8_t *y_pre, int y_pre_stride,
-    const uint8_t *u_src, const uint8_t *v_src, int uv_src_stride, const uint8_t *u_pre,
-    const uint8_t *v_pre, int uv_pre_stride, unsigned int block_width, unsigned int block_height,
-    int ss_x, int ss_y, int strength, const int *blk_fw, int use_whole_blk, uint32_t *u_accum,
-    uint16_t *u_count, uint32_t *v_accum, uint16_t *v_count, const uint16_t *y_dist,
-    const uint16_t *u_dist, const uint16_t *v_dist) {
+    const uint8_t *u_pre, const uint8_t *v_pre, int uv_pre_stride, unsigned int block_width,
+    unsigned int block_height, int ss_x, int ss_y, int strength, const int *blk_fw,
+    int use_whole_blk, uint32_t *u_accum, uint16_t *u_count, uint32_t *v_accum, uint16_t *v_count,
+    const uint16_t *y_dist, const uint16_t *u_dist, const uint16_t *v_dist) {
     const unsigned int uv_width = block_width >> ss_x, uv_height = block_height >> ss_y;
 
     unsigned int       blk_col = 0, uv_blk_col = 0;
@@ -882,14 +810,7 @@ static void av1_apply_temporal_filter_chroma(
         } else
             neighbors = chroma_single_ss_single_column_neighbors;
         if (use_whole_blk) {
-            av1_apply_temporal_filter_chroma_8(y_src + blk_col,
-                                               y_src_stride,
-                                               y_pre + blk_col,
-                                               y_pre_stride,
-                                               u_src + uv_blk_col,
-                                               v_src + uv_blk_col,
-                                               uv_src_stride,
-                                               u_pre + uv_blk_col,
+            av1_apply_temporal_filter_chroma_8(u_pre + uv_blk_col,
                                                v_pre + uv_blk_col,
                                                uv_pre_stride,
                                                uv_width,
@@ -909,14 +830,7 @@ static void av1_apply_temporal_filter_chroma(
                                                bottom_weight,
                                                NULL);
         } else {
-            av1_apply_temporal_filter_chroma_8(y_src + blk_col,
-                                               y_src_stride,
-                                               y_pre + blk_col,
-                                               y_pre_stride,
-                                               u_src + uv_blk_col,
-                                               v_src + uv_blk_col,
-                                               uv_src_stride,
-                                               u_pre + uv_blk_col,
+            av1_apply_temporal_filter_chroma_8(u_pre + uv_blk_col,
                                                v_pre + uv_blk_col,
                                                uv_pre_stride,
                                                uv_width,
@@ -947,14 +861,7 @@ static void av1_apply_temporal_filter_chroma(
         neighbors = chroma_single_ss_left_column_neighbors;
     } else
         neighbors = chroma_no_ss_left_column_neighbors;
-    av1_apply_temporal_filter_chroma_8(y_src + blk_col,
-                                       y_src_stride,
-                                       y_pre + blk_col,
-                                       y_pre_stride,
-                                       u_src + uv_blk_col,
-                                       v_src + uv_blk_col,
-                                       uv_src_stride,
-                                       u_pre + uv_blk_col,
+    av1_apply_temporal_filter_chroma_8(u_pre + uv_blk_col,
                                        v_pre + uv_blk_col,
                                        uv_pre_stride,
                                        uv_width,
@@ -985,14 +892,7 @@ static void av1_apply_temporal_filter_chroma(
     } else
         neighbors = chroma_no_ss_middle_column_neighbors;
     for (; uv_blk_col < uv_mid_width; blk_col += blk_col_step, uv_blk_col += uv_blk_col_step) {
-        av1_apply_temporal_filter_chroma_8(y_src + blk_col,
-                                           y_src_stride,
-                                           y_pre + blk_col,
-                                           y_pre_stride,
-                                           u_src + uv_blk_col,
-                                           v_src + uv_blk_col,
-                                           uv_src_stride,
-                                           u_pre + uv_blk_col,
+        av1_apply_temporal_filter_chroma_8(u_pre + uv_blk_col,
                                            v_pre + uv_blk_col,
                                            uv_pre_stride,
                                            uv_width,
@@ -1020,14 +920,7 @@ static void av1_apply_temporal_filter_chroma(
 
     // Middle Second
     for (; uv_blk_col < uv_last_width; blk_col += blk_col_step, uv_blk_col += uv_blk_col_step) {
-        av1_apply_temporal_filter_chroma_8(y_src + blk_col,
-                                           y_src_stride,
-                                           y_pre + blk_col,
-                                           y_pre_stride,
-                                           u_src + uv_blk_col,
-                                           v_src + uv_blk_col,
-                                           uv_src_stride,
-                                           u_pre + uv_blk_col,
+        av1_apply_temporal_filter_chroma_8(u_pre + uv_blk_col,
                                            v_pre + uv_blk_col,
                                            uv_pre_stride,
                                            uv_width,
@@ -1055,14 +948,7 @@ static void av1_apply_temporal_filter_chroma(
         neighbors = chroma_single_ss_right_column_neighbors;
     } else
         neighbors = chroma_no_ss_right_column_neighbors;
-    av1_apply_temporal_filter_chroma_8(y_src + blk_col,
-                                       y_src_stride,
-                                       y_pre + blk_col,
-                                       y_pre_stride,
-                                       u_src + uv_blk_col,
-                                       v_src + uv_blk_col,
-                                       uv_src_stride,
-                                       u_pre + uv_blk_col,
+    av1_apply_temporal_filter_chroma_8(u_pre + uv_blk_col,
                                        v_pre + uv_blk_col,
                                        uv_pre_stride,
                                        uv_width,
@@ -1144,16 +1030,8 @@ void svt_av1_apply_temporal_filter_sse4_1(
     u_dist_ptr = u_dist + 1;
     v_dist_ptr = v_dist + 1;
 
-    av1_apply_temporal_filter_luma(y_src,
-                                   y_src_stride,
-                                   y_pre,
+    av1_apply_temporal_filter_luma(y_pre,
                                    y_pre_stride,
-                                   u_src,
-                                   v_src,
-                                   uv_src_stride,
-                                   u_pre,
-                                   v_pre,
-                                   uv_pre_stride,
                                    block_width,
                                    block_height,
                                    ss_x,
@@ -1167,14 +1045,7 @@ void svt_av1_apply_temporal_filter_sse4_1(
                                    u_dist_ptr,
                                    v_dist_ptr);
 
-    av1_apply_temporal_filter_chroma(y_src,
-                                     y_src_stride,
-                                     y_pre,
-                                     y_pre_stride,
-                                     u_src,
-                                     v_src,
-                                     uv_src_stride,
-                                     u_pre,
+    av1_apply_temporal_filter_chroma(u_pre,
                                      v_pre,
                                      uv_pre_stride,
                                      block_width,

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -2122,8 +2122,7 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                SuperBlock *sb_ptr, uint32_t sb_addr, uint32_t sb_origin_x,
                                uint32_t sb_origin_y, EncDecContext *context_ptr) {
     EbBool               is_16bit = context_ptr->is_16bit;
-    EbPictureBufferDesc *recon_buffer =
-        is_16bit ? pcs_ptr->recon_picture16bit_ptr : pcs_ptr->recon_picture_ptr;
+    EbPictureBufferDesc *recon_buffer;
     EbPictureBufferDesc *coeff_buffer_sb = sb_ptr->quantized_coeff;
     EbPictureBufferDesc *input_picture;
     ModeDecisionContext *md_context_ptr;
@@ -2139,9 +2138,6 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
     uint32_t              y_has_coeff;
     uint32_t              u_has_coeff;
     uint32_t              v_has_coeff;
-    uint64_t              y_coeff_bits;
-    uint64_t              cb_coeff_bits;
-    uint64_t              cr_coeff_bits;
     uint64_t              y_full_distortion[DIST_CALC_TOTAL];
     EB_ALIGN(16) uint64_t y_tu_full_distortion[DIST_CALC_TOTAL];
     uint32_t              count_non_zero_coeffs[3];
@@ -2386,7 +2382,6 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
         PartitionType part = blk_ptr->part;
 
         const BlockGeom *blk_geom = context_ptr->blk_geom = get_blk_geom_mds(blk_it);
-        UNUSED(blk_geom);
         sb_ptr->cu_partition_array[blk_it] = context_ptr->md_context->md_blk_arr_nsq[blk_it].part;
         if (pcs_ptr->update_cdf) {
             blk_ptr->av1xd->tile_ctx = &pcs_ptr->ec_ctx_array[sb_addr];
@@ -2406,7 +2401,7 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
             for (int32_t d1_itr = (int32_t)blk_it + offset_d1;
                  d1_itr < (int32_t)blk_it + offset_d1 + num_d1_block;
                  d1_itr++) {
-                const BlockGeom *blk_geom = context_ptr->blk_geom = get_blk_geom_mds(d1_itr);
+                blk_geom = context_ptr->blk_geom = get_blk_geom_mds(d1_itr);
 
                 // PU Stack variables
                 PredictionUnit *     pu_ptr           = (PredictionUnit *)NULL; //  done
@@ -2415,7 +2410,7 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
 
                 EbPictureBufferDesc *inverse_quant_buffer = context_ptr->inverse_quant_buffer;
 
-                BlkStruct *blk_ptr = context_ptr->blk_ptr =
+                blk_ptr = context_ptr->blk_ptr =
                     &context_ptr->md_context->md_blk_arr_nsq[d1_itr];
 
                 context_ptr->blk_origin_x = (uint16_t)(sb_origin_x + blk_geom->origin_x);
@@ -2553,8 +2548,6 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                            .ed_ref_mv_stack[blk_ptr->prediction_unit_array[0]
                                                                 .ref_frame_type],
                                        sizeof(CandidateMv) * MAX_REF_MV_STACK_SIZE);
-
-                                pu_ptr = blk_ptr->prediction_unit_array;
                                 // Set MvUnit
                                 context_ptr->mv_unit.pred_direction =
                                     (uint8_t)pu_ptr->inter_pred_direction_index;
@@ -3094,20 +3087,16 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                     y_full_distortion[DIST_CALC_RESIDUAL]   = 0;
                     y_full_distortion[DIST_CALC_PREDICTION] = 0;
 
-                    y_coeff_bits  = 0;
-                    cb_coeff_bits = 0;
-                    cr_coeff_bits = 0;
 
-                    uint32_t tot_tu = context_ptr->blk_geom->txb_count[blk_ptr->tx_depth];
-                    uint8_t  tu_it;
+                    uint16_t tot_tu         = context_ptr->blk_geom->txb_count[blk_ptr->tx_depth];
                     uint16_t cb_qp          = blk_ptr->qp;
                     uint32_t component_mask = context_ptr->blk_geom->has_uv
                                                   ? PICTURE_BUFFER_DESC_FULL_MASK
                                                   : PICTURE_BUFFER_DESC_LUMA_MASK;
 
                     if (context_ptr->md_context->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds].merge_flag == EB_FALSE) {
-                        for (uint8_t tu_it = 0; tu_it < tot_tu; tu_it++) {
-                            context_ptr->txb_itr = tu_it;
+                        for (uint16_t tu_it = 0; tu_it < tot_tu; tu_it++) {
+                            context_ptr->txb_itr = (uint8_t)tu_it;
                             uint8_t uv_pass =
                                 blk_ptr->tx_depth && tu_it ? 0 : 1; //NM: 128x128 exeption
                             txb_origin_x =
@@ -3284,12 +3273,6 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 blk_ptr->txb_array[context_ptr->txb_itr].nz_coef_count[2] =
                                     (uint16_t)count_non_zero_coeffs[2];
 
-                                y_coeff_bits += y_txb_coeff_bits;
-                                if (context_ptr->blk_geom->has_uv && uv_pass) {
-                                    cb_coeff_bits += cb_txb_coeff_bits;
-                                    cr_coeff_bits += cr_txb_coeff_bits;
-                                }
-
                                 y_full_distortion[DIST_CALC_RESIDUAL] +=
                                     y_tu_full_distortion[DIST_CALC_RESIDUAL];
                                 y_full_distortion[DIST_CALC_PREDICTION] +=
@@ -3434,9 +3417,9 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                     //reset coeff buffer offsets at the start of a new Tx loop
                     context_ptr->coded_area_sb    = coded_area_org;
                     context_ptr->coded_area_sb_uv = coded_area_org_uv;
-                    for (tu_it = 0; tu_it < tot_tu; tu_it++) {
+                    for (uint16_t tu_it = 0; tu_it < tot_tu; tu_it++) {
                         uint8_t uv_pass = blk_ptr->tx_depth && tu_it ? 0 : 1; //NM: 128x128 exeption
-                        context_ptr->txb_itr = tu_it;
+                        context_ptr->txb_itr = (uint8_t)tu_it;
                         txb_origin_x = context_ptr->blk_origin_x +
                                        (context_ptr->blk_geom
                                             ->tx_org_x[is_inter][blk_ptr->tx_depth][context_ptr->txb_itr] -
@@ -3652,11 +3635,8 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                 context_ptr->blk_geom
                                     ->tx_height_uv[blk_ptr->tx_depth][context_ptr->txb_itr],
                                 NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
-                        }
-
-                        // Update the cr DC Sign Level Coeff Neighbor Array
-                        if (context_ptr->blk_geom->has_uv && uv_pass) {
-                            uint8_t dc_sign_level_coeff =
+                            // Update the cr DC Sign Level Coeff Neighbor Array
+                            dc_sign_level_coeff =
                                 (uint8_t)blk_ptr->quantized_dc[2][context_ptr->txb_itr];
                             neighbor_array_unit_mode_write(
                                 pcs_ptr->ep_cr_dc_sign_level_coeff_neighbor_array[tile_idx],
@@ -3734,99 +3714,92 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                     if (scs_ptr->use_output_stat_file) {
                         if (context_ptr->md_context->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds].ref_frame_index_l0 >= 0) {
                             eb_block_on_mutex(ref_obj_0->referenced_area_mutex);
-                            {
-                                if (context_ptr->mv_unit.pred_direction == UNI_PRED_LIST_0 ||
-                                    context_ptr->mv_unit.pred_direction == BI_PRED) {
-                                    //List0-Y
-                                    uint16_t origin_x =
-                                        MAX(0,
-                                            (int16_t)context_ptr->blk_origin_x +
-                                                (context_ptr->mv_unit.mv[REF_LIST_0].x >> 3));
-                                    uint16_t origin_y =
-                                        MAX(0,
-                                            (int16_t)context_ptr->blk_origin_y +
-                                                (context_ptr->mv_unit.mv[REF_LIST_0].y >> 3));
-                                    origin_x =
-                                        MIN(origin_x,
-                                            pcs_ptr->parent_pcs_ptr->aligned_width - blk_geom->bwidth);
-                                    origin_y = MIN(
-                                        origin_y,
-                                        pcs_ptr->parent_pcs_ptr->aligned_height - blk_geom->bheight);
-                                    uint16_t sb_origin_x =
-                                        origin_x / context_ptr->sb_sz * context_ptr->sb_sz;
-                                    uint16_t sb_origin_y =
-                                        origin_y / context_ptr->sb_sz * context_ptr->sb_sz;
-                                    uint32_t pic_width_in_sb =
-                                        (pcs_ptr->parent_pcs_ptr->aligned_width + scs_ptr->sb_sz - 1) /
-                                        scs_ptr->sb_sz;
-                                    uint16_t sb_index =
-                                        sb_origin_x / context_ptr->sb_sz +
-                                        pic_width_in_sb * (sb_origin_y / context_ptr->sb_sz);
-                                    uint16_t width, height, weight;
-                                    weight = 1
-                                             << (4 - pcs_ptr->parent_pcs_ptr->temporal_layer_index);
+                            if (context_ptr->mv_unit.pred_direction == UNI_PRED_LIST_0 ||
+                                context_ptr->mv_unit.pred_direction == BI_PRED) {
+                                //List0-Y
+                                uint16_t origin_x = MAX(
+                                    0,
+                                    (int16_t)context_ptr->blk_origin_x +
+                                        (context_ptr->mv_unit.mv[REF_LIST_0].x >> 3));
+                                uint16_t origin_y = MAX(
+                                    0,
+                                    (int16_t)context_ptr->blk_origin_y +
+                                        (context_ptr->mv_unit.mv[REF_LIST_0].y >> 3));
+                                origin_x = MIN(
+                                    origin_x,
+                                    pcs_ptr->parent_pcs_ptr->aligned_width - blk_geom->bwidth);
+                                origin_y = MIN(
+                                    origin_y,
+                                    pcs_ptr->parent_pcs_ptr->aligned_height - blk_geom->bheight);
+                                uint16_t sb_origin_x1 = origin_x / context_ptr->sb_sz *
+                                    context_ptr->sb_sz;
+                                uint16_t sb_origin_y1 = origin_y / context_ptr->sb_sz *
+                                    context_ptr->sb_sz;
+                                uint32_t pic_width_in_sb = (pcs_ptr->parent_pcs_ptr->aligned_width +
+                                                            scs_ptr->sb_sz - 1) /
+                                    scs_ptr->sb_sz;
+                                uint16_t sb_index = sb_origin_x1 / context_ptr->sb_sz +
+                                    pic_width_in_sb * (sb_origin_y1 / context_ptr->sb_sz);
+                                uint16_t width, height, weight;
+                                weight = 1 << (4 - pcs_ptr->parent_pcs_ptr->temporal_layer_index);
 
-                                    width = MIN(sb_origin_x + context_ptr->sb_sz,
-                                                origin_x + blk_geom->bwidth) -
-                                            origin_x;
-                                    height = MIN(sb_origin_y + context_ptr->sb_sz,
+                                width = MIN(sb_origin_x1 + context_ptr->sb_sz,
+                                            origin_x + blk_geom->bwidth) -
+                                    origin_x;
+                                height = MIN(sb_origin_y1 + context_ptr->sb_sz,
+                                             origin_y + blk_geom->bheight) -
+                                    origin_y;
+                                ref_obj_0->stat_struct.referenced_area[sb_index] += width * height *
+                                    weight;
+
+                                if (origin_x + blk_geom->bwidth >
+                                    sb_origin_x1 + context_ptr->sb_sz) {
+                                    sb_origin_x1 = (origin_x / context_ptr->sb_sz + 1) *
+                                        context_ptr->sb_sz;
+                                    sb_origin_y1 = origin_y / context_ptr->sb_sz *
+                                        context_ptr->sb_sz;
+                                    sb_index = sb_origin_x1 / context_ptr->sb_sz +
+                                        pic_width_in_sb * (sb_origin_y1 / context_ptr->sb_sz);
+                                    width = origin_x + blk_geom->bwidth -
+                                        MAX(sb_origin_x1, origin_x);
+                                    height = MIN(sb_origin_y1 + context_ptr->sb_sz,
                                                  origin_y + blk_geom->bheight) -
-                                             origin_y;
-                                    ref_obj_0->stat_struct.referenced_area[sb_index] +=
-                                        width * height * weight;
-
-                                    if (origin_x + blk_geom->bwidth >
-                                        sb_origin_x + context_ptr->sb_sz) {
-                                        sb_origin_x = (origin_x / context_ptr->sb_sz + 1) *
-                                                      context_ptr->sb_sz;
-                                        sb_origin_y =
-                                            origin_y / context_ptr->sb_sz * context_ptr->sb_sz;
-                                        sb_index =
-                                            sb_origin_x / context_ptr->sb_sz +
-                                            pic_width_in_sb * (sb_origin_y / context_ptr->sb_sz);
-                                        width = origin_x + blk_geom->bwidth -
-                                                MAX(sb_origin_x, origin_x);
-                                        height = MIN(sb_origin_y + context_ptr->sb_sz,
-                                                     origin_y + blk_geom->bheight) -
-                                                 origin_y;
-                                        ref_obj_0->stat_struct.referenced_area[sb_index] +=
-                                            width * height * weight;
-                                    }
-                                    if (origin_y + blk_geom->bheight >
-                                        sb_origin_y + context_ptr->sb_sz) {
-                                        sb_origin_x =
-                                            (origin_x / context_ptr->sb_sz) * context_ptr->sb_sz;
-                                        sb_origin_y = (origin_y / context_ptr->sb_sz + 1) *
-                                                      context_ptr->sb_sz;
-                                        sb_index =
-                                            sb_origin_x / context_ptr->sb_sz +
-                                            pic_width_in_sb * (sb_origin_y / context_ptr->sb_sz);
-                                        width = MIN(sb_origin_x + context_ptr->sb_sz,
-                                                    origin_x + blk_geom->bwidth) -
-                                                origin_x;
-                                        height = origin_y + blk_geom->bheight -
-                                                 MAX(sb_origin_y, origin_y);
-                                        ref_obj_0->stat_struct.referenced_area[sb_index] +=
-                                            width * height * weight;
-                                    }
-                                    if (origin_x + blk_geom->bwidth >
-                                            sb_origin_x + context_ptr->sb_sz &&
-                                        origin_y + blk_geom->bheight >
-                                            sb_origin_y + context_ptr->sb_sz) {
-                                        sb_origin_x = (origin_x / context_ptr->sb_sz + 1) *
-                                                      context_ptr->sb_sz;
-                                        sb_origin_y = (origin_y / context_ptr->sb_sz + 1) *
-                                                      context_ptr->sb_sz;
-                                        sb_index =
-                                            sb_origin_x / context_ptr->sb_sz +
-                                            pic_width_in_sb * (sb_origin_y / context_ptr->sb_sz);
-                                        width = origin_x + blk_geom->bwidth -
-                                                MAX(sb_origin_x, origin_x);
-                                        height = origin_y + blk_geom->bheight -
-                                                 MAX(sb_origin_y, origin_y);
-                                        ref_obj_0->stat_struct.referenced_area[sb_index] +=
-                                            width * height * weight;
-                                    }
+                                        origin_y;
+                                    ref_obj_0->stat_struct.referenced_area[sb_index] += width *
+                                        height * weight;
+                                }
+                                if (origin_y + blk_geom->bheight >
+                                    sb_origin_y1 + context_ptr->sb_sz) {
+                                    sb_origin_x1 = (origin_x / context_ptr->sb_sz) *
+                                        context_ptr->sb_sz;
+                                    sb_origin_y1 = (origin_y / context_ptr->sb_sz + 1) *
+                                        context_ptr->sb_sz;
+                                    sb_index = sb_origin_x1 / context_ptr->sb_sz +
+                                        pic_width_in_sb * (sb_origin_y1 / context_ptr->sb_sz);
+                                    width = MIN(sb_origin_x1 + context_ptr->sb_sz,
+                                                origin_x + blk_geom->bwidth) -
+                                        origin_x;
+                                    height = origin_y + blk_geom->bheight -
+                                        MAX(sb_origin_y1, origin_y);
+                                    ref_obj_0->stat_struct.referenced_area[sb_index] += width *
+                                        height * weight;
+                                }
+                                if (origin_x + blk_geom->bwidth >
+                                        sb_origin_x1 + context_ptr->sb_sz &&
+                                    origin_y + blk_geom->bheight >
+                                        sb_origin_y1 + context_ptr->sb_sz) {
+                                    sb_origin_x1 = (origin_x / context_ptr->sb_sz + 1) *
+                                        context_ptr->sb_sz;
+                                    sb_origin_y1 = (origin_y / context_ptr->sb_sz + 1) *
+                                        context_ptr->sb_sz;
+                                    sb_index = sb_origin_x1 / context_ptr->sb_sz +
+                                        pic_width_in_sb * (sb_origin_y1 / context_ptr->sb_sz);
+                                    width = origin_x + blk_geom->bwidth -
+                                        MAX(sb_origin_x1, origin_x);
+                                    height = origin_y + blk_geom->bheight -
+                                        MAX(sb_origin_y1, origin_y);
+                                    ref_obj_0->stat_struct.referenced_area[sb_index] += width *
+                                        height * weight;
                                 }
                             }
                             eb_release_mutex(ref_obj_0->referenced_area_mutex);
@@ -3837,89 +3810,88 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                             if (context_ptr->mv_unit.pred_direction == UNI_PRED_LIST_1 ||
                                 context_ptr->mv_unit.pred_direction == BI_PRED) {
                                 //List1-Y
-                                uint16_t origin_x =
-                                    MAX(0,
-                                        (int16_t)context_ptr->blk_origin_x +
-                                            (context_ptr->mv_unit.mv[REF_LIST_1].x >> 3));
-                                uint16_t origin_y =
-                                    MAX(0,
-                                        (int16_t)context_ptr->blk_origin_y +
-                                            (context_ptr->mv_unit.mv[REF_LIST_1].y >> 3));
-                                origin_x =
-                                    MIN(origin_x,
-                                        pcs_ptr->parent_pcs_ptr->aligned_width - blk_geom->bwidth);
-                                origin_y =
-                                    MIN(origin_y,
-                                        pcs_ptr->parent_pcs_ptr->aligned_height - blk_geom->bheight);
-                                uint16_t sb_origin_x =
-                                    origin_x / context_ptr->sb_sz * context_ptr->sb_sz;
-                                uint16_t sb_origin_y =
-                                    origin_y / context_ptr->sb_sz * context_ptr->sb_sz;
-                                uint32_t pic_width_in_sb =
-                                    (pcs_ptr->parent_pcs_ptr->aligned_width + scs_ptr->sb_sz - 1) /
+                                uint16_t origin_x = MAX(
+                                    0,
+                                    (int16_t)context_ptr->blk_origin_x +
+                                        (context_ptr->mv_unit.mv[REF_LIST_1].x >> 3));
+                                uint16_t origin_y = MAX(
+                                    0,
+                                    (int16_t)context_ptr->blk_origin_y +
+                                        (context_ptr->mv_unit.mv[REF_LIST_1].y >> 3));
+                                origin_x = MIN(
+                                    origin_x,
+                                    pcs_ptr->parent_pcs_ptr->aligned_width - blk_geom->bwidth);
+                                origin_y = MIN(
+                                    origin_y,
+                                    pcs_ptr->parent_pcs_ptr->aligned_height - blk_geom->bheight);
+                                uint16_t sb_origin_x2 = origin_x / context_ptr->sb_sz *
+                                    context_ptr->sb_sz;
+                                uint16_t sb_origin_y2 = origin_y / context_ptr->sb_sz *
+                                    context_ptr->sb_sz;
+                                uint32_t pic_width_in_sb = (pcs_ptr->parent_pcs_ptr->aligned_width +
+                                                            scs_ptr->sb_sz - 1) /
                                     scs_ptr->sb_sz;
-                                uint16_t sb_index =
-                                    sb_origin_x / context_ptr->sb_sz +
-                                    pic_width_in_sb * (sb_origin_y / context_ptr->sb_sz);
+                                uint16_t sb_index = sb_origin_x2 / context_ptr->sb_sz +
+                                    pic_width_in_sb * (sb_origin_y2 / context_ptr->sb_sz);
                                 uint16_t width, height, weight;
                                 weight = 1 << (4 - pcs_ptr->parent_pcs_ptr->temporal_layer_index);
 
-                                width = MIN(sb_origin_x + context_ptr->sb_sz,
+                                width = MIN(sb_origin_x2 + context_ptr->sb_sz,
                                             origin_x + blk_geom->bwidth) -
-                                        origin_x;
-                                height = MIN(sb_origin_y + context_ptr->sb_sz,
+                                    origin_x;
+                                height = MIN(sb_origin_y2 + context_ptr->sb_sz,
                                              origin_y + blk_geom->bheight) -
-                                         origin_y;
-                                ref_obj_1->stat_struct.referenced_area[sb_index] +=
-                                    width * height * weight;
+                                    origin_y;
+                                ref_obj_1->stat_struct.referenced_area[sb_index] += width * height *
+                                    weight;
                                 if (origin_x + blk_geom->bwidth >
-                                    sb_origin_x + context_ptr->sb_sz) {
-                                    sb_origin_x =
-                                        (origin_x / context_ptr->sb_sz + 1) * context_ptr->sb_sz;
-                                    sb_origin_y =
-                                        origin_y / context_ptr->sb_sz * context_ptr->sb_sz;
-                                    sb_index = sb_origin_x / context_ptr->sb_sz +
-                                               pic_width_in_sb * (sb_origin_y / context_ptr->sb_sz);
-                                    width =
-                                        origin_x + blk_geom->bwidth - MAX(sb_origin_x, origin_x);
-                                    height = MIN(sb_origin_y + context_ptr->sb_sz,
+                                    sb_origin_x2 + context_ptr->sb_sz) {
+                                    sb_origin_x2 = (origin_x / context_ptr->sb_sz + 1) *
+                                        context_ptr->sb_sz;
+                                    sb_origin_y2 = origin_y / context_ptr->sb_sz *
+                                        context_ptr->sb_sz;
+                                    sb_index = sb_origin_x2 / context_ptr->sb_sz +
+                                        pic_width_in_sb * (sb_origin_y2 / context_ptr->sb_sz);
+                                    width = origin_x + blk_geom->bwidth -
+                                        MAX(sb_origin_x2, origin_x);
+                                    height = MIN(sb_origin_y2 + context_ptr->sb_sz,
                                                  origin_y + blk_geom->bheight) -
-                                             origin_y;
-                                    ref_obj_1->stat_struct.referenced_area[sb_index] +=
-                                        width * height * weight;
+                                        origin_y;
+                                    ref_obj_1->stat_struct.referenced_area[sb_index] += width *
+                                        height * weight;
                                 }
                                 if (origin_y + blk_geom->bheight >
-                                    sb_origin_y + context_ptr->sb_sz) {
-                                    sb_origin_x =
-                                        (origin_x / context_ptr->sb_sz) * context_ptr->sb_sz;
-                                    sb_origin_y =
-                                        (origin_y / context_ptr->sb_sz + 1) * context_ptr->sb_sz;
-                                    sb_index = sb_origin_x / context_ptr->sb_sz +
-                                               pic_width_in_sb * (sb_origin_y / context_ptr->sb_sz);
-                                    width = MIN(sb_origin_x + context_ptr->sb_sz,
+                                    sb_origin_y2 + context_ptr->sb_sz) {
+                                    sb_origin_x2 = (origin_x / context_ptr->sb_sz) *
+                                        context_ptr->sb_sz;
+                                    sb_origin_y2 = (origin_y / context_ptr->sb_sz + 1) *
+                                        context_ptr->sb_sz;
+                                    sb_index = sb_origin_x2 / context_ptr->sb_sz +
+                                        pic_width_in_sb * (sb_origin_y2 / context_ptr->sb_sz);
+                                    width = MIN(sb_origin_x2 + context_ptr->sb_sz,
                                                 origin_x + blk_geom->bwidth) -
-                                            origin_x;
-                                    height =
-                                        origin_y + blk_geom->bheight - MAX(sb_origin_y, origin_y);
-                                    ref_obj_1->stat_struct.referenced_area[sb_index] +=
-                                        width * height * weight;
+                                        origin_x;
+                                    height = origin_y + blk_geom->bheight -
+                                        MAX(sb_origin_y2, origin_y);
+                                    ref_obj_1->stat_struct.referenced_area[sb_index] += width *
+                                        height * weight;
                                 }
                                 if (origin_x + blk_geom->bwidth >
-                                        sb_origin_x + context_ptr->sb_sz &&
+                                        sb_origin_x2 + context_ptr->sb_sz &&
                                     origin_y + blk_geom->bheight >
-                                        sb_origin_y + context_ptr->sb_sz) {
-                                    sb_origin_x =
-                                        (origin_x / context_ptr->sb_sz + 1) * context_ptr->sb_sz;
-                                    sb_origin_y =
-                                        (origin_y / context_ptr->sb_sz + 1) * context_ptr->sb_sz;
-                                    sb_index = sb_origin_x / context_ptr->sb_sz +
-                                               pic_width_in_sb * (sb_origin_y / context_ptr->sb_sz);
-                                    width =
-                                        origin_x + blk_geom->bwidth - MAX(sb_origin_x, origin_x);
-                                    height =
-                                        origin_y + blk_geom->bheight - MAX(sb_origin_y, origin_y);
-                                    ref_obj_1->stat_struct.referenced_area[sb_index] +=
-                                        width * height * weight;
+                                        sb_origin_y2 + context_ptr->sb_sz) {
+                                    sb_origin_x2 = (origin_x / context_ptr->sb_sz + 1) *
+                                        context_ptr->sb_sz;
+                                    sb_origin_y2 = (origin_y / context_ptr->sb_sz + 1) *
+                                        context_ptr->sb_sz;
+                                    sb_index = sb_origin_x2 / context_ptr->sb_sz +
+                                        pic_width_in_sb * (sb_origin_y2 / context_ptr->sb_sz);
+                                    width = origin_x + blk_geom->bwidth -
+                                        MAX(sb_origin_x2, origin_x);
+                                    height = origin_y + blk_geom->bheight -
+                                        MAX(sb_origin_y2, origin_y);
+                                    ref_obj_1->stat_struct.referenced_area[sb_index] += width *
+                                        height * weight;
                                 }
                             }
                             eb_release_mutex(ref_obj_1->referenced_area_mutex);

--- a/Source/Lib/Encoder/Codec/EbDeblockingFilter.c
+++ b/Source/Lib/Encoder/Codec/EbDeblockingFilter.c
@@ -825,10 +825,9 @@ uint64_t picture_sse_calculations(PictureControlSet *pcs_ptr, EbPictureBufferDes
             recon_coeff_buffer = &(
                 (recon_ptr
                      ->buffer_y)[recon_ptr->origin_x + recon_ptr->origin_y * recon_ptr->stride_y]);
-            input_buffer =
-                &((input_picture_ptr
-                       ->buffer_y)[input_picture_ptr->origin_x +
-                                   input_picture_ptr->origin_y * input_picture_ptr->stride_y]);
+            input_buffer = &((input_picture_ptr->buffer_y)[input_picture_ptr->origin_x +
+                                                           input_picture_ptr->origin_y *
+                                                               input_picture_ptr->stride_y]);
 
             while (row_index < input_picture_ptr->height) {
                 column_index = 0;

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -322,9 +322,6 @@ static void enc_dec_configure_sb(EncDecContext *context_ptr, SuperBlock *sb_ptr,
 EbBool assign_enc_dec_segments(EncDecSegments *segmentPtr, uint16_t *segmentInOutIndex,
                                EncDecTasks *taskPtr, EbFifo *srmFifoPtr) {
     EbBool           continue_processing_flag = EB_FALSE;
-    EbObjectWrapper *wrapper_ptr;
-    EncDecTasks *    feedback_task_ptr;
-
     uint32_t row_segment_index = 0;
     uint32_t segment_index;
     uint32_t right_segment_index;
@@ -419,7 +416,6 @@ EbBool assign_enc_dec_segments(EncDecSegments *segmentPtr, uint16_t *segmentInOu
                     *segmentInOutIndex =
                         segmentPtr->row_array[row_segment_index + 1].current_seg_index;
                     ++segmentPtr->row_array[row_segment_index + 1].current_seg_index;
-                    self_assigned            = EB_TRUE;
                     continue_processing_flag = EB_TRUE;
 
                     //fprintf(trace, "Start  Pic: %u Seg: %u\n",
@@ -431,8 +427,9 @@ EbBool assign_enc_dec_segments(EncDecSegments *segmentPtr, uint16_t *segmentInOu
         }
 
         if (feedback_row_index > 0) {
+            EbObjectWrapper *wrapper_ptr;
             eb_get_empty_object(srmFifoPtr, &wrapper_ptr);
-            feedback_task_ptr                      = (EncDecTasks *)wrapper_ptr->object_ptr;
+            EncDecTasks *    feedback_task_ptr     = (EncDecTasks *)wrapper_ptr->object_ptr;
             feedback_task_ptr->input_type          = ENCDEC_TASKS_ENCDEC_INPUT;
             feedback_task_ptr->enc_dec_segment_row = feedback_row_index;
             feedback_task_ptr->pcs_wrapper_ptr     = taskPtr->pcs_wrapper_ptr;

--- a/Source/Lib/Encoder/Codec/EbFullLoop.c
+++ b/Source/Lib/Encoder/Codec/EbFullLoop.c
@@ -1451,10 +1451,6 @@ void eb_av1_optimize_b(ModeDecisionContext *md_context, int16_t txb_skip_context
     int                    sharpness       = 0; // No Sharpness
     // Perform a fast RDOQ stage for inter and chroma blocks
     int                    fast_mode       = (is_inter && plane);
-    AQ_MODE                aq_mode         = NO_AQ;
-    DELTAQ_MODE            deltaq_mode     = NO_DELTA_Q;
-    int8_t                 segment_id      = 0;
-    int                    sb_energy_level = 0;
     const ScanOrder *const scan_order      = &av1_scan_orders[tx_size][tx_type];
     const int16_t *        scan            = scan_order->scan;
     const int              shift           = av1_get_tx_scale(tx_size);
@@ -1475,11 +1471,7 @@ void eb_av1_optimize_b(ModeDecisionContext *md_context, int16_t txb_skip_context
         update_coeff_eob_fast(eob, shift, p->dequant_qtx, scan, coeff_ptr, qcoeff_ptr, dqcoeff_ptr);
         if (*eob == 0) return;
     }
-    const int rshift =
-        (sharpness + (aq_mode == VARIANCE_AQ && segment_id < 4 ? 7 - segment_id : 2) +
-         (aq_mode != VARIANCE_AQ && deltaq_mode > NO_DELTA_Q && sb_energy_level < 0
-              ? (3 - sb_energy_level)
-              : 0));
+    const int     rshift = sharpness + 2;
     const int64_t rdmult =
         (((int64_t)lambda * plane_rd_mult[is_inter][plane_type]) + 2) >> rshift;
     uint8_t        levels_buf[TX_PAD_2D];

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -486,7 +486,6 @@ void update_global_motion_detection_over_time(EncodeContext *          encode_co
                                               PictureParentControlSet *pcs_ptr) {
     uint32_t total_pan_pictures     = 0;
     uint32_t total_checked_pictures = 0;
-    uint32_t total_tilt_pictures    = 0;
     (void)scs_ptr;
 
     // Determine number of frames to check (8 frames)
@@ -504,8 +503,6 @@ void update_global_motion_detection_over_time(EncodeContext *          encode_co
 
         if (temp_pcs_ptr->slice_type != I_SLICE) {
             total_pan_pictures += (temp_pcs_ptr->is_pan == EB_TRUE);
-
-            total_tilt_pictures += (temp_pcs_ptr->is_tilt == EB_TRUE);
 
             // Keep track of checked pictures
             total_checked_pictures++;

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -198,13 +198,12 @@ int64_t     pick_wedge_fixed_sign(ModeDecisionCandidate *candidate_ptr, PictureC
                                   ModeDecisionContext *context_ptr, const BlockSize bsize,
                                   const int16_t *const residual1, const int16_t *const diff10,
                                   const int8_t wedge_sign, int8_t *const best_wedge_index);
-void model_rd_for_sb_with_curvfit(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
-                                  BlockSize bsize, int bw, int bh, uint8_t *src_buf,
-                                  uint32_t src_stride, uint8_t *pred_buf, uint32_t pred_stride,
-                                  int plane_from, int plane_to, int mi_row, int mi_col,
-                                  int *out_rate_sum, int64_t *out_dist_sum, int *skip_txfm_sb,
-                                  int64_t *skip_sse_sb, int *plane_rate, int64_t *plane_sse,
-                                  int64_t *plane_dist);
+void        model_rd_for_sb_with_curvfit(PictureControlSet *  picture_control_set_ptr,
+                                         ModeDecisionContext *context_ptr, BlockSize bsize, int bw, int bh,
+                                         uint8_t *src_buf, uint32_t src_stride, uint8_t *pred_buf,
+                                         uint32_t pred_stride, int plane_from, int plane_to, int mi_row,
+                                         int mi_col, int *out_rate_sum, int64_t *out_dist_sum,
+                                         int *plane_rate, int64_t *plane_sse, int64_t *plane_dist);
 
 static int64_t pick_interintra_wedge(ModeDecisionCandidate *candidate_ptr,
                                      PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
@@ -453,8 +452,6 @@ void inter_intra_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                                                  &dist_sum,
                                                  NULL,
                                                  NULL,
-                                                 NULL,
-                                                 NULL,
                                                  NULL);
                 } else {
                     model_rd_for_sb_with_curvfit(pcs_ptr,
@@ -472,8 +469,6 @@ void inter_intra_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                                                  0,
                                                  &rate_sum,
                                                  &dist_sum,
-                                                 NULL,
-                                                 NULL,
                                                  NULL,
                                                  NULL,
                                                  NULL);

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -601,20 +601,9 @@ void *motion_estimation_kernel(void *input_ptr) {
     EbThreadContext *          thread_context_ptr = (EbThreadContext *)input_ptr;
     MotionEstimationContext_t *context_ptr = (MotionEstimationContext_t *)thread_context_ptr->priv;
 
-    PictureParentControlSet *pcs_ptr;
-    SequenceControlSet *     scs_ptr;
-
     EbObjectWrapper *       in_results_wrapper_ptr;
-    PictureDecisionResults *in_results_ptr;
 
     EbObjectWrapper *        out_results_wrapper_ptr;
-    MotionEstimationResults *out_results_ptr;
-
-    EbPictureBufferDesc *input_picture_ptr;
-
-    EbPictureBufferDesc *input_padded_picture_ptr;
-
-    uint32_t buffer_index;
 
     uint32_t sb_index;
     uint32_t x_sb_index;
@@ -646,9 +635,11 @@ void *motion_estimation_kernel(void *input_ptr) {
         EB_GET_FULL_OBJECT(context_ptr->picture_decision_results_input_fifo_ptr,
                            &in_results_wrapper_ptr);
 
-        in_results_ptr = (PictureDecisionResults *)in_results_wrapper_ptr->object_ptr;
-        pcs_ptr        = (PictureParentControlSet *)in_results_ptr->pcs_wrapper_ptr->object_ptr;
-        scs_ptr        = (SequenceControlSet *)pcs_ptr->scs_wrapper_ptr->object_ptr;
+        PictureDecisionResults *in_results_ptr = (PictureDecisionResults *)
+                                                     in_results_wrapper_ptr->object_ptr;
+        PictureParentControlSet *pcs_ptr = (PictureParentControlSet *)
+                                               in_results_ptr->pcs_wrapper_ptr->object_ptr;
+        SequenceControlSet *scs_ptr = (SequenceControlSet *)pcs_ptr->scs_wrapper_ptr->object_ptr;
 
         pa_ref_obj_ = (EbPaReferenceObject *)pcs_ptr->pa_reference_picture_wrapper_ptr->object_ptr;
         // Set 1/4 and 1/16 ME input buffer(s); filtered or decimated
@@ -661,9 +652,9 @@ void *motion_estimation_kernel(void *input_ptr) {
             (scs_ptr->down_sampling_method_me_search == ME_FILTERED_DOWNSAMPLED)
                 ? (EbPictureBufferDesc *)pa_ref_obj_->sixteenth_filtered_picture_ptr
                 : (EbPictureBufferDesc *)pa_ref_obj_->sixteenth_decimated_picture_ptr;
-        input_padded_picture_ptr = (EbPictureBufferDesc *)pa_ref_obj_->input_padded_picture_ptr;
+        EbPictureBufferDesc *input_padded_picture_ptr = pa_ref_obj_->input_padded_picture_ptr;
 
-        input_picture_ptr = pcs_ptr->enhanced_picture_ptr;
+        EbPictureBufferDesc *input_picture_ptr = pcs_ptr->enhanced_picture_ptr;
 
         context_ptr->me_context_ptr->me_alt_ref =
             in_results_ptr->task_type == 1 ? EB_TRUE : EB_FALSE;
@@ -745,9 +736,9 @@ void *motion_estimation_kernel(void *input_ptr) {
                                 : BLOCK_SIZE_64;
 
                         // Load the SB from the input to the intermediate SB buffer
-                        buffer_index = (input_picture_ptr->origin_y + sb_origin_y) *
-                                           input_picture_ptr->stride_y +
-                                       input_picture_ptr->origin_x + sb_origin_x;
+                        uint32_t buffer_index = (input_picture_ptr->origin_y + sb_origin_y) *
+                                input_picture_ptr->stride_y +
+                            input_picture_ptr->origin_x + sb_origin_x;
 
                         context_ptr->me_context_ptr->hme_search_type = HME_RECTANGULAR;
 
@@ -846,9 +837,6 @@ void *motion_estimation_kernel(void *input_ptr) {
                 // SB Loop
                 for (y_sb_index = y_sb_start_index; y_sb_index < y_sb_end_index; ++y_sb_index) {
                     for (x_sb_index = x_sb_start_index; x_sb_index < x_sb_end_index; ++x_sb_index) {
-                        sb_origin_x = x_sb_index * scs_ptr->sb_sz;
-                        sb_origin_y = y_sb_index * scs_ptr->sb_sz;
-
                         sb_index = (uint16_t)(x_sb_index + y_sb_index * pic_width_in_sb);
 
                         open_loop_intra_search_sb(
@@ -1004,7 +992,8 @@ void *motion_estimation_kernel(void *input_ptr) {
             eb_get_empty_object(context_ptr->motion_estimation_results_output_fifo_ptr,
                                 &out_results_wrapper_ptr);
 
-            out_results_ptr = (MotionEstimationResults *)out_results_wrapper_ptr->object_ptr;
+            MotionEstimationResults *out_results_ptr = (MotionEstimationResults *)
+                                                           out_results_wrapper_ptr->object_ptr;
             out_results_ptr->pcs_wrapper_ptr = in_results_ptr->pcs_wrapper_ptr;
             out_results_ptr->segment_index   = segment_index;
 

--- a/Source/Lib/Encoder/Codec/EbNeighborArrays.c
+++ b/Source/Lib/Encoder/Codec/EbNeighborArrays.c
@@ -477,8 +477,6 @@ void neighbor_array_unit16bit_sample_write(NeighborArrayUnit *na_unit_ptr, uint1
                   get_neighbor_array_unit_top_index(na_unit_ptr,
                                                     pic_origin_x); //CHKN * na_unit_ptr->unit_size;
 
-        dst_step  = na_unit_ptr->unit_size;
-        read_step = na_unit_ptr->unit_size;
         count     = block_width;
 
         for (idx = 0; idx < count; ++idx) {


### PR DESCRIPTION
# Description

Fixes some variableScope and unreadVariable issues

once I get confirmation that this pr is lossless, I will squash the commits.

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] obj-2-slow
- [ ] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
