### PR TITLE
Fix read when -n > number of frames in y4m

### DIFF
--- a/Source/App/EncApp/EbAppInputy4m.c
+++ b/Source/App/EncApp/EbAppInputy4m.c
@@ -24,6 +24,13 @@ char *copy_until_char_or_newline(char *src, char *dst, char chr) {
 
     return src;
 }
+/* only reads the y4m header, needed when we reach end of the file and loop to the beginning */
+int32_t read_and_skip_y4m_header(EbConfig *cfg) {
+    char  buffer[YFM_HEADER_MAX];
+    char *fresult = fgets(buffer, sizeof(buffer), cfg->input_file);
+    if (fresult == NULL) return EB_ErrorBadParameter;
+    return EB_ErrorNone;
+}
 
 /* reads the y4m header and parses the input parameters */
 int32_t read_y4m_header(EbConfig *cfg) {

--- a/Source/App/EncApp/EbAppInputy4m.h
+++ b/Source/App/EncApp/EbAppInputy4m.h
@@ -12,6 +12,8 @@
 
 int32_t read_y4m_header(EbConfig *cfg);
 
+int32_t read_and_skip_y4m_header(EbConfig *cfg);
+
 int32_t read_y4m_frame_delimiter(EbConfig *cfg);
 
 EbBool check_if_y4m(EbConfig *cfg);

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -730,6 +730,10 @@ void read_input_frames(EbConfig *config, uint8_t is_16bit, EbBufferHeaderType *h
 
             if (read_size != header_ptr->n_filled_len) {
                 fseek(input_file, 0, SEEK_SET);
+                if (config->y4m_input == EB_TRUE) {
+                    read_and_skip_y4m_header(config);
+                    read_y4m_frame_delimiter(config);
+                }
                 header_ptr->n_filled_len =
                     (uint32_t)fread(input_ptr->luma, 1, luma_read_size, input_file);
                 header_ptr->n_filled_len += (uint32_t)fread(


### PR DESCRIPTION
# Description
Fix error when -n > number of frames in y4m
```
Failed to read proper y4m frame delimeter. Read broken.
```
# Issue
Fixes #1285 
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@tszumski 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
