### PR TITLE
fprintf was replaced with SVT_FATAL when memory allocation fails

### DIFF
--- a/Source/Lib/Common/Codec/EbMalloc.c
+++ b/Source/Lib/Common/Codec/EbMalloc.c
@@ -7,7 +7,6 @@
 
 #include "EbMalloc.h"
 #include "EbThreads.h"
-#define LOG_TAG "SvtMalloc"
 #include "EbLog.h"
 
 #ifdef DEBUG_MEMORY_USAGE

--- a/Source/Lib/Common/Codec/EbMalloc.c
+++ b/Source/Lib/Common/Codec/EbMalloc.c
@@ -5,10 +5,16 @@
 #include <stdint.h>
 #include <limits.h>
 
-#define LOG_TAG "SvtMalloc"
 #include "EbMalloc.h"
 #include "EbThreads.h"
+#define LOG_TAG "SvtMalloc"
 #include "EbLog.h"
+
+void eb_print_alloc_fail(const char* file, int line)
+{
+    if (file)
+        SVT_FATAL("allocate memory failed, at %s, L%d\n", file, line);
+}
 
 #ifdef DEBUG_MEMORY_USAGE
 

--- a/Source/Lib/Common/Codec/EbMalloc.c
+++ b/Source/Lib/Common/Codec/EbMalloc.c
@@ -12,8 +12,7 @@
 
 void eb_print_alloc_fail(const char* file, int line)
 {
-    if (file)
-        SVT_FATAL("allocate memory failed, at %s, L%d\n", file, line);
+    SVT_FATAL("allocate memory failed, at %s, L%d\n", file, line);
 }
 
 #ifdef DEBUG_MEMORY_USAGE

--- a/Source/Lib/Common/Codec/EbMalloc.c
+++ b/Source/Lib/Common/Codec/EbMalloc.c
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <limits.h>
 
+#define LOG_TAG "SvtMalloc"
 #include "EbMalloc.h"
 #include "EbThreads.h"
 #include "EbLog.h"

--- a/Source/Lib/Common/Codec/EbMalloc.h
+++ b/Source/Lib/Common/Codec/EbMalloc.h
@@ -9,7 +9,6 @@
 
 #include "EbSvtAv1Enc.h"
 #include "EbDefinitions.h"
-#define LOG_TAG "SvtMalloc"
 #include "EbLog.h"
 
 #ifndef NDEBUG

--- a/Source/Lib/Common/Codec/EbMalloc.h
+++ b/Source/Lib/Common/Codec/EbMalloc.h
@@ -9,6 +9,7 @@
 
 #include "EbSvtAv1Enc.h"
 #include "EbDefinitions.h"
+#include "EbLog.h"
 
 #ifndef NDEBUG
 #define DEBUG_MEMORY_USAGE
@@ -47,7 +48,7 @@ void eb_remove_mem_entry(void* ptr, EbPtrType type);
 #define EB_NO_THROW_ADD_MEM(p, size, type)                                               \
     do {                                                                                 \
         if (!p)                                                                          \
-            fprintf(stderr, "allocate memory failed, at %s, L%d\n", __FILE__, __LINE__); \
+            SVT_FATAL("allocate memory failed, at %s, L%d\n", __FILE__, __LINE__);       \
         else                                                                             \
             EB_ADD_MEM_ENTRY(p, type, size);                                             \
     } while (0)

--- a/Source/Lib/Common/Codec/EbMalloc.h
+++ b/Source/Lib/Common/Codec/EbMalloc.h
@@ -9,11 +9,12 @@
 
 #include "EbSvtAv1Enc.h"
 #include "EbDefinitions.h"
-#include "EbLog.h"
 
 #ifndef NDEBUG
 #define DEBUG_MEMORY_USAGE
 #endif
+
+void eb_print_alloc_fail(const char* file, int line);
 
 #ifdef DEBUG_MEMORY_USAGE
 void eb_print_memory_usage(void);
@@ -48,7 +49,7 @@ void eb_remove_mem_entry(void* ptr, EbPtrType type);
 #define EB_NO_THROW_ADD_MEM(p, size, type)                                               \
     do {                                                                                 \
         if (!p)                                                                          \
-            SVT_FATAL("allocate memory failed, at %s, L%d\n", __FILE__, __LINE__);       \
+            eb_print_alloc_fail(__FILE__, __LINE__);                                     \
         else                                                                             \
             EB_ADD_MEM_ENTRY(p, type, size);                                             \
     } while (0)

--- a/Source/Lib/Common/Codec/EbMalloc.h
+++ b/Source/Lib/Common/Codec/EbMalloc.h
@@ -9,6 +9,7 @@
 
 #include "EbSvtAv1Enc.h"
 #include "EbDefinitions.h"
+#define LOG_TAG "SvtMalloc"
 #include "EbLog.h"
 
 #ifndef NDEBUG


### PR DESCRIPTION
# Description
fprintf was replaced with SVT_FATAL when memory allocation fails

# Issue
Addresses #1387 

# Author(s)
palexander-14

# Performance impact
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [ x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x ] N/A

# Merge method
- [ x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
