### PR TITLE
Travis CI: Allow failures on IBM Z job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ before_cache:
 
 # Build matrix
 jobs:
+  allow_failures:
+    - arch: s390x
   fast_finish: true
   include:
     # Multiple CPU Architectures


### PR DESCRIPTION
# Description
Temporarily allow the IBM Z job to fail on Travis CI. 

# Issue
Succeeds #1394 and unblocks #1393.

# Author(s)
@EwoutH 

# Performance impact
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] other
- [ ] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
