### PR TITLE
valgrind: Add an exit code if it is failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,4 +67,4 @@ jobs:
             - valgrind
       script:
         - *base_script
-        - travis_wait 60 valgrind -- SvtAv1EncApp --preset 4 -i akiyo_cif.y4m -n 20 -b test1.ivf
+        - travis_wait 60 valgrind --error-exitcode=1 -- SvtAv1EncApp --preset 4 -i akiyo_cif.y4m -n 20 -b test1.ivf


### PR DESCRIPTION
# Description

Makes valgrind exit with an error code of 1 if it catches an error

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
