### PR TITLE
Fix valgrind for -tbr param

### DIFF
--- a/Source/Lib/Encoder/Codec/EbRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbRateControlProcess.c
@@ -2915,7 +2915,7 @@ void frame_level_rc_input_picture_cvbr(PictureControlSet *pcs_ptr, SequenceContr
         while (ref_qp_table_index >= qp_search_min && ref_qp_table_index <= qp_search_max &&
                !best_qp_found) {
             ref_qp_index =
-                CLIP3(scs_ptr->static_config.min_qp_allowed, MAX_REF_QP_NUM, ref_qp_table_index);
+                CLIP3(scs_ptr->static_config.min_qp_allowed, MAX_REF_QP_NUM - 1, ref_qp_table_index);
             high_level_rate_control_ptr->pred_bits_ref_qp_per_sw[ref_qp_index] = 0;
 
             queue_entry_index_temp = (uint32_t)queue_entry_index_head_temp;


### PR DESCRIPTION
# Description
Fix valgrind error for command line (-enc-mode: 8, 7, 6, 5, 4, 3, 2):
```./SvtAv1EncApp -lp 8 -i /root/mount_nvme/kirland_640_480_30.yuv -w 640 -h 480 -enc-mode 8 -rc 2 -tbr 1000 -fps 60 -n 17 -b tbr-kirland0.ivf 2>vg-tbr-kirland0.log```

Invalid read of size 4
   at 0x50193AA: frame_level_rc_input_picture_cvbr (EbRateControlProcess.c:2942)
   by 0x501BE86: rate_control_kernel (EbRateControlProcess.c:5493)
   by 0x5E57EA4: start_thread (in /usr/lib64/libpthread-2.17.so)
   by 0x646C8DC: clone (in /usr/lib64/libc-2.17.so)
 Address 0x3bebefb8 is 0 bytes after a block of size 2,456 alloc'd
   at 0x4C2B955: calloc (vg_replace_malloc.c:711)
   by 0x5014DE2: rate_control_context_ctor (EbRateControlProcess.c:392)
   by 0x4F6A626: svt_av1_enc_init (EbEncHandle.c:1562)
   by 0x114A24: init_encoder (EbAppContext.c:453)
   by 0x10E6B3: main (EbAppMain.c:160)

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@tszumski 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
