### PR TITLE
Sppeedup picture_sse_calculations by using SIMD kernels

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbPictureOperators_Intrinsic_AVX2.c
@@ -1535,7 +1535,7 @@ uint64_t spatial_full_distortion_kernel_avx2(uint8_t *input, uint32_t input_offs
                 inp += input_stride;
                 rec += recon_stride;
             } while (--h);
-        } else { // 128
+        } else if (area_width == 128) {
             do {
                 spatial_full_distortion_kernel32_avx2_intrin(inp + 0 * 32, rec + 0 * 32, &sum);
                 spatial_full_distortion_kernel32_avx2_intrin(inp + 1 * 32, rec + 1 * 32, &sum);
@@ -1544,6 +1544,20 @@ uint64_t spatial_full_distortion_kernel_avx2(uint8_t *input, uint32_t input_offs
                 inp += input_stride;
                 rec += recon_stride;
             } while (--h);
+        } else {
+            __m256i sum64 = _mm256_setzero_si256();
+            do {
+                for (uint32_t w = 0; w < area_width; w += 32) {
+                    spatial_full_distortion_kernel32_avx2_intrin(inp + w, rec + w, &sum);
+                }
+                inp += input_stride;
+                rec += recon_stride;
+
+                sum32_to64(&sum, &sum64);
+            } while (--h);
+            __m128i s = _mm_add_epi64(_mm256_castsi256_si128(sum64),
+                                      _mm256_extracti128_si256(sum64, 1));
+            return _mm_extract_epi64(s, 0) + _mm_extract_epi64(s, 1);
         }
     }
 

--- a/Source/Lib/Common/ASM_AVX512/EbPictureOperators_Intrinsic_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/EbPictureOperators_Intrinsic_AVX512.c
@@ -11,6 +11,17 @@
 #include "EbPictureOperators_SSE2.h"
 #include "EbMemory_AVX2.h"
 
+/*******************************************************************************
+ * Helper function that add 32bit values from sum32 to 64bit values in sum64
+ * sum32 is also zeroed
+*******************************************************************************/
+static INLINE void sum32_to64_avx512(__m512i *const sum32, __m512i *const sum64) {
+    //Save partial sum into large 64bit register instead of 32 bit (which could overflow)
+    *sum64 = _mm512_add_epi64(*sum64, _mm512_unpacklo_epi32(*sum32, _mm512_setzero_si512()));
+    *sum64 = _mm512_add_epi64(*sum64, _mm512_unpackhi_epi32(*sum32, _mm512_setzero_si512()));
+    *sum32 = _mm512_setzero_si512();
+}
+
 static INLINE void residual32x2_avx512(const uint8_t *input, const uint32_t input_stride,
                                        const uint8_t *pred, const uint32_t pred_stride,
                                        int16_t *residual, const uint32_t residual_stride) {
@@ -327,13 +338,30 @@ uint64_t spatial_full_distortion_kernel_avx512(uint8_t *input, uint32_t input_of
                     inp += input_stride;
                     rec += recon_stride;
                 } while (--h);
-            } else { // 128
+            } else if (area_width == 128) {
                 do {
                     SpatialFullDistortionKernel64_AVX512_INTRIN(inp, rec, &sum512);
                     SpatialFullDistortionKernel64_AVX512_INTRIN(inp + 64, rec + 64, &sum512);
                     inp += input_stride;
                     rec += recon_stride;
                 } while (--h);
+            } else {
+                __m512i sum64 = _mm512_setzero_si512();
+                do {
+                    for (uint32_t w = 0; w < area_width; w += 64) {
+                        SpatialFullDistortionKernel64_AVX512_INTRIN(inp + w, rec + w, &sum512);
+                    }
+                    sum32_to64_avx512(&sum512, &sum64);
+                    inp += input_stride;
+                    rec += recon_stride;
+                } while (--h);
+
+                const __m256i sum_L = _mm512_castsi512_si256(sum64);
+                const __m256i sum_H = _mm512_extracti64x4_epi64(sum64, 1);
+                sum       = _mm256_add_epi64(sum_L, sum_H);
+                __m128i s = _mm_add_epi64(_mm256_castsi256_si128(sum),
+                                          _mm256_extracti128_si256(sum, 1));
+                return _mm_extract_epi64(s, 0) + _mm_extract_epi64(s, 1);
             }
 
             const __m256i sum512_L = _mm512_castsi512_si256(sum512);

--- a/Source/Lib/Encoder/Codec/EbDeblockingFilter.c
+++ b/Source/Lib/Encoder/Codec/EbDeblockingFilter.c
@@ -812,174 +812,129 @@ uint64_t picture_sse_calculations(PictureControlSet *pcs_ptr, EbPictureBufferDes
     const uint32_t ss_x = scs_ptr->subsampling_x;
     const uint32_t ss_y = scs_ptr->subsampling_y;
 
+    uint8_t *input_buffer;
+    uint8_t *recon_coeff_buffer;
+
     if (!is_16bit) {
         EbPictureBufferDesc *input_picture_ptr =
             (EbPictureBufferDesc *)pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
 
-        uint32_t column_index;
-        uint32_t row_index           = 0;
-        uint64_t residual_distortion = 0;
-        EbByte   input_buffer;
-        EbByte   recon_coeff_buffer;
         if (plane == 0) {
-            recon_coeff_buffer = &(
+            recon_coeff_buffer = (uint8_t *)&(
                 (recon_ptr
                      ->buffer_y)[recon_ptr->origin_x + recon_ptr->origin_y * recon_ptr->stride_y]);
-            input_buffer = &((input_picture_ptr->buffer_y)[input_picture_ptr->origin_x +
-                                                           input_picture_ptr->origin_y *
-                                                               input_picture_ptr->stride_y]);
+            input_buffer = (uint8_t *)&(
+                (input_picture_ptr
+                     ->buffer_y)[input_picture_ptr->origin_x +
+                                 input_picture_ptr->origin_y * input_picture_ptr->stride_y]);
 
-            while (row_index < input_picture_ptr->height) {
-                column_index = 0;
-                while (column_index < input_picture_ptr->width) {
-                    residual_distortion += (int64_t)SQR((int64_t)(input_buffer[column_index]) -
-                                                        (recon_coeff_buffer[column_index]));
-                    ++column_index;
-                }
-                input_buffer += input_picture_ptr->stride_y;
-                recon_coeff_buffer += recon_ptr->stride_y;
-                ++row_index;
-            }
-
-            return residual_distortion;
+            return spatial_full_distortion_kernel(input_buffer,
+                                                  0,
+                                                  input_picture_ptr->stride_y,
+                                                  recon_coeff_buffer,
+                                                  0,
+                                                  recon_ptr->stride_y,
+                                                  input_picture_ptr->width,
+                                                  input_picture_ptr->height);
         }
-
         else if (plane == 1) {
-            recon_coeff_buffer =
-                &((recon_ptr->buffer_cb)[recon_ptr->origin_x / 2 +
-                                         recon_ptr->origin_y / 2 * recon_ptr->stride_cb]);
-            input_buffer = &((input_picture_ptr->buffer_cb)[input_picture_ptr->origin_x / 2 +
-                                                            input_picture_ptr->origin_y / 2 *
-                                                                input_picture_ptr->stride_cb]);
+            recon_coeff_buffer = (uint8_t *)&(
+                (recon_ptr->buffer_cb)[recon_ptr->origin_x / 2 +
+                                       recon_ptr->origin_y / 2 * recon_ptr->stride_cb]);
+            input_buffer = (uint8_t *)&(
+                (input_picture_ptr
+                     ->buffer_cb)[input_picture_ptr->origin_x / 2 +
+                                  input_picture_ptr->origin_y / 2 * input_picture_ptr->stride_cb]);
 
-            while (row_index < (uint32_t)(input_picture_ptr->height >> ss_y)) {
-                column_index = 0;
-                while (column_index < (uint32_t)(input_picture_ptr->width >> ss_x)) {
-                    residual_distortion += (int64_t)SQR((int64_t)(input_buffer[column_index]) -
-                                                        (recon_coeff_buffer[column_index]));
-                    ++column_index;
-                }
-
-                input_buffer += input_picture_ptr->stride_cb;
-                recon_coeff_buffer += recon_ptr->stride_cb;
-                ++row_index;
-            }
-
-            return residual_distortion;
+            return spatial_full_distortion_kernel(input_buffer,
+                                                  0,
+                                                  input_picture_ptr->stride_cb,
+                                                  recon_coeff_buffer,
+                                                  0,
+                                                  recon_ptr->stride_cb,
+                                                  input_picture_ptr->width >> ss_x,
+                                                  input_picture_ptr->height >> ss_y);
         } else if (plane == 2) {
-            recon_coeff_buffer =
-                &((recon_ptr->buffer_cr)[recon_ptr->origin_x / 2 +
-                                         recon_ptr->origin_y / 2 * recon_ptr->stride_cr]);
-            input_buffer        = &((input_picture_ptr->buffer_cr)[input_picture_ptr->origin_x / 2 +
-                                                            input_picture_ptr->origin_y / 2 *
-                                                                input_picture_ptr->stride_cr]);
+            recon_coeff_buffer = (uint8_t *)&(
+                (recon_ptr->buffer_cr)[recon_ptr->origin_x / 2 +
+                                       recon_ptr->origin_y / 2 * recon_ptr->stride_cr]);
+            input_buffer = (uint8_t *)&(
+                (input_picture_ptr
+                     ->buffer_cr)[input_picture_ptr->origin_x / 2 +
+                                  input_picture_ptr->origin_y / 2 * input_picture_ptr->stride_cr]);
 
-            while (row_index < (uint32_t)(input_picture_ptr->height >> ss_y)) {
-                column_index = 0;
-                while (column_index < (uint32_t)(input_picture_ptr->width >> ss_x)) {
-                    residual_distortion += (int64_t)SQR((int64_t)(input_buffer[column_index]) -
-                                                        (recon_coeff_buffer[column_index]));
-                    ++column_index;
-                }
-
-                input_buffer += input_picture_ptr->stride_cr;
-                recon_coeff_buffer += recon_ptr->stride_cr;
-                ++row_index;
-            }
-
-            return residual_distortion;
+            return spatial_full_distortion_kernel(input_buffer,
+                                                  0,
+                                                  input_picture_ptr->stride_cr,
+                                                  recon_coeff_buffer,
+                                                  0,
+                                                  recon_ptr->stride_cr,
+                                                  input_picture_ptr->width >> ss_x,
+                                                  input_picture_ptr->height >> ss_y);
         }
         return 0;
     } else {
         EbPictureBufferDesc *input_picture_ptr = (EbPictureBufferDesc *)pcs_ptr->input_frame16bit;
 
-        uint32_t  column_index;
-        uint32_t  row_index           = 0;
-        uint64_t  residual_distortion = 0;
-        uint16_t *input_buffer;
-        uint16_t *recon_coeff_buffer;
         if (plane == 0) {
-            recon_coeff_buffer = (uint16_t *)&(
+            recon_coeff_buffer = (uint8_t *)&(
                 (recon_ptr
                      ->buffer_y)[(recon_ptr->origin_x + recon_ptr->origin_y * recon_ptr->stride_y)
                                  << is_16bit]);
-            input_buffer = (uint16_t *)&(
+            input_buffer = (uint8_t *)&(
                 (input_picture_ptr
                      ->buffer_y)[(input_picture_ptr->origin_x +
                                   input_picture_ptr->origin_y * input_picture_ptr->stride_y)
                                  << is_16bit]);
 
-            while (row_index < input_picture_ptr->height) {
-                column_index = 0;
-                while (column_index < input_picture_ptr->width) {
-                    residual_distortion +=
-                        (int64_t)SQR(((int64_t)input_buffer[column_index]) -
-                                     (int64_t)(recon_coeff_buffer[column_index]));
-                    ++column_index;
-                }
-
-                input_buffer += input_picture_ptr->stride_y;
-                recon_coeff_buffer += recon_ptr->stride_y;
-                ++row_index;
-            }
-
-            return residual_distortion;
+            return full_distortion_kernel16_bits(input_buffer,
+                                                 0,
+                                                 input_picture_ptr->stride_y,
+                                                 recon_coeff_buffer,
+                                                 0,
+                                                 recon_ptr->stride_y,
+                                                 input_picture_ptr->width,
+                                                 input_picture_ptr->height);
         }
-
         else if (plane == 1) {
-            recon_coeff_buffer = (uint16_t *)&(
+            recon_coeff_buffer = (uint8_t *)&(
                 (recon_ptr->buffer_cb)[(recon_ptr->origin_x / 2 +
                                         recon_ptr->origin_y / 2 * recon_ptr->stride_cb)
                                        << is_16bit]);
-            input_buffer = (uint16_t *)&(
+            input_buffer = (uint8_t *)&(
                 (input_picture_ptr
                      ->buffer_cb)[(input_picture_ptr->origin_x / 2 +
                                    input_picture_ptr->origin_y / 2 * input_picture_ptr->stride_cb)
                                   << is_16bit]);
 
-            while (row_index < (uint32_t)(input_picture_ptr->height >> ss_y)) {
-                column_index = 0;
-                while (column_index < (uint32_t)(input_picture_ptr->width >> ss_x)) {
-                    residual_distortion +=
-                        (int64_t)SQR(((int64_t)input_buffer[column_index]) -
-                                     (int64_t)(recon_coeff_buffer[column_index]));
-                    ++column_index;
-                }
-
-                input_buffer += input_picture_ptr->stride_cb;
-                recon_coeff_buffer += recon_ptr->stride_cb;
-                ++row_index;
-            }
-
-            return residual_distortion;
+            return full_distortion_kernel16_bits(input_buffer,
+                                                 0,
+                                                 input_picture_ptr->stride_cb,
+                                                 recon_coeff_buffer,
+                                                 0,
+                                                 recon_ptr->stride_cb,
+                                                 input_picture_ptr->width >> ss_x,
+                                                 input_picture_ptr->height >> ss_y);
         } else if (plane == 2) {
-            recon_coeff_buffer = (uint16_t *)&(
+            recon_coeff_buffer = (uint8_t *)&(
                 (recon_ptr->buffer_cr)[(recon_ptr->origin_x / 2 +
                                         recon_ptr->origin_y / 2 * recon_ptr->stride_cr)
                                        << is_16bit]);
-            input_buffer = (uint16_t *)&(
+            input_buffer = (uint8_t *)&(
                 (input_picture_ptr
                      ->buffer_cr)[(input_picture_ptr->origin_x / 2 +
                                    input_picture_ptr->origin_y / 2 * input_picture_ptr->stride_cr)
                                   << is_16bit]);
 
-            while (row_index < (uint32_t)(input_picture_ptr->height >> ss_y)) {
-                column_index = 0;
-                while (column_index < (uint32_t)(input_picture_ptr->width >> ss_x)) {
-                    residual_distortion +=
-                        (int64_t)SQR(((int64_t)input_buffer[column_index]) -
-                                     (int64_t)(recon_coeff_buffer[column_index]));
-                    ++column_index;
-                }
-
-                input_buffer += input_picture_ptr->stride_cr;
-                recon_coeff_buffer += recon_ptr->stride_cr;
-                ++row_index;
-            }
-
-            return residual_distortion;
+            return full_distortion_kernel16_bits(input_buffer,
+                                                 0,
+                                                 input_picture_ptr->stride_cr,
+                                                 recon_coeff_buffer,
+                                                 0,
+                                                 recon_ptr->stride_cr,
+                                                 input_picture_ptr->width >> ss_x,
+                                                 input_picture_ptr->height >> ss_y);
         }
-
         return 0;
     }
 }


### PR DESCRIPTION
# Description
Speedup picture_sse_calculations() kernel by using SIMD implementation

Speedup:
8b	M8 0,55%
8b	M6 2,51%
8b	M4 0,34%
8b	M2 0,31%
8b	M0 0,00%

10b	M8 1,32%
10b	M6 2,03%
10b	M4 0,73%
10b	M2 1,36%
10b	M0 0,65%

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@tszumski 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [x] speed
- [x] 8 bit
- [x] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
