### PR TITLE
Small speed improvement

### DIFF
--- a/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
@@ -1820,11 +1820,7 @@ static void tf_16x16_sub_pel_search(PictureParentControlSet *pcs_ptr, MeContext 
                             src_16bit[C_Y] + bsize * idx_y * stride_src[C_Y] + bsize * idx_x;
 
                         unsigned int sse;
-#if PR_1311
                         distortion = variance_highbd(
-#else
-                        distortion = variance_highbd_c(
-#endif
                             pred_y_ptr, stride_pred[C_Y], src_y_ptr, stride_src[C_Y], 16, 16, &sse);
                     }
                     if (distortion < context_ptr->tf_16x16_block_error[idx_32x32 * 4 + idx_16x16]) {
@@ -1897,11 +1893,7 @@ static void tf_16x16_sub_pel_search(PictureParentControlSet *pcs_ptr, MeContext 
                         ;
 
                         unsigned int sse;
-#if PR_1311
                         distortion = variance_highbd(
-#else
-                        distortion = variance_highbd_c(
-#endif
                             pred_y_ptr, stride_pred[C_Y], src_y_ptr, stride_src[C_Y], 16, 16, &sse);
                     }
                     if (distortion < context_ptr->tf_16x16_block_error[idx_32x32 * 4 + idx_16x16]) {
@@ -2144,11 +2136,7 @@ static void tf_32x32_sub_pel_search(PictureParentControlSet *pcs_ptr, MeContext 
                     ;
 
                     unsigned int sse;
-#if PR_1311
                     distortion = variance_highbd(
-#else
-                    distortion = variance_highbd_c(
-#endif
                         pred_y_ptr, stride_pred[C_Y], src_y_ptr, stride_src[C_Y], 32, 32, &sse);
                 }
                 if (distortion < context_ptr->tf_32x32_block_error[idx_32x32]) {
@@ -2219,11 +2207,7 @@ static void tf_32x32_sub_pel_search(PictureParentControlSet *pcs_ptr, MeContext 
                         src_16bit[C_Y] + bsize * idx_y * stride_src[C_Y] + bsize * idx_x;
 
                     unsigned int sse;
-#if PR_1311
                     distortion = variance_highbd(
-#else
-                    distortion = variance_highbd_c(
-#endif
                         pred_y_ptr, stride_pred[C_Y], src_y_ptr, stride_src[C_Y], 32, 32, &sse);
                 }
                 if (distortion < context_ptr->tf_32x32_block_error[idx_32x32]) {

--- a/Source/Lib/Encoder/Codec/corner_match.c
+++ b/Source/Lib/Encoder/Codec/corner_match.c
@@ -68,18 +68,19 @@ static INLINE int is_eligible_point(int pointx, int pointy, int width, int heigh
             pointy + MATCH_SZ_BY2 < height);
 }
 
-static INLINE int is_eligible_distance(int point1x, int point1y, int point2x, int point2y, int thresh) {
+static INLINE int is_eligible_distance(int point1x, int point1y, int point2x, int point2y,
+                                       int threshSqr) {
     const int xdist = point1x - point2x;
     const int ydist = point1y - point2y;
-    return (xdist * xdist + ydist * ydist) <= thresh;
+    return (xdist * xdist + ydist * ydist) <= threshSqr;
 }
 
 static void improve_correspondence(unsigned char *frm, unsigned char *ref, int width, int height,
                                    int frm_stride, int ref_stride, Correspondence *correspondences,
                                    int num_correspondences) {
     int i;
-    int thresh = (width < height ? height : width) >> 4;
-    thresh *= thresh;
+    const int thresh   = (width < height ? height : width) >> 4;
+    const int threshSqr = thresh * thresh;
     for (i = 0; i < num_correspondences; ++i) {
         int    x, y, best_x = 0, best_y = 0;
         double best_match_ncc = 0.0;
@@ -93,7 +94,7 @@ static void improve_correspondence(unsigned char *frm, unsigned char *ref, int w
                                           correspondences[i].y,
                                           correspondences[i].rx + x,
                                           correspondences[i].ry + y,
-                                          thresh))
+                                          threshSqr))
                     continue;
                 match_ncc = eb_av1_compute_cross_correlation(frm,
                                                              frm_stride,
@@ -126,7 +127,7 @@ static void improve_correspondence(unsigned char *frm, unsigned char *ref, int w
                                           correspondences[i].y + y,
                                           correspondences[i].rx,
                                           correspondences[i].ry,
-                                          thresh))
+                                          threshSqr))
                     continue;
                 match_ncc = eb_av1_compute_cross_correlation(ref,
                                                              ref_stride,
@@ -154,8 +155,8 @@ int av1_determine_correspondence(unsigned char *frm, int *frm_corners, int num_f
     int             i, j;
     Correspondence *correspondences     = (Correspondence *)correspondence_pts;
     int             num_correspondences = 0;
-    int             thresh              = (width < height ? height : width) >> 4;
-    thresh *= thresh;
+    const int       thresh              = (width < height ? height : width) >> 4;
+    const int       threshSqr           = thresh * thresh;
     for (i = 0; i < num_frm_corners; ++i) {
         double best_match_ncc = 0.0;
         double template_norm;
@@ -169,7 +170,7 @@ int av1_determine_correspondence(unsigned char *frm, int *frm_corners, int num_f
                                       frm_corners[2 * i + 1],
                                       ref_corners[2 * j],
                                       ref_corners[2 * j + 1],
-                                      thresh))
+                                      threshSqr))
                 continue;
             match_ncc = eb_av1_compute_cross_correlation(frm,
                                                          frm_stride,

--- a/test/convolve_2d_test.cc
+++ b/test/convolve_2d_test.cc
@@ -422,6 +422,8 @@ class AV1Convolve2DTest : public ::testing::TestWithParam<Convolve2DParam> {
         // fill the input data with random
         prepare_data(input_w, input_h);
 
+        setup_common_rtcd_internal(get_cpu_flags_to_use());
+
         // loop the filter type and subpixel position
         const int output_w = block_size_wide[block_idx];
         const int output_h = block_size_high[block_idx];


### PR DESCRIPTION
# Description

1. Move some calculation before function call
2. Fix calling C kernel while avx2 version is available 
3. Fix unit test for AVX512 code

Speedup:

	8bit M8 0,19%
	8bit M6 0,09%
	8bit M4 -0,29%
	8bit M2 0,63%
	8bit M0 0,00%

	10b M8 2,73%
	10b M6 3,41%
	10b M4 0,78%
	10b M2 0,85%
	10b M0 0,64%


# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@tszumski 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [x] speed
- [x] 8 bit
- [x] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
