### PR TITLE
Modification of sad_loop_kernel_{sse4_1/avx2/avx512} to support odd and even block width/height

### DIFF
--- a/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
+++ b/Source/Lib/Common/ASM_AVX512/EbHighbdIntraPrediction_AVX512.c
@@ -644,7 +644,6 @@ static INLINE void h_pred_32(uint16_t **const dst, const ptrdiff_t stride, const
 static INLINE void h_pred_32x8(uint16_t **dst, const ptrdiff_t stride, const uint16_t *const left) {
     // dst and it's stride must be 32-byte aligned.
     assert(!((intptr_t)*dst % 32));
-    assert(!(stride % 32));
 
     const __m128i left_u16 = _mm_loadu_si128((const __m128i *)left);
 
@@ -745,8 +744,8 @@ static INLINE void h_pred_64(uint16_t **const dst, const ptrdiff_t stride, const
     // Broadcast the 16-bit left pixel to 256-bit register.
     const __m512i row = _mm512_broadcastw_epi16(left);
 
-    zz_store_512(*dst + 0x00, row);
-    zz_store_512(*dst + 0x20, row);
+    zz_storeu_512(*dst + 0x00, row);
+    zz_storeu_512(*dst + 0x20, row);
 
     *dst += stride;
 }
@@ -755,7 +754,6 @@ static INLINE void h_pred_64(uint16_t **const dst, const ptrdiff_t stride, const
 static INLINE void h_pred_64x8(uint16_t **dst, const ptrdiff_t stride, const uint16_t *const left) {
     // dst and it's stride must be 32-byte aligned.
     assert(!((intptr_t)*dst % 32));
-    assert(!(stride % 32));
 
     __m128i left_u16 = _mm_loadu_si128((const __m128i *)left);
 

--- a/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -2011,8 +2011,8 @@ void sad_loop_kernel_generalized_avx2(
                     temp_ref += 8;
                 }
                 if (width_calc >= 4) {
-                    s0 = _mm_loadu_si128((__m128i *)temp_ref);
-                    s1 = _mm_loadu_si128((__m128i *)(temp_ref + ref_stride));
+                    s0 = _mm_lddqu_si128((__m128i *)temp_ref);
+                    s1 = _mm_lddqu_si128((__m128i *)(temp_ref + ref_stride));
                     s2 = _mm_cvtsi32_si128(*(uint32_t *)temp_src);
                     s5 = _mm_cvtsi32_si128(*(uint32_t *)(temp_src + src_stride));
                     s3 = _mm_mpsadbw_epu8(s0, s2, 0);
@@ -2094,7 +2094,7 @@ void sad_loop_kernel_generalized_avx2(
                     temp_ref += 8;
                 }
                 if (width_calc >= 4) {
-                    s0 = _mm_loadu_si128((__m128i *)temp_ref);
+                    s0 = _mm_lddqu_si128((__m128i *)temp_ref);
                     s2 = _mm_cvtsi32_si128(*(uint32_t *)temp_src);
                     s3 = _mm_mpsadbw_epu8(s0, s2, 0);
 
@@ -2320,8 +2320,8 @@ void sad_loop_kernel_avx2_intrin(
                     p_ref = ref + j;
                     s3    = _mm_setzero_si128();
                     for (k = 0; k + 2 <= block_height; k += 2) {
-                        s0 = _mm_loadu_si128((__m128i *)p_ref);
-                        s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
+                        s0 = _mm_lddqu_si128((__m128i *)p_ref);
+                        s1 = _mm_lddqu_si128((__m128i *)(p_ref + ref_stride));
                         s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
                         s5 = _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride));
                         s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
@@ -2352,8 +2352,8 @@ void sad_loop_kernel_avx2_intrin(
                     p_ref = ref + j;
                     s3    = _mm_setzero_si128();
                     for (k = 0; k + 2 <= block_height; k += 2) {
-                        s0 = _mm_loadu_si128((__m128i *)p_ref);
-                        s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
+                        s0 = _mm_lddqu_si128((__m128i *)p_ref);
+                        s1 = _mm_lddqu_si128((__m128i *)(p_ref + ref_stride));
                         s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
                         s5 = _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride));
                         s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));

--- a/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -1937,7 +1937,7 @@ void sad_loop_kernel_generalized_avx2(
 
     __m128i leftover_mask32b = _mm_set1_epi32(-1);
     if (leftover) {
-        for (k = 0; k < (search_area_width & 3); k++)
+        for (k = 0; k <(uint32_t)(search_area_width & 3); k++)
             leftover_mask32b = _mm_slli_si128(leftover_mask32b, 4);
     }
 

--- a/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -1911,7 +1911,7 @@ void sad_loop_kernel_sparse_avx2_intrin(
 
 /*******************************************************************************
  * Requirement: block_height < 64
- * General version for SAD computing that support any width and height
+ * General version for SAD computing that support any block width and height
 *******************************************************************************/
 void sad_loop_kernel_generalized_avx2(
     uint8_t * src, // input parameter, source samples Ptr

--- a/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/EbComputeSAD_Intrinsic_AVX2.c
@@ -1908,9 +1908,281 @@ void sad_loop_kernel_sparse_avx2_intrin(
     *y_search_center = y_best;
 }
 #endif
+
 /*******************************************************************************
- * Requirement: width   = 4, 6, 8, 12, 16, 24, 32, 48 or 64 to use SIMD
- * otherwise C version is used
+ * Requirement: block_height < 64
+ * General version for SAD computing that support any width and height
+*******************************************************************************/
+void sad_loop_kernel_generalized_avx2(
+    uint8_t * src, // input parameter, source samples Ptr
+    uint32_t  src_stride, // input parameter, source stride
+    uint8_t * ref, // input parameter, reference samples Ptr
+    uint32_t  ref_stride, // input parameter, reference stride
+    uint32_t  block_height, // input parameter, block height (M)
+    uint32_t  block_width, // input parameter, block width (N)
+    uint64_t *best_sad, int16_t *x_search_center, int16_t *y_search_center,
+    uint32_t src_stride_raw, // input parameter, source stride (no line skipping)
+    int16_t search_area_width, int16_t search_area_height, __m128i leftover_mask) {
+
+    int16_t  i, j;
+    uint32_t k, l;
+    const uint8_t *p_ref, *p_src;
+    __m128i        s0, s1, s2, s3, s4, s5;
+    __m256i        ss0, ss1, ss2, ss3, ss4, ss5, ss6, ss7;
+    __m256i        ss8, ss9, ss10, ss11;
+    uint32_t       low_sum   = 0xffffff;
+    uint32_t       tem_sum_1 = 0;
+    int16_t        x_best = *x_search_center, y_best = *y_search_center;
+    uint32_t       leftover = search_area_width & 7;
+
+    for (i = 0; i < search_area_height; i++) {
+        for (j = 0; j < search_area_width; j += 8) {
+            p_src = src;
+            p_ref = ref + j;
+            ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
+            ss8 = ss9 = ss10 = ss11 = _mm256_setzero_si256();
+            for (k = 0; k + 2 <= block_height; k += 2) {
+                uint32_t       width_calc = block_width;
+                const uint8_t *temp_src   = p_src;
+                const uint8_t *temp_ref   = p_ref;
+                if (width_calc >= 32) {
+                    ss0 = _mm256_loadu_si256((__m256i *)temp_ref);
+                    ss1 = _mm256_loadu_si256((__m256i *)(temp_ref + 8));
+                    ss2 = _mm256_loadu_si256((__m256i *)temp_src);
+                    ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                    ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                    ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                    ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+
+                    ss0 = _mm256_loadu_si256((__m256i *)(temp_ref + ref_stride));
+                    ss1 = _mm256_loadu_si256((__m256i *)(temp_ref + ref_stride + 8));
+                    ss2 = _mm256_loadu_si256((__m256i *)(temp_src + src_stride));
+                    ss8 = _mm256_adds_epu16(ss8, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                    ss9 = _mm256_adds_epu16(ss9, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                    ss10 = _mm256_adds_epu16(ss10, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                    ss11 = _mm256_adds_epu16(ss11, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+
+                    width_calc -= 32;
+                    temp_src += 32;
+                    temp_ref += 32;
+                }
+                if (width_calc >= 16) {
+                    ss0 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)temp_ref)),
+                        _mm_loadu_si128((__m128i *)(temp_ref + ref_stride)),
+                        0x1);
+                    ss1 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(temp_ref + 8))),
+                        _mm_loadu_si128((__m128i *)(temp_ref + ref_stride + 8)),
+                        0x1);
+                    ss2 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)temp_src)),
+                        _mm_loadu_si128((__m128i *)(temp_src + src_stride)),
+                        0x1);
+                    ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                    ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                    ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                    ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+
+                    width_calc -= 16;
+                    temp_src += 16;
+                    temp_ref += 16;
+                }
+                if (width_calc >= 8) {
+                    s0 = _mm_loadu_si128((__m128i *)temp_ref);
+                    s1 = _mm_loadu_si128((__m128i *)(temp_ref + ref_stride));
+                    s2 = _mm_loadl_epi64((__m128i *)temp_src);
+                    s5 = _mm_loadl_epi64((__m128i *)(temp_src + src_stride));
+                    s3 = _mm_mpsadbw_epu8(s0, s2, 0);
+                    s4 = _mm_mpsadbw_epu8(s0, s2, 5);
+                    s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s1, s5, 0));
+                    s4 = _mm_adds_epu16(s4, _mm_mpsadbw_epu8(s1, s5, 5));
+
+                    ss0 = _mm256_inserti128_si256(_mm256_castsi128_si256(s3), s4, 0x1);
+                    ss3 = _mm256_adds_epu16(ss3, ss0);
+                    width_calc -= 8;
+                    temp_src += 8;
+                    temp_ref += 8;
+                }
+                if (width_calc >= 4) {
+                    s0 = _mm_loadu_si128((__m128i *)temp_ref);
+                    s1 = _mm_loadu_si128((__m128i *)(temp_ref + ref_stride));
+                    s2 = _mm_cvtsi32_si128(*(uint32_t *)temp_src);
+                    s5 = _mm_cvtsi32_si128(*(uint32_t *)(temp_src + src_stride));
+                    s3 = _mm_mpsadbw_epu8(s0, s2, 0);
+                    s4 = _mm_mpsadbw_epu8(s1, s5, 0);
+
+                    ss0 = _mm256_inserti128_si256(_mm256_castsi128_si256(s3), s4, 0x1);
+                    ss4 = _mm256_adds_epu16(ss4, ss0);
+                    width_calc -= 4;
+                    temp_src += 4;
+                    temp_ref += 4;
+                }
+                if (width_calc > 0) {
+                    DECLARE_ALIGNED(16, uint16_t, tsum[8]);
+                    memset(tsum, 0, 8 * sizeof(uint16_t));
+                    for (uint32_t search_area = 0; search_area < 8; search_area++) {
+                        for (l = 0; l < width_calc; l++) {
+                            tsum[search_area] += EB_ABS_DIFF(temp_src[l], temp_ref[l]) +
+                                EB_ABS_DIFF(temp_src[src_stride + l], temp_ref[ref_stride + l]);
+                        }
+                        temp_ref += 1;
+                    }
+                    s4  = _mm_loadu_si128((__m128i *)tsum);
+                    ss0 = _mm256_insertf128_si256(_mm256_setzero_si256(), s4, 0x1);
+                    ss5 = _mm256_adds_epu16(ss5, ss0);
+                }
+                p_src += 2 * src_stride;
+                p_ref += 2 * ref_stride;
+            }
+            //when height is not multiple of 2,then compute last line
+            if (k < block_height) {
+                uint32_t       width_calc = block_width;
+                const uint8_t *temp_src   = p_src;
+                const uint8_t *temp_ref   = p_ref;
+                if (width_calc >= 32) {
+                    ss0 = _mm256_loadu_si256((__m256i *)temp_ref);
+                    ss1 = _mm256_loadu_si256((__m256i *)(temp_ref + 8));
+                    ss2 = _mm256_loadu_si256((__m256i *)temp_src);
+                    ss8 = _mm256_adds_epu16(ss8, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                    ss9 = _mm256_adds_epu16(ss9, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                    ss10 = _mm256_adds_epu16(ss10, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                    ss11 = _mm256_adds_epu16(ss11, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+
+                    width_calc -= 32;
+                    temp_src += 32;
+                    temp_ref += 32;
+                }
+                if (width_calc >= 16) {
+                    ss0 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)temp_ref)),
+                        _mm_setzero_si128(),
+                        0x1);
+                    ss1 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(temp_ref + 8))),
+                        _mm_setzero_si128(),
+                        0x1);
+                    ss2 = _mm256_insertf128_si256(
+                        _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)temp_src)),
+                        _mm_setzero_si128(),
+                        0x1);
+                    ss8 = _mm256_adds_epu16(ss8, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                    ss9 = _mm256_adds_epu16(ss9, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                    ss10 = _mm256_adds_epu16(ss10, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                    ss11 = _mm256_adds_epu16(ss11, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+
+                    width_calc -= 16;
+                    temp_src += 16;
+                    temp_ref += 16;
+                }
+                if (width_calc >= 8) {
+                    s0 = _mm_loadu_si128((__m128i *)temp_ref);
+                    s2 = _mm_loadl_epi64((__m128i *)temp_src);
+                    s3 = _mm_mpsadbw_epu8(s0, s2, 0);
+                    s4 = _mm_mpsadbw_epu8(s0, s2, 5);
+
+                    ss0 = _mm256_inserti128_si256(_mm256_castsi128_si256(s3), s4, 0x1);
+                    ss8 = _mm256_adds_epu16(ss8, ss0);
+                    width_calc -= 8;
+                    temp_src += 8;
+                    temp_ref += 8;
+                }
+                if (width_calc >= 4) {
+                    s0 = _mm_loadu_si128((__m128i *)temp_ref);
+                    s2 = _mm_cvtsi32_si128(*(uint32_t *)temp_src);
+                    s3 = _mm_mpsadbw_epu8(s0, s2, 0);
+
+                    ss0 = _mm256_inserti128_si256(_mm256_setzero_si256(), s3, 0x1);
+                    ss9 = _mm256_adds_epu16(ss9, ss0);
+                    width_calc -= 4;
+                    temp_src += 4;
+                    temp_ref += 4;
+                }
+                if (width_calc > 0) {
+                    DECLARE_ALIGNED(16, uint16_t, tsum[8]);
+                    memset(tsum, 0, 8 * sizeof(uint16_t));
+                    for (uint32_t search_area = 0; search_area < 8; search_area++) {
+                        for (l = 0; l < width_calc; l++) {
+                            tsum[search_area] += EB_ABS_DIFF(temp_src[l], temp_ref[l]);
+                        }
+                        temp_ref += 1;
+                    }
+                    s4  = _mm_loadu_si128((__m128i *)tsum);
+                    ss0 = _mm256_insertf128_si256(_mm256_setzero_si256(), s4, 0x1);
+                    ss10 = _mm256_adds_epu16(ss10, ss0);
+                }
+                p_src += src_stride;
+                p_ref += ref_stride;
+            }
+
+            ss0 = _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4), _mm256_adds_epu16(ss5, ss6));
+            ss1 = _mm256_adds_epu16(_mm256_adds_epu16(ss8, ss9), _mm256_adds_epu16(ss10, ss11));
+            ss0 = _mm256_adds_epu16(ss0, ss1);
+            s3  = _mm_adds_epu16(_mm256_castsi256_si128(ss0), _mm256_extracti128_si256(ss0, 1));
+            if (leftover && (j + 8) >= search_area_width) {
+                s3 = _mm_or_si128(s3, leftover_mask);
+            }
+            s3        = _mm_minpos_epu16(s3);
+            tem_sum_1 = _mm_extract_epi16(s3, 0);
+            if (tem_sum_1 < low_sum) {
+                if (tem_sum_1 != 0xFFFF) { // no overflow
+                    low_sum = tem_sum_1;
+                    x_best  = (int16_t)(j + _mm_extract_epi16(s3, 1));
+                    y_best  = i;
+                } else {
+                    __m256i ss12, ss13;
+                    ss0 = _mm256_unpacklo_epi16(ss3, _mm256_setzero_si256());
+                    ss3 = _mm256_unpackhi_epi16(ss3, _mm256_setzero_si256());
+                    ss1 = _mm256_unpacklo_epi16(ss4, _mm256_setzero_si256());
+                    ss4 = _mm256_unpackhi_epi16(ss4, _mm256_setzero_si256());
+                    ss2 = _mm256_unpacklo_epi16(ss5, _mm256_setzero_si256());
+                    ss5 = _mm256_unpackhi_epi16(ss5, _mm256_setzero_si256());
+                    ss7 = _mm256_unpacklo_epi16(ss6, _mm256_setzero_si256());
+                    ss6 = _mm256_unpackhi_epi16(ss6, _mm256_setzero_si256());
+                    ss0 = _mm256_add_epi32(_mm256_add_epi32(ss0, ss1), _mm256_add_epi32(ss2, ss7));
+                    ss3 = _mm256_add_epi32(_mm256_add_epi32(ss3, ss4), _mm256_add_epi32(ss5, ss6));
+
+                    ss12 = _mm256_unpacklo_epi16(ss8, _mm256_setzero_si256());
+                    ss13 = _mm256_unpackhi_epi16(ss8, _mm256_setzero_si256());
+                    ss1 = _mm256_unpacklo_epi16(ss9, _mm256_setzero_si256());
+                    ss4 = _mm256_unpackhi_epi16(ss9, _mm256_setzero_si256());
+                    ss2 = _mm256_unpacklo_epi16(ss10, _mm256_setzero_si256());
+                    ss5 = _mm256_unpackhi_epi16(ss10, _mm256_setzero_si256());
+                    ss7 = _mm256_unpacklo_epi16(ss11, _mm256_setzero_si256());
+                    ss6 = _mm256_unpackhi_epi16(ss11, _mm256_setzero_si256());
+                    ss12 = _mm256_add_epi32(_mm256_add_epi32(ss12, ss1), _mm256_add_epi32(ss2, ss7));
+                    ss13 = _mm256_add_epi32(_mm256_add_epi32(ss13, ss4), _mm256_add_epi32(ss5, ss6));
+
+                    ss0 = _mm256_add_epi32(ss0, ss12);
+                    ss3 = _mm256_add_epi32(ss3,ss13);
+
+                    s0  = _mm_add_epi32(_mm256_castsi256_si128(ss0),
+                                       _mm256_extracti128_si256(ss0, 1));
+                    s3  = _mm_add_epi32(_mm256_castsi256_si128(ss3),
+                                       _mm256_extracti128_si256(ss3, 1));
+                    UPDATE_BEST(s0, 0, 0);
+                    UPDATE_BEST(s0, 1, 0);
+                    UPDATE_BEST(s0, 2, 0);
+                    UPDATE_BEST(s0, 3, 0);
+                    UPDATE_BEST(s3, 0, 4);
+                    UPDATE_BEST(s3, 1, 4);
+                    UPDATE_BEST(s3, 2, 4);
+                    UPDATE_BEST(s3, 3, 4);
+                }
+            }
+        }
+        ref += src_stride_raw;
+    }
+
+    *best_sad = low_sum;
+    *x_search_center = x_best;
+    *y_search_center = y_best;
+}
+
+
+/*******************************************************************************
+ * Requirement: width   = 4, 6, 8, 12, 16, 24, 32, 48 or 64 to use optimized SIMD
+ * otherwise general/slower SIMD verison is used
  * Requirement: block_height <= 64
  * Requirement: block_height % 2 = 0 when width = 4, 6 or 8
 *******************************************************************************/
@@ -2031,7 +2303,7 @@ void sad_loop_kernel_avx2_intrin(
                     p_src = src;
                     p_ref = ref + j;
                     s3    = _mm_setzero_si128();
-                    for (k = 0; k < block_height; k += 2) {
+                    for (k = 0; k + 2 <= block_height; k += 2) {
                         s0 = _mm_loadu_si128((__m128i *)p_ref);
                         s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
                         s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
@@ -2041,6 +2313,15 @@ void sad_loop_kernel_avx2_intrin(
                         p_src += src_stride << 1;
                         p_ref += ref_stride << 1;
                     }
+
+                    if (k < block_height) {
+                        s0 = _mm_lddqu_si128((__m128i *)p_ref);
+                        s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
+                        s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
+                        p_src += src_stride << 1;
+                        p_ref += ref_stride << 1;
+                    }
+
                     s3        = _mm_minpos_epu16(s3);
                     tem_sum_1 = _mm_extract_epi16(s3, 0);
                     if (tem_sum_1 < low_sum) {
@@ -2054,7 +2335,7 @@ void sad_loop_kernel_avx2_intrin(
                     p_src = src;
                     p_ref = ref + j;
                     s3    = _mm_setzero_si128();
-                    for (k = 0; k < block_height; k += 2) {
+                    for (k = 0; k + 2 <= block_height; k += 2) {
                         s0 = _mm_loadu_si128((__m128i *)p_ref);
                         s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
                         s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
@@ -2064,6 +2345,15 @@ void sad_loop_kernel_avx2_intrin(
                         p_src += src_stride << 1;
                         p_ref += ref_stride << 1;
                     }
+
+                    if (k < block_height) {
+                        s0 = _mm_lddqu_si128((__m128i *)p_ref);
+                        s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
+                        s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
+                        p_src += src_stride << 1;
+                        p_ref += ref_stride << 1;
+                    }
+
                     s3        = _mm_or_si128(s3, s8);
                     s3        = _mm_minpos_epu16(s3);
                     tem_sum_1 = _mm_extract_epi16(s3, 0);
@@ -2203,7 +2493,7 @@ void sad_loop_kernel_avx2_intrin(
                     p_src = src;
                     p_ref = ref + j;
                     s3    = _mm_setzero_si128();
-                    for (k = 0; k < block_height; k += 2) {
+                    for (k = 0; k + 2 <= block_height; k += 2) {
                         //Note: _mm_lddqu_si128 is used instead of _mm_loadu_si128 because clang Release configuration is emitting wrong assembly instructions
                         s0 = _mm_lddqu_si128((__m128i *)p_ref);
                         s1 = _mm_lddqu_si128((__m128i *)(p_ref + ref_stride));
@@ -2211,6 +2501,14 @@ void sad_loop_kernel_avx2_intrin(
                         s5 = _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride));
                         s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
                         s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s1, s5, 0));
+                        p_src += src_stride << 1;
+                        p_ref += ref_stride << 1;
+                    }
+
+                    if (k < block_height) {
+                        s0 = _mm_lddqu_si128((__m128i *)p_ref);
+                        s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
+                        s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
                         p_src += src_stride << 1;
                         p_ref += ref_stride << 1;
                     }
@@ -2244,7 +2542,7 @@ void sad_loop_kernel_avx2_intrin(
                     p_src = src;
                     p_ref = ref + j;
                     s3    = _mm_setzero_si128();
-                    for (k = 0; k < block_height; k += 2) {
+                    for (k = 0; k + 2 <= block_height; k += 2) {
                         //Note: _mm_lddqu_si128 is used instead of _mm_loadu_si128 because clang Release configuration is emitting wrong assembly instructions
                         s0 = _mm_lddqu_si128((__m128i *)p_ref);
                         s1 = _mm_lddqu_si128((__m128i *)(p_ref + ref_stride));
@@ -2255,6 +2553,15 @@ void sad_loop_kernel_avx2_intrin(
                         p_src += src_stride << 1;
                         p_ref += ref_stride << 1;
                     }
+
+                    if (k < block_height) {
+                        s0 = _mm_lddqu_si128((__m128i *)p_ref);
+                        s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
+                        s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
+                        p_src += src_stride << 1;
+                        p_ref += ref_stride << 1;
+                    }
+
                     s3        = _mm_or_si128(s3, s8);
 
                     DECLARE_ALIGNED(16, uint16_t, tsum[8]);
@@ -2381,7 +2688,7 @@ void sad_loop_kernel_avx2_intrin(
                     p_src = src;
                     p_ref = ref + j;
                     s3 = s4 = _mm_setzero_si128();
-                    for (k = 0; k < block_height; k += 2) {
+                    for (k = 0; k + 2 <= block_height; k += 2) {
                         s0 = _mm_loadu_si128((__m128i *)p_ref);
                         s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
                         s2 = _mm_loadl_epi64((__m128i *)p_src);
@@ -2393,6 +2700,16 @@ void sad_loop_kernel_avx2_intrin(
                         p_src += src_stride << 1;
                         p_ref += ref_stride << 1;
                     }
+
+                    if (k < block_height) {
+                        s0 = _mm_loadu_si128((__m128i *)p_ref);
+                        s2 = _mm_loadl_epi64((__m128i *)p_src);
+                        s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
+                        s4 = _mm_adds_epu16(s4, _mm_mpsadbw_epu8(s0, s2, 5));
+                        p_src += src_stride << 1;
+                        p_ref += ref_stride << 1;
+                    }
+
                     s3        = _mm_adds_epu16(s3, s4);
                     s3        = _mm_minpos_epu16(s3);
                     tem_sum_1 = _mm_extract_epi16(s3, 0);
@@ -2407,7 +2724,7 @@ void sad_loop_kernel_avx2_intrin(
                     p_src = src;
                     p_ref = ref + j;
                     s3 = s4 = _mm_setzero_si128();
-                    for (k = 0; k < block_height; k += 2) {
+                    for (k = 0; k + 2 <= block_height; k += 2) {
                         s0 = _mm_loadu_si128((__m128i *)p_ref);
                         s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
                         s2 = _mm_loadl_epi64((__m128i *)p_src);
@@ -2419,6 +2736,16 @@ void sad_loop_kernel_avx2_intrin(
                         p_src += src_stride << 1;
                         p_ref += ref_stride << 1;
                     }
+
+                    if (k < block_height) {
+                        s0 = _mm_loadu_si128((__m128i *)p_ref);
+                        s2 = _mm_loadl_epi64((__m128i *)p_src);
+                        s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
+                        s4 = _mm_adds_epu16(s4, _mm_mpsadbw_epu8(s0, s2, 5));
+                        p_src += src_stride << 1;
+                        p_ref += ref_stride << 1;
+                    }
+
                     s3        = _mm_adds_epu16(s3, s4);
                     s3        = _mm_or_si128(s3, s8);
                     s3        = _mm_minpos_epu16(s3);
@@ -2440,7 +2767,7 @@ void sad_loop_kernel_avx2_intrin(
                     p_src = src;
                     p_ref = ref + j;
                     ss3 = ss4 = ss5 = _mm256_setzero_si256();
-                    for (k = 0; k < block_height; k += 2) {
+                    for (k = 0; k + 2 <= block_height; k += 2) {
                         ss0 = _mm256_insertf128_si256(
                             _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
                             _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
@@ -2459,6 +2786,27 @@ void sad_loop_kernel_avx2_intrin(
                         p_src += 2 * src_stride;
                         p_ref += 2 * ref_stride;
                     }
+
+                    if (k < block_height) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        p_src += 2 * src_stride;
+                        p_ref += 2 * ref_stride;
+                    }
+
                     ss3       = _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4),ss5);
                     s3        = _mm_adds_epu16(_mm256_castsi256_si128(ss3),
                                         _mm256_extracti128_si256(ss3, 1));
@@ -2475,7 +2823,7 @@ void sad_loop_kernel_avx2_intrin(
                     p_src = src;
                     p_ref = ref + j;
                     ss3 = ss4 = ss5 = _mm256_setzero_si256();
-                    for (k = 0; k < block_height; k += 2) {
+                    for (k = 0; k + 2 <= block_height; k += 2) {
                         ss0 = _mm256_insertf128_si256(
                             _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
                             _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
@@ -2494,6 +2842,27 @@ void sad_loop_kernel_avx2_intrin(
                         p_src += 2 * src_stride;
                         p_ref += 2 * ref_stride;
                     }
+
+                    if (k < block_height) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        p_src += 2 * src_stride;
+                        p_ref += 2 * ref_stride;
+                    }
+
                     ss3       = _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4),ss5);
                     s3        = _mm_adds_epu16(_mm256_castsi256_si128(ss3),
                                         _mm256_extracti128_si256(ss3, 1));
@@ -2514,7 +2883,7 @@ void sad_loop_kernel_avx2_intrin(
                     p_src = src;
                     p_ref = ref + j;
                     ss3 = ss4 = ss5 = _mm256_setzero_si256();
-                    for (k = 0; k < block_height; k += 2) {
+                    for (k = 0; k + 2 <= block_height; k += 2) {
                         ss0 = _mm256_insertf128_si256(
                             _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
                             _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
@@ -2533,6 +2902,27 @@ void sad_loop_kernel_avx2_intrin(
                         p_src += 2 * src_stride;
                         p_ref += 2 * ref_stride;
                     }
+
+                    if (k < block_height) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        p_src += 2 * src_stride;
+                        p_ref += 2 * ref_stride;
+                    }
+
                     ss3       = _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4),ss5);
                     s3        = _mm256_castsi256_si128(ss3);
                     s5        = _mm256_extracti128_si256(ss3, 1);
@@ -2562,7 +2952,7 @@ void sad_loop_kernel_avx2_intrin(
                     p_src = src;
                     p_ref = ref + j;
                     ss3 = ss4 = ss5 = _mm256_setzero_si256();
-                    for (k = 0; k < block_height; k += 2) {
+                    for (k = 0; k + 2 <= block_height; k += 2) {
                         ss0 = _mm256_insertf128_si256(
                             _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
                             _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
@@ -2581,6 +2971,27 @@ void sad_loop_kernel_avx2_intrin(
                         p_src += 2 * src_stride;
                         p_ref += 2 * ref_stride;
                     }
+
+                    if (k < block_height) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        p_src += 2 * src_stride;
+                        p_ref += 2 * ref_stride;
+                    }
+
                     ss3       = _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4),ss5);
                     s3        = _mm256_castsi256_si128(ss3);
                     s5        = _mm256_extracti128_si256(ss3, 1);
@@ -2615,7 +3026,7 @@ void sad_loop_kernel_avx2_intrin(
                     p_src = src;
                     p_ref = ref + j;
                     ss3 = ss4 = ss5 = _mm256_setzero_si256();
-                    for (k = 0; k < block_height; k += 2) {
+                    for (k = 0; k + 2 <= block_height; k += 2) {
                         ss0 = _mm256_insertf128_si256(
                             _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
                             _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
@@ -2634,6 +3045,27 @@ void sad_loop_kernel_avx2_intrin(
                         p_src += 2 * src_stride;
                         p_ref += 2 * ref_stride;
                     }
+
+                    if (k < block_height) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        p_src += 2 * src_stride;
+                        p_ref += 2 * ref_stride;
+                    }
+
                     ss3       = _mm256_adds_epu16(ss3, ss4);
                     ss0       = _mm256_adds_epu16(ss3, ss5);
                     s0        = _mm_adds_epu16(_mm256_castsi256_si128(ss0),
@@ -2672,7 +3104,7 @@ void sad_loop_kernel_avx2_intrin(
                     p_src = src;
                     p_ref = ref + j;
                     ss3 = ss4 = ss5 = _mm256_setzero_si256();
-                    for (k = 0; k < block_height; k += 2) {
+                    for (k = 0; k + 2 <= block_height; k += 2) {
                         ss0 = _mm256_insertf128_si256(
                             _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
                             _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
@@ -2691,6 +3123,27 @@ void sad_loop_kernel_avx2_intrin(
                         p_src += 2 * src_stride;
                         p_ref += 2 * ref_stride;
                     }
+
+                    if (k < block_height) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        p_src += 2 * src_stride;
+                        p_ref += 2 * ref_stride;
+                    }
+
                     ss3       = _mm256_adds_epu16(ss3, ss4);
                     ss0       = _mm256_adds_epu16(ss3, ss5);
                     s0        = _mm_adds_epu16(_mm256_castsi256_si128(ss0),
@@ -2859,7 +3312,7 @@ void sad_loop_kernel_avx2_intrin(
                     p_src = src;
                     p_ref = ref + j;
                     ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
-                    for (k = 0; k < block_height; k += 2) {
+                    for (k = 0; k + 2 <= block_height; k += 2) {
                         ss0 = _mm256_insertf128_si256(
                             _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
                             _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
@@ -2879,6 +3332,28 @@ void sad_loop_kernel_avx2_intrin(
                         p_src += 2 * src_stride;
                         p_ref += 2 * ref_stride;
                     }
+
+                    if (k < block_height) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += src_stride;
+                        p_ref += ref_stride;
+                    }
+
                     ss3 =
                         _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4), _mm256_adds_epu16(ss5, ss6));
                     s3        = _mm256_castsi256_si128(ss3);
@@ -2909,7 +3384,7 @@ void sad_loop_kernel_avx2_intrin(
                     p_src = src;
                     p_ref = ref + j;
                     ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
-                    for (k = 0; k < block_height; k += 2) {
+                    for (k = 0; k + 2 <= block_height; k += 2) {
                         ss0 = _mm256_insertf128_si256(
                             _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
                             _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
@@ -2929,6 +3404,28 @@ void sad_loop_kernel_avx2_intrin(
                         p_src += 2 * src_stride;
                         p_ref += 2 * ref_stride;
                     }
+
+                    if (k < block_height) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += src_stride;
+                        p_ref += ref_stride;
+                    }
+
                     ss3 =
                         _mm256_adds_epu16(_mm256_adds_epu16(ss3, ss4), _mm256_adds_epu16(ss5, ss6));
                     s3        = _mm256_castsi256_si128(ss3);
@@ -2964,7 +3461,7 @@ void sad_loop_kernel_avx2_intrin(
                     p_src = src;
                     p_ref = ref + j;
                     ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
-                    for (k = 0; k < block_height; k += 2) {
+                    for (k = 0; k + 2 <= block_height; k += 2) {
                         ss0 = _mm256_insertf128_si256(
                             _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
                             _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
@@ -2984,6 +3481,28 @@ void sad_loop_kernel_avx2_intrin(
                         p_src += 2 * src_stride;
                         p_ref += 2 * ref_stride;
                     }
+
+                    if (k < block_height) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += src_stride;
+                        p_ref += ref_stride;
+                    }
+
                     ss3       = _mm256_adds_epu16(ss3, ss4);
                     ss5       = _mm256_adds_epu16(ss5, ss6);
                     ss0       = _mm256_adds_epu16(ss3, ss5);
@@ -3023,7 +3542,7 @@ void sad_loop_kernel_avx2_intrin(
                     p_src = src;
                     p_ref = ref + j;
                     ss3 = ss4 = ss5 = ss6 = _mm256_setzero_si256();
-                    for (k = 0; k < block_height; k += 2) {
+                    for (k = 0; k + 2 <= block_height; k += 2) {
                         ss0 = _mm256_insertf128_si256(
                             _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
                             _mm_loadu_si128((__m128i *)(p_ref + ref_stride)),
@@ -3043,6 +3562,28 @@ void sad_loop_kernel_avx2_intrin(
                         p_src += 2 * src_stride;
                         p_ref += 2 * ref_stride;
                     }
+
+                    if (k < block_height) {
+                        ss0 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_ref)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss1 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)(p_ref + 8))),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss2 = _mm256_insertf128_si256(
+                            _mm256_castsi128_si256(_mm_loadu_si128((__m128i *)p_src)),
+                            _mm_setzero_si128(),
+                            0x1);
+                        ss3 = _mm256_adds_epu16(ss3, _mm256_mpsadbw_epu8(ss0, ss2, 0));
+                        ss4 = _mm256_adds_epu16(ss4, _mm256_mpsadbw_epu8(ss0, ss2, 45)); // 101 101
+                        ss5 = _mm256_adds_epu16(ss5, _mm256_mpsadbw_epu8(ss1, ss2, 18)); // 010 010
+                        ss6 = _mm256_adds_epu16(ss6, _mm256_mpsadbw_epu8(ss1, ss2, 63)); // 111 111
+                        p_src += src_stride;
+                        p_ref += ref_stride;
+                    }
+
                     ss3       = _mm256_adds_epu16(ss3, ss4);
                     ss5       = _mm256_adds_epu16(ss5, ss6);
                     ss0       = _mm256_adds_epu16(ss3, ss5);
@@ -4231,18 +4772,19 @@ void sad_loop_kernel_avx2_intrin(
         break;
 
     default:
-        sad_loop_kernel_c(src,
-                          src_stride,
-                          ref,
-                          ref_stride,
-                          block_height,
-                          block_width,
-                          best_sad,
-                          x_search_center,
-                          y_search_center,
-                          src_stride_raw,
-                          search_area_width,
-                          search_area_height);
+        sad_loop_kernel_generalized_avx2(src,
+                                         src_stride,
+                                         ref,
+                                         ref_stride,
+                                         block_height,
+                                         block_width,
+                                         best_sad,
+                                         x_search_center,
+                                         y_search_center,
+                                         src_stride_raw,
+                                         search_area_width,
+                                         search_area_height,
+                                         s8);
         return;
     }
 

--- a/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
@@ -627,6 +627,12 @@ static INLINE void sad_loop_kernel_4_avx2(const uint8_t *const src, const uint32
     *sum = _mm256_adds_epu16(*sum, _mm256_mpsadbw_epu8(rr0, ss0, 0));
 }
 
+/*******************************************************************************
+* Function helper adds to "sum" vector SAD's for block width of 4, uses AVX2 instructions
+* Requirement: width = 4
+* Requirement: height = 1
+* Compute one line
+*******************************************************************************/
 static INLINE void sad_loop_kernel_4_oneline_avx2(const uint8_t *const src,
                                                   const uint8_t *const ref, __m256i *const sum) {
     const __m256i ss0 = _mm256_insertf128_si256(
@@ -647,6 +653,12 @@ static INLINE void sad_loop_kernel_4_sse4_1(const uint8_t *const src, const uint
     *sum             = _mm_adds_epu16(*sum, _mm_mpsadbw_epu8(r1, s1, 0));
 }
 
+/*******************************************************************************
+* Function helper adds to "sum" vector SAD's for block width of 4, uses sse4_1 instructions
+* Requirement: width = 4
+* Requirement: height = 1
+* Compute one line
+*******************************************************************************/
 static INLINE void sad_loop_kernel_4_oneline_sse4_1(const uint8_t *const src,
                                                     const uint8_t *const ref, __m128i *const sum) {
     const __m128i s0 = _mm_cvtsi32_si128(*(uint32_t *)src);
@@ -669,6 +681,12 @@ static INLINE void sad_loop_kernel_8_avx2(const uint8_t *const src, const uint32
     *sum = _mm256_adds_epu16(*sum, _mm256_mpsadbw_epu8(rr0, ss0, (5 << 3) | 5)); // 101 101
 }
 
+/*******************************************************************************
+* Function helper adds to "sum" vector SAD's for block width of 8, uses AVX2 instructions
+* Requirement: width = 8
+* Requirement: height = 1
+* Compute one line
+*******************************************************************************/
 static INLINE void sad_loop_kernel_8_oneline_avx2(const uint8_t *const src,
                                                   const uint8_t *const ref, __m256i *const sum) {
     const __m256i ss0 = _mm256_insertf128_si256(
@@ -711,6 +729,12 @@ SIMD_INLINE void sad_loop_kernel_12_avx512(const uint8_t *const src, const uint3
     *sum = _mm512_adds_epu16(*sum, _mm512_dbsad_epu8(ss2, rr1, 0x94));
 }
 
+/*******************************************************************************
+* Function helper adds to "sums" vectors SAD's for block width of 12, uses AVX512 instructions
+* Requirement: width = 12
+* Requirement: height = 1
+* Compute one line
+*******************************************************************************/
 SIMD_INLINE void sad_loop_kernel_12_oneline_avx512(const uint8_t *const src,
                                                    const uint8_t *const ref, __m512i *const sum) {
     const __m128i s0  = _mm_loadu_si128((__m128i *)src);
@@ -761,6 +785,12 @@ SIMD_INLINE void sad_loop_kernel_16_avx512(const uint8_t *const src, const uint3
     *sum = _mm512_adds_epu16(*sum, _mm512_dbsad_epu8(ss3, rr1, 0xE9));
 }
 
+/*******************************************************************************
+* Function helper adds to "sums" vectors SAD's for block width of 16, uses AVX512 instructions
+* Requirement: width = 16
+* Requirement: height = 1
+* Compute one line
+*******************************************************************************/
 SIMD_INLINE void sad_loop_kernel_16_oneline_avx512(const uint8_t *const src,
                                                    const uint8_t *const ref, __m512i *const sum) {
     const __m128i s0  = _mm_loadu_si128((__m128i *)src);
@@ -816,6 +846,12 @@ SIMD_INLINE void sad_loop_kernel_12_2sum_avx512(const uint8_t *const src, const 
     sum[0] = _mm512_adds_epu16(sum[0], _mm512_dbsad_epu8(ss2, rr1, 0x94));
 }
 
+/*******************************************************************************
+* Function helper adds to two elements "sums" vectors SAD's for block width of 12, uses AVX512 instructions
+* Requirement: width = 12
+* Requirement: height = 1
+* Compute one line
+*******************************************************************************/
 SIMD_INLINE void sad_loop_kernel_12_2sum_oneline_avx512(const uint8_t *const src,
                                                         const uint8_t *const ref, __m512i sum[2]) {
     const __m128i s0  = _mm_loadu_si128((__m128i *)src);
@@ -866,6 +902,12 @@ SIMD_INLINE void sad_loop_kernel_16_2sum_avx512(const uint8_t *const src, const 
     sum[1] = _mm512_adds_epu16(sum[1], _mm512_dbsad_epu8(ss3, rr1, 0xE9));
 }
 
+/*******************************************************************************
+* Function helper adds to two elements "sums" vectors SAD's for block width of 16, uses AVX512 instructions
+* Requirement: width = 16
+* Requirement: height = 1
+* Compute one line
+*******************************************************************************/
 SIMD_INLINE void sad_loop_kernel_16_2sum_oneline_avx512(const uint8_t *const src,
                                                          const uint8_t *const ref, __m512i sum[2]) {
     const __m128i s0  = _mm_loadu_si128((__m128i *)src);
@@ -916,6 +958,12 @@ static INLINE void sad_loop_kernel_12_avx2(const uint8_t *const src, const uint3
     *sum = _mm256_adds_epu16(*sum, _mm256_mpsadbw_epu8(rr1, ss0, (2 << 3) | 2)); // 010 010
 }
 
+/*******************************************************************************
+* Function helper adds to "sums" vectors SAD's for block width of 12, uses AVX2 instructions
+* Requirement: width = 12
+* Requirement: height = 1
+* Compute one line
+*******************************************************************************/
 static INLINE void sad_loop_kernel_12_oneline_avx2(const uint8_t *const src,
                                                    const uint8_t *const ref, __m256i *const sum) {
     const __m256i ss0 = _mm256_insertf128_si256(
@@ -950,6 +998,12 @@ static INLINE void sad_loop_kernel_16_avx2(const uint8_t *const src, const uint3
     *sum = _mm256_adds_epu16(*sum, _mm256_mpsadbw_epu8(rr1, ss0, (7 << 3) | 7)); // 111 111
 }
 
+/*******************************************************************************
+* Function helper adds to "sums" vectors SAD's for block width of 16, uses AVX512 instructions
+* Requirement: width = 16
+* Requirement: height = 1
+* Compute one line
+*******************************************************************************/
 static INLINE void sad_loop_kernel_16_oneline_avx2(const uint8_t *const src,
                                                    const uint8_t *const ref, __m256i *const sum) {
     const __m256i ss0 = _mm256_insertf128_si256(
@@ -989,6 +1043,12 @@ static INLINE void sad_loop_kernel_12_2sum_avx2(const uint8_t *const src, const 
     sums[0] = _mm256_adds_epu16(sums[0], _mm256_mpsadbw_epu8(rr1, ss0, (2 << 3) | 2)); // 010 010
 }
 
+/*******************************************************************************
+* Function helper adds to two elements "sums" vectors SAD's for block width of 12, uses AVX2 instructions
+* Requirement: width = 12
+* Requirement: height = 1
+* Compute one line
+*******************************************************************************/
 static INLINE void sad_loop_kernel_12_2sum_oneline_avx2(const uint8_t *const src,
                                                    const uint8_t *const ref, __m256i sums[2]) {
     const __m256i ss0 = _mm256_insertf128_si256(
@@ -1023,6 +1083,12 @@ static INLINE void sad_loop_kernel_16_2sum_avx2(const uint8_t *const src, const 
     sums[1] = _mm256_adds_epu16(sums[1], _mm256_mpsadbw_epu8(rr1, ss0, (7 << 3) | 7)); // 111 111
 }
 
+/*******************************************************************************
+* Function helper adds to two elements "sums" vectors SAD's for block width of 16, uses AVX2 instructions
+* Requirement: width = 16
+* Requirement: height = 1
+* Compute one line
+*******************************************************************************/
 static INLINE void sad_loop_kernel_16_2sum_oneline_avx2(const uint8_t *const src,
                                                         const uint8_t *const ref, __m256i sums[2]) {
     const __m256i ss0 = _mm256_insertf128_si256(
@@ -1760,6 +1826,10 @@ static INLINE __m128i complement_4_to_6(uint8_t *ref, uint32_t ref_stride, uint8
     return sum;
 }
 
+/*******************************************************************************
+ * Requirement: block_height < 64
+ * General version for SAD computing that support any block width and height
+*******************************************************************************/
 void sad_loop_kernel_generalized_avx512(
     uint8_t * src, // input parameter, source samples Ptr
     uint32_t  src_stride, // input parameter, source stride
@@ -1999,7 +2069,7 @@ void sad_loop_kernel_generalized_avx512(
 
 /*******************************************************************************
 * Requirement: width   = 4, 6, 8, 12, 16, 24, 32, 48 or 64 to use SIMD
-* otherwise C version is used
+* otherwise general/slower SIMD verison is used
 * Requirement: height <= 64
 * Requirement: height % 2 = 0
 *******************************************************************************/

--- a/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
@@ -2569,7 +2569,7 @@ void sad_loop_kernel_avx512_intrin(
             break;
 
         case 32:
-            if (height <= 8) {
+            if (height <= 16) {
                 y = 0;
                 do {
                     __m512i sum512 = _mm512_setzero_si512();
@@ -2583,25 +2583,6 @@ void sad_loop_kernel_avx512_intrin(
                         sad_loop_kernel_32_avx512(s, r, &sum512);
                         s += src_stride;
                         r += ref_stride;
-                    } while (--h);
-
-                    update_256_pel(sum512, 0, y, &best_s, &best_x, &best_y);
-                    ref += src_stride_raw;
-                } while (++y < search_area_height);
-            } else if (height <= 16) {
-                y = 0;
-                do {
-                    __m512i sum512 = _mm512_setzero_si512();
-
-                    s = src;
-                    r = ref;
-
-                    h = height2;
-                    do {
-                        sad_loop_kernel_32_avx512(s, r, &sum512);
-                        sad_loop_kernel_32_avx512(s + src_stride, r + ref_stride, &sum512);
-                        s += 2 * src_stride;
-                        r += 2 * ref_stride;
                     } while (--h);
 
                     update_512_pel(sum512, 0, y, &best_s, &best_x, &best_y);
@@ -3584,7 +3565,7 @@ void sad_loop_kernel_avx512_intrin(
             break;
 
         case 32:
-            if (height <= 8) {
+            if (height <= 16) {
                 y = 0;
                 do {
                     for (x = 0; x <= search_area_width - 16; x += 16) {
@@ -3599,46 +3580,6 @@ void sad_loop_kernel_avx512_intrin(
                             sad_loop_kernel_32_avx512(s, r, &sum512);
                             s += src_stride;
                             r += ref_stride;
-                        } while (--h);
-
-                        update_256_pel(sum512, x, y, &best_s, &best_x, &best_y);
-                    }
-
-                    // leftover
-                    for (; x < search_area_width; x += 8) {
-                        __m256i sum256 = _mm256_setzero_si256();
-
-                        s = src;
-                        r = ref + x;
-
-                        h = height;
-                        do {
-                            sad_loop_kernel_32_avx2(s, r, &sum256);
-                            s += src_stride;
-                            r += ref_stride;
-                        } while (--h);
-
-                        update_leftover_256_pel(
-                            sum256, search_area_width, x, y, mask128, &best_s, &best_x, &best_y);
-                    }
-
-                    ref += src_stride_raw;
-                } while (++y < search_area_height);
-            } else if (height <= 16) {
-                y = 0;
-                do {
-                    for (x = 0; x <= search_area_width - 16; x += 16) {
-                        __m512i sum512 = _mm512_setzero_si512();
-
-                        s = src;
-                        r = ref + x;
-
-                        h = height2;
-                        do {
-                            sad_loop_kernel_32_avx512(s, r, &sum512);
-                            sad_loop_kernel_32_avx512(s + src_stride, r + ref_stride, &sum512);
-                            s += 2 * src_stride;
-                            r += 2 * ref_stride;
                         } while (--h);
 
                         update_512_pel(sum512, x, y, &best_s, &best_x, &best_y);

--- a/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
@@ -1844,12 +1844,17 @@ void sad_loop_kernel_avx512_intrin(
                     s = src;
                     r = ref;
 
-                    h = height2;
-                    do {
+                    h = height;
+                    while (h >= 2) {
                         sad_loop_kernel_4_sse4_1(s, src_stride, r, ref_stride, &sum);
                         s += 2 * src_stride;
                         r += 2 * ref_stride;
-                    } while (--h);
+                        h -= 2;
+                    };
+
+                    if (h) {
+                        sad_loop_kernel_4_oneline_sse4_1(s, r, &sum);
+                    }
 
                     __m128i sum2 = complement_4_to_6(ref, ref_stride, src, src_stride, height, 8);
                     sum          = _mm_adds_epu16(sum, sum2);
@@ -1865,12 +1870,17 @@ void sad_loop_kernel_avx512_intrin(
                     s = src;
                     r = ref;
 
-                    h = height2;
-                    do {
+                    h = height;
+                    while (h >= 2) {
                         sad_loop_kernel_4_avx2(s, src_stride, r, ref_stride, &sum256);
                         s += 2 * src_stride;
                         r += 2 * ref_stride;
-                    } while (--h);
+                        h -= 2;
+                    };
+
+                    if (h) {
+                        sad_loop_kernel_4_oneline_avx2(s, r, &sum256);
+                    }
 
                     __m128i sum = complement_4_to_6(ref, ref_stride, src, src_stride, height, 8);
                     sum256      = _mm256_adds_epu16(
@@ -2480,12 +2490,17 @@ void sad_loop_kernel_avx512_intrin(
                         s = src;
                         r = ref;
 
-                        h = height2;
-                        do {
+                        h = height;
+                        while (h >= 2) {
                             sad_loop_kernel_4_sse4_1(s, src_stride, r, ref_stride, &sum);
                             s += 2 * src_stride;
                             r += 2 * ref_stride;
-                        } while (--h);
+                            h -= 2;
+                        };
+
+                        if (h) {
+                            sad_loop_kernel_4_oneline_sse4_1(s, r, &sum);
+                        }
 
                         __m128i sum2 = complement_4_to_6(
                             ref, ref_stride, src, src_stride, height, 8);
@@ -2500,12 +2515,17 @@ void sad_loop_kernel_avx512_intrin(
                         s = src;
                         r = ref + 8;
 
-                        h = height2;
-                        do {
+                        h = height;
+                        while (h >= 2) {
                             sad_loop_kernel_4_sse4_1(s, src_stride, r, ref_stride, &sum);
                             s += 2 * src_stride;
                             r += 2 * ref_stride;
-                        } while (--h);
+                            h -= 2;
+                        };
+
+                        if (h) {
+                            sad_loop_kernel_4_oneline_sse4_1(s, r, &sum);
+                        }
 
                         __m128i sum2 = complement_4_to_6(
                             ref + 8, ref_stride, src, src_stride, height, 8);
@@ -2525,12 +2545,17 @@ void sad_loop_kernel_avx512_intrin(
                         s = src;
                         r = ref;
 
-                        h = height2;
-                        do {
+                        h = height;
+                        while (h >= 2) {
                             sad_loop_kernel_4_avx2(s, src_stride, r, ref_stride, &sum256);
                             s += 2 * src_stride;
                             r += 2 * ref_stride;
-                        } while (--h);
+                            h -= 2;
+                        };
+
+                        if (h) {
+                            sad_loop_kernel_4_oneline_avx2(s, r, &sum256);
+                        }
 
                         __m128i sum = complement_4_to_6(
                             ref, ref_stride, src, src_stride, height, 8);
@@ -2546,12 +2571,17 @@ void sad_loop_kernel_avx512_intrin(
                         s = src;
                         r = ref + 8;
 
-                        h = height2;
-                        do {
+                        h = height;
+                        while (h >= 2) {
                             sad_loop_kernel_4_avx2(s, src_stride, r, ref_stride, &sum256);
                             s += 2 * src_stride;
                             r += 2 * ref_stride;
-                        } while (--h);
+                            h -= 2;
+                        };
+
+                        if (h) {
+                            sad_loop_kernel_4_oneline_avx2(s, r, &sum256);
+                        }
 
                         __m128i sum = complement_4_to_6(
                             ref + 8, ref_stride, src, src_stride, height, 8);
@@ -3236,12 +3266,17 @@ void sad_loop_kernel_avx512_intrin(
                         s = src;
                         r = ref + x;
 
-                        h = height2;
-                        do {
+                        h = height;
+                        while (h >= 2) {
                             sad_loop_kernel_4_sse4_1(s, src_stride, r, ref_stride, &sum);
                             s += 2 * src_stride;
                             r += 2 * ref_stride;
-                        } while (--h);
+                            h -= 2;
+                        };
+
+                        if (h) {
+                            sad_loop_kernel_4_oneline_sse4_1(s, r, &sum);
+                        }
 
                         __m128i sum2 = complement_4_to_6(
                             ref + x, ref_stride, src, src_stride, height, 8);
@@ -3256,12 +3291,17 @@ void sad_loop_kernel_avx512_intrin(
                         s = src;
                         r = ref + x;
 
-                        h = height2;
-                        do {
+                        h = height;
+                        while (h >= 2) {
                             sad_loop_kernel_4_sse4_1(s, src_stride, r, ref_stride, &sum);
                             s += 2 * src_stride;
                             r += 2 * ref_stride;
-                        } while (--h);
+                            h -= 2;
+                        };
+
+                        if (h) {
+                            sad_loop_kernel_4_oneline_sse4_1(s, r, &sum);
+                        }
 
                         sum = _mm_or_si128(sum, mask128);
 
@@ -3283,12 +3323,17 @@ void sad_loop_kernel_avx512_intrin(
                         s = src;
                         r = ref + x;
 
-                        h = height2;
-                        do {
+                        h = height;
+                        while (h >= 2) {
                             sad_loop_kernel_4_avx2(s, src_stride, r, ref_stride, &sum256);
                             s += 2 * src_stride;
                             r += 2 * ref_stride;
-                        } while (--h);
+                            h -= 2;
+                        };
+
+                        if (h) {
+                            sad_loop_kernel_4_oneline_avx2(s, r, &sum256);
+                        }
 
                         __m128i sum = complement_4_to_6(
                             ref + x, ref_stride, src, src_stride, height, 8);
@@ -3304,12 +3349,17 @@ void sad_loop_kernel_avx512_intrin(
                         s = src;
                         r = ref + x;
 
-                        h = height2;
-                        do {
+                        h = height;
+                        while (h >= 2) {
                             sad_loop_kernel_4_avx2(s, src_stride, r, ref_stride, &sum256);
                             s += 2 * src_stride;
                             r += 2 * ref_stride;
-                        } while (--h);
+                            h -= 2;
+                        };
+
+                        if (h) {
+                            sad_loop_kernel_4_oneline_avx2(s, r, &sum256);
+                        }
 
                         __m128i sum = complement_4_to_6(
                             ref + x, ref_stride, src, src_stride, height, leftover);

--- a/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
@@ -1952,13 +1952,19 @@ void sad_loop_kernel_avx512_intrin(
                     s = src;
                     r = ref;
 
-                    h = height2;
-                    do {
+                    h = height;
+                    while (h >= 2) {
                         sad_loop_kernel_16_avx2(s, src_stride, r, ref_stride, &sum256);
                         sad_loop_kernel_8_avx2(s + 16, src_stride, r + 16, ref_stride, &sum256);
                         s += 2 * src_stride;
                         r += 2 * ref_stride;
-                    } while (--h);
+                        h -= 2;
+                    };
+
+                    if (h) {
+                        sad_loop_kernel_16_oneline_avx2(s, r, &sum256);
+                        sad_loop_kernel_8_oneline_avx2(s + 16, r + 16, &sum256);
+                    }
 
                     update_some_pel(sum256, 0, y, &best_s, &best_x, &best_y);
                     ref += src_stride_raw;
@@ -1971,13 +1977,19 @@ void sad_loop_kernel_avx512_intrin(
                     s = src;
                     r = ref;
 
-                    h = height2;
-                    do {
+                    h = height;
+                    while (h >= 2) {
                         sad_loop_kernel_16_avx2(s, src_stride, r, ref_stride, &sums256[0]);
                         sad_loop_kernel_8_avx2(s + 16, src_stride, r + 16, ref_stride, &sums256[1]);
                         s += 2 * src_stride;
                         r += 2 * ref_stride;
-                    } while (--h);
+                        h -= 2;
+                    };
+
+                    if (h) {
+                        sad_loop_kernel_16_oneline_avx2(s, r, &sums256[0]);
+                        sad_loop_kernel_8_oneline_avx2(s + 16, r + 16, &sums256[1]);
+                    }
 
                     update_leftover8_1024_pel(sums256, 0, y, &best_s, &best_x, &best_y);
                     ref += src_stride_raw;
@@ -2614,14 +2626,21 @@ void sad_loop_kernel_avx512_intrin(
                     s = src;
                     r = ref;
 
-                    h = height2;
-                    do {
+                    h = height;
+                    while (h >= 2) {
                         sad_loop_kernel_16_avx512(s, src_stride, r, ref_stride, &sum512);
                         sad_loop_kernel_8_avx2(s + 16, src_stride, r + 16, ref_stride, &sums256[0]);
                         sad_loop_kernel_8_avx2(s + 16, src_stride, r + 24, ref_stride, &sums256[1]);
                         s += 2 * src_stride;
                         r += 2 * ref_stride;
-                    } while (--h);
+                        h -= 2;
+                    };
+
+                    if (h) {
+                        sad_loop_kernel_16_oneline_avx512(s, r, &sum512);
+                        sad_loop_kernel_8_oneline_avx2(s + 16, r + 16, &sums256[0]);
+                        sad_loop_kernel_8_oneline_avx2(s + 16, r + 24, &sums256[1]);
+                    }
 
                     update_384_pel(sum512, sums256, 0, y, &best_s, &best_x, &best_y);
                     ref += src_stride_raw;
@@ -2635,14 +2654,21 @@ void sad_loop_kernel_avx512_intrin(
                     s = src;
                     r = ref;
 
-                    h = height2;
-                    do {
+                    h = height;
+                    while (h >= 2) {
                         sad_loop_kernel_16_avx512(s, src_stride, r, ref_stride, &sum512);
                         sad_loop_kernel_8_avx2(s + 16, src_stride, r + 16, ref_stride, &sums256[0]);
                         sad_loop_kernel_8_avx2(s + 16, src_stride, r + 24, ref_stride, &sums256[1]);
                         s += 2 * src_stride;
                         r += 2 * ref_stride;
-                    } while (--h);
+                        h -= 2;
+                    };
+
+                    if (h) {
+                        sad_loop_kernel_16_oneline_avx512(s, r, &sum512);
+                        sad_loop_kernel_8_oneline_avx2(s + 16, r + 16, &sums256[0]);
+                        sad_loop_kernel_8_oneline_avx2(s + 16, r + 24, &sums256[1]);
+                    }
 
                     update_768_pel(sum512, sums256, 0, y, &best_s, &best_x, &best_y);
                     ref += src_stride_raw;
@@ -3521,8 +3547,8 @@ void sad_loop_kernel_avx512_intrin(
                         s = src;
                         r = ref + x;
 
-                        h = height2;
-                        do {
+                        h = height;
+                        while (h >= 2) {
                             sad_loop_kernel_16_avx512(s, src_stride, r, ref_stride, &sum512);
                             sad_loop_kernel_8_avx2(
                                 s + 16, src_stride, r + 16, ref_stride, &sums256[0]);
@@ -3530,7 +3556,14 @@ void sad_loop_kernel_avx512_intrin(
                                 s + 16, src_stride, r + 24, ref_stride, &sums256[1]);
                             s += 2 * src_stride;
                             r += 2 * ref_stride;
-                        } while (--h);
+                            h -= 2;
+                        };
+
+                        if (h) {
+                            sad_loop_kernel_16_oneline_avx512(s, r, &sum512);
+                            sad_loop_kernel_8_oneline_avx2(s + 16, r + 16, &sums256[0]);
+                            sad_loop_kernel_8_oneline_avx2(s + 16, r + 24, &sums256[1]);
+                        }
 
                         update_384_pel(sum512, sums256, x, y, &best_s, &best_x, &best_y);
                     }
@@ -3542,13 +3575,19 @@ void sad_loop_kernel_avx512_intrin(
                         s = src;
                         r = ref + x;
 
-                        h = height2;
-                        do {
+                        h = height;
+                        while (h >= 2) {
                             sad_loop_kernel_16_avx2(s, src_stride, r, ref_stride, &sum256);
                             sad_loop_kernel_8_avx2(s + 16, src_stride, r + 16, ref_stride, &sum256);
                             s += 2 * src_stride;
                             r += 2 * ref_stride;
-                        } while (--h);
+                            h -= 2;
+                        };
+
+                        if (h) {
+                            sad_loop_kernel_16_oneline_avx2(s, r, &sum256);
+                            sad_loop_kernel_8_oneline_avx2(s + 16, r + 16, &sum256);
+                        }
 
                         update_leftover_512_pel(
                             sum256, search_area_width, x, y, mask256, &best_s, &best_x, &best_y);
@@ -3568,8 +3607,8 @@ void sad_loop_kernel_avx512_intrin(
                         s = src;
                         r = ref + x;
 
-                        h = height2;
-                        do {
+                        h = height;
+                        while (h >= 2) {
                             sad_loop_kernel_16_avx512(s, src_stride, r, ref_stride, &sum512);
                             sad_loop_kernel_8_avx2(
                                 s + 16, src_stride, r + 16, ref_stride, &sums256[0]);
@@ -3577,7 +3616,14 @@ void sad_loop_kernel_avx512_intrin(
                                 s + 16, src_stride, r + 24, ref_stride, &sums256[1]);
                             s += 2 * src_stride;
                             r += 2 * ref_stride;
-                        } while (--h);
+                            h -= 2;
+                        };
+
+                        if (h) {
+                            sad_loop_kernel_16_oneline_avx512(s, r, &sum512);
+                            sad_loop_kernel_8_oneline_avx2(s + 16, r + 16, &sums256[0]);
+                            sad_loop_kernel_8_oneline_avx2(s + 16, r + 24, &sums256[1]);
+                        }
 
                         update_768_pel(sum512, sums256, x, y, &best_s, &best_x, &best_y);
                     }
@@ -3589,14 +3635,20 @@ void sad_loop_kernel_avx512_intrin(
                         s = src;
                         r = ref + x;
 
-                        h = height2;
-                        do {
+                        h = height;
+                        while (h >= 2) {
                             sad_loop_kernel_16_avx2(s, src_stride, r, ref_stride, &sums256[0]);
                             sad_loop_kernel_8_avx2(
                                 s + 16, src_stride, r + 16, ref_stride, &sums256[1]);
                             s += 2 * src_stride;
                             r += 2 * ref_stride;
-                        } while (--h);
+                            h -= 2;
+                        };
+
+                        if (h) {
+                            sad_loop_kernel_16_oneline_avx2(s, r, &sums256[0]);
+                            sad_loop_kernel_8_oneline_avx2(s + 16, r + 16, &sums256[1]);
+                        }
 
                         update_leftover8_1024_pel(sums256, x, y, &best_s, &best_x, &best_y);
 
@@ -3609,14 +3661,20 @@ void sad_loop_kernel_avx512_intrin(
                         s = src;
                         r = ref + x;
 
-                        h = height2;
-                        do {
+                        h = height;
+                        while (h >= 2) {
                             sad_loop_kernel_16_avx2(s, src_stride, r, ref_stride, &sums256[0]);
                             sad_loop_kernel_8_avx2(
                                 s + 16, src_stride, r + 16, ref_stride, &sums256[1]);
                             s += 2 * src_stride;
                             r += 2 * ref_stride;
-                        } while (--h);
+                            h -= 2;
+                        };
+
+                        if (h) {
+                            sad_loop_kernel_16_oneline_avx2(s, r, &sums256[0]);
+                            sad_loop_kernel_8_oneline_avx2(s + 16, r + 16, &sums256[1]);
+                        }
 
                         update_leftover_1024_pel(sums256,
                                                  search_area_width,

--- a/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
+++ b/Source/Lib/Encoder/ASM_AVX512/EbComputeSAD_Intrinsic_AVX512.c
@@ -1780,9 +1780,9 @@ void sad_loop_kernel_generalized_avx512(
     __m128i leftover_mask = _mm_set1_epi32(-1);
     __m128i leftover_mask32b = _mm_set1_epi32(-1);
     if (leftover) {
-        for (k = 0; k < (search_area_width & 7); k++)
+        for (k = 0; k < (uint32_t)(search_area_width & 7); k++)
             leftover_mask = _mm_slli_si128(leftover_mask, 2);
-        for (k = 0; k < (search_area_width & 3); k++)
+        for (k = 0; k < (uint32_t)(search_area_width & 3); k++)
             leftover_mask32b = _mm_slli_si128(leftover_mask32b, 4);
     }
 

--- a/Source/Lib/Encoder/ASM_SSE4_1/EbComputeSAD_Intrinsic_SSE4_1.c
+++ b/Source/Lib/Encoder/ASM_SSE4_1/EbComputeSAD_Intrinsic_SSE4_1.c
@@ -124,7 +124,7 @@ void sad_loop_kernel_sse4_1_intrin(
                 p_src = src;
                 p_ref = ref + j;
                 s3    = _mm_setzero_si128();
-                for (k = 0; k < block_height; k += 2) {
+                for (k = 0; k + 2 <= block_height; k += 2) {
                     s0 = _mm_loadu_si128((__m128i *)p_ref);
                     s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
                     s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
@@ -134,6 +134,15 @@ void sad_loop_kernel_sse4_1_intrin(
                     p_src += src_stride << 1;
                     p_ref += ref_stride << 1;
                 }
+
+                if (k < block_height) {
+                    s0 = _mm_loadu_si128((__m128i *)p_ref);
+                    s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
+                    s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
+                    p_src += src_stride << 1;
+                    p_ref += ref_stride << 1;
+                }
+
                 s3      = _mm_minpos_epu16(s3);
                 tem_sum = _mm_extract_epi16(s3, 0);
                 if (tem_sum < low_sum) {
@@ -147,7 +156,7 @@ void sad_loop_kernel_sse4_1_intrin(
                 p_src = src;
                 p_ref = ref + j;
                 s3    = _mm_setzero_si128();
-                for (k = 0; k < block_height; k += 2) {
+                for (k = 0; k + 2 <= block_height; k += 2) {
                     s0 = _mm_loadu_si128((__m128i *)p_ref);
                     s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
                     s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
@@ -157,6 +166,15 @@ void sad_loop_kernel_sse4_1_intrin(
                     p_src += src_stride << 1;
                     p_ref += ref_stride << 1;
                 }
+
+                if (k < block_height) {
+                    s0 = _mm_loadu_si128((__m128i *)p_ref);
+                    s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
+                    s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
+                    p_src += src_stride << 1;
+                    p_ref += ref_stride << 1;
+                }
+
                 s3      = _mm_or_si128(s3, s8);
                 s3      = _mm_minpos_epu16(s3);
                 tem_sum = _mm_extract_epi16(s3, 0);
@@ -176,13 +194,21 @@ void sad_loop_kernel_sse4_1_intrin(
                 p_src = src;
                 p_ref = ref + j;
                 s3    = _mm_setzero_si128();
-                for (k = 0; k < block_height; k += 2) {
+                for (k = 0; k + 2 <= block_height; k += 2) {
                     s0 = _mm_loadu_si128((__m128i *)p_ref);
                     s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
                     s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
                     s5 = _mm_cvtsi32_si128(*(uint32_t *)(p_src + src_stride));
                     s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
                     s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s1, s5, 0));
+                    p_src += src_stride << 1;
+                    p_ref += ref_stride << 1;
+                }
+
+                if (k < block_height) {
+                    s0 = _mm_loadu_si128((__m128i *)p_ref);
+                    s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
+                    s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
                     p_src += src_stride << 1;
                     p_ref += ref_stride << 1;
                 }
@@ -216,7 +242,7 @@ void sad_loop_kernel_sse4_1_intrin(
                 p_src = src;
                 p_ref = ref + j;
                 s3    = _mm_setzero_si128();
-                for (k = 0; k < block_height; k += 2) {
+                for (k = 0; k + 2 <= block_height; k += 2) {
                     s0 = _mm_loadu_si128((__m128i *)p_ref);
                     s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
                     s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
@@ -226,6 +252,15 @@ void sad_loop_kernel_sse4_1_intrin(
                     p_src += src_stride << 1;
                     p_ref += ref_stride << 1;
                 }
+
+                if (k < block_height) {
+                    s0 = _mm_loadu_si128((__m128i *)p_ref);
+                    s2 = _mm_cvtsi32_si128(*(uint32_t *)p_src);
+                    s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
+                    p_src += src_stride << 1;
+                    p_ref += ref_stride << 1;
+                }
+
                 s3      = _mm_or_si128(s3, s8);
 
                 DECLARE_ALIGNED(16, uint16_t, tsum[8]);
@@ -262,7 +297,7 @@ void sad_loop_kernel_sse4_1_intrin(
                 p_src = src;
                 p_ref = ref + j;
                 s3 = s4 = _mm_setzero_si128();
-                for (k = 0; k < block_height; k += 2) {
+                for (k = 0; k + 2 <= block_height; k += 2) {
                     s0 = _mm_loadu_si128((__m128i *)p_ref);
                     s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
                     s2 = _mm_loadl_epi64((__m128i *)p_src);
@@ -274,6 +309,16 @@ void sad_loop_kernel_sse4_1_intrin(
                     p_src += src_stride << 1;
                     p_ref += ref_stride << 1;
                 }
+
+                if (k < block_height) {
+                    s0 = _mm_loadu_si128((__m128i *)p_ref);
+                    s2 = _mm_loadl_epi64((__m128i *)p_src);
+                    s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
+                    s4 = _mm_adds_epu16(s4, _mm_mpsadbw_epu8(s0, s2, 5));
+                    p_src += src_stride << 1;
+                    p_ref += ref_stride << 1;
+                }
+
                 s3      = _mm_adds_epu16(s3, s4);
                 s3      = _mm_minpos_epu16(s3);
                 tem_sum = _mm_extract_epi16(s3, 0);
@@ -288,7 +333,7 @@ void sad_loop_kernel_sse4_1_intrin(
                 p_src = src;
                 p_ref = ref + j;
                 s3 = s4 = _mm_setzero_si128();
-                for (k = 0; k < block_height; k += 2) {
+                for (k = 0; k + 2 <= block_height; k += 2) {
                     s0 = _mm_loadu_si128((__m128i *)p_ref);
                     s1 = _mm_loadu_si128((__m128i *)(p_ref + ref_stride));
                     s2 = _mm_loadl_epi64((__m128i *)p_src);
@@ -300,6 +345,16 @@ void sad_loop_kernel_sse4_1_intrin(
                     p_src += src_stride << 1;
                     p_ref += ref_stride << 1;
                 }
+
+                if (k < block_height) {
+                    s0 = _mm_loadu_si128((__m128i *)p_ref);
+                    s2 = _mm_loadl_epi64((__m128i *)p_src);
+                    s3 = _mm_adds_epu16(s3, _mm_mpsadbw_epu8(s0, s2, 0));
+                    s4 = _mm_adds_epu16(s4, _mm_mpsadbw_epu8(s0, s2, 5));
+                    p_src += src_stride << 1;
+                    p_ref += ref_stride << 1;
+                }
+
                 s3      = _mm_adds_epu16(s3, s4);
                 s3      = _mm_or_si128(s3, s8);
                 s3      = _mm_minpos_epu16(s3);

--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -7913,7 +7913,6 @@ void hme_level_0(
     search_region_index =
         x_top_left_search_region + y_top_left_search_region * sixteenth_ref_pic_ptr->stride_y;
 
-    if (((sb_width & 7) == 0) || (sb_width == 4) || (sb_width == 6) || (sb_width == 12)) {
 #if !REMOVE_UNUSED_CODE_PH2
         if ((search_area_width & 15) == 0) {
             // Only width equals 16 (SB equals 64) is updated
@@ -7959,25 +7958,6 @@ void hme_level_0(
 #if !REMOVE_UNUSED_CODE_PH2
         }
 #endif
-    } else {
-        sad_loop_kernel_c(
-            &context_ptr->sixteenth_sb_buffer[0],
-            context_ptr->sixteenth_sb_buffer_stride,
-            &sixteenth_ref_pic_ptr->buffer_y[search_region_index],
-            (context_ptr->hme_search_method == FULL_SAD_SEARCH)
-                ? sixteenth_ref_pic_ptr->stride_y
-                : sixteenth_ref_pic_ptr->stride_y * 2,
-            (context_ptr->hme_search_method == FULL_SAD_SEARCH) ? sb_height : sb_height >> 1,
-            sb_width,
-            /* results */
-            level0Bestsad_,
-            xLevel0SearchCenter,
-            yLevel0SearchCenter,
-            /* range */
-            sixteenth_ref_pic_ptr->stride_y,
-            search_area_width,
-            search_area_height);
-    }
 
     *level0Bestsad_ =
         (context_ptr->hme_search_method == FULL_SAD_SEARCH)
@@ -8119,46 +8099,25 @@ void hme_level_1(
     search_region_index =
         x_top_left_search_region + y_top_left_search_region * quarter_ref_pic_ptr->stride_y;
 
-    if (((sb_width & 7) == 0) || (sb_width == 4) || (sb_width == 6) || (sb_width == 12)) {
-        // Put the first search location into level0 results
-        sad_loop_kernel(
-            &context_ptr->quarter_sb_buffer[0],
-            (context_ptr->hme_search_method == FULL_SAD_SEARCH)
-                ? context_ptr->quarter_sb_buffer_stride
-                : context_ptr->quarter_sb_buffer_stride * 2,
-            &quarter_ref_pic_ptr->buffer_y[search_region_index],
-            (context_ptr->hme_search_method == FULL_SAD_SEARCH) ? quarter_ref_pic_ptr->stride_y
-                                                                : quarter_ref_pic_ptr->stride_y * 2,
-            (context_ptr->hme_search_method == FULL_SAD_SEARCH) ? sb_height : sb_height >> 1,
-            sb_width,
-            /* results */
-            level1Bestsad_,
-            xLevel1SearchCenter,
-            yLevel1SearchCenter,
-            /* range */
-            quarter_ref_pic_ptr->stride_y,
-            search_area_width,
-            search_area_height);
-    } else {
-        sad_loop_kernel_c(
-            &context_ptr->quarter_sb_buffer[0],
-            (context_ptr->hme_search_method == FULL_SAD_SEARCH)
-                ? context_ptr->quarter_sb_buffer_stride
-                : context_ptr->quarter_sb_buffer_stride * 2,
-            &quarter_ref_pic_ptr->buffer_y[search_region_index],
-            (context_ptr->hme_search_method == FULL_SAD_SEARCH) ? quarter_ref_pic_ptr->stride_y
-                                                                : quarter_ref_pic_ptr->stride_y * 2,
-            (context_ptr->hme_search_method == FULL_SAD_SEARCH) ? sb_height : sb_height >> 1,
-            sb_width,
-            /* results */
-            level1Bestsad_,
-            xLevel1SearchCenter,
-            yLevel1SearchCenter,
-            /* range */
-            quarter_ref_pic_ptr->stride_y,
-            search_area_width,
-            search_area_height);
-    }
+    // Put the first search location into level0 results
+    sad_loop_kernel(
+        &context_ptr->quarter_sb_buffer[0],
+        (context_ptr->hme_search_method == FULL_SAD_SEARCH)
+            ? context_ptr->quarter_sb_buffer_stride
+            : context_ptr->quarter_sb_buffer_stride * 2,
+        &quarter_ref_pic_ptr->buffer_y[search_region_index],
+        (context_ptr->hme_search_method == FULL_SAD_SEARCH) ? quarter_ref_pic_ptr->stride_y
+                                                            : quarter_ref_pic_ptr->stride_y * 2,
+        (context_ptr->hme_search_method == FULL_SAD_SEARCH) ? sb_height : sb_height >> 1,
+        sb_width,
+        /* results */
+        level1Bestsad_,
+        xLevel1SearchCenter,
+        yLevel1SearchCenter,
+        /* range */
+        quarter_ref_pic_ptr->stride_y,
+        search_area_width,
+        search_area_height);
 
     *level1Bestsad_ =
         (context_ptr->hme_search_method == FULL_SAD_SEARCH)
@@ -8308,45 +8267,25 @@ void hme_level_2(PictureParentControlSet *pcs_ptr, // input parameter, Picture c
     y_top_left_search_region = ((int16_t)ref_pic_ptr->origin_y + origin_y) + y_search_area_origin;
     search_region_index =
         x_top_left_search_region + y_top_left_search_region * ref_pic_ptr->stride_y;
-    if ((((sb_width & 7) == 0) && (sb_width != 40) && (sb_width != 56))) {
-        // Put the first search location into level0 results
-        sad_loop_kernel(
-            context_ptr->sb_src_ptr,
-            (context_ptr->hme_search_method == FULL_SAD_SEARCH) ? context_ptr->sb_src_stride
-                                                                : context_ptr->sb_src_stride * 2,
-            &ref_pic_ptr->buffer_y[search_region_index],
-            (context_ptr->hme_search_method == FULL_SAD_SEARCH) ? ref_pic_ptr->stride_y
-                                                                : ref_pic_ptr->stride_y * 2,
-            (context_ptr->hme_search_method == FULL_SAD_SEARCH) ? sb_height : sb_height >> 1,
-            sb_width,
-            /* results */
-            level2Bestsad_,
-            xLevel2SearchCenter,
-            yLevel2SearchCenter,
-            /* range */
-            ref_pic_ptr->stride_y,
-            search_area_width,
-            search_area_height);
-    } else {
-        // Put the first search location into level0 results
-        sad_loop_kernel_c(
-            context_ptr->sb_src_ptr,
-            (context_ptr->hme_search_method == FULL_SAD_SEARCH) ? context_ptr->sb_src_stride
-                                                                : context_ptr->sb_src_stride * 2,
-            &ref_pic_ptr->buffer_y[search_region_index],
-            (context_ptr->hme_search_method == FULL_SAD_SEARCH) ? ref_pic_ptr->stride_y
-                                                                : ref_pic_ptr->stride_y * 2,
-            (context_ptr->hme_search_method == FULL_SAD_SEARCH) ? sb_height : sb_height >> 1,
-            sb_width,
-            /* results */
-            level2Bestsad_,
-            xLevel2SearchCenter,
-            yLevel2SearchCenter,
-            /* range */
-            ref_pic_ptr->stride_y,
-            search_area_width,
-            search_area_height);
-    }
+
+    // Put the first search location into level0 results
+    sad_loop_kernel(
+        context_ptr->sb_src_ptr,
+        (context_ptr->hme_search_method == FULL_SAD_SEARCH) ? context_ptr->sb_src_stride
+                                                            : context_ptr->sb_src_stride * 2,
+        &ref_pic_ptr->buffer_y[search_region_index],
+        (context_ptr->hme_search_method == FULL_SAD_SEARCH) ? ref_pic_ptr->stride_y
+                                                            : ref_pic_ptr->stride_y * 2,
+        (context_ptr->hme_search_method == FULL_SAD_SEARCH) ? sb_height : sb_height >> 1,
+        sb_width,
+        /* results */
+        level2Bestsad_,
+        xLevel2SearchCenter,
+        yLevel2SearchCenter,
+        /* range */
+        ref_pic_ptr->stride_y,
+        search_area_width,
+        search_area_height);
 
     *level2Bestsad_ =
         (context_ptr->hme_search_method == FULL_SAD_SEARCH)

--- a/test/SadTest.cc
+++ b/test/SadTest.cc
@@ -104,10 +104,37 @@ BlkSize TEST_BLOCK_SIZES[] = {
     BlkSize(64, 24), BlkSize(48, 24), BlkSize(32, 24), BlkSize(24, 32),
     BlkSize(48, 48), BlkSize(48, 16), BlkSize(48, 32), BlkSize(16, 48),
     BlkSize(32, 48), BlkSize(48, 64), BlkSize(64, 48)};
+
 BlkSize TEST_BLOCK_SIZES_SMALL[] = {
     BlkSize(6, 2),   BlkSize(6, 4),   BlkSize(6, 8),   BlkSize(6, 16),
     BlkSize(6, 32),  BlkSize(12, 2),  BlkSize(12, 4),  BlkSize(12, 8),
-    BlkSize(12, 16), BlkSize(12, 32)};
+    BlkSize(12, 16), BlkSize(12, 32), BlkSize(31, 1),  BlkSize(31, 2),
+    BlkSize(31, 3),  BlkSize(15, 10), BlkSize(6, 10),  BlkSize(7, 10),
+    BlkSize(5, 11),  BlkSize(6, 11),  BlkSize(4, 11),  BlkSize(8, 11),
+    BlkSize(7, 11),  BlkSize(5, 10),  BlkSize(16, 10), BlkSize(17, 10),
+    BlkSize(15, 11), BlkSize(16, 11), BlkSize(17, 11), BlkSize(18, 11),
+    BlkSize(19, 11), BlkSize(31, 8),  BlkSize(16, 5),  BlkSize(16, 17),
+    BlkSize(16, 31), BlkSize(16, 33), BlkSize(12, 5),  BlkSize(12, 17),
+    BlkSize(12, 31), BlkSize(12, 33), BlkSize(31, 7),  BlkSize(31, 6),
+    BlkSize(31, 5),  BlkSize(31, 4),  BlkSize(39, 1),  BlkSize(3, 40),
+    BlkSize(43, 4),  BlkSize(43, 5),  BlkSize(41, 5),  BlkSize(55, 3),
+    BlkSize(37, 37), BlkSize(41, 21), BlkSize(51, 21), BlkSize(63, 21),
+    BlkSize(63, 27), BlkSize(63, 33), BlkSize(63, 32), BlkSize(4, 2),
+    BlkSize(4, 3),   BlkSize(4, 4),   BlkSize(4, 8),   BlkSize(4, 9),
+    BlkSize(4, 16),  BlkSize(4, 17),  BlkSize(4, 32),  BlkSize(4, 33),
+    BlkSize(6, 3),   BlkSize(6, 9),   BlkSize(6, 17),  BlkSize(6, 33),
+    BlkSize(8, 2),   BlkSize(8, 3),   BlkSize(8, 4),   BlkSize(8, 8),
+    BlkSize(8, 9),   BlkSize(8, 15),  BlkSize(8, 16),  BlkSize(8, 31),
+    BlkSize(8, 32),  BlkSize(12, 3),  BlkSize(12, 9),  BlkSize(12, 15),
+    BlkSize(12, 31), BlkSize(16, 2),  BlkSize(16, 3),  BlkSize(16, 4),
+    BlkSize(16, 8),  BlkSize(16, 9),  BlkSize(16, 15), BlkSize(16, 16),
+    BlkSize(16, 31), BlkSize(16, 32), BlkSize(24, 2),  BlkSize(24, 3),
+    BlkSize(24, 4),  BlkSize(24, 8),  BlkSize(24, 9),  BlkSize(24, 15),
+    BlkSize(24, 16), BlkSize(24, 31), BlkSize(24, 32), BlkSize(32, 2),
+    BlkSize(32, 3),  BlkSize(32, 4),  BlkSize(32, 8),  BlkSize(32, 9),
+    BlkSize(32, 15), BlkSize(32, 16), BlkSize(32, 31), BlkSize(32, 32),
+    BlkSize(32, 33),
+};
 TestPattern TEST_PATTERNS[] = {REF_MAX, SRC_MAX, RANDOM, UNALIGN};
 SADPattern TEST_SAD_PATTERNS[] = {BUF_MAX, BUF_MIN, BUF_SMALL, BUF_RANDOM};
 typedef std::tuple<TestPattern, BlkSize> Testsad_Param;
@@ -615,7 +642,7 @@ SearchArea TEST_AREAS[] = {
     SearchArea(32, 12)};
 
 SearchArea TEST_LOOP_AREAS[] = {
-    SearchArea(8, 15),   SearchArea(16, 31),
+    SearchArea(8, 15),    SearchArea(16, 31),   SearchArea(12, 31),
     SearchArea(64, 125),  SearchArea(192, 75),  SearchArea(128, 50),
     SearchArea(64, 25),   SearchArea(240, 200), SearchArea(144, 120),
     SearchArea(96, 80),   SearchArea(48, 40),   SearchArea(240, 120),
@@ -883,7 +910,6 @@ INSTANTIATE_TEST_CASE_P(
                        ::testing::ValuesIn(TEST_LOOP_AREAS),
                        ::testing::ValuesIn(TEST_FUNC_PAIRS)));
 
-#if !REMOVE_ME_SUBPEL_CODE
 INSTANTIATE_TEST_CASE_P(
     LOOPSAD_SMALL, sad_LoopTest,
     ::testing::Combine(::testing::ValuesIn(TEST_PATTERNS),
@@ -891,6 +917,7 @@ INSTANTIATE_TEST_CASE_P(
                        ::testing::ValuesIn(TEST_LOOP_AREAS),
                        ::testing::ValuesIn(TEST_FUNC_PAIRS_SMALL)));
 
+#if !REMOVE_ME_SUBPEL_CODE
 INSTANTIATE_TEST_CASE_P(
     HMESAD, sad_LoopTest,
     ::testing::Combine(::testing::ValuesIn(TEST_PATTERNS),


### PR DESCRIPTION
# Description

Modification of sad_loop_kernel_{sse4_1/avx2/avx512} to support odd and even block width/height

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@tszumski 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [x] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
