### PR TITLE
Add pick_wedge_fixed_sign after estimating wedge_sign

### DIFF
--- a/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
@@ -666,6 +666,7 @@ static void pick_interinter_wedge(ModeDecisionCandidate * candidate_ptr,
         picture_control_set_ptr->parent_pcs_ptr->wedge_mode == 3) {
         wedge_sign =
                 estimate_wedge_sign(picture_control_set_ptr, context_ptr, bsize, p0, bw, p1, bw);
+        pick_wedge_fixed_sign(candidate_ptr, picture_control_set_ptr, context_ptr, bsize, residual1, diff10, wedge_sign, &wedge_index);    
     } else {
         pick_wedge(picture_control_set_ptr,
                    context_ptr,

--- a/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
@@ -666,7 +666,7 @@ static void pick_interinter_wedge(ModeDecisionCandidate * candidate_ptr,
         picture_control_set_ptr->parent_pcs_ptr->wedge_mode == 3) {
         wedge_sign =
                 estimate_wedge_sign(picture_control_set_ptr, context_ptr, bsize, p0, bw, p1, bw);
-        pick_wedge_fixed_sign(candidate_ptr, picture_control_set_ptr, context_ptr, bsize, residual1, diff10, wedge_sign, &wedge_index);    
+        pick_wedge_fixed_sign(candidate_ptr, picture_control_set_ptr, context_ptr, bsize, residual1, diff10, wedge_sign, &wedge_index);
     } else {
         pick_wedge(picture_control_set_ptr,
                    context_ptr,


### PR DESCRIPTION
# Description
This PR addresses issue #1382 where I got a seg fault whenever I set wedge_mode to be 2. This was due to the fact that wedge_index was not picked in this mode. After looking into the implementation in libaom, I noticed that after estimating the wedge_sign, wedge index with fixed sign was picked. It can be found [here](https://aomedia.googlesource.com/aom/+/refs/heads/master/av1/encoder/compound_type.c#321)  

So this fix was just adding this function.

# Issue
Fixes #1382 

# Author(s)
@nasirhemed

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
