### PR TITLE
Add a faster M7

### DIFF
--- a/Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.c
@@ -1091,7 +1091,11 @@ IntMv gm_get_motion_vector_enc(const EbWarpedMotionParams *gm, int32_t allow_hp,
     if (is_integer) { integer_mv_precision(&res.as_mv); }
     return res;
 }
+#if OPT_9
+void init_xd(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr) {
+#else
 void mvp_bypass_init(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr) {
+#endif
     TileInfo *tile = &context_ptr->sb_ptr->tile_info;
 
     int32_t       mi_row = context_ptr->blk_origin_y >> MI_SIZE_LOG2;
@@ -1139,7 +1143,7 @@ void mvp_bypass_init(PictureControlSet *pcs_ptr, ModeDecisionContext *context_pt
     xd->mi               = pcs_ptr->mi_grid_base + offset;
 
     xd->mi[0]->mbmi.block_mi.partition = from_shape_to_part[context_ptr->blk_geom->shape];
-
+#if !OPT_9
     // Set to 0 the fields which would have been set by setup_ref_mv_list()
     memset(xd->ref_mv_count, 0, sizeof(uint8_t) * MODE_CTX_REF_FRAMES);
 #if MEM_OPT_MV_STACK
@@ -1155,6 +1159,7 @@ void mvp_bypass_init(PictureControlSet *pcs_ptr, ModeDecisionContext *context_pt
                MODE_CTX_REF_FRAMES * MAX_MV_REF_CANDIDATES);
     memset(context_ptr->blk_ptr->inter_mode_ctx, 0, sizeof(int16_t) * MODE_CTX_REF_FRAMES);
     memset(xd->ref_mv_count, 0, sizeof(int8_t) * MODE_CTX_REF_FRAMES);
+#endif
 }
 
 void generate_av1_mvp_table(TileInfo *tile, ModeDecisionContext *context_ptr, BlkStruct *blk_ptr,

--- a/Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.h
+++ b/Source/Lib/Encoder/Codec/EbAdaptiveMotionVectorPrediction.h
@@ -31,7 +31,11 @@ struct InterPredictionContext;
 extern EbErrorType clip_mv(uint32_t blk_origin_x, uint32_t blk_origin_y, int16_t *mv_x,
                            int16_t *mv_y, uint32_t picture_width, uint32_t picture_height,
                            uint32_t tb_size);
+#if OPT_9
+void init_xd(PictureControlSet *pcs_ptr, struct ModeDecisionContext *context_ptr);
+#else
 void mvp_bypass_init(PictureControlSet *pcs_ptr, struct ModeDecisionContext *context_ptr);
+#endif
 void generate_av1_mvp_table(TileInfo *tile, struct ModeDecisionContext *context_ptr,
                             BlkStruct  *blk_ptr, const BlockGeom *blk_geom, uint16_t blk_origin_x,
                             uint16_t blk_origin_y, MvReferenceFrame *ref_frames, uint32_t tot_refs,

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -1859,14 +1859,14 @@ void set_obmc_controls(ModeDecisionContext *mdctxt, uint8_t obmc_mode) {
 #if MD_REFERENCE_MASKING
 #if !SOFT_CYCLES_REDUCTION
 #if PRUNING_PER_INTER_TYPE
-void set_inter_inter_distortion_based_reference_pruning_controls(
+void set_dist_based_ref_pruning_controls(
     ModeDecisionContext *mdctxt, uint8_t inter_inter_distortion_based_reference_pruning_mode) {
     RefPruningControls *ref_pruning_ctrls = &mdctxt->ref_pruning_ctrls;
 
     switch (inter_inter_distortion_based_reference_pruning_mode) {
-    case 0: ref_pruning_ctrls->inter_to_inter_pruning_enabled = 0; break;
+    case 0: ref_pruning_ctrls->enabled = 0; break;
     case 1:
-        ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
+        ref_pruning_ctrls->enabled = 1;
 
         ref_pruning_ctrls->best_refs[PA_ME_GROUP]         = 7;
         ref_pruning_ctrls->best_refs[UNI_3x3_GROUP]       = 2;
@@ -1894,7 +1894,7 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
 
         break;
     case 2:
-        ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
+        ref_pruning_ctrls->enabled = 1;
 
         ref_pruning_ctrls->best_refs[PA_ME_GROUP]         = 6;
         ref_pruning_ctrls->best_refs[UNI_3x3_GROUP]       = 2;
@@ -1921,7 +1921,7 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 0;
         break;
     case 3:
-        ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
+        ref_pruning_ctrls->enabled = 1;
 
         ref_pruning_ctrls->best_refs[PA_ME_GROUP]         = 5;
         ref_pruning_ctrls->best_refs[UNI_3x3_GROUP]       = 2;
@@ -1948,7 +1948,7 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 0;
         break;
     case 4:
-        ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
+        ref_pruning_ctrls->enabled = 1;
 
         ref_pruning_ctrls->best_refs[PA_ME_GROUP]         = 4;
         ref_pruning_ctrls->best_refs[UNI_3x3_GROUP]       = 2;
@@ -1975,7 +1975,7 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
         ref_pruning_ctrls->closest_refs[PRED_ME_GROUP]       = 0;
         break;
     case 5:
-        ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
+        ref_pruning_ctrls->enabled = 1;
 
         ref_pruning_ctrls->best_refs[PA_ME_GROUP]         = 3;
         ref_pruning_ctrls->best_refs[UNI_3x3_GROUP]       = 2;
@@ -2003,7 +2003,7 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
 
         break;
     case 6:
-        ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
+        ref_pruning_ctrls->enabled = 1;
 
         ref_pruning_ctrls->best_refs[PA_ME_GROUP]         = 2;
         ref_pruning_ctrls->best_refs[UNI_3x3_GROUP]       = 2;
@@ -2034,38 +2034,38 @@ void set_inter_inter_distortion_based_reference_pruning_controls(
     }
 }
 #else
-void set_inter_inter_distortion_based_reference_pruning_controls(ModeDecisionContext *mdctxt, uint8_t inter_inter_distortion_based_reference_pruning_mode) {
+void set_dist_based_ref_pruning_controls(ModeDecisionContext *mdctxt, uint8_t inter_inter_distortion_based_reference_pruning_mode) {
 
     RefPruningControls *ref_pruning_ctrls = &mdctxt->ref_pruning_ctrls;
 
     switch (inter_inter_distortion_based_reference_pruning_mode)
     {
     case 0:
-        ref_pruning_ctrls->inter_to_inter_pruning_enabled = 0;
+        ref_pruning_ctrls->enabled = 0;
         ref_pruning_ctrls->best_refs = 7;
         break;
     case 1:
-        ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
+        ref_pruning_ctrls->enabled = 1;
         ref_pruning_ctrls->best_refs = 6;
         break;
     case 2:
-        ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
+        ref_pruning_ctrls->enabled = 1;
         ref_pruning_ctrls->best_refs = 5;
         break;
     case 3:
-        ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
+        ref_pruning_ctrls->enabled = 1;
         ref_pruning_ctrls->best_refs = 4;
 
 
         break;
     case 4:
-        ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
+        ref_pruning_ctrls->enabled = 1;
         ref_pruning_ctrls->best_refs = 3;
 
 
         break;
     case 5:
-        ref_pruning_ctrls->inter_to_inter_pruning_enabled = 1;
+        ref_pruning_ctrls->enabled = 1;
         ref_pruning_ctrls->best_refs = 2;
 
 
@@ -2103,7 +2103,27 @@ void set_inter_intra_distortion_based_reference_pruning_controls(ModeDecisionCon
 }
 #endif
 #endif
+#if BLOCK_BASED_DEPTH_REFINMENT
+void set_block_based_depth_refinement_controls(ModeDecisionContext *mdctxt, uint8_t block_based_depth_refinement_level) {
 
+    DepthRefinementCtrls *depth_refinement_ctrls = &mdctxt->depth_refinement_ctrls;
+
+    switch (block_based_depth_refinement_level)
+    {
+    case 0:
+        depth_refinement_ctrls->enabled = 0;
+        break;
+    case 1:
+        depth_refinement_ctrls->enabled = 1;
+        depth_refinement_ctrls->parent_to_current_th = -10;
+        depth_refinement_ctrls->sub_to_current_th = 5;
+        break;
+    default:
+        assert(0);
+        break;
+    }
+}
+#endif
 #if !REMOVE_USELESS_CODE
 #if BLOCK_REDUCTION_ALGORITHM_1 || BLOCK_REDUCTION_ALGORITHM_2
 void set_block_based_depth_reduction_controls(ModeDecisionContext *mdctxt, uint8_t block_based_depth_reduction_level) {
@@ -2228,6 +2248,56 @@ void md_nsq_motion_search_controls(ModeDecisionContext *mdctxt, uint8_t md_nsq_m
     }
 }
 #endif
+#if UNIFY_PME_SIGNALS
+void md_pme_search_controls(ModeDecisionContext *mdctxt, uint8_t md_pme_level) {
+
+    MdPmeCtrls *md_pme_ctrls = &mdctxt->md_pme_ctrls;
+
+    switch (md_pme_level)
+    {
+    case 0:
+        md_pme_ctrls->enabled = 0;
+        break;
+
+    case 1:
+        md_pme_ctrls->enabled = 1;
+        md_pme_ctrls->use_ssd = 1;
+        md_pme_ctrls->full_pel_search_width = 15;
+        md_pme_ctrls->full_pel_search_height = 15;
+        md_pme_ctrls->pre_fp_pme_to_me_cost_th = MAX_SIGNED_VALUE;
+        md_pme_ctrls->pre_fp_pme_to_me_mv_th = MIN_SIGNED_VALUE;
+        md_pme_ctrls->post_fp_pme_to_me_cost_th = MAX_SIGNED_VALUE;
+        md_pme_ctrls->post_fp_pme_to_me_mv_th = MIN_SIGNED_VALUE;
+        break;
+
+    case 2:
+        md_pme_ctrls->enabled = 1;
+        md_pme_ctrls->use_ssd = 1;
+        md_pme_ctrls->full_pel_search_width = 7;
+        md_pme_ctrls->full_pel_search_height = 5;
+        md_pme_ctrls->pre_fp_pme_to_me_cost_th = MAX_SIGNED_VALUE;
+        md_pme_ctrls->pre_fp_pme_to_me_mv_th = MIN_SIGNED_VALUE;
+        md_pme_ctrls->post_fp_pme_to_me_cost_th = MAX_SIGNED_VALUE;
+        md_pme_ctrls->post_fp_pme_to_me_mv_th = MIN_SIGNED_VALUE;
+        break;
+
+    case 3:
+        md_pme_ctrls->enabled = 1;
+        md_pme_ctrls->use_ssd = 1;
+        md_pme_ctrls->full_pel_search_width = 7;
+        md_pme_ctrls->full_pel_search_height = 5;
+        md_pme_ctrls->pre_fp_pme_to_me_cost_th = 100;
+        md_pme_ctrls->pre_fp_pme_to_me_mv_th = 16;
+        md_pme_ctrls->post_fp_pme_to_me_cost_th = 25;
+        md_pme_ctrls->post_fp_pme_to_me_mv_th = 32;
+        break;
+
+    default:
+        assert(0);
+        break;
+    }
+}
+#endif
 #if ADAPTIVE_ME_SEARCH
 /*
  * Control Adaptive ME search
@@ -2321,6 +2391,34 @@ void md_sq_motion_search_controls(ModeDecisionContext *mdctxt, uint8_t md_sq_mv_
         md_sq_me_ctrls->sprs_lev2_w = 3;
         md_sq_me_ctrls->sprs_lev2_h = 3;
         break;
+#if OPT_ADAPT_ME
+    case 4:
+        md_sq_me_ctrls->enabled = 1;
+        md_sq_me_ctrls->use_ssd = 0;
+        md_sq_me_ctrls->pame_distortion_th = 10;
+
+        md_sq_me_ctrls->sprs_lev0_enabled = 1;
+        md_sq_me_ctrls->sprs_lev0_step = 4;
+        md_sq_me_ctrls->sprs_lev0_w = 15;
+        md_sq_me_ctrls->sprs_lev0_h = 15;
+        md_sq_me_ctrls->max_sprs_lev0_w = 150;
+        md_sq_me_ctrls->max_sprs_lev0_h = 150;
+        md_sq_me_ctrls->sprs_lev0_multiplier = 100;
+
+        md_sq_me_ctrls->sprs_lev1_enabled = 1;
+        md_sq_me_ctrls->sprs_lev1_step = 2;
+        md_sq_me_ctrls->sprs_lev1_w = 4;
+        md_sq_me_ctrls->sprs_lev1_h = 4;
+        md_sq_me_ctrls->max_sprs_lev1_w = 50;
+        md_sq_me_ctrls->max_sprs_lev1_h = 50;
+        md_sq_me_ctrls->sprs_lev1_multiplier = 100;
+
+        md_sq_me_ctrls->sprs_lev2_enabled = 1;
+        md_sq_me_ctrls->sprs_lev2_step = 1;
+        md_sq_me_ctrls->sprs_lev2_w = 3;
+        md_sq_me_ctrls->sprs_lev2_h = 3;
+        break;
+#endif
     default:
         assert(0);
         break;
@@ -3638,6 +3736,24 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 #endif
 #endif
 #endif
+#if FAST_TXT
+    // Tx_search Level for Luma                       Settings
+    // TX_SEARCH_DCT_DCT_ONLY                         DCT_DCT only
+    // TX_SEARCH_DCT_TX_TYPES                         Tx search DCT type(s): DCT_DCT, V_DCT, H_DCT
+    // TX_SEARCH_ALL_TX_TYPES                         Tx search all type(s)
+    if (pd_pass == PD_PASS_0)
+        context_ptr->tx_search_level = TX_SEARCH_DCT_DCT_ONLY;
+    else if (pd_pass == PD_PASS_1)
+        context_ptr->tx_search_level = TX_SEARCH_DCT_DCT_ONLY;
+    else
+        if (enc_mode <= ENC_M6)
+            context_ptr->tx_search_level = TX_SEARCH_ALL_TX_TYPES;
+        else
+            if (pcs_ptr->parent_pcs_ptr->slice_type == I_SLICE)
+                context_ptr->tx_search_level = TX_SEARCH_ALL_TX_TYPES;
+            else
+                context_ptr->tx_search_level = TX_SEARCH_DCT_TX_TYPES;
+#else
     // Tx_search Level                                Settings
     // 0                                              OFF
     // 1                                              Tx search at encdec
@@ -3690,6 +3806,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     }
     else
         context_ptr->tx_search_level = TX_SEARCH_ENC_DEC;
+#endif
 #endif
 #endif
 #if TXT_CONTROL
@@ -3929,6 +4046,17 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 #endif
     set_txt_cycle_reduction_controls(context_ptr, txt_cycles_reduction_level);
 #endif
+#if IFS_PUSH_BACK_STAGE_3
+    if (pd_pass == PD_PASS_0)
+        context_ptr->interpolation_search_level = IFS_OFF;
+    else if (pd_pass == PD_PASS_1)
+        context_ptr->interpolation_search_level = IFS_OFF;
+    else
+        if (enc_mode <= ENC_M6)
+            context_ptr->interpolation_search_level = IFS_MDS1;
+        else
+            context_ptr->interpolation_search_level = IFS_MDS3;
+#else
     // Interpolation search Level                     Settings
     // 0                                              OFF
     // 1                                              Interpolation search at
@@ -3967,7 +4095,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 #endif
     else
         context_ptr->interpolation_search_level = IT_SEARCH_OFF;
-
+#endif
     // Set Chroma Mode
     // Level                Settings
     // CHROMA_MODE_0  0     Full chroma search @ MD
@@ -4621,7 +4749,11 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 #if UNIFY_SC_NSC
 #if JUNE26_ADOPTIONS
 #if SHIFT_PRESETS
+#if BALANCE_M6_M7 // gmv
+            if (enc_mode <= ENC_M6)
+#else
             if (enc_mode <= ENC_M5)
+#endif
 #else
             if (enc_mode <= ENC_M6)
 #endif
@@ -4892,7 +5024,11 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
             context_ptr->bipred3x3_injection = 1;
 #if FAST_M8_V1
 #if SHIFT_PRESETS
+#if BALANCE_M6_M7 // bipred3x3
+        else if (enc_mode <= ENC_M6)
+#else
         else if (enc_mode <= ENC_M5)
+#endif
 #else
         else if (enc_mode <= ENC_M7)
 #endif
@@ -5039,7 +5175,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         else
             context_ptr->inter_compound_mode = 0;
 #endif
-
+#if !UNIFY_PME_SIGNALS
 #if UPGRADE_SUBPEL
 // Level                Settings
 // 0                    Level 0: OFF
@@ -5292,7 +5428,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     // |CLASS_5 |                             |No Tx Size Search               |SSD @ Frequency Domain                   |Tx Size Search  (f(Tx Size Search Level))|
     // |CLASS_8 |                             |SSD @ Frequency Domain          |                                         |SSD @ Spatial Domain                     |
     // |________|_____________________________|________________________________|_________________________________________|_________________________________________|
-
+#endif
     if (pd_pass == PD_PASS_0) {
         context_ptr->md_staging_mode = MD_STAGING_MODE_0;
     }
@@ -6609,6 +6745,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 #if UNIFY_LEVELS
     }
 #endif
+#if !UNIFY_PME_SIGNALS
     // Set pred ME full search area
 #if UNIFY_SC_NSC
     if (pd_pass == PD_PASS_0) {
@@ -6701,7 +6838,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         }
     }
 #endif
-
+#endif
 #if !INTER_COMP_REDESIGN
     // comp_similar_mode
     // 0: OFF
@@ -6980,33 +7117,33 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 
 #if MD_REFERENCE_MASKING
 #if !SOFT_CYCLES_REDUCTION
-    // Set inter_inter_distortion_based_reference_pruning
+    // Set dist_based_ref_pruning
     if (pcs_ptr->slice_type != I_SLICE) {
         if (pd_pass == PD_PASS_0)
 #if ON_OFF_FEATURE_MRP
-            context_ptr->inter_inter_distortion_based_reference_pruning = override_feature_level(context_ptr->mrp_level,0,0,0);
+            context_ptr->dist_based_ref_pruning = override_feature_level(context_ptr->mrp_level,0,0,0);
 #else
-            context_ptr->inter_inter_distortion_based_reference_pruning = 0;
+            context_ptr->dist_based_ref_pruning = 0;
 #endif
         else if (pd_pass == PD_PASS_1)
 #if ON_OFF_FEATURE_MRP
-            context_ptr->inter_inter_distortion_based_reference_pruning = override_feature_level(context_ptr->mrp_level,0,0,0);
+            context_ptr->dist_based_ref_pruning = override_feature_level(context_ptr->mrp_level,0,0,0);
 #else
-            context_ptr->inter_inter_distortion_based_reference_pruning = 0;
+            context_ptr->dist_based_ref_pruning = 0;
 #endif
 #if MAY23_M0_ADOPTIONS
 #if PRUNING_PER_INTER_TYPE
 #if !REDUCE_MR_COMP_CANDS
         else if (MR_MODE)
-            context_ptr->inter_inter_distortion_based_reference_pruning = 0;
+            context_ptr->dist_based_ref_pruning = 0;
 #endif
 #if !JUNE15_ADOPTIONS
 #if NEW_MRP_SETTINGS
         else if (enc_mode <= ENC_M0 && pcs_ptr->parent_pcs_ptr->sc_content_detected)
 #if ON_OFF_FEATURE_MRP
-            context_ptr->inter_inter_distortion_based_reference_pruning = override_feature_level(context_ptr->mrp_level,0,0,0);
+            context_ptr->dist_based_ref_pruning = override_feature_level(context_ptr->mrp_level,0,0,0);
 #else
-            context_ptr->inter_inter_distortion_based_reference_pruning = 0;
+            context_ptr->dist_based_ref_pruning = 0;
 #endif
 #endif
         else if (enc_mode <= ENC_M0)
@@ -7014,26 +7151,26 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         else if (MR_MODE || (enc_mode <= ENC_M0 && !pcs_ptr->parent_pcs_ptr->sc_content_detected))
 #endif
 #if ON_OFF_FEATURE_MRP
-            context_ptr->inter_inter_distortion_based_reference_pruning = override_feature_level(context_ptr->mrp_level,1,0,0);
+            context_ptr->dist_based_ref_pruning = override_feature_level(context_ptr->mrp_level,1,0,0);
 #else
-            context_ptr->inter_inter_distortion_based_reference_pruning = 1;
+            context_ptr->dist_based_ref_pruning = 1;
 #endif
         else
 #if ON_OFF_FEATURE_MRP
-            context_ptr->inter_inter_distortion_based_reference_pruning = override_feature_level(context_ptr->mrp_level,4,0,0);
+            context_ptr->dist_based_ref_pruning = override_feature_level(context_ptr->mrp_level,4,0,0);
 #else
-            context_ptr->inter_inter_distortion_based_reference_pruning = 4;
+            context_ptr->dist_based_ref_pruning = 4;
 #endif
 #else
        else if (enc_mode <= ENC_M0)
-            context_ptr->inter_inter_distortion_based_reference_pruning = 0;
+            context_ptr->dist_based_ref_pruning = 0;
         else
-            context_ptr->inter_inter_distortion_based_reference_pruning = 3;
+            context_ptr->dist_based_ref_pruning = 3;
 #endif
 #else
 #if MAY19_ADOPTIONS
         else if (MR_MODE)
-            context_ptr->inter_inter_distortion_based_reference_pruning = 0;
+            context_ptr->dist_based_ref_pruning = 0;
 #endif
 #if MAR25_ADOPTIONS
 #if MAY16_7PM_ADOPTIONS
@@ -7053,29 +7190,29 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 #endif
 #endif
 #endif
-            context_ptr->inter_inter_distortion_based_reference_pruning = 0;
+            context_ptr->dist_based_ref_pruning = 0;
 #if !MAY19_ADOPTIONS
 #if M1_COMBO_1 || NEW_M1_CAND
         else if (enc_mode <= ENC_M1)
-            context_ptr->inter_inter_distortion_based_reference_pruning = 3;
+            context_ptr->dist_based_ref_pruning = 3;
 #endif
 #endif
         else
-            context_ptr->inter_inter_distortion_based_reference_pruning = 3;
+            context_ptr->dist_based_ref_pruning = 3;
 #else
         else
-            context_ptr->inter_inter_distortion_based_reference_pruning = 0; // 3 as default mode
+            context_ptr->dist_based_ref_pruning = 0; // 3 as default mode
 #endif
 #endif
     }
     else {
 #if ON_OFF_FEATURE_MRP
-        context_ptr->inter_inter_distortion_based_reference_pruning = override_feature_level(context_ptr->mrp_level,0,0,0);
+        context_ptr->dist_based_ref_pruning = override_feature_level(context_ptr->mrp_level,0,0,0);
 #else
-        context_ptr->inter_inter_distortion_based_reference_pruning = 0;
+        context_ptr->dist_based_ref_pruning = 0;
 #endif
     }
-    set_inter_inter_distortion_based_reference_pruning_controls(context_ptr, context_ptr->inter_inter_distortion_based_reference_pruning);
+    set_dist_based_ref_pruning_controls(context_ptr, context_ptr->dist_based_ref_pruning);
 #endif
 #if !REMOVE_USELESS_CODE
     // Set inter_intra_distortion_based_reference_pruning
@@ -7092,6 +7229,20 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     }
     set_inter_intra_distortion_based_reference_pruning_controls(context_ptr, context_ptr->inter_intra_distortion_based_reference_pruning);
 #endif
+#endif
+#if BLOCK_BASED_DEPTH_REFINMENT
+    // Set block_based_depth_refinement_level
+    if (enc_mode <= ENC_M6)
+        context_ptr->block_based_depth_refinement_level = 0;
+    else {
+        if (pcs_ptr->slice_type == I_SLICE) {
+            context_ptr->block_based_depth_refinement_level = 0;
+        }
+        else {
+            context_ptr->block_based_depth_refinement_level = 1;
+        }
+    }
+    set_block_based_depth_refinement_controls(context_ptr, context_ptr->block_based_depth_refinement_level);
 #endif
 #if !REMOVE_USELESS_CODE
 #if BLOCK_REDUCTION_ALGORITHM_1 || BLOCK_REDUCTION_ALGORITHM_2
@@ -7168,9 +7319,15 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
             context_ptr->md_sq_mv_search_level = 1;
         else if (enc_mode <= ENC_M5)
             context_ptr->md_sq_mv_search_level = 2;
+#if OPT_ADAPT_ME
+        else if (enc_mode <= ENC_M6)
+            context_ptr->md_sq_mv_search_level = 3;
+        else
+            context_ptr->md_sq_mv_search_level = 4;
+#else
         else
             context_ptr->md_sq_mv_search_level = 3;
-
+#endif
     md_sq_motion_search_controls(context_ptr, context_ptr->md_sq_mv_search_level);
 #endif
 #if ADD_MD_NSQ_SEARCH
@@ -7228,6 +7385,22 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 
     md_nsq_motion_search_controls(context_ptr, context_ptr->md_nsq_mv_search_level);
 #endif
+#if UNIFY_PME_SIGNALS
+    // Set PME level
+    if (pd_pass == PD_PASS_0)
+        context_ptr->md_pme_level = 0;
+    else if (pd_pass == PD_PASS_1)
+        context_ptr->md_pme_level = 3;
+    else
+        if (enc_mode <= ENC_M2)
+            context_ptr->md_pme_level = 1;
+        else if (enc_mode <= ENC_M6)
+            context_ptr->md_pme_level = 2;
+        else
+            context_ptr->md_pme_level = 3;
+    md_pme_search_controls(context_ptr, context_ptr->md_pme_level);
+#endif
+
 #if PERFORM_SUB_PEL_MD
 #if UPGRADE_SUBPEL
     if (pd_pass == PD_PASS_0)
@@ -7361,6 +7534,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         context_ptr->bipred3x3_number_input_mv = 1;
 #endif
 #endif
+#if !SHUT_FAST_RATE_PD0
     // Set md_skip_mvp_generation (and use (0,0) as MVP instead)
     if (pd_pass == PD_PASS_0)
         context_ptr->md_skip_mvp_generation = EB_TRUE;
@@ -7368,7 +7542,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         context_ptr->md_skip_mvp_generation = EB_FALSE;
     else
         context_ptr->md_skip_mvp_generation = EB_FALSE;
-
+#endif
     // Set dc_cand_only_flag
     if (pd_pass == PD_PASS_0)
         context_ptr->dc_cand_only_flag = EB_TRUE;
@@ -7395,7 +7569,15 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         context_ptr->disable_angle_z2_intra_flag = EB_TRUE;
     else
         context_ptr->disable_angle_z2_intra_flag = EB_FALSE;
-
+#if SHUT_FAST_RATE_PD0
+    // Use coeff rate and slit flag rate only (i.e. no fast rate)
+    if (pd_pass == PD_PASS_0)
+        context_ptr->shut_fast_rate = EB_TRUE;
+    else if (pd_pass == PD_PASS_1)
+        context_ptr->shut_fast_rate = EB_FALSE;
+    else
+        context_ptr->shut_fast_rate = EB_FALSE;
+#else
     // Set full_cost_derivation_fast_rate_blind_flag
     if (pd_pass == PD_PASS_0)
         context_ptr->full_cost_shut_fast_rate_flag = EB_TRUE;
@@ -7403,6 +7585,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         context_ptr->full_cost_shut_fast_rate_flag = EB_FALSE;
     else
         context_ptr->full_cost_shut_fast_rate_flag = EB_FALSE;
+#endif
 #if !PD0_INTER_CAND
     // Set best_me_cand_only_flag
     if (pd_pass == PD_PASS_0)
@@ -9171,6 +9354,7 @@ static void build_cand_block_array(SequenceControlSet *scs_ptr, PictureControlSe
     }
 }
 #endif
+#if !OPT_5
 uint64_t  pd_level_tab[2][9][2][3] =
 {
     {
@@ -9408,6 +9592,7 @@ static uint64_t generate_best_part_cost(
     }
     return best_part_cost;
 }
+#endif
 #if ADAPTIVE_TXT_CR
 void generate_statistics_txt(
     SequenceControlSet  *scs_ptr,
@@ -9752,7 +9937,11 @@ void generate_statistics_nsq(
                         uint8_t sq_size_idx = 7 - (uint8_t)eb_log2f((uint8_t)blk_geom->sq_size);
                         uint64_t band_width = (sq_size_idx == 0) ? 100 : (sq_size_idx == 1) ? 50 : 20;
                         uint8_t part_idx = part_to_shape[context_ptr->md_blk_arr_nsq[blk_index].part];
+#if OPT_2
+                        uint8_t sse_g_band = (!context_ptr->md_disallow_nsq && context_ptr->md_local_blk_unit[blk_geom->sqi_mds].avail_blk_flag) ?
+#else
                         uint8_t sse_g_band = context_ptr->md_local_blk_unit[blk_geom->sqi_mds].avail_blk_flag ?
+#endif
                             context_ptr->md_local_blk_unit[blk_geom->sqi_mds].sse_gradian_band[part_idx] : 1;
                         const uint32_t count_non_zero_coeffs = context_ptr->md_local_blk_unit[blk_index].count_non_zero_coeffs;
                         const uint32_t total_samples = (blk_geom->bwidth*blk_geom->bheight);
@@ -10129,6 +10318,74 @@ uint16_t depth_cycles_reduction_th[6][5][4] = {
 };
 #endif
 #endif
+#if BLOCK_BASED_DEPTH_REFINMENT
+uint8_t is_parent_to_current_deviation_small(SequenceControlSet *scs_ptr,
+    ModeDecisionContext *mdctxt, const BlockGeom *blk_geom) {
+
+    int64_t parent_to_current_deviation = MIN_SIGNED_VALUE;
+    // block-based depth refinement using cost is applicable for only [s_depth=-1, e_depth=1]
+        // Get the parent of the current block
+    uint32_t parent_depth_idx_mds =
+        (blk_geom->sqi_mds -
+        (blk_geom->quadi - 3) * ns_depth_offset[scs_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth]) -
+        parent_depth_offset[scs_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth];
+
+    if (mdctxt->md_local_blk_unit[parent_depth_idx_mds].avail_blk_flag) {
+        parent_to_current_deviation =
+            (int64_t)(((int64_t)MAX(mdctxt->md_local_blk_unit[parent_depth_idx_mds].default_cost, 1) - (int64_t)MAX((mdctxt->md_local_blk_unit[blk_geom->sqi_mds].default_cost * 4), 1)) * 100) /
+            (int64_t)MAX((mdctxt->md_local_blk_unit[blk_geom->sqi_mds].default_cost * 4), 1);
+    }
+
+    if (parent_to_current_deviation <= mdctxt->depth_refinement_ctrls.parent_to_current_th)
+        return EB_TRUE;
+
+    return EB_FALSE;
+}
+
+uint8_t is_child_to_current_deviation_small(SequenceControlSet *scs_ptr,
+    ModeDecisionContext *mdctxt, const BlockGeom *blk_geom, uint32_t blk_index) {
+
+    int64_t child_to_current_deviation = MIN_SIGNED_VALUE;
+
+    uint32_t child_block_idx_1, child_block_idx_2, child_block_idx_3, child_block_idx_4;
+    child_block_idx_1 = blk_index + d1_depth_offset[scs_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth];
+    child_block_idx_2 = child_block_idx_1 + ns_depth_offset[scs_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth + 1];
+    child_block_idx_3 = child_block_idx_2 + ns_depth_offset[scs_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth + 1];
+    child_block_idx_4 = child_block_idx_3 + ns_depth_offset[scs_ptr->seq_header.sb_size == BLOCK_128X128][blk_geom->depth + 1];
+
+    uint64_t child_cost = 0;
+    uint8_t child_cnt = 0;
+    if (mdctxt->md_local_blk_unit[child_block_idx_1].avail_blk_flag) {
+        child_cost += mdctxt->md_local_blk_unit[child_block_idx_1].default_cost;
+        child_cnt++;
+    }
+    if (mdctxt->md_local_blk_unit[child_block_idx_2].avail_blk_flag) {
+        child_cost += mdctxt->md_local_blk_unit[child_block_idx_2].default_cost;
+        child_cnt++;
+    }
+    if (mdctxt->md_local_blk_unit[child_block_idx_3].avail_blk_flag) {
+        child_cost += mdctxt->md_local_blk_unit[child_block_idx_3].default_cost;
+        child_cnt++;
+    }
+    if (mdctxt->md_local_blk_unit[child_block_idx_4].avail_blk_flag) {
+        child_cost += mdctxt->md_local_blk_unit[child_block_idx_4].default_cost;
+        child_cnt++;
+    }
+
+    if (child_cnt) {
+        child_cost = (child_cost / child_cnt) * 4;
+        child_to_current_deviation =
+            (int64_t)(((int64_t)MAX(child_cost, 1) - (int64_t)MAX(mdctxt->md_local_blk_unit[blk_geom->sqi_mds].default_cost, 1)) * 100) /
+            (int64_t)(MAX(mdctxt->md_local_blk_unit[blk_geom->sqi_mds].default_cost, 1));
+    }
+
+
+    if (child_to_current_deviation <= mdctxt->depth_refinement_ctrls.sub_to_current_th)
+        return EB_TRUE;
+
+    return EB_FALSE;
+}
+#endif
 static void perform_pred_depth_refinement(SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
                                           ModeDecisionContext *context_ptr, uint32_t sb_index) {
 #if DEPTH_PART_CLEAN_UP
@@ -10157,9 +10414,9 @@ static void perform_pred_depth_refinement(SequenceControlSet *scs_ptr, PictureCo
 
     results_ptr->leaf_count = 0;
     blk_index               = 0;
-
+#if !OPT_5
     SuperBlock *sb_ptr = pcs_ptr->sb_ptr_array[sb_index];
-
+#endif
     while (blk_index < scs_ptr->max_block_cnt) {
         const BlockGeom *blk_geom = get_blk_geom_mds(blk_index);
         const unsigned   tot_d1_blocks = blk_geom->sq_size == 128
@@ -10180,6 +10437,7 @@ static void perform_pred_depth_refinement(SequenceControlSet *scs_ptr, PictureCo
                     int8_t e_depth = 0;
 
                     if (context_ptr->pd_pass == PD_PASS_0) {
+#if !OPT_5
                         uint32_t full_lambda =  context_ptr->hbd_mode_decision ?
                             context_ptr->full_lambda_md[EB_10_BIT_MD] :
                             context_ptr->full_lambda_md[EB_8_BIT_MD];
@@ -10196,7 +10454,7 @@ static void perform_pred_depth_refinement(SequenceControlSet *scs_ptr, PictureCo
                             pcs_ptr,
                             context_ptr,
                             sb_index);
-
+#endif
 #if FIX_MR_PD1
 #if MR_MODE_FOR_PIC_MULTI_PASS_PD_MODE_1
 #if MAR19_ADOPTIONS
@@ -10455,7 +10713,11 @@ static void perform_pred_depth_refinement(SequenceControlSet *scs_ptr, PictureCo
                         }
 #endif
 #endif
+#if OPT_5
+                        else {
+#else
                         else if (best_part_cost < early_exit_th) {
+#endif
 #else
                         if (best_part_cost < early_exit_th && pcs_ptr->parent_pcs_ptr->multi_pass_pd_level != MULTI_PASS_PD_LEVEL_0 && !MR_MODE_MULTI_PASS_PD) {
 #endif
@@ -10468,6 +10730,7 @@ static void perform_pred_depth_refinement(SequenceControlSet *scs_ptr, PictureCo
                             s_depth = 0;
                             e_depth = 0;
                         }
+#if !OPT_5
                         else {
                         derive_start_end_depth(pcs_ptr,
                                                sb_ptr,
@@ -10476,6 +10739,7 @@ static void perform_pred_depth_refinement(SequenceControlSet *scs_ptr, PictureCo
                                                &e_depth,
                                                blk_geom);
                         }
+#endif
 #if DEPTH_CYCLES_REDUCTION
  #if ADAPTIVE_DEPTH_CR
                         DepthCycleRControls*depth_cycle_red_ctrls = &context_ptr->depth_cycles_red_ctrls;
@@ -10816,6 +11080,15 @@ static void perform_pred_depth_refinement(SequenceControlSet *scs_ptr, PictureCo
                     uint8_t sq_size_idx = 7 - (uint8_t)eb_log2f((uint8_t)blk_geom->sq_size);
 #endif
                     // Add block indices of upper depth(s)
+#if BLOCK_BASED_DEPTH_REFINMENT
+                    // Block-based depth refinement using cost is applicable for only [s_depth=-1, e_depth=1]
+                    uint8_t add_parent_depth = 1;
+                    if (context_ptr->depth_refinement_ctrls.enabled && s_depth == -1 && pcs_ptr->parent_pcs_ptr->sb_geom[sb_index].block_is_allowed[blk_index] && blk_geom->sq_size < ((scs_ptr->seq_header.sb_size == BLOCK_128X128) ? 128 : 64)) {
+                        add_parent_depth = is_parent_to_current_deviation_small(
+                            scs_ptr, context_ptr, blk_geom);
+                    }
+                    if (add_parent_depth)
+#endif
                     if (s_depth != 0)
 #if TRACK_PER_DEPTH_DELTA
 #if ADAPTIVE_DEPTH_CR
@@ -10830,6 +11103,15 @@ static void perform_pred_depth_refinement(SequenceControlSet *scs_ptr, PictureCo
                             results_ptr, blk_index, scs_ptr->seq_header.sb_size, s_depth);
 #endif
                     // Add block indices of lower depth(s)
+#if BLOCK_BASED_DEPTH_REFINMENT
+                    // Block-based depth refinement using cost is applicable for only [s_depth=-1, e_depth=1]
+                    uint8_t add_sub_depth = 1;
+                    if (context_ptr->depth_refinement_ctrls.enabled && e_depth == 1 && pcs_ptr->parent_pcs_ptr->sb_geom[sb_index].block_is_allowed[blk_index]) {
+                        add_sub_depth = is_child_to_current_deviation_small(
+                            scs_ptr, context_ptr, blk_geom, blk_index);
+                    }
+                    if (add_sub_depth)
+#endif
                     if (e_depth != 0)
 #if TRACK_PER_DEPTH_DELTA
 #if ADAPTIVE_DEPTH_CR
@@ -11374,12 +11656,7 @@ void *mode_decision_kernel(void *input_ptr) {
                     // Build the t=0 cand_block_array
                     build_starting_cand_block_array(scs_ptr, pcs_ptr, context_ptr, mdc_ptr);
 #endif
-                    // Multi-Pass PD Path
-                    // For each SB, all blocks are tested in PD0 (4421 blocks if 128x128 SB, and 1101 blocks if 64x64 SB).
-                    // Then the PD0 predicted Partitioning Structure is refined by considering up to three refinements depths away from the predicted depth, both in the direction of smaller block sizes and in the direction of larger block sizes (up to Pred - 3 / Pred + 3 refinement). The selection of the refinement depth is performed using the cost
-                    // deviation between the current depth cost and candidate depth cost. The generated blocks are used as input candidates to PD1.
-                    // The PD1 predicted Partitioning Structure is also refined (up to Pred - 1 / Pred + 1 refinement) using the square (SQ) vs. non-square (NSQ) decision(s)
-                    // inside the predicted depth and using coefficient information. The final set of blocks is evaluated in PD2 to output the final Partitioning Structure
+                    // Multi-Pass PD
 #if DEPTH_PART_CLEAN_UP
 #if ADD_NEW_MPPD_LEVEL
                     if ((pcs_ptr->parent_pcs_ptr->multi_pass_pd_level == MULTI_PASS_PD_LEVEL_0 ||
@@ -11427,7 +11704,7 @@ void *mode_decision_kernel(void *input_ptr) {
                             scs_ptr, pcs_ptr, context_ptr->md_context);
 #endif
 
-                        // [PD_PASS_0] Mode Decision - Reduce the total number of partitions to be tested in later stages.
+                        // [PD_PASS_0]
                         // Input : mdc_blk_ptr built @ mdc process (up to 4421)
                         // Output: md_blk_arr_nsq reduced set of block(s)
 
@@ -11436,8 +11713,8 @@ void *mode_decision_kernel(void *input_ptr) {
                         build_starting_cand_block_array(scs_ptr, pcs_ptr, context_ptr->md_context, sb_index);
 #endif
 
-                        // PD0 MD Tool(s) : Best ME candidate only as INTER candidate(s), DC only as INTRA candidate(s), Chroma blind, Spatial SSE,
-                        // no MVP table generation, no fast rate @ full cost derivation, Md-Stage 0 and Md-Stage 2 using count=1 (i.e. only best md-stage-0 candidate)
+                        // PD0 MD Tool(s) : ME_MV(s) as INTER candidate(s), DC as INTRA candidate, luma only, Frequency domain SSE,
+                        // no fast rate (no MVP table generation), MDS0 then MDS3, reduced NIC(s), 1 ref per list,..
                         mode_decision_sb(scs_ptr,
                                          pcs_ptr,
                                          mdc_ptr,
@@ -11448,7 +11725,9 @@ void *mode_decision_kernel(void *input_ptr) {
                                          context_ptr->md_context);
 #if SB_CLASSIFIER
 #if ADAPTIVE_DEPTH_CR
+#if !OPT_10
                         if (1) {
+#endif
 #else
                         if (pcs_ptr->slice_type != I_SLICE) {
 #endif
@@ -11457,10 +11736,12 @@ void *mode_decision_kernel(void *input_ptr) {
 #endif
                             context_ptr->md_context->sb_class = determine_sb_class(
                                 scs_ptr, pcs_ptr, context_ptr->md_context, sb_index);
+#if !OPT_10
                         }
 #endif
+#endif
 
-                        // Perform Pred_0 depth refinement - Add blocks to be considered in the next stage(s) of PD based on depth cost.
+                        // Perform Pred_0 depth refinement - add depth(s) to be considered in the next stage(s)
                         perform_pred_depth_refinement(
                             scs_ptr, pcs_ptr, context_ptr->md_context, sb_index);
 
@@ -11512,13 +11793,12 @@ void *mode_decision_kernel(void *input_ptr) {
 #endif
 
                             // [PD_PASS_1] Mode Decision - Further reduce the number of
-                            // partitions to be considered in later PD stages. This pass uses more accurate
+                            // depth(s) to be considered in later PD stages. This pass uses more accurate
                             // info than PD0 to give a better PD estimate.
                             // Input : mdc_blk_ptr built @ PD0 refinement
                             // Output: md_blk_arr_nsq reduced set of block(s)
 
-                            // PD1 MD Tool(s) : ME and Predictive ME only as INTER candidate(s) but MRP blind (only reference index 0 for motion compensation),
-                            // DC only as INTRA candidate(s)
+                            // PD1 MD Tool(s): PME,..
                             mode_decision_sb(scs_ptr,
                                              pcs_ptr,
                                              mdc_ptr,
@@ -11528,15 +11808,16 @@ void *mode_decision_kernel(void *input_ptr) {
                                              sb_index,
                                              context_ptr->md_context);
 
-                            // Perform Pred_1 depth refinement - Add blocks to be considered in the next stage(s) of PD based on depth cost.
+                            // Perform Pred_1 depth refinement - add depth(s) to be considered in the next stage(s)
                             perform_pred_depth_refinement(
                                 scs_ptr, pcs_ptr, context_ptr->md_context, sb_index);
-
+#if !OPT_10
                             // Re-build mdc_blk_ptr for the 3rd PD Pass [PD_PASS_2]
 #if DEPTH_PART_CLEAN_UP
                             build_cand_block_array(scs_ptr, pcs_ptr, context_ptr->md_context, sb_index);
 #else
                             build_cand_block_array(scs_ptr, pcs_ptr, sb_index);
+#endif
 #endif
                             // Reset neighnor information to current SB @ position (0,0)
                             copy_neighbour_arrays(pcs_ptr,
@@ -11568,7 +11849,7 @@ void *mode_decision_kernel(void *input_ptr) {
                     signal_derivation_enc_dec_kernel_oq(scs_ptr, pcs_ptr, context_ptr->md_context);
 #endif
 #if OPT_BLOCK_INDICES_GEN_0
-                    // Re-build mdc_blk_ptr for the 2nd PD Pass [PD_PASS_1]
+                    // Re-build mdc_blk_ptr for the 3rd PD Pass [PD_PASS_2]
                     if(pcs_ptr->parent_pcs_ptr->multi_pass_pd_level != MULTI_PASS_PD_OFF)
                     build_cand_block_array(scs_ptr, pcs_ptr, context_ptr->md_context, sb_index);
 #if OPT_BLOCK_INDICES_GEN_4
@@ -11584,7 +11865,6 @@ void *mode_decision_kernel(void *input_ptr) {
                     // Output: md_blk_arr_nsq reduced set of block(s)
 
                     // PD2 MD Tool(s): default MD Tool(s)
-
                     mode_decision_sb(scs_ptr,
                                      pcs_ptr,
                                      mdc_ptr,

--- a/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
@@ -3158,11 +3158,15 @@ void interpolation_filter_search(PictureControlSet *          picture_control_se
                                  EbPictureBufferDesc *ref_pic_list1, uint8_t hbd_mode_decision,
                                  uint8_t bit_depth) {
     const Av1Common *cm = picture_control_set_ptr->parent_pcs_ptr->av1_cm; //&cpi->common;
+#if IFS_PUSH_BACK_STAGE_3
+    EbBool use_uv = EB_FALSE;
+#else
     EbBool           use_uv =
             (md_context_ptr->blk_geom->has_uv && md_context_ptr->chroma_level <= CHROMA_MODE_1 &&
              md_context_ptr->interpolation_search_level != IT_SEARCH_FAST_LOOP_UV_BLIND)
             ? EB_TRUE
             : EB_FALSE;
+#endif
     const int32_t num_planes      = use_uv ? MAX_MB_PLANE : 1;
     int32_t       tmp_rate;
     int64_t       tmp_dist;
@@ -6689,7 +6693,11 @@ EbErrorType inter_pu_prediction_av1(uint8_t hbd_mode_decision, ModeDecisionConte
         return return_error;
     }
 #if FIX_IFS_OFF_CASE
+#if IFS_PUSH_BACK_STAGE_3
+    if (md_context_ptr->interpolation_search_level != IFS_OFF) {
+#else
     if (md_context_ptr->interpolation_search_level != IT_SEARCH_OFF) {
+#endif
 #else
     if (md_context_ptr->interpolation_search_level == IT_SEARCH_OFF)
         candidate_buffer_ptr->candidate_ptr->interp_filters = 0;

--- a/Source/Lib/Encoder/Codec/EbModeDecision.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.h
@@ -171,7 +171,10 @@ typedef uint64_t (*EbFastCostFunc)(BlkStruct *                  blk_ptr,
                                    uint64_t lambda, EbBool use_ssd, PictureControlSet *pcs_ptr,
                                    CandidateMv *ref_mv_stack, const BlockGeom *blk_geom,
                                    uint32_t miRow, uint32_t miCol, uint8_t enable_inter_intra,
-                                   EbBool full_cost_shut_fast_rate_flag, uint8_t md_pass,
+#if !SHUT_FAST_RATE_PD0
+                                   EbBool full_cost_shut_fast_rate_flag,
+#endif
+                                   uint8_t md_pass,
                                    uint32_t left_neighbor_mode, uint32_t top_neighbor_mode);
 
 typedef EbErrorType (*EB_FULL_COST_FUNC)(

--- a/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
@@ -1099,7 +1099,11 @@ EbErrorType signal_derivation_mode_decision_config_kernel_oq(
 #endif
 #else
 #if SHIFT_PRESETS
+#if BALANCE_M6_M7 // filter_intra
+            if (pcs_ptr->enc_mode <= ENC_M6)
+#else
             if (pcs_ptr->enc_mode <= ENC_M5)
+#endif
 #else
             if (pcs_ptr->enc_mode <= ENC_M6)
 #endif

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -565,10 +565,21 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
         }
 #endif
 #endif
+#if FASTEST_HME
+        else if (pcs_ptr->enc_mode <= ENC_M6) {
+            me_context_ptr->hme_level0_total_search_area_width = me_context_ptr->hme_level0_total_search_area_height = 32;
+            me_context_ptr->hme_level0_max_total_search_area_width = me_context_ptr->hme_level0_max_total_search_area_height = 128;
+        }
+        else {
+            me_context_ptr->hme_level0_total_search_area_width = me_context_ptr->hme_level0_total_search_area_height = 16;
+            me_context_ptr->hme_level0_max_total_search_area_width = me_context_ptr->hme_level0_max_total_search_area_height = 64;
+        }
+#else
         else {
             me_context_ptr->hme_level0_total_search_area_width = me_context_ptr->hme_level0_total_search_area_height = 32;
             me_context_ptr->hme_level0_max_total_search_area_width = me_context_ptr->hme_level0_max_total_search_area_height = 128;
         }
+#endif
 #else
         else {
             me_context_ptr->hme_level0_total_search_area_width = me_context_ptr->hme_level0_total_search_area_height = 100;
@@ -1027,7 +1038,11 @@ EbErrorType signal_derivation_me_kernel_oq(SequenceControlSet *       scs_ptr,
 #if UNIFY_SC_NSC
 #if JUNE26_ADOPTIONS
 #if SHIFT_PRESETS
+#if BALANCE_M6_M7 // gmv
+        if (enc_mode <= ENC_M6)
+#else
         if (enc_mode <= ENC_M5)
+#endif
 #else
         if (enc_mode <= ENC_M6)
 #endif

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -1786,7 +1786,11 @@ EbErrorType signal_derivation_multi_processes_oq(
 #if M6_LOOP_FILTER_MODE
 #if UNIFY_SC_NSC
 #if SHIFT_PRESETS
+#if BALANCE_M6_M7 // loop_filter
+        if (pcs_ptr->enc_mode <= ENC_M6)
+#else
         if (pcs_ptr->enc_mode <= ENC_M5)
+#endif
 #else
         if (pcs_ptr->enc_mode <= ENC_M6)
 #endif
@@ -2186,11 +2190,22 @@ EbErrorType signal_derivation_multi_processes_oq(
         else
             pcs_ptr->intra_pred_mode = 3;
 #else
+#if FASTER_INTRA
+        else if (pcs_ptr->enc_mode <= ENC_M6)
+#else
         else
+#endif
             if (pcs_ptr->temporal_layer_index == 0)
                 pcs_ptr->intra_pred_mode = 1;
             else
                 pcs_ptr->intra_pred_mode = 3;
+#if FASTER_INTRA
+    else
+        if (pcs_ptr->slice_type == I_SLICE)
+            pcs_ptr->intra_pred_mode = 1;
+        else
+            pcs_ptr->intra_pred_mode = 3;
+#endif
 #endif
 #else
         else if (pcs_ptr->enc_mode <= ENC_M7)
@@ -2725,7 +2740,11 @@ EbErrorType signal_derivation_multi_processes_oq(
                 context_ptr->tf_level = 0;
         }
 #if SHIFT_PRESETS
+#if BALANCE_M6_M7 // tf
+        else if (pcs_ptr->enc_mode <= ENC_M6) {
+#else
         else if (pcs_ptr->enc_mode <= ENC_M5) {
+#endif
 #else
         else if (pcs_ptr->enc_mode <= ENC_M6) {
 #endif

--- a/Source/Lib/Encoder/Codec/EbRateDistortionCost.c
+++ b/Source/Lib/Encoder/Codec/EbRateDistortionCost.c
@@ -560,7 +560,10 @@ uint64_t av1_intra_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidat
                              uint64_t luma_distortion, uint64_t chroma_distortion, uint64_t lambda,
                              EbBool use_ssd, PictureControlSet *pcs_ptr, CandidateMv *ref_mv_stack,
                              const BlockGeom *blk_geom, uint32_t miRow, uint32_t miCol,
-                             uint8_t enable_inter_intra, EbBool full_cost_shut_fast_rate_flag,
+                             uint8_t enable_inter_intra,
+#if !SHUT_FAST_RATE_PD0
+                             EbBool full_cost_shut_fast_rate_flag,
+#endif
                              uint8_t md_pass, uint32_t left_neighbor_mode,
                              uint32_t top_neighbor_mode)
 
@@ -802,9 +805,13 @@ uint64_t av1_intra_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidat
         chroma_rate = (uint32_t)(intra_chroma_mode_bits_num + intra_chroma_ang_mode_bits_num);
 
         // Keep the Fast Luma and Chroma rate for future use
+#if SHUT_FAST_RATE_PD0
+        candidate_ptr->fast_luma_rate = luma_rate;
+        candidate_ptr->fast_chroma_rate = chroma_rate;
+#else
         candidate_ptr->fast_luma_rate   = (full_cost_shut_fast_rate_flag) ? 0 : luma_rate;
         candidate_ptr->fast_chroma_rate = (full_cost_shut_fast_rate_flag) ? 0 : chroma_rate;
-
+#endif
         if (use_ssd) {
             int32_t         current_q_index = frm_hdr->quantization_params.base_q_idx;
             Dequants *const dequants = &pcs_ptr->parent_pcs_ptr->deq_bd;
@@ -1372,7 +1379,10 @@ uint64_t av1_inter_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidat
                              uint64_t luma_distortion, uint64_t chroma_distortion, uint64_t lambda,
                              EbBool use_ssd, PictureControlSet *pcs_ptr, CandidateMv *ref_mv_stack,
                              const BlockGeom *blk_geom, uint32_t miRow, uint32_t miCol,
-                             uint8_t enable_inter_intra, EbBool full_cost_shut_fast_rate_flag,
+                             uint8_t enable_inter_intra,
+#if !SHUT_FAST_RATE_PD0
+                             EbBool full_cost_shut_fast_rate_flag,
+#endif
                              uint8_t md_pass, uint32_t left_neighbor_mode,
                              uint32_t top_neighbor_mode)
 
@@ -1648,8 +1658,13 @@ uint64_t av1_inter_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidat
     //chroma_rate = intra_chroma_mode_bits_num + intra_chroma_ang_mode_bits_num;
 
     // Keep the Fast Luma and Chroma rate for future use
+#if SHUT_FAST_RATE_PD0
+    candidate_ptr->fast_luma_rate = luma_rate;
+    candidate_ptr->fast_chroma_rate = chroma_rate;
+#else
     candidate_ptr->fast_luma_rate   = (full_cost_shut_fast_rate_flag) ? 0 : luma_rate;
     candidate_ptr->fast_chroma_rate = 0; // (full_cost_shut_fast_rate_flag) ? 0 : chroma_rate
+#endif
     if (use_ssd) {
         int32_t         current_q_index = frm_hdr->quantization_params.base_q_idx;
         Dequants *const dequants = &pcs_ptr->parent_pcs_ptr->deq_bd;
@@ -1858,6 +1873,9 @@ EbErrorType av1_full_cost(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
 
     // For CFL, costs of alphas are not computed in fast loop, since they are computed in the full loop. The rate costs are added to the full loop.
     // In fast loop CFL alphas are not know yet. The chroma mode bits are calculated based on DC Mode, and if CFL is the winner compared to CFL, ChromaBits are updated in Full loop
+#if SHUT_FAST_RATE_PD0
+    if (!context_ptr->shut_fast_rate)
+#endif
     if (context_ptr->blk_geom->has_uv) {
         if (candidate_buffer_ptr->candidate_ptr->type == INTRA_MODE &&
             candidate_buffer_ptr->candidate_ptr->intra_chroma_mode == UV_CFL_PRED) {

--- a/Source/Lib/Encoder/Codec/EbRateDistortionCost.h
+++ b/Source/Lib/Encoder/Codec/EbRateDistortionCost.h
@@ -126,7 +126,10 @@ extern uint64_t av1_intra_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *c
                                     PictureControlSet *pcs_ptr, CandidateMv *ref_mv_stack,
                                     const BlockGeom *blk_geom, uint32_t miRow, uint32_t miCol,
                                     uint8_t enable_inter_intra,
-                                    EbBool full_cost_shut_fast_rate_flag, uint8_t md_pass,
+#if !SHUT_FAST_RATE_PD0
+                                    EbBool full_cost_shut_fast_rate_flag,
+#endif
+                                    uint8_t md_pass,
                                     uint32_t left_neighbor_mode, uint32_t top_neighbor_mode);
 
 extern uint64_t av1_inter_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidate_ptr,
@@ -135,7 +138,10 @@ extern uint64_t av1_inter_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *c
                                     PictureControlSet *pcs_ptr, CandidateMv *ref_mv_stack,
                                     const BlockGeom *blk_geom, uint32_t miRow, uint32_t miCol,
                                     uint8_t enable_inter_intra,
-                                    EbBool full_cost_shut_fast_rate_flag, uint8_t md_pass,
+#if !SHUT_FAST_RATE_PD0
+                                    EbBool full_cost_shut_fast_rate_flag,
+#endif
+                                    uint8_t md_pass,
                                     uint32_t left_neighbor_mode, uint32_t top_neighbor_mode);
 
 extern EbErrorType av1_intra_full_cost(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr,

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -1022,7 +1022,11 @@ void *resource_coordination_kernel(void *input_ptr) {
                 scs_ptr->seq_header.filter_intra_level =
 #if JUNE17_ADOPTIONS
 #if SHIFT_PRESETS
+#if BALANCE_M6_M7 // filter_intra
+                (scs_ptr->static_config.enc_mode <= ENC_M6) ? 1 : 0;
+#else
                 (scs_ptr->static_config.enc_mode <= ENC_M5) ? 1 : 0;
+#endif
 #else
                 (scs_ptr->static_config.enc_mode <= ENC_M6) ? 1 : 0;
 #endif

--- a/Source/Lib/Encoder/Codec/mcomp.c
+++ b/Source/Lib/Encoder/Codec/mcomp.c
@@ -449,3 +449,11 @@ int svt_av1_find_best_sub_pixel_tree(MacroBlockD *xd, const struct AV1Common *co
   return besterr;
 }
 #endif
+#if FP_MV_COST
+// =============================================================================
+//  SVT Functions
+// =============================================================================
+int fp_mv_err_cost(const MV *mv, const MV_COST_PARAMS *mv_cost_params) {
+    return svt_mv_err_cost_(mv, mv_cost_params);
+}
+#endif


### PR DESCRIPTION
# Description

M7 Only:
- Cost-based pred refinement.
- Faster txt search level (only DCT tx types).
- Faster adaptive ME level.
- IFS @ MDS3.
- Faster INTRA level.
- ME_MV-based PME optimizations.

M7 & below:
- Improve PD0 rate estimation.
- Add mvcost @ the ME of MD: PME, adaptive ME, NSQ ME search.
- Bypass distortion_based_modulator() if no NSQ.
- No T-1 @ PD0 and no recon samples update if no INTRA canidatess..
- Bypass sse_gradian_band init if no NSQ.
- Bypass variance computation @ PD0; source_variance used only @ PD2.
- Shut useless pred depth refinement operations.
- Use the actual number of fast loop candidates instead of MAX_NFL_BUF @ fast_cost_init.
- Bypass useless neighbor update if no fast rate.
- Bypass  MVP init if no fast rate.
- Bypass ref masking init if only 1 ref per list.
- Bypass ref_best_cost_sq_table init if no prune_ref_frame_for_rec_partitions.

# Issue
Fixes #1438

# Author(s)
@hguermaz 

# Performance impact
- [x] quality
- [ ] memory
- [x] speed
- [x] 8 bit
- [x] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] Google Lowres 
- [ ] N/A

| Preset(s)| BD-Rate  Deviation| Speed Deviation| 
| -- | -- | --
|M0 | -0.03% | -3.5%|
|M1 | -0.04% | -4.0%|
|M2 | -0.33% | -7.0%|
|M3 | -0.29% | -5.0%|
|M4 | -0.25% | -6.0%|
|M5 | -0.45% | -3.0%|
|M6 | -2.45% |  -12.5%|
|M7 | 4.33% | 58.5%|

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
