### PR TITLE
DecApp: Fix decoder segfault issues

### DIFF
--- a/Source/Lib/Common/Codec/EbUtility.h
+++ b/Source/Lib/Common/Codec/EbUtility.h
@@ -291,6 +291,8 @@ typedef enum MinigopIndex {
 // Right shift that replicates gcc's implementation
 
 static inline int gcc_right_shift(int a, unsigned shift) {
+    if (!a)
+        return 0;
     if (a > 0)
         return a >> shift;
     static const unsigned sbit = 1u << (sizeof(sbit) * CHAR_BIT - 1);

--- a/Source/Lib/Decoder/Codec/EbDecObmc.c
+++ b/Source/Lib/Decoder/Codec/EbDecObmc.c
@@ -194,13 +194,13 @@ static INLINE void dec_build_prediction_by_above_pred(
     int                  mi_x, mi_y;
     uint8_t *            tmp_recon_buf;
     int32_t              tmp_recon_stride;
-    backup_pi->mi                       = above_mbmi;
-    av1_modify_neighbor_predictor_for_obmc(backup_pi->mi);
+    BlockModeInfo        bakup_abv_mbmi = *above_mbmi;
+    av1_modify_neighbor_predictor_for_obmc(&bakup_abv_mbmi);
 
-    const int num_refs = 1 + has_second_ref(backup_pi->mi);
+    const int num_refs = 1 + has_second_ref(&bakup_abv_mbmi);
 
     for (int ref = 0; ref < num_refs; ++ref) {
-        const MvReferenceFrame frame = backup_pi->mi->ref_frame[ref];
+        const MvReferenceFrame frame = bakup_abv_mbmi.ref_frame[ref];
         backup_pi->block_ref_sf[ref] = get_ref_scale_factors(dec_handle, frame);
 
         if ((!av1_is_valid_scale(backup_pi->block_ref_sf[ref]))) {
@@ -351,13 +351,13 @@ static INLINE void dec_build_prediction_by_left_pred(
     int                  mi_x, mi_y;
     uint8_t *            tmp_recon_buf;
     int32_t              tmp_recon_stride;
-    backup_pi->mi                        = left_mbmi;
-    av1_modify_neighbor_predictor_for_obmc(backup_pi->mi);
+    BlockModeInfo        bakup_left_mbmi = *left_mbmi;
+    av1_modify_neighbor_predictor_for_obmc(&bakup_left_mbmi);
 
-    const int num_refs = 1 + has_second_ref(backup_pi->mi);
+    const int num_refs = 1 + has_second_ref(&bakup_left_mbmi);
 
     for (int ref = 0; ref < num_refs; ++ref) {
-        const MvReferenceFrame frame = backup_pi->mi->ref_frame[ref];
+        const MvReferenceFrame frame = bakup_left_mbmi.ref_frame[ref];
         backup_pi->block_ref_sf[ref] = get_ref_scale_factors(dec_handle, frame);
 
         if ((!av1_is_valid_scale(backup_pi->block_ref_sf[ref]))) {

--- a/Source/Lib/Decoder/Codec/EbDecParseBlock.c
+++ b/Source/Lib/Decoder/Codec/EbDecParseBlock.c
@@ -1275,12 +1275,13 @@ void update_chroma_trans_info(ParseCtxt *parse_ctx, PartitionInfo *part_info, Bl
 
     /* TODO: Make plane loop and avoid the unroll */
     for (int idy = 0, force_split_cnt = 0; idy < max_blocks_high; idy += height) {
-        for (int idx = 0, num_chroma_tus = 0; idx < max_blocks_wide;
-             idx += width, force_split_cnt++) {
+        for (int idx = 0; idx < max_blocks_wide; idx += width, force_split_cnt++) {
             if (color_config.mono_chrome) continue;
 
             /* Update Chroma Transform Info */
             if (!part_info->is_chroma_ref) continue;
+
+            int num_chroma_tus = 0;
 
             step_r = tx_size_high_unit[tx_size_uv];
             step_c = tx_size_wide_unit[tx_size_uv];
@@ -1520,7 +1521,8 @@ void read_block_tx_size(ParseCtxt *parse_ctx, PartitionInfo *part_info, BlockSiz
 
         // Luma trans_info update
         for (int idy = 0; idy < height; idy += bh)
-            for (int idx = 0, num_luma_tus = 0; idx < width; idx += bw) {
+            for (int idx = 0; idx < width; idx += bw) {
+                int num_luma_tus = 0;
                 read_var_tx_size(parse_ctx, part_info, max_tx_size, idy, idx, 0, &num_luma_tus);
                 parse_ctx->num_tus[AOM_PLANE_Y][force_split_cnt] = num_luma_tus;
                 force_split_cnt++;

--- a/Source/Lib/Decoder/Codec/EbDecPicMgr.c
+++ b/Source/Lib/Decoder/Codec/EbDecPicMgr.c
@@ -181,8 +181,6 @@ EbDecPicBuf *dec_pic_mgr_get_cur_pic(EbDecHandle *dec_handle_ptr) {
 static INLINE void dec_ref_count_and_rel(EbDecPicBuf *ps_pic_buf) {
     if (ps_pic_buf != NULL) {
         ps_pic_buf->ref_count--;
-        assert(ps_pic_buf->ref_count == 0);
-
         if (ps_pic_buf->ref_count == 0) ps_pic_buf->is_free = 1;
     }
 }


### PR DESCRIPTION
# Description

Fixes some issues that were introduced by the cppcheck commits

# Issue

Fixes #1423

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@1480c1

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
