### PR TITLE
Generalize sad loop kernels

### DIFF
--- a/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -2204,8 +2204,9 @@ void sad_loop_kernel_avx2_intrin(
                     p_ref = ref + j;
                     s3    = _mm_setzero_si128();
                     for (k = 0; k < block_height; k += 2) {
-                        s0 = _mm_loadu_si128((__m128i *)p_ref);
-                        s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
+                        //Note: _mm_lddqu_si128 is used instead of _mm_loadu_si128 because clang Release configuration is emitting wrong assembly instructions
+                        s0 = _mm_lddqu_si128((__m128i *)p_ref);
+                        s1 = _mm_lddqu_si128((__m128i *)(p_ref + ref_stride));
                         s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
                         s5 = _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride));
                         s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
@@ -2244,8 +2245,9 @@ void sad_loop_kernel_avx2_intrin(
                     p_ref = ref + j;
                     s3    = _mm_setzero_si128();
                     for (k = 0; k < block_height; k += 2) {
-                        s0 = _mm_loadu_si128((__m128i *)p_ref);
-                        s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
+                        //Note: _mm_lddqu_si128 is used instead of _mm_loadu_si128 because clang Release configuration is emitting wrong assembly instructions
+                        s0 = _mm_lddqu_si128((__m128i *)p_ref);
+                        s1 = _mm_lddqu_si128((__m128i *)(p_ref + ref_stride));
                         s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
                         s5 = _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride));
                         s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));

--- a/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -16,6 +16,7 @@
 #include <immintrin.h>
 #include "EbMemory_AVX2.h"
 #include "EbComputeSAD.h"
+#include "EbComputeSAD_C.h"
 
 #define UPDATE_BEST(s, k, offset)        \
     tem_sum_1 = _mm_extract_epi32(s, k); \
@@ -1908,9 +1909,10 @@ void sad_loop_kernel_sparse_avx2_intrin(
 }
 #endif
 /*******************************************************************************
- * Requirement: width   = 4, 8, 16, 24, 32, 48 or 64
+ * Requirement: width   = 4, 6, 8, 12, 16, 24, 32, 48 or 64 to use SIMD
+ * otherwise C version is used
  * Requirement: block_height <= 64
- * Requirement: block_height % 2 = 0 when width = 4 or 8
+ * Requirement: block_height % 2 = 0 when width = 4, 6 or 8
 *******************************************************************************/
 void sad_loop_kernel_avx2_intrin(
     uint8_t * src, // input parameter, source samples Ptr
@@ -2076,7 +2078,212 @@ void sad_loop_kernel_avx2_intrin(
         }
 
         break;
+    case 6:
+        if (!(block_height % 4)) {
+            uint32_t src_stride_t = 3 * src_stride;
+            uint32_t ref_stride_t = 3 * ref_stride;
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss5 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k += 4) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_loadu_si128((__m128i *)(p_ref + 2 * ref_stride)),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(
+                                _mm_loadu_si128((__m128i *)(p_ref + ref_stride))),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride_t)),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_unpacklo_epi64(
+                                _mm_cvtsi32_si128(*(uint32_t *)p_src),
+                                _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride)))),
+                            _mm_unpacklo_epi64(
+                                _mm_cvtsi32_si128(*(uint32_t *)(p_src + 2 * src_stride)),
+                                _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride_t))),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        p_src += src_stride << 2;
+                        p_ref += ref_stride << 2;
+                    }
+                    ss3       = _mm256_adds_epu16(ss3, ss5);
+                    s3        = _mm_adds_epu16(_mm256_castsi256_si128(ss3),
+                                        _mm256_extracti128_si256(ss3, 1));
 
+                    DECLARE_ALIGNED(16, uint16_t, tsum[8]);
+                    memset(tsum, 0, 8 * sizeof(uint16_t));
+                    p_ref = ref + j;
+                    for (uint32_t search_area = 0; search_area < 8; search_area++) {
+                        for (uint32_t y = 0; y < block_height; y++) {
+                            tsum[search_area] +=
+                                EB_ABS_DIFF(src[y * src_stride + 4],
+                                            p_ref[y * ref_stride + 4]) +
+                                EB_ABS_DIFF(src[y * src_stride + 5],
+                                            p_ref[y * ref_stride + 5]);
+                        }
+                        p_ref += 1;
+                    }
+                    s4 = _mm_loadu_si128((__m128i *)tsum);
+                    s3 = _mm_adds_epu16(s3, s4);
+
+                    s3        = _mm_minpos_epu16(s3);
+                    tem_sum_1 = _mm_extract_epi16(s3, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = (int16_t)(j + _mm_extract_epi16(s3, 1));
+                        y_best  = i;
+                    }
+                }
+
+                if (leftover) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss5 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k += 4) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_loadu_si128((__m128i *)(p_ref + 2 * ref_stride)),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(
+                                _mm_loadu_si128((__m128i *)(p_ref + ref_stride))),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride_t)),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_unpacklo_epi64(
+                                _mm_cvtsi32_si128(*(uint32_t *)p_src),
+                                _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride)))),
+                            _mm_unpacklo_epi64(
+                                _mm_cvtsi32_si128(*(uint32_t *)(p_src + 2 * src_stride)),
+                                _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride_t))),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        p_src += src_stride << 2;
+                        p_ref += ref_stride << 2;
+                    }
+                    ss3       = _mm256_adds_epu16(ss3, ss5);
+                    s3        = _mm_adds_epu16(_mm256_castsi256_si128(ss3),
+                                        _mm256_extracti128_si256(ss3, 1));
+                    s3        = _mm_or_si128(s3, s8);
+
+                    DECLARE_ALIGNED(16, uint16_t, tsum[8]);
+                    memset(tsum, 0, 8 * sizeof(uint16_t));
+                    p_ref = ref + j;
+                    for (uint32_t search_area = 0; search_area < leftover; search_area++) {
+                        for (uint32_t y = 0; y < block_height; y++) {
+                            tsum[search_area] +=
+                                EB_ABS_DIFF(src[y * src_stride + 4],
+                                            p_ref[y * ref_stride + 4]) +
+                                EB_ABS_DIFF(src[y * src_stride + 5],
+                                            p_ref[y * ref_stride + 5]);
+                        }
+                        p_ref += 1;
+                    }
+                    s4 = _mm_loadu_si128((__m128i *)tsum);
+                    s3 = _mm_adds_epu16(s3, s4);
+
+                    s3        = _mm_minpos_epu16(s3);
+                    tem_sum_1 = _mm_extract_epi16(s3, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = (int16_t)(j + _mm_extract_epi16(s3, 1));
+                        y_best  = i;
+                    }
+                }
+                ref += src_stride_raw;
+            }
+        } else {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    s3    = _mm_setzero_si128();
+                    for (k = 0; k < block_height; k += 2) {
+                        s0 = _mm_loadu_si128((__m128i *)p_ref);
+                        s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
+                        s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
+                        s5 = _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride));
+                        s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
+                        s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s1, s5, 0));
+                        p_src += src_stride << 1;
+                        p_ref += ref_stride << 1;
+                    }
+
+                    DECLARE_ALIGNED(16, uint16_t, tsum[8]);
+                    memset(tsum, 0, 8 * sizeof(uint16_t));
+                    p_ref   = ref + j;
+                    for (uint32_t search_area = 0; search_area < 8; search_area++) {
+                        for (uint32_t y = 0; y < block_height; y++) {
+                            tsum[search_area] +=
+                                EB_ABS_DIFF(src[y * src_stride + 4],
+                                            p_ref[y * ref_stride + 4]) +
+                                EB_ABS_DIFF(src[y * src_stride + 5],
+                                            p_ref[y * ref_stride + 5]);
+                        }
+                        p_ref += 1;
+                    }
+                    s4 = _mm_loadu_si128((__m128i *)tsum);
+                    s3 = _mm_adds_epu16(s3, s4);
+
+                    s3        = _mm_minpos_epu16(s3);
+                    tem_sum_1 = _mm_extract_epi16(s3, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = (int16_t)(j + _mm_extract_epi16(s3, 1));
+                        y_best  = i;
+                    }
+                }
+
+                if (leftover) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    s3    = _mm_setzero_si128();
+                    for (k = 0; k < block_height; k += 2) {
+                        s0 = _mm_loadu_si128((__m128i *)p_ref);
+                        s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
+                        s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
+                        s5 = _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride));
+                        s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
+                        s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s1, s5, 0));
+                        p_src += src_stride << 1;
+                        p_ref += ref_stride << 1;
+                    }
+                    s3        = _mm_or_si128(s3, s8);
+
+                    DECLARE_ALIGNED(16, uint16_t, tsum[8]);
+                    memset(tsum, 0, 8 * sizeof(uint16_t));
+                    p_ref = ref + j;
+                    for (uint32_t search_area = 0; search_area < leftover; search_area++) {
+                        for (uint32_t y = 0; y < block_height; y++) {
+                            tsum[search_area] +=
+                                EB_ABS_DIFF(src[y * src_stride + 4],
+                                            p_ref[y * ref_stride + 4]) +
+                                EB_ABS_DIFF(src[y * src_stride + 5],
+                                            p_ref[y * ref_stride + 5]);
+                        }
+                        p_ref += 1;
+                    }
+                    s4 = _mm_loadu_si128((__m128i *)tsum);
+                    s3 = _mm_adds_epu16(s3, s4);
+
+                    s3        = _mm_minpos_epu16(s3);
+                    tem_sum_1 = _mm_extract_epi16(s3, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = (int16_t)(j + _mm_extract_epi16(s3, 1));
+                        y_best  = i;
+                    }
+                }
+                ref += src_stride_raw;
+            }
+        }
+
+        break;
     case 8:
         if (!(block_height % 4)) {
             uint32_t src_stride_t = 3 * src_stride;
@@ -2224,7 +2431,307 @@ void sad_loop_kernel_avx2_intrin(
             }
         }
         break;
+    case 12:
+        if (block_height <= 16) {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k += 2) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride + 8)),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_loadu_si128((__m128i *)(p_src + src_stride)),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        p_src += 2 * src_stride;
+                        p_ref += 2 * ref_stride;
+                    }
+                    ss3       = _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4),ss5);
+                    s3        = _mm_adds_epu16(_mm256_castsi256_si128(ss3),
+                                        _mm256_extracti128_si256(ss3, 1));
+                    s3        = _mm_minpos_epu16(s3);
+                    tem_sum_1 = _mm_extract_epi16(s3, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = (int16_t)(j + _mm_extract_epi16(s3, 1));
+                        y_best  = i;
+                    }
+                }
 
+                if (leftover) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k += 2) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride + 8)),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_loadu_si128((__m128i *)(p_src + src_stride)),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        p_src += 2 * src_stride;
+                        p_ref += 2 * ref_stride;
+                    }
+                    ss3       = _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4),ss5);
+                    s3        = _mm_adds_epu16(_mm256_castsi256_si128(ss3),
+                                        _mm256_extracti128_si256(ss3, 1));
+                    s3        = _mm_or_si128(s3, s8);
+                    s3        = _mm_minpos_epu16(s3);
+                    tem_sum_1 = _mm_extract_epi16(s3, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = (int16_t)(j + _mm_extract_epi16(s3, 1));
+                        y_best  = i;
+                    }
+                }
+                ref += src_stride_raw;
+            }
+        } else if (block_height <= 32) {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k += 2) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride + 8)),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_loadu_si128((__m128i *)(p_src + src_stride)),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        p_src += 2 * src_stride;
+                        p_ref += 2 * ref_stride;
+                    }
+                    ss3       = _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4),ss5);
+                    s3        = _mm256_castsi256_si128(ss3);
+                    s5        = _mm256_extracti128_si256(ss3, 1);
+                    s4        = _mm_minpos_epu16(s3);
+                    s6        = _mm_minpos_epu16(s5);
+                    s4        = _mm_unpacklo_epi16(s4, s4);
+                    s4        = _mm_unpacklo_epi32(s4, s4);
+                    s4        = _mm_unpacklo_epi64(s4, s4);
+                    s6        = _mm_unpacklo_epi16(s6, s6);
+                    s6        = _mm_unpacklo_epi32(s6, s6);
+                    s6        = _mm_unpacklo_epi64(s6, s6);
+                    s3        = _mm_sub_epi16(s3, s4);
+                    s5        = _mm_adds_epu16(s5, s3);
+                    s5        = _mm_sub_epi16(s5, s6);
+                    s5        = _mm_minpos_epu16(s5);
+                    tem_sum_1 = _mm_extract_epi16(s5, 0);
+                    tem_sum_1 += _mm_extract_epi16(s4, 0);
+                    tem_sum_1 += _mm_extract_epi16(s6, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = (int16_t)(j + _mm_extract_epi16(s5, 1));
+                        y_best  = i;
+                    }
+                }
+
+                if (leftover) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k += 2) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride + 8)),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_loadu_si128((__m128i *)(p_src + src_stride)),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        p_src += 2 * src_stride;
+                        p_ref += 2 * ref_stride;
+                    }
+                    ss3       = _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4),ss5);
+                    s3        = _mm256_castsi256_si128(ss3);
+                    s5        = _mm256_extracti128_si256(ss3, 1);
+                    s3        = _mm_or_si128(s3, s8);
+                    s5        = _mm_or_si128(s5, s8);
+                    s4        = _mm_minpos_epu16(s3);
+                    s6        = _mm_minpos_epu16(s5);
+                    s4        = _mm_unpacklo_epi16(s4, s4);
+                    s4        = _mm_unpacklo_epi32(s4, s4);
+                    s4        = _mm_unpacklo_epi64(s4, s4);
+                    s6        = _mm_unpacklo_epi16(s6, s6);
+                    s6        = _mm_unpacklo_epi32(s6, s6);
+                    s6        = _mm_unpacklo_epi64(s6, s6);
+                    s3        = _mm_sub_epi16(s3, s4);
+                    s5        = _mm_adds_epu16(s5, s3);
+                    s5        = _mm_sub_epi16(s5, s6);
+                    s5        = _mm_minpos_epu16(s5);
+                    tem_sum_1 = _mm_extract_epi16(s5, 0);
+                    tem_sum_1 += _mm_extract_epi16(s4, 0);
+                    tem_sum_1 += _mm_extract_epi16(s6, 0);
+                    if (tem_sum_1 < low_sum) {
+                        low_sum = tem_sum_1;
+                        x_best  = (int16_t)(j + _mm_extract_epi16(s5, 1));
+                        y_best  = i;
+                    }
+                }
+                ref += src_stride_raw;
+            }
+        } else {
+            for (i = 0; i < search_area_height; i++) {
+                for (j = 0; j <= search_area_width - 8; j += 8) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k += 2) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride + 8)),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_loadu_si128((__m128i *)(p_src + src_stride)),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        p_src += 2 * src_stride;
+                        p_ref += 2 * ref_stride;
+                    }
+                    ss3       = _mm256_adds_epu16(ss3, ss4);
+                    ss0       = _mm256_adds_epu16(ss3, ss5);
+                    s0        = _mm_adds_epu16(_mm256_castsi256_si128(ss0),
+                                        _mm256_extracti128_si256(ss0, 1));
+                    s0        = _mm_minpos_epu16(s0);
+                    tem_sum_1 = _mm_extract_epi16(s0, 0);
+                    if (tem_sum_1 < low_sum) {
+                        if (tem_sum_1 != 0xFFFF) { // no overflow
+                            low_sum = tem_sum_1;
+                            x_best  = (int16_t)(j + _mm_extract_epi16(s0, 1));
+                            y_best  = i;
+                        } else {
+                            ss4 = _mm256_unpacklo_epi16(ss3, _mm256_setzero_si256());
+                            ss3 = _mm256_unpackhi_epi16(ss3, _mm256_setzero_si256());
+                            ss6 = _mm256_unpacklo_epi16(ss5, _mm256_setzero_si256());
+                            ss5 = _mm256_unpackhi_epi16(ss5, _mm256_setzero_si256());
+                            ss4 = _mm256_add_epi32(ss4, ss6);
+                            ss3 = _mm256_add_epi32(ss3, ss5);
+                            s0  = _mm_add_epi32(_mm256_castsi256_si128(ss4),
+                                               _mm256_extracti128_si256(ss4, 1));
+                            s3  = _mm_add_epi32(_mm256_castsi256_si128(ss3),
+                                               _mm256_extracti128_si256(ss3, 1));
+                            UPDATE_BEST(s0, 0, 0);
+                            UPDATE_BEST(s0, 1, 0);
+                            UPDATE_BEST(s0, 2, 0);
+                            UPDATE_BEST(s0, 3, 0);
+                            UPDATE_BEST(s3, 0, 4);
+                            UPDATE_BEST(s3, 1, 4);
+                            UPDATE_BEST(s3, 2, 4);
+                            UPDATE_BEST(s3, 3, 4);
+                        }
+                    }
+                }
+
+                if (leftover) {
+                    p_src = src;
+                    p_ref = ref + j;
+                    ss3 = ss4 = ss5 = _mm256_setzero_si256();
+                    for (k = 0; k < block_height; k += 2) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_loadu_si128((__m128i *)(p_ref + ref_stride + 8)),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_loadu_si128((__m128i *)(p_src + src_stride)),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        p_src += 2 * src_stride;
+                        p_ref += 2 * ref_stride;
+                    }
+                    ss3       = _mm256_adds_epu16(ss3, ss4);
+                    ss0       = _mm256_adds_epu16(ss3, ss5);
+                    s0        = _mm_adds_epu16(_mm256_castsi256_si128(ss0),
+                                        _mm256_extracti128_si256(ss0, 1));
+                    s0        = _mm_or_si128(s0, s8);
+                    s0        = _mm_minpos_epu16(s0);
+                    tem_sum_1 = _mm_extract_epi16(s0, 0);
+                    if (tem_sum_1 < low_sum) {
+                        if (tem_sum_1 != 0xFFFF) { // no overflow
+                            low_sum = tem_sum_1;
+                            x_best  = (int16_t)(j + _mm_extract_epi16(s0, 1));
+                            y_best  = i;
+                        } else {
+                            ss4 = _mm256_unpacklo_epi16(ss3, _mm256_setzero_si256());
+                            ss3 = _mm256_unpackhi_epi16(ss3, _mm256_setzero_si256());
+                            ss6 = _mm256_unpacklo_epi16(ss5, _mm256_setzero_si256());
+                            ss5 = _mm256_unpackhi_epi16(ss5, _mm256_setzero_si256());
+                            ss4 = _mm256_add_epi32(ss4, ss6);
+                            ss3 = _mm256_add_epi32(ss3, ss5);
+                            s0  = _mm_add_epi32(_mm256_castsi256_si128(ss4),
+                                               _mm256_extracti128_si256(ss4, 1));
+                            s3  = _mm_add_epi32(_mm256_castsi256_si128(ss3),
+                                               _mm256_extracti128_si256(ss3, 1));
+                            k   = leftover;
+                            while (k > 0) {
+                                for (l = 0; l < 4 && k; l++, k--) {
+                                    tem_sum_1 = _mm_extract_epi32(s0, 0);
+                                    s0        = _mm_srli_si128(s0, 4);
+                                    if (tem_sum_1 < low_sum) {
+                                        low_sum = tem_sum_1;
+                                        x_best  = (int16_t)(j + leftover - k);
+                                        y_best  = i;
+                                    }
+                                }
+                                s0 = s3;
+                            }
+                        }
+                    }
+                }
+                ref += src_stride_raw;
+            }
+        }
+        break;
     case 16:
         if (block_height <= 16) {
             for (i = 0; i < search_area_height; i++) {
@@ -3721,7 +4228,20 @@ void sad_loop_kernel_avx2_intrin(
         }
         break;
 
-    default: assert(0); break;
+    default:
+        sad_loop_kernel_c(src,
+                          src_stride,
+                          ref,
+                          ref_stride,
+                          block_height,
+                          block_width,
+                          best_sad,
+                          x_search_center,
+                          y_search_center,
+                          src_stride_raw,
+                          search_area_width,
+                          search_area_height);
+        return;
     }
 
     *best_sad        = low_sum;

--- a/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
@@ -653,6 +653,11 @@ static INLINE void sad_loop_kernel_8_avx2(const uint8_t *const src, const uint32
     *sum = _mm256_adds_epu16(*sum, _mm256_mpsadbw_epu8(rr0, ss0, (5 << 3) | 5)); // 101 101
 }
 
+/*******************************************************************************
+* Function helper adds to "sums" vectors SAD's for block width of 12, uses AVX512 instructions
+* Requirement: width = 12
+* Requirement: height = 2
+*******************************************************************************/
 SIMD_INLINE void sad_loop_kernel_12_avx512(const uint8_t *const src, const uint32_t src_stride,
                                            const uint8_t *const ref, const uint32_t ref_stride,
                                            __m512i *const sum) {
@@ -706,6 +711,11 @@ SIMD_INLINE void sad_loop_kernel_16_avx512(const uint8_t *const src, const uint3
     *sum = _mm512_adds_epu16(*sum, _mm512_dbsad_epu8(ss3, rr1, 0xE9));
 }
 
+/*******************************************************************************
+* Function helper adds to two elements "sums" vectors SAD's for block width of 12, uses AVX512 instructions
+* Requirement: width = 12
+* Requirement: height = 2
+*******************************************************************************/
 SIMD_INLINE void sad_loop_kernel_12_2sum_avx512(const uint8_t *const src, const uint32_t src_stride,
                                                 const uint8_t *const ref, const uint32_t ref_stride,
                                                 __m512i sum[2]) {
@@ -759,6 +769,11 @@ SIMD_INLINE void sad_loop_kernel_16_2sum_avx512(const uint8_t *const src, const 
     sum[1] = _mm512_adds_epu16(sum[1], _mm512_dbsad_epu8(ss3, rr1, 0xE9));
 }
 
+/*******************************************************************************
+* Function helper adds to "sums" vectors SAD's for block width of 12, uses AVX2 instructions
+* Requirement: width = 12
+* Requirement: height = 2
+*******************************************************************************/
 static INLINE void sad_loop_kernel_12_avx2(const uint8_t *const src, const uint32_t src_stride,
                                            const uint8_t *const ref, const uint32_t ref_stride,
                                            __m256i *const sum) {
@@ -800,6 +815,11 @@ static INLINE void sad_loop_kernel_16_avx2(const uint8_t *const src, const uint3
     *sum = _mm256_adds_epu16(*sum, _mm256_mpsadbw_epu8(rr1, ss0, (7 << 3) | 7)); // 111 111
 }
 
+/*******************************************************************************
+* Function helper adds to two elements "sums" vectors SAD's for block width of 12, uses AVX2 instructions
+* Requirement: width = 12
+* Requirement: height = 2
+*******************************************************************************/
 static INLINE void sad_loop_kernel_12_2sum_avx2(const uint8_t *const src, const uint32_t src_stride,
                                                 const uint8_t *const ref, const uint32_t ref_stride,
                                                 __m256i sums[2]) {
@@ -1544,6 +1564,10 @@ SIMD_INLINE void update_leftover_2048_pel(const __m256i sums256[4], const int16_
     }
 }
 
+/*******************************************************************************
+* Requirement: search_size <= 8,
+* Returns "search_size" of SAD's for all height in 5th and 6th col
+*******************************************************************************/
 static INLINE __m128i complement_4_to_6(uint8_t *ref, uint32_t ref_stride, uint8_t *src,
                                         uint32_t src_stride, uint32_t height,uint32_t search_size) {
     __m128i sum;
@@ -1561,7 +1585,8 @@ static INLINE __m128i complement_4_to_6(uint8_t *ref, uint32_t ref_stride, uint8
 }
 
 /*******************************************************************************
-* Requirement: width   = 4, 8, 16, 24, 32, 48 or 64
+* Requirement: width   = 4, 6, 8, 12, 16, 24, 32, 48 or 64 to use SIMD
+* otherwise C version is used
 * Requirement: height <= 64
 * Requirement: height % 2 = 0
 *******************************************************************************/

--- a/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
@@ -1662,7 +1662,8 @@ void sad_loop_kernel_avx512_intrin(
                     } while (--h);
 
                     __m128i sum = complement_4_to_6(ref, ref_stride, src, src_stride, height, 8);
-                    sum256      = _mm256_adds_epu16(sum256, _mm256_zextsi128_si256(sum));
+                    sum256      = _mm256_adds_epu16(
+                        sum256, _mm256_insertf128_si256(_mm256_setzero_si256(), sum, 0));
 
                     update_small_pel(sum256, 0, y, &best_s, &best_x, &best_y);
                     ref += src_stride_raw;
@@ -2255,7 +2256,8 @@ void sad_loop_kernel_avx512_intrin(
 
                         __m128i sum = complement_4_to_6(
                             ref, ref_stride, src, src_stride, height, 8);
-                        sum256 = _mm256_adds_epu16(sum256, _mm256_zextsi128_si256(sum));
+                        sum256 = _mm256_adds_epu16(
+                            sum256, _mm256_insertf128_si256(_mm256_setzero_si256(), sum, 0));
 
                         update_small_pel(sum256, 0, y, &best_s, &best_x, &best_y);
                     }
@@ -2275,7 +2277,8 @@ void sad_loop_kernel_avx512_intrin(
 
                         __m128i sum = complement_4_to_6(
                             ref + 8, ref_stride, src, src_stride, height, 8);
-                        sum256 = _mm256_adds_epu16(sum256, _mm256_zextsi128_si256(sum));
+                        sum256 = _mm256_adds_epu16(
+                            sum256, _mm256_insertf128_si256(_mm256_setzero_si256(), sum, 0));
 
                         update_small_pel(sum256, 8, y, &best_s, &best_x, &best_y);
                     }
@@ -2957,7 +2960,8 @@ void sad_loop_kernel_avx512_intrin(
 
                         __m128i sum = complement_4_to_6(
                             ref + x, ref_stride, src, src_stride, height, 8);
-                        sum256 = _mm256_adds_epu16(sum256, _mm256_zextsi128_si256(sum));
+                        sum256 = _mm256_adds_epu16(
+                            sum256, _mm256_insertf128_si256(_mm256_setzero_si256(), sum, 0));
 
                         update_small_pel(sum256, x, y, &best_s, &best_x, &best_y);
                     }
@@ -2977,7 +2981,8 @@ void sad_loop_kernel_avx512_intrin(
 
                         __m128i sum = complement_4_to_6(
                             ref + x, ref_stride, src, src_stride, height, leftover);
-                        sum256 = _mm256_adds_epu16(sum256, _mm256_zextsi128_si256(sum));
+                        sum256 = _mm256_adds_epu16(
+                            sum256, _mm256_insertf128_si256(_mm256_setzero_si256(), sum, 0));
 
                         update_leftover_small_pel(sum256, x, y, mask128, &best_s, &best_x, &best_y);
                     }

--- a/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
@@ -17,6 +17,8 @@
 #include <immintrin.h>
 #include "EbMemory_AVX2.h"
 #include "transpose_avx2.h"
+#include "EbUtility.h"
+#include "EbComputeSAD_C.h"
 
 static INLINE void sad64_kernel_avx512(const __m512i s, const uint8_t *const ref,
                                        __m512i *const sum) {
@@ -651,6 +653,31 @@ static INLINE void sad_loop_kernel_8_avx2(const uint8_t *const src, const uint32
     *sum = _mm256_adds_epu16(*sum, _mm256_mpsadbw_epu8(rr0, ss0, (5 << 3) | 5)); // 101 101
 }
 
+SIMD_INLINE void sad_loop_kernel_12_avx512(const uint8_t *const src, const uint32_t src_stride,
+                                           const uint8_t *const ref, const uint32_t ref_stride,
+                                           __m512i *const sum) {
+    const __m128i s0  = _mm_loadu_si128((__m128i *)src);
+    const __m128i s1  = _mm_loadu_si128((__m128i *)(src + src_stride));
+    const __m256i s01 = _mm256_insertf128_si256(_mm256_castsi128_si256(s0), s1, 1);
+    const __m512i s   = _mm512_castsi256_si512(s01);
+    const __m512i ss0 = _mm512_permutexvar_epi32(
+        _mm512_setr_epi32(0, 0, 0, 0, 0, 0, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4), s);
+    const __m512i ss1 = _mm512_permutexvar_epi32(
+        _mm512_setr_epi32(1, 1, 1, 1, 1, 1, 1, 1, 5, 5, 5, 5, 5, 5, 5, 5), s);
+    const __m512i ss2 = _mm512_permutexvar_epi32(
+        _mm512_setr_epi32(2, 2, 2, 2, 2, 2, 2, 2, 6, 6, 6, 6, 6, 6, 6, 6), s);
+
+    const __m256i r0  = _mm256_loadu_si256((__m256i *)ref);
+    const __m256i r1  = _mm256_loadu_si256((__m256i *)(ref + ref_stride));
+    const __m512i r   = _mm512_inserti64x4(_mm512_castsi256_si512(r0), r1, 1);
+    const __m512i rr0 = _mm512_permutexvar_epi64(_mm512_setr_epi64(0, 1, 1, 2, 4, 5, 5, 6), r);
+    const __m512i rr1 = _mm512_permutexvar_epi64(_mm512_setr_epi64(1, 2, 2, 3, 5, 6, 6, 7), r);
+
+    *sum = _mm512_adds_epu16(*sum, _mm512_dbsad_epu8(ss0, rr0, 0x94));
+    *sum = _mm512_adds_epu16(*sum, _mm512_dbsad_epu8(ss1, rr0, 0xE9));
+    *sum = _mm512_adds_epu16(*sum, _mm512_dbsad_epu8(ss2, rr1, 0x94));
+}
+
 SIMD_INLINE void sad_loop_kernel_16_avx512(const uint8_t *const src, const uint32_t src_stride,
                                            const uint8_t *const ref, const uint32_t ref_stride,
                                            __m512i *const sum) {
@@ -677,6 +704,31 @@ SIMD_INLINE void sad_loop_kernel_16_avx512(const uint8_t *const src, const uint3
     *sum = _mm512_adds_epu16(*sum, _mm512_dbsad_epu8(ss1, rr0, 0xE9));
     *sum = _mm512_adds_epu16(*sum, _mm512_dbsad_epu8(ss2, rr1, 0x94));
     *sum = _mm512_adds_epu16(*sum, _mm512_dbsad_epu8(ss3, rr1, 0xE9));
+}
+
+SIMD_INLINE void sad_loop_kernel_12_2sum_avx512(const uint8_t *const src, const uint32_t src_stride,
+                                                const uint8_t *const ref, const uint32_t ref_stride,
+                                                __m512i sum[2]) {
+    const __m128i s0  = _mm_loadu_si128((__m128i *)src);
+    const __m128i s1  = _mm_loadu_si128((__m128i *)(src + src_stride));
+    const __m256i s01 = _mm256_insertf128_si256(_mm256_castsi128_si256(s0), s1, 1);
+    const __m512i s   = _mm512_castsi256_si512(s01);
+    const __m512i ss0 = _mm512_permutexvar_epi32(
+        _mm512_setr_epi32(0, 0, 0, 0, 0, 0, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4), s);
+    const __m512i ss1 = _mm512_permutexvar_epi32(
+        _mm512_setr_epi32(1, 1, 1, 1, 1, 1, 1, 1, 5, 5, 5, 5, 5, 5, 5, 5), s);
+    const __m512i ss2 = _mm512_permutexvar_epi32(
+        _mm512_setr_epi32(2, 2, 2, 2, 2, 2, 2, 2, 6, 6, 6, 6, 6, 6, 6, 6), s);
+
+    const __m256i r0  = _mm256_loadu_si256((__m256i *)ref);
+    const __m256i r1  = _mm256_loadu_si256((__m256i *)(ref + ref_stride));
+    const __m512i r   = _mm512_inserti64x4(_mm512_castsi256_si512(r0), r1, 1);
+    const __m512i rr0 = _mm512_permutexvar_epi64(_mm512_setr_epi64(0, 1, 1, 2, 4, 5, 5, 6), r);
+    const __m512i rr1 = _mm512_permutexvar_epi64(_mm512_setr_epi64(1, 2, 2, 3, 5, 6, 6, 7), r);
+
+    sum[0] = _mm512_adds_epu16(sum[0], _mm512_dbsad_epu8(ss0, rr0, 0x94));
+    sum[1] = _mm512_adds_epu16(sum[1], _mm512_dbsad_epu8(ss1, rr0, 0xE9));
+    sum[0] = _mm512_adds_epu16(sum[0], _mm512_dbsad_epu8(ss2, rr1, 0x94));
 }
 
 SIMD_INLINE void sad_loop_kernel_16_2sum_avx512(const uint8_t *const src, const uint32_t src_stride,
@@ -707,6 +759,26 @@ SIMD_INLINE void sad_loop_kernel_16_2sum_avx512(const uint8_t *const src, const 
     sum[1] = _mm512_adds_epu16(sum[1], _mm512_dbsad_epu8(ss3, rr1, 0xE9));
 }
 
+static INLINE void sad_loop_kernel_12_avx2(const uint8_t *const src, const uint32_t src_stride,
+                                           const uint8_t *const ref, const uint32_t ref_stride,
+                                           __m256i *const sum) {
+    const __m256i ss0 = _mm256_insertf128_si256(
+        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)src)),
+        _mm_loadu_si128((__m128i *)(src + src_stride)),
+        1);
+    const __m256i rr0 = _mm256_insertf128_si256(
+        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)ref)),
+        _mm_loadu_si128((__m128i *)(ref + ref_stride)),
+        1);
+    const __m256i rr1 = _mm256_insertf128_si256(
+        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(ref + 8))),
+        _mm_loadu_si128((__m128i *)(ref + ref_stride + 8)),
+        1);
+    *sum = _mm256_adds_epu16(*sum, _mm256_mpsadbw_epu8(rr0, ss0, (0 << 3) | 0)); // 000 000
+    *sum = _mm256_adds_epu16(*sum, _mm256_mpsadbw_epu8(rr0, ss0, (5 << 3) | 5)); // 101 101
+    *sum = _mm256_adds_epu16(*sum, _mm256_mpsadbw_epu8(rr1, ss0, (2 << 3) | 2)); // 010 010
+}
+
 static INLINE void sad_loop_kernel_16_avx2(const uint8_t *const src, const uint32_t src_stride,
                                            const uint8_t *const ref, const uint32_t ref_stride,
                                            __m256i *const sum) {
@@ -726,6 +798,26 @@ static INLINE void sad_loop_kernel_16_avx2(const uint8_t *const src, const uint3
     *sum = _mm256_adds_epu16(*sum, _mm256_mpsadbw_epu8(rr0, ss0, (5 << 3) | 5)); // 101 101
     *sum = _mm256_adds_epu16(*sum, _mm256_mpsadbw_epu8(rr1, ss0, (2 << 3) | 2)); // 010 010
     *sum = _mm256_adds_epu16(*sum, _mm256_mpsadbw_epu8(rr1, ss0, (7 << 3) | 7)); // 111 111
+}
+
+static INLINE void sad_loop_kernel_12_2sum_avx2(const uint8_t *const src, const uint32_t src_stride,
+                                                const uint8_t *const ref, const uint32_t ref_stride,
+                                                __m256i sums[2]) {
+    const __m256i ss0 = _mm256_insertf128_si256(
+        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)src)),
+        _mm_loadu_si128((__m128i *)(src + src_stride)),
+        1);
+    const __m256i rr0 = _mm256_insertf128_si256(
+        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)ref)),
+        _mm_loadu_si128((__m128i *)(ref + ref_stride)),
+        1);
+    const __m256i rr1 = _mm256_insertf128_si256(
+        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(ref + 8))),
+        _mm_loadu_si128((__m128i *)(ref + ref_stride + 8)),
+        1);
+    sums[0] = _mm256_adds_epu16(sums[0], _mm256_mpsadbw_epu8(rr0, ss0, (0 << 3) | 0)); // 000 000
+    sums[1] = _mm256_adds_epu16(sums[1], _mm256_mpsadbw_epu8(rr0, ss0, (5 << 3) | 5)); // 101 101
+    sums[0] = _mm256_adds_epu16(sums[0], _mm256_mpsadbw_epu8(rr1, ss0, (2 << 3) | 2)); // 010 010
 }
 
 static INLINE void sad_loop_kernel_16_2sum_avx2(const uint8_t *const src, const uint32_t src_stride,
@@ -1452,6 +1544,22 @@ SIMD_INLINE void update_leftover_2048_pel(const __m256i sums256[4], const int16_
     }
 }
 
+static INLINE __m128i complement_4_to_6(uint8_t *ref, uint32_t ref_stride, uint8_t *src,
+                                        uint32_t src_stride, uint32_t height,uint32_t search_size) {
+    __m128i sum;
+    DECLARE_ALIGNED(16, uint16_t, tsum[8]);
+    memset(tsum, 0, 8 * sizeof(uint16_t));
+    for (uint32_t search_area = 0; search_area < search_size; search_area++) {
+        for (uint32_t y = 0; y < height; y++) {
+            tsum[search_area] += EB_ABS_DIFF(src[y * src_stride + 4], ref[y * ref_stride + 4]) +
+                EB_ABS_DIFF(src[y * src_stride + 5], ref[y * ref_stride + 5]);
+        }
+        ref += 1;
+    }
+    sum = _mm_loadu_si128((__m128i *)tsum);
+    return sum;
+}
+
 /*******************************************************************************
 * Requirement: width   = 4, 8, 16, 24, 32, 48 or 64
 * Requirement: height <= 64
@@ -1516,6 +1624,52 @@ void sad_loop_kernel_avx512_intrin(
             }
             break;
 
+        case 6:
+            if (height <= 4) {
+                y = 0;
+                do {
+                    __m128i sum = _mm_setzero_si128();
+
+                    s = src;
+                    r = ref;
+
+                    h = height2;
+                    do {
+                        sad_loop_kernel_4_sse4_1(s, src_stride, r, ref_stride, &sum);
+                        s += 2 * src_stride;
+                        r += 2 * ref_stride;
+                    } while (--h);
+
+                    __m128i sum2 = complement_4_to_6(ref, ref_stride, src, src_stride, height, 8);
+                    sum          = _mm_adds_epu16(sum, sum2);
+
+                    update_best(sum, 0, y, &best_s, &best_x, &best_y);
+                    ref += src_stride_raw;
+                } while (++y < search_area_height);
+            } else {
+                y = 0;
+                do {
+                    __m256i sum256 = _mm256_setzero_si256();
+
+                    s = src;
+                    r = ref;
+
+                    h = height2;
+                    do {
+                        sad_loop_kernel_4_avx2(s, src_stride, r, ref_stride, &sum256);
+                        s += 2 * src_stride;
+                        r += 2 * ref_stride;
+                    } while (--h);
+
+                    __m128i sum = complement_4_to_6(ref, ref_stride, src, src_stride, height, 8);
+                    sum256      = _mm256_adds_epu16(sum256, _mm256_zextsi128_si256(sum));
+
+                    update_small_pel(sum256, 0, y, &best_s, &best_x, &best_y);
+                    ref += src_stride_raw;
+                } while (++y < search_area_height);
+            }
+            break;
+
         case 8:
             // Note: Tried _mm512_dbsad_epu8 but is even slower.
             y = 0;
@@ -1535,6 +1689,64 @@ void sad_loop_kernel_avx512_intrin(
                 update_small_pel(sum256, 0, y, &best_s, &best_x, &best_y);
                 ref += src_stride_raw;
             } while (++y < search_area_height);
+            break;
+
+        case 12:
+            if (height <= 16) {
+                y = 0;
+                do {
+                    __m256i sum256 = _mm256_setzero_si256();
+
+                    s = src;
+                    r = ref;
+
+                    h = height2;
+                    do {
+                        sad_loop_kernel_12_avx2(s, src_stride, r, ref_stride, &sum256);
+                        s += 2 * src_stride;
+                        r += 2 * ref_stride;
+                    } while (--h);
+
+                    update_small_pel(sum256, 0, y, &best_s, &best_x, &best_y);
+                    ref += src_stride_raw;
+                } while (++y < search_area_height);
+            } else if (height <= 32) {
+                y = 0;
+                do {
+                    __m256i sum256 = _mm256_setzero_si256();
+
+                    s = src;
+                    r = ref;
+
+                    h = height2;
+                    do {
+                        sad_loop_kernel_12_avx2(s, src_stride, r, ref_stride, &sum256);
+                        s += 2 * src_stride;
+                        r += 2 * ref_stride;
+                    } while (--h);
+
+                    update_some_pel(sum256, 0, y, &best_s, &best_x, &best_y);
+                    ref += src_stride_raw;
+                } while (++y < search_area_height);
+            } else {
+                y = 0;
+                do {
+                    __m256i sums256[2] = {_mm256_setzero_si256(), _mm256_setzero_si256()};
+
+                    s = src;
+                    r = ref;
+
+                    h = height2;
+                    do {
+                        sad_loop_kernel_12_2sum_avx2(s, src_stride, r, ref_stride, sums256);
+                        s += 2 * src_stride;
+                        r += 2 * ref_stride;
+                    } while (--h);
+
+                    update_leftover8_1024_pel(sums256, 0, y, &best_s, &best_x, &best_y);
+                    ref += src_stride_raw;
+                } while (++y < search_area_height);
+            }
             break;
 
         case 16:
@@ -1791,9 +2003,7 @@ void sad_loop_kernel_avx512_intrin(
             }
             break;
 
-        default:
-            assert(width == 64);
-
+        case 64:
             if (height <= 16) {
                 y = 0;
                 do {
@@ -1885,6 +2095,21 @@ void sad_loop_kernel_avx512_intrin(
                 } while (++y < search_area_height);
             }
             break;
+
+        default:
+            sad_loop_kernel_c(src,
+                              src_stride,
+                              ref,
+                              ref_stride,
+                              height,
+                              width,
+                              best_sad,
+                              x_search_center,
+                              y_search_center,
+                              src_stride_raw,
+                              search_area_width,
+                              search_area_height);
+            return;
         }
     } else if (search_area_width == 16) {
         switch (width) {
@@ -1966,6 +2191,100 @@ void sad_loop_kernel_avx512_intrin(
             }
             break;
 
+        case 6:
+            if (height <= 4) {
+                y = 0;
+                do {
+                    {
+                        __m128i sum = _mm_setzero_si128();
+
+                        s = src;
+                        r = ref;
+
+                        h = height2;
+                        do {
+                            sad_loop_kernel_4_sse4_1(s, src_stride, r, ref_stride, &sum);
+                            s += 2 * src_stride;
+                            r += 2 * ref_stride;
+                        } while (--h);
+
+                        __m128i sum2 = complement_4_to_6(
+                            ref, ref_stride, src, src_stride, height, 8);
+                        sum = _mm_adds_epu16(sum, sum2);
+
+                        update_best(sum, 0, y, &best_s, &best_x, &best_y);
+                    }
+
+                    {
+                        __m128i sum = _mm_setzero_si128();
+
+                        s = src;
+                        r = ref + 8;
+
+                        h = height2;
+                        do {
+                            sad_loop_kernel_4_sse4_1(s, src_stride, r, ref_stride, &sum);
+                            s += 2 * src_stride;
+                            r += 2 * ref_stride;
+                        } while (--h);
+
+                        __m128i sum2 = complement_4_to_6(
+                            ref + 8, ref_stride, src, src_stride, height, 8);
+                        sum = _mm_adds_epu16(sum, sum2);
+
+                        update_best(sum, 8, y, &best_s, &best_x, &best_y);
+                    }
+
+                    ref += src_stride_raw;
+                } while (++y < search_area_height);
+            } else {
+                y = 0;
+                do {
+                    {
+                        __m256i sum256 = _mm256_setzero_si256();
+
+                        s = src;
+                        r = ref;
+
+                        h = height2;
+                        do {
+                            sad_loop_kernel_4_avx2(s, src_stride, r, ref_stride, &sum256);
+                            s += 2 * src_stride;
+                            r += 2 * ref_stride;
+                        } while (--h);
+
+                        __m128i sum = complement_4_to_6(
+                            ref, ref_stride, src, src_stride, height, 8);
+                        sum256 = _mm256_adds_epu16(sum256, _mm256_zextsi128_si256(sum));
+
+                        update_small_pel(sum256, 0, y, &best_s, &best_x, &best_y);
+                    }
+
+                    {
+                        __m256i sum256 = _mm256_setzero_si256();
+
+                        s = src;
+                        r = ref + 8;
+
+                        h = height2;
+                        do {
+                            sad_loop_kernel_4_avx2(s, src_stride, r, ref_stride, &sum256);
+                            s += 2 * src_stride;
+                            r += 2 * ref_stride;
+                        } while (--h);
+
+                        __m128i sum = complement_4_to_6(
+                            ref + 8, ref_stride, src, src_stride, height, 8);
+                        sum256 = _mm256_adds_epu16(sum256, _mm256_zextsi128_si256(sum));
+
+                        update_small_pel(sum256, 8, y, &best_s, &best_x, &best_y);
+                    }
+
+                    ref += src_stride_raw;
+                } while (++y < search_area_height);
+            }
+            break;
+
         case 8:
             // Note: Tried _mm512_dbsad_epu8 but is even slower.
             y = 0;
@@ -2004,6 +2323,64 @@ void sad_loop_kernel_avx512_intrin(
 
                 ref += src_stride_raw;
             } while (++y < search_area_height);
+            break;
+
+        case 12:
+            if (height <= 16) {
+                y = 0;
+                do {
+                    __m512i sum512 = _mm512_setzero_si512();
+
+                    s = src;
+                    r = ref;
+
+                    h = height2;
+                    do {
+                        sad_loop_kernel_12_avx512(s, src_stride, r, ref_stride, &sum512);
+                        s += 2 * src_stride;
+                        r += 2 * ref_stride;
+                    } while (--h);
+
+                    update_256_pel(sum512, 0, y, &best_s, &best_x, &best_y);
+                    ref += src_stride_raw;
+                } while (++y < search_area_height);
+            } else if (height <= 32) {
+                y = 0;
+                do {
+                    __m512i sum512 = _mm512_setzero_si512();
+
+                    s = src;
+                    r = ref;
+
+                    h = height2;
+                    do {
+                        sad_loop_kernel_12_avx512(s, src_stride, r, ref_stride, &sum512);
+                        s += 2 * src_stride;
+                        r += 2 * ref_stride;
+                    } while (--h);
+
+                    update_512_pel(sum512, 0, y, &best_s, &best_x, &best_y);
+                    ref += src_stride_raw;
+                } while (++y < search_area_height);
+            } else {
+                y = 0;
+                do {
+                    __m512i sums512[2] = {_mm512_setzero_si512(), _mm512_setzero_si512()};
+
+                    s = src;
+                    r = ref;
+
+                    h = height2;
+                    do {
+                        sad_loop_kernel_12_2sum_avx512(s, src_stride, r, ref_stride, sums512);
+                        s += 2 * src_stride;
+                        r += 2 * ref_stride;
+                    } while (--h);
+
+                    update_1024_pel(sums512, 0, y, &best_s, &best_x, &best_y);
+                    ref += src_stride_raw;
+                } while (++y < search_area_height);
+            }
             break;
 
         case 16:
@@ -2290,9 +2667,7 @@ void sad_loop_kernel_avx512_intrin(
             }
             break;
 
-        default:
-            assert(width == 64);
-
+        case 64:
             if (height <= 16) {
                 y = 0;
                 do {
@@ -2411,6 +2786,21 @@ void sad_loop_kernel_avx512_intrin(
                 } while (++y < search_area_height);
             }
             break;
+
+        default:
+            sad_loop_kernel_c(src,
+                              src_stride,
+                              ref,
+                              ref_stride,
+                              height,
+                              width,
+                              best_sad,
+                              x_search_center,
+                              y_search_center,
+                              src_stride_raw,
+                              search_area_width,
+                              search_area_height);
+            return;
         }
     } else {
         const uint32_t leftover = search_area_width & 7;
@@ -2501,6 +2891,102 @@ void sad_loop_kernel_avx512_intrin(
             }
             break;
 
+        case 6:
+            if (height <= 4) {
+                y = 0;
+                do {
+                    for (x = 0; x <= search_area_width - 8; x += 8) {
+                        __m128i sum = _mm_setzero_si128();
+
+                        s = src;
+                        r = ref + x;
+
+                        h = height2;
+                        do {
+                            sad_loop_kernel_4_sse4_1(s, src_stride, r, ref_stride, &sum);
+                            s += 2 * src_stride;
+                            r += 2 * ref_stride;
+                        } while (--h);
+
+                        __m128i sum2 = complement_4_to_6(
+                            ref + x, ref_stride, src, src_stride, height, 8);
+                        sum  = _mm_adds_epu16(sum, sum2);
+
+                        update_best(sum, x, y, &best_s, &best_x, &best_y);
+                    }
+
+                    if (leftover) {
+                        __m128i sum = _mm_setzero_si128();
+
+                        s = src;
+                        r = ref + x;
+
+                        h = height2;
+                        do {
+                            sad_loop_kernel_4_sse4_1(s, src_stride, r, ref_stride, &sum);
+                            s += 2 * src_stride;
+                            r += 2 * ref_stride;
+                        } while (--h);
+
+                        sum = _mm_or_si128(sum, mask128);
+
+                        __m128i sum2 = complement_4_to_6(
+                            ref + x, ref_stride, src, src_stride, height, leftover);
+                        sum = _mm_adds_epu16(sum, sum2);
+
+                        update_best(sum, x, y, &best_s, &best_x, &best_y);
+                    }
+
+                    ref += src_stride_raw;
+                } while (++y < search_area_height);
+            } else {
+                y = 0;
+                do {
+                    for (x = 0; x <= search_area_width - 8; x += 8) {
+                        __m256i sum256 = _mm256_setzero_si256();
+
+                        s = src;
+                        r = ref + x;
+
+                        h = height2;
+                        do {
+                            sad_loop_kernel_4_avx2(s, src_stride, r, ref_stride, &sum256);
+                            s += 2 * src_stride;
+                            r += 2 * ref_stride;
+                        } while (--h);
+
+                        __m128i sum = complement_4_to_6(
+                            ref + x, ref_stride, src, src_stride, height, 8);
+                        sum256 = _mm256_adds_epu16(sum256, _mm256_zextsi128_si256(sum));
+
+                        update_small_pel(sum256, x, y, &best_s, &best_x, &best_y);
+                    }
+
+                    if (leftover) {
+                        __m256i sum256 = _mm256_setzero_si256();
+
+                        s = src;
+                        r = ref + x;
+
+                        h = height2;
+                        do {
+                            sad_loop_kernel_4_avx2(s, src_stride, r, ref_stride, &sum256);
+                            s += 2 * src_stride;
+                            r += 2 * ref_stride;
+                        } while (--h);
+
+                        __m128i sum = complement_4_to_6(
+                            ref + x, ref_stride, src, src_stride, height, leftover);
+                        sum256 = _mm256_adds_epu16(sum256, _mm256_zextsi128_si256(sum));
+
+                        update_leftover_small_pel(sum256, x, y, mask128, &best_s, &best_x, &best_y);
+                    }
+
+                    ref += src_stride_raw;
+                } while (++y < search_area_height);
+            }
+            break;
+
         case 8:
             // Note: Tried _mm512_dbsad_epu8 but is even slower.
             y = 0;
@@ -2539,6 +3025,152 @@ void sad_loop_kernel_avx512_intrin(
 
                 ref += src_stride_raw;
             } while (++y < search_area_height);
+            break;
+
+        case 12:
+            if (height <= 16) {
+                y = 0;
+                do {
+                    for (x = 0; x <= search_area_width - 16; x += 16) {
+                        __m512i sum512 = _mm512_setzero_si512();
+
+                        s = src;
+                        r = ref + x;
+
+                        h = height2;
+                        do {
+                            sad_loop_kernel_12_avx512(s, src_stride, r, ref_stride, &sum512);
+                            s += 2 * src_stride;
+                            r += 2 * ref_stride;
+                        } while (--h);
+
+                        update_256_pel(sum512, x, y, &best_s, &best_x, &best_y);
+                    }
+
+                    // leftover
+                    for (; x < search_area_width; x += 8) {
+                        __m256i sum256 = _mm256_setzero_si256();
+
+                        s = src;
+                        r = ref + x;
+
+                        h = height2;
+                        do {
+                            sad_loop_kernel_12_avx2(s, src_stride, r, ref_stride, &sum256);
+                            s += 2 * src_stride;
+                            r += 2 * ref_stride;
+                        } while (--h);
+
+                        update_leftover_256_pel(
+                            sum256, search_area_width, x, y, mask128, &best_s, &best_x, &best_y);
+                    }
+
+                    ref += src_stride_raw;
+                } while (++y < search_area_height);
+            } else if (height <= 32) {
+                y = 0;
+                do {
+                    for (x = 0; x <= search_area_width - 16; x += 16) {
+                        __m512i sum512 = _mm512_setzero_si512();
+
+                        s = src;
+                        r = ref + x;
+
+                        h = height2;
+                        do {
+                            sad_loop_kernel_12_avx512(s, src_stride, r, ref_stride, &sum512);
+                            s += 2 * src_stride;
+                            r += 2 * ref_stride;
+                        } while (--h);
+
+                        update_512_pel(sum512, x, y, &best_s, &best_x, &best_y);
+                    }
+
+                    // leftover
+                    for (; x < search_area_width; x += 8) {
+                        __m256i sum256 = _mm256_setzero_si256();
+
+                        s = src;
+                        r = ref + x;
+
+                        h = height2;
+                        do {
+                            sad_loop_kernel_12_avx2(s, src_stride, r, ref_stride, &sum256);
+                            s += 2 * src_stride;
+                            r += 2 * ref_stride;
+                        } while (--h);
+
+                        update_leftover_512_pel(
+                            sum256, search_area_width, x, y, mask256, &best_s, &best_x, &best_y);
+                    }
+
+                    ref += src_stride_raw;
+                } while (++y < search_area_height);
+            } else {
+                const uint32_t leftover16 = search_area_width & 15;
+
+                y = 0;
+                do {
+                    for (x = 0; x <= search_area_width - 16; x += 16) {
+                        __m512i sums512[2] = {_mm512_setzero_si512(), _mm512_setzero_si512()};
+
+                        s = src;
+                        r = ref + x;
+
+                        h = height2;
+                        do {
+                            sad_loop_kernel_12_2sum_avx512(s, src_stride, r, ref_stride, sums512);
+                            s += 2 * src_stride;
+                            r += 2 * ref_stride;
+                        } while (--h);
+
+                        update_1024_pel(sums512, x, y, &best_s, &best_x, &best_y);
+                    }
+
+                    if (leftover16 >= 8) {
+                        __m256i sums256[2] = {_mm256_setzero_si256(), _mm256_setzero_si256()};
+
+                        s = src;
+                        r = ref + x;
+
+                        h = height2;
+                        do {
+                            sad_loop_kernel_12_2sum_avx2(s, src_stride, r, ref_stride, sums256);
+                            s += 2 * src_stride;
+                            r += 2 * ref_stride;
+                        } while (--h);
+
+                        update_leftover8_1024_pel(sums256, x, y, &best_s, &best_x, &best_y);
+                        x += 8;
+                    }
+
+                    if (leftover) {
+                        __m256i sums256[2] = {_mm256_setzero_si256(), _mm256_setzero_si256()};
+
+                        s = src;
+                        r = ref + x;
+
+                        h = height2;
+                        do {
+                            sad_loop_kernel_12_2sum_avx2(s, src_stride, r, ref_stride, sums256);
+                            s += 2 * src_stride;
+                            r += 2 * ref_stride;
+                        } while (--h);
+
+                        update_leftover_1024_pel(sums256,
+                                                 search_area_width,
+                                                 x,
+                                                 y,
+                                                 leftover,
+                                                 mask128,
+                                                 &best_s,
+                                                 &best_x,
+                                                 &best_y);
+                    }
+
+                    ref += src_stride_raw;
+                } while (++y < search_area_height);
+            }
             break;
 
         case 16:
@@ -3353,9 +3985,7 @@ void sad_loop_kernel_avx512_intrin(
             }
             break;
 
-        default:
-            assert(width == 64);
-
+        case 64:
             if (height <= 16) {
                 const uint32_t leftover16 = search_area_width & 15;
 
@@ -3684,6 +4314,21 @@ void sad_loop_kernel_avx512_intrin(
                 } while (++y < search_area_height);
             }
             break;
+
+        default:
+            sad_loop_kernel_c(src,
+                              src_stride,
+                              ref,
+                              ref_stride,
+                              height,
+                              width,
+                              best_sad,
+                              x_search_center,
+                              y_search_center,
+                              src_stride_raw,
+                              search_area_width,
+                              search_area_height);
+            return;
         }
     }
 

--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -7913,7 +7913,7 @@ void hme_level_0(
     search_region_index =
         x_top_left_search_region + y_top_left_search_region * sixteenth_ref_pic_ptr->stride_y;
 
-    if (((sb_width & 7) == 0) || (sb_width == 4)) {
+    if (((sb_width & 7) == 0) || (sb_width == 4) || (sb_width == 6) || (sb_width == 12)) {
 #if !REMOVE_UNUSED_CODE_PH2
         if ((search_area_width & 15) == 0) {
             // Only width equals 16 (SB equals 64) is updated
@@ -8119,7 +8119,7 @@ void hme_level_1(
     search_region_index =
         x_top_left_search_region + y_top_left_search_region * quarter_ref_pic_ptr->stride_y;
 
-    if (((sb_width & 7) == 0) || (sb_width == 4)) {
+    if (((sb_width & 7) == 0) || (sb_width == 4) || (sb_width == 6) || (sb_width == 12)) {
         // Put the first search location into level0 results
         sad_loop_kernel(
             &context_ptr->quarter_sb_buffer[0],

--- a/test/SadTest.cc
+++ b/test/SadTest.cc
@@ -104,6 +104,10 @@ BlkSize TEST_BLOCK_SIZES[] = {
     BlkSize(64, 24), BlkSize(48, 24), BlkSize(32, 24), BlkSize(24, 32),
     BlkSize(48, 48), BlkSize(48, 16), BlkSize(48, 32), BlkSize(16, 48),
     BlkSize(32, 48), BlkSize(48, 64), BlkSize(64, 48)};
+BlkSize TEST_BLOCK_SIZES_SMALL[] = {
+    BlkSize(6, 2),   BlkSize(6, 4),   BlkSize(6, 8),   BlkSize(6, 16),
+    BlkSize(6, 32),  BlkSize(12, 2),  BlkSize(12, 4),  BlkSize(12, 8),
+    BlkSize(12, 16), BlkSize(12, 32)};
 TestPattern TEST_PATTERNS[] = {REF_MAX, SRC_MAX, RANDOM, UNALIGN};
 SADPattern TEST_SAD_PATTERNS[] = {BUF_MAX, BUF_MIN, BUF_SMALL, BUF_RANDOM};
 typedef std::tuple<TestPattern, BlkSize> Testsad_Param;
@@ -648,6 +652,14 @@ FuncPair TEST_FUNC_PAIRS[] = {
 #endif
 };
 
+FuncPair TEST_FUNC_PAIRS_SMALL[] = {
+    FuncPair(sad_loop_kernel_c, sad_loop_kernel_sse4_1_intrin),
+    FuncPair(sad_loop_kernel_c, sad_loop_kernel_avx2_intrin),
+#ifndef NON_AVX512_SUPPORT
+    FuncPair(sad_loop_kernel_c, sad_loop_kernel_avx512_intrin),
+#endif
+};
+
 #if !REMOVE_ME_SUBPEL_CODE
 FuncPair TEST_HME_FUNC_PAIRS[] = {
     FuncPair(sad_loop_kernel_c, sad_loop_kernel_sse4_1_hme_l0_intrin),
@@ -871,6 +883,13 @@ INSTANTIATE_TEST_CASE_P(
                        ::testing::ValuesIn(TEST_FUNC_PAIRS)));
 
 #if !REMOVE_ME_SUBPEL_CODE
+INSTANTIATE_TEST_CASE_P(
+    LOOPSAD_SMALL, sad_LoopTest,
+    ::testing::Combine(::testing::ValuesIn(TEST_PATTERNS),
+                       ::testing::ValuesIn(TEST_BLOCK_SIZES_SMALL),
+                       ::testing::ValuesIn(TEST_LOOP_AREAS),
+                       ::testing::ValuesIn(TEST_FUNC_PAIRS_SMALL)));
+
 INSTANTIATE_TEST_CASE_P(
     HMESAD, sad_LoopTest,
     ::testing::Combine(::testing::ValuesIn(TEST_PATTERNS),


### PR DESCRIPTION
# Description
Generalize sad loop kernels to support width=6, 12

Previously some c code was being used when sb_width is non-multiple of 8 and not equals 4 for sad calculation.

Speed results(from unit tests):
-	sad_loop_kernel_sse4_1_intrin (for w=6 speedup is ~2.5x comapred to C, for w=12 speedup is  ~54x compared to C)
-	sad_loop_kernel_avx2_intrin (for w=6 speedup is ~2.5x comapred to C, for w=12 speedup is  ~81x compared to C)
-	sad_loop_kernel_avx512_intrin (for w=6 speedup is ~2.5x comapred to C, for w=12 speedup is  ~100x compared to C)

Speed results for command line: ```-enc-mode 7 -q 63 -intra-period  119 -lad 0 -lp 8  -n 2000 -i snow_mnt_480p_65f.y4m  -b out.bin```
Master: 26.825 fps
Changes: 27.768 fps


# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@tszumski 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [x] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
