### PR TITLE
Add new NSQ reduction tools and re-arrange the prests

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -499,6 +499,12 @@ extern "C" {
 #define FILTER_INTRA_CLI    1 // Improve CLI support for Filter Intra (OFF / Fully ON / Other Levels)
 #define TX_EARLY_EXIT       1 // Variance/cost_depth_1-to-cost_depth_0 based early txs exit
 
+#define MOVE_SIGNALS_TO_MD               1 // move txs_in_inter_classes, compound_mode and inter_intra to MD
+#define SHUT_SIMILARITY_FEATURES         1 // turn off features related to similar blocks
+#define MERGE_SQW_FEATURES               1 // Merge nsq_hv_level and sq_weight; if sq_weight on, so is nsq_hv_level
+#define SHUT_EDGE_BASED_SKIP_ANGLE_INTRA 1 // Turn off edge_based_skip_angle_intra_feature
+#define MOVE_TXT_TXS_STATS_TO_FUNCS      1 // Cleanup TXT/TXS stats code by creating functions for stats-based decisions
+
 #endif
 
 ///////// END MASTER_SYNCH

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -1036,12 +1036,12 @@ void unipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, Picture
                     uint8_t inter_type;
                     uint8_t is_ii_allowed =
 #if INTRA_COMPOUND_OPT
-                        svt_is_interintra_allowed(context_ptr->md_enable_inter_intra == 1 , context_ptr->blk_geom->bsize, NEWMV, rf);
+                        svt_is_interintra_allowed(context_ptr->md_inter_intra_level == 1 , context_ptr->blk_geom->bsize, NEWMV, rf);
 #else
                         0; //svt_is_interintra_allowed(pcs_ptr->parent_pcs_ptr->enable_inter_intra, bsize, NEWMV, rf);
 #endif
 #if INTRA_COMPOUND_OPT
-                    if (context_ptr->md_enable_inter_intra > 2)
+                    if (context_ptr->md_inter_intra_level > 2)
 #if DECOUPLE_ME_RES
                         if (pcs_ptr->parent_pcs_ptr->pa_me_data->me_results[me_sb_addr]->do_comp[0][list0_ref_index] == 0)
 #else
@@ -1215,13 +1215,13 @@ void unipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, Picture
                              EB_FALSE)) {
                         uint8_t inter_type;
 #if INTRA_COMPOUND_OPT
-                        uint8_t is_ii_allowed   = svt_is_interintra_allowed(context_ptr->md_enable_inter_intra == 1,
+                        uint8_t is_ii_allowed   = svt_is_interintra_allowed(context_ptr->md_inter_intra_level == 1,
                             context_ptr->blk_geom->bsize, NEWMV, rf);
 #else
                         uint8_t is_ii_allowed   = 0;
 #endif
 #if INTRA_COMPOUND_OPT
-                    if (context_ptr->md_enable_inter_intra > 2)
+                    if (context_ptr->md_inter_intra_level > 2)
 #if DECOUPLE_ME_RES
                         if (pcs_ptr->parent_pcs_ptr->pa_me_data->me_results[me_sb_addr]->do_comp[1][list1_ref_index] == 0)
 #else
@@ -1877,11 +1877,11 @@ void inject_mvp_candidates_ii(struct ModeDecisionContext *context_ptr, PictureCo
         if (inj_mv) {
             uint8_t inter_type;
             uint8_t is_ii_allowed =
-                svt_is_interintra_allowed(context_ptr->md_enable_inter_intra, bsize, NEARESTMV, rf);
+                svt_is_interintra_allowed(context_ptr->md_inter_intra_level, bsize, NEARESTMV, rf);
 #if INTRA_COMPOUND_OPT
             uint8_t ref_idx_0 = get_ref_frame_idx(rf[0]);
 
-            if (context_ptr->md_enable_inter_intra > 2)
+            if (context_ptr->md_inter_intra_level > 2)
                 if (ref_idx_0 > context_ptr->inter_comp_ctrls.mrp_pruning_w_distance - 1)
                     is_ii_allowed = 0;
 #endif
@@ -1994,11 +1994,11 @@ void inject_mvp_candidates_ii(struct ModeDecisionContext *context_ptr, PictureCo
             if (inj_mv) {
                 uint8_t inter_type;
                 uint8_t is_ii_allowed = svt_is_interintra_allowed(
-                    context_ptr->md_enable_inter_intra, bsize, NEARMV, rf);
+                    context_ptr->md_inter_intra_level, bsize, NEARMV, rf);
 #if INTRA_COMPOUND_OPT
             uint8_t ref_idx_0 = get_ref_frame_idx(rf[0]);
 
-            if (context_ptr->md_enable_inter_intra > 2)
+            if (context_ptr->md_inter_intra_level > 2)
                 if (ref_idx_0 > context_ptr->inter_comp_ctrls.mrp_pruning_w_distance - 1)
                     is_ii_allowed = 0;
 #endif
@@ -3703,17 +3703,17 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
                      EB_FALSE)) {
                 uint8_t inter_type;
                 uint8_t is_ii_allowed = svt_is_interintra_allowed(
-                    context_ptr->md_enable_inter_intra,
+                    context_ptr->md_inter_intra_level,
                     bsize,
                     NEWMV,
                     (const MvReferenceFrame[]){to_inject_ref_type, -1});
 #if INTRA_COMPOUND_OPT
 #if DECOUPLE_ME_RES
-                if (context_ptr->md_enable_inter_intra > 2)
+                if (context_ptr->md_inter_intra_level > 2)
                     if (pcs_ptr->parent_pcs_ptr->pa_me_data->me_results[me_sb_addr]->do_comp[0][list0_ref_index] == 0)
                         is_ii_allowed = 0;
 #else
-                if (context_ptr->md_enable_inter_intra > 2)
+                if (context_ptr->md_inter_intra_level > 2)
                     if  (pcs_ptr->parent_pcs_ptr->me_results[me_sb_addr]->do_comp[0][list0_ref_index] == 0 )
                         is_ii_allowed = 0;
 #endif
@@ -3861,17 +3861,17 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
 
                     uint8_t inter_type;
                     uint8_t is_ii_allowed = svt_is_interintra_allowed(
-                        context_ptr->md_enable_inter_intra,
+                        context_ptr->md_inter_intra_level,
                         bsize,
                         NEWMV,
                         (const MvReferenceFrame[]){to_inject_ref_type, -1});
 #if INTRA_COMPOUND_OPT
 #if DECOUPLE_ME_RES
-                    if (context_ptr->md_enable_inter_intra > 2)
+                    if (context_ptr->md_inter_intra_level > 2)
                         if (pcs_ptr->parent_pcs_ptr->pa_me_data->me_results[me_sb_addr]->do_comp[1][list1_ref_index] == 0)
                             is_ii_allowed = 0;
 #else
-                    if (context_ptr->md_enable_inter_intra > 2)
+                    if (context_ptr->md_inter_intra_level > 2)
                         if  ( pcs_ptr->parent_pcs_ptr->me_results[me_sb_addr]->do_comp[1][list1_ref_index] == 0)
                                 is_ii_allowed = 0;
 #endif
@@ -4227,12 +4227,12 @@ void inject_predictive_me_candidates(
 #endif
                     uint8_t is_ii_allowed =
 #if INTRA_COMPOUND_OPT
-                        svt_is_interintra_allowed(context_ptr->md_enable_inter_intra == 1, bsize, NEWMV, rf);
+                        svt_is_interintra_allowed(context_ptr->md_inter_intra_level == 1, bsize, NEWMV, rf);
 #else
                         0; // svt_is_interintra_allowed(pcs_ptr->parent_pcs_ptr->enable_inter_intra, bsize, NEWMV, rf);
 #endif
 #if INTRA_COMPOUND_OPT
-                    if (context_ptr->md_enable_inter_intra > 2)
+                    if (context_ptr->md_inter_intra_level > 2)
                         if (is_reference_best_pme(context_ptr , 0 ,ref_pic_index ,1)  == 0)
                             is_ii_allowed = 0;
 #endif
@@ -4343,12 +4343,12 @@ void inject_predictive_me_candidates(
 #endif
                         uint8_t is_ii_allowed =
 #if INTRA_COMPOUND_OPT
-                        svt_is_interintra_allowed(context_ptr->md_enable_inter_intra == 1, bsize, NEWMV, rf);
+                        svt_is_interintra_allowed(context_ptr->md_inter_intra_level == 1, bsize, NEWMV, rf);
 #else
                             0; // svt_is_interintra_allowed(pcs_ptr->parent_pcs_ptr->enable_inter_intra, bsize, NEWMV, rf);
 #endif
 #if INTRA_COMPOUND_OPT
-                    if (context_ptr->md_enable_inter_intra > 2)
+                    if (context_ptr->md_inter_intra_level > 2)
                         if (is_reference_best_pme(context_ptr , 0 ,ref_pic_index ,1)  == 0)
                             is_ii_allowed = 0;
 #endif
@@ -4680,7 +4680,7 @@ void inject_inter_candidates(PictureControlSet *pcs_ptr, ModeDecisionContext *co
                            context_ptr->blk_geom->bheight >= 8) ||
                           params_l0->wmtype <= TRANSLATION))) {
                         int is_ii_allowed = svt_is_interintra_allowed(
-                            context_ptr->md_enable_inter_intra,
+                            context_ptr->md_inter_intra_level,
                             bsize,
                             GLOBALMV,
                             (const MvReferenceFrame[]){to_inject_ref_type, -1});
@@ -4883,7 +4883,7 @@ void inject_inter_candidates(PictureControlSet *pcs_ptr, ModeDecisionContext *co
                                              : 1;
             if (inj_mv && inside_tile) {
                 uint8_t is_ii_allowed = svt_is_interintra_allowed(
-                    context_ptr->md_enable_inter_intra,
+                    context_ptr->md_inter_intra_level,
                     bsize,
                     GLOBALMV,
                     (const MvReferenceFrame[]){to_inject_ref_type, -1});

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
@@ -656,7 +656,9 @@ typedef struct ModeDecisionContext {
     uint8_t *    left_txfm_context;
     // square cost weighting for deciding if a/b shapes could be skipped
     uint32_t sq_weight;
+#if !MERGE_SQW_FEATURES
     uint32_t nsq_hv_level;
+#endif
     // signal for enabling shortcut to skip search depths
     MD_COMP_TYPE compound_types_to_try;
 #if !PD0_INTER_CAND
@@ -680,7 +682,7 @@ typedef struct ModeDecisionContext {
 #endif
     uint8_t      md_enable_paeth;
     uint8_t      md_enable_smooth;
-    uint8_t      md_enable_inter_intra;
+    uint8_t      md_inter_intra_level;
 #if FILTER_INTRA_CLI
     uint8_t      md_filter_intra_level;
 #else
@@ -834,6 +836,11 @@ typedef struct ModeDecisionContext {
 #if MEM_OPT_MD_BUF_DESC
     EbPictureBufferDesc* temp_residual_ptr;
     EbPictureBufferDesc* temp_recon_ptr;
+#endif
+#if MOVE_SIGNALS_TO_MD
+    uint8_t txs_in_inter_classes;
+    uint8_t nic_scaling_level;
+    uint8_t inter_compound_mode;
 #endif
 } ModeDecisionContext;
 

--- a/Source/Lib/Encoder/Codec/EbPictureControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbPictureControlSet.h
@@ -740,7 +740,7 @@ typedef struct PictureParentControlSet {
     uint8_t            loop_filter_mode;
     uint8_t            intra_pred_mode;
     uint8_t            tx_size_search_mode;
-#if APR22_ADOPTIONS
+#if APR22_ADOPTIONS && !MOVE_SIGNALS_TO_MD
     uint8_t            txs_in_inter_classes;
 #endif
     uint8_t            frame_end_cdf_update_mode; // mm-signal: 0: OFF, 1:ON
@@ -866,12 +866,16 @@ typedef struct PictureParentControlSet {
     // I Slice has the value of the next ALT_REF picture
     uint64_t          filtered_sse_uv;
     FrameHeader       frm_hdr;
+#if !MOVE_SIGNALS_TO_MD
     uint8_t           compound_mode;
+#endif
 #if !SHUT_ME_CAND_SORTING
     uint8_t           prune_unipred_at_me;
 #endif
     uint16_t *        altref_buffer_highbd[3];
+#if MOVE_SIGNALS_TO_MD
     uint8_t           enable_inter_intra;
+#endif
 #if OBMC_CLI
     uint8_t           pic_obmc_level;
 #else

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -2255,6 +2255,7 @@ EbErrorType signal_derivation_multi_processes_oq(
         else
             pcs_ptr->tx_size_search_mode = 0;
 
+#if !MOVE_SIGNALS_TO_MD
 #if APR22_ADOPTIONS
     // Assign whether to use TXS in inter classes (if TXS is ON)
     // 0 OFF - TXS in intra classes only
@@ -2300,6 +2301,7 @@ EbErrorType signal_derivation_multi_processes_oq(
 #endif
 #endif
 #endif
+#endif
 #if !INTER_COMP_REDESIGN
         // Set Wedge mode      Settings
         // 0                 FULL: Full search
@@ -2335,6 +2337,7 @@ EbErrorType signal_derivation_multi_processes_oq(
     pcs_ptr->wedge_mode = 0;
 #endif
 #endif
+#if !MOVE_SIGNALS_TO_MD
         // inter intra pred                      Settings
         // 0                                     OFF
         // 1                                     ON
@@ -2473,6 +2476,7 @@ EbErrorType signal_derivation_multi_processes_oq(
 #if !WEDGE_SYNCH
         if (pcs_ptr->wedge_mode > 0 && pcs_ptr->compound_mode != 2)
             SVT_LOG("wedge_mode set but will not be active\n");
+#endif
 #endif
         // Set frame end cdf update mode      Settings
         // 0                                     OFF


### PR DESCRIPTION
# Description

Add a faster M8, and apply general presets tuning/shifting.

Move some features to be set at MD.

Add NSQ reduction tools to switch modes for unlikely blocks.  
-If an SQ block has zero coefficients, then use a more aggressive mode (i.e. preset level) for the NSQ blocks.
-Collect picture-level statistics of selected partitions; use the information to apply a more aggressive mode (i.e. preset level) for unlikely blocks (determined by comparing the probability of a block to a threshold).

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

Fixes #1405 

# Author(s)

@PhoenixWorthVCD 
@NaderMahdi 
@hguermaz 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [x] quality
- [ ] memory
- [x] speed
- [x] 8 bit
- [x] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
