### PR TITLE
Improve INTER Pred

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -359,7 +359,7 @@ extern "C" {
 #define PERFORM_SUB_PEL_TF         1 // Perform subpel @ TF
 #define PERFORM_SUB_PEL_MD         1 // Perform subpel @ MD
 #define FIX_IFS_OFF_CASE           1 // Bug fix: interpolation filter is hard-coded to regular when IFS is OFF (prevented testing bilinear @ PD0)
-#define SEARCH_TOP_N               1 // Perform 1/2 Pel search @ MD for the top N Full-Pel position(s). Used N=5 for M0 and N=3 for M1
+#define SEARCH_TOP_N               0 // Useless when UPGRADE_SUBPEL is ON Perform 1/2 Pel search @ MD for the top N Full-Pel position(s). Used N=5 for M0 and N=3 for M1
 
 
 #endif
@@ -499,12 +499,19 @@ extern "C" {
 #define FILTER_INTRA_CLI    1 // Improve CLI support for Filter Intra (OFF / Fully ON / Other Levels)
 #define TX_EARLY_EXIT       1 // Variance/cost_depth_1-to-cost_depth_0 based early txs exit
 
+#define REF_PRUNE_CAT_TUNE 1 // Tune the allowable references per category to improve trade-offs
+#define INCREASE_WM_CANDS  1 // Use WM for PME candidates; increase number of NEW_MV cands used for WM
+
+#define ADAPTIVE_ME_SEARCH  1 // Add Adaptive ME: detect and improve the pred of high active block(s)
+#define FIX_MV_BOUND        1 // Clip inherited ME MVs to stay within pic boundaries
+#define IMPROVE_GMV         1 // Make GMV params/candidates derivation multi-ref aware, and set multi-ref to be considered = f(input_complexity)
+#define ENABLE_GM_ID_EXIT   1 // Enable gm_identiy_exit
+#define UPGRADE_SUBPEL      1 // Upgrade subpel of me and of pme to use libaom subpel search
+#define REMOVE_USELESS_CODE 1 // Remove useless code
+
 #endif
 
 ///////// END MASTER_SYNCH
-
-#define REF_PRUNE_CAT_TUNE 1 // Tune the allowable references per category to improve trade-offs
-#define INCREASE_WM_CANDS  1 // Use WM for PME candidates; increase number of NEW_MV cands used for WM
 
 #if DECOUPLE_ME_RES
 #define UPDATED_LINKS 100 //max number of pictures a dep-Cnt-cleanUp triggering picture can process
@@ -525,8 +532,12 @@ extern "C" {
 #endif
 
 #define ALT_REF_QP_THRESH 20
+#if UPGRADE_SUBPEL
+// Q threshold for high precision mv.
+#define HIGH_PRECISION_MV_QTHRESH 128
+#else
 #define HIGH_PRECISION_MV_QTHRESH 150
-
+#endif
 // Actions in the second pass: Frame and SB QP assignment and temporal filtering strenght change
 //FOR DEBUGGING - Do not remove
 #define NO_ENCDEC         0 // bypass encDec to test cmpliance of MD. complained achieved when skip_flag is OFF. Port sample code from VCI-SW_AV1_Candidate1 branch
@@ -566,7 +577,9 @@ typedef enum GM_LEVEL {
     GM_DOWN      = 1, // Downsampled search mode, with a downsampling factor of 2 in each dimension
 #if GM_DOWN_16
     GM_DOWN16    = 2, // Downsampled search mode, with a downsampling factor of 4 in each dimension
+#if !IMPROVE_GMV
     GM_TRAN_ONLY = 3 // Translation only using ME MV.
+#endif
 #else
     GM_TRAN_ONLY = 2 // Translation only using ME MV.
 #endif

--- a/Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.c
@@ -1109,7 +1109,10 @@ void mvp_bypass_init(PictureControlSet *pcs_ptr, ModeDecisionContext *context_pt
     xd->mb_to_bottom_edge = ((cm->mi_rows - bh - mi_row) * MI_SIZE) * 8;
     xd->mb_to_left_edge   = -((mi_col * MI_SIZE) * 8);
     xd->mb_to_right_edge  = ((cm->mi_cols - bw - mi_col) * MI_SIZE) * 8;
-
+#if UPGRADE_SUBPEL
+    xd->mi_row = -xd->mb_to_top_edge / (8 * MI_SIZE);
+    xd->mi_col = -xd->mb_to_left_edge / (8 * MI_SIZE);
+#endif
     xd->up_available   = (mi_row > tile->mi_row_start);
     xd->left_available = (mi_col > tile->mi_col_start);
 
@@ -1175,7 +1178,10 @@ void generate_av1_mvp_table(TileInfo *tile, ModeDecisionContext *context_ptr, Bl
     xd->mb_to_bottom_edge = ((cm->mi_rows - bh - mi_row) * MI_SIZE) * 8;
     xd->mb_to_left_edge   = -((mi_col * MI_SIZE) * 8);
     xd->mb_to_right_edge  = ((cm->mi_cols - bw - mi_col) * MI_SIZE) * 8;
-
+#if UPGRADE_SUBPEL
+    xd->mi_row = -xd->mb_to_top_edge / (8 * MI_SIZE);
+    xd->mi_col = -xd->mb_to_left_edge / (8 * MI_SIZE);
+#endif
     memset(xd->ref_mv_count, 0, sizeof(xd->ref_mv_count));
 #if MEM_OPT_MV_STACK
     memset(context_ptr->ed_ref_mv_stack,

--- a/Source/Lib/Encoder/Codec/EbCodingUnit.h
+++ b/Source/Lib/Encoder/Codec/EbCodingUnit.h
@@ -279,6 +279,10 @@ typedef struct MacroBlockD {
     int32_t mb_to_right_edge;
     int32_t mb_to_top_edge;
     int32_t mb_to_bottom_edge;
+#if UPGRADE_SUBPEL
+    int mi_row; // Row position in mi units
+    int mi_col; // Column position in mi units
+#endif
     uint8_t neighbors_ref_counts[TOTAL_REFS_PER_FRAME];
 #if !SB_MEM_OPT
     uint8_t                  use_intrabc;

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -2072,6 +2072,7 @@ void set_inter_inter_distortion_based_reference_pruning_controls(ModeDecisionCon
 }
 #endif
 #endif
+#if !REMOVE_USELESS_CODE
 void set_inter_intra_distortion_based_reference_pruning_controls(ModeDecisionContext *mdctxt, uint8_t inter_intra_distortion_based_reference_pruning_mode) {
 
     RefPruningControls *ref_pruning_ctrls = &mdctxt->ref_pruning_ctrls;
@@ -2096,8 +2097,9 @@ void set_inter_intra_distortion_based_reference_pruning_controls(ModeDecisionCon
     }
 }
 #endif
+#endif
 
-
+#if !REMOVE_USELESS_CODE
 #if BLOCK_REDUCTION_ALGORITHM_1 || BLOCK_REDUCTION_ALGORITHM_2
 void set_block_based_depth_reduction_controls(ModeDecisionContext *mdctxt, uint8_t block_based_depth_reduction_level) {
 
@@ -2148,7 +2150,11 @@ void set_block_based_depth_reduction_controls(ModeDecisionContext *mdctxt, uint8
     }
 }
 #endif
+#endif
 #if ADD_MD_NSQ_SEARCH
+/*
+ * Control NSQ search
+ */
 void md_nsq_motion_search_controls(ModeDecisionContext *mdctxt, uint8_t md_nsq_mv_search_level) {
 
     MdNsqMotionSearchCtrls *md_nsq_motion_search_ctrls = &mdctxt->md_nsq_motion_search_ctrls;
@@ -2217,7 +2223,171 @@ void md_nsq_motion_search_controls(ModeDecisionContext *mdctxt, uint8_t md_nsq_m
     }
 }
 #endif
+#if ADAPTIVE_ME_SEARCH
+/*
+ * Control Adaptive ME search
+ */
+void md_sq_motion_search_controls(ModeDecisionContext *mdctxt, uint8_t md_sq_mv_search_level) {
+
+    MdSqMotionSearchCtrls *md_sq_me_ctrls = &mdctxt->md_sq_me_ctrls;
+
+    switch (md_sq_mv_search_level) {
+    case 0:
+        md_sq_me_ctrls->enabled = 0;
+        break;
+    case 1:
+        md_sq_me_ctrls->enabled = 1;
+        md_sq_me_ctrls->use_ssd = 0;
+
+        md_sq_me_ctrls->pame_distortion_th = 10;
+
+        md_sq_me_ctrls->sprs_lev0_enabled = 1;
+        md_sq_me_ctrls->sprs_lev0_step = 4;
+        md_sq_me_ctrls->sprs_lev0_w = 15;
+        md_sq_me_ctrls->sprs_lev0_h = 15;
+        md_sq_me_ctrls->max_sprs_lev0_w = 150;
+        md_sq_me_ctrls->max_sprs_lev0_h = 150;
+        md_sq_me_ctrls->sprs_lev0_multiplier = 500;
+
+        md_sq_me_ctrls->sprs_lev1_enabled = 1;
+        md_sq_me_ctrls->sprs_lev1_step = 2;
+        md_sq_me_ctrls->sprs_lev1_w = 4;
+        md_sq_me_ctrls->sprs_lev1_h = 4;
+        md_sq_me_ctrls->max_sprs_lev1_w = 50;
+        md_sq_me_ctrls->max_sprs_lev1_h = 50;
+        md_sq_me_ctrls->sprs_lev1_multiplier = 500;
+
+        md_sq_me_ctrls->sprs_lev2_enabled = 1;
+        md_sq_me_ctrls->sprs_lev2_step = 1;
+        md_sq_me_ctrls->sprs_lev2_w = 3;
+        md_sq_me_ctrls->sprs_lev2_h = 3;
+        break;
+    case 2:
+        md_sq_me_ctrls->enabled = 1;
+        md_sq_me_ctrls->use_ssd = 0;
+
+        md_sq_me_ctrls->pame_distortion_th = 10;
+
+        md_sq_me_ctrls->sprs_lev0_enabled = 1;
+        md_sq_me_ctrls->sprs_lev0_step = 4;
+        md_sq_me_ctrls->sprs_lev0_w = 15;
+        md_sq_me_ctrls->sprs_lev0_h = 15;
+        md_sq_me_ctrls->max_sprs_lev0_w = 150;
+        md_sq_me_ctrls->max_sprs_lev0_h = 150;
+        md_sq_me_ctrls->sprs_lev0_multiplier = 400;
+
+        md_sq_me_ctrls->sprs_lev1_enabled = 1;
+        md_sq_me_ctrls->sprs_lev1_step = 2;
+        md_sq_me_ctrls->sprs_lev1_w = 4;
+        md_sq_me_ctrls->sprs_lev1_h = 4;
+        md_sq_me_ctrls->max_sprs_lev1_w = 50;
+        md_sq_me_ctrls->max_sprs_lev1_h = 50;
+        md_sq_me_ctrls->sprs_lev1_multiplier = 400;
+
+        md_sq_me_ctrls->sprs_lev2_enabled = 1;
+        md_sq_me_ctrls->sprs_lev2_step = 1;
+        md_sq_me_ctrls->sprs_lev2_w = 3;
+        md_sq_me_ctrls->sprs_lev2_h = 3;
+        break;
+    case 3:
+        md_sq_me_ctrls->enabled = 1;
+        md_sq_me_ctrls->use_ssd = 0;
+
+        md_sq_me_ctrls->pame_distortion_th = 10;
+
+        md_sq_me_ctrls->sprs_lev0_enabled = 1;
+        md_sq_me_ctrls->sprs_lev0_step = 4;
+        md_sq_me_ctrls->sprs_lev0_w = 15;
+        md_sq_me_ctrls->sprs_lev0_h = 15;
+        md_sq_me_ctrls->max_sprs_lev0_w = 150;
+        md_sq_me_ctrls->max_sprs_lev0_h = 150;
+        md_sq_me_ctrls->sprs_lev0_multiplier = 300;
+
+        md_sq_me_ctrls->sprs_lev1_enabled = 1;
+        md_sq_me_ctrls->sprs_lev1_step = 2;
+        md_sq_me_ctrls->sprs_lev1_w = 4;
+        md_sq_me_ctrls->sprs_lev1_h = 4;
+        md_sq_me_ctrls->max_sprs_lev1_w = 50;
+        md_sq_me_ctrls->max_sprs_lev1_h = 50;
+        md_sq_me_ctrls->sprs_lev1_multiplier = 300;
+
+        md_sq_me_ctrls->sprs_lev2_enabled = 1;
+        md_sq_me_ctrls->sprs_lev2_step = 1;
+        md_sq_me_ctrls->sprs_lev2_w = 3;
+        md_sq_me_ctrls->sprs_lev2_h = 3;
+        break;
+    default:
+        assert(0);
+        break;
+    }
+}
+#endif
 #if PERFORM_SUB_PEL_MD
+#if UPGRADE_SUBPEL
+/*
+ * Control Subpel search of ME MV(s)
+ */
+void md_subpel_me_controls(ModeDecisionContext *mdctxt, uint8_t md_subpel_me_level) {
+    MdSubPelSearchCtrls *md_subpel_me_ctrls = &mdctxt->md_subpel_me_ctrls;
+
+    switch (md_subpel_me_level) {
+    case 0:
+        md_subpel_me_ctrls->enabled = 0;
+        break;
+    case 1:
+        md_subpel_me_ctrls->enabled = 1;
+        md_subpel_me_ctrls->subpel_search_type = USE_8_TAPS;
+        md_subpel_me_ctrls->subpel_iters_per_step = 2;
+        md_subpel_me_ctrls->eight_pel_search_enabled = 1;
+        break;
+    case 2:
+        md_subpel_me_ctrls->enabled = 1;
+        md_subpel_me_ctrls->subpel_search_type = USE_4_TAPS;
+        md_subpel_me_ctrls->subpel_iters_per_step = 2;
+        md_subpel_me_ctrls->eight_pel_search_enabled = 0;
+        break;
+    case 3:
+        md_subpel_me_ctrls->enabled = 1;
+        md_subpel_me_ctrls->subpel_search_type = USE_4_TAPS;
+        md_subpel_me_ctrls->subpel_iters_per_step = 1;
+        md_subpel_me_ctrls->eight_pel_search_enabled = 0;
+        break;
+    default: assert(0); break;
+    }
+}
+
+/*
+ * Control Subpel search of PME MV(s)
+ */
+void md_subpel_pme_controls(ModeDecisionContext *mdctxt, uint8_t md_subpel_pme_level) {
+    MdSubPelSearchCtrls *md_subpel_pme_ctrls = &mdctxt->md_subpel_pme_ctrls;
+
+    switch (md_subpel_pme_level) {
+    case 0:
+        md_subpel_pme_ctrls->enabled = 0;
+        break;
+    case 1:
+        md_subpel_pme_ctrls->enabled = 1;
+        md_subpel_pme_ctrls->subpel_search_type = USE_8_TAPS;
+        md_subpel_pme_ctrls->subpel_iters_per_step = 2;
+        md_subpel_pme_ctrls->eight_pel_search_enabled = 1;
+        break;
+    case 2:
+        md_subpel_pme_ctrls->enabled = 1;
+        md_subpel_pme_ctrls->subpel_search_type = USE_4_TAPS;
+        md_subpel_pme_ctrls->subpel_iters_per_step = 2;
+        md_subpel_pme_ctrls->eight_pel_search_enabled = 0;
+        break;
+    case 3:
+        md_subpel_pme_ctrls->enabled = 1;
+        md_subpel_pme_ctrls->subpel_search_type = USE_4_TAPS;
+        md_subpel_pme_ctrls->subpel_iters_per_step = 1;
+        md_subpel_pme_ctrls->eight_pel_search_enabled = 0;
+        break;
+    default: assert(0); break;
+    }
+}
+#else
 #if REMOVE_MR_MACRO
 void md_subpel_search_controls(ModeDecisionContext *mdctxt, uint8_t md_subpel_search_level, EbEncMode enc_mode) {
 #else
@@ -2352,6 +2522,7 @@ void md_subpel_search_controls(ModeDecisionContext *mdctxt, uint8_t md_subpel_se
     md_subpel_search_ctrls->eight_pel_interpolation = 0;
 
 }
+#endif
 #endif
 #if SB_CLASSIFIER
 /******************************************************
@@ -4650,7 +4821,12 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     else
         context_ptr->bipred3x3_injection =
         sequence_control_set_ptr->static_config.bipred_3x3_inject;
-
+#if UPGRADE_SUBPEL
+    // Level                Settings
+    // 0                    Level 0: OFF
+    // 1                    Level 1: pme_distortion to me_distortion deviation on, and search restricted to 1 ref per list
+    // 2                    Level 2: pme_distortion to me_distortion deviation off
+#else
     // Level                Settings
     // 0                    Level 0: OFF
     // 1                    Level 1: sub-pel refinement off
@@ -4661,14 +4837,17 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     // 6                    Level 6: (H + V + D) 1/2 & 1/4 refinement = 8 half-pel + 8 quarter-pel = 16 positions + pred_me_distortion to pa_me_distortion deviation off
 
     // NB: if PME_UP_TO_4_REF is ON, levels 1-5 are restricted to using max 4 ref frames, and 1/8 Pel refinement is always performed for the 8 positions for levels 1-6
+#endif
     if (pcs_ptr->slice_type != I_SLICE) {
 
         if (pd_pass == PD_PASS_0)
             context_ptr->predictive_me_level = 0;
         else if (pd_pass == PD_PASS_1)
-
+#if UPGRADE_SUBPEL
+            context_ptr->predictive_me_level = 1;
+#else
             context_ptr->predictive_me_level = 2;
-
+#endif
         else
 
             if (sequence_control_set_ptr->static_config.pred_me == DEFAULT) {
@@ -4736,11 +4915,17 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 #endif
 #endif
 #endif
+#if UPGRADE_SUBPEL
+                        context_ptr->predictive_me_level = 2;
+#else
                         context_ptr->predictive_me_level = 6;
+#endif
 #if MAR12_M8_ADOPTIONS
 #if REVERT_WHITE // Pred_ME
 #if JUNE26_ADOPTIONS
+#if !UPGRADE_SUBPEL
                     else if (enc_mode <= ENC_M5)
+#endif
 #else
 #if JUNE25_ADOPTIONS
                     else if (enc_mode <= ENC_M6)
@@ -4766,7 +4951,9 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
                             context_ptr->predictive_me_level = 0;
 #else
 #if M1_C3_ADOPTIONS
+#if !UPGRADE_SUBPEL
                         context_ptr->predictive_me_level = 4;
+#endif
 #else
                         context_ptr->predictive_me_level = 5;
 #endif
@@ -4781,7 +4968,11 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
                 else if (enc_mode <= ENC_M6)
 #endif
 #endif
+#if UPGRADE_SUBPEL
+                    context_ptr->predictive_me_level = 1;
+#else
                     context_ptr->predictive_me_level = 2;
+#endif
 #endif
 #if REVERT_WHITE // Pred_ME
             else
@@ -6482,6 +6673,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     }
     set_inter_inter_distortion_based_reference_pruning_controls(context_ptr, context_ptr->inter_inter_distortion_based_reference_pruning);
 #endif
+#if !REMOVE_USELESS_CODE
     // Set inter_intra_distortion_based_reference_pruning
     if (pcs_ptr->slice_type != I_SLICE) {
         if (pd_pass == PD_PASS_0)
@@ -6496,6 +6688,8 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     }
     set_inter_intra_distortion_based_reference_pruning_controls(context_ptr, context_ptr->inter_intra_distortion_based_reference_pruning);
 #endif
+#endif
+#if !REMOVE_USELESS_CODE
 #if BLOCK_REDUCTION_ALGORITHM_1 || BLOCK_REDUCTION_ALGORITHM_2
     if (pd_pass == PD_PASS_0)
         context_ptr->block_based_depth_reduction_level = 0;
@@ -6555,6 +6749,22 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 #endif
     set_block_based_depth_reduction_controls(context_ptr, context_ptr->block_based_depth_reduction_level);
 #endif
+#endif
+#if ADAPTIVE_ME_SEARCH
+    if (pd_pass == PD_PASS_0)
+        context_ptr->md_sq_mv_search_level = 0;
+    else if (pd_pass == PD_PASS_1)
+        context_ptr->md_sq_mv_search_level = 0;
+    else
+        if (enc_mode <= ENC_M0)
+            context_ptr->md_sq_mv_search_level = 1;
+        else if (enc_mode <= ENC_M5)
+            context_ptr->md_sq_mv_search_level = 2;
+        else
+            context_ptr->md_sq_mv_search_level = 3;
+
+    md_sq_motion_search_controls(context_ptr, context_ptr->md_sq_mv_search_level);
+#endif
 #if ADD_MD_NSQ_SEARCH
     if (pd_pass == PD_PASS_0)
         context_ptr->md_nsq_mv_search_level = 0;
@@ -6611,6 +6821,31 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     md_nsq_motion_search_controls(context_ptr, context_ptr->md_nsq_mv_search_level);
 #endif
 #if PERFORM_SUB_PEL_MD
+#if UPGRADE_SUBPEL
+    if (pd_pass == PD_PASS_0)
+        context_ptr->md_subpel_me_level = 3;
+    else if (pd_pass == PD_PASS_1)
+        context_ptr->md_subpel_me_level = 3;
+    else
+        if (enc_mode <= ENC_M7)
+            context_ptr->md_subpel_me_level = 1;
+        else
+            context_ptr->md_subpel_me_level = 2;
+
+    md_subpel_me_controls(context_ptr, context_ptr->md_subpel_me_level);
+
+    if (pd_pass == PD_PASS_0)
+        context_ptr->md_subpel_pme_level = 3;
+    else if (pd_pass == PD_PASS_1)
+        context_ptr->md_subpel_pme_level = 3;
+    else
+        if (enc_mode <= ENC_M7)
+            context_ptr->md_subpel_pme_level = 1;
+        else
+            context_ptr->md_subpel_pme_level = 2;
+
+    md_subpel_pme_controls(context_ptr, context_ptr->md_subpel_pme_level);
+#else
     if (pd_pass == PD_PASS_0)
 #if ADD_SKIP_INTRA_SIGNAL
 #if JUNE26_ADOPTIONS
@@ -6652,6 +6887,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     md_subpel_search_controls(context_ptr, context_ptr->md_subpel_search_level,enc_mode);
 #else
     md_subpel_search_controls(context_ptr, context_ptr->md_subpel_search_level);
+#endif
 #endif
 #endif
     // Set max_ref_count @ MD

--- a/Source/Lib/Encoder/Codec/EbEntropyCoding.c
+++ b/Source/Lib/Encoder/Codec/EbEntropyCoding.c
@@ -1848,7 +1848,7 @@ void write_drl_idx(FRAME_CONTEXT *frame_context, AomWriter *ec_writer, BlkStruct
 }
 
 #endif
-extern MvJointType av1_get_mv_joint(int32_t diff[2]);
+extern MvJointType svt_av1_get_mv_joint(int32_t diff[2]);
 static void        encode_mv_component(AomWriter *w, int32_t comp, NmvComponent *mvcomp,
                                        MvSubpelPrecision precision) {
     int32_t       offset;
@@ -4884,7 +4884,7 @@ void eb_av1_encode_dv(AomWriter *w, const MV *mv, const MV *ref, NmvContext *mvc
     assert((ref->col & 7) == 0);
     assert((ref->row & 7) == 0);
     const MV          diff = {mv->row - ref->row, mv->col - ref->col};
-    const MvJointType j    = av1_get_mv_joint((int32_t *)&diff);
+    const MvJointType j    = svt_av1_get_mv_joint((int32_t *)&diff);
 
     aom_write_symbol(w, j, mvctx->joints_cdf, MV_JOINTS);
     if (mv_joint_vertical(j)) encode_mv_component(w, diff.row, &mvctx->comps[0], MV_SUBPEL_NONE);

--- a/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbGlobalMotionEstimation.c
@@ -20,7 +20,12 @@
 #include "EbUtility.h"
 #include "global_motion.h"
 #include "corner_detect.h"
-
+#if IMPROVE_GMV
+// Normalized distortion-based thresholds
+#define GMV_ME_SAD_TH_0  0
+#define GMV_ME_SAD_TH_1  5
+#define GMV_ME_SAD_TH_2 10
+#endif
 void global_motion_estimation(PictureParentControlSet *pcs_ptr, MeContext *context_ptr,
                               EbPictureBufferDesc *input_picture_ptr) {
     // Get downsampled pictures with a downsampling factor of 2 in each dimension
@@ -31,7 +36,9 @@ void global_motion_estimation(PictureParentControlSet *pcs_ptr, MeContext *conte
     EbPictureBufferDesc *sixteenth_ref_pic_ptr;
     EbPictureBufferDesc *sixteenth_picture_ptr;
 #endif
+#if !IMPROVE_GMV
     EbPictureBufferDesc *ref_picture_ptr;
+#endif
     SequenceControlSet * scs_ptr = (SequenceControlSet *)pcs_ptr->scs_wrapper_ptr->object_ptr;
     pa_reference_object =
             (EbPaReferenceObject *)pcs_ptr->pa_reference_picture_wrapper_ptr->object_ptr;
@@ -47,12 +54,59 @@ void global_motion_estimation(PictureParentControlSet *pcs_ptr, MeContext *conte
 #endif
     uint32_t num_of_list_to_search =
             (pcs_ptr->slice_type == P_SLICE) ? (uint32_t)REF_LIST_0 : (uint32_t)REF_LIST_1;
+#if IMPROVE_GMV
+    // Initilize global motion to be OFF for all references frames.
+    memset(pcs_ptr->is_global_motion, EB_FALSE, MAX_NUM_OF_REF_PIC_LIST * REF_LIST_MAX_DEPTH);
+    // Initilize wmtype to be IDENTITY for all references frames
+    // Ref List Loop
+    for (uint32_t list_index = REF_LIST_0; list_index <= num_of_list_to_search; ++list_index) {
+#if ON_OFF_FEATURE_MRP
+        uint32_t num_of_ref_pic_to_search = pcs_ptr->slice_type == P_SLICE
+            ? pcs_ptr->mrp_ctrls.ref_list0_count_try
+            : list_index == REF_LIST_0 ? pcs_ptr->mrp_ctrls.ref_list0_count_try
+            : pcs_ptr->mrp_ctrls.ref_list1_count_try;
+#else
+        uint32_t num_of_ref_pic_to_search = pcs_ptr->slice_type == P_SLICE
+            ? pcs_ptr->ref_list0_count_try
+            : list_index == REF_LIST_0 ? pcs_ptr->ref_list0_count_try
+            : pcs_ptr->ref_list1_count_try;
+#endif
+        // Ref Picture Loop
+        for (uint32_t ref_pic_index = 0; ref_pic_index < num_of_ref_pic_to_search; ++ref_pic_index) {
+            pcs_ptr->global_motion_estimation[list_index][ref_pic_index].wmtype = IDENTITY;
+        }
+    }
+    // Derive total_me_sad
+    uint32_t total_me_sad = 0;
+    for (uint16_t sb_index = 0; sb_index < pcs_ptr->sb_total_count; ++sb_index) {
+        total_me_sad += pcs_ptr->rc_me_distortion[sb_index];
+    }
+    uint32_t average_me_sad = total_me_sad / (input_picture_ptr->width * input_picture_ptr->height);
+    // Derive global_motion_estimation level
 
+    uint8_t global_motion_estimation_level;
+    // 0: skip GMV params derivation
+    // 1: use up to 1 ref per list @ the GMV params derivation
+    // 2: use up to 2 ref per list @ the GMV params derivation
+    // 3: all refs @ the GMV params derivation
+    if (average_me_sad == GMV_ME_SAD_TH_0)
+        global_motion_estimation_level = 0;
+    else if (average_me_sad < GMV_ME_SAD_TH_1)
+        global_motion_estimation_level = 1;
+    else if (average_me_sad < GMV_ME_SAD_TH_2)
+        global_motion_estimation_level = 2;
+    else
+        global_motion_estimation_level = 3;
+
+    if (global_motion_estimation_level)
+#endif
     for (uint32_t list_index = REF_LIST_0; list_index <= num_of_list_to_search; ++list_index) {
         uint32_t num_of_ref_pic_to_search;
+#if !IMPROVE_GMV
         if (context_ptr->me_alt_ref == EB_TRUE)
             num_of_ref_pic_to_search = 1;
         else
+#endif
 #if ON_OFF_FEATURE_MRP
             num_of_ref_pic_to_search = pcs_ptr->slice_type == P_SLICE
                                      ? pcs_ptr->mrp_ctrls.ref_list0_count_try:
@@ -64,18 +118,28 @@ void global_motion_estimation(PictureParentControlSet *pcs_ptr, MeContext *conte
                                           : list_index == REF_LIST_0 ? pcs_ptr->ref_list0_count_try
                                           : pcs_ptr->ref_list1_count_try;
 #endif
-
+#if !IMPROVE_GMV
         // Limit the global motion search to the first frame types of ref lists
         num_of_ref_pic_to_search = MIN(num_of_ref_pic_to_search, 1);
-
+#endif
+#if IMPROVE_GMV
+        if (global_motion_estimation_level == 1)
+            num_of_ref_pic_to_search = MIN(num_of_ref_pic_to_search, 1);
+        else if (global_motion_estimation_level == 2)
+            num_of_ref_pic_to_search = MIN(num_of_ref_pic_to_search, 2);
+#endif
         // Ref Picture Loop
         for (uint32_t ref_pic_index = 0; ref_pic_index < num_of_ref_pic_to_search;
              ++ref_pic_index) {
             EbPaReferenceObject *reference_object;
-
+#if IMPROVE_GMV
+            EbPictureBufferDesc *ref_picture_ptr;
+#endif
+#if !IMPROVE_GMV
             if (context_ptr->me_alt_ref == EB_TRUE)
                 reference_object = (EbPaReferenceObject *)context_ptr->alt_ref_reference_ptr;
             else
+#endif
                 reference_object =
                         (EbPaReferenceObject *)pcs_ptr->ref_pa_pic_ptr_array[list_index][ref_pic_index]
                                 ->object_ptr;
@@ -116,13 +180,33 @@ void global_motion_estimation(PictureParentControlSet *pcs_ptr, MeContext *conte
         if (context_ptr->gm_identiy_exit) {
             if (list_index == 0) {
                 if (pcs_ptr->global_motion_estimation[0][0].wmtype == IDENTITY) {
+#if !IMPROVE_GMV
                     pcs_ptr->global_motion_estimation[1][0].wmtype = IDENTITY;
+#endif
                     break;
                 }
             }
         }
 #endif
     }
+#if IMPROVE_GMV
+    for (uint32_t list_index = REF_LIST_0; list_index <= num_of_list_to_search; ++list_index) {
+        uint32_t num_of_ref_pic_to_search = pcs_ptr->slice_type == P_SLICE
+            ? pcs_ptr->ref_list0_count
+            : list_index == REF_LIST_0
+            ? pcs_ptr->ref_list0_count
+            : pcs_ptr->ref_list1_count;
+
+        // Ref Picture Loop
+        for (uint32_t ref_pic_index = 0; ref_pic_index < num_of_ref_pic_to_search;
+            ++ref_pic_index) {
+            pcs_ptr->is_global_motion[list_index][ref_pic_index] = EB_FALSE;
+            if (pcs_ptr->global_motion_estimation[list_index][ref_pic_index].wmtype >
+                TRANSLATION)
+                pcs_ptr->is_global_motion[list_index][ref_pic_index] = EB_TRUE;
+        }
+    }
+#endif
 }
 
 static INLINE int convert_to_trans_prec(int allow_hp, int coor) {

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -39,6 +39,7 @@ typedef struct InitialRateControlContext {
 /**************************************
 * Macros
 **************************************/
+#if !IMPROVE_GMV
 #define PAN_SB_PERCENTAGE 75
 #define LOW_AMPLITUDE_TH 16
 
@@ -423,7 +424,7 @@ void detect_global_motion(PictureParentControlSet *pcs_ptr) {
         }
     }
 }
-
+#endif
 static void initial_rate_control_context_dctor(EbPtr p) {
     EbThreadContext *          thread_context_ptr = (EbThreadContext *)p;
     InitialRateControlContext *obj = (InitialRateControlContext *)thread_context_ptr->priv;
@@ -483,6 +484,7 @@ void release_pa_reference_objects(SequenceControlSet *scs_ptr, PictureParentCont
 
     return;
 }
+#if !IMPROVE_GMV
 
 /************************************************
 * Global Motion Detection Based on ME information
@@ -550,6 +552,7 @@ void update_global_motion_detection_over_time(EncodeContext *          encode_co
     }
     return;
 }
+#endif
 
 /************************************************
 * Update BEA Information Based on Lookahead
@@ -2025,9 +2028,11 @@ void *initial_rate_control_kernel(void *input_ptr) {
             SequenceControlSet *scs_ptr = (SequenceControlSet *)
                                               pcs_ptr->scs_wrapper_ptr->object_ptr;
             EncodeContext *encode_context_ptr = (EncodeContext *)scs_ptr->encode_context_ptr;
+#if !IMPROVE_GMV
             // Mark picture when global motion is detected using ME results
             //reset intra_coded_estimation_sb
             me_based_global_motion_detection(pcs_ptr);
+#endif
 #if TPL_LA
             if (scs_ptr->static_config.look_ahead_distance == 0 || scs_ptr->static_config.enable_tpl_la == 0) {
                 // Release Pa Ref pictures when not needed
@@ -2217,7 +2222,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                                     scs_ptr, encode_context_ptr, pcs_ptr, frames_in_sw);
                             }
                         }
-
+#if !IMPROVE_GMV
                         // Mark each input picture as PAN or not
                         // If a lookahead is present then check PAN for a period of time
                         if (!pcs_ptr->end_of_sequence_flag &&
@@ -2228,7 +2233,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                         } else {
                             if (pcs_ptr->slice_type != I_SLICE) detect_global_motion(pcs_ptr);
                         }
-
+#endif
                         // BACKGROUND ENHANCEMENT Part II
                         if (!pcs_ptr->end_of_sequence_flag &&
                             scs_ptr->static_config.look_ahead_distance != 0) {

--- a/Source/Lib/Encoder/Codec/EbMdRateEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMdRateEstimation.c
@@ -680,14 +680,14 @@ static void update_mv_component_stats(int comp, NmvComponent *mvcomp, MvSubpelPr
     }
 }
 
-MvJointType av1_get_mv_joint(const MV *mv);
+MvJointType svt_av1_get_mv_joint(const MV *mv);
 /*******************************************************************************
  * Updates all the mv stats/CDF for the current block
  ******************************************************************************/
 static void av1_update_mv_stats(const MV *mv, const MV *ref, NmvContext *mvctx,
                                 MvSubpelPrecision precision) {
     const MV          diff = {mv->row - ref->row, mv->col - ref->col};
-    const MvJointType j    = av1_get_mv_joint(&diff);
+    const MvJointType j    = svt_av1_get_mv_joint(&diff);
 
     update_cdf(mvctx->joints_cdf, j, MV_JOINTS);
 

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -30,7 +30,9 @@
 #include "aom_dsp_rtcd.h"
 #include "EbLog.h"
 #include "EbResize.h"
-
+#if UPGRADE_SUBPEL
+#include "mcomp.h"
+#endif
 #define INCRMENT_CAND_TOTAL_COUNT(cnt)                                                     \
     MULTI_LINE_MACRO_BEGIN cnt++;                                                          \
     if (cnt >= MODE_DECISION_CANDIDATE_MAX_COUNT_Y)                                          \
@@ -4183,6 +4185,313 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
     // update the total number of candidates injected
     (*candidate_total_cnt) = cand_total_cnt;
 }
+#if IMPROVE_GMV
+void inject_global_candidates(const SequenceControlSet *  scs_ptr,
+    struct ModeDecisionContext *context_ptr, PictureControlSet *pcs_ptr,
+    EbBool is_compound_enabled, EbBool allow_bipred, uint32_t *candidate_total_cnt) {
+
+    ModeDecisionCandidate *cand_array = context_ptr->fast_candidate_array;
+    uint32_t cand_total_cnt = (*candidate_total_cnt);
+    MD_COMP_TYPE cur_type;
+    MD_COMP_TYPE tot_comp_types = context_ptr->compound_types_to_try;
+    uint8_t inj_mv;
+    int inside_tile = 1;
+    MacroBlockD *xd = context_ptr->blk_ptr->av1xd;
+    int umv0tile = (scs_ptr->static_config.unrestricted_motion_vector == 0);
+    uint32_t  mi_row = context_ptr->blk_origin_y >> MI_SIZE_LOG2;
+    uint32_t  mi_col = context_ptr->blk_origin_x >> MI_SIZE_LOG2;
+    BlockSize bsize = context_ptr->blk_geom->bsize; // bloc size
+
+    for (uint32_t ref_it = 0; ref_it < pcs_ptr->parent_pcs_ptr->tot_ref_frame_types; ++ref_it) {
+
+        MvReferenceFrame ref_pair = pcs_ptr->parent_pcs_ptr->ref_frame_type_arr[ref_it];
+        MvReferenceFrame rf[2];
+        av1_set_ref_frame(rf, ref_pair);
+
+        //single ref/list
+        if (rf[1] == NONE_FRAME) {
+            MvReferenceFrame frame_type = rf[0];
+            uint8_t          list_idx = get_list_idx(rf[0]);
+            uint8_t          ref_idx = get_ref_frame_idx(rf[0]);
+
+
+            if (!is_valid_unipred_ref(context_ptr, GLOBAL_GROUP, list_idx, ref_idx)) continue;
+
+            if (ref_idx > context_ptr->md_max_ref_count - 1)
+                continue;
+
+            // Get gm params
+            EbWarpedMotionParams *gm_params = &pcs_ptr->parent_pcs_ptr->global_motion[frame_type];
+
+            IntMv mv = gm_get_motion_vector_enc(
+                gm_params,
+                pcs_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv,
+                context_ptr->blk_geom->bsize,
+                mi_col,
+                mi_row,
+                0 /* force_integer_mv */);
+
+            int16_t to_inject_mv_x = mv.as_mv.col;
+            int16_t to_inject_mv_y = mv.as_mv.row;
+
+            inj_mv = 1; // Always test GLOBAL even if MV already injected as rate diff might be significant
+            if (umv0tile)
+                inside_tile = is_inside_tile_boundary(&(xd->tile),
+                    to_inject_mv_x,
+                    to_inject_mv_y,
+                    mi_col,
+                    mi_row,
+                    context_ptr->blk_geom->bsize);
+
+            inj_mv = inj_mv && inside_tile;
+
+            if (inj_mv && (((gm_params->wmtype > TRANSLATION && context_ptr->blk_geom->bwidth >= 8 && context_ptr->blk_geom->bheight >= 8) || gm_params->wmtype <= TRANSLATION))) {
+
+                uint8_t inter_type;
+                uint8_t is_ii_allowed = svt_is_interintra_allowed(
+                    context_ptr->md_enable_inter_intra, bsize, GLOBALMV, rf);
+
+                uint8_t tot_inter_types = is_ii_allowed ? II_COUNT : 1;
+
+                for (inter_type = 0; inter_type < tot_inter_types; inter_type++) {
+                    cand_array[cand_total_cnt].type = INTER_MODE;
+
+                    cand_array[cand_total_cnt].inter_mode = GLOBALMV;
+                    cand_array[cand_total_cnt].pred_mode = GLOBALMV;
+                    cand_array[cand_total_cnt].motion_mode = gm_params->wmtype > TRANSLATION
+                        ? WARPED_CAUSAL
+                        : SIMPLE_TRANSLATION;
+
+                    cand_array[cand_total_cnt].wm_params_l0 = *gm_params;
+                    cand_array[cand_total_cnt].wm_params_l1 = *gm_params;
+
+                    cand_array[cand_total_cnt].is_compound = 0;
+                    cand_array[cand_total_cnt].distortion_ready = 0;
+                    cand_array[cand_total_cnt].use_intrabc = 0;
+                    cand_array[cand_total_cnt].merge_flag = EB_FALSE;
+                    cand_array[cand_total_cnt].prediction_direction[0] = list_idx;
+                    cand_array[cand_total_cnt].is_new_mv = 0;
+                    if (list_idx == 0) {
+                        cand_array[cand_total_cnt].motion_vector_xl0 = to_inject_mv_x;
+                        cand_array[cand_total_cnt].motion_vector_yl0 = to_inject_mv_y;
+                        context_ptr->injected_mv_x_l0_array[context_ptr->injected_mv_count_l0] =
+                            to_inject_mv_x;
+                        context_ptr->injected_mv_y_l0_array[context_ptr->injected_mv_count_l0] =
+                            to_inject_mv_y;
+                        context_ptr->injected_ref_type_l0_array[context_ptr->injected_mv_count_l0] =
+                            frame_type;
+                        ++context_ptr->injected_mv_count_l0;
+                    }
+                    else {
+                        cand_array[cand_total_cnt].motion_vector_xl1 = to_inject_mv_x;
+                        cand_array[cand_total_cnt].motion_vector_yl1 = to_inject_mv_y;
+                        context_ptr->injected_mv_x_l1_array[context_ptr->injected_mv_count_l1] =
+                            to_inject_mv_x;
+                        context_ptr->injected_mv_y_l1_array[context_ptr->injected_mv_count_l1] =
+                            to_inject_mv_y;
+                        context_ptr->injected_ref_type_l1_array[context_ptr->injected_mv_count_l1] =
+                            frame_type;
+                        ++context_ptr->injected_mv_count_l1;
+                    }
+
+                    cand_array[cand_total_cnt].drl_index = 0;
+                    cand_array[cand_total_cnt].ref_mv_index = 0;
+
+                    cand_array[cand_total_cnt].ref_frame_type = frame_type;
+                    cand_array[cand_total_cnt].ref_frame_index_l0 = (list_idx == 0) ? ref_idx : -1;
+                    cand_array[cand_total_cnt].ref_frame_index_l1 = (list_idx == 1) ? ref_idx : -1;
+                    cand_array[cand_total_cnt].transform_type[0] = DCT_DCT;
+                    cand_array[cand_total_cnt].transform_type_uv = DCT_DCT;
+                    if (inter_type == 0) {
+                        cand_array[cand_total_cnt].is_interintra_used = 0;
+                    }
+                    else {
+                        if (is_ii_allowed) {
+                            if (inter_type == 1) {
+                                inter_intra_search(
+                                    pcs_ptr, context_ptr, &cand_array[cand_total_cnt]);
+                                cand_array[cand_total_cnt].is_interintra_used = 1;
+                                cand_array[cand_total_cnt].use_wedge_interintra = 1;
+
+                            }
+                            else if (inter_type == 2) {
+                                cand_array[cand_total_cnt].is_interintra_used = 1;
+                                cand_array[cand_total_cnt].interintra_mode =
+                                    cand_array[cand_total_cnt - 1].interintra_mode;
+                                cand_array[cand_total_cnt].use_wedge_interintra = 0;
+                            }
+                        }
+                    }
+                    INCRMENT_CAND_TOTAL_COUNT(cand_total_cnt);
+                }
+                if (list_idx == 0) {
+                    cand_array[cand_total_cnt].motion_vector_xl0 = to_inject_mv_x;
+                    cand_array[cand_total_cnt].motion_vector_yl0 = to_inject_mv_y;
+                    context_ptr->injected_mv_x_l0_array[context_ptr->injected_mv_count_l0] =
+                        to_inject_mv_x;
+                    context_ptr->injected_mv_y_l0_array[context_ptr->injected_mv_count_l0] =
+                        to_inject_mv_y;
+                    context_ptr->injected_ref_type_l0_array[context_ptr->injected_mv_count_l0] =
+                        frame_type;
+                    ++context_ptr->injected_mv_count_l0;
+                }
+                else {
+                    cand_array[cand_total_cnt].motion_vector_xl1 = to_inject_mv_x;
+                    cand_array[cand_total_cnt].motion_vector_yl1 = to_inject_mv_y;
+                    context_ptr->injected_mv_x_l1_array[context_ptr->injected_mv_count_l1] =
+                        to_inject_mv_x;
+                    context_ptr->injected_mv_y_l1_array[context_ptr->injected_mv_count_l1] =
+                        to_inject_mv_y;
+                    context_ptr->injected_ref_type_l1_array[context_ptr->injected_mv_count_l1] =
+                        frame_type;
+                    ++context_ptr->injected_mv_count_l1;
+                }
+            }
+        }
+        else if (is_compound_enabled && allow_bipred) {
+
+            uint8_t ref_idx_0 = get_ref_frame_idx(rf[0]);
+            uint8_t ref_idx_1 = get_ref_frame_idx(rf[1]);
+            uint8_t list_idx_0 = get_list_idx(rf[0]);
+            uint8_t list_idx_1 = get_list_idx(rf[1]);
+
+            if (!is_valid_bipred_ref(
+                context_ptr, GLOBAL_GROUP, list_idx_0, ref_idx_0, list_idx_1, ref_idx_1)) return;
+
+            if (ref_idx_0 > context_ptr->md_max_ref_count - 1 ||
+                ref_idx_1 > context_ptr->md_max_ref_count - 1)
+                return;
+
+            // Get gm params
+            EbWarpedMotionParams *gm_params_0 =
+                &pcs_ptr->parent_pcs_ptr->global_motion[svt_get_ref_frame_type(
+                    list_idx_0, ref_idx_0)];
+
+            EbWarpedMotionParams *gm_params_1 =
+                &pcs_ptr->parent_pcs_ptr->global_motion[svt_get_ref_frame_type(
+                    list_idx_1, ref_idx_1)];
+
+            IntMv mv_0 = gm_get_motion_vector_enc(
+                gm_params_0,
+                pcs_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv,
+                context_ptr->blk_geom->bsize,
+                mi_col,
+                mi_row,
+                0 /* force_integer_mv */);
+
+            int16_t to_inject_mv_x_l0 = mv_0.as_mv.col;
+            int16_t to_inject_mv_y_l0 = mv_0.as_mv.row;
+
+            IntMv mv_1 = gm_get_motion_vector_enc(
+                gm_params_1,
+                pcs_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv,
+                context_ptr->blk_geom->bsize,
+                mi_col,
+                mi_row,
+                0 /* force_integer_mv */);
+
+            int16_t to_inject_mv_x_l1 = mv_1.as_mv.col;
+            int16_t to_inject_mv_y_l1 = mv_1.as_mv.row;
+
+            inj_mv = 1; // Always test GLOBAL-GLOBAL even if MV already injected as rate diff might be significant
+            if (umv0tile) {
+                inside_tile = is_inside_tile_boundary(&(xd->tile),
+                    to_inject_mv_x_l0,
+                    to_inject_mv_y_l0,
+                    mi_col,
+                    mi_row,
+                    context_ptr->blk_geom->bsize) &&
+                    is_inside_tile_boundary(&(xd->tile),
+                        to_inject_mv_x_l1,
+                        to_inject_mv_y_l1,
+                        mi_col,
+                        mi_row,
+                        context_ptr->blk_geom->bsize);
+            }
+
+            inj_mv = inj_mv && inside_tile;
+
+            if (inj_mv && gm_params_0->wmtype > TRANSLATION && gm_params_1->wmtype > TRANSLATION) {
+                uint8_t to_inject_ref_type = av1_ref_frame_type(rf);
+
+                // Warped prediction is only compatible with MD_COMP_AVG and MD_COMP_DIST.
+                for (cur_type = MD_COMP_AVG;
+                    cur_type <= MIN(MD_COMP_DIST, tot_comp_types);
+                    cur_type++) {
+                    cand_array[cand_total_cnt].type = INTER_MODE;
+                    cand_array[cand_total_cnt].distortion_ready = 0;
+                    cand_array[cand_total_cnt].use_intrabc = 0;
+
+                    cand_array[cand_total_cnt].merge_flag = EB_FALSE;
+
+                    cand_array[cand_total_cnt].prediction_direction[0] = BI_PRED;
+
+                    cand_array[cand_total_cnt].inter_mode = GLOBAL_GLOBALMV;
+                    cand_array[cand_total_cnt].pred_mode = GLOBAL_GLOBALMV;
+                    cand_array[cand_total_cnt].motion_mode =
+                        gm_params_0->wmtype > TRANSLATION ? WARPED_CAUSAL
+                        : SIMPLE_TRANSLATION;
+                    cand_array[cand_total_cnt].wm_params_l0 = *gm_params_0;
+                    cand_array[cand_total_cnt].wm_params_l1 = *gm_params_1;
+                    cand_array[cand_total_cnt].is_compound = 1;
+                    cand_array[cand_total_cnt].is_interintra_used = 0;
+                    cand_array[cand_total_cnt].is_new_mv = 0;
+                    cand_array[cand_total_cnt].drl_index = 0;
+                    // will be needed later by the rate estimation
+                    cand_array[cand_total_cnt].ref_mv_index = 0;
+                    cand_array[cand_total_cnt].ref_frame_type = to_inject_ref_type;
+                    cand_array[cand_total_cnt].ref_frame_index_l0 = ref_idx_0;
+                    cand_array[cand_total_cnt].ref_frame_index_l1 = ref_idx_1;
+                    cand_array[cand_total_cnt].transform_type[0] = DCT_DCT;
+                    cand_array[cand_total_cnt].transform_type_uv = DCT_DCT;
+                    // Set the MV to frame MV
+
+                    cand_array[cand_total_cnt].motion_vector_xl0 =
+                        to_inject_mv_x_l0;
+                    cand_array[cand_total_cnt].motion_vector_yl0 =
+                        to_inject_mv_y_l0;
+                    cand_array[cand_total_cnt].motion_vector_xl1 =
+                        to_inject_mv_x_l1;
+                    cand_array[cand_total_cnt].motion_vector_yl1 =
+                        to_inject_mv_y_l1;
+                    //GLOB-GLOB
+#if INTER_COMP_REDESIGN
+                    if (cur_type == MD_COMP_AVG && tot_comp_types > MD_COMP_AVG)
+                        calc_pred_masked_compound(
+                            pcs_ptr, context_ptr, &cand_array[cand_total_cnt]);
+
+                    if (context_ptr->inter_comp_ctrls.similar_predictions)
+                        if (cur_type > MD_COMP_AVG &&
+                            context_ptr->prediction_mse <=
+                            context_ptr->inter_comp_ctrls.similar_predictions_th)
+                            continue;
+
+#endif
+                    determine_compound_mode(pcs_ptr,
+                        context_ptr,
+                        &cand_array[cand_total_cnt],
+                        cur_type);
+                    INCRMENT_CAND_TOTAL_COUNT(cand_total_cnt);
+                }
+                context_ptr->injected_mv_x_bipred_l0_array
+                    [context_ptr->injected_mv_count_bipred] = to_inject_mv_x_l0;
+                context_ptr->injected_mv_y_bipred_l0_array
+                    [context_ptr->injected_mv_count_bipred] = to_inject_mv_y_l0;
+                context_ptr->injected_mv_x_bipred_l1_array
+                    [context_ptr->injected_mv_count_bipred] = to_inject_mv_x_l1;
+                context_ptr->injected_mv_y_bipred_l1_array
+                    [context_ptr->injected_mv_count_bipred] = to_inject_mv_y_l1;
+                context_ptr->injected_ref_type_bipred_array
+                    [context_ptr->injected_mv_count_bipred] =
+                    to_inject_ref_type;
+                ++context_ptr->injected_mv_count_bipred;
+            }
+        }
+    }
+    // update the total number of candidates injected
+    (*candidate_total_cnt) = cand_total_cnt;
+}
+#endif
 #if INTER_COMP_REDESIGN
 uint8_t is_reference_best_pme(ModeDecisionContext *context_ptr, uint8_t list_index,
     uint8_t ref_index, uint8_t best_x_reference){
@@ -4224,8 +4533,306 @@ void inject_predictive_me_candidates(
     if (context_ptr->source_variance < context_ptr->inter_comp_ctrls.wedge_variance_th)
         tot_comp_types = MIN(tot_comp_types, MD_COMP_DIFF0);
 #endif
+#if UPGRADE_SUBPEL
 #if INCREASE_WM_CANDS
     Mv mv;
+    MvUnit mv_unit;
+#endif
+    for (uint32_t ref_it = 0; ref_it < pcs_ptr->parent_pcs_ptr->tot_ref_frame_types; ++ref_it) {
+        MvReferenceFrame ref_pair = pcs_ptr->parent_pcs_ptr->ref_frame_type_arr[ref_it];
+        MvReferenceFrame rf[2];
+        av1_set_ref_frame(rf, ref_pair);
+
+        //single ref/list
+        if (rf[1] == NONE_FRAME) {
+            MvReferenceFrame frame_type = rf[0];
+            uint8_t          list_idx = get_list_idx(rf[0]);
+            uint8_t          ref_idx = get_ref_frame_idx(rf[0]);
+
+            if (context_ptr->valid_pme_mv[list_idx][ref_idx]) {
+                int16_t to_inject_mv_x = context_ptr->best_pme_mv[list_idx][ref_idx][0];
+                int16_t to_inject_mv_y = context_ptr->best_pme_mv[list_idx][ref_idx][1];
+
+                uint8_t inj_mv =
+                    list_idx == 0
+                    ? context_ptr->injected_mv_count_l0 == 0 ||
+                    mrp_is_already_injected_mv_l0(
+                        context_ptr, to_inject_mv_x, to_inject_mv_y, frame_type) ==
+                    EB_FALSE
+                    : context_ptr->injected_mv_count_l1 == 0 ||
+                    mrp_is_already_injected_mv_l1(
+                        context_ptr, to_inject_mv_x, to_inject_mv_y, frame_type) ==
+                    EB_FALSE;
+
+                if (inj_mv) {
+                    uint8_t inter_type;
+                    uint8_t is_ii_allowed = svt_is_interintra_allowed(
+                        context_ptr->md_enable_inter_intra == 1, bsize, NEWMV, rf);
+
+                    if (context_ptr->md_enable_inter_intra > 2)
+                        if (is_reference_best_pme(context_ptr, list_idx, ref_idx, 1) == 0)
+                            is_ii_allowed = 0;
+                    uint8_t tot_inter_types = is_ii_allowed ? II_COUNT : 1;
+                    uint8_t is_obmc_allowed =
+                        obmc_motion_mode_allowed(
+                            pcs_ptr, context_ptr, bsize, rf[0], rf[1], NEWMV) == OBMC_CAUSAL;
+
+                    if (context_ptr->obmc_ctrls.pme_best_ref)
+                        if (context_ptr->pme_res[0][0].list_i != list_idx ||
+                            context_ptr->pme_res[0][0].ref_i != ref_idx)
+                            is_obmc_allowed = 0;
+#if INCREASE_WM_CANDS
+                    uint8_t is_warp_allowed = warped_motion_mode_allowed(pcs_ptr, context_ptr);
+                    tot_inter_types = is_warp_allowed ? tot_inter_types + 1 : tot_inter_types;
+#endif
+                    tot_inter_types = is_obmc_allowed ? tot_inter_types + 1 : tot_inter_types;
+                    for (inter_type = 0; inter_type < tot_inter_types; inter_type++) {
+                        cand_array[cand_total_cnt].type = INTER_MODE;
+                        cand_array[cand_total_cnt].distortion_ready = 0;
+                        cand_array[cand_total_cnt].use_intrabc = 0;
+                        cand_array[cand_total_cnt].merge_flag = EB_FALSE;
+                        cand_array[cand_total_cnt].prediction_direction[0] = list_idx;
+                        cand_array[cand_total_cnt].inter_mode = NEWMV;
+                        cand_array[cand_total_cnt].pred_mode = NEWMV;
+                        cand_array[cand_total_cnt].motion_mode = SIMPLE_TRANSLATION;
+                        cand_array[cand_total_cnt].is_compound = 0;
+                        cand_array[cand_total_cnt].is_interintra_used = 0;
+                        cand_array[cand_total_cnt].is_new_mv = 1;
+                        cand_array[cand_total_cnt].drl_index = 0;
+                        if (list_idx == 0) {
+                            cand_array[cand_total_cnt].motion_vector_xl0 = to_inject_mv_x;
+                            cand_array[cand_total_cnt].motion_vector_yl0 = to_inject_mv_y;
+                            context_ptr->injected_mv_x_l0_array[context_ptr->injected_mv_count_l0] =
+                                to_inject_mv_x;
+                            context_ptr->injected_mv_y_l0_array[context_ptr->injected_mv_count_l0] =
+                                to_inject_mv_y;
+                            context_ptr
+                                ->injected_ref_type_l0_array[context_ptr->injected_mv_count_l0] =
+                                frame_type;
+                            ++context_ptr->injected_mv_count_l0;
+                        }
+                        else {
+                            cand_array[cand_total_cnt].motion_vector_xl1 = to_inject_mv_x;
+                            cand_array[cand_total_cnt].motion_vector_yl1 = to_inject_mv_y;
+                            context_ptr->injected_mv_x_l1_array[context_ptr->injected_mv_count_l1] =
+                                to_inject_mv_x;
+                            context_ptr->injected_mv_y_l1_array[context_ptr->injected_mv_count_l1] =
+                                to_inject_mv_y;
+                            context_ptr
+                                ->injected_ref_type_l1_array[context_ptr->injected_mv_count_l1] =
+                                frame_type;
+                            ++context_ptr->injected_mv_count_l1;
+                        }
+                        cand_array[cand_total_cnt].ref_mv_index = 0;
+                        cand_array[cand_total_cnt].ref_frame_type = frame_type;
+                        cand_array[cand_total_cnt].ref_frame_index_l0 =
+                            (list_idx == 0) ? ref_idx : -1;
+                        cand_array[cand_total_cnt].ref_frame_index_l1 =
+                            (list_idx == 1) ? ref_idx : -1;
+                        cand_array[cand_total_cnt].transform_type[0] = DCT_DCT;
+                        cand_array[cand_total_cnt].transform_type_uv = DCT_DCT;
+
+                        choose_best_av1_mv_pred(
+                            context_ptr,
+                            cand_array[cand_total_cnt].md_rate_estimation_ptr,
+                            context_ptr->blk_ptr,
+                            cand_array[cand_total_cnt].ref_frame_type,
+                            cand_array[cand_total_cnt].is_compound,
+                            cand_array[cand_total_cnt].pred_mode,
+                            list_idx == 0 ? cand_array[cand_total_cnt].motion_vector_xl0
+                            : cand_array[cand_total_cnt].motion_vector_xl1,
+                            list_idx == 0 ? cand_array[cand_total_cnt].motion_vector_yl0
+                            : cand_array[cand_total_cnt].motion_vector_yl1,
+                            0,
+                            0,
+                            &cand_array[cand_total_cnt].drl_index,
+                            best_pred_mv);
+
+                        cand_array[cand_total_cnt].motion_vector_pred_x[list_idx] =
+                            best_pred_mv[0].as_mv.col;
+                        cand_array[cand_total_cnt].motion_vector_pred_y[list_idx] =
+                            best_pred_mv[0].as_mv.row;
+                        if (inter_type == 0) {
+                            cand_array[cand_total_cnt].is_interintra_used = 0;
+                            cand_array[cand_total_cnt].motion_mode = SIMPLE_TRANSLATION;
+                        }
+                        else {
+#if INCREASE_WM_CANDS
+                            if (is_warp_allowed && inter_type == (tot_inter_types - (1 + is_obmc_allowed))) {
+                                cand_array[cand_total_cnt].is_interintra_used = 0;
+                                cand_array[cand_total_cnt].motion_mode = WARPED_CAUSAL;
+                                cand_array[cand_total_cnt].wm_params_l0.wmtype = AFFINE;
+
+                                mv.x = to_inject_mv_x;
+                                mv.y = to_inject_mv_y;
+                                mv_unit.mv[list_idx] = mv;
+                                mv_unit.pred_direction = cand_array[cand_total_cnt].prediction_direction[0];
+                                cand_array[cand_total_cnt].local_warp_valid = warped_motion_parameters(
+                                    pcs_ptr,
+                                    context_ptr->blk_ptr,
+                                    &mv_unit,
+                                    context_ptr->blk_geom,
+                                    context_ptr->blk_origin_x,
+                                    context_ptr->blk_origin_y,
+                                    cand_array[cand_total_cnt].ref_frame_type,
+                                    &cand_array[cand_total_cnt].wm_params_l0,
+                                    &cand_array[cand_total_cnt].num_proj_ref);
+                            }
+#endif
+                            if (is_obmc_allowed && inter_type == tot_inter_types - 1) {
+                                cand_array[cand_total_cnt].is_interintra_used = 0;
+                                cand_array[cand_total_cnt].motion_mode = OBMC_CAUSAL;
+
+                                obmc_motion_refinement(
+                                    pcs_ptr, context_ptr, &cand_array[cand_total_cnt], list_idx);
+                            }
+                        }
+#if INCREASE_WM_CANDS
+                        if (!(is_warp_allowed && inter_type == (tot_inter_types - (1 + is_obmc_allowed))))
+                            INCRMENT_CAND_TOTAL_COUNT(cand_total_cnt);
+                        else if (cand_array[cand_total_cnt].local_warp_valid)
+                            INCRMENT_CAND_TOTAL_COUNT(cand_total_cnt);
+#else
+                        INCRMENT_CAND_TOTAL_COUNT(cand_total_cnt);
+#endif
+                    }
+                }
+            }
+        }
+
+        else if (is_compound_enabled && allow_bipred) {
+            uint8_t ref_idx_0 = get_ref_frame_idx(rf[0]);
+            uint8_t ref_idx_1 = get_ref_frame_idx(rf[1]);
+            uint8_t list_idx_0 = get_list_idx(rf[0]);
+            uint8_t list_idx_1 = get_list_idx(rf[1]);
+
+            if (context_ptr->valid_pme_mv[list_idx_0][ref_idx_0] &&
+                context_ptr->valid_pme_mv[list_idx_1][ref_idx_1]) {
+
+                int16_t to_inject_mv_x_l0 =
+                    context_ptr->best_pme_mv[list_idx_0][ref_idx_0][0];
+                int16_t to_inject_mv_y_l0 =
+                    context_ptr->best_pme_mv[list_idx_0][ref_idx_0][1];
+                int16_t to_inject_mv_x_l1 =
+                    context_ptr->best_pme_mv[list_idx_1][ref_idx_1][0];
+                int16_t to_inject_mv_y_l1 =
+                    context_ptr->best_pme_mv[list_idx_1][ref_idx_1][1];
+
+                MvReferenceFrame rf[2];
+                rf[0] = svt_get_ref_frame_type(list_idx_0, ref_idx_0);
+                rf[1] = svt_get_ref_frame_type(list_idx_1, ref_idx_1);
+                uint8_t to_inject_ref_type = av1_ref_frame_type(rf);
+                if (context_ptr->injected_mv_count_bipred == 0 ||
+                    mrp_is_already_injected_mv_bipred(context_ptr,
+                        to_inject_mv_x_l0,
+                        to_inject_mv_y_l0,
+                        to_inject_mv_x_l1,
+                        to_inject_mv_y_l1,
+                        to_inject_ref_type) == EB_FALSE) {
+                    if (context_ptr->inter_comp_ctrls.mrp_pruning_w_distortion)
+
+                        if (is_reference_best_pme(context_ptr, list_idx_0, ref_idx_0, 2) == 0 ||
+                            is_reference_best_pme(context_ptr, list_idx_1, ref_idx_1, 2) == 0)
+                            tot_comp_types = MD_COMP_AVG;
+
+                    for (MD_COMP_TYPE cur_type = MD_COMP_AVG; cur_type <= tot_comp_types; cur_type++) {
+
+                        // If two predictors are very similar, skip wedge compound mode search
+                        if (cur_type == MD_COMP_WEDGE &&
+                            context_ptr->inter_comp_ctrls.similar_predictions)
+                            if (context_ptr->prediction_mse < 8)
+                                continue;
+
+                        cand_array[cand_total_cnt].type = INTER_MODE;
+                        cand_array[cand_total_cnt].distortion_ready = 0;
+                        cand_array[cand_total_cnt].use_intrabc = 0;
+                        cand_array[cand_total_cnt].merge_flag = EB_FALSE;
+                        cand_array[cand_total_cnt].is_new_mv = 1;
+                        cand_array[cand_total_cnt].drl_index = 0;
+                        // Set the MV to ME result
+                        cand_array[cand_total_cnt].motion_vector_xl0 = to_inject_mv_x_l0;
+                        cand_array[cand_total_cnt].motion_vector_yl0 = to_inject_mv_y_l0;
+                        cand_array[cand_total_cnt].motion_vector_xl1 = to_inject_mv_x_l1;
+                        cand_array[cand_total_cnt].motion_vector_yl1 = to_inject_mv_y_l1;
+                        // will be needed later by the rate estimation
+                        cand_array[cand_total_cnt].ref_mv_index = 0;
+                        cand_array[cand_total_cnt].inter_mode = NEW_NEWMV;
+                        cand_array[cand_total_cnt].pred_mode = NEW_NEWMV;
+                        cand_array[cand_total_cnt].motion_mode = SIMPLE_TRANSLATION;
+                        cand_array[cand_total_cnt].is_compound = 1;
+                        cand_array[cand_total_cnt].is_interintra_used = 0;
+                        cand_array[cand_total_cnt].prediction_direction[0] = BI_PRED;
+
+                        MvReferenceFrame rf[2];
+                        rf[0] = svt_get_ref_frame_type(list_idx_0, ref_idx_0);
+                        rf[1] = svt_get_ref_frame_type(list_idx_1, ref_idx_1);
+                        cand_array[cand_total_cnt].ref_frame_type = av1_ref_frame_type(rf);
+                        cand_array[cand_total_cnt].ref_frame_index_l0 = ref_idx_0;
+                        cand_array[cand_total_cnt].ref_frame_index_l1 = ref_idx_1;
+
+                        cand_array[cand_total_cnt].transform_type[0] = DCT_DCT;
+                        cand_array[cand_total_cnt].transform_type_uv = DCT_DCT;
+
+                        choose_best_av1_mv_pred(context_ptr,
+                            cand_array[cand_total_cnt].md_rate_estimation_ptr,
+                            context_ptr->blk_ptr,
+                            cand_array[cand_total_cnt].ref_frame_type,
+                            cand_array[cand_total_cnt].is_compound,
+                            cand_array[cand_total_cnt].pred_mode,
+                            cand_array[cand_total_cnt].motion_vector_xl0,
+                            cand_array[cand_total_cnt].motion_vector_yl0,
+                            cand_array[cand_total_cnt].motion_vector_xl1,
+                            cand_array[cand_total_cnt].motion_vector_yl1,
+                            &cand_array[cand_total_cnt].drl_index,
+                            best_pred_mv);
+
+                        cand_array[cand_total_cnt].motion_vector_pred_x[REF_LIST_0] =
+                            best_pred_mv[0].as_mv.col;
+                        cand_array[cand_total_cnt].motion_vector_pred_y[REF_LIST_0] =
+                            best_pred_mv[0].as_mv.row;
+                        cand_array[cand_total_cnt].motion_vector_pred_x[REF_LIST_1] =
+                            best_pred_mv[1].as_mv.col;
+                        cand_array[cand_total_cnt].motion_vector_pred_y[REF_LIST_1] =
+                            best_pred_mv[1].as_mv.row;
+
+                        //MVP REFINE
+                        if (cur_type == MD_COMP_AVG && tot_comp_types > MD_COMP_AVG)
+                            calc_pred_masked_compound(
+                                pcs_ptr, context_ptr, &cand_array[cand_total_cnt]);
+
+                        if (context_ptr->inter_comp_ctrls.similar_predictions)
+                            if (cur_type > MD_COMP_AVG &&
+                                context_ptr->prediction_mse <=
+                                context_ptr->inter_comp_ctrls.similar_predictions_th)
+                                continue;
+
+                        determine_compound_mode(
+                            pcs_ptr, context_ptr, &cand_array[cand_total_cnt], cur_type);
+                        INCRMENT_CAND_TOTAL_COUNT(cand_total_cnt);
+                        context_ptr
+                            ->injected_mv_x_bipred_l0_array[context_ptr->injected_mv_count_bipred] =
+                            to_inject_mv_x_l0;
+                        context_ptr
+                            ->injected_mv_y_bipred_l0_array[context_ptr->injected_mv_count_bipred] =
+                            to_inject_mv_y_l0;
+                        context_ptr
+                            ->injected_mv_x_bipred_l1_array[context_ptr->injected_mv_count_bipred] =
+                            to_inject_mv_x_l1;
+                        context_ptr
+                            ->injected_mv_y_bipred_l1_array[context_ptr->injected_mv_count_bipred] =
+                            to_inject_mv_y_l1;
+
+                        context_ptr->injected_ref_type_bipred_array
+                            [context_ptr->injected_mv_count_bipred] = to_inject_ref_type;
+                        ++context_ptr->injected_mv_count_bipred;
+                    }
+                }
+            }
+        }
+    }
+#else
+#if INCREASE_WM_CANDS
+    Mv mv_0;
     MvUnit mv_unit;
 #endif
     uint8_t list_index;
@@ -4696,7 +5303,7 @@ void inject_predictive_me_candidates(
                 }
             }
     }
-
+#endif
     (*candidate_total_cnt) = cand_total_cnt;
 }
 
@@ -4707,18 +5314,24 @@ void inject_inter_candidates(PictureControlSet *pcs_ptr, ModeDecisionContext *co
 
     FrameHeader *          frm_hdr        = &pcs_ptr->parent_pcs_ptr->frm_hdr;
     uint32_t               cand_total_cnt = *candidate_total_cnt;
+#if !IMPROVE_GMV
     ModeDecisionCandidate *cand_array     = context_ptr->fast_candidate_array;
+#endif
     EbBool       is_compound_enabled      = (frm_hdr->reference_mode == SINGLE_REFERENCE) ? 0 : 1;
+#if !IMPROVE_GMV
     MacroBlockD *xd                       = context_ptr->blk_ptr->av1xd;
     int          umv0tile = (scs_ptr->static_config.unrestricted_motion_vector == 0);
+#endif
     MeSbResults *me_results =
         pcs_ptr->parent_pcs_ptr->pa_me_data->me_results[context_ptr->me_sb_addr];
     EbBool allow_bipred = context_ptr->blk_geom->bwidth != 4 && context_ptr->blk_geom->bheight != 4;
+#if !IMPROVE_GMV
     BlockSize bsize     = context_ptr->blk_geom->bsize; // bloc size
 
     MD_COMP_TYPE tot_comp_types = context_ptr->compound_types_to_try;
     if (context_ptr->source_variance < context_ptr->inter_comp_ctrls.wedge_variance_th)
         tot_comp_types = MIN(tot_comp_types, MD_COMP_DIFF0);
+#endif
     uint32_t mi_row = context_ptr->blk_origin_y >> MI_SIZE_LOG2;
     uint32_t mi_col = context_ptr->blk_origin_x >> MI_SIZE_LOG2;
     eb_av1_count_overlappable_neighbors(
@@ -4769,6 +5382,14 @@ void inject_inter_candidates(PictureControlSet *pcs_ptr, ModeDecisionContext *co
                           context_ptr->me_block_offset,
                           &cand_total_cnt);
     if (context_ptr->global_mv_injection) {
+#if IMPROVE_GMV
+        inject_global_candidates(scs_ptr,
+            context_ptr,
+            pcs_ptr,
+            is_compound_enabled,
+            allow_bipred,
+            &cand_total_cnt);
+#else
         if (pcs_ptr->parent_pcs_ptr->gm_level <= GM_DOWN16) {
             for (unsigned list_ref_index_l0 = 0; list_ref_index_l0 < 1; ++list_ref_index_l0)
                 for (unsigned list_ref_index_l1 = 0; list_ref_index_l1 < 1; ++list_ref_index_l1) {
@@ -5173,6 +5794,7 @@ void inject_inter_candidates(PictureControlSet *pcs_ptr, ModeDecisionContext *co
                 }
             }
         }
+#endif
     }
 
     // Warped Motion
@@ -5596,7 +6218,21 @@ void intra_bc_search(PictureControlSet *pcs, ModeDecisionContext *context_ptr,
     for (int i = 0; i < 2; i++)
         for (int j = 0; j < 2; j++) free(x->hash_value_buffer[i][j]);
 }
+#if UPGRADE_SUBPEL
+void svt_init_mv_cost_params(MV_COST_PARAMS *mv_cost_params,
+    ModeDecisionContext *context_ptr,
+    const MV *ref_mv, uint8_t base_q_idx) {
 
+    mv_cost_params->ref_mv = ref_mv;
+    mv_cost_params->full_ref_mv = get_fullmv_from_mv(ref_mv);
+    mv_cost_params->mv_cost_type = MV_COST_ENTROPY;
+    mv_cost_params->error_per_bit = AOMMAX(context_ptr->full_lambda_md[EB_8_BIT_MD] >> RD_EPB_SHIFT, 1);
+    mv_cost_params->sad_per_bit = sad_per_bit16lut_8[base_q_idx];
+    mv_cost_params->mvjcost = context_ptr->md_rate_estimation_ptr->nmv_vec_cost;
+    mv_cost_params->mvcost[0] = context_ptr->md_rate_estimation_ptr->nmvcoststack[0];
+    mv_cost_params->mvcost[1] = context_ptr->md_rate_estimation_ptr->nmvcoststack[1];
+}
+#endif
 void inject_intra_bc_candidates(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
                                 const SequenceControlSet *scs_ptr, BlkStruct *blk_ptr,
                                 uint32_t *cand_cnt) {

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
@@ -36,7 +36,11 @@ extern "C" {
 #define DEPTH_ONE_STEP 21
 #define DEPTH_TWO_STEP 5
 #define DEPTH_THREE_STEP 1
+#if ADAPTIVE_ME_SEARCH || UPGRADE_SUBPEL
+#define MAX_MVP_CANIDATES 4
+#else
 #define PRED_ME_MAX_MVP_CANIDATES 4
+#endif
 #define PRED_ME_DEVIATION_TH 50
 #define PRED_ME_FULL_PEL_REF_WINDOW_WIDTH_15 15
 #define PRED_ME_FULL_PEL_REF_WINDOW_HEIGHT_15 15
@@ -167,7 +171,12 @@ typedef enum InterCandGroup {
     WARP_GROUP          = 4,
     NRST_NEAR_GROUP     = 5,
     PRED_ME_GROUP       = 6,
+#if IMPROVE_GMV
+    GLOBAL_GROUP        = 7,
+    TOT_INTER_GROUP     = 8,
+#else
     TOT_INTER_GROUP     = 7
+#endif
 } InterCandGroup;
 #endif
 #endif
@@ -242,7 +251,9 @@ typedef struct  InterCompoundControls {
 #endif
 #if MD_REFERENCE_MASKING
 typedef struct RefPruningControls {
+#if !REMOVE_USELESS_CODE
     uint8_t intra_to_inter_pruning_enabled; // 0: OFF; 1: use intra to inter distortion deviation to derive best_refs
+#endif
     uint8_t inter_to_inter_pruning_enabled; // 0: OFF; 1: use inter to inter distortion deviation to derive best_refs
 #if PRUNING_PER_INTER_TYPE
     uint8_t best_refs[TOT_INTER_GROUP];     // 0: OFF; 1: limit the injection to the best references based on distortion
@@ -252,6 +263,7 @@ typedef struct RefPruningControls {
 #endif
 }RefPruningControls;
 #endif
+#if !REMOVE_USELESS_CODE
 #if BLOCK_REDUCTION_ALGORITHM_1 || BLOCK_REDUCTION_ALGORITHM_2
 typedef struct DepthReductionCtrls {
     uint8_t enabled;
@@ -270,6 +282,7 @@ typedef struct DepthReductionCtrls {
 
 }DepthReductionCtrls;
 #endif
+#endif
 #if ADD_MD_NSQ_SEARCH
 typedef struct MdNsqMotionSearchCtrls {
     uint8_t enabled;                    // 0: NSQ motion search @ MD OFF; 1: NSQ motion search @ MD ON
@@ -287,7 +300,45 @@ typedef struct MdNsqMotionSearchCtrls {
 #endif
 }MdNsqMotionSearchCtrls;
 #endif
+#if ADAPTIVE_ME_SEARCH
+typedef struct MdSqMotionSearchCtrls {
+    uint8_t enabled;                    // 0: SQ motion search @ MD OFF; 1: SQ motion search @ MD ON
+    uint8_t use_ssd;                    // 0: search using SAD; 1: search using SSD
+
+    uint16_t pame_distortion_th;        // TH for pa_me distortion to determine whether to search (distortion per pixel)
+
+    uint8_t  sprs_lev0_enabled;         // 0: OFF; 1: ON
+    uint8_t  sprs_lev0_step;            // Sparse search step
+    uint16_t sprs_lev0_w;               // Sparse search area width
+    uint16_t sprs_lev0_h;               // Sparse search area height
+    uint16_t max_sprs_lev0_w;           // Max Sparse search area width
+    uint16_t max_sprs_lev0_h;           // Max Sparse search area height
+    int16_t sprs_lev0_multiplier;       // search area multiplier (is a % -- 100 is no scaling)
+
+    uint8_t  sprs_lev1_enabled;         // 0: OFF; 1: ON
+    uint8_t  sprs_lev1_step;            // Sparse search step
+    uint16_t sprs_lev1_w;               // Sparse search area width
+    uint16_t sprs_lev1_h;               // Sparse search area height
+    uint16_t max_sprs_lev1_w;           // Max Sparse search area width
+    uint16_t max_sprs_lev1_h;           // Max Sparse search area height
+    int16_t sprs_lev1_multiplier;       // search area multiplier (is a % -- 100 is no scaling)
+
+    uint8_t  sprs_lev2_enabled;         // 0: OFF; 1: ON
+    uint8_t  sprs_lev2_step;            // Sparse search step
+    uint16_t sprs_lev2_w;               // Sparse search area width
+    uint16_t sprs_lev2_h;               // Sparse search area height
+}MdSqMotionSearchCtrls;
+#endif
+
 #if PERFORM_SUB_PEL_MD
+#if UPGRADE_SUBPEL
+typedef struct MdSubPelSearchCtrls {
+    uint8_t enabled;                             // 0: subpel search @ MD OFF; 1: subpel search @ MD ON
+    SUBPEL_SEARCH_TYPE subpel_search_type;       // USE_8_TAPS | USE_4_TAPS | USE_2_TAPS | USE_2_TAPS_ORIG (not supported)
+    int subpel_iters_per_step;                   // Maximum number of steps in logarithmic subpel search before giving up.
+    uint8_t eight_pel_search_enabled;            // 0: OFF; 1: ON
+}MdSubPelSearchCtrls;
+#else
 typedef struct MdSubPelSearchCtrls {
     uint8_t enabled;                             // 0: subpel search @ MD OFF; 1: subpel search @ MD ON
     uint8_t use_ssd;                             // 0: search using SAD; 1: search using SSD
@@ -319,6 +370,7 @@ typedef struct MdSubPelSearchCtrls {
     uint8_t eight_pel_search_pos_cnt;           // [1:MD_MOTION_SEARCH_MAX_BEST_MV] total number of eight-pel position(s) to search (i.e. perform 1/8 Pel for the top quarter_pel_search_pos_cnt best MV)
 #endif
 }MdSubPelSearchCtrls;
+#endif
 #if SEARCH_TOP_N
 typedef struct MdMotionSearchResults {
     uint32_t dist; // distortion
@@ -566,9 +618,14 @@ typedef struct ModeDecisionContext {
     EbBool               spatial_sse_full_loop_level;
     EbBool               blk_skip_decision;
     int8_t               rdoq_level;
-    int16_t              sb_me_mv[BLOCK_MAX_COUNT_SB_128][2][4][2];
+    int16_t              sb_me_mv[BLOCK_MAX_COUNT_SB_128][MAX_NUM_OF_REF_PIC_LIST][MAX_REF_IDX][2];
+#if UPGRADE_SUBPEL
+    int16_t              best_pme_mv[MAX_NUM_OF_REF_PIC_LIST][MAX_REF_IDX][2];
+    int8_t               valid_pme_mv[MAX_NUM_OF_REF_PIC_LIST][MAX_REF_IDX];
+#else
     int16_t              best_spatial_pred_mv[2][4][2];
     int8_t               valid_refined_mv[2][4];
+#endif
     EbPictureBufferDesc *input_sample16bit_buffer;
     uint16_t             tile_index;
     DECLARE_ALIGNED(16, uint8_t, pred0[2 * MAX_SB_SQUARE]);
@@ -693,19 +750,35 @@ typedef struct ModeDecisionContext {
 #endif
 #if MD_REFERENCE_MASKING
     uint8_t      inter_inter_distortion_based_reference_pruning;
+#if !REMOVE_USELESS_CODE
     uint8_t      inter_intra_distortion_based_reference_pruning;
 #endif
+#endif
+#if !REMOVE_USELESS_CODE
 #if BLOCK_REDUCTION_ALGORITHM_1 || BLOCK_REDUCTION_ALGORITHM_2
     uint8_t      block_based_depth_reduction_level;
     DepthReductionCtrls depth_reduction_ctrls;
+#endif
+#endif
+#if ADAPTIVE_ME_SEARCH
+    // Control signals for MD sparse search (used for increasing ME search for active clips)
+    uint8_t md_sq_mv_search_level;
+    MdSqMotionSearchCtrls md_sq_me_ctrls;
 #endif
 #if ADD_MD_NSQ_SEARCH
     uint8_t md_nsq_mv_search_level ;
     MdNsqMotionSearchCtrls md_nsq_motion_search_ctrls;
 #endif
 #if PERFORM_SUB_PEL_MD
+#if UPGRADE_SUBPEL
+    uint8_t md_subpel_me_level;
+    MdSubPelSearchCtrls md_subpel_me_ctrls;
+    uint8_t md_subpel_pme_level;
+    MdSubPelSearchCtrls md_subpel_pme_ctrls;
+#else
     uint8_t md_subpel_search_level;
     MdSubPelSearchCtrls md_subpel_search_ctrls;
+#endif
 #if SEARCH_TOP_N
     MdMotionSearchResults md_motion_search_best_mv[MD_MOTION_SEARCH_MAX_BEST_MV];
 #endif
@@ -834,6 +907,19 @@ typedef struct ModeDecisionContext {
 #if MEM_OPT_MD_BUF_DESC
     EbPictureBufferDesc* temp_residual_ptr;
     EbPictureBufferDesc* temp_recon_ptr;
+#endif
+#if ADAPTIVE_ME_SEARCH || UPGRADE_SUBPEL
+    // Array for all nearest/near MVs for a block for single ref case
+    MV mvp_array[MAX_NUM_OF_REF_PIC_LIST][REF_LIST_MAX_DEPTH][MAX_MVP_CANIDATES];
+    // Count of all nearest/near MVs for a block for single ref case
+    int8_t  mvp_count[MAX_NUM_OF_REF_PIC_LIST][REF_LIST_MAX_DEPTH];
+#if ADAPTIVE_ME_SEARCH
+    // Start/end position for MD sparse search
+    int16_t sprs_lev0_start_x;
+    int16_t sprs_lev0_end_x;
+    int16_t sprs_lev0_start_y;
+    int16_t sprs_lev0_end_y;
+#endif
 #endif
 } ModeDecisionContext;
 

--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.h
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.h
@@ -93,7 +93,15 @@ extern "C" {
 #define F2 2
 #define MAX_SSE_VALUE 128 * 128 * 255 * 255
 #define  MAX_SAD_VALUE 128*128*255
+#if ADAPTIVE_ME_SEARCH
+// Thresholds used for determining level of motion (used in sparse search)
+#define MEDIUM_TEMPORAL_MV_TH   2048
+#define LOW_TEMPORAL_MV_TH      1024
 
+#define HIGH_SPATIAL_MV_TH      2048
+#define MEDIUM_SPATIAL_MV_TH    512
+#define LOW_SPATIAL_MV_TH       256
+#endif
 // Interpolation Filters
     static const int32_t me_if_coeff[3][4] = {
         { -4, 54, 16, -2 }, // F0

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.c
@@ -1337,7 +1337,9 @@ static void picture_parent_control_set_dctor(EbPtr ptr) {
     EB_FREE_ARRAY(obj->rusi_picture[2]);
 
     EB_FREE_ARRAY(obj->av1x);
-
+#if IMPROVE_GMV //--
+    EB_DESTROY_MUTEX(obj->me_processed_sb_mutex);
+#endif
     EB_DESTROY_MUTEX(obj->rc_distortion_histogram_mutex);
     EB_DESTROY_SEMAPHORE(obj->temp_filt_done_semaphore);
     EB_DESTROY_MUTEX(obj->temp_filt_mutex);
@@ -1507,6 +1509,9 @@ EbErrorType picture_parent_control_set_ctor(PictureParentControlSet *object_ptr,
     EB_MALLOC_ARRAY(object_ptr->non_moving_index_array, object_ptr->sb_total_count);
     // SB noise variance array
     EB_MALLOC_ARRAY(object_ptr->sb_flat_noise_array, object_ptr->sb_total_count);
+#if IMPROVE_GMV //--
+    EB_CREATE_MUTEX(object_ptr->me_processed_sb_mutex);
+#endif
     EB_CREATE_MUTEX(object_ptr->rc_distortion_histogram_mutex);
     EB_MALLOC_ARRAY(object_ptr->sb_depth_mode_array, object_ptr->sb_total_count);
     EB_CREATE_SEMAPHORE(object_ptr->temp_filt_done_semaphore, 0, 1);

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -615,8 +615,10 @@ typedef struct PictureParentControlSet {
     int      kf_zeromotion_pct; // percent of zero motion blocks
     uint8_t  fade_out_from_black;
     uint8_t  fade_in_to_black;
+#if !IMPROVE_GMV
     EbBool   is_pan;
     EbBool   is_tilt;
+#endif
     uint8_t *sb_flat_noise_array;
     uint16_t non_moving_index_average; // used by ModeDecisionConfigurationProcess()
     int16_t  non_moving_index_min_distance;
@@ -652,6 +654,10 @@ typedef struct PictureParentControlSet {
     uint16_t *ois_distortion_histogram;
     uint32_t *intra_sad_interval_index;
     uint32_t *inter_sad_interval_index;
+#if IMPROVE_GMV //--
+    uint16_t me_processed_sb_count;
+    EbHandle me_processed_sb_mutex;
+#endif
     EbHandle  rc_distortion_histogram_mutex;
 #if !REMOVE_UNUSED_CODE_PH2
     // Open loop Intra candidate Search Results

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -7141,7 +7141,9 @@ void* picture_decision_kernel(void *input_ptr)
                             pcs_ptr->me_segments_row_count = (uint8_t)(scs_ptr->me_segment_row_count_array[pcs_ptr->temporal_layer_index]);
                             pcs_ptr->me_segments_total_count = (uint16_t)(pcs_ptr->me_segments_column_count  * pcs_ptr->me_segments_row_count);
                             pcs_ptr->me_segments_completion_mask = 0;
-
+#if IMPROVE_GMV
+                            pcs_ptr->me_processed_sb_count = 0;
+#endif
                             //****************************************************
                             // Picture resizing for super-res tool
                             //****************************************************

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -26,7 +26,12 @@
 #include "EbLog.h"
 #include "EbCommonUtils.h"
 #include "EbResize.h"
-
+#if UPGRADE_SUBPEL
+#include "mv.h"
+#include "mcomp.h"
+#include "av1me.h"
+#include "limits.h"
+#endif
 #if LOG_MV_VALIDITY
 void check_mv_validity(int16_t x_mv, int16_t y_mv, uint8_t need_shift);
 #endif
@@ -1456,7 +1461,9 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->best_refs[WARP_GROUP]          = 7;
         ref_pruning_ctrls->best_refs[NRST_NEAR_GROUP]     = 7;
         ref_pruning_ctrls->best_refs[PRED_ME_GROUP]       = 7;
-
+#if IMPROVE_GMV
+        ref_pruning_ctrls->best_refs[GLOBAL_GROUP]        = 7;
+#endif
 #if REF_PRUNE_CAT_TUNE
         ref_pruning_ctrls->closest_refs[PA_ME_GROUP] = 1;
         ref_pruning_ctrls->closest_refs[UNI_3x3_GROUP] = 1;
@@ -1477,6 +1484,9 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->closest_refs[WARP_GROUP]          = 0;
         ref_pruning_ctrls->closest_refs[NRST_NEAR_GROUP]     = 1;
         ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 0;
+#endif
+#if IMPROVE_GMV
+        ref_pruning_ctrls->closest_refs[GLOBAL_GROUP]        = 1;
 #endif
         break;
     case 2:
@@ -1502,7 +1512,9 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
 #endif
         ref_pruning_ctrls->best_refs[NRST_NEAR_GROUP]     = 6;
         ref_pruning_ctrls->best_refs[PRED_ME_GROUP]       = 6;
-
+#if IMPROVE_GMV
+        ref_pruning_ctrls->best_refs[GLOBAL_GROUP]        = 7;
+#endif
 #if REF_PRUNE_CAT_TUNE
         ref_pruning_ctrls->closest_refs[PA_ME_GROUP]         = 1;
         ref_pruning_ctrls->closest_refs[UNI_3x3_GROUP]       = 1;
@@ -1523,6 +1535,9 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->closest_refs[WARP_GROUP]          = 0;
         ref_pruning_ctrls->closest_refs[NRST_NEAR_GROUP]     = 1;
         ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 0;
+#endif
+#if IMPROVE_GMV
+        ref_pruning_ctrls->closest_refs[GLOBAL_GROUP]        = 1;
 #endif
         break;
     case 3:
@@ -1548,7 +1563,9 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
 #endif
         ref_pruning_ctrls->best_refs[NRST_NEAR_GROUP]     = 5;
         ref_pruning_ctrls->best_refs[PRED_ME_GROUP]       = 5;
-
+#if IMPROVE_GMV
+        ref_pruning_ctrls->best_refs[GLOBAL_GROUP]        = 7;
+#endif
 #if REF_PRUNE_CAT_TUNE
         ref_pruning_ctrls->closest_refs[PA_ME_GROUP]         = 1;
         ref_pruning_ctrls->closest_refs[UNI_3x3_GROUP]       = 1;
@@ -1569,6 +1586,9 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->closest_refs[WARP_GROUP]          = 0;
         ref_pruning_ctrls->closest_refs[NRST_NEAR_GROUP]     = 1;
         ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 0;
+#endif
+#if IMPROVE_GMV
+        ref_pruning_ctrls->closest_refs[GLOBAL_GROUP]        = 1;
 #endif
         break;
     case 4:
@@ -1594,7 +1614,9 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
 #endif
         ref_pruning_ctrls->best_refs[NRST_NEAR_GROUP]     = 4;
         ref_pruning_ctrls->best_refs[PRED_ME_GROUP]       = 4;
-
+#if IMPROVE_GMV
+        ref_pruning_ctrls->best_refs[GLOBAL_GROUP]        = 7;
+#endif
 #if REF_PRUNE_CAT_TUNE
         ref_pruning_ctrls->closest_refs[PA_ME_GROUP]         = 1;
         ref_pruning_ctrls->closest_refs[UNI_3x3_GROUP]       = 1;
@@ -1616,6 +1638,9 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->closest_refs[NRST_NEAR_GROUP]     = 1;
         ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 0;
 #endif
+#if IMPROVE_GMV
+        ref_pruning_ctrls->closest_refs[GLOBAL_GROUP]        = 1;
+#endif
         break;
     case 5:
         ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
@@ -1631,6 +1656,9 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->best_refs[WARP_GROUP]          = 3;
         ref_pruning_ctrls->best_refs[NRST_NEAR_GROUP]     = 3;
         ref_pruning_ctrls->best_refs[PRED_ME_GROUP]       = 3;
+#if IMPROVE_GMV
+        ref_pruning_ctrls->best_refs[GLOBAL_GROUP]        = 7;
+#endif
 
         ref_pruning_ctrls->closest_refs[PA_ME_GROUP]         = 0;
         ref_pruning_ctrls->closest_refs[UNI_3x3_GROUP]       = 0;
@@ -1643,7 +1671,9 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->closest_refs[WARP_GROUP]          = 0;
         ref_pruning_ctrls->closest_refs[NRST_NEAR_GROUP]     = 1;
         ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 0;
-
+#if IMPROVE_GMV
+        ref_pruning_ctrls->closest_refs[GLOBAL_GROUP]        = 1;
+#endif
         break;
     case 6:
         ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
@@ -1659,6 +1689,9 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->best_refs[WARP_GROUP]          = 2;
         ref_pruning_ctrls->best_refs[NRST_NEAR_GROUP]     = 2;
         ref_pruning_ctrls->best_refs[PRED_ME_GROUP]       = 2;
+#if IMPROVE_GMV
+        ref_pruning_ctrls->best_refs[GLOBAL_GROUP]        = 7;
+#endif
 
         ref_pruning_ctrls->closest_refs[PA_ME_GROUP]         = 0;
         ref_pruning_ctrls->closest_refs[UNI_3x3_GROUP]       = 0;
@@ -1671,7 +1704,9 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->closest_refs[WARP_GROUP]          = 0;
         ref_pruning_ctrls->closest_refs[NRST_NEAR_GROUP]     = 1;
         ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 0;
-
+#if IMPROVE_GMV
+        ref_pruning_ctrls->closest_refs[GLOBAL_GROUP]        = 1;
+#endif
         break;
     default: assert(0); break;
     }
@@ -4561,7 +4596,12 @@ void md_full_pel_search(ModeDecisionContext *context_ptr, EbPictureBufferDesc *i
                         EbPictureBufferDesc *ref_pic, uint32_t input_origin_index, EbBool use_ssd,
                         int16_t mvx, int16_t mvy, int16_t search_position_start_x,
                         int16_t search_position_end_x, int16_t search_position_start_y,
-                        int16_t search_position_end_y, int16_t search_step,
+                        int16_t search_position_end_y,
+#if ADAPTIVE_ME_SEARCH
+                        int16_t sparse_search_step,
+#else
+                        int16_t search_step,
+#endif
 #if SEARCH_TOP_N
                         uint8_t track_best_fp_pos,
 #endif
@@ -4721,12 +4761,34 @@ void md_full_pel_search(ModeDecisionContext *context_ptr, EbPictureBufferDesc *i
              refinement_pos_x <= search_position_end_x;
              ++refinement_pos_x) {
 #else
+#if ADAPTIVE_ME_SEARCH
+    for (int32_t refinement_pos_x = search_position_start_x;
+         refinement_pos_x <= search_position_end_x;
+         refinement_pos_x = refinement_pos_x + sparse_search_step) {
+        for (int32_t refinement_pos_y = search_position_start_y;
+             refinement_pos_y <= search_position_end_y;
+             refinement_pos_y = refinement_pos_y + sparse_search_step) {
+#else
     for (int32_t refinement_pos_x = search_position_start_x;
          refinement_pos_x <= search_position_end_x;
          ++refinement_pos_x) {
         for (int32_t refinement_pos_y = search_position_start_y;
              refinement_pos_y <= search_position_end_y;
              ++refinement_pos_y) {
+#endif
+#endif
+#if ADAPTIVE_ME_SEARCH
+            // If sparse search level_1
+            if (sparse_search_step == 2) {
+                // If search level_0 previously performed
+                if (context_ptr->md_sq_me_ctrls.sprs_lev0_enabled && context_ptr->md_sq_me_ctrls.sprs_lev0_step == 4) {
+                    // If level_0 range
+                    if ((refinement_pos_x + (mvx >> 3)) >= context_ptr->sprs_lev0_start_x && (refinement_pos_x + (mvx >> 3)) <= context_ptr->sprs_lev0_end_x && (refinement_pos_y + (mvy >> 3)) >= context_ptr->sprs_lev0_start_y && (refinement_pos_y + (mvy >> 3)) <= context_ptr->sprs_lev0_end_y)
+                        // If level_0 position
+                        if (refinement_pos_x % 4 == 0 && refinement_pos_y % 4 == 0)
+                            continue;
+                }
+            }
 #endif
             int32_t ref_origin_index = ref_pic->origin_x +
                 (context_ptr->blk_origin_x + (mvx >> 3) + refinement_pos_x) +
@@ -4779,22 +4841,32 @@ void md_full_pel_search(ModeDecisionContext *context_ptr, EbPictureBufferDesc *i
                 }
                 // Update max_dist_best_mv_idx spot if better distortion
                 if (distortion < max_dist) {
+#if ADAPTIVE_ME_SEARCH
+                    context_ptr->md_motion_search_best_mv[max_dist_best_mv_idx].mvx = mvx + (refinement_pos_x * 8);
+                    context_ptr->md_motion_search_best_mv[max_dist_best_mv_idx].mvy = mvy + (refinement_pos_y * 8);
+#else
                     context_ptr->md_motion_search_best_mv[max_dist_best_mv_idx].mvx = mvx + (refinement_pos_x * search_step);
                     context_ptr->md_motion_search_best_mv[max_dist_best_mv_idx].mvy = mvy + (refinement_pos_y * search_step);
+#endif
                     context_ptr->md_motion_search_best_mv[max_dist_best_mv_idx].dist = distortion;
                 }
             }
 #endif
             if (distortion < *best_distortion) {
+#if ADAPTIVE_ME_SEARCH
+                *best_mvx = mvx + (refinement_pos_x * 8);
+                *best_mvy = mvy + (refinement_pos_y * 8);
+#else
                 *best_mvx        = mvx + (refinement_pos_x * search_step);
                 *best_mvy        = mvy + (refinement_pos_y * search_step);
+#endif
                 *best_distortion = distortion;
             }
         }
     }
 #endif
 }
-
+#if !UPGRADE_SUBPEL
 #if ADD_MD_NSQ_SEARCH
 // HPs are the 8 performed positions when search area is 3x3, search_step is 4 (1/2 Pel search), search_pattern is 0 (H,V,D), search_central_position is 0
 // XX.......HP.......HP.......HP.......XX
@@ -5031,7 +5103,7 @@ void md_sub_pel_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context_
         }
     }
 }
-
+#endif
 void    av1_set_ref_frame(MvReferenceFrame *rf, int8_t ref_frame_type);
 uint8_t get_max_drl_index(uint8_t refmvCnt, PredictionMode mode);
 uint8_t is_me_data_present(struct ModeDecisionContext *context_ptr, const MeSbResults *me_results,
@@ -5222,11 +5294,19 @@ void md_nsq_motion_search(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
             0,
             0,
             0,
+#if ADAPTIVE_ME_SEARCH
+            1,
+#else
             8,
+#endif
 #if SEARCH_TOP_N
 #if IMPROVE_QUARTER_PEL
 #if IMPROVE_EIGHT_PEL
+#if UPGRADE_SUBPEL
+            context_ptr->md_subpel_me_ctrls.sub_search_pos_cnt > 1,
+#else
             context_ptr->md_subpel_search_ctrls.half_pel_search_pos_cnt > 1 || context_ptr->md_subpel_search_ctrls.quarter_pel_search_pos_cnt > 1 || context_ptr->md_subpel_search_ctrls.eight_pel_search_pos_cnt > 1,
+#endif
 #else
             context_ptr->md_subpel_search_ctrls.half_pel_search_pos_cnt > 1 || context_ptr->md_subpel_search_ctrls.quarter_pel_search_pos_cnt > 1,
 #endif
@@ -5312,9 +5392,17 @@ void md_nsq_motion_search(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
         +(context_ptr->md_nsq_motion_search_ctrls.full_pel_search_width >> 1),
         -(context_ptr->md_nsq_motion_search_ctrls.full_pel_search_height >> 1),
         +(context_ptr->md_nsq_motion_search_ctrls.full_pel_search_height >> 1),
+#if ADAPTIVE_ME_SEARCH
+        1,
+#else
         8,
+#endif
 #if SEARCH_TOP_N
+#if UPGRADE_SUBPEL
+        context_ptr->md_subpel_me_ctrls.sub_search_pos_cnt > 1,
+#else
         context_ptr->md_subpel_search_ctrls.half_pel_search_pos_cnt > 1,
+#endif
 #endif
         &best_search_mvx,
         &best_search_mvy,
@@ -5370,6 +5458,378 @@ void md_nsq_motion_search(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
     }
 }
 #endif
+#if FIX_MV_BOUND
+/*
+   clips input MV (in 1/8 precision) to stay within boundaries of a given ref pic
+*/
+void clip_mv_on_pic_boundary(int32_t blk_origin_x, int32_t blk_origin_y, int32_t bwidth, int32_t bheight,
+    EbPictureBufferDesc *ref_pic, int16_t* mvx, int16_t* mvy)
+{
+
+    if (blk_origin_x + (*mvx >> 3) + bwidth > ref_pic->max_width + ref_pic->origin_x)
+        *mvx = (ref_pic->max_width - blk_origin_x) << 3;
+
+    if (blk_origin_y + (*mvy >> 3) + bheight > ref_pic->max_height + ref_pic->origin_y)
+        *mvy = (ref_pic->max_height - blk_origin_y) << 3;
+
+    if (blk_origin_x + (*mvx >> 3) < -ref_pic->origin_x)
+        *mvx = (-blk_origin_x - bwidth) << 3;
+
+    if (blk_origin_y + (*mvy >> 3) < -ref_pic->origin_y)
+        *mvy = (-blk_origin_y - bheight) << 3;
+
+}
+#endif
+#if ADAPTIVE_ME_SEARCH
+/*
+ * Check the size of the spatial MVs and MVPs of the given block
+ *
+ * Return a motion category, based on the MV size.
+ */
+uint8_t check_spatial_mv_size(ModeDecisionContext *ctx, uint8_t list_idx, uint8_t ref_idx, int16_t *me_mv_x, int16_t *me_mv_y) {
+    uint8_t search_area_multiplier = 0;
+
+    // Iterate over all MVPs; if large, set high search_area_multiplier
+    for (int8_t mvp_index = 0; mvp_index < ctx->mvp_count[list_idx][ref_idx]; mvp_index++) {
+        if (ctx->mvp_array[list_idx][ref_idx][mvp_index].col > HIGH_SPATIAL_MV_TH ||
+            ctx->mvp_array[list_idx][ref_idx][mvp_index].row > HIGH_SPATIAL_MV_TH ||
+            *me_mv_x > HIGH_SPATIAL_MV_TH ||
+            *me_mv_y > HIGH_SPATIAL_MV_TH) {
+            search_area_multiplier = MAX(3, search_area_multiplier);
+            return search_area_multiplier; // reached MAX value already
+        }
+        else if (ctx->mvp_array[list_idx][ref_idx][mvp_index].col > MEDIUM_SPATIAL_MV_TH ||
+            ctx->mvp_array[list_idx][ref_idx][mvp_index].row > MEDIUM_SPATIAL_MV_TH ||
+            *me_mv_x > MEDIUM_SPATIAL_MV_TH ||
+            *me_mv_y > MEDIUM_SPATIAL_MV_TH) {
+            search_area_multiplier = MAX(2, search_area_multiplier);
+        }
+        else if (ctx->mvp_array[list_idx][ref_idx][mvp_index].col > LOW_SPATIAL_MV_TH ||
+            ctx->mvp_array[list_idx][ref_idx][mvp_index].row > LOW_SPATIAL_MV_TH ||
+            *me_mv_x > LOW_SPATIAL_MV_TH ||
+            *me_mv_y > LOW_SPATIAL_MV_TH) {
+            search_area_multiplier = MAX(1, search_area_multiplier);
+        }
+    }
+    return search_area_multiplier;
+}
+
+/*
+ * Check the size of the temporal MVs
+ *
+ * Return a motion category, based on the MV size.
+ */
+uint8_t check_temporal_mv_size(PictureControlSet *pcs, ModeDecisionContext *ctx) {
+    uint8_t search_area_multiplier = 0;
+
+    Av1Common * cm = pcs->parent_pcs_ptr->av1_cm;
+    int32_t     mi_row = ctx->blk_origin_y >> MI_SIZE_LOG2;
+    int32_t     mi_col = ctx->blk_origin_x >> MI_SIZE_LOG2;
+    TPL_MV_REF *prev_frame_mvs = pcs->tpl_mvs + (mi_row >> 1) * (cm->mi_stride >> 1) +
+        (mi_col >> 1);
+    TPL_MV_REF *mv = prev_frame_mvs;
+    if (prev_frame_mvs->mfmv0.as_int != INVALID_MV) {
+        if (ABS(mv->mfmv0.as_mv.row) > MEDIUM_TEMPORAL_MV_TH ||
+            ABS(mv->mfmv0.as_mv.col) > MEDIUM_TEMPORAL_MV_TH) {
+            search_area_multiplier = MAX(2, search_area_multiplier);
+        }
+        else if (ABS(mv->mfmv0.as_mv.row) > LOW_TEMPORAL_MV_TH ||
+            ABS(mv->mfmv0.as_mv.col) > LOW_TEMPORAL_MV_TH) {
+            search_area_multiplier = MAX(1, search_area_multiplier);
+        }
+    }
+
+    return search_area_multiplier;
+}
+/*
+ * Detect if block has high motion, and if so, perform an expanded ME search.
+ */
+void md_sq_motion_search(PictureControlSet *pcs, ModeDecisionContext *ctx,
+    EbPictureBufferDesc *input_picture_ptr, uint32_t input_origin_index, uint8_t list_idx, uint8_t ref_idx, int16_t *me_mv_x, int16_t *me_mv_y) {
+
+    uint8_t hbd_mode_decision = ctx->hbd_mode_decision == EB_DUAL_BIT_MD
+        ? EB_8_BIT_MD
+        : ctx->hbd_mode_decision;
+    EbReferenceObject *ref_obj = pcs->ref_pic_ptr_array[list_idx][ref_idx]->object_ptr;
+    EbPictureBufferDesc *ref_pic =
+        hbd_mode_decision ? ref_obj->reference_picture16bit : ref_obj->reference_picture;
+
+    MdSqMotionSearchCtrls *md_sq_me_ctrls = &ctx->md_sq_me_ctrls;
+    uint16_t dist = ABS((int16_t)(pcs->picture_number - pcs->parent_pcs_ptr->ref_pic_poc_array[list_idx][ref_idx]));
+    uint8_t search_area_multiplier = 0;
+
+    // Get pa_me distortion and MVs
+    int16_t  pa_me_mvx = (int16_t)~0;
+    int16_t  pa_me_mvy = (int16_t)~0;
+    uint32_t pa_me_distortion = (uint32_t)~0;
+    md_full_pel_search(
+        ctx,
+        input_picture_ptr,
+        ref_pic,
+        input_origin_index,
+        md_sq_me_ctrls->use_ssd,
+        *me_mv_x,
+        *me_mv_y,
+        0,
+        0,
+        0,
+        0,
+        1,
+#if SEARCH_TOP_N
+        0,
+#endif
+        &pa_me_mvx,
+        &pa_me_mvy,
+        &pa_me_distortion);
+
+    // Identify potential high active block(s) and ME failure using 2 checks : (1) high ME_MV distortion, (2) active co - located block for non - intra ref(Temporal - MV(s)) or active surrounding block(s) for intra ref(Spatial - MV(s))
+    if (ctx->blk_geom->sq_size <= 64) {
+
+        uint32_t fast_lambda = ctx->hbd_mode_decision ?
+            ctx->fast_lambda_md[EB_10_BIT_MD] :
+            ctx->fast_lambda_md[EB_8_BIT_MD];
+
+        // Check if pa_me distortion is above the per-pixel threshold.  Rate is set to 16.
+        if (RDCOST(fast_lambda, 16, pa_me_distortion) >
+            RDCOST(fast_lambda, 16, md_sq_me_ctrls->pame_distortion_th * ctx->blk_geom->bwidth * ctx->blk_geom->bheight)) {
+
+            EbReferenceObject *ref_obj = (EbReferenceObject *)pcs->ref_pic_ptr_array[list_idx][ref_idx]->object_ptr;
+
+            if (!(ref_obj == NULL || ref_obj->frame_type == KEY_FRAME || ref_obj->frame_type == INTRA_ONLY_FRAME)) {
+                search_area_multiplier = check_temporal_mv_size(pcs, ctx);
+            }
+            else {
+                search_area_multiplier = check_spatial_mv_size(ctx, list_idx, ref_idx, me_mv_x, me_mv_y);
+            }
+        }
+    }
+
+    // If high motion was detected, perform an expanded ME search
+    if (search_area_multiplier) {
+
+        int16_t  best_search_mvx = (int16_t)~0;
+        int16_t  best_search_mvy = (int16_t)~0;
+        uint32_t best_search_distortion = (uint32_t)~0;
+
+        int8_t round_up = ((dist % 8) == 0) ? 0 : 1;
+        dist = ((dist * 5) / 8) + round_up; // factor to slow down the search region growth to MAX
+
+        // Sparse-search Level_0
+        if (md_sq_me_ctrls->sprs_lev0_enabled) {
+
+            uint16_t sprs_lev0_w = (md_sq_me_ctrls->sprs_lev0_multiplier * MIN((md_sq_me_ctrls->sprs_lev0_w * search_area_multiplier * dist), md_sq_me_ctrls->max_sprs_lev0_w)) / 100;
+            uint16_t sprs_lev0_h = (md_sq_me_ctrls->sprs_lev0_multiplier * MIN((md_sq_me_ctrls->sprs_lev0_h * search_area_multiplier * dist), md_sq_me_ctrls->max_sprs_lev0_h)) / 100;
+            uint8_t sprs_lev0_step = md_sq_me_ctrls->sprs_lev0_step;
+
+            // Derive start/end position of sparse search (must be a multiple of the step size)
+            int16_t search_position_start_x = -(((sprs_lev0_w >> 1) / sprs_lev0_step) * sprs_lev0_step);
+            int16_t search_position_end_x = +(((sprs_lev0_w >> 1) / sprs_lev0_step) * sprs_lev0_step);
+            int16_t search_position_start_y = -(((sprs_lev0_h >> 1) / sprs_lev0_step) * sprs_lev0_step);
+            int16_t search_position_end_y = +(((sprs_lev0_h >> 1) / sprs_lev0_step) * sprs_lev0_step);
+
+            ctx->sprs_lev0_start_x = (*me_mv_x >> 3) + search_position_start_x;
+            ctx->sprs_lev0_end_x = (*me_mv_x >> 3) + search_position_end_x;
+            ctx->sprs_lev0_start_y = (*me_mv_y >> 3) + search_position_start_y;
+            ctx->sprs_lev0_end_y = (*me_mv_y >> 3) + search_position_end_y;
+
+            md_full_pel_search(
+                ctx,
+                input_picture_ptr,
+                ref_pic,
+                input_origin_index,
+                md_sq_me_ctrls->use_ssd,
+                *me_mv_x,
+                *me_mv_y,
+                search_position_start_x,
+                search_position_end_x,
+                search_position_start_y,
+                search_position_end_y,
+                sprs_lev0_step,
+#if SEARCH_TOP_N
+                0,
+#endif
+                &best_search_mvx,
+                &best_search_mvy,
+                &best_search_distortion);
+
+
+            *me_mv_x = best_search_mvx;
+            *me_mv_y = best_search_mvy;
+        }
+
+        // Sparse-search Level_1
+        if (md_sq_me_ctrls->sprs_lev1_enabled) {
+
+            uint16_t sprs_lev1_w = (md_sq_me_ctrls->sprs_lev1_multiplier * MIN((md_sq_me_ctrls->sprs_lev1_w * search_area_multiplier * dist), md_sq_me_ctrls->max_sprs_lev1_w)) / 100;
+            uint16_t sprs_lev1_h = (md_sq_me_ctrls->sprs_lev1_multiplier * MIN((md_sq_me_ctrls->sprs_lev1_h * search_area_multiplier * dist), md_sq_me_ctrls->max_sprs_lev1_h)) / 100;
+            uint8_t sprs_lev1_step = md_sq_me_ctrls->sprs_lev1_step;
+
+            // Derive start/end position of sparse search (must be a multiple of the step size)
+            int16_t search_position_start_x = -(((sprs_lev1_w >> 1) / sprs_lev1_step) * sprs_lev1_step);
+            int16_t search_position_end_x = +(((sprs_lev1_w >> 1) / sprs_lev1_step) * sprs_lev1_step);
+            int16_t search_position_start_y = -(((sprs_lev1_h >> 1) / sprs_lev1_step) * sprs_lev1_step);
+            int16_t search_position_end_y = +(((sprs_lev1_h >> 1) / sprs_lev1_step) * sprs_lev1_step);
+
+            search_position_start_x = (search_position_start_x % 4 == 0) ? search_position_start_x - 2 : search_position_start_x;
+            search_position_end_x = (search_position_end_x % 4 == 0) ? search_position_end_x + 2 : search_position_end_x;
+            search_position_start_y = (search_position_start_y % 4 == 0) ? search_position_start_y - 2 : search_position_start_y;
+            search_position_end_y = (search_position_end_y % 4 == 0) ? search_position_end_y + 2 : search_position_end_y;
+
+            md_full_pel_search(
+                ctx,
+                input_picture_ptr,
+                ref_pic,
+                input_origin_index,
+                md_sq_me_ctrls->use_ssd,
+                *me_mv_x,
+                *me_mv_y,
+                search_position_start_x,
+                search_position_end_x,
+                search_position_start_y,
+                search_position_end_y,
+                sprs_lev1_step,
+#if SEARCH_TOP_N
+                0,
+#endif
+                &best_search_mvx,
+                &best_search_mvy,
+                &best_search_distortion);
+
+            *me_mv_x = best_search_mvx;
+            *me_mv_y = best_search_mvy;
+        }
+
+        // Sparse-search Level_2
+        if (md_sq_me_ctrls->sprs_lev2_enabled) {
+            md_full_pel_search(
+                ctx,
+                input_picture_ptr,
+                ref_pic,
+                input_origin_index,
+                md_sq_me_ctrls->use_ssd,
+                *me_mv_x,
+                *me_mv_y,
+                -(((md_sq_me_ctrls->sprs_lev2_w >> 1) / md_sq_me_ctrls->sprs_lev2_step) * md_sq_me_ctrls->sprs_lev2_step),
+                +(((md_sq_me_ctrls->sprs_lev2_w >> 1) / md_sq_me_ctrls->sprs_lev2_step) * md_sq_me_ctrls->sprs_lev2_step),
+                -(((md_sq_me_ctrls->sprs_lev2_h >> 1) / md_sq_me_ctrls->sprs_lev2_step) * md_sq_me_ctrls->sprs_lev2_step),
+                +(((md_sq_me_ctrls->sprs_lev2_h >> 1) / md_sq_me_ctrls->sprs_lev2_step) * md_sq_me_ctrls->sprs_lev2_step),
+                md_sq_me_ctrls->sprs_lev2_step,
+                &best_search_mvx,
+                &best_search_mvy,
+                &best_search_distortion);
+
+            *me_mv_x = best_search_mvx;
+            *me_mv_y = best_search_mvy;
+        }
+        // Check that the resulting MV is within the AV1 limits
+        check_mv_validity(*me_mv_x, *me_mv_y, 0);
+    }
+}
+#endif
+#if UPGRADE_SUBPEL
+void svt_init_mv_cost_params(MV_COST_PARAMS *mv_cost_params, ModeDecisionContext *context_ptr, const MV *ref_mv, uint8_t base_q_idx);
+extern AomVarianceFnPtr mefn_ptr[BlockSizeS_ALL];
+/*
+ * Perform 1/2-Pel, 1/4-Pel, and 1/8-Pel search around the best Full-Pel position
+ */
+int md_subpel_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr, MdSubPelSearchCtrls md_subpel_ctrls,
+    EbPictureBufferDesc *input_picture_ptr,
+    uint8_t list_idx, uint8_t ref_idx, int16_t *me_mv_x, int16_t *me_mv_y, int16_t ref_mv_x, int16_t ref_mv_y) {
+
+    FrameHeader *frm_hdr = &pcs_ptr->parent_pcs_ptr->frm_hdr;
+
+    const Av1Common *const cm = pcs_ptr->parent_pcs_ptr->av1_cm;
+    MacroBlockD *xd = context_ptr->blk_ptr->av1xd;
+
+    // ref_mv is used to calculate the cost of the motion vector
+    MV ref_mv;
+    ref_mv.col = ref_mv_x;
+    ref_mv.row = ref_mv_y;
+
+    // High level params
+    SUBPEL_MOTION_SEARCH_PARAMS ms_params_struct;
+    SUBPEL_MOTION_SEARCH_PARAMS *ms_params = &ms_params_struct;
+
+    ms_params->allow_hp = md_subpel_ctrls.eight_pel_search_enabled && pcs_ptr->parent_pcs_ptr->frm_hdr.allow_high_precision_mv;
+    ms_params->forced_stop = EIGHTH_PEL;
+    ms_params->iters_per_step = md_subpel_ctrls.subpel_iters_per_step; // Maximum number of steps in logarithmic subpel search before giving up.
+    ms_params->cost_list = NULL;
+    // Derive mv_limits (TODO Hsan_Subpel should be derived under md_context @ eack block)
+    // Set up limit values for MV components.
+    // Mv beyond the range do not produce new/different prediction block.
+    MvLimits mv_limits;
+    int mi_row = xd->mi_row;
+    int mi_col = xd->mi_col;
+    int mi_width = mi_size_wide[context_ptr->blk_geom->bsize];
+    int mi_height = mi_size_high[context_ptr->blk_geom->bsize];
+    mv_limits.row_min = -(((mi_row + mi_height) * MI_SIZE) + AOM_INTERP_EXTEND);
+    mv_limits.col_min = -(((mi_col + mi_width) * MI_SIZE) + AOM_INTERP_EXTEND);
+    mv_limits.row_max = (cm->mi_rows - mi_row) * MI_SIZE + AOM_INTERP_EXTEND;
+    mv_limits.col_max = (cm->mi_cols - mi_col) * MI_SIZE + AOM_INTERP_EXTEND;
+    eb_av1_set_mv_search_range(&mv_limits, &ref_mv);
+    svt_av1_set_subpel_mv_search_range(&ms_params->mv_limits, (FullMvLimits *)&mv_limits, &ref_mv);
+
+    // Mvcost params
+    svt_init_mv_cost_params(&ms_params->mv_cost_params, context_ptr, &ref_mv, frm_hdr->quantization_params.base_q_idx);
+
+    // Subpel variance params
+    ms_params->var_params.vfp = &mefn_ptr[context_ptr->blk_geom->bsize];
+    ms_params->var_params.subpel_search_type = md_subpel_ctrls.subpel_search_type;
+    ms_params->var_params.w = block_size_wide[context_ptr->blk_geom->bsize];
+    ms_params->var_params.h = block_size_high[context_ptr->blk_geom->bsize];
+
+    // Ref and src buffers
+    MSBuffers *ms_buffers = &ms_params->var_params.ms_buffers;
+
+    // Ref buffer
+    EbReferenceObject *  ref_obj = pcs_ptr->ref_pic_ptr_array[list_idx][ref_idx]->object_ptr;
+    EbPictureBufferDesc *ref_pic = ref_obj->reference_picture; // 10BIT not supported
+    int32_t ref_origin_index = ref_pic->origin_x + context_ptr->blk_origin_x + (context_ptr->blk_origin_y + ref_pic->origin_y) * ref_pic->stride_y;
+
+    // Ref buffer
+    struct svt_buf_2d ref_struct;
+    struct svt_buf_2d *ref = &ref_struct;
+    ref->buf = ref_pic->buffer_y + ref_origin_index;
+    ref->buf0 = NULL;
+    ref->width = ref_pic->width;
+    ref->height = ref_pic->height;
+    ref->stride = ref_pic->stride_y;
+    ms_buffers->ref = ref;
+
+    // Src buffer
+    uint32_t input_origin_index = (context_ptr->blk_origin_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_y + (context_ptr->blk_origin_x + input_picture_ptr->origin_x);
+    struct svt_buf_2d src_struct;
+    struct svt_buf_2d *src = &src_struct;
+    src->buf = input_picture_ptr->buffer_y + input_origin_index;
+    src->buf0 = NULL;
+    src->width = input_picture_ptr->width;
+    src->height = input_picture_ptr->height;
+    src->stride = input_picture_ptr->stride_y;
+    ms_buffers->src = src;
+
+    svt_av1_set_ms_compound_refs(ms_buffers, NULL, NULL, 0, 0);
+    ms_buffers->wsrc = NULL;
+    ms_buffers->obmc_mask = NULL;
+
+    int_mv best_mv;
+    best_mv.as_mv.col = *me_mv_x >> 3;
+    best_mv.as_mv.row = *me_mv_y >> 3;
+
+    int not_used = 0;
+    MV subpel_start_mv = get_mv_from_fullmv(&best_mv.as_fullmv);
+    unsigned int pred_sse = 0; // not used
+    int besterr = svt_av1_find_best_sub_pixel_tree(
+        xd, (const struct AV1Common *const) cm, ms_params, subpel_start_mv, &best_mv.as_mv, &not_used,
+        &pred_sse,
+        NULL);
+
+    *me_mv_x = best_mv.as_mv.col;
+    *me_mv_y = best_mv.as_mv.row;
+
+    return besterr;
+
+}
+#else
 #if PERFORM_SUB_PEL_MD
 void md_subpel_search_pa_me_cand(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
     EbPictureBufferDesc *input_picture_ptr, uint32_t input_origin_index,
@@ -5597,12 +6057,17 @@ void md_subpel_search_pa_me_cand(PictureControlSet *pcs_ptr, ModeDecisionContext
     *me_mv_y = best_search_mvy;
 }
 #endif
-
+#endif
 // Copy ME_MVs (generated @ PA) from input buffer (pcs_ptr-> .. ->me_results) to local
 // MD buffers (context_ptr->sb_me_mv)
+#if UPGRADE_SUBPEL
+void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
+    EbPictureBufferDesc *input_picture_ptr) {
+#else
 void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
                         EbPictureBufferDesc *input_picture_ptr, uint32_t input_origin_index,
                         uint32_t blk_origin_index) {
+#endif
     const SequenceControlSet *scs_ptr = (SequenceControlSet *)pcs_ptr->scs_wrapper_ptr->object_ptr;
 
     derive_me_offsets(scs_ptr, pcs_ptr, context_ptr);
@@ -5616,10 +6081,23 @@ void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                                           : pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
 
     //Update input origin
+#if UPGRADE_SUBPEL
+    uint32_t input_origin_index = (context_ptr->blk_origin_y + input_picture_ptr->origin_y) *
+#else
     input_origin_index = (context_ptr->blk_origin_y + input_picture_ptr->origin_y) *
+#endif
             input_picture_ptr->stride_y +
         (context_ptr->blk_origin_x + input_picture_ptr->origin_x);
-
+#if ADAPTIVE_ME_SEARCH
+    // Get parent_depth_idx_mds
+    uint16_t parent_depth_idx_mds = 0;
+    if (context_ptr->blk_geom->sq_size < ((scs_ptr->seq_header.sb_size == BLOCK_128X128) ? 128 : 64))
+        //Set parent to be considered
+        parent_depth_idx_mds =
+        (context_ptr->blk_geom->sqi_mds -
+        (context_ptr->blk_geom->quadi - 3) * ns_depth_offset[scs_ptr->seq_header.sb_size == BLOCK_128X128][context_ptr->blk_geom->depth]) -
+        parent_depth_offset[scs_ptr->seq_header.sb_size == BLOCK_128X128][context_ptr->blk_geom->depth];
+#endif
     for (uint32_t ref_it = 0; ref_it < pcs_ptr->parent_pcs_ptr->tot_ref_frame_types; ++ref_it) {
         MvReferenceFrame ref_pair = pcs_ptr->parent_pcs_ptr->ref_frame_type_arr[ref_it];
 
@@ -5629,7 +6107,10 @@ void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context
         if (rf[1] == NONE_FRAME) {
             uint8_t list_idx = get_list_idx(rf[0]);
             uint8_t ref_idx  = get_ref_frame_idx(rf[0]);
-
+#if FIX_MV_BOUND
+            EbReferenceObject *ref_obj = pcs_ptr->ref_pic_ptr_array[list_idx][ref_idx]->object_ptr;
+            EbPictureBufferDesc *ref_pic = hbd_mode_decision ? ref_obj->reference_picture16bit : ref_obj->reference_picture;
+#endif
             // Get the ME MV
 #if DECOUPLE_ME_RES
             const MeSbResults *me_results =
@@ -5649,6 +6130,34 @@ void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                 int16_t me_mv_y;
 #if ME_MEM_OPT
 #if REMOVE_MRP_MODE
+#if ADAPTIVE_ME_SEARCH
+                if (context_ptr->md_local_blk_unit[context_ptr->blk_geom->sqi_mds].avail_blk_flag &&
+                    // If NSQ then use the MV of SQ as default MV center
+                    (context_ptr->blk_geom->bwidth != context_ptr->blk_geom->bheight) &&
+                    // Not applicable for BLOCK_128X64 and BLOCK_64X128 as the 2nd part of each and BLOCK_128X128 do not share the same me_results
+                    context_ptr->blk_geom->bsize != BLOCK_64X128 && context_ptr->blk_geom->bsize != BLOCK_128X64) {
+
+                    me_mv_x = (context_ptr->sb_me_mv[context_ptr->blk_geom->sqi_mds][list_idx][ref_idx][0] + 4) & ~0x07;
+                    me_mv_y = (context_ptr->sb_me_mv[context_ptr->blk_geom->sqi_mds][list_idx][ref_idx][1] + 4) & ~0x07;
+
+#if FIX_MV_BOUND
+                    clip_mv_on_pic_boundary(context_ptr->blk_origin_x, context_ptr->blk_origin_y, context_ptr->blk_geom->bwidth, context_ptr->blk_geom->bheight,
+                        ref_pic, &me_mv_x, &me_mv_y);
+#endif
+
+                }
+                else if (context_ptr->blk_geom->bsize == BLOCK_4X4 && context_ptr->md_local_blk_unit[parent_depth_idx_mds].avail_blk_flag) {
+                    me_mv_x = (context_ptr->sb_me_mv[parent_depth_idx_mds][list_idx][ref_idx][0] + 4) & ~0x07;
+                    me_mv_y = (context_ptr->sb_me_mv[parent_depth_idx_mds][list_idx][ref_idx][1] + 4) & ~0x07;
+
+#if FIX_MV_BOUND
+                    clip_mv_on_pic_boundary(context_ptr->blk_origin_x, context_ptr->blk_origin_y, context_ptr->blk_geom->bwidth, context_ptr->blk_geom->bheight,
+                        ref_pic, &me_mv_x, &me_mv_y);
+#endif
+
+                }
+                else {
+#endif
                 if (list_idx == 0) {
                     me_mv_x = (me_results->me_mv_array[context_ptr->me_block_offset*MAX_PA_ME_MV + ref_idx].x_mv) << 1;
                     me_mv_y = (me_results->me_mv_array[context_ptr->me_block_offset*MAX_PA_ME_MV + ref_idx].y_mv) << 1;
@@ -5657,6 +6166,9 @@ void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                     me_mv_x = (me_results->me_mv_array[context_ptr->me_block_offset*MAX_PA_ME_MV + 4 + ref_idx].x_mv) << 1;
                     me_mv_y = (me_results->me_mv_array[context_ptr->me_block_offset*MAX_PA_ME_MV + 4 + ref_idx].y_mv) << 1;
                 }
+#if ADAPTIVE_ME_SEARCH
+                }
+#endif
 #else
                 uint32_t pu_stride = scs_ptr->mrp_mode == 0 ? ME_MV_MRP_MODE_0 : ME_MV_MRP_MODE_1;
                 if (list_idx == 0) {
@@ -5700,8 +6212,33 @@ void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                                   &me_mv_x,
                                   &me_mv_y);
                 }
+#if ADAPTIVE_ME_SEARCH
+                else if (context_ptr->md_sq_me_ctrls.enabled) {
+                    md_sq_motion_search(pcs_ptr,
+                        context_ptr,
+                        input_picture_ptr,
+                        input_origin_index,
+                        list_idx,
+                        ref_idx,
+                        &me_mv_x,
+                        &me_mv_y);
+                }
+#endif
 #if PERFORM_SUB_PEL_MD
+#if UPGRADE_SUBPEL
+                if (context_ptr->md_subpel_me_ctrls.enabled) {
 
+                    md_subpel_search(pcs_ptr,
+                        context_ptr,
+                        context_ptr->md_subpel_me_ctrls,
+                        pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr, // 10BIT not supported
+                        list_idx,
+                        ref_idx,
+                        &me_mv_x,
+                        &me_mv_y,
+                        context_ptr->mvp_array[list_idx][ref_idx][0].col,  // use nearest as a ref MV
+                        context_ptr->mvp_array[list_idx][ref_idx][0].row); // use nearest as a ref MV
+#else
                 if (context_ptr->md_subpel_search_ctrls.enabled &&
                   (((context_ptr->blk_geom->bwidth == context_ptr->blk_geom->bheight) && ((context_ptr->blk_geom->bsize != BLOCK_4X4) || (context_ptr->md_subpel_search_ctrls.do_4x4))) || // SQ no 4x4 or do_4x4
                    ((context_ptr->blk_geom->bwidth != context_ptr->blk_geom->bheight) && context_ptr->md_subpel_search_ctrls.do_nsq))) { // NSQ and do_nsq == 1
@@ -5715,6 +6252,7 @@ void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                         ref_idx,
                         &me_mv_x,
                         &me_mv_y);
+#endif
                 }
 #endif
 #endif
@@ -5756,10 +6294,9 @@ void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                     me_mv_y = best_search_mvy;
                 }
 #endif
-#if PERFORM_SUB_PEL_MD
-
+#if PERFORM_SUB_PEL_MD && !UPGRADE_SUBPEL
                 if (context_ptr->md_subpel_search_ctrls.enabled) {
-
+#if !ADAPTIVE_ME_SEARCH
                     // Get parent_depth_idx_mds
                     uint16_t parent_depth_idx_mds = 0;
                     if (context_ptr->blk_geom->sq_size <
@@ -5771,7 +6308,7 @@ void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                             [context_ptr->blk_geom->depth]) -
                         parent_depth_offset[scs_ptr->seq_header.sb_size == BLOCK_128X128]
                         [context_ptr->blk_geom->depth];
-
+#endif
                     // If 4x4 but do_4x4 == 0 then inherit Parent MV (already refined)
                     if (!context_ptr->md_subpel_search_ctrls.do_4x4 && (context_ptr->blk_geom->bsize == BLOCK_4X4) && context_ptr->md_local_blk_unit[parent_depth_idx_mds].avail_blk_flag) {
 
@@ -5809,11 +6346,18 @@ void read_refine_me_mvs(PictureControlSet *pcs_ptr, ModeDecisionContext *context
                 context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds][list_idx][ref_idx][1] =
                     me_mv_y;
 #endif
+#if FIX_MV_BOUND
+                clip_mv_on_pic_boundary(context_ptr->blk_origin_x, context_ptr->blk_origin_y,
+                    context_ptr->blk_geom->bwidth, context_ptr->blk_geom->bheight, ref_pic,
+                    &context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds][list_idx][ref_idx][0],
+                    &context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds][list_idx][ref_idx][1]);
+#endif
             }
         }
     }
 }
 #if MD_REFERENCE_MASKING
+#if !REMOVE_USELESS_CODE
 uint32_t early_intra_evaluation(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
                             EbPictureBufferDesc *input_picture_ptr, uint32_t input_origin_index,
                             int32_t blk_origin_index, EbBool use_ssd) {
@@ -5899,14 +6443,21 @@ uint32_t early_intra_evaluation(PictureControlSet *pcs_ptr, ModeDecisionContext 
     }
     return distortion;
 }
+#endif
 #if !ABILITY_TO_USE_CLOSEST_ONLY
 // Tag ref frame(s) as to_do or not
 #define MIN_REF_TO_TAG 2
 #endif
+#if REMOVE_USELESS_CODE
+static void perform_md_reference_pruning(PictureControlSet *  pcs_ptr,
+                                         ModeDecisionContext *context_ptr,
+                                         EbPictureBufferDesc *input_picture_ptr) {
+#else
 static void perform_md_reference_pruning(PictureControlSet *  pcs_ptr,
                                          ModeDecisionContext *context_ptr,
                                          EbPictureBufferDesc *input_picture_ptr,
                                          uint32_t             blk_origin_index) {
+#endif
     uint32_t early_inter_distortion_array[MAX_NUM_OF_REF_PIC_LIST * REF_LIST_MAX_DEPTH];
 
     // Reset ref_filtering_res
@@ -5923,10 +6474,13 @@ static void perform_md_reference_pruning(PictureControlSet *  pcs_ptr,
     for (uint32_t li = 0; li < MAX_NUM_OF_REF_PIC_LIST; li++)
         for (uint32_t ri = 0; ri < REF_LIST_MAX_DEPTH; ri++)
             early_inter_distortion_array[li * REF_LIST_MAX_DEPTH + ri] = (uint32_t)~0;
-    if ((!context_ptr->ref_pruning_ctrls.inter_to_inter_pruning_enabled &&
-         !context_ptr->ref_pruning_ctrls.intra_to_inter_pruning_enabled) ||
+    if ((!context_ptr->ref_pruning_ctrls.inter_to_inter_pruning_enabled) ||
+#if !REMOVE_USELESS_CODE
+        &&
+         !context_ptr->ref_pruning_ctrls.intra_to_inter_pruning_enabled)
+#endif
         (pcs_ptr->parent_pcs_ptr->ref_list0_count_try == 1 &&
-         pcs_ptr->parent_pcs_ptr->ref_list1_count_try == 1))
+        pcs_ptr->parent_pcs_ptr->ref_list1_count_try == 1))
         return;
 
     uint8_t hbd_mode_decision = context_ptr->hbd_mode_decision == EB_DUAL_BIT_MD
@@ -5940,32 +6494,39 @@ static void perform_md_reference_pruning(PictureControlSet *  pcs_ptr,
     uint32_t input_origin_index = (context_ptr->blk_origin_y + input_picture_ptr->origin_y) *
             input_picture_ptr->stride_y +
         (context_ptr->blk_origin_x + input_picture_ptr->origin_x);
-
+#if !REMOVE_USELESS_CODE
     uint32_t early_intra_distortion = (uint32_t)~0;
     // INTRA not supported if sq_size > 64
     if (context_ptr->ref_pruning_ctrls.intra_to_inter_pruning_enabled &&
         context_ptr->blk_geom->sq_size <= 64) {
+#if !ADAPTIVE_ME_SEARCH && !UPGRADE_SUBPEL
         // Distortion measure
         const EbBool use_ssd = EB_FALSE;
         early_intra_distortion = early_intra_evaluation(
             pcs_ptr, context_ptr, input_picture_ptr, input_origin_index, blk_origin_index, use_ssd);
+#else
+        early_intra_distortion = early_intra_evaluation(
+            pcs_ptr, context_ptr, input_picture_ptr, input_origin_index, blk_origin_index, EB_FALSE);
+#endif
     }
-
+#endif
     for (uint32_t ref_it = 0; ref_it < pcs_ptr->parent_pcs_ptr->tot_ref_frame_types; ++ref_it) {
         MvReferenceFrame ref_pair = pcs_ptr->parent_pcs_ptr->ref_frame_type_arr[ref_it];
-
+#if !ADAPTIVE_ME_SEARCH && !UPGRADE_SUBPEL
         MacroBlockD *xd = context_ptr->blk_ptr->av1xd;
         IntMv        nearestmv[2], nearmv[2], ref_mv[2];
-
+#endif
         MvReferenceFrame rf[2];
         av1_set_ref_frame(rf, ref_pair);
 
         if (rf[1] == NONE_FRAME) {
             uint32_t         best_mvp_distortion = (int32_t)~0;
+#if !ADAPTIVE_ME_SEARCH && !UPGRADE_SUBPEL
             MvReferenceFrame frame_type          = rf[0];
+#endif
             uint8_t          list_idx            = get_list_idx(rf[0]);
             uint8_t          ref_idx             = get_ref_frame_idx(rf[0]);
-
+#if !ADAPTIVE_ME_SEARCH && !UPGRADE_SUBPEL
             // Evaluate MVP (if available)
             int16_t mvp_x_array[PRED_ME_MAX_MVP_CANIDATES];
             int16_t mvp_y_array[PRED_ME_MAX_MVP_CANIDATES];
@@ -6006,19 +6567,46 @@ static void perform_md_reference_pruning(PictureControlSet *  pcs_ptr,
                     mvp_count++;
                 }
             }
+#endif
             // Step 1: derive the best MVP in term of distortion
-
+#if ADAPTIVE_ME_SEARCH || UPGRADE_SUBPEL
+            for (int8_t mvp_index = 0; mvp_index < context_ptr->mvp_count[list_idx][ref_idx]; mvp_index++) {
+#else
             for (int8_t mvp_index = 0; mvp_index < mvp_count; mvp_index++) {
+#endif
                 // MVP Distortion
                 EbReferenceObject *ref_obj =
                     pcs_ptr->ref_pic_ptr_array[list_idx][ref_idx]->object_ptr;
                 EbPictureBufferDesc *ref_pic = hbd_mode_decision ? ref_obj->reference_picture16bit
                                                                  : ref_obj->reference_picture;
-
+#if REMOVE_USELESS_CODE //
+                clip_mv_on_pic_boundary(context_ptr->blk_origin_x, context_ptr->blk_origin_y, context_ptr->blk_geom->bwidth, context_ptr->blk_geom->bheight,
+                    ref_pic, &context_ptr->mvp_array[list_idx][ref_idx][mvp_index].col, &context_ptr->mvp_array[list_idx][ref_idx][mvp_index].row);
+#else
+                // Skip the pred_me at the boundary
+#if ADAPTIVE_ME_SEARCH || UPGRADE_SUBPEL
+                if (context_ptr->blk_origin_x + (context_ptr->mvp_array[list_idx][ref_idx][mvp_index].col >> 3) +
+                    context_ptr->blk_geom->bwidth >
+                    ref_pic->max_width + ref_pic->origin_x ||
+                    context_ptr->blk_origin_y + (context_ptr->mvp_array[list_idx][ref_idx][mvp_index].row >> 3) +
+                    context_ptr->blk_geom->bheight >
+                    ref_pic->max_height + ref_pic->origin_y ||
+                    context_ptr->blk_origin_x +
+                    (context_ptr->mvp_array[list_idx][ref_idx][mvp_index].col >> 3) < -ref_pic->origin_x ||
+                    context_ptr->blk_origin_y +
+                    (context_ptr->mvp_array[list_idx][ref_idx][mvp_index].row >> 3) < -ref_pic->origin_y)
+                    continue;
+#endif
+#endif
                 // Never be negative here
                 int32_t ref_origin_index = ref_pic->origin_x +
+#if ADAPTIVE_ME_SEARCH || UPGRADE_SUBPEL
+                    (context_ptr->blk_origin_x + (context_ptr->mvp_array[list_idx][ref_idx][mvp_index].col >> 3)) +
+                    (context_ptr->blk_origin_y + (context_ptr->mvp_array[list_idx][ref_idx][mvp_index].row >> 3) +
+#else
                     (context_ptr->blk_origin_x + (mvp_x_array[mvp_index] >> 3)) +
                     (context_ptr->blk_origin_y + (mvp_y_array[mvp_index] >> 3) +
+#endif
                      ref_pic->origin_y) *
                         ref_pic->stride_y;
                 assert((context_ptr->blk_geom->bwidth >> 3) < 17);
@@ -6067,7 +6655,27 @@ static void perform_md_reference_pruning(PictureControlSet *  pcs_ptr,
                     pcs_ptr->ref_pic_ptr_array[list_idx][ref_idx]->object_ptr;
                 EbPictureBufferDesc *ref_pic = hbd_mode_decision ? ref_obj->reference_picture16bit
                                                                  : ref_obj->reference_picture;
-
+#if REMOVE_USELESS_CODE //
+                clip_mv_on_pic_boundary(context_ptr->blk_origin_x, context_ptr->blk_origin_y, context_ptr->blk_geom->bwidth, context_ptr->blk_geom->bheight,
+                    ref_pic, &me_mv_x, &me_mv_y);
+#else
+#if ADAPTIVE_ME_SEARCH || UPGRADE_SUBPEL
+                // Check the boundary, may over the boundary because of the round-up
+                EbBool out_of_boundary = EB_FALSE;
+                if (context_ptr->blk_origin_x + (me_mv_x >> 3) +
+                    context_ptr->blk_geom->bwidth >
+                    ref_pic->max_width + ref_pic->origin_x ||
+                    context_ptr->blk_origin_y + (me_mv_y >> 3) +
+                    context_ptr->blk_geom->bheight >
+                    ref_pic->max_height + ref_pic->origin_y ||
+                    context_ptr->blk_origin_x +
+                    (me_mv_x >> 3) < -ref_pic->origin_x ||
+                    context_ptr->blk_origin_y +
+                    (me_mv_y >> 3) < -ref_pic->origin_y)
+                    out_of_boundary = EB_TRUE;
+                if (!out_of_boundary) {
+#endif
+#endif
                 // Never be negative here
                 int32_t ref_origin_index = ref_pic->origin_x +
                     (context_ptr->blk_origin_x + (me_mv_x >> 3)) +
@@ -6089,6 +6697,11 @@ static void perform_md_reference_pruning(PictureControlSet *  pcs_ptr,
                             ref_pic->stride_y,
                             context_ptr->blk_geom->bheight,
                             context_ptr->blk_geom->bwidth);
+#if !REMOVE_USELESS_CODE //
+#if ADAPTIVE_ME_SEARCH || UPGRADE_SUBPEL
+                }
+#endif
+#endif
             }
 
             // early_inter_distortion_array
@@ -6099,7 +6712,7 @@ static void perform_md_reference_pruning(PictureControlSet *  pcs_ptr,
             }
             early_inter_distortion_array[list_idx * REF_LIST_MAX_DEPTH + ref_idx] = MIN(
                 pa_me_distortion, best_mvp_distortion);
-        }
+       }
     }
 
     // Sort early_inter_distortion_array
@@ -6114,10 +6727,11 @@ static void perform_md_reference_pruning(PictureControlSet *  pcs_ptr,
     for (unsigned gi = 0; gi < TOT_INTER_GROUP; gi++) {
         uint8_t best_refs        = context_ptr->ref_pruning_ctrls.best_refs[gi];
         uint8_t total_tagged_ref = 0;
-
+#if !REMOVE_USELESS_CODE
         // inter-to-inter distortion based ref masking
         if (context_ptr->ref_pruning_ctrls.inter_to_inter_pruning_enabled) {
             total_tagged_ref = 0;
+#endif
             for (unsigned li = 0; li < MAX_NUM_OF_REF_PIC_LIST; li++)
                 for (unsigned ri = 0; ri < REF_LIST_MAX_DEPTH; ri++)
                     if (context_ptr->ref_filtering_res[gi][li][ri].valid_ref) {
@@ -6129,8 +6743,8 @@ static void perform_md_reference_pruning(PictureControlSet *  pcs_ptr,
                             total_tagged_ref++;
                         }
                     }
+#if !REMOVE_USELESS_CODE
         }
-
         // intra-to-inter distortion based ref masking
         if (context_ptr->ref_pruning_ctrls.intra_to_inter_pruning_enabled) {
             total_tagged_ref = 0;
@@ -6144,16 +6758,80 @@ static void perform_md_reference_pruning(PictureControlSet *  pcs_ptr,
                             total_tagged_ref++;
                     }
         }
+#endif
     }
 }
 #endif
+#if ADAPTIVE_ME_SEARCH || UPGRADE_SUBPEL
+/*
+ * Read/store all nearest/near MVs for a block for single ref case, and save the best distortion for each ref.
+ */
+void build_single_ref_mvp_array(PictureControlSet *pcs, ModeDecisionContext *ctx) {
 
+    for (uint32_t ref_it = 0; ref_it < pcs->parent_pcs_ptr->tot_ref_frame_types; ++ref_it) {
+        MvReferenceFrame ref_pair = pcs->parent_pcs_ptr->ref_frame_type_arr[ref_it];
+
+        MacroBlockD *xd = ctx->blk_ptr->av1xd;
+        IntMv        nearestmv[2], nearmv[2], ref_mv[2];
+
+        MvReferenceFrame rf[2];
+        av1_set_ref_frame(rf, ref_pair);
+        // Single ref
+        if (rf[1] == NONE_FRAME) {
+
+            MvReferenceFrame frame_type = rf[0];
+            uint8_t list_idx = get_list_idx(rf[0]);
+            uint8_t ref_idx = get_ref_frame_idx(rf[0]);
+            uint8_t drli, max_drl_index;
+            int8_t mvp_count = 0;
+
+            //NEAREST
+            ctx->mvp_array[list_idx][ref_idx][mvp_count].col =
+                (ctx->md_local_blk_unit[ctx->blk_geom->blkidx_mds].ref_mvs[frame_type][0].as_mv.col + 4) & ~0x07;
+            ctx->mvp_array[list_idx][ref_idx][mvp_count].row =
+                (ctx->md_local_blk_unit[ctx->blk_geom->blkidx_mds].ref_mvs[frame_type][0].as_mv.row + 4) & ~0x07;
+            mvp_count++;
+
+            //NEAR
+            max_drl_index = get_max_drl_index(xd->ref_mv_count[frame_type], NEARMV);
+
+            for (drli = 0; drli < max_drl_index; drli++) {
+                get_av1_mv_pred_drl(ctx,
+                    ctx->blk_ptr,
+                    frame_type,
+                    0,
+                    NEARMV,
+                    drli,
+                    nearestmv,
+                    nearmv,
+                    ref_mv);
+
+                if (((nearmv[0].as_mv.col + 4) & ~0x07) != ctx->mvp_array[list_idx][ref_idx][0].col &&
+                    ((nearmv[0].as_mv.row + 4) & ~0x07) != ctx->mvp_array[list_idx][ref_idx][0].row) {
+                    ctx->mvp_array[list_idx][ref_idx][mvp_count].col = (nearmv[0].as_mv.col + 4) & ~0x07;
+                    ctx->mvp_array[list_idx][ref_idx][mvp_count].row = (nearmv[0].as_mv.row + 4) & ~0x07;
+                    mvp_count++;
+                }
+            }
+            ctx->mvp_count[list_idx][ref_idx] = mvp_count;
+        }
+    }
+}
+#endif
 #if PRUNING_PER_INTER_TYPE
 EbBool is_valid_unipred_ref(struct ModeDecisionContext *context_ptr, uint8_t inter_cand_group, uint8_t list_idx, uint8_t ref_idx);
 #endif
+#if UPGRADE_SUBPEL
+/*
+ * Perform Full-Pel, 1/2-Pel, 1/4-Pel, and 1/8-Pel search around the best MVP for single ref frames
+ */
+void predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
+    EbPictureBufferDesc *input_picture_ptr) {
+#else
 void predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,
                           EbPictureBufferDesc *input_picture_ptr, uint32_t input_origin_index,
                           uint32_t blk_origin_index) {
+#endif
     EbBool use_ssd = EB_TRUE;
 #if ADD_SAD_AT_PME_SIGNAL
     if (context_ptr->use_sad_at_pme)
@@ -6171,19 +6849,27 @@ void predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
                                           : pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
 
     //Update input origin
+#if UPGRADE_SUBPEL
+    uint32_t input_origin_index =
+        (context_ptr->blk_origin_y + input_picture_ptr->origin_y) * input_picture_ptr->stride_y +
+        (context_ptr->blk_origin_x + input_picture_ptr->origin_x);
+
+    // Reset valid_refined_mv
+    memset(context_ptr->valid_pme_mv, 0, 8); // [2][4]
+#else
     input_origin_index = (context_ptr->blk_origin_y + input_picture_ptr->origin_y) *
             input_picture_ptr->stride_y +
         (context_ptr->blk_origin_x + input_picture_ptr->origin_x);
 
     // Reset valid_refined_mv
     memset(context_ptr->valid_refined_mv, 0, 8); // [2][4]
-
+#endif
     for (uint32_t ref_it = 0; ref_it < pcs_ptr->parent_pcs_ptr->tot_ref_frame_types; ++ref_it) {
         MvReferenceFrame ref_pair = pcs_ptr->parent_pcs_ptr->ref_frame_type_arr[ref_it];
-
+#if !ADAPTIVE_ME_SEARCH && !UPGRADE_SUBPEL
         MacroBlockD *xd = context_ptr->blk_ptr->av1xd;
         IntMv        nearestmv[2], nearmv[2], ref_mv[2];
-
+#endif
         MvReferenceFrame rf[2];
         av1_set_ref_frame(rf, ref_pair);
 
@@ -6193,12 +6879,15 @@ void predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
         int16_t  best_search_mvx        = (int16_t)~0;
         int16_t  best_search_mvy        = (int16_t)~0;
         uint32_t best_search_distortion = (int32_t)~0;
-
+#if !ADAPTIVE_ME_SEARCH && !UPGRADE_SUBPEL
         // Step 0: derive the MVP list; 1 nearest and up to 3 near
         int16_t mvp_x_array[PRED_ME_MAX_MVP_CANIDATES];
         int16_t mvp_y_array[PRED_ME_MAX_MVP_CANIDATES];
+#endif
         if (rf[1] == NONE_FRAME) {
+#if !ADAPTIVE_ME_SEARCH && !UPGRADE_SUBPEL
             MvReferenceFrame frame_type = rf[0];
+#endif
             uint8_t          list_idx   = get_list_idx(rf[0]);
             uint8_t          ref_idx    = get_ref_frame_idx(rf[0]);
 #if PRED_ME_REF_MASKING
@@ -6212,8 +6901,13 @@ void predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
             if (context_ptr->pd_pass == PD_PASS_2) if (ref_idx > 0) continue;
 #endif
 #endif
+#if UPGRADE_SUBPEL
+            if (ref_idx > 1 && context_ptr->predictive_me_level == 1)
+                continue;
+#else
             if (ref_idx > 1 && context_ptr->predictive_me_level <= 5)
                 continue;
+#endif
             if (ref_idx > context_ptr->md_max_ref_count - 1)
                 continue;
             // Get the ME MV
@@ -6292,7 +6986,12 @@ void predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
                     }
                 }
             }
+#if UPGRADE_SUBPEL
+            if (pa_me_distortion != 0 || context_ptr->predictive_me_level >= 2) {
+#else
             if (pa_me_distortion != 0 || context_ptr->predictive_me_level >= 5) {
+#endif
+#if !ADAPTIVE_ME_SEARCH && !UPGRADE_SUBPEL
                 int8_t mvp_count = 0;
                 //NEAREST
                 mvp_x_array[mvp_count] = (context_ptr
@@ -6331,6 +7030,7 @@ void predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
                         mvp_count++;
                     }
                 }
+#endif
                 // Step 1: derive the best MVP in term of distortion
                 int16_t best_mvp_x = 0;
                 int16_t best_mvp_y = 0;
@@ -6344,11 +7044,31 @@ void predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
                 // Use scaled references if resolution of the reference is different from that of the input
                 // -------
                 use_scaled_rec_refs_if_needed(pcs_ptr, input_picture_ptr, ref_obj, &ref_pic);
-
+#if ADAPTIVE_ME_SEARCH || UPGRADE_SUBPEL
+                for (int8_t mvp_index = 0; mvp_index < context_ptr->mvp_count[list_idx][ref_idx]; mvp_index++) {
+#else
                 for (int8_t mvp_index = 0; mvp_index < mvp_count; mvp_index++) {
+#endif
                     uint32_t mvp_distortion = 0;
                     // MVP Distortion
+#if REMOVE_USELESS_CODE //
+                    clip_mv_on_pic_boundary(context_ptr->blk_origin_x, context_ptr->blk_origin_y, context_ptr->blk_geom->bwidth, context_ptr->blk_geom->bheight,
+                        ref_pic, &context_ptr->mvp_array[list_idx][ref_idx][mvp_index].col, &context_ptr->mvp_array[list_idx][ref_idx][mvp_index].row);
+#else
                     // Skip the pred_me at the boundary
+#if ADAPTIVE_ME_SEARCH || UPGRADE_SUBPEL
+                    if (context_ptr->blk_origin_x + (context_ptr->mvp_array[list_idx][ref_idx][mvp_index].col >> 3) +
+                        context_ptr->blk_geom->bwidth >
+                        ref_pic->max_width + ref_pic->origin_x ||
+                        context_ptr->blk_origin_y + (context_ptr->mvp_array[list_idx][ref_idx][mvp_index].row >> 3) +
+                        context_ptr->blk_geom->bheight >
+                        ref_pic->max_height + ref_pic->origin_y ||
+                        context_ptr->blk_origin_x +
+                        (context_ptr->mvp_array[list_idx][ref_idx][mvp_index].col >> 3) < -ref_pic->origin_x ||
+                        context_ptr->blk_origin_y +
+                        (context_ptr->mvp_array[list_idx][ref_idx][mvp_index].row >> 3) < -ref_pic->origin_y)
+                        continue;
+#else
                     if (context_ptr->blk_origin_x + (mvp_x_array[mvp_index] >> 3) +
                                 context_ptr->blk_geom->bwidth >
                             ref_pic->max_width + ref_pic->origin_x ||
@@ -6360,10 +7080,17 @@ void predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
                         context_ptr->blk_origin_y + (mvp_y_array[mvp_index] >> 3) <
                             -ref_pic->origin_y)
                         continue;
+#endif
+#endif
                     int32_t ref_origin_index = ref_pic->origin_x +
+#if ADAPTIVE_ME_SEARCH || UPGRADE_SUBPEL
+                        (context_ptr->blk_origin_x + (context_ptr->mvp_array[list_idx][ref_idx][mvp_index].col >> 3)) +
+                        (context_ptr->blk_origin_y + (context_ptr->mvp_array[list_idx][ref_idx][mvp_index].row >> 3) +
+#else
                         (context_ptr->blk_origin_x + (mvp_x_array[mvp_index] >> 3)) +
                         (context_ptr->blk_origin_y + (mvp_y_array[mvp_index] >> 3) +
-                         ref_pic->origin_y) *
+#endif
+                            ref_pic->origin_y) *
                             ref_pic->stride_y;
                     if (use_ssd) {
                         EbSpatialFullDistType spatial_full_dist_type_fun = hbd_mode_decision
@@ -6403,8 +7130,13 @@ void predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
 
                     if (mvp_distortion < best_mvp_distortion) {
                         best_mvp_distortion = mvp_distortion;
+#if ADAPTIVE_ME_SEARCH || UPGRADE_SUBPEL
+                        best_mvp_x = context_ptr->mvp_array[list_idx][ref_idx][mvp_index].col;
+                        best_mvp_y = context_ptr->mvp_array[list_idx][ref_idx][mvp_index].row;
+#else
                         best_mvp_x          = mvp_x_array[mvp_index];
                         best_mvp_y          = mvp_y_array[mvp_index];
+#endif
                     }
                 }
 
@@ -6427,14 +7159,41 @@ void predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
                                    +(context_ptr->pred_me_full_pel_search_width >> 1),
                                    -(context_ptr->pred_me_full_pel_search_height >> 1),
                                    +(context_ptr->pred_me_full_pel_search_height >> 1),
+#if ADAPTIVE_ME_SEARCH
+                                   1,
+#else
                                    8,
+#endif
 #if SEARCH_TOP_N
                                    0,
 #endif
                                    &best_search_mvx,
                                    &best_search_mvy,
                                    &best_search_distortion);
+#if UPGRADE_SUBPEL
+                int besterr = (int)best_search_distortion;
+                if (context_ptr->md_subpel_pme_ctrls.enabled) {
 
+                    besterr = md_subpel_search(pcs_ptr,
+                        context_ptr,
+                        context_ptr->md_subpel_pme_ctrls,
+                        pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr, // 10BIT not supported
+                        list_idx,
+                        ref_idx,
+                        &best_search_mvx,
+                        &best_search_mvy,
+                        best_mvp_x,
+                        best_mvp_y);
+                }
+#if LOG_MV_VALIDITY
+                //check if final MV is within AV1 limits
+                check_mv_validity(best_search_mvx,
+                    best_search_mvy, 0);
+#endif
+                context_ptr->best_pme_mv[list_idx][ref_idx][0] = best_search_mvx;
+                context_ptr->best_pme_mv[list_idx][ref_idx][1] = best_search_mvy;
+                context_ptr->valid_pme_mv[list_idx][ref_idx] = 1;
+#else
                 EbBool exit_predictive_me_sub_pel;
 
                 if (pa_me_distortion == 0)
@@ -6629,8 +7388,13 @@ void predictive_me_search(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
                     context_ptr->best_spatial_pred_mv[list_idx][ref_idx][1] = best_search_mvy;
                     context_ptr->valid_refined_mv[list_idx][ref_idx]        = 1;
                 }
+#endif
 #if PME_SORT_REF
+#if UPGRADE_SUBPEL
+                context_ptr->pme_res[list_idx][ref_idx].dist = (uint32_t)besterr;
+#else
                 context_ptr->pme_res[list_idx][ref_idx].dist = best_search_distortion;
+#endif
 #endif
             }
         }
@@ -11053,6 +11817,14 @@ void move_blk_data_redund(PictureControlSet *pcs, ModeDecisionContext *context_p
     dst_cu->drl_ctx_near[0] = src_cu->drl_ctx_near[0];
     dst_cu->drl_ctx_near[1] = src_cu->drl_ctx_near[1];
 #endif
+#if UPGRADE_SUBPEL
+    for (int list_idx = 0; list_idx < MAX_NUM_OF_REF_PIC_LIST; list_idx++) {
+        for (int ref_idx = 0; ref_idx < MAX_REF_IDX; ref_idx++) {
+            context_ptr->sb_me_mv[dst_cu->mds_idx][list_idx][ref_idx][0] = context_ptr->sb_me_mv[src_cu->mds_idx][list_idx][ref_idx][0];
+            context_ptr->sb_me_mv[dst_cu->mds_idx][list_idx][ref_idx][1] = context_ptr->sb_me_mv[src_cu->mds_idx][list_idx][ref_idx][1];
+        }
+    }
+#endif
 }
 
 void check_redundant_block(const BlockGeom *blk_geom, ModeDecisionContext *context_ptr,
@@ -11843,8 +12615,9 @@ static void search_best_independent_uv_mode(PictureControlSet *  pcs_ptr,
     if (context_ptr->chroma_at_last_md_stage)
         context_ptr->md_staging_skip_rdoq = tem_md_staging_skip_rdoq;
 }
-
+#if !UPGRADE_SUBPEL
 extern AomVarianceFnPtr mefn_ptr[BlockSizeS_ALL];
+#endif
 unsigned int eb_av1_get_sby_perpixel_variance(const AomVarianceFnPtr *fn_ptr, const uint8_t *src,
                                               int stride, BlockSize bs);
 
@@ -12443,13 +13216,29 @@ void md_encode_block(PictureControlSet *pcs_ptr, ModeDecisionContext *context_pt
     } else {
         mvp_bypass_init(pcs_ptr, context_ptr);
     }
-
+#if ADAPTIVE_ME_SEARCH || UPGRADE_SUBPEL
+    // Read MVPs (rounded-up to the closest integer) for use in md_sq_motion_search() and/or predictive_me_search() and/or perform_md_reference_pruning()
+    if (pcs_ptr->slice_type != I_SLICE &&
+#if ADAPTIVE_ME_SEARCH && UPGRADE_SUBPEL
+    (context_ptr->md_sq_me_ctrls.enabled || context_ptr->predictive_me_level || context_ptr->ref_pruning_ctrls.inter_to_inter_pruning_enabled || context_ptr->md_subpel_me_ctrls.enabled || context_ptr->md_subpel_pme_ctrls.enabled))
+#elif ADAPTIVE_ME_SEARCH
+    (context_ptr->md_sq_me_ctrls.enabled || context_ptr->predictive_me_level || context_ptr->ref_pruning_ctrls.inter_to_inter_pruning_enabled || context_ptr->ref_pruning_ctrls.intra_to_inter_pruning_enabled))
+#else
+        (context_ptr->predictive_me_level || context_ptr->ref_pruning_ctrls.inter_to_inter_pruning_enabled || context_ptr->ref_pruning_ctrls.intra_to_inter_pruning_enabled || context_ptr->md_subpel_me_ctrls.enabled || context_ptr->md_subpel_pme_ctrls.enabled))
+#endif
+        build_single_ref_mvp_array(pcs_ptr, context_ptr);
+#endif
 #if ADD_MD_NSQ_SEARCH
     if (pcs_ptr->slice_type != I_SLICE)
 #endif
     // Read and (if needed) perform 1/8 Pel ME MVs refinement
+#if UPGRADE_SUBPEL
+        read_refine_me_mvs(
+            pcs_ptr, context_ptr, input_picture_ptr);
+#else
     read_refine_me_mvs(
         pcs_ptr, context_ptr, input_picture_ptr, input_origin_index, blk_origin_index);
+#endif
 #if PME_SORT_REF
     for (uint32_t li = 0; li < MAX_NUM_OF_REF_PIC_LIST; ++li) {
         for (uint32_t ri = 0; ri < REF_LIST_MAX_DEPTH; ++ri) {
@@ -12464,15 +13253,25 @@ void md_encode_block(PictureControlSet *pcs_ptr, ModeDecisionContext *context_pt
 #endif
 #if MD_REFERENCE_MASKING
     // Perform md reference pruning
+#if REMOVE_USELESS_CODE
+    perform_md_reference_pruning(
+        pcs_ptr, context_ptr, input_picture_ptr);
+#else
     perform_md_reference_pruning(
         pcs_ptr, context_ptr, input_picture_ptr, blk_origin_index);
 #endif
+#endif
     // Perform ME search around the best MVP
+#if UPGRADE_SUBPEL
+    if (context_ptr->predictive_me_level)
+        predictive_me_search(
+            pcs_ptr, context_ptr, input_picture_ptr);
+#else
     if (context_ptr->predictive_me_level)
         predictive_me_search(
             pcs_ptr, context_ptr, input_picture_ptr, input_origin_index, blk_origin_index);
     //for every CU, perform Luma DC/V/H/S intra prediction to be used later in inter-intra search
-
+#endif
     int allow_ii = is_interintra_allowed_bsize(context_ptr->blk_geom->bsize);
     if (context_ptr->md_enable_inter_intra && allow_ii)
         precompute_intra_pred_for_inter_intra(pcs_ptr, context_ptr);
@@ -13142,6 +13941,7 @@ uint32_t get_number_of_blocks(uint32_t block_idx) {
         : blk_geom->sq_size > 8 ? 25 : blk_geom->sq_size == 8 ? 5 : 1;
     return tot_d1_blocks;
 }
+#if !REMOVE_USELESS_CODE
 /***********************************
 Mark the blocks of the lower depth
 to be skipped
@@ -13184,6 +13984,7 @@ static void set_child_to_be_skipped(ModeDecisionContext *context_ptr, uint32_t b
             set_child_to_be_skipped(context_ptr, child_block_idx_4, sb_size, depth_step - 1);
     }
 }
+#endif
 #if BLOCK_REDUCTION_ALGORITHM_1 || BLOCK_REDUCTION_ALGORITHM_2
 void derive_shape_default_cost(
     ModeDecisionContext *context_ptr) {
@@ -13334,7 +14135,7 @@ void derive_shape_default_cost(
 
     }
 }
-
+#if !REMOVE_USELESS_CODE
 void block_based_depth_reduction(
     SequenceControlSet *scs_ptr,
     ModeDecisionContext *context_ptr) {
@@ -13458,6 +14259,7 @@ void block_based_depth_reduction(
 #endif
 
 }
+#endif
 #endif
 #if COEFF_BASED_BYPASS_NSQ
 #if MERGED_COEFF_BAND
@@ -14295,7 +15097,7 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
 #if BLOCK_REDUCTION_ALGORITHM_1 || BLOCK_REDUCTION_ALGORITHM_2
             // To call derive_shape_default_cost() before sq_weight() to take advantage of the default cost derivation(s)
             derive_shape_default_cost(context_ptr);
-
+#if !REMOVE_USELESS_CODE
             // Here d1 is already performed but not d2
             if (context_ptr->depth_reduction_ctrls.enabled &&
                 context_ptr->md_blk_arr_nsq[blk_geom->sqi_mds].split_flag == EB_TRUE &&  // could be further splitted
@@ -14305,6 +15107,7 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
                     scs_ptr,
                     context_ptr);
             }
+#endif
 #endif
         } else if (d1_first_block)
             d1_first_block = 0;

--- a/Source/Lib/Encoder/Codec/EbRateDistortionCost.c
+++ b/Source/Lib/Encoder/Codec/EbRateDistortionCost.c
@@ -66,14 +66,14 @@ uint8_t av1_drl_ctx(const CandidateMv *ref_mv_stack, int32_t ref_idx) {
 //    MV_JOINT_HNZVNZ = 3, /* Both components nonzero */
 //} MvJointType;
 
-MvJointType av1_get_mv_joint(const MV *mv) {
+MvJointType svt_av1_get_mv_joint(const MV *mv) {
     if (mv->row == 0)
         return mv->col == 0 ? MV_JOINT_ZERO : MV_JOINT_HNZVZ;
     else
         return mv->col == 0 ? MV_JOINT_HZVNZ : MV_JOINT_HNZVNZ;
 }
 int32_t mv_cost(const MV *mv, const int32_t *joint_cost, int32_t *const comp_cost[2]) {
-    int32_t jn_c = av1_get_mv_joint(mv);
+    int32_t jn_c = svt_av1_get_mv_joint(mv);
     int32_t res  = joint_cost[jn_c] + comp_cost[0][mv->row] + comp_cost[1][mv->col];
 
     return res;

--- a/Source/Lib/Encoder/Codec/av1me.c
+++ b/Source/Lib/Encoder/Codec/av1me.c
@@ -119,10 +119,10 @@ void eb_av1_set_mv_search_range(MvLimits *mv_limits, const MV *mv) {
     if (mv_limits->row_max > row_max) mv_limits->row_max = row_max;
 }
 
-MvJointType av1_get_mv_joint(const MV *mv);
+MvJointType svt_av1_get_mv_joint(const MV *mv);
 
 static INLINE int mv_cost(const MV *mv, const int *joint_cost, int *const comp_cost[2]) {
-    return joint_cost[av1_get_mv_joint(mv)] + comp_cost[0][mv->row] + comp_cost[1][mv->col];
+    return joint_cost[svt_av1_get_mv_joint(mv)] + comp_cost[0][mv->row] + comp_cost[1][mv->col];
 }
 
 #define PIXEL_TRANSFORM_ERROR_SCALE 4

--- a/Source/Lib/Encoder/Codec/av1me.h
+++ b/Source/Lib/Encoder/Codec/av1me.h
@@ -9,8 +9,8 @@
  * PATENTS file, you can obtain it at https://www.aomedia.org/license/patent-license.
  */
 
-#ifndef AOM_AV1_ENCODER_MCOMP_H_
-#define AOM_AV1_ENCODER_MCOMP_H_
+#ifndef AOM_AV1_ENCODER_ME_H_
+#define AOM_AV1_ENCODER_ME_H_
 
 #include "EbDefinitions.h"
 #include "EbCodingUnit.h"
@@ -91,4 +91,4 @@ int eb_av1_full_pixel_search(struct PictureControlSet *pcs, IntraBcContext /*MAC
 } // extern "C"
 #endif
 
-#endif // AOM_AV1_ENCODER_MCOMP_H_
+#endif // AOM_AV1_ENCODER_ME_H_

--- a/Source/Lib/Encoder/Codec/mcomp.c
+++ b/Source/Lib/Encoder/Codec/mcomp.c
@@ -1,0 +1,451 @@
+/*
+ * Copyright (c) 2016, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 2 Clause License and
+ * the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+ * was not distributed with this source code in the LICENSE file, you can
+ * obtain it at www.aomedia.org/license/software. If the Alliance for Open
+ * Media Patent License 1.0 was not distributed with this source code in the
+ * PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+ */
+
+#include <limits.h>
+#include <math.h>
+#include <stdio.h>
+
+#include "mcomp.h"
+#include "mv.h"
+#include "Av1Common.h"
+#include "EbCodingUnit.h"
+#include "EbBlockStructures.h"
+#include "av1me.h"
+#include "aom_dsp_rtcd.h"
+#if UPGRADE_SUBPEL
+// ============================================================================
+//  Cost of motion vectors
+// ============================================================================
+// TODO(any): Adaptively adjust the regularization strength based on image size
+// and motion activity instead of using hard-coded values. It seems like we
+// roughly half the lambda for each increase in resolution
+// These are multiplier used to perform regularization in motion compensation
+// when x->mv_cost_type is set to MV_COST_L1.
+// LOWRES
+#define SSE_LAMBDA_LOWRES 2   // Used by mv_cost_err_fn
+#define SAD_LAMBDA_LOWRES 32  // Used by mvsad_err_cost during full pixel search
+// MIDRES
+#define SSE_LAMBDA_MIDRES 0   // Used by mv_cost_err_fn
+#define SAD_LAMBDA_MIDRES 15  // Used by mvsad_err_cost during full pixel search
+// HDRES
+#define SSE_LAMBDA_HDRES 1  // Used by mv_cost_err_fn
+#define SAD_LAMBDA_HDRES 8  // Used by mvsad_err_cost during full pixel search
+
+// Returns the rate of encoding the current motion vector based on the
+// joint_cost and comp_cost. joint_costs covers the cost of transmitting
+// JOINT_MV, and comp_cost covers the cost of transmitting the actual motion
+// vector.
+MvJointType svt_av1_get_mv_joint(const MV *mv);
+static INLINE int svt_mv_cost(const MV *mv, const int *joint_cost,
+                          const int *const comp_cost[2]) {
+  return joint_cost[svt_av1_get_mv_joint(mv)] + comp_cost[0][mv->row] +
+         comp_cost[1][mv->col];
+}
+
+#define CONVERT_TO_CONST_MVCOST(ptr) ((const int *const *)(ptr))
+// Returns the cost of encoding the motion vector diff := *mv - *ref. The cost
+// is defined as the rate required to encode diff * weight, rounded to the
+// nearest 2 ** 7.
+// This is NOT used during motion compensation.
+int svt_av1_mv_bit_cost(const MV *mv, const MV *ref_mv, const int *mvjcost,
+                    int *mvcost[2], int weight) {
+  const MV diff = { mv->row - ref_mv->row, mv->col - ref_mv->col };
+  return ROUND_POWER_OF_TWO(
+      svt_mv_cost(&diff, mvjcost, CONVERT_TO_CONST_MVCOST(mvcost)) * weight, 7);
+}
+
+// Returns the cost of using the current mv during the motion search. This is
+// used when var is used as the error metric.
+#define PIXEL_TRANSFORM_ERROR_SCALE 4
+static INLINE int svt_mv_err_cost(const MV *mv, const MV *ref_mv,
+                              const int *mvjcost, const int *const mvcost[2],
+                              int error_per_bit, MV_COST_TYPE mv_cost_type) {
+  const MV diff = { mv->row - ref_mv->row, mv->col - ref_mv->col };
+  const MV abs_diff = { abs(diff.row), abs(diff.col) };
+
+  switch (mv_cost_type) {
+    case MV_COST_ENTROPY:
+      if (mvcost) {
+        return (int)ROUND_POWER_OF_TWO_64(
+            (int64_t)svt_mv_cost(&diff, mvjcost, mvcost) * error_per_bit,
+            RDDIV_BITS + AV1_PROB_COST_SHIFT - RD_EPB_SHIFT +
+                PIXEL_TRANSFORM_ERROR_SCALE);
+      }
+      return 0;
+    case MV_COST_L1_LOWRES:
+      return (SSE_LAMBDA_LOWRES * (abs_diff.row + abs_diff.col)) >> 3;
+    case MV_COST_L1_MIDRES:
+      return (SSE_LAMBDA_MIDRES * (abs_diff.row + abs_diff.col)) >> 3;
+    case MV_COST_L1_HDRES:
+      return (SSE_LAMBDA_HDRES * (abs_diff.row + abs_diff.col)) >> 3;
+    case MV_COST_NONE: return 0;
+    default: assert(0 && "Invalid rd_cost_type"); return 0;
+  }
+}
+
+static INLINE int svt_mv_err_cost_(const MV *mv,
+                               const MV_COST_PARAMS *mv_cost_params) {
+  return svt_mv_err_cost(mv, mv_cost_params->ref_mv, mv_cost_params->mvjcost,
+                     mv_cost_params->mvcost, mv_cost_params->error_per_bit,
+                     mv_cost_params->mv_cost_type);
+}
+
+// =============================================================================
+//  Subpixel Motion Search: Translational
+// =============================================================================
+#define INIT_SUBPEL_STEP_SIZE (4)
+
+/*
+ * To avoid the penalty for crossing cache-line read, preload the reference
+ * area in a small buffer, which is aligned to make sure there won't be crossing
+ * cache-line read while reading from this buffer. This reduced the cpu
+ * cycles spent on reading ref data in sub-pixel filter functions.
+ * TODO: Currently, since sub-pixel search range here is -3 ~ 3, copy 22 rows x
+ * 32 cols area that is enough for 16x16 macroblock. Later, for SPLITMV, we
+ * could reduce the area.
+ */
+
+// Returns the subpel offset used by various subpel variance functions [m]sv[a]f
+static INLINE int svt_get_subpel_part(int x) { return x & 7; }
+
+// Gets the address of the ref buffer at subpel location (r, c), rounded to the
+// nearest fullpel precision toward - \infty
+
+static INLINE const uint8_t *svt_get_buf_from_mv(const struct svt_buf_2d *buf,
+                                             const MV mv) {
+  const int offset = (mv.row >> 3) * buf->stride + (mv.col >> 3);
+  return &buf->buf[offset];
+}
+
+// Calculates the variance of prediction residue.
+static int svt_upsampled_pref_error(MacroBlockD *xd, const struct AV1Common *const cm,
+                                const MV *this_mv,
+                                const SUBPEL_SEARCH_VAR_PARAMS *var_params,
+                                unsigned int *sse) {
+  const AomVarianceFnPtr *vfp = var_params->vfp;
+  const SUBPEL_SEARCH_TYPE subpel_search_type = var_params->subpel_search_type;
+
+  const MSBuffers *ms_buffers = &var_params->ms_buffers;
+  const uint8_t *src = ms_buffers->src->buf;
+  const uint8_t *ref = svt_get_buf_from_mv(ms_buffers->ref, *this_mv);
+  const int src_stride = ms_buffers->src->stride;
+  const int ref_stride = ms_buffers->ref->stride;
+#if 0 // only 8BIT support
+  const uint8_t *second_pred = ms_buffers->second_pred;
+  const uint8_t *mask = ms_buffers->mask;
+  const int mask_stride = ms_buffers->mask_stride;
+  const int invert_mask = ms_buffers->inv_mask;
+#endif
+  const int w = var_params->w;
+  const int h = var_params->h;
+  const int mi_row = xd->mi_row;
+  const int mi_col = xd->mi_col;
+  const int subpel_x_q3 = svt_get_subpel_part(this_mv->col);
+  const int subpel_y_q3 = svt_get_subpel_part(this_mv->row);
+
+  unsigned int besterr;
+#if 0 // only 8BIT support
+  if (is_cur_buf_hbd(xd)) {
+    DECLARE_ALIGNED(16, uint16_t, pred16[MAX_SB_SQUARE]);
+    uint8_t *pred8 = CONVERT_TO_BYTEPTR(pred16);
+    if (second_pred != NULL) {
+      if (mask) {
+        aom_highbd_comp_mask_upsampled_pred(
+            xd, cm, mi_row, mi_col, this_mv, pred8, second_pred, w, h,
+            subpel_x_q3, subpel_y_q3, ref, ref_stride, mask, mask_stride,
+            invert_mask, xd->bd, subpel_search_type);
+      } else {
+        aom_highbd_comp_avg_upsampled_pred(
+            xd, cm, mi_row, mi_col, this_mv, pred8, second_pred, w, h,
+            subpel_x_q3, subpel_y_q3, ref, ref_stride, xd->bd,
+            subpel_search_type);
+      }
+    } else {
+      aom_highbd_upsampled_pred(xd, cm, mi_row, mi_col, this_mv, pred8, w, h,
+                                subpel_x_q3, subpel_y_q3, ref, ref_stride,
+                                xd->bd, subpel_search_type);
+    }
+    besterr = vfp->vf(pred8, w, src, src_stride, sse);
+  } else
+#endif
+  {
+    DECLARE_ALIGNED(16, uint8_t, pred[MAX_SB_SQUARE]);
+#if 0 // only single ref support
+    if (second_pred != NULL) {
+      if (mask) {
+        aom_comp_mask_upsampled_pred(
+            xd, cm, mi_row, mi_col, this_mv, pred, second_pred, w, h,
+            subpel_x_q3, subpel_y_q3, ref, ref_stride, mask, mask_stride,
+            invert_mask, subpel_search_type);
+      } else {
+        aom_comp_avg_upsampled_pred(xd, cm, mi_row, mi_col, this_mv, pred,
+                                    second_pred, w, h, subpel_x_q3, subpel_y_q3,
+                                    ref, ref_stride, subpel_search_type);
+      }
+    } else
+#endif
+    {
+      aom_upsampled_pred(xd, cm, mi_row, mi_col, this_mv, pred, w, h,
+                         subpel_x_q3, subpel_y_q3, ref, ref_stride,
+                         subpel_search_type);
+    }
+
+    besterr = vfp->vf(pred, w, src, src_stride, sse);
+  }
+
+  return besterr;
+}
+
+// Checks whether this_mv is better than best_mv. This function incorporates
+// both prediction error and residue into account.
+static AOM_FORCE_INLINE unsigned int svt_check_better(
+    MacroBlockD *xd, const struct AV1Common *const cm, const MV *this_mv, MV *best_mv,
+    const SubpelMvLimits *mv_limits, const SUBPEL_SEARCH_VAR_PARAMS *var_params,
+    const MV_COST_PARAMS *mv_cost_params, unsigned int *besterr,
+    unsigned int *sse1, int *distortion, int *is_better) {
+  unsigned int cost;
+  if (svt_av1_is_subpelmv_in_range(mv_limits, *this_mv)) {
+    unsigned int sse;
+    int thismse;
+    thismse = svt_upsampled_pref_error(xd, cm, this_mv, var_params, &sse);
+    cost = svt_mv_err_cost_(this_mv, mv_cost_params);
+    cost += thismse;
+    if (cost < *besterr) {
+      *besterr = cost;
+      *best_mv = *this_mv;
+      *distortion = thismse;
+      *sse1 = sse;
+      *is_better |= 1;
+    }
+  } else {
+    cost = INT_MAX;
+  }
+  return cost;
+}
+
+static INLINE MV svt_get_best_diag_step(int step_size, unsigned int left_cost,
+                                    unsigned int right_cost,
+                                    unsigned int up_cost,
+                                    unsigned int down_cost) {
+  const MV diag_step = { up_cost <= down_cost ? -step_size : step_size,
+                         left_cost <= right_cost ? -step_size : step_size };
+
+  return diag_step;
+}
+
+static AOM_FORCE_INLINE MV
+svt_first_level_check(MacroBlockD *xd, const struct AV1Common *const cm, const MV this_mv,
+                  MV *best_mv, const int hstep, const SubpelMvLimits *mv_limits,
+                  const SUBPEL_SEARCH_VAR_PARAMS *var_params,
+                  const MV_COST_PARAMS *mv_cost_params, unsigned int *besterr,
+                  unsigned int *sse1, int *distortion) {
+  int dummy = 0;
+  const MV left_mv = { this_mv.row, this_mv.col - hstep };
+  const MV right_mv = { this_mv.row, this_mv.col + hstep };
+  const MV top_mv = { this_mv.row - hstep, this_mv.col };
+  const MV bottom_mv = { this_mv.row + hstep, this_mv.col };
+
+  const unsigned int left =
+      svt_check_better(xd, cm, &left_mv, best_mv, mv_limits, var_params,
+                   mv_cost_params, besterr, sse1, distortion, &dummy);
+  const unsigned int right =
+      svt_check_better(xd, cm, &right_mv, best_mv, mv_limits, var_params,
+                   mv_cost_params, besterr, sse1, distortion, &dummy);
+  const unsigned int up =
+      svt_check_better(xd, cm, &top_mv, best_mv, mv_limits, var_params,
+                   mv_cost_params, besterr, sse1, distortion, &dummy);
+  const unsigned int down =
+      svt_check_better(xd, cm, &bottom_mv, best_mv, mv_limits, var_params,
+                   mv_cost_params, besterr, sse1, distortion, &dummy);
+
+  const MV diag_step = svt_get_best_diag_step(hstep, left, right, up, down);
+  const MV diag_mv = { this_mv.row + diag_step.row,
+                       this_mv.col + diag_step.col };
+
+  // Check the diagonal direction with the best mv
+  svt_check_better(xd, cm, &diag_mv, best_mv, mv_limits, var_params, mv_cost_params,
+               besterr, sse1, distortion, &dummy);
+
+  return diag_step;
+}
+
+// A newer version of second level check that gives better quality.
+// TODO(chiyotsai@google.com): evaluate this on subpel_search_types different
+// from av1_find_best_sub_pixel_tree
+static AOM_FORCE_INLINE void svt_second_level_check_v2(
+    MacroBlockD *xd, const struct AV1Common *const cm, const MV this_mv, MV diag_step,
+    MV *best_mv, const SubpelMvLimits *mv_limits,
+    const SUBPEL_SEARCH_VAR_PARAMS *var_params,
+    const MV_COST_PARAMS *mv_cost_params, unsigned int *besterr,
+    unsigned int *sse1, int *distortion, int is_scaled) {
+  assert(best_mv->row == this_mv.row + diag_step.row ||
+         best_mv->col == this_mv.col + diag_step.col);
+  if (CHECK_MV_EQUAL(this_mv, *best_mv)) {
+    return;
+  } else if (this_mv.row == best_mv->row) {
+    // Search away from diagonal step since diagonal search did not provide any
+    // improvement
+    diag_step.row *= -1;
+  } else if (this_mv.col == best_mv->col) {
+    diag_step.col *= -1;
+  }
+
+  const MV row_bias_mv = { best_mv->row + diag_step.row, best_mv->col };
+  const MV col_bias_mv = { best_mv->row, best_mv->col + diag_step.col };
+  const MV diag_bias_mv = { best_mv->row + diag_step.row,
+                            best_mv->col + diag_step.col };
+  int has_better_mv = 0;
+#if 0 // USE_2_TAPS_ORIG not supported
+  if (var_params->subpel_search_type != USE_2_TAPS_ORIG) {
+#endif
+      svt_check_better(xd, cm, &row_bias_mv, best_mv, mv_limits, var_params,
+                 mv_cost_params, besterr, sse1, distortion, &has_better_mv);
+      svt_check_better(xd, cm, &col_bias_mv, best_mv, mv_limits, var_params,
+                 mv_cost_params, besterr, sse1, distortion, &has_better_mv);
+
+    // Do an additional search if the second iteration gives a better mv
+    if (has_better_mv) {
+        svt_check_better(xd, cm, &diag_bias_mv, best_mv, mv_limits, var_params,
+                   mv_cost_params, besterr, sse1, distortion, &has_better_mv);
+    }
+#if 0 // USE_2_TAPS_ORIG not supported
+  } else {
+
+      svt_check_better(xd, cm, &row_bias_mv, best_mv, mv_limits, var_params,
+          mv_cost_params, besterr, sse1, distortion, &has_better_mv,
+          is_scaled);
+      svt_check_better(xd, cm, &col_bias_mv, best_mv, mv_limits, var_params,
+          mv_cost_params, besterr, sse1, distortion, &has_better_mv,
+          is_scaled);
+
+      // Do an additional search if the second iteration gives a better mv
+      if (has_better_mv) {
+          svt_check_better(xd, cm, &diag_bias_mv, best_mv, mv_limits, var_params,
+              mv_cost_params, besterr, sse1, distortion,
+              &has_better_mv, is_scaled);
+      }
+  }
+#else
+      (void)is_scaled;
+#endif
+}
+
+// Gets the error at the beginning when the mv has fullpel precision
+static unsigned int svt_upsampled_setup_center_error(
+    MacroBlockD *xd, const struct AV1Common *const cm, const MV *bestmv,
+    const SUBPEL_SEARCH_VAR_PARAMS *var_params,
+    const MV_COST_PARAMS *mv_cost_params, unsigned int *sse1, int *distortion) {
+  unsigned int besterr = svt_upsampled_pref_error(xd, cm, bestmv, var_params, sse1);
+  *distortion = besterr;
+  besterr += svt_mv_err_cost_(bestmv, mv_cost_params);
+  return besterr;
+}
+
+// Checks the list of mvs searched in the last iteration and see if we are
+// repeating it. If so, return 1. Otherwise we update the last_mv_search_list
+// with current_mv and return 0.
+static INLINE int svt_check_repeated_mv_and_update(int_mv *last_mv_search_list,
+                                               const MV current_mv, int iter) {
+  if (last_mv_search_list) {
+    if (CHECK_MV_EQUAL(last_mv_search_list[iter].as_mv, current_mv)) {
+      return 1;
+    }
+
+    last_mv_search_list[iter].as_mv = current_mv;
+  }
+  return 0;
+}
+
+int svt_av1_find_best_sub_pixel_tree(MacroBlockD *xd, const struct AV1Common *const cm,
+                                 const SUBPEL_MOTION_SEARCH_PARAMS *ms_params,
+                                 MV start_mv, MV *bestmv, int *distortion,
+                                 unsigned int *sse1,
+                                 int_mv *last_mv_search_list) {
+  const int allow_hp = ms_params->allow_hp;
+  const int forced_stop = ms_params->forced_stop;
+  const int iters_per_step = ms_params->iters_per_step;
+
+  const MV_COST_PARAMS *mv_cost_params = &ms_params->mv_cost_params;
+  const SUBPEL_SEARCH_VAR_PARAMS *var_params = &ms_params->var_params;
+#if 0// USE_2_TAPS_ORIG not supported
+  const SUBPEL_SEARCH_TYPE subpel_search_type =
+      ms_params->var_params.subpel_search_type;
+#endif
+  const SubpelMvLimits *mv_limits = &ms_params->mv_limits;
+
+  // How many steps to take. A round of 0 means fullpel search only, 1 means
+  // half-pel, and so on.
+  const int round = AOMMIN(FULL_PEL - forced_stop, 3 - !allow_hp);
+  int hstep = INIT_SUBPEL_STEP_SIZE;  // Step size, initialized to 4/8=1/2 pel
+
+  unsigned int besterr;
+
+  *bestmv = start_mv;
+#if 1 // ref scaling not supported
+  const int is_scaled = 0;
+#else
+  const struct scale_factors *const sf = is_intrabc_block(xd->mi[0])
+                                             ? &cm->sf_identity
+                                             : xd->block_ref_scale_factors[0];
+  const int is_scaled = av1_is_scaled(sf);
+#endif
+#if 0// USE_2_TAPS_ORIG not supported
+  if (subpel_search_type != USE_2_TAPS_ORIG) {
+#endif
+    besterr = svt_upsampled_setup_center_error(xd, cm, bestmv, var_params,
+                                           mv_cost_params, sse1, distortion);
+#if 0// USE_2_TAPS_ORIG not supported
+  }
+  else {
+      besterr = setup_center_error(xd, bestmv, var_params, mv_cost_params, sse1,
+          distortion);
+  }
+#endif
+
+
+  // If forced_stop is FULL_PEL, return.
+  if (!round) return besterr;
+
+  for (int iter = 0; iter < round; ++iter) {
+    MV iter_center_mv = *bestmv;
+    if (svt_check_repeated_mv_and_update(last_mv_search_list, iter_center_mv,
+                                     iter)) {
+      return INT_MAX;
+    }
+
+    MV diag_step;
+#if 0 // USE_2_TAPS_ORIG not supported
+    if (subpel_search_type != USE_2_TAPS_ORIG) {
+#endif
+        diag_step = svt_first_level_check(xd, cm, iter_center_mv, bestmv, hstep,
+            mv_limits, var_params, mv_cost_params,
+            &besterr, sse1, distortion);
+#if 0 // USE_2_TAPS_ORIG not supported
+    }
+    else {
+        diag_step = svt_first_level_check_fast(xd, cm, iter_center_mv, bestmv, hstep,
+            mv_limits, var_params, mv_cost_params,
+            &besterr, sse1, distortion, is_scaled);
+    }
+#endif
+    // Check diagonal sub-pixel position
+    if (!CHECK_MV_EQUAL(iter_center_mv, *bestmv) && iters_per_step > 1) {
+        svt_second_level_check_v2(xd, cm, iter_center_mv, diag_step, bestmv,
+                            mv_limits, var_params, mv_cost_params, &besterr,
+                            sse1, distortion, is_scaled);
+    }
+
+    hstep >>= 1;
+  }
+
+  return besterr;
+}
+#endif

--- a/Source/Lib/Encoder/Codec/mcomp.h
+++ b/Source/Lib/Encoder/Codec/mcomp.h
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2016, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 2 Clause License and
+ * the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+ * was not distributed with this source code in the LICENSE file, you can
+ * obtain it at www.aomedia.org/license/software. If the Alliance for Open
+ * Media Patent License 1.0 was not distributed with this source code in the
+ * PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+ */
+
+#ifndef AOM_AV1_ENCODER_MCOMP_H_
+#define AOM_AV1_ENCODER_MCOMP_H_
+
+#include "mv.h"
+#include "EbCodingUnit.h"
+#include "EbBlockStructures.h"
+#include "Av1Common.h"
+#include "av1me.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+#if UPGRADE_SUBPEL
+// =============================================================================
+//  Cost functions
+// =============================================================================
+
+enum {
+  MV_COST_ENTROPY,    // Use the entropy rate of the mv as the cost
+  MV_COST_L1_LOWRES,  // Use the l1 norm of the mv as the cost (<480p)
+  MV_COST_L1_MIDRES,  // Use the l1 norm of the mv as the cost (>=480p)
+  MV_COST_L1_HDRES,   // Use the l1 norm of the mv as the cost (>=720p)
+  MV_COST_NONE        // Use 0 as as cost irrespective of the current mv
+} UENUM1BYTE(MV_COST_TYPE);
+
+typedef struct {
+  // The reference mv used to compute the mv cost
+  const MV *ref_mv;
+  FULLPEL_MV full_ref_mv;
+  MV_COST_TYPE mv_cost_type;
+  const int *mvjcost;
+  const int *mvcost[2];
+  int error_per_bit;
+  // A multiplier used to convert rate to sad cost
+  int sad_per_bit;
+} MV_COST_PARAMS;
+
+// =============================================================================
+//  Motion Search
+// =============================================================================
+extern struct svt_buf_2d {
+    uint8_t *buf;
+    uint8_t *buf0;
+    int width;
+    int height;
+    int stride;
+} svt_buf_2d;
+
+typedef struct {
+  // The reference buffer
+  struct svt_buf_2d *ref;
+
+  // The source and predictors/mask used by translational search
+  struct svt_buf_2d *src;
+  uint8_t *second_pred;
+  uint8_t *mask;
+  int mask_stride;
+  int inv_mask;
+
+  // The weighted source and mask used by OBMC
+  int32_t *wsrc;
+  int32_t *obmc_mask;
+} MSBuffers;
+
+static INLINE void svt_av1_set_ms_compound_refs(MSBuffers *ms_buffers,
+                                            uint8_t *second_pred,
+                                            uint8_t *mask,
+                                            int mask_stride, int invert_mask) {
+  ms_buffers->second_pred = second_pred;
+  ms_buffers->mask = mask;
+  ms_buffers->mask_stride = mask_stride;
+  ms_buffers->inv_mask = invert_mask;
+}
+
+// =============================================================================
+//  Subpixel Motion Search
+// =============================================================================
+enum {
+  EIGHTH_PEL,
+  QUARTER_PEL,
+  HALF_PEL,
+  FULL_PEL
+} UENUM1BYTE(SUBPEL_FORCE_STOP);
+
+typedef struct {
+
+  const AomVarianceFnPtr *vfp;
+
+  SUBPEL_SEARCH_TYPE subpel_search_type;
+
+  // Source and reference buffers
+  MSBuffers ms_buffers;
+
+  int w, h;
+} SUBPEL_SEARCH_VAR_PARAMS;
+
+// This struct holds subpixel motion search parameters that should be constant
+// during the search
+typedef struct {
+  // High level motion search settings
+  int allow_hp;
+  const int *cost_list;
+  SUBPEL_FORCE_STOP forced_stop;
+  int iters_per_step;
+
+  SubpelMvLimits mv_limits;
+
+  // For calculating mv cost
+  MV_COST_PARAMS mv_cost_params;
+
+  // Distortion calculation params
+  SUBPEL_SEARCH_VAR_PARAMS var_params;
+
+} SUBPEL_MOTION_SEARCH_PARAMS;
+
+
+typedef int(fractional_mv_step_fp)(MacroBlockD *xd, const struct AV1Common *const cm,
+                                   const SUBPEL_MOTION_SEARCH_PARAMS *ms_params,
+                                   MV start_mv, MV *bestmv, int *distortion,
+                                   unsigned int *sse1,
+                                   int_mv *last_mv_search_list);
+
+extern fractional_mv_step_fp svt_av1_find_best_sub_pixel_tree;
+
+static INLINE void svt_av1_set_subpel_mv_search_range(SubpelMvLimits *subpel_limits,
+                                                  const FullMvLimits *mv_limits,
+                                                  const MV *ref_mv) {
+  const int max_mv = GET_MV_SUBPEL(MAX_FULL_PEL_VAL);
+  const int minc =
+      AOMMAX(GET_MV_SUBPEL(mv_limits->col_min), ref_mv->col - max_mv);
+  const int maxc =
+      AOMMIN(GET_MV_SUBPEL(mv_limits->col_max), ref_mv->col + max_mv);
+  const int minr =
+      AOMMAX(GET_MV_SUBPEL(mv_limits->row_min), ref_mv->row - max_mv);
+  const int maxr =
+      AOMMIN(GET_MV_SUBPEL(mv_limits->row_max), ref_mv->row + max_mv);
+
+  subpel_limits->col_min = AOMMAX(MV_LOW + 1, minc);
+  subpel_limits->col_max = AOMMIN(MV_UPP - 1, maxc);
+  subpel_limits->row_min = AOMMAX(MV_LOW + 1, minr);
+  subpel_limits->row_max = AOMMIN(MV_UPP - 1, maxr);
+}
+
+static INLINE int svt_av1_is_subpelmv_in_range(const SubpelMvLimits *mv_limits,
+                                           MV mv) {
+  return (mv.col >= mv_limits->col_min) && (mv.col <= mv_limits->col_max) &&
+         (mv.row >= mv_limits->row_min) && (mv.row <= mv_limits->row_max);
+}
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+#endif
+#endif  // AOM_AV1_ENCODER_MCOMP_H_

--- a/Source/Lib/Encoder/Codec/mv.h
+++ b/Source/Lib/Encoder/Codec/mv.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2016, Alliance for Open Media. All rights reserved
+ *
+ * This source code is subject to the terms of the BSD 2 Clause License and
+ * the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+ * was not distributed with this source code in the LICENSE file, you can
+ * obtain it at www.aomedia.org/license/software. If the Alliance for Open
+ * Media Patent License 1.0 was not distributed with this source code in the
+ * PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+ */
+
+#ifndef AOM_AV1_COMMON_MV_H_
+#define AOM_AV1_COMMON_MV_H_
+
+#include "EbBlockStructures.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MARK_MV_INVALID(mv)                \
+  do {                                     \
+    ((int_mv *)(mv))->as_int = INVALID_MV; \
+  } while (0);
+#define CHECK_MV_EQUAL(x, y) (((x).row == (y).row) && ((x).col == (y).col))
+
+static const MV kZeroMv = { 0, 0 };
+static const FULLPEL_MV kZeroFullMv = { 0, 0 };
+
+typedef union int_mv {
+  uint32_t as_int;
+  MV as_mv;
+  FULLPEL_MV as_fullmv;
+} int_mv; /* facilitates faster equality tests and copies */
+
+// The mv limit for fullpel mvs
+typedef struct {
+  int col_min;
+  int col_max;
+  int row_min;
+  int row_max;
+} FullMvLimits;
+
+// The mv limit for subpel mvs
+typedef struct {
+  int col_min;
+  int col_max;
+  int row_min;
+  int row_max;
+} SubpelMvLimits;
+
+#endif  // AOM_AV1_COMMON_MV_H_


### PR DESCRIPTION
# Description

- Detect and improve the pred of high active block(s) @ MD (i.e. post ME), and fix MV bound: clip inherited ME MVs to stay within pic boundaries
- Make GMV params/candidates derivation multi-ref aware, and set multi-ref to be considered = f(input_complexity), and enable gm_identiy_exit.
- Upgrade subpel of me and of pme to use libaom subpel search.

# Issue
Fixes #1414 

# Author(s)
@hguermaz 

# Performance impact
- [x] quality
- [ ] memory
- [x] speed
- [x] 8 bit
- [x] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] Google Lowres 
- [ ] N/A

| Preset(s)| BD-Rate  Deviation| Speed Deviation| 
| -- | -- | --
|M0 | -0.25% | 11.23%|
|M1 | -0.30% | 7.10%|
|M2 | -0.41% | 6.93%|
|M3 | -0.56% | 11.17%|
|M4 | -0.57% | 12.44%|
|M5 | -0.51% | 11.09%|
|M6 | -1.04% | 4.93%|
|M7 | -1.19% | 4.22%|

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
