### PR TITLE
Adoptions of fixes for R2R in 10bit from svt-01 branch

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -77,6 +77,8 @@ extern "C" {
 #define RESTRUCTURE_SAD 1
 #endif
 
+#define FIX_HBD_R2R 1 // Fix 10bit error in over-boundaries CUs (incomplete SB)
+
 typedef enum MeHpMode {
     EX_HP_MODE         = 0, // Exhaustive  1/2-pel serach mode.
     REFINEMENT_HP_MODE = 1,// Refinement 1/2-pel serach mode.

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -2287,6 +2287,32 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                        context_ptr->input_sample16bit_buffer->stride_cr,
                        sb_width >> 1,
                        sb_height >> 1);
+#if FIX_HBD_R2R
+        // PAD the packed source in incomplete sb up to max SB size
+        pad_input_picture_16bit(
+                (uint16_t *)context_ptr->input_sample16bit_buffer->buffer_y,
+                context_ptr->input_sample16bit_buffer->stride_y,
+                sb_width,
+                sb_height,
+                scs_ptr->sb_size_pix - sb_width,
+                scs_ptr->sb_size_pix - sb_height);
+
+        pad_input_picture_16bit(
+                (uint16_t *)context_ptr->input_sample16bit_buffer->buffer_cb,
+                context_ptr->input_sample16bit_buffer->stride_cb,
+                sb_width >> 1,
+                sb_height >> 1,
+                (scs_ptr->sb_size_pix- sb_width  )>>1,
+                (scs_ptr->sb_size_pix - sb_height)>>1);
+
+        pad_input_picture_16bit(
+                (uint16_t *)context_ptr->input_sample16bit_buffer->buffer_cr,
+                context_ptr->input_sample16bit_buffer->stride_cr,
+                sb_width >> 1,
+                sb_height >> 1,
+                (scs_ptr->sb_size_pix - sb_width  )>>1,
+                (scs_ptr->sb_size_pix  - sb_height)>>1);
+#endif
         }
 
         if (context_ptr->md_context->hbd_mode_decision == 0)
@@ -2294,8 +2320,13 @@ EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *p
                                  pcs_ptr,
                                  sb_origin_x,
                                  sb_origin_y,
+#if FIX_HBD_R2R
+                                 scs_ptr->sb_size_pix,
+                                 scs_ptr->sb_size_pix);
+#else
                                  sb_width,
                                  sb_height);
+#endif
     }
 
     if (is_16bit && scs_ptr->static_config.encoder_bit_depth == EB_8BIT) {

--- a/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureAnalysisProcess.c
@@ -3608,6 +3608,16 @@ void *picture_analysis_kernel(void *input_ptr) {
                              input_picture_ptr->origin_x,
                              input_picture_ptr->origin_y);
 
+#if FIX_HBD_R2R
+            // PAD the bit inc buffer in 10bit
+            if (scs_ptr->static_config.encoder_bit_depth > EB_8BIT)
+                generate_padding(input_picture_ptr->buffer_bit_inc_y,
+                        input_picture_ptr->stride_bit_inc_y,
+                        input_picture_ptr->width,
+                        input_picture_ptr->height,
+                        input_picture_ptr->origin_x,
+                        input_picture_ptr->origin_y);
+#endif
             // Padding the chroma if over_boundary_block_mode is enabled
             if (scs_ptr->over_boundary_block_mode == 1) {
                 generate_padding(input_picture_ptr->buffer_cb,
@@ -3623,6 +3633,24 @@ void *picture_analysis_kernel(void *input_ptr) {
                         input_picture_ptr->height >> scs_ptr->subsampling_y,
                         input_picture_ptr->origin_x >> scs_ptr->subsampling_x,
                         input_picture_ptr->origin_y >> scs_ptr->subsampling_y);
+#if FIX_HBD_R2R
+                // PAD the bit inc buffer in 10bit
+                if (scs_ptr->static_config.encoder_bit_depth > EB_8BIT) {
+                    generate_padding(input_picture_ptr->buffer_bit_inc_cb,
+                            input_picture_ptr->stride_bit_inc_cb,
+                            input_picture_ptr->width >> scs_ptr->subsampling_x,
+                            input_picture_ptr->height >> scs_ptr->subsampling_y,
+                            input_picture_ptr->origin_x >> scs_ptr->subsampling_x,
+                            input_picture_ptr->origin_y >> scs_ptr->subsampling_y);
+
+                    generate_padding(input_picture_ptr->buffer_bit_inc_cr,
+                            input_picture_ptr->stride_bit_inc_cr,
+                            input_picture_ptr->width >> scs_ptr->subsampling_x,
+                            input_picture_ptr->height >> scs_ptr->subsampling_y,
+                            input_picture_ptr->origin_x >> scs_ptr->subsampling_x,
+                            input_picture_ptr->origin_y >> scs_ptr->subsampling_y);
+                }
+#endif
             }
             {
                 uint8_t *pa =

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -7094,13 +7094,44 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
                    context_ptr->input_sample16bit_buffer->stride_cr,
                    sb_width >> 1,
                    sb_height >> 1);
+#if FIX_HBD_R2R
+        // PAD the packed source in incomplete sb up to max SB size
+        pad_input_picture_16bit(
+                (uint16_t *)context_ptr->input_sample16bit_buffer->buffer_y,
+                context_ptr->input_sample16bit_buffer->stride_y,
+                sb_width,
+                sb_height,
+                scs_ptr->sb_size_pix - sb_width,
+                scs_ptr->sb_size_pix - sb_height);
 
+        pad_input_picture_16bit(
+                (uint16_t *)context_ptr->input_sample16bit_buffer->buffer_cb,
+                context_ptr->input_sample16bit_buffer->stride_cb,
+                sb_width >> 1,
+                sb_height >> 1,
+                (scs_ptr->sb_size_pix- sb_width  )>>1,
+                (scs_ptr->sb_size_pix - sb_height)>>1);
+
+        pad_input_picture_16bit(
+                (uint16_t *)context_ptr->input_sample16bit_buffer->buffer_cr,
+                context_ptr->input_sample16bit_buffer->stride_cr,
+                sb_width >> 1,
+                sb_height >> 1,
+                (scs_ptr->sb_size_pix - sb_width  )>>1,
+                (scs_ptr->sb_size_pix  - sb_height)>>1);
+
+#endif
         store16bit_input_src(context_ptr->input_sample16bit_buffer,
                              pcs_ptr,
                              sb_origin_x,
                              sb_origin_y,
+#if FIX_HBD_R2R
+                             scs_ptr->sb_size_pix,
+                             scs_ptr->sb_size_pix);
+#else
                              sb_width,
                              sb_height);
+#endif
         //input_picture_ptr = context_ptr->input_sample16bit_buffer;
         input_picture_ptr = pcs_ptr->input_frame16bit;
     }


### PR DESCRIPTION
# Description

Adoptions of fixes for R2R in 10bit from svt-01 branch
#define FIX_HBD_R2R         1 // Fix 10bit error in over-boundaries CUs (incomplete SB)

After apllying this PR there is no R2R in objective-2-slow
For command line (from issue #1312):
```
SvtAv1EncApp.exe -w 1920 -h 1080 -i Cactus_10bit_1920x1080_50Hz_P420.yuv -b out.av1 -bit-depth 10 -n 100 -enc-mode 8 -lp 8
```
R2R still persist
# Issue
#1312
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [x] 8 bit
- [x] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] objective-2-slow
- [ ] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
