### PR TITLE
Fix AVX512, SAD_LOOP fix calculation 16,5 for search area 8,x or 16,x

### DIFF
--- a/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
@@ -1540,12 +1540,36 @@ void sad_loop_kernel_avx512_intrin(
                     s = src;
                     r = ref;
 
-                    h = height2;
-                    do {
+                    h = height;
+                    while (h >= 2) {
                         sad_loop_kernel_16_avx2(s, src_stride, r, ref_stride, &sum256);
                         s += 2 * src_stride;
                         r += 2 * ref_stride;
-                    } while (--h);
+                        h -= 2;
+                    };
+
+                    if (h) {
+                        const __m256i ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)s)),
+                            _mm_setzero_si128(),
+                            1);
+                        const __m256i rr0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)r)),
+                            _mm_setzero_si128(),
+                            1);
+                        const __m256i rr1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(r + 8))),
+                            _mm_setzero_si128(),
+                            1);
+                        sum256 = _mm256_adds_epu16(
+                            sum256, _mm256_mpsadbw_epu8(rr0, ss0, (0 << 3) | 0)); // 000 000
+                        sum256 = _mm256_adds_epu16(
+                            sum256, _mm256_mpsadbw_epu8(rr0, ss0, (5 << 3) | 5)); // 101 101
+                        sum256 = _mm256_adds_epu16(
+                            sum256, _mm256_mpsadbw_epu8(rr1, ss0, (2 << 3) | 2)); // 010 010
+                        sum256 = _mm256_adds_epu16(
+                            sum256, _mm256_mpsadbw_epu8(rr1, ss0, (7 << 3) | 7)); // 111 111
+                    };
 
                     update_small_pel(sum256, 0, y, &best_s, &best_x, &best_y);
                     ref += src_stride_raw;
@@ -2009,12 +2033,41 @@ void sad_loop_kernel_avx512_intrin(
                     s = src;
                     r = ref;
 
-                    h = height2;
-                    do {
+                    h = height;
+                    while (h >= 2) {
                         sad_loop_kernel_16_avx512(s, src_stride, r, ref_stride, &sum512);
                         s += 2 * src_stride;
                         r += 2 * ref_stride;
-                    } while (--h);
+                        h -= 2;
+                    };
+
+                    if (h) {
+                        const __m128i s0  = _mm_loadu_si128((__m128i *)s);
+                        const __m256i s01 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(s0), _mm_setzero_si128(), 1);
+                        const __m512i s   = _mm512_castsi256_si512(s01);
+                        const __m512i ss0 = _mm512_permutexvar_epi32(
+                            _mm512_setr_epi32(0, 0, 0, 0, 0, 0, 0, 0, 4, 4, 4, 4, 4, 4, 4, 4), s);
+                        const __m512i ss1 = _mm512_permutexvar_epi32(
+                            _mm512_setr_epi32(1, 1, 1, 1, 1, 1, 1, 1, 5, 5, 5, 5, 5, 5, 5, 5), s);
+                        const __m512i ss2 = _mm512_permutexvar_epi32(
+                            _mm512_setr_epi32(2, 2, 2, 2, 2, 2, 2, 2, 6, 6, 6, 6, 6, 6, 6, 6), s);
+                        const __m512i ss3 = _mm512_permutexvar_epi32(
+                            _mm512_setr_epi32(3, 3, 3, 3, 3, 3, 3, 3, 7, 7, 7, 7, 7, 7, 7, 7), s);
+
+                        const __m256i r0 = _mm256_loadu_si256((__m256i *)r);
+                        const __m512i r  = _mm512_inserti64x4(
+                            _mm512_castsi256_si512(r0), _mm256_setzero_si256(), 1);
+                        const __m512i rr0 = _mm512_permutexvar_epi64(
+                            _mm512_setr_epi64(0, 1, 1, 2, 4, 5, 5, 6), r);
+                        const __m512i rr1 = _mm512_permutexvar_epi64(
+                            _mm512_setr_epi64(1, 2, 2, 3, 5, 6, 6, 7), r);
+
+                        sum512 = _mm512_adds_epu16(sum512, _mm512_dbsad_epu8(ss0, rr0, 0x94));
+                        sum512 = _mm512_adds_epu16(sum512, _mm512_dbsad_epu8(ss1, rr0, 0xE9));
+                        sum512 = _mm512_adds_epu16(sum512, _mm512_dbsad_epu8(ss2, rr1, 0x94));
+                        sum512 = _mm512_adds_epu16(sum512, _mm512_dbsad_epu8(ss3, rr1, 0xE9));
+                    };
 
                     update_256_pel(sum512, 0, y, &best_s, &best_x, &best_y);
                     ref += src_stride_raw;
@@ -2613,8 +2666,7 @@ void sad_loop_kernel_avx512_intrin(
                                 1);
                             const __m256i rr1 = _mm256_insertf128_si256(
                                 _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(r + 8))),
-                                _mm_setzero_si128()
-                                    ,
+                                _mm_setzero_si128(),
                                 1);
 
                             sum256 = _mm256_adds_epu16(

--- a/test/SadTest.cc
+++ b/test/SadTest.cc
@@ -607,6 +607,7 @@ SearchArea TEST_AREAS[] = {
     SearchArea(32, 12)};
 
 SearchArea TEST_LOOP_AREAS[] = {
+    SearchArea(8, 15),   SearchArea(16, 31),
     SearchArea(64, 125),  SearchArea(192, 75),  SearchArea(128, 50),
     SearchArea(64, 25),   SearchArea(240, 200), SearchArea(144, 120),
     SearchArea(96, 80),   SearchArea(48, 40),   SearchArea(240, 120),


### PR DESCRIPTION
# Description
Incorrect calculate SAD for size (16,5) when search area width is 8 or 16. Fixed UT to cover this issue. 

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [x] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [x] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
