### PR TITLE
Early tx_depth=2 exit

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -501,6 +501,8 @@ extern "C" {
 
 #define OBMC_CLI            1 // Improve CLI support for OBMC (OFF / Fully ON / Other Levels).
 #define FILTER_INTRA_CLI    1 // Improve CLI support for Filter Intra (OFF / Fully ON / Other Levels)
+#define TX_EARLY_EXIT       1 // Variance/cost_depth_1-to-cost_depth_0 based early txs exit
+
 #endif
 
 ///////// END MASTER_SYNCH

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -2324,7 +2324,7 @@ static void av1_copy_frame_mvs(PictureControlSet *pcs_ptr, const Av1Common *cons
 *   Coefficient Samples
 *
 *******************************************/
-EB_EXTERN void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
+EB_EXTERN void av1_encode_decode(SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
                                SuperBlock *sb_ptr, uint32_t sb_addr, uint32_t sb_origin_x,
                                uint32_t sb_origin_y, EncDecContext *context_ptr) {
     EbBool               is_16bit = context_ptr->is_16bit;

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.h
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.h
@@ -26,7 +26,7 @@ extern EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureControlS
 uint8_t get_skip_tx_search_flag(int32_t sq_size, uint64_t ref_fast_cost, uint64_t cu_cost,
                                 uint64_t weight);
 
-extern void av1_encode_pass(SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
+extern void av1_encode_decode(SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
                             SuperBlock *sb_ptr, uint32_t sb_addr, uint32_t sb_origin_x,
                             uint32_t sb_origin_y, EncDecContext *context_ptr);
 

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -10316,7 +10316,7 @@ void build_starting_cand_block_array(SequenceControlSet *scs_ptr, PictureControl
 *  elements to be sent to the entropy coding engine
 *
 ********************************************************************************/
-void *enc_dec_kernel(void *input_ptr) {
+void *mode_decision_kernel(void *input_ptr) {
     // Context & SCS & PCS
     EbThreadContext *   thread_context_ptr = (EbThreadContext *)input_ptr;
     EncDecContext *     context_ptr        = (EncDecContext *)thread_context_ptr->priv;
@@ -10852,7 +10852,7 @@ void *enc_dec_kernel(void *input_ptr) {
                                     context_ptr);
 #else
                     // Encode Pass
-                    av1_encode_pass(
+                    av1_encode_decode(
                         scs_ptr, pcs_ptr, sb_ptr, sb_index, sb_origin_x, sb_origin_y, context_ptr);
 #endif
 

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.h
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.h
@@ -113,7 +113,7 @@ extern EbErrorType enc_dec_context_ctor(EbThreadContext *  thread_context_ptr,
                                         const EbEncHandle *enc_handle_ptr, int index,
                                         int tasks_index, int demux_index);
 
-extern void *enc_dec_kernel(void *input_ptr);
+extern void *mode_decision_kernel(void *input_ptr);
 
 #ifdef __cplusplus
 }

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -66,6 +66,9 @@ static int32_t nsq_weight_per_qp[64] = { -5,  -5,  -5,  -5,  -5,  -5,  -5,  -5, 
 #endif
 #endif
 #endif
+#if TX_EARLY_EXIT
+#define TXS_EXIT_VAR_TH 256
+#endif
 EbErrorType generate_md_stage_0_cand(SuperBlock *sb_ptr, ModeDecisionContext *context_ptr,
                                      uint32_t *         fast_candidate_total_count,
                                      PictureControlSet *pcs_ptr);
@@ -9651,6 +9654,11 @@ void perform_tx_partitioning(ModeDecisionCandidateBuffer *candidate_buffer,
             if (!is_best_has_coeff)
                 continue;
         }
+#if TX_EARLY_EXIT
+        // Variance/cost_depth_1-to-cost_depth_0 based early txs exit
+        if (context_ptr->source_variance < TXS_EXIT_VAR_TH && context_ptr->tx_depth == 2 && best_tx_depth == 0)
+            continue;
+#endif
         tx_reset_neighbor_arrays(pcs_ptr, context_ptr, is_inter, context_ptr->tx_depth);
         ModeDecisionCandidateBuffer *tx_candidate_buffer = (context_ptr->tx_depth == 0)
             ? candidate_buffer

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -1755,7 +1755,7 @@ EB_API EbErrorType svt_av1_enc_init(EbComponentType *svt_enc_component)
 
     // EncDec Process
     EB_CREATE_THREAD_ARRAY(enc_handle_ptr->enc_dec_thread_handle_array, control_set_ptr->enc_dec_process_init_count,
-        enc_dec_kernel,
+        mode_decision_kernel,
         enc_handle_ptr->enc_dec_context_ptr_array);
 
     // Dlf Process


### PR DESCRIPTION
# Description

- Use the variance of the current block, and the tx_depth=1 vs. tx_depth=0 decision to skip tx_depth=2.
- Also renamed enc_dec_kernel() to mode_decision_kernel(), and renamed av1_encode_pass() to av1_encode_decode().
# Issue
Related to #1405
Fixes #1415

# Author(s)
@hguermaz 

# Performance impact
- [x] quality
- [ ] memory
- [x] speed
- [x] 8 bit
- [x] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] Google Lowres
- [ ] N/A

| Preset(s)| Speed Deviation| BD-Rate  Deviation|
| -- | -- | --
|M0 | 1.0% | 0.02%|
|M4 | 0.5% | 0.00%|

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
