### PR TITLE
fix bug for two crash！

### DIFF
--- a/Source/Lib/Encoder/Codec/EbPredictionStructure.c
+++ b/Source/Lib/Encoder/Codec/EbPredictionStructure.c
@@ -1977,7 +1977,7 @@ EbErrorType prediction_structure_group_ctor(PredictionStructureGroup *pred_struc
     // Insert manual prediction structure into array
     if (config->enable_manual_pred_struct) {
         prediction_structure_config_array[config->hierarchical_levels].entry_count = config->manual_pred_struct_entry_num;
-        eb_memcpy(prediction_structure_config_array[config->hierarchical_levels].entry_array,
+        memcpy(prediction_structure_config_array[config->hierarchical_levels].entry_array,
           &config->pred_struct[config->manual_pred_struct_entry_num - 1],
           sizeof(PredictionStructureConfigEntry));
         if (config->manual_pred_struct_entry_num > 1) {

--- a/Source/Lib/Encoder/Codec/EbPredictionStructure.c
+++ b/Source/Lib/Encoder/Codec/EbPredictionStructure.c
@@ -1977,7 +1977,7 @@ EbErrorType prediction_structure_group_ctor(PredictionStructureGroup *pred_struc
     // Insert manual prediction structure into array
     if (config->enable_manual_pred_struct) {
         prediction_structure_config_array[config->hierarchical_levels].entry_count = config->manual_pred_struct_entry_num;
-        memcpy(prediction_structure_config_array[config->hierarchical_levels].entry_array,
+        EB_MEMCPY(prediction_structure_config_array[config->hierarchical_levels].entry_array,
           &config->pred_struct[config->manual_pred_struct_entry_num - 1],
           sizeof(PredictionStructureConfigEntry));
         if (config->manual_pred_struct_entry_num > 1) {

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2268,7 +2268,7 @@ void copy_api_from_app(
     scs_ptr->static_config.enable_manual_pred_struct    = config_struct->enable_manual_pred_struct;
     if(scs_ptr->static_config.enable_manual_pred_struct){
         scs_ptr->static_config.manual_pred_struct_entry_num = config_struct->manual_pred_struct_entry_num;
-        memcpy(&scs_ptr->static_config.pred_struct[0], &config_struct->pred_struct[0],config_struct->manual_pred_struct_entry_num*sizeof(PredictionStructureConfigEntry));
+        EB_MEMCPY(&scs_ptr->static_config.pred_struct[0], &config_struct->pred_struct[0],config_struct->manual_pred_struct_entry_num*sizeof(PredictionStructureConfigEntry));
         switch (scs_ptr->static_config.manual_pred_struct_entry_num) {
             case 1:
                 scs_ptr->static_config.hierarchical_levels =  0;

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2268,7 +2268,7 @@ void copy_api_from_app(
     scs_ptr->static_config.enable_manual_pred_struct    = config_struct->enable_manual_pred_struct;
     if(scs_ptr->static_config.enable_manual_pred_struct){
         scs_ptr->static_config.manual_pred_struct_entry_num = config_struct->manual_pred_struct_entry_num;
-        eb_memcpy(&scs_ptr->static_config.pred_struct[0], &config_struct->pred_struct[0],config_struct->manual_pred_struct_entry_num*sizeof(PredictionStructureConfigEntry));
+        memcpy(&scs_ptr->static_config.pred_struct[0], &config_struct->pred_struct[0],config_struct->manual_pred_struct_entry_num*sizeof(PredictionStructureConfigEntry));
         switch (scs_ptr->static_config.manual_pred_struct_entry_num) {
             case 1:
                 scs_ptr->static_config.hierarchical_levels =  0;


### PR DESCRIPTION
bug occurrence conditions：
when command line set parameter："-pred-struct-file", or Sample.cfg set parameter "PredStructFile", the crash will coming！
bug fixed：
when code coming to the two crash points，the eb_memcpy has been not setted，so should using  function memcpy to instead of function eb_memcpy.

# Description


# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
