### PR TITLE
remove testing on IBMZ architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,6 @@ jobs:
       arch: arm64
     - name: PowerPC GCC build
       arch: ppc64le
-    - name: IBM Z GCC build
-      arch: s390x
     # Valgrind on Linux
     - name: Valgrind
       env: build_type=debug


### PR DESCRIPTION
# Description
Remove testing on IBMZ architecture in travis

# Author(s)
@ttrigui 

# Performance impact
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [X] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [X] N/A

# Merge method
- [X] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
