### PR TITLE
Libvpx: Fix conflicts with libvpx and add it to GitHub Actions

### DIFF
--- a/.github/workflows/mingw-w64.yml
+++ b/.github/workflows/mingw-w64.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
-          install: mingw-w64-x86_64-ccache mingw-w64-x86_64-yasm mingw-w64-x86_64-nasm mingw-w64-x86_64-cmake mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-ninja mingw-w64-x86_64-dav1d make
+          install: mingw-w64-x86_64-ccache mingw-w64-x86_64-yasm mingw-w64-x86_64-nasm mingw-w64-x86_64-cmake mingw-w64-x86_64-pkg-config mingw-w64-x86_64-gcc mingw-w64-x86_64-ninja mingw-w64-x86_64-dav1d make diffutils
           update: true
 
       - name: Set ccache dir
@@ -67,10 +67,19 @@ jobs:
           cmake --build aom-build --target install
           pkg-config --debug --libs aom
 
+      - name: Clone libvpx
+        run: git clone https://chromium.googlesource.com/webm/libvpx
+      - name: Configure libvpx
+        shell: msys2 {0}
+        run: |
+          mkdir -p vpx-build && cd vpx-build || exit 1
+          ../libvpx/configure  --prefix=/mingw64 --disable-{examples,webm-io,libyuv,postproc,shared,unit-tests,docs,install-bins} --enable-{vp9-postproc,vp9-highbitdepth}
+          make -j $(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu) install
+
       - name: Configure FFmpeg
         shell: msys2 {0}
         run: |
-          ./configure --arch=x86_64 --pkg-config-flags="--static" --cc="${CC:-ccache gcc}" --cxx="${CXX:-ccache g++}" --enable-{gpl,static} --enable-lib{aom,svtav1,dav1d}  --disable-shared || {
+          ./configure --arch=x86_64 --pkg-config-flags="--static" --cc="${CC:-ccache gcc}" --cxx="${CXX:-ccache g++}" --enable-{gpl,static} --enable-lib{vpx,aom,svtav1,dav1d}  --disable-shared || {
             cat ffbuild/config.log
             exit 1
           }

--- a/.github/workflows/patches.yml
+++ b/.github/workflows/patches.yml
@@ -82,10 +82,18 @@ jobs:
           sudo -E cmake -S aom -B aom-build -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DENABLE_TESTS=0 -DENABLE_EXAMPLES=0 -DENABLE_DOCS=0 -DENABLE_TESTDATA=0 -DENABLE_TOOLS=0
           sudo -E cmake --build aom-build --target install
 
+      - name: Clone libvpx
+        run: git clone https://chromium.googlesource.com/webm/libvpx
+      - name: Configure libvpx
+        run: |
+          mkdir -p vpx-build && cd vpx-build || exit 1
+          ../libvpx/configure --disable-{examples,webm-io,libyuv,postproc,shared,unit-tests,docs,install-bins} --enable-{vp9-postproc,vp9-highbitdepth}
+          sudo -E make -j $(getconf _NPROCESSORS_ONLN 2>/dev/null || sysctl -n hw.ncpu) install
+
       - name: Configure FFmpeg
         run: |
           [ -d ~/.ccache ] && sudo chown -R "$USER": ~/.ccache
-          ./configure --arch=x86_64 --pkg-config-flags="--static" --cc="${CC:-ccache gcc}" --cxx="${CXX:-ccache g++}" --enable-{gpl,static} --enable-lib{aom,svtav1} --disable-shared || {
+          ./configure --arch=x86_64 --pkg-config-flags="--static" --cc="${CC:-ccache gcc}" --cxx="${CXX:-ccache g++}" --enable-{gpl,static} --enable-lib{vpx,aom,svtav1} --disable-shared || {
             less ffbuild/config.log
             exit 1
           }

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -1247,7 +1247,7 @@ void tpl_mc_flow_dispenser(
                                                   &inter_pred_params);
                         eb_aom_subtract_block(16, 16, src_diff, 16, src_mb, input_picture_ptr->stride_y, predictor, 16);
 
-                        wht_fwd_txfm(src_diff, 16, coeff, tx_size, 8, 0);
+                        svt_av1_wht_fwd_txfm(src_diff, 16, coeff, tx_size, 8, 0);
 
                         inter_cost = svt_aom_satd(coeff, 256);
                         if (inter_cost < best_inter_cost) {
@@ -1351,7 +1351,7 @@ void tpl_mc_flow_dispenser(
                     }
 
                     eb_aom_subtract_block(16, 16, src_diff, 16, src_mb, input_picture_ptr->stride_y, dst_buffer, dst_buffer_stride);
-                    wht_fwd_txfm(src_diff, 16, coeff, tx_size, 8, 0);
+                    svt_av1_wht_fwd_txfm(src_diff, 16, coeff, tx_size, 8, 0);
 
                     uint16_t eob;
 

--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -22,6 +22,7 @@
 
 #include "EbEncIntraPrediction.h"
 #include "EbLambdaRateTables.h"
+#include "EbTransforms.h"
 
 #include "EbLog.h"
 #include "EbResize.h"
@@ -13298,9 +13299,6 @@ EbErrorType open_loop_intra_search_sb(PictureParentControlSet *pcs_ptr, uint32_t
 }
 #endif
 #if TPL_LA
-void wht_fwd_txfm(int16_t *src_diff, int bw,
-                  int32_t *coeff, TxSize tx_size,
-                  int bit_depth, int is_hbd);
 
 EbErrorType open_loop_intra_search_mb(
     PictureParentControlSet *pcs_ptr, uint32_t sb_index,
@@ -13406,7 +13404,7 @@ EbErrorType open_loop_intra_search_mb(
 
                 // Distortion
                 eb_aom_subtract_block(16, 16, src_diff, 16, src, input_ptr->stride_y, predictor, 16);
-                wht_fwd_txfm(src_diff, 16, coeff, 2/*TX_16X16*/, 8, 0);
+                svt_av1_wht_fwd_txfm(src_diff, 16, coeff, 2/*TX_16X16*/, 8, 0);
                 intra_cost = svt_aom_satd(coeff, 16 * 16);
 
                 // printf("open_loop_intra_search_mb aom_satd mbxy %d %d, mode=%d, satd=%d, dst[0~4]=0x%d,%d,%d,%d\n", cu_origin_x, cu_origin_y, ois_intra_mode, intra_cost, predictor[0], predictor[1], predictor[2], predictor[3]);

--- a/Source/Lib/Encoder/Codec/EbTransforms.c
+++ b/Source/Lib/Encoder/Codec/EbTransforms.c
@@ -3637,18 +3637,17 @@ void svt_av1_fwd_txfm(int16_t *src_diff, TranLow *coeff, int diff_stride,
     svt_av1_highbd_fwd_txfm(src_diff, coeff, diff_stride, txfm_param);
 }
 
-void wht_fwd_txfm(int16_t *src_diff, int bw,
-                  int32_t *coeff, TxSize tx_size,
-                  int bit_depth, int is_hbd) {
-  TxfmParam txfm_param;
-  txfm_param.tx_type = DCT_DCT;
-  txfm_param.tx_size = tx_size;
-  txfm_param.lossless = 0;
-  txfm_param.tx_set_type = EXT_TX_SET_ALL16;
+void svt_av1_wht_fwd_txfm(int16_t *src_diff, int bw, int32_t *coeff, TxSize tx_size, int bit_depth,
+                          int is_hbd) {
+    TxfmParam txfm_param;
+    txfm_param.tx_type     = DCT_DCT;
+    txfm_param.tx_size     = tx_size;
+    txfm_param.lossless    = 0;
+    txfm_param.tx_set_type = EXT_TX_SET_ALL16;
 
-  txfm_param.bd = bit_depth;
-  txfm_param.is_hbd = is_hbd;
-  svt_av1_fwd_txfm(src_diff, coeff, bw, &txfm_param);
+    txfm_param.bd     = bit_depth;
+    txfm_param.is_hbd = is_hbd;
+    svt_av1_fwd_txfm(src_diff, coeff, bw, &txfm_param);
 }
 #endif
 
@@ -3656,4 +3655,3 @@ void wht_fwd_txfm(int16_t *src_diff, int bw,
  * Map Chroma QP
  *********************************************************************/
 uint8_t map_chroma_qp(uint8_t qp) { return qp; }
-

--- a/Source/Lib/Encoder/Codec/EbTransforms.h
+++ b/Source/Lib/Encoder/Codec/EbTransforms.h
@@ -149,7 +149,7 @@ extern int32_t av1_quantize_inv_quantize(
         int16_t dc_sign_context, PredictionMode pred_mode, EbBool is_intra_bc, uint32_t lambda,EbBool is_encode_pass);
 
 #if TPL_LA
-void wht_fwd_txfm(int16_t *src_diff, int bw,
+void svt_av1_wht_fwd_txfm(int16_t *src_diff, int bw,
                   int32_t *coeff, TxSize tx_size,
                   int bit_depth, int is_hbd);
 #endif


### PR DESCRIPTION
# Description

311be07bbcafc4e46679fb8d1e578cfb4d7e25c9 introduced a function that conflicts with a function in libvpx, this renames it and adds libvpx to the list of libraries compiled with FFmpeg to catch any conflicts.

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
