### PR TITLE
macOS: Delete build folder before reconfiguring cmake

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -143,6 +143,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: svtav1-macOS-unittest
+          path: Bin/Release
       - name: Run unit tests
         run: |
           parallel -u -j 4 GTEST_SHARD_INDEX={} ./Bin/Release/SvtAv1UnitTests ::: $(seq 0 $((GTEST_TOTAL_SHARDS - 1)))
@@ -161,5 +162,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: svtav1-macOS-unittest
+          path: Bin/Release
       - name: Run e2e tests
         run: ./Bin/Release/SvtAv1E2ETests --gtest_filter=-*DummySrcTest*

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -118,10 +118,11 @@ jobs:
             "::set-env name=PATH::/usr/local/opt/ccache/libexec:$PATH" \
             "::set-env name=CCACHE_DIR::$HOME/.ccache"
           clang -v
+          rm -rf macos-build
       - name: Run CMake
         run: |
-          cmake -S "$GITHUB_WORKSPACE" -B Build -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=ON -BBUILD_DEC=OFF -DBUILD_APPS=OFF
-          cmake --build Build --config Release --target all --target TestVectors
+          cmake -S "$GITHUB_WORKSPACE" -B macos-build -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=ON -DBUILD_APPS=OFF
+          cmake --build macos-build --config Release --target all --target TestVectors
       - name: Upload unit-tests (macOS)
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
# Description

Should fix issues such as where a PR introduces a new file, but due to using glob, cmake doesn't detect if it's been added or deleted in the unit test job

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
