### PR TITLE
Increase references and WM candidates at MD stage 0 candidate generation

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -503,6 +503,9 @@ extern "C" {
 
 ///////// END MASTER_SYNCH
 
+#define REF_PRUNE_CAT_TUNE 1 // Tune the allowable references per category to improve trade-offs
+#define INCREASE_WM_CANDS  1 // Use WM for PME candidates; increase number of NEW_MV cands used for WM
+
 #if DECOUPLE_ME_RES
 #define UPDATED_LINKS 100 //max number of pictures a dep-Cnt-cleanUp triggering picture can process
 #endif

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -100,6 +100,14 @@ uint8_t is_me_data_present(
 static INLINE int is_inter_mode(PredictionMode mode) {
     return mode >= SINGLE_INTER_MODE_START && mode < SINGLE_INTER_MODE_END;
 }
+#if INCREASE_WM_CANDS
+EbBool warped_motion_mode_allowed(PictureControlSet* pcs, ModeDecisionContext* ctx) {
+    FrameHeader *frm_hdr = &pcs->parent_pcs_ptr->frm_hdr;
+    return frm_hdr->allow_warped_motion && has_overlappable_candidates(ctx->blk_ptr) &&
+        ctx->blk_geom->bwidth >= 8 && ctx->blk_geom->bheight >= 8 &&
+        ctx->warped_motion_injection;
+}
+#endif
 MotionMode obmc_motion_mode_allowed(const PictureControlSet *   pcs_ptr,
                                     struct ModeDecisionContext *context_ptr, const BlockSize bsize,
                                     MvReferenceFrame rf0, MvReferenceFrame rf1,
@@ -3158,8 +3166,13 @@ void inject_warped_motion_candidates(
         }
     }
     // NEWMV L0
+#if INCREASE_WM_CANDS
+    const MV neighbors[13] = {
+        {0, 0}, {0, -1}, {1, 0}, {0, 1}, {-1, 0}, {0, -2}, {2, 0}, {0, 2}, {-2, 0}, {1, 1}, {-1, 1}, {1, -1}, {-1, 1} };
+#else
     const MV neighbors[9] = {
         {0, 0}, {0, -1}, {1, 0}, {0, 1}, {-1, 0}, {0, -2}, {2, 0}, {0, 2}, {-2, 0} };
+#endif
     IntMv  best_pred_mv[2] = { {0}, {0} };
 
     uint8_t total_me_cnt = me_results->total_me_candidate_index[context_ptr->me_block_offset];
@@ -3202,8 +3215,11 @@ void inject_warped_motion_candidates(
                 context_ptr->blk_geom->shape);
 
             if (!skip_cand) {
+#if INCREASE_WM_CANDS
+                for (int i = 0; i < 13; i++) {
+#else
                 for (int i = 0; i < 9; i++) {
-
+#endif
                     cand_array[can_idx].type = INTER_MODE;
                     cand_array[can_idx].distortion_ready = 0;
                     cand_array[can_idx].use_intrabc = 0;
@@ -3298,7 +3314,11 @@ void inject_warped_motion_candidates(
                 to_inject_ref_type,
                 context_ptr->blk_geom->shape);
             if (!skip_cand) {
+#if INCREASE_WM_CANDS
+                for (int i = 0; i < 13; i++) {
+#else
                 for (int i = 0; i < 9; i++) {
+#endif
 
                     cand_array[can_idx].type = INTER_MODE;
                     cand_array[can_idx].distortion_ready = 0;
@@ -4203,6 +4223,10 @@ void inject_predictive_me_candidates(
     if (context_ptr->source_variance < context_ptr->inter_comp_ctrls.wedge_variance_th)
         tot_comp_types = MIN(tot_comp_types, MD_COMP_DIFF0);
 #endif
+#if INCREASE_WM_CANDS
+    Mv mv;
+    MvUnit mv_unit;
+#endif
     uint8_t list_index;
     uint8_t ref_pic_index;
     list_index = REF_LIST_0;
@@ -4250,6 +4274,10 @@ void inject_predictive_me_candidates(
                            context_ptr->pme_res[0][0].ref_i != ref_pic_index )
                              is_obmc_allowed = 0;
 #endif
+#if INCREASE_WM_CANDS
+                    uint8_t is_warp_allowed = warped_motion_mode_allowed(pcs_ptr, context_ptr);
+                    tot_inter_types = is_warp_allowed ? tot_inter_types + 1 : tot_inter_types;
+#endif
                     tot_inter_types = is_obmc_allowed ? tot_inter_types + 1 : tot_inter_types;
                     for (inter_type = 0; inter_type < tot_inter_types; inter_type++) {
                         cand_array[cand_total_cnt].type                    = INTER_MODE;
@@ -4295,6 +4323,28 @@ void inject_predictive_me_candidates(
                             cand_array[cand_total_cnt].is_interintra_used = 0;
                             cand_array[cand_total_cnt].motion_mode        = SIMPLE_TRANSLATION;
                         } else {
+#if INCREASE_WM_CANDS
+                            if (is_warp_allowed && inter_type == (tot_inter_types - (1 + is_obmc_allowed))) {
+                                cand_array[cand_total_cnt].is_interintra_used = 0;
+                                cand_array[cand_total_cnt].motion_mode = WARPED_CAUSAL;
+                                cand_array[cand_total_cnt].wm_params_l0.wmtype = AFFINE;
+
+                                mv.x = to_inject_mv_x;
+                                mv.y = to_inject_mv_y;
+                                mv_unit.mv[list_index] = mv;
+                                mv_unit.pred_direction = cand_array[cand_total_cnt].prediction_direction[0];
+                                cand_array[cand_total_cnt].local_warp_valid = warped_motion_parameters(
+                                    pcs_ptr,
+                                    context_ptr->blk_ptr,
+                                    &mv_unit,
+                                    context_ptr->blk_geom,
+                                    context_ptr->blk_origin_x,
+                                    context_ptr->blk_origin_y,
+                                    cand_array[cand_total_cnt].ref_frame_type,
+                                    &cand_array[cand_total_cnt].wm_params_l0,
+                                    &cand_array[cand_total_cnt].num_proj_ref);
+                            }
+#endif
                             if (is_obmc_allowed && inter_type == tot_inter_types - 1) {
                                 cand_array[cand_total_cnt].is_interintra_used = 0;
                                 cand_array[cand_total_cnt].motion_mode        = OBMC_CAUSAL;
@@ -4304,6 +4354,28 @@ void inject_predictive_me_candidates(
                             }
                         }
 
+#if INCREASE_WM_CANDS
+                        if (!(is_warp_allowed && inter_type == (tot_inter_types - (1 + is_obmc_allowed)))) {
+                            INCRMENT_CAND_TOTAL_COUNT(cand_total_cnt);
+                            context_ptr->injected_mv_x_l0_array[context_ptr->injected_mv_count_l0] =
+                                to_inject_mv_x;
+                            context_ptr->injected_mv_y_l0_array[context_ptr->injected_mv_count_l0] =
+                                to_inject_mv_y;
+                            context_ptr->injected_ref_type_l0_array[context_ptr->injected_mv_count_l0] =
+                                to_inject_ref_type;
+                            ++context_ptr->injected_mv_count_l0;
+                        }
+                        else if (cand_array[cand_total_cnt].local_warp_valid) {
+                            INCRMENT_CAND_TOTAL_COUNT(cand_total_cnt);
+                            context_ptr->injected_mv_x_l0_array[context_ptr->injected_mv_count_l0] =
+                                to_inject_mv_x;
+                            context_ptr->injected_mv_y_l0_array[context_ptr->injected_mv_count_l0] =
+                                to_inject_mv_y;
+                            context_ptr->injected_ref_type_l0_array[context_ptr->injected_mv_count_l0] =
+                                to_inject_ref_type;
+                            ++context_ptr->injected_mv_count_l0;
+                        }
+#else
                         INCRMENT_CAND_TOTAL_COUNT(cand_total_cnt);
                         context_ptr->injected_mv_x_l0_array[context_ptr->injected_mv_count_l0] =
                             to_inject_mv_x;
@@ -4312,6 +4384,7 @@ void inject_predictive_me_candidates(
                         context_ptr->injected_ref_type_l0_array[context_ptr->injected_mv_count_l0] =
                             to_inject_ref_type;
                         ++context_ptr->injected_mv_count_l0;
+#endif
                     }
                 }
             }
@@ -4365,6 +4438,10 @@ void inject_predictive_me_candidates(
                                 context_ptr->pme_res[0][0].ref_i != ref_pic_index)
                                     is_obmc_allowed = 0;
 #endif
+#if INCREASE_WM_CANDS
+                        uint8_t is_warp_allowed = warped_motion_mode_allowed(pcs_ptr, context_ptr);
+                        tot_inter_types = is_warp_allowed ? tot_inter_types + 1 : tot_inter_types;
+#endif
                         tot_inter_types = is_obmc_allowed ? tot_inter_types + 1 : tot_inter_types;
                         for (inter_type = 0; inter_type < tot_inter_types; inter_type++) {
                             cand_array[cand_total_cnt].type                    = INTER_MODE;
@@ -4411,6 +4488,28 @@ void inject_predictive_me_candidates(
                                 cand_array[cand_total_cnt].is_interintra_used = 0;
                                 cand_array[cand_total_cnt].motion_mode        = SIMPLE_TRANSLATION;
                             } else {
+#if INCREASE_WM_CANDS
+                                if (is_warp_allowed && inter_type == (tot_inter_types - (1 + is_obmc_allowed))) {
+                                    cand_array[cand_total_cnt].is_interintra_used = 0;
+                                    cand_array[cand_total_cnt].motion_mode = WARPED_CAUSAL;
+                                    cand_array[cand_total_cnt].wm_params_l0.wmtype = AFFINE;
+
+                                    mv.x = to_inject_mv_x;
+                                    mv.y = to_inject_mv_y;
+                                    mv_unit.mv[list_index] = mv;
+                                    mv_unit.pred_direction = cand_array[cand_total_cnt].prediction_direction[0];
+                                    cand_array[cand_total_cnt].local_warp_valid = warped_motion_parameters(
+                                        pcs_ptr,
+                                        context_ptr->blk_ptr,
+                                        &mv_unit,
+                                        context_ptr->blk_geom,
+                                        context_ptr->blk_origin_x,
+                                        context_ptr->blk_origin_y,
+                                        cand_array[cand_total_cnt].ref_frame_type,
+                                        &cand_array[cand_total_cnt].wm_params_l0,
+                                        &cand_array[cand_total_cnt].num_proj_ref);
+                                }
+#endif
                                 if (is_obmc_allowed && inter_type == tot_inter_types - 1) {
                                     cand_array[cand_total_cnt].is_interintra_used = 0;
                                     cand_array[cand_total_cnt].motion_mode        = OBMC_CAUSAL;
@@ -4422,6 +4521,30 @@ void inject_predictive_me_candidates(
                                 }
                             }
 
+#if INCREASE_WM_CANDS
+                            if (!(is_warp_allowed && inter_type == (tot_inter_types - (1 + is_obmc_allowed)))) {
+                                INCRMENT_CAND_TOTAL_COUNT(cand_total_cnt);
+                                context_ptr->injected_mv_x_l1_array[context_ptr->injected_mv_count_l1] =
+                                    to_inject_mv_x;
+                                context_ptr->injected_mv_y_l1_array[context_ptr->injected_mv_count_l1] =
+                                    to_inject_mv_y;
+                                context_ptr
+                                    ->injected_ref_type_l1_array[context_ptr->injected_mv_count_l1] =
+                                    to_inject_ref_type;
+                                ++context_ptr->injected_mv_count_l1;
+                            }
+                            else if (cand_array[cand_total_cnt].local_warp_valid) {
+                                INCRMENT_CAND_TOTAL_COUNT(cand_total_cnt);
+                                context_ptr->injected_mv_x_l1_array[context_ptr->injected_mv_count_l1] =
+                                    to_inject_mv_x;
+                                context_ptr->injected_mv_y_l1_array[context_ptr->injected_mv_count_l1] =
+                                    to_inject_mv_y;
+                                context_ptr
+                                    ->injected_ref_type_l1_array[context_ptr->injected_mv_count_l1] =
+                                    to_inject_ref_type;
+                                ++context_ptr->injected_mv_count_l1;
+                            }
+#else
                             INCRMENT_CAND_TOTAL_COUNT(cand_total_cnt);
                             context_ptr->injected_mv_x_l1_array[context_ptr->injected_mv_count_l1] =
                                 to_inject_mv_x;
@@ -4431,6 +4554,7 @@ void inject_predictive_me_candidates(
                                 ->injected_ref_type_l1_array[context_ptr->injected_mv_count_l1] =
                                 to_inject_ref_type;
                             ++context_ptr->injected_mv_count_l1;
+#endif
                         }
                     }
                 }
@@ -5051,9 +5175,13 @@ void inject_inter_candidates(PictureControlSet *pcs_ptr, ModeDecisionContext *co
     }
 
     // Warped Motion
+#if INCREASE_WM_CANDS
+    if (warped_motion_mode_allowed(pcs_ptr, context_ptr)) {
+#else
     if (frm_hdr->allow_warped_motion && has_overlappable_candidates(context_ptr->blk_ptr) &&
         context_ptr->blk_geom->bwidth >= 8 && context_ptr->blk_geom->bheight >= 8 &&
         context_ptr->warped_motion_injection) {
+#endif
         inject_warped_motion_candidates(
             pcs_ptr, context_ptr, context_ptr->blk_ptr, &cand_total_cnt, me_results);
     }

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -3167,7 +3167,8 @@ void inject_warped_motion_candidates(
     }
     // NEWMV L0
 #if INCREASE_WM_CANDS
-    const MV neighbors[13] = {
+#define NUM_WM_NEIGHBOUR_POS 13
+    const MV neighbors[NUM_WM_NEIGHBOUR_POS] = {
         {0, 0}, {0, -1}, {1, 0}, {0, 1}, {-1, 0}, {0, -2}, {2, 0}, {0, 2}, {-2, 0}, {1, 1}, {-1, 1}, {1, -1}, {-1, 1} };
 #else
     const MV neighbors[9] = {
@@ -3216,7 +3217,7 @@ void inject_warped_motion_candidates(
 
             if (!skip_cand) {
 #if INCREASE_WM_CANDS
-                for (int i = 0; i < 13; i++) {
+                for (int i = 0; i < NUM_WM_NEIGHBOUR_POS; i++) {
 #else
                 for (int i = 0; i < 9; i++) {
 #endif
@@ -3315,7 +3316,7 @@ void inject_warped_motion_candidates(
                 context_ptr->blk_geom->shape);
             if (!skip_cand) {
 #if INCREASE_WM_CANDS
-                for (int i = 0; i < 13; i++) {
+                for (int i = 0; i < NUM_WM_NEIGHBOUR_POS; i++) {
 #else
                 for (int i = 0; i < 9; i++) {
 #endif

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -1453,19 +1453,19 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->best_refs[NRST_NEW_NEAR_GROUP] = 7;
 #endif
 #endif
-#if REF_PRUNE_CAT_TUNE
-        ref_pruning_ctrls->closest_refs[PA_ME_GROUP]         = 1;
-        ref_pruning_ctrls->closest_refs[UNI_3x3_GROUP]       = 1;
-        ref_pruning_ctrls->closest_refs[BI_3x3_GROUP]        = 1;
-        ref_pruning_ctrls->closest_refs[NRST_NEW_NEAR_GROUP] = 1;
-        ref_pruning_ctrls->closest_refs[WARP_GROUP]          = 1;
-        ref_pruning_ctrls->closest_refs[NRST_NEAR_GROUP]     = 1;
-        ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 1;
-#else
         ref_pruning_ctrls->best_refs[WARP_GROUP]          = 7;
         ref_pruning_ctrls->best_refs[NRST_NEAR_GROUP]     = 7;
         ref_pruning_ctrls->best_refs[PRED_ME_GROUP]       = 7;
 
+#if REF_PRUNE_CAT_TUNE
+        ref_pruning_ctrls->closest_refs[PA_ME_GROUP] = 1;
+        ref_pruning_ctrls->closest_refs[UNI_3x3_GROUP] = 1;
+        ref_pruning_ctrls->closest_refs[BI_3x3_GROUP] = 1;
+        ref_pruning_ctrls->closest_refs[NRST_NEW_NEAR_GROUP] = 1;
+        ref_pruning_ctrls->closest_refs[WARP_GROUP] = 1;
+        ref_pruning_ctrls->closest_refs[NRST_NEAR_GROUP] = 1;
+        ref_pruning_ctrls->closest_refs[PRED_ME_GROUP] = 1;
+#else
         ref_pruning_ctrls->closest_refs[PA_ME_GROUP]         = 0;
         ref_pruning_ctrls->closest_refs[UNI_3x3_GROUP]       = 0;
         ref_pruning_ctrls->closest_refs[BI_3x3_GROUP]        = 1;

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -1438,7 +1438,11 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
 
         ref_pruning_ctrls->best_refs[PA_ME_GROUP]         = 7;
+#if REF_PRUNE_CAT_TUNE
+        ref_pruning_ctrls->best_refs[UNI_3x3_GROUP]       = 7;
+#else
         ref_pruning_ctrls->best_refs[UNI_3x3_GROUP]       = 2;
+#endif
         ref_pruning_ctrls->best_refs[BI_3x3_GROUP]        = 2;
 #if JUNE23_ADOPTIONS
         ref_pruning_ctrls->best_refs[NRST_NEW_NEAR_GROUP] = 0;
@@ -1449,6 +1453,15 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->best_refs[NRST_NEW_NEAR_GROUP] = 7;
 #endif
 #endif
+#if REF_PRUNE_CAT_TUNE
+        ref_pruning_ctrls->closest_refs[PA_ME_GROUP]         = 1;
+        ref_pruning_ctrls->closest_refs[UNI_3x3_GROUP]       = 1;
+        ref_pruning_ctrls->closest_refs[BI_3x3_GROUP]        = 1;
+        ref_pruning_ctrls->closest_refs[NRST_NEW_NEAR_GROUP] = 1;
+        ref_pruning_ctrls->closest_refs[WARP_GROUP]          = 1;
+        ref_pruning_ctrls->closest_refs[NRST_NEAR_GROUP]     = 1;
+        ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 1;
+#else
         ref_pruning_ctrls->best_refs[WARP_GROUP]          = 7;
         ref_pruning_ctrls->best_refs[NRST_NEAR_GROUP]     = 7;
         ref_pruning_ctrls->best_refs[PRED_ME_GROUP]       = 7;
@@ -1464,23 +1477,41 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->closest_refs[WARP_GROUP]          = 0;
         ref_pruning_ctrls->closest_refs[NRST_NEAR_GROUP]     = 1;
         ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 0;
-
+#endif
         break;
     case 2:
         ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
 
+#if REF_PRUNE_CAT_TUNE
+        ref_pruning_ctrls->best_refs[PA_ME_GROUP]         = 7;
+        ref_pruning_ctrls->best_refs[UNI_3x3_GROUP]       = 7;
+#else
         ref_pruning_ctrls->best_refs[PA_ME_GROUP]         = 6;
         ref_pruning_ctrls->best_refs[UNI_3x3_GROUP]       = 2;
+#endif
         ref_pruning_ctrls->best_refs[BI_3x3_GROUP]        = 2;
 #if OPTIMIZE_NEAREST_NEW_NEAR
         ref_pruning_ctrls->best_refs[NRST_NEW_NEAR_GROUP] = 0;
 #else
         ref_pruning_ctrls->best_refs[NRST_NEW_NEAR_GROUP] = 6;
 #endif
+#if REF_PRUNE_CAT_TUNE
+        ref_pruning_ctrls->best_refs[WARP_GROUP]          = 7;
+#else
         ref_pruning_ctrls->best_refs[WARP_GROUP]          = 6;
+#endif
         ref_pruning_ctrls->best_refs[NRST_NEAR_GROUP]     = 6;
         ref_pruning_ctrls->best_refs[PRED_ME_GROUP]       = 6;
 
+#if REF_PRUNE_CAT_TUNE
+        ref_pruning_ctrls->closest_refs[PA_ME_GROUP]         = 1;
+        ref_pruning_ctrls->closest_refs[UNI_3x3_GROUP]       = 1;
+        ref_pruning_ctrls->closest_refs[BI_3x3_GROUP]        = 1;
+        ref_pruning_ctrls->closest_refs[NRST_NEW_NEAR_GROUP] = 1;
+        ref_pruning_ctrls->closest_refs[WARP_GROUP]          = 1;
+        ref_pruning_ctrls->closest_refs[NRST_NEAR_GROUP]     = 1;
+        ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 1;
+#else
         ref_pruning_ctrls->closest_refs[PA_ME_GROUP]         = 0;
         ref_pruning_ctrls->closest_refs[UNI_3x3_GROUP]       = 0;
         ref_pruning_ctrls->closest_refs[BI_3x3_GROUP]        = 1;
@@ -1492,22 +1523,41 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->closest_refs[WARP_GROUP]          = 0;
         ref_pruning_ctrls->closest_refs[NRST_NEAR_GROUP]     = 1;
         ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 0;
+#endif
         break;
     case 3:
         ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
 
+#if REF_PRUNE_CAT_TUNE
+        ref_pruning_ctrls->best_refs[PA_ME_GROUP]         = 7;
+        ref_pruning_ctrls->best_refs[UNI_3x3_GROUP]       = 7;
+#else
         ref_pruning_ctrls->best_refs[PA_ME_GROUP]         = 5;
         ref_pruning_ctrls->best_refs[UNI_3x3_GROUP]       = 2;
+#endif
         ref_pruning_ctrls->best_refs[BI_3x3_GROUP]        = 2;
 #if OPTIMIZE_NEAREST_NEW_NEAR
         ref_pruning_ctrls->best_refs[NRST_NEW_NEAR_GROUP] = 0;
 #else
         ref_pruning_ctrls->best_refs[NRST_NEW_NEAR_GROUP] = 5;
 #endif
+#if REF_PRUNE_CAT_TUNE
+        ref_pruning_ctrls->best_refs[WARP_GROUP]          = 7;
+#else
         ref_pruning_ctrls->best_refs[WARP_GROUP]          = 5;
+#endif
         ref_pruning_ctrls->best_refs[NRST_NEAR_GROUP]     = 5;
         ref_pruning_ctrls->best_refs[PRED_ME_GROUP]       = 5;
 
+#if REF_PRUNE_CAT_TUNE
+        ref_pruning_ctrls->closest_refs[PA_ME_GROUP]         = 1;
+        ref_pruning_ctrls->closest_refs[UNI_3x3_GROUP]       = 1;
+        ref_pruning_ctrls->closest_refs[BI_3x3_GROUP]        = 1;
+        ref_pruning_ctrls->closest_refs[NRST_NEW_NEAR_GROUP] = 1;
+        ref_pruning_ctrls->closest_refs[WARP_GROUP]          = 1;
+        ref_pruning_ctrls->closest_refs[NRST_NEAR_GROUP]     = 1;
+        ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 1;
+#else
         ref_pruning_ctrls->closest_refs[PA_ME_GROUP]         = 0;
         ref_pruning_ctrls->closest_refs[UNI_3x3_GROUP]       = 0;
         ref_pruning_ctrls->closest_refs[BI_3x3_GROUP]        = 1;
@@ -1519,22 +1569,41 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->closest_refs[WARP_GROUP]          = 0;
         ref_pruning_ctrls->closest_refs[NRST_NEAR_GROUP]     = 1;
         ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 0;
+#endif
         break;
     case 4:
         ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
 
+#if REF_PRUNE_CAT_TUNE
+        ref_pruning_ctrls->best_refs[PA_ME_GROUP]         = 7;
+        ref_pruning_ctrls->best_refs[UNI_3x3_GROUP]       = 7;
+#else
         ref_pruning_ctrls->best_refs[PA_ME_GROUP]         = 4;
         ref_pruning_ctrls->best_refs[UNI_3x3_GROUP]       = 2;
+#endif
         ref_pruning_ctrls->best_refs[BI_3x3_GROUP]        = 2;
 #if OPTIMIZE_NEAREST_NEW_NEAR
         ref_pruning_ctrls->best_refs[NRST_NEW_NEAR_GROUP] = 0;
 #else
         ref_pruning_ctrls->best_refs[NRST_NEW_NEAR_GROUP] = 4;
 #endif
+#if REF_PRUNE_CAT_TUNE
+        ref_pruning_ctrls->best_refs[WARP_GROUP]          = 7;
+#else
         ref_pruning_ctrls->best_refs[WARP_GROUP]          = 4;
+#endif
         ref_pruning_ctrls->best_refs[NRST_NEAR_GROUP]     = 4;
         ref_pruning_ctrls->best_refs[PRED_ME_GROUP]       = 4;
 
+#if REF_PRUNE_CAT_TUNE
+        ref_pruning_ctrls->closest_refs[PA_ME_GROUP]         = 1;
+        ref_pruning_ctrls->closest_refs[UNI_3x3_GROUP]       = 1;
+        ref_pruning_ctrls->closest_refs[BI_3x3_GROUP]        = 1;
+        ref_pruning_ctrls->closest_refs[NRST_NEW_NEAR_GROUP] = 1;
+        ref_pruning_ctrls->closest_refs[WARP_GROUP]          = 1;
+        ref_pruning_ctrls->closest_refs[NRST_NEAR_GROUP]     = 1;
+        ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 1;
+#else
         ref_pruning_ctrls->closest_refs[PA_ME_GROUP]         = 0;
         ref_pruning_ctrls->closest_refs[UNI_3x3_GROUP]       = 0;
         ref_pruning_ctrls->closest_refs[BI_3x3_GROUP]        = 1;
@@ -1546,6 +1615,7 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->closest_refs[WARP_GROUP]          = 0;
         ref_pruning_ctrls->closest_refs[NRST_NEAR_GROUP]     = 1;
         ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 0;
+#endif
         break;
     case 5:
         ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;


### PR DESCRIPTION
# Description

Increase the number of WM candidates prepared during candidate generation by expanding the number of neighbour positions  searched and adding WM candidates for PME MVs.

Increase the number of reference frames used for certain reference pruning categories, and change used levels to always prepare candidates for at least the closest reference frames.

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

Fixes #1405 
Fixes #1411 

# Author(s)

@PhoenixWorthVCD 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [x] quality
- [ ] memory
- [ ] speed
- [x] 8 bit
- [x] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] Google Lowres
- [ ] N/A

| Mode | BDR | Speed |
|-|-|-
|M1|-0.33%|No change|
|M3|-0.33%|No change|
|M5|-0.34% | No change |

Expected gain: -0.3% BD-rate, no speed cost in M1-M5; -0.15% BD-rate, no speed cost in M0

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
