### PR TITLE
SvtEncApp: do not count frame twice in 2 passes mode

### DIFF
--- a/Source/App/EncApp/EbAppMain.c
+++ b/Source/App/EncApp/EbAppMain.c
@@ -50,7 +50,8 @@ extern AppExitConditionType process_output_recon_buffer(EbConfig *    config,
 
 extern AppExitConditionType process_output_stream_buffer(EbConfig *    config,
                                                          EbAppContext *app_call_back,
-                                                         uint8_t       pic_send_done);
+                                                         uint8_t       pic_send_done,
+                                                         int32_t      *frame_count);
 
 volatile int32_t keep_running = 1;
 
@@ -214,6 +215,8 @@ static EbErrorType encode(int32_t argc, char *argv[], EncodePass pass) {
             fprintf(stderr, "%sEncoding          ", get_pass_name(pass));
             fflush(stdout);
 
+            int32_t total_frames = 0;
+
             while (exit_condition == APP_ExitConditionNone) {
                 exit_condition = APP_ExitConditionFinished;
                 for (uint32_t inst_cnt = 0; inst_cnt < num_channels; ++inst_cnt) {
@@ -231,7 +234,7 @@ static EbErrorType encode(int32_t argc, char *argv[], EncodePass pass) {
                                 (exit_cond_input[inst_cnt] == APP_ExitConditionNone) ||
                                         (exit_cond_recon[inst_cnt] == APP_ExitConditionNone)
                                     ? 0
-                                    : 1);
+                                    : 1, &total_frames);
                         if (((exit_cond_recon[inst_cnt] == APP_ExitConditionFinished ||
                               !configs[inst_cnt]->recon_file) &&
                              exit_cond_output[inst_cnt] == APP_ExitConditionFinished &&

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -1089,7 +1089,7 @@ void process_output_statistics_buffer(EbBufferHeaderType *header_ptr, EbConfig *
 }
 
 AppExitConditionType process_output_stream_buffer(EbConfig *config, EbAppContext *app_call_back,
-                                                  uint8_t pic_send_done) {
+                                                  uint8_t pic_send_done, int32_t *frame_count) {
     AppPortActiveType *  port_state = &app_call_back->output_stream_port_active;
     EbBufferHeaderType * header_ptr;
     EbComponentType *    component_handle = (EbComponentType *)app_call_back->svt_encoder_handle;
@@ -1099,9 +1099,6 @@ AppExitConditionType process_output_stream_buffer(EbConfig *config, EbAppContext
 
     uint64_t *total_latency = &config->performance_context.total_latency;
     uint32_t *max_latency   = &config->performance_context.max_latency;
-
-    // System performance variables
-    static int32_t frame_count = 0;
 
     // Local variables
     uint64_t finish_s_time = 0;
@@ -1164,9 +1161,9 @@ AppExitConditionType process_output_stream_buffer(EbConfig *config, EbAppContext
             // Release the output buffer
             svt_av1_enc_release_out_buffer(&header_ptr);
 
-            ++frame_count;
+            ++*frame_count;
             if (!config->no_progress && !(header_ptr->flags & EB_BUFFERFLAG_IS_ALT_REF))
-                fprintf(stderr, "\b\b\b\b\b\b\b\b\b%9d", frame_count);
+                fprintf(stderr, "\b\b\b\b\b\b\b\b\b%9d", *frame_count);
 
             //++frame_count;
             fflush(stdout);
@@ -1180,12 +1177,12 @@ AppExitConditionType process_output_stream_buffer(EbConfig *config, EbAppContext
                     (double)(config->performance_context.frame_count);
             }
 
-            if (!(frame_count % SPEED_MEASUREMENT_INTERVAL)) {
+            if (!(*frame_count % SPEED_MEASUREMENT_INTERVAL)) {
                 {
                     fprintf(stderr, "\n");
                     fprintf(stderr,
                             "Average System Encoding Speed:        %.2f\n",
-                            (double)(frame_count) / config->performance_context.total_encode_time);
+                            (double)(*frame_count) / config->performance_context.total_encode_time);
                 }
             }
         }


### PR DESCRIPTION
test steps:
run "SvtAv1EncApp -n 10 -lad 0 -q 20 -intra-period 119 -lp 1 -i test.y4m -b two_passes.ivf --passes 2 --preset 4"
check the frame count print for the second pass, it will start from 1 instead of 11

# Description


# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->
fixes https://github.com/OpenVisualCloud/SVT-AV1/issues/1369

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
