### PR TITLE
Improve Lambda Generation and optimize preset trade-offs

### DIFF
--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -274,11 +274,12 @@ typedef struct EbSvtAv1EncConfiguration {
     int sg_filter_mode;
     int wn_filter_mode;
 
+#if 0 //!REMOVE_EDGE_SKIP_ANGLE_INTRA
     /* edge based skip angle intra
     *
     * Default is -1. */
     int edge_skp_angle_intra;
-
+#endif
     /* enable angle intra
     *
     * Default is -1. */
@@ -345,10 +346,12 @@ typedef struct EbSvtAv1EncConfiguration {
     * Default is -1. */
     int prune_unipred_me;
 #endif
+#if 0 //!REMOVE_REF_FOR_RECT_PART
     /* prune ref frame for rec partitions
     *
     * Default is -1. */
     int prune_ref_rec_part;
+#endif
     /* nsq table
     *
     * Default is -1. */

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -88,7 +88,9 @@
 #if 0//!REMOVE_COMBINE_CLASS12
 #define CLASS_12_TOKEN "-class-12"
 #endif
+#if 0 //!REMOVE_EDGE_SKIP_ANGLE_INTRA
 #define EDGE_SKIP_ANGLE_INTRA_TOKEN "-intra-edge-skp"
+#endif
 #define INTRA_ANGLE_DELTA_TOKEN "-intra-angle-delta"
 #define INTER_INTRA_COMPOUND_TOKEN "-interintra-comp"
 #define PAETH_TOKEN "-paeth"
@@ -104,7 +106,9 @@
 #if 0//!SHUT_ME_CAND_SORTING
 #define PRUNE_UNIPRED_ME_TOKEN "-prune-unipred-me"
 #endif
+#if 0 //!REMOVE_REF_FOR_RECT_PART
 #define PRUNE_REF_REC_PART_TOKEN "-prune-ref-rec-part"
+#endif
 #define NSQ_TABLE_TOKEN "-nsq-table-use"
 #define FRAME_END_CDF_UPDATE_TOKEN "-framend-cdf-upd-mode"
 #define LOCAL_WARPED_ENABLE_TOKEN "-local-warp"
@@ -224,7 +228,9 @@
 
 #define STAT_REPORT_NEW_TOKEN "--enable-stat-report"
 #define RESTORATION_ENABLE_NEW_TOKEN "--enable-restoration-filtering"
+#if 0 //!REMOVE_EDGE_SKIP_ANGLE_INTRA
 #define EDGE_SKIP_ANGLE_INTRA_NEW_TOKEN "--enable-intra-edge-skp"
+#endif
 #define INTER_INTRA_COMPOUND_NEW_TOKEN "--enable-interintra-comp"
 #define FRAC_SEARCH_64_NEW_TOKEN "--enable-frac-search-64"
 #define MFMV_ENABLE_NEW_TOKEN "--enable-mfmv"
@@ -236,7 +242,9 @@
 #if 0//!SHUT_ME_CAND_SORTING
 #define PRUNE_UNIPRED_ME_NEW_TOKEN "--enable-prune-unipred-me"
 #endif
+#if 0 //!REMOVE_REF_FOR_RECT_PART
 #define PRUNE_REF_REC_PART_NEW_TOKEN "--enable-prune-ref-rec-part"
+#endif
 #define NSQ_TABLE_NEW_TOKEN "--enable-nsq-table-use"
 #define FRAME_END_CDF_UPDATE_NEW_TOKEN "--enable-framend-cdf-upd-mode"
 #define LOCAL_WARPED_ENABLE_NEW_TOKEN "--enable-local-warp"
@@ -511,9 +519,11 @@ static void set_class_12_flag(const char *value, EbConfig *cfg) {
     cfg->combine_class_12 = strtol(value, NULL, 0);
 };
 #endif
+#if 0 //!REMOVE_EDGE_SKIP_ANGLE_INTRA
 static void set_edge_skip_angle_intra_flag(const char *value, EbConfig *cfg) {
     cfg->edge_skp_angle_intra = strtol(value, NULL, 0);
 };
+#endif
 static void set_intra_angle_delta_flag(const char *value, EbConfig *cfg) {
     cfg->intra_angle_delta = strtol(value, NULL, 0);
 };
@@ -556,9 +566,11 @@ static void set_prune_unipred_me_flag(const char *value, EbConfig *cfg) {
     cfg->prune_unipred_me = strtol(value, NULL, 0);
 };
 #endif
+#if 0 //!REMOVE_REF_FOR_RECT_PART
 static void set_prune_ref_rec_part_flag(const char *value, EbConfig *cfg) {
     cfg->prune_ref_rec_part = strtol(value, NULL, 0);
 };
+#endif
 static void set_nsq_table_flag(const char *value, EbConfig *cfg) {
     cfg->nsq_table = strtol(value, NULL, 0);
 };
@@ -1152,10 +1164,12 @@ ConfigEntry config_entry_specific[] = {
      "Enable prune unipred at me (0: OFF, 1: ON, -1: DEFAULT)",
      set_prune_unipred_me_flag},
 #endif
+#if 0 //!REMOVE_REF_FOR_RECT_PART
     {SINGLE_INPUT,
      PRUNE_REF_REC_PART_NEW_TOKEN,
      "Enable prune ref frame for rec partitions (0: OFF, 1: ON, -1: DEFAULT)",
      set_prune_ref_rec_part_flag},
+#endif
     {SINGLE_INPUT,
      NSQ_TABLE_NEW_TOKEN,
      "Enable nsq table (0: OFF, 1: ON, -1: DEFAULT)",
@@ -1189,11 +1203,13 @@ ConfigEntry config_entry_specific[] = {
      "Enable combine MD Class1&2 (0: OFF, 1: ON, -1: DEFAULT)",
      set_class_12_flag},
 #endif
+#if 0 //!REMOVE_EDGE_SKIP_ANGLE_INTRA
     // EDGE SKIP ANGLE INTRA
     {SINGLE_INPUT,
      EDGE_SKIP_ANGLE_INTRA_NEW_TOKEN,
      "Enable intra edge filtering (0: OFF, 1: ON (default))",
      set_edge_skip_angle_intra_flag},
+#endif
     // INTRA ANGLE DELTA
     {SINGLE_INPUT,
      INTRA_ANGLE_DELTA_TOKEN,
@@ -1543,7 +1559,9 @@ ConfigEntry config_entry[] = {
 #if 0//!SHUT_ME_CAND_SORTING
     {SINGLE_INPUT, PRUNE_UNIPRED_ME_TOKEN, "PruneUnipredMe", set_prune_unipred_me_flag},
 #endif
+#if 0 //!REMOVE_REF_FOR_RECT_PART
     {SINGLE_INPUT, PRUNE_REF_REC_PART_TOKEN, "PruneRefRecPart", set_prune_ref_rec_part_flag},
+#endif
     {SINGLE_INPUT, NSQ_TABLE_TOKEN, "NsqTable", set_nsq_table_flag},
     {SINGLE_INPUT, FRAME_END_CDF_UPDATE_TOKEN, "FrameEndCdfUpdate", set_frame_end_cdf_update_flag},
 
@@ -1562,11 +1580,13 @@ ConfigEntry config_entry[] = {
     // CLASS 12
     {SINGLE_INPUT, CLASS_12_TOKEN, "CombineClass12", set_class_12_flag},
 #endif
+#if 0 //!REMOVE_EDGE_SKIP_ANGLE_INTRA
     // EDGE SKIP ANGLE INTRA
     {SINGLE_INPUT,
      EDGE_SKIP_ANGLE_INTRA_TOKEN,
      "EdgeSkipAngleIntra",
      set_edge_skip_angle_intra_flag},
+#endif
     // INTRA ANGLE DELTA
     {SINGLE_INPUT, INTRA_ANGLE_DELTA_TOKEN, "IntraAngleDelta", set_intra_angle_delta_flag},
 
@@ -1728,10 +1748,12 @@ ConfigEntry config_entry[] = {
      RESTORATION_ENABLE_NEW_TOKEN,
      "Restoration Filter",
      set_enable_restoration_filter_flag},
+#if 0 //!REMOVE_EDGE_SKIP_ANGLE_INTRA
     {SINGLE_INPUT,
      EDGE_SKIP_ANGLE_INTRA_NEW_TOKEN,
      "Edge Skip Angle Intra",
      set_edge_skip_angle_intra_flag},
+#endif
     {SINGLE_INPUT,
      INTER_INTRA_COMPOUND_NEW_TOKEN,
      "Inter Intra Compound",
@@ -1748,7 +1770,9 @@ ConfigEntry config_entry[] = {
 #if 0//!SHUT_ME_CAND_SORTING
     {SINGLE_INPUT, PRUNE_UNIPRED_ME_NEW_TOKEN, "Prune Uni pred Me", set_prune_unipred_me_flag},
 #endif
+#if 0 //!REMOVE_REF_FOR_RECT_PART
     {SINGLE_INPUT, PRUNE_REF_REC_PART_NEW_TOKEN, "Prune Ref Rec Part", set_prune_ref_rec_part_flag},
+#endif
     {SINGLE_INPUT, NSQ_TABLE_NEW_TOKEN, "Nsq Table", set_nsq_table_flag},
     {SINGLE_INPUT,
      FRAME_END_CDF_UPDATE_NEW_TOKEN,
@@ -1860,7 +1884,9 @@ void eb_config_ctor(EbConfig *config_ptr) {
 #if 0//!REMOVE_COMBINE_CLASS12
     config_ptr->combine_class_12                          = DEFAULT;
 #endif
+#if 0 //!REMOVE_EDGE_SKIP_ANGLE_INTRA
     config_ptr->edge_skp_angle_intra                      = DEFAULT;
+#endif
     config_ptr->intra_angle_delta                         = DEFAULT;
     config_ptr->inter_intra_compound                      = DEFAULT;
     config_ptr->enable_paeth                              = DEFAULT;
@@ -1879,7 +1905,9 @@ void eb_config_ctor(EbConfig *config_ptr) {
 #if 0//!SHUT_ME_CAND_SORTING
     config_ptr->prune_unipred_me                          = DEFAULT;
 #endif
+#if 0 //!REMOVE_REF_FOR_RECT_PART
     config_ptr->prune_ref_rec_part                        = DEFAULT;
+#endif
     config_ptr->nsq_table                                 = DEFAULT;
     config_ptr->frame_end_cdf_update                      = DEFAULT;
     config_ptr->set_chroma_mode                           = DEFAULT;
@@ -2904,8 +2932,10 @@ const char *handle_warnings(const char *token, char *print_message, uint8_t doub
     if (EB_STRCMP(token, STAT_REPORT_TOKEN) == 0) linked_token = STAT_REPORT_NEW_TOKEN;
     if (EB_STRCMP(token, RESTORATION_ENABLE_TOKEN) == 0)
         linked_token = RESTORATION_ENABLE_NEW_TOKEN;
+#if 0 //!REMOVE_EDGE_SKIP_ANGLE_INTRA
     if (EB_STRCMP(token, EDGE_SKIP_ANGLE_INTRA_TOKEN) == 0)
         linked_token = EDGE_SKIP_ANGLE_INTRA_NEW_TOKEN;
+#endif
     if (EB_STRCMP(token, INTER_INTRA_COMPOUND_TOKEN) == 0)
         linked_token = INTER_INTRA_COMPOUND_NEW_TOKEN;
     if (EB_STRCMP(token, MFMV_ENABLE_TOKEN) == 0) linked_token = MFMV_ENABLE_NEW_TOKEN;
@@ -2917,8 +2947,10 @@ const char *handle_warnings(const char *token, char *print_message, uint8_t doub
 #if 0//!SHUT_ME_CAND_SORTING
     if (EB_STRCMP(token, PRUNE_UNIPRED_ME_TOKEN) == 0) linked_token = PRUNE_UNIPRED_ME_NEW_TOKEN;
 #endif
+#if 0 //!REMOVE_REF_FOR_RECT_PART
     if (EB_STRCMP(token, PRUNE_REF_REC_PART_TOKEN) == 0)
         linked_token = PRUNE_REF_REC_PART_NEW_TOKEN;
+#endif
     if (EB_STRCMP(token, NSQ_TABLE_TOKEN) == 0) linked_token = NSQ_TABLE_NEW_TOKEN;
     if (EB_STRCMP(token, FRAME_END_CDF_UPDATE_TOKEN) == 0)
         linked_token = FRAME_END_CDF_UPDATE_NEW_TOKEN;

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -278,10 +278,12 @@ typedef struct EbConfig {
     ****************************************/
     int combine_class_12;
 #endif
+#if 0 //!REMOVE_EDGE_SKIP_ANGLE_INTRA
     /****************************************
      * edge based skip angle intra
     ****************************************/
     int edge_skp_angle_intra;
+#endif
     /****************************************
      * intra angle delta
     ****************************************/
@@ -330,10 +332,12 @@ typedef struct EbConfig {
      ****************************************/
     int prune_unipred_me;
 #endif
+#if 0 //!REMOVE_REF_FOR_RECT_PART
     /****************************************
       * prune ref frame for rec partitions
      ****************************************/
     int prune_ref_rec_part;
+#endif
     /****************************************
       * nsq table
      ****************************************/

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -137,7 +137,9 @@ EbErrorType copy_configuration_parameters(EbConfig *config, EbAppContext *callba
 #if 0//!REMOVE_COMBINE_CLASS12
     callback_data->eb_enc_parameters.combine_class_12         = config->combine_class_12;
 #endif
+#if 0 //!REMOVE_EDGE_SKIP_ANGLE_INTRA
     callback_data->eb_enc_parameters.edge_skp_angle_intra     = config->edge_skp_angle_intra;
+#endif
     callback_data->eb_enc_parameters.intra_angle_delta        = config->intra_angle_delta;
     callback_data->eb_enc_parameters.inter_intra_compound     = config->inter_intra_compound;
     callback_data->eb_enc_parameters.enable_paeth             = config->enable_paeth;
@@ -156,7 +158,9 @@ EbErrorType copy_configuration_parameters(EbConfig *config, EbAppContext *callba
 #if 0//!SHUT_ME_CAND_SORTING
     callback_data->eb_enc_parameters.prune_unipred_me         = config->prune_unipred_me;
 #endif
+#if 0 //!REMOVE_REF_FOR_RECT_PART
     callback_data->eb_enc_parameters.prune_ref_rec_part       = config->prune_ref_rec_part;
+#endif
     callback_data->eb_enc_parameters.nsq_table                = config->nsq_table;
     callback_data->eb_enc_parameters.frame_end_cdf_update     = config->frame_end_cdf_update;
 #if  1//OBMC_CLI

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -534,6 +534,9 @@ extern "C" {
 #endif
 
 #define USE_GF_UPDATE_FOR_LAMBDA         1 // Scale sse lambda based on where the frame is positioned in the miniGOP (based on TL)
+#define NEW_LAMBDA_SCALING_FACTOR        1 // Change the value of one of the parameters used during TPL scaling factor generation
+#define AUG25_ADOPTS                     1 // M1, M2, and M3 adoptions
+#define AUG27_ADOPTS                     1 // M4-M7 adoptions
 
 #endif
 

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -538,6 +538,20 @@ extern "C" {
 #define AUG25_ADOPTS                     1 // M1, M2, and M3 adoptions
 #define AUG27_ADOPTS                     1 // M4-M7 adoptions
 
+#define REMOVE_UNUSED_SIGNALS            1 // remove signals which are no longer used/have only one used level
+#if REMOVE_UNUSED_SIGNALS
+#define REMOVE_MD_TXT_SEARCH_LEVEL       1 // remove md_txt_search_level
+#define REMOVE_IND_CHROMA_NICS           1 // remove independent_chroma_nics
+#define REMOVE_LIBAOM_SHORTCUT_THS       1 // remove libaom_short_cuts_ths
+#define REMOVE_INTRA_CHROMA_FOLLOWS_LUMA 1 // remove intra_chroma_search_follows_intra_luma_injection
+#define REMOVE_IFS_BLK_SIZE              1 // remove interpolation_filter_search_blk_size
+#define REMOVE_EDGE_SKIP_ANGLE_INTRA     1 // remove edge_based_skip_angle_intra
+#define REMOVE_REF_FOR_RECT_PART         1 // remove prune_ref_frame_for_rec_partitions
+#define REMOVE_SIMILARITY_FEATS          1 // remove similarity features (intra_similar_mode and signals part of inter compound)
+#define REMOVE_OLD_NSQ_CR                1 // remove old NSQ cycles reduction feature (replaced by adaptive_md_cycles_level)
+#define REMOVE_OLD_DEPTH_CR              1 // remove old depth cycles reduction feature (replaced by adaptive_md_cycles_level)
+#endif
+#define REMOVE_TF_REF_PRUNING_FUNCS      1 // remove redundant functions for setting TF ref pruning settings (which are always off)
 #endif
 
 // start

--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -532,6 +532,9 @@ extern "C" {
 #define FIRST_PASS_SETUP     1
 #define FASTER_FIRST_PASS    1
 #endif
+
+#define USE_GF_UPDATE_FOR_LAMBDA         1 // Scale sse lambda based on where the frame is positioned in the miniGOP (based on TL)
+
 #endif
 
 // start

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.h
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.h
@@ -28,10 +28,10 @@ extern EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureControlS
                                     const MdcSbData *const mdcResultTbPtr, SuperBlock *sb_ptr,
                                     uint16_t sb_origin_x, uint16_t sb_origin_y, uint32_t sb_addr,
                                     ModeDecisionContext *context_ptr);
-
+#if !REMOVE_MD_TXT_SEARCH_LEVEL
 uint8_t get_skip_tx_search_flag(int32_t sq_size, uint64_t ref_fast_cost, uint64_t cu_cost,
                                 uint64_t weight);
-
+#endif
 extern void av1_encode_decode(SequenceControlSet *scs_ptr, PictureControlSet *pcs_ptr,
                             SuperBlock *sb_ptr, uint32_t sb_addr, uint32_t sb_origin_x,
                             uint32_t sb_origin_y, EncDecContext *context_ptr);

--- a/Source/Lib/Encoder/Codec/EbEncCdef.c
+++ b/Source/Lib/Encoder/Codec/EbEncCdef.c
@@ -1219,6 +1219,9 @@ void finish_cdef_search(EncDecContext *context_ptr, PictureControlSet *pcs_ptr,
     uint32_t fast_lambda, full_lambda = 0;
 #if SYNCH_LAMBDA
     (*av1_lambda_assignment_function_table[pcs_ptr->parent_pcs_ptr->pred_structure])(
+#if USE_GF_UPDATE_FOR_LAMBDA
+        pcs_ptr,
+#endif
         &fast_lambda,
         &full_lambda,
         (uint8_t)pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr->bit_depth,

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -3265,10 +3265,18 @@ void adaptive_md_cycles_redcution_controls(ModeDecisionContext *mdctxt, uint8_t 
         break;
     case 2:
         adaptive_md_cycles_red_ctrls->enabled = 1;
+#if AUG25_ADOPTS
+        adaptive_md_cycles_red_ctrls->skip_nsq_th = 100;
+#else
         adaptive_md_cycles_red_ctrls->skip_nsq_th = 0;
+#endif
         adaptive_md_cycles_red_ctrls->switch_mode_th = 700;
 #if UNIFY_LEVELS
+#if AUG25_ADOPTS
+        adaptive_md_cycles_red_ctrls->mode_offset = 2;
+#else
         adaptive_md_cycles_red_ctrls->mode_offset = 1;
+#endif
 #else
         adaptive_md_cycles_red_ctrls->mode_offset = 2;
 #endif
@@ -3278,7 +3286,11 @@ void adaptive_md_cycles_redcution_controls(ModeDecisionContext *mdctxt, uint8_t 
         adaptive_md_cycles_red_ctrls->skip_nsq_th = 200;
         adaptive_md_cycles_red_ctrls->switch_mode_th = 1000;
 #if UNIFY_LEVELS
+#if AUG25_ADOPTS
+        adaptive_md_cycles_red_ctrls->mode_offset = 2;
+#else
         adaptive_md_cycles_red_ctrls->mode_offset = 1;
+#endif
 #else
         adaptive_md_cycles_red_ctrls->mode_offset = 2;
 #endif
@@ -3300,7 +3312,11 @@ void adaptive_md_cycles_redcution_controls(ModeDecisionContext *mdctxt, uint8_t 
     case 5:
         adaptive_md_cycles_red_ctrls->enabled = 1;
         adaptive_md_cycles_red_ctrls->skip_nsq_th = 500;
+#if AUG25_ADOPTS
+        adaptive_md_cycles_red_ctrls->switch_mode_th = 1500;
+#else
         adaptive_md_cycles_red_ctrls->switch_mode_th = 1000;
+#endif
 #if UNIFY_LEVELS
         adaptive_md_cycles_red_ctrls->mode_offset = 1;
 #else
@@ -4117,7 +4133,11 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         DEFAULT) {
 #if UNIFY_SC_NSC
 #if SHIFT_PRESETS
+#if AUG27_ADOPTS
+        if (enc_mode <= ENC_M5)
+#else
         if (enc_mode <= ENC_M4)
+#endif
 #else
         if (enc_mode <= ENC_M5)
 #endif
@@ -4876,6 +4896,9 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
                     context_ptr->new_nearest_near_comb_injection = 0;
             else
 #endif
+#if AUG25_ADOPTS
+                if (enc_mode <= ENC_M1)
+#else
 #if AUG5_ADOPTS
                 if (enc_mode <= ENC_M2)
 #else
@@ -4883,6 +4906,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
                 if (enc_mode <= ENC_M1)
 #else
                 if (enc_mode <= ENC_M0)
+#endif
 #endif
 #endif
                     context_ptr->new_nearest_near_comb_injection = 1;
@@ -5163,7 +5187,11 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 #endif
         if (sequence_control_set_ptr->compound_mode) {
             if (sequence_control_set_ptr->static_config.compound_level == DEFAULT) {
+#if AUG25_ADOPTS
+                if (enc_mode <= ENC_M0)
+#else
                 if (enc_mode <= ENC_M1)
+#endif
                     context_ptr->inter_compound_mode = 1;
                 else if (enc_mode <= ENC_M3)
 #if SHUT_SIMILARITY_FEATURES
@@ -5856,7 +5884,15 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     else
 #if UNIFY_SC_NSC
 #if AUG5_ADOPTS
+#if AUG27_ADOPTS
+        if (enc_mode <= ENC_M5)
+#else
+#if AUG25_ADOPTS
+        if (enc_mode <= ENC_M3)
+#else
         if (enc_mode <= ENC_M2)
+#endif
+#endif
             context_ptr->md_stage_1_cand_prune_th = (uint64_t)~0;
 #else
         if (enc_mode <= ENC_M1)
@@ -5945,7 +5981,15 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 #if PRESETS_SHIFT
 #if APR25_10AM_ADOPTIONS
 #if UNIFY_SC_NSC
+#if AUG27_ADOPTS
+        if (enc_mode <= ENC_M5)
+#else
+#if AUG25_ADOPTS
+        if (enc_mode <= ENC_M3)
+#else
         if (enc_mode <= ENC_M2)
+#endif
+#endif
 #else
 #if PRESET_SHIFITNG
         if (enc_mode <= ENC_M2 ||
@@ -6489,8 +6533,15 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
                     if (enc_mode <= ENC_M0)
                         context_ptr->sq_weight = 105;
 #if JULY31_PRESETS_ADOPTIONS
+#if AUG25_ADOPTS
+                    else if (enc_mode <= ENC_M1)
+                        context_ptr->sq_weight = 100;
+                    else if (enc_mode <= ENC_M2)
+                        context_ptr->sq_weight = 95;
+#else
                     else if (enc_mode <= ENC_M1)
                         context_ptr->sq_weight = 95;
+#endif
                     else
                         context_ptr->sq_weight = 90;
 #else
@@ -6870,13 +6921,23 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     if (!mode_offset) {
 #endif
 #if SWITCH_MODE_BASED_ON_SQ_COEFF
+#if AUG25_ADOPTS
+        if (pd_pass < PD_PASS_2)
+            context_ptr->switch_md_mode_based_on_sq_coeff = 0;
+        else if (pcs_ptr->slice_type == I_SLICE)
+#else
         if (pcs_ptr->slice_type == I_SLICE)
+#endif
             context_ptr->switch_md_mode_based_on_sq_coeff = 0;
 #if AUG5_ADOPTS
         else if (enc_mode <= ENC_MR)
             context_ptr->switch_md_mode_based_on_sq_coeff = 0;
 #endif
+#if AUG25_ADOPTS
+        else if (enc_mode <= ENC_M2)
+#else
         else if (enc_mode <= ENC_M1)
+#endif
             context_ptr->switch_md_mode_based_on_sq_coeff = 1;
 #if SHIFT_PRESETS
         else if (enc_mode <= ENC_M3)
@@ -7048,13 +7109,25 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         else if (enc_mode <= ENC_M0)
             context_ptr->nic_scaling_level = 1;
         else if (enc_mode <= ENC_M1)
+#if AUG25_ADOPTS
+#if AUG27_ADOPTS
+            context_ptr->nic_scaling_level = 3;
+#else
+            context_ptr->nic_scaling_level = 2;
+#endif
+#else
             context_ptr->nic_scaling_level = 4;
+#endif
         else if (enc_mode <= ENC_M2)
             context_ptr->nic_scaling_level = 6;
 #if SHIFT_PRESETS
-        else if (pcs_ptr->enc_mode <= ENC_M3)
+#if AUG27_ADOPTS
+        else if (enc_mode <= ENC_M4)
 #else
-        else if (pcs_ptr->enc_mode <= ENC_M4)
+        else if (enc_mode <= ENC_M3)
+#endif
+#else
+        else if (enc_mode <= ENC_M4)
 #endif
             context_ptr->nic_scaling_level = 8;
         else
@@ -7321,12 +7394,24 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     else if (pd_pass == PD_PASS_1)
         context_ptr->md_sq_mv_search_level = 0;
     else
+#if AUG25_ADOPTS
+        if (enc_mode <= ENC_M3)
+#else
         if (enc_mode <= ENC_M0)
+#endif
             context_ptr->md_sq_mv_search_level = 1;
+#if AUG25_ADOPTS
+        else if (enc_mode <= ENC_M4)
+#else
         else if (enc_mode <= ENC_M5)
+#endif
             context_ptr->md_sq_mv_search_level = 2;
 #if OPT_ADAPT_ME
+#if AUG25_ADOPTS
+        else if (enc_mode <= ENC_M5)
+#else
         else if (enc_mode <= ENC_M6)
+#endif
             context_ptr->md_sq_mv_search_level = 3;
         else
             context_ptr->md_sq_mv_search_level = 4;
@@ -7412,7 +7497,11 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     if (pd_pass == PD_PASS_0)
 #if FAST_M8_V1
 #if SHIFT_PRESETS
+#if AUG27_ADOPTS
+        context_ptr->md_subpel_me_level = enc_mode <= ENC_M4 ? 3 : 0;
+#else
         context_ptr->md_subpel_me_level = enc_mode <= ENC_M5 ? 3 : 0;
+#endif
 #else
         context_ptr->md_subpel_me_level = enc_mode <= ENC_M7 ? 3 : 0;
 #endif
@@ -7422,10 +7511,14 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     else if (pd_pass == PD_PASS_1)
         context_ptr->md_subpel_me_level = 3;
     else
+#if AUG27_ADOPTS
+        if (enc_mode <= ENC_M4)
+#else
 #if SHIFT_PRESETS
         if (enc_mode <= ENC_M5)
 #else
         if (enc_mode <= ENC_M7)
+#endif
 #endif
             context_ptr->md_subpel_me_level = 1;
         else
@@ -7436,7 +7529,11 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     if (pd_pass == PD_PASS_0)
 #if FAST_M8_V1
 #if SHIFT_PRESETS
+#if AUG27_ADOPTS
+        context_ptr->md_subpel_pme_level = enc_mode <= ENC_M4 ? 3 : 0;
+#else
         context_ptr->md_subpel_pme_level = enc_mode <= ENC_M5 ? 3 : 0;
+#endif
 #else
         context_ptr->md_subpel_pme_level = enc_mode <= ENC_M7 ? 3 : 0;
 #endif
@@ -7446,10 +7543,14 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     else if (pd_pass == PD_PASS_1)
         context_ptr->md_subpel_pme_level = 3;
     else
+#if AUG27_ADOPTS
+        if (enc_mode <= ENC_M4)
+#else
 #if SHIFT_PRESETS
         if (enc_mode <= ENC_M5)
 #else
         if (enc_mode <= ENC_M7)
+#endif
 #endif
             context_ptr->md_subpel_pme_level = 1;
         else

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -252,6 +252,9 @@ static void reset_enc_dec(EncDecContext *context_ptr, PictureControlSet *pcs_ptr
 #endif
 #if TPL_LA_LAMBDA_SCALING
     (*av1_lambda_assignment_function_table[pcs_ptr->parent_pcs_ptr->pred_structure])(
+#if USE_GF_UPDATE_FOR_LAMBDA
+        pcs_ptr,
+#endif
 #if QP2QINDEX
         &context_ptr->pic_fast_lambda[EB_8_BIT_MD],
         &context_ptr->pic_full_lambda[EB_8_BIT_MD],
@@ -268,6 +271,9 @@ static void reset_enc_dec(EncDecContext *context_ptr, PictureControlSet *pcs_ptr
         EB_TRUE);
 
     (*av1_lambda_assignment_function_table[pcs_ptr->parent_pcs_ptr->pred_structure])(
+#if USE_GF_UPDATE_FOR_LAMBDA
+        pcs_ptr,
+#endif
 #if QP2QINDEX
         &context_ptr->pic_fast_lambda[EB_10_BIT_MD],
         &context_ptr->pic_full_lambda[EB_10_BIT_MD],

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -3099,6 +3099,7 @@ uint8_t m1_nsq_cycles_reduction_th[21] = {
 };
 #endif
 #endif
+#if !REMOVE_OLD_NSQ_CR
 #if NSQ_CYCLES_REDUCTION
 #if ADAPTIVE_NSQ_CR
 void set_nsq_cycle_redcution_controls(ModeDecisionContext *mdctxt, uint16_t nsq_cycles_red_mode) {
@@ -3240,7 +3241,7 @@ void set_nsq_cycle_redcution_controls(ModeDecisionContext *mdctxt, uint8_t nsq_c
 }
 #endif
 #endif
-
+#endif
 #if SOFT_CYCLES_REDUCTION
 #if SWITCH_MODE_BASED_ON_STATISTICS
 void adaptive_md_cycles_redcution_controls(ModeDecisionContext *mdctxt, uint8_t adaptive_md_cycles_red_mode) {
@@ -3469,6 +3470,7 @@ void adaptive_md_cycles_redcution_controls(ModeDecisionContext *mdctxt, uint8_t 
 }
 #endif
 #endif
+#if !REMOVE_OLD_DEPTH_CR
 #if DEPTH_CYCLES_REDUCTION
 void set_depth_cycle_redcution_controls(ModeDecisionContext *mdctxt, uint8_t depth_cycles_red_mode) {
 
@@ -3517,6 +3519,7 @@ void set_depth_cycle_redcution_controls(ModeDecisionContext *mdctxt, uint8_t dep
         break;
     }
 }
+#endif
 #endif
 #if COEFF_BASED_TXT_BYPASS
 void set_txt_cycle_reduction_controls(ModeDecisionContext *mdctxt, uint8_t txt_cycles_red_mode) {
@@ -3831,6 +3834,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 #endif
 #endif
 #endif
+#if !REMOVE_MD_TXT_SEARCH_LEVEL
 #if TXT_CONTROL
     // Set MD tx_level
     // md_txt_search_level                            Settings
@@ -4026,6 +4030,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         context_ptr->tx_search_reduced_set = 0;
     else
         context_ptr->tx_search_reduced_set = 1;
+#endif
 #endif
 #if COEFF_BASED_TXT_BYPASS
     uint8_t txt_cycles_reduction_level = 0;
@@ -4357,6 +4362,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         MR_MODE ? 0 : (context_ptr->chroma_level == CHROMA_MODE_0 && !pcs_ptr->parent_pcs_ptr->sc_content_detected) ? 1 : 0;
 #endif
 #endif
+#if !REMOVE_IND_CHROMA_NICS
 #if M5_CHROMA_NICS
     // Chroma independent modes nics
     // Level                Settings
@@ -4383,6 +4389,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     context_ptr->independent_chroma_nics = enc_mode <= ENC_M4 ? 0 : 1;
 #else
     context_ptr->independent_chroma_nics = enc_mode == ENC_M5 ? 1 : 0;
+#endif
 #endif
 #endif
 #endif
@@ -4425,6 +4432,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         context_ptr->chroma_at_last_md_stage = 0; // Indeprndent chroma search at last MD stage is not supported when CFL is off
 #endif
 #endif
+#if !REMOVE_LIBAOM_SHORTCUT_THS
 #if CFL_REDUCED_ALPHA
     // libaom_short_cuts_ths
     // 1                    faster than libaom
@@ -4464,6 +4472,8 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 #endif
 #endif
 #endif
+#endif
+#if !REMOVE_INTRA_CHROMA_FOLLOWS_LUMA
 #if UV_SEARCH_MODE_INJCECTION
     // 0                    inject all supprted chroma mode
     // 1                    follow the luma injection
@@ -4498,6 +4508,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         context_ptr->intra_chroma_search_follows_intra_luma_injection = 1;
     else
         context_ptr->intra_chroma_search_follows_intra_luma_injection = 0;
+#endif
 #endif
 #endif
 #endif
@@ -5507,6 +5518,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     else
         context_ptr->combine_class12 = sequence_control_set_ptr->static_config.combine_class_12;
 #endif
+#if !REMOVE_IFS_BLK_SIZE
     // Set interpolation filter search blk size
     // Level                Settings
     // 0                    ON for 8x8 and above
@@ -5530,6 +5542,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
             context_ptr->interpolation_filter_search_blk_size = 0;
         else
             context_ptr->interpolation_filter_search_blk_size = 1;
+#endif
 #endif
 
     // spatial_sse_full_loop_level | Default Encoder Settings            | Command Line Settings
@@ -5674,6 +5687,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
             context_ptr->redundant_blk =
             sequence_control_set_ptr->static_config.enable_redundant_blk;
 
+#if !REMOVE_EDGE_SKIP_ANGLE_INTRA
     // Set edge_skp_angle_intra
     if (sequence_control_set_ptr->static_config.encoder_bit_depth == EB_8BIT)
         if (pd_pass == PD_PASS_0)
@@ -5764,7 +5778,8 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
             sequence_control_set_ptr->static_config.edge_skp_angle_intra;
     else
         context_ptr->edge_based_skip_angle_intra = 0;
-
+#endif
+#if !REMOVE_REF_FOR_RECT_PART
     // Set prune_ref_frame_for_rec_partitions
     if (pd_pass == PD_PASS_0)
 #if ON_OFF_FEATURE_MRP
@@ -5830,7 +5845,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         else
             context_ptr->prune_ref_frame_for_rec_partitions =
             sequence_control_set_ptr->static_config.prune_ref_rec_part;
-
+#endif
 #if !INTER_COMP_REDESIGN
     // Derive INTER/INTER WEDGE variance TH
     // Phoenix: Active only when inter/inter compound is on
@@ -6250,7 +6265,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
         }
 #endif
 #endif
-
+#if !REMOVE_OLD_NSQ_CR
 #if NSQ_CYCLES_REDUCTION
         // NSQ cycles reduction level: TBD
         uint8_t nsq_cycles_red_mode = 0;
@@ -6328,6 +6343,8 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
             context_ptr->coeff_area_based_bypass_nsq_th = MAX(nsq_cycle_red_ctrls->th, context_ptr->coeff_area_based_bypass_nsq_th);
 #endif
 #endif
+#endif
+#if !REMOVE_OLD_DEPTH_CR
 #if DEPTH_CYCLES_REDUCTION
         // Depth cycles reduction level: TBD
         uint8_t depth_cycles_red_mode = 0;
@@ -6401,6 +6418,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
 #endif
 #endif
         set_depth_cycle_redcution_controls(context_ptr, depth_cycles_red_mode);
+#endif
 #endif
 #if SOFT_CYCLES_REDUCTION
         uint8_t adaptive_md_cycles_level = 0;
@@ -7185,6 +7203,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     else
         context_ptr->md_palette_level = pcs_ptr->parent_pcs_ptr->palette_level;
 #endif
+#if !REMOVE_SIMILARITY_FEATS
     // intra_similar_mode
     // 0: OFF
     // 1: If previous similar block is intra, do not inject any inter
@@ -7192,6 +7211,7 @@ EbErrorType signal_derivation_enc_dec_kernel_oq(
     context_ptr->intra_similar_mode = 0;
 #else
     context_ptr->intra_similar_mode = 1;
+#endif
 #endif
 
 #if MD_REFERENCE_MASKING
@@ -10847,6 +10867,7 @@ static void perform_pred_depth_refinement(SequenceControlSet *scs_ptr, PictureCo
                                                blk_geom);
                         }
 #endif
+#if !REMOVE_OLD_DEPTH_CR
 #if DEPTH_CYCLES_REDUCTION
  #if ADAPTIVE_DEPTH_CR
                         DepthCycleRControls*depth_cycle_red_ctrls = &context_ptr->depth_cycles_red_ctrls;
@@ -10895,6 +10916,7 @@ static void perform_pred_depth_refinement(SequenceControlSet *scs_ptr, PictureCo
                             s_depth = MAX(s_depth, addj_s_depth);
                             e_depth = MIN(e_depth, addj_e_depth);
                         }
+#endif
 #endif
 #endif
                     } else if (context_ptr->pd_pass == PD_PASS_1) {

--- a/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
+++ b/Source/Lib/Encoder/Codec/EbEncInterPrediction.c
@@ -6307,6 +6307,7 @@ void calc_pred_masked_compound(PictureControlSet *    pcs_ptr,
                 bwidth);
         }
 
+#if !REMOVE_SIMILARITY_FEATS
         if (context_ptr->inter_comp_ctrls.similar_predictions) {
             const AomVarianceFnPtr *fn_ptr = &mefn_ptr[context_ptr->blk_geom->bsize];
             unsigned int sse;
@@ -6316,6 +6317,7 @@ void calc_pred_masked_compound(PictureControlSet *    pcs_ptr,
             context_ptr->prediction_mse =
                 ROUND_POWER_OF_TWO(sse, num_pels_log2_lookup[context_ptr->blk_geom->bsize]);
         }
+#endif
 }
 #endif
 void search_compound_diff_wedge(PictureControlSet *    picture_control_set_ptr,
@@ -6704,10 +6706,15 @@ EbErrorType inter_pu_prediction_av1(uint8_t hbd_mode_decision, ModeDecisionConte
     else {
 #endif
         if (md_context_ptr->md_staging_skip_interpolation_search == EB_FALSE) {
+#if REMOVE_IFS_BLK_SIZE
+            // ON for 8x8 and above
+            uint16_t capped_size = 4;
+#else
             uint16_t capped_size =
                     md_context_ptr->interpolation_filter_search_blk_size == 0
                     ? 4
                     : md_context_ptr->interpolation_filter_search_blk_size == 1 ? 8 : 16;
+#endif
 
             if (md_context_ptr->blk_geom->bwidth > capped_size &&
                 md_context_ptr->blk_geom->bheight > capped_size) {

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -816,7 +816,11 @@ static void generate_lambda_scaling_factor(PictureParentControlSet         *pcs_
     const int num_cols = (mi_cols_sr + num_mi_w - 1) / num_mi_w;
     const int num_rows = (cm->mi_rows + num_mi_h - 1) / num_mi_h;
     const int stride   = mi_cols_sr >> (1 + pcs_ptr->is_720p_or_larger);
+#if NEW_LAMBDA_SCALING_FACTOR
+    const double c = 1.2;
+#else
     const double c = 2;
+#endif
 
     for (int row = 0; row < num_rows; row++) {
         for (int col = 0; col < num_cols; col++) {

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -3275,8 +3275,8 @@ void inject_warped_motion_candidates(
             to_inject_mv_y =
                 context_ptr
                 ->sb_me_mv[context_ptr->blk_geom->blkidx_mds][REF_LIST_0][list0_ref_index][1];
-            uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_0, list0_ref_index);
 #if !REMOVE_REF_FOR_RECT_PART
+            uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_0, list0_ref_index);
             uint8_t skip_cand = check_ref_beackout(
                 context_ptr,
                 to_inject_ref_type,
@@ -3379,8 +3379,8 @@ void inject_warped_motion_candidates(
             to_inject_mv_y =
                 context_ptr
                 ->sb_me_mv[context_ptr->blk_geom->blkidx_mds][REF_LIST_1][list1_ref_index][1];
-            uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_1, list1_ref_index);
 #if !REMOVE_REF_FOR_RECT_PART
+            uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_1, list1_ref_index);
             uint8_t skip_cand = check_ref_beackout(
                 context_ptr,
                 to_inject_ref_type,

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -7356,7 +7356,9 @@ uint32_t product_full_mode_decision(
 #endif
     uint32_t                     *best_intra_mode)
 {
+#if !REMOVE_REF_FOR_RECT_PART
     uint32_t                  cand_index;
+#endif
     uint64_t                  lowest_cost = 0xFFFFFFFFFFFFFFFFull;
     uint64_t                  lowest_intra_cost = 0xFFFFFFFFFFFFFFFFull;
     uint32_t                  lowest_cost_index = 0;
@@ -7399,7 +7401,11 @@ uint32_t product_full_mode_decision(
 
     // Find the candidate with the lowest cost
     for (uint32_t i = 0; i < candidate_total_count; ++i) {
+#if REMOVE_REF_FOR_RECT_PART
+        uint32_t cand_index = best_candidate_index_array[i];
+#else
         cand_index = best_candidate_index_array[i];
+#endif
 
         // Compute fullCostBis
         if ((*(buffer_ptr_array[cand_index]->full_cost_ptr) < lowest_intra_cost) && buffer_ptr_array[cand_index]->candidate_ptr->type == INTRA_MODE) {

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -840,7 +840,7 @@ EbErrorType mode_decision_scratch_candidate_buffer_ctor(ModeDecisionCandidateBuf
         buffer_ptr->recon_ptr, eb_picture_buffer_desc_ctor, (EbPtr)&picture_buffer_desc_init_data);
     return EB_ErrorNone;
 }
-
+#if !REMOVE_REF_FOR_RECT_PART
 uint8_t check_ref_beackout(struct ModeDecisionContext *context_ptr, uint8_t ref_frame_type,
                            Part shape) {
     uint8_t       skip_candidate     = 0;
@@ -858,6 +858,7 @@ uint8_t check_ref_beackout(struct ModeDecisionContext *context_ptr, uint8_t ref_
     }
     return skip_candidate;
 }
+#endif
 /***************************************
 * return true if the MV candidate is already injected
 ***************************************/
@@ -1032,8 +1033,10 @@ void unipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, Picture
                         (bipred_3x3_y_pos[bipred_index] << 1);
                 }
                 uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_0, list0_ref_index);
+#if !REMOVE_REF_FOR_RECT_PART
                 uint8_t skip_cand          = check_ref_beackout(
                     context_ptr, to_inject_ref_type, context_ptr->blk_geom->shape);
+#endif
 
                 inside_tile = 1;
                 if (umv0tile)
@@ -1043,7 +1046,11 @@ void unipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, Picture
                                                           mi_col,
                                                           mi_row,
                                                           context_ptr->blk_geom->bsize);
+#if REMOVE_REF_FOR_RECT_PART
+                uint8_t skip_cand = (!inside_tile);
+#else
                 skip_cand = skip_cand || (!inside_tile);
+#endif
 
 #if INTRA_COMPOUND_OPT
                     MvReferenceFrame rf[2];
@@ -1212,8 +1219,10 @@ void unipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, Picture
                     }
                     uint8_t to_inject_ref_type =
                         svt_get_ref_frame_type(REF_LIST_1, list1_ref_index);
+#if !REMOVE_REF_FOR_RECT_PART
                     uint8_t skip_cand = check_ref_beackout(
                         context_ptr, to_inject_ref_type, context_ptr->blk_geom->shape);
+#endif
 
                     inside_tile = 1;
                     if (umv0tile)
@@ -1223,7 +1232,11 @@ void unipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, Picture
                                                               mi_col,
                                                               mi_row,
                                                               context_ptr->blk_geom->bsize);
+#if REMOVE_REF_FOR_RECT_PART
+                    uint8_t skip_cand = (!inside_tile);
+#else
                     skip_cand = skip_cand || (!inside_tile);
+#endif
 
 #if INTRA_COMPOUND_OPT
                     MvReferenceFrame rf[2];
@@ -1465,8 +1478,10 @@ void bipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, PictureC
                     uint8_t to_inject_ref_type = av1_ref_frame_type((const MvReferenceFrame[]){
                         svt_get_ref_frame_type(me_block_results_ptr->ref0_list, list0_ref_index),
                         svt_get_ref_frame_type(me_block_results_ptr->ref1_list, list1_ref_index)});
+#if !REMOVE_REF_FOR_RECT_PART
                     uint8_t skip_cand          = check_ref_beackout(
                         context_ptr, to_inject_ref_type, context_ptr->blk_geom->shape);
+#endif
 
                     int inside_tile = umv0tile ? is_inside_tile_boundary(&(xd->tile),
                                                               to_inject_mv_x_l0,
@@ -1475,7 +1490,11 @@ void bipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, PictureC
                                                               mi_row,
                                                               context_ptr->blk_geom->bsize)
                                                : 1;
+#if REMOVE_REF_FOR_RECT_PART
+                    uint8_t skip_cand = (!inside_tile);
+#else
                     skip_cand = skip_cand || (!inside_tile);
+#endif
                     if (!skip_cand &&
                         (context_ptr->injected_mv_count_bipred == 0 ||
                          mrp_is_already_injected_mv_bipred(context_ptr,
@@ -1505,6 +1524,8 @@ void bipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, PictureC
                                     get_wedge_params_bits(context_ptr->blk_geom->bsize) == 0)
                                 continue;
 #endif
+#if !REMOVE_SIMILARITY_FEATS
+
                             // If two predictors are very similar, skip wedge compound mode search
 #if INTER_COMP_REDESIGN
                             if (cur_type == MD_COMP_WEDGE && context_ptr->inter_comp_ctrls.similar_predictions)
@@ -1513,7 +1534,7 @@ void bipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, PictureC
 #endif
                                 if (context_ptr->prediction_mse < 8)
                                     continue;
-
+#endif
                             cand_array[cand_total_cnt].type             = INTER_MODE;
                             cand_array[cand_total_cnt].distortion_ready = 0;
                             cand_array[cand_total_cnt].use_intrabc      = 0;
@@ -1570,12 +1591,14 @@ void bipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, PictureC
                             if (cur_type == MD_COMP_AVG && tot_comp_types > MD_COMP_AVG)
                                 calc_pred_masked_compound(
                                     pcs_ptr, context_ptr, &cand_array[cand_total_cnt]);
+#if !REMOVE_SIMILARITY_FEATS
                             //BIP 3x3
                             if (context_ptr->inter_comp_ctrls.similar_predictions)
                                 if (cur_type > MD_COMP_AVG &&
                                     context_ptr->prediction_mse <=
                                     context_ptr->inter_comp_ctrls.similar_predictions_th )
                                     continue;
+#endif
 #endif
                             //BIP 3x3
                             determine_compound_mode(
@@ -1638,8 +1661,10 @@ void bipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, PictureC
                     uint8_t to_inject_ref_type = av1_ref_frame_type((const MvReferenceFrame[]){
                         svt_get_ref_frame_type(me_block_results_ptr->ref0_list, list0_ref_index),
                         svt_get_ref_frame_type(me_block_results_ptr->ref1_list, list1_ref_index)});
+#if !REMOVE_REF_FOR_RECT_PART
                     uint8_t skip_cand          = check_ref_beackout(
                         context_ptr, to_inject_ref_type, context_ptr->blk_geom->shape);
+#endif
 
                     int inside_tile =  umv0tile ? is_inside_tile_boundary(&(xd->tile),
                                                               to_inject_mv_x_l0,
@@ -1654,7 +1679,11 @@ void bipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, PictureC
                                                               mi_row,
                                                               context_ptr->blk_geom->bsize)
                                                 : 1;
+#if REMOVE_REF_FOR_RECT_PART
+                    uint8_t skip_cand = (!inside_tile);
+#else
                     skip_cand = skip_cand || (!inside_tile);
+#endif
                     if (!skip_cand &&
                         (context_ptr->injected_mv_count_bipred == 0 ||
                          mrp_is_already_injected_mv_bipred(context_ptr,
@@ -1685,6 +1714,7 @@ void bipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, PictureC
                                     get_wedge_params_bits(context_ptr->blk_geom->bsize) == 0)
                                 continue;
 #endif
+#if !REMOVE_SIMILARITY_FEATS
                             // If two predictors are very similar, skip wedge compound mode search
 #if INTER_COMP_REDESIGN
                             if (cur_type == MD_COMP_WEDGE && context_ptr->inter_comp_ctrls.similar_predictions)
@@ -1693,6 +1723,7 @@ void bipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, PictureC
 #endif
                                 if (context_ptr->prediction_mse < 8)
                                     continue;
+#endif
                             cand_array[cand_total_cnt].type             = INTER_MODE;
                             cand_array[cand_total_cnt].distortion_ready = 0;
                             cand_array[cand_total_cnt].use_intrabc      = 0;
@@ -1750,12 +1781,14 @@ void bipred_3x3_candidates_injection(const SequenceControlSet *scs_ptr, PictureC
                             if (cur_type == MD_COMP_AVG && tot_comp_types > MD_COMP_AVG)
                                 calc_pred_masked_compound(
                                     pcs_ptr, context_ptr, &cand_array[cand_total_cnt]);
+#if !REMOVE_SIMILARITY_FEATS
                             //BIP 3x3
                             if (context_ptr->inter_comp_ctrls.similar_predictions)
                                 if (cur_type > MD_COMP_AVG &&
                                     context_ptr->prediction_mse <=
                                     context_ptr->inter_comp_ctrls.similar_predictions_th )
                                     continue;
+#endif
 #endif
                             //BIP 3x3
                             determine_compound_mode(
@@ -2202,6 +2235,7 @@ void inject_mvp_candidates_ii(struct ModeDecisionContext *context_ptr, PictureCo
                             get_wedge_params_bits(context_ptr->blk_geom->bsize) == 0)
                         continue;
 #endif
+#if !REMOVE_SIMILARITY_FEATS
                     // If two predictors are very similar, skip wedge compound mode search
 #if INTER_COMP_REDESIGN
                     if (cur_type == MD_COMP_WEDGE && context_ptr->inter_comp_ctrls.similar_predictions)
@@ -2210,6 +2244,7 @@ void inject_mvp_candidates_ii(struct ModeDecisionContext *context_ptr, PictureCo
 #endif
                         if (context_ptr->prediction_mse < 64)
                             continue;
+#endif
                     cand_array[cand_idx].type               = INTER_MODE;
                     cand_array[cand_idx].inter_mode         = NEAREST_NEARESTMV;
                     cand_array[cand_idx].pred_mode          = NEAREST_NEARESTMV;
@@ -2262,12 +2297,13 @@ void inject_mvp_candidates_ii(struct ModeDecisionContext *context_ptr, PictureCo
                     if (cur_type == MD_COMP_AVG && tot_comp_types > MD_COMP_AVG)
                         calc_pred_masked_compound(
                             pcs_ptr, context_ptr, &cand_array[cand_idx]);
-
+#if !REMOVE_SIMILARITY_FEATS
                     if (context_ptr->inter_comp_ctrls.similar_predictions)
                         if (cur_type > MD_COMP_AVG &&
                             context_ptr->prediction_mse <=
                             context_ptr->inter_comp_ctrls.similar_predictions_th )
                             continue;
+#endif
 #endif
                     determine_compound_mode(pcs_ptr, context_ptr, &cand_array[cand_idx], cur_type);
                     INCRMENT_CAND_TOTAL_COUNT(cand_idx);
@@ -2330,6 +2366,7 @@ void inject_mvp_candidates_ii(struct ModeDecisionContext *context_ptr, PictureCo
                                 get_wedge_params_bits(context_ptr->blk_geom->bsize) == 0)
                             continue;
 #endif
+#if !REMOVE_SIMILARITY_FEATS
                         // If two predictors are very similar, skip wedge compound mode search
 #if INTER_COMP_REDESIGN
                         if (cur_type == MD_COMP_WEDGE && context_ptr->inter_comp_ctrls.similar_predictions)
@@ -2338,6 +2375,7 @@ void inject_mvp_candidates_ii(struct ModeDecisionContext *context_ptr, PictureCo
 #endif
                             if (context_ptr->prediction_mse < 64)
                                 continue;
+#endif
                         cand_array[cand_idx].type                    = INTER_MODE;
                         cand_array[cand_idx].inter_mode              = NEAR_NEARMV;
                         cand_array[cand_idx].pred_mode               = NEAR_NEARMV;
@@ -2386,13 +2424,13 @@ void inject_mvp_candidates_ii(struct ModeDecisionContext *context_ptr, PictureCo
                         if (cur_type == MD_COMP_AVG && tot_comp_types > MD_COMP_AVG)
                             calc_pred_masked_compound(
                                 pcs_ptr, context_ptr, &cand_array[cand_idx]);
-
+#if !REMOVE_SIMILARITY_FEATS
                         if (context_ptr->inter_comp_ctrls.similar_predictions)
                             if (cur_type > MD_COMP_AVG &&
                                 context_ptr->prediction_mse <=
                                 context_ptr->inter_comp_ctrls.similar_predictions_th )
                                 continue;
-
+#endif
 #endif
                         determine_compound_mode(
                             pcs_ptr, context_ptr, &cand_array[cand_idx], cur_type);
@@ -2538,6 +2576,7 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
                                 get_wedge_params_bits(context_ptr->blk_geom->bsize) == 0)
                             continue;
 #endif
+#if !REMOVE_SIMILARITY_FEATS
                         // If two predictors are very similar, skip wedge compound mode search
 #if INTER_COMP_REDESIGN
                         if (cur_type == MD_COMP_WEDGE && context_ptr->inter_comp_ctrls.similar_predictions)
@@ -2546,6 +2585,7 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
 #endif
                             if (context_ptr->prediction_mse < 8)
                                 continue;
+#endif
                         cand_array[cand_idx].type               = INTER_MODE;
                         cand_array[cand_idx].inter_mode         = NEAREST_NEWMV;
                         cand_array[cand_idx].pred_mode          = NEAREST_NEWMV;
@@ -2601,13 +2641,13 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
                         if (cur_type == MD_COMP_AVG && tot_comp_types > MD_COMP_AVG)
                             calc_pred_masked_compound(
                                 pcs_ptr, context_ptr, &cand_array[cand_idx]);
-
+#if !REMOVE_SIMILARITY_FEATS
                         if (context_ptr->inter_comp_ctrls.similar_predictions)
                             if (cur_type > MD_COMP_AVG &&
                                 context_ptr->prediction_mse <=
                                 context_ptr->inter_comp_ctrls.similar_predictions_th )
                                 continue;
-
+#endif
 #endif
                         determine_compound_mode(
                             pcs_ptr, context_ptr, &cand_array[cand_idx], cur_type);
@@ -2685,6 +2725,7 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
                                 get_wedge_params_bits(context_ptr->blk_geom->bsize) == 0)
                             continue;
 #endif
+#if !REMOVE_SIMILARITY_FEATS
                         // If two predictors are very similar, skip wedge compound mode search
 #if INTER_COMP_REDESIGN
                         if (cur_type == MD_COMP_WEDGE && context_ptr->inter_comp_ctrls.similar_predictions)
@@ -2693,6 +2734,7 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
 #endif
                             if (context_ptr->prediction_mse < 8)
                                 continue;
+#endif
                         cand_array[cand_idx].type                    = INTER_MODE;
                         cand_array[cand_idx].inter_mode              = NEW_NEARESTMV;
                         cand_array[cand_idx].pred_mode               = NEW_NEARESTMV;
@@ -2747,13 +2789,13 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
                         if (cur_type == MD_COMP_AVG && tot_comp_types > MD_COMP_AVG)
                             calc_pred_masked_compound(
                                 pcs_ptr, context_ptr, &cand_array[cand_idx]);
-
+#if !REMOVE_SIMILARITY_FEATS
                         if (context_ptr->inter_comp_ctrls.similar_predictions)
                             if (cur_type > MD_COMP_AVG &&
                                 context_ptr->prediction_mse <=
                                 context_ptr->inter_comp_ctrls.similar_predictions_th )
                                 continue;
-
+#endif
 #endif
                         determine_compound_mode(
                             pcs_ptr, context_ptr, &cand_array[cand_idx], cur_type);
@@ -2812,6 +2854,7 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
 
 #endif
                         for (MD_COMP_TYPE cur_type = MD_COMP_AVG; cur_type <= tot_comp_types; cur_type++) {
+#if !REMOVE_SIMILARITY_FEATS
                             // If two predictors are very similar, skip wedge compound mode search
 #if INTER_COMP_REDESIGN
                             if (cur_type == MD_COMP_WEDGE && context_ptr->inter_comp_ctrls.similar_predictions)
@@ -2820,7 +2863,7 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
 #endif
                                 if (context_ptr->prediction_mse < 8)
                                     continue;
-
+#endif
                             cand_array[cand_idx].type               = INTER_MODE;
                             cand_array[cand_idx].inter_mode         = NEW_NEARMV;
                             cand_array[cand_idx].pred_mode          = NEW_NEARMV;
@@ -2871,12 +2914,13 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
                             if (cur_type == MD_COMP_AVG && tot_comp_types > MD_COMP_AVG)
                                 calc_pred_masked_compound(
                                     pcs_ptr, context_ptr, &cand_array[cand_idx]);
-
+#if !REMOVE_SIMILARITY_FEATS
                             if (context_ptr->inter_comp_ctrls.similar_predictions)
                                 if (cur_type > MD_COMP_AVG &&
                                     context_ptr->prediction_mse <=
                                     context_ptr->inter_comp_ctrls.similar_predictions_th )
                                     continue;
+#endif
 #endif
                             determine_compound_mode(
                                 pcs_ptr, context_ptr, &cand_array[cand_idx], cur_type);
@@ -2937,6 +2981,7 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
 
 #endif
                         for (MD_COMP_TYPE cur_type = MD_COMP_AVG; cur_type <= tot_comp_types; cur_type++) {
+#if !REMOVE_SIMILARITY_FEATS
                             // If two predictors are very similar, skip wedge compound mode search
 #if INTER_COMP_REDESIGN
                             if (cur_type == MD_COMP_WEDGE && context_ptr->inter_comp_ctrls.similar_predictions)
@@ -2945,7 +2990,7 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
 #endif
                                 if (context_ptr->prediction_mse < 8)
                                     continue;
-
+#endif
                             cand_array[cand_idx].type               = INTER_MODE;
                             cand_array[cand_idx].inter_mode         = NEAR_NEWMV;
                             cand_array[cand_idx].pred_mode          = NEAR_NEWMV;
@@ -2994,12 +3039,13 @@ void inject_new_nearest_new_comb_candidates(const SequenceControlSet *  scs_ptr,
                             if (cur_type == MD_COMP_AVG && tot_comp_types > MD_COMP_AVG)
                                 calc_pred_masked_compound(
                                     pcs_ptr, context_ptr, &cand_array[cand_idx]);
-
+#if !REMOVE_SIMILARITY_FEATS
                             if (context_ptr->inter_comp_ctrls.similar_predictions)
                                 if (cur_type > MD_COMP_AVG &&
                                     context_ptr->prediction_mse <=
                                     context_ptr->inter_comp_ctrls.similar_predictions_th )
                                     continue;
+#endif
 #endif
                             determine_compound_mode(
                                 pcs_ptr, context_ptr, &cand_array[cand_idx], cur_type);
@@ -3230,12 +3276,14 @@ void inject_warped_motion_candidates(
                 context_ptr
                 ->sb_me_mv[context_ptr->blk_geom->blkidx_mds][REF_LIST_0][list0_ref_index][1];
             uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_0, list0_ref_index);
+#if !REMOVE_REF_FOR_RECT_PART
             uint8_t skip_cand = check_ref_beackout(
                 context_ptr,
                 to_inject_ref_type,
                 context_ptr->blk_geom->shape);
 
             if (!skip_cand) {
+#endif
 #if INCREASE_WM_CANDS
                 for (int i = 0; i < NUM_WM_NEIGHBOUR_POS; i++) {
 #else
@@ -3308,7 +3356,9 @@ void inject_warped_motion_candidates(
                             INCRMENT_CAND_TOTAL_COUNT(can_idx);
                     }
                 }
+#if !REMOVE_REF_FOR_RECT_PART
             }
+#endif
         }
         /**************
            NEWMV L1
@@ -3330,11 +3380,13 @@ void inject_warped_motion_candidates(
                 context_ptr
                 ->sb_me_mv[context_ptr->blk_geom->blkidx_mds][REF_LIST_1][list1_ref_index][1];
             uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_1, list1_ref_index);
+#if !REMOVE_REF_FOR_RECT_PART
             uint8_t skip_cand = check_ref_beackout(
                 context_ptr,
                 to_inject_ref_type,
                 context_ptr->blk_geom->shape);
             if (!skip_cand) {
+#endif
 #if INCREASE_WM_CANDS
                 for (int i = 0; i < NUM_WM_NEIGHBOUR_POS; i++) {
 #else
@@ -3412,7 +3464,9 @@ void inject_warped_motion_candidates(
                             INCRMENT_CAND_TOTAL_COUNT(can_idx);
                     }
                 }
+#if !REMOVE_REF_FOR_RECT_PART
             }
+#endif
         }
     }
 
@@ -3729,9 +3783,10 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
                 context_ptr
                 ->sb_me_mv[context_ptr->blk_geom->blkidx_mds][REF_LIST_0][list0_ref_index][1];
             uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_0, list0_ref_index);
+#if !REMOVE_REF_FOR_RECT_PART
             uint8_t skip_cand =
                 check_ref_beackout(context_ptr, to_inject_ref_type, context_ptr->blk_geom->shape);
-
+#endif
             inside_tile = 1;
             if (umv0tile)
                 inside_tile = is_inside_tile_boundary(&(xd->tile),
@@ -3740,7 +3795,11 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
                                                       mi_col,
                                                       mi_row,
                                                       context_ptr->blk_geom->bsize);
+#if REMOVE_REF_FOR_RECT_PART
+            uint8_t skip_cand = (!inside_tile);
+#else
             skip_cand = skip_cand || (!inside_tile);
+#endif
 
             if (!skip_cand &&
                 (context_ptr->injected_mv_count_l0 == 0 ||
@@ -3886,8 +3945,10 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
                 int16_t to_inject_mv_y = context_ptr->sb_me_mv[context_ptr->blk_geom->blkidx_mds]
                     [REF_LIST_1][list1_ref_index][1];
                 uint8_t to_inject_ref_type = svt_get_ref_frame_type(REF_LIST_1, list1_ref_index);
+#if !REMOVE_REF_FOR_RECT_PART
                 uint8_t skip_cand          = check_ref_beackout(
                     context_ptr, to_inject_ref_type, context_ptr->blk_geom->shape);
+#endif
 
                 inside_tile = 1;
                 if (umv0tile)
@@ -3897,7 +3958,11 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
                                                           mi_col,
                                                           mi_row,
                                                           context_ptr->blk_geom->bsize);
+#if REMOVE_REF_FOR_RECT_PART
+                uint8_t skip_cand = !inside_tile;
+#else
                 skip_cand = skip_cand || !inside_tile;
+#endif
 
                 if (!skip_cand &&
                     (context_ptr->injected_mv_count_l1 == 0 ||
@@ -4053,8 +4118,10 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
                     uint8_t to_inject_ref_type = av1_ref_frame_type((const MvReferenceFrame[]){
                         svt_get_ref_frame_type(me_block_results_ptr->ref0_list, list0_ref_index),
                         svt_get_ref_frame_type(me_block_results_ptr->ref1_list, list1_ref_index)});
+#if !REMOVE_REF_FOR_RECT_PART
                     uint8_t skip_cand          = check_ref_beackout(
                         context_ptr, to_inject_ref_type, context_ptr->blk_geom->shape);
+#endif
 
                     inside_tile = 1;
                     if (umv0tile) {
@@ -4071,7 +4138,11 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
                                                               mi_row,
                                                               context_ptr->blk_geom->bsize);
                     }
+#if REMOVE_REF_FOR_RECT_PART
+                    uint8_t skip_cand = (!inside_tile);
+#else
                     skip_cand = skip_cand || (!inside_tile);
+#endif
                     if (!skip_cand &&
                         (context_ptr->injected_mv_count_bipred == 0 ||
                          mrp_is_already_injected_mv_bipred(context_ptr,
@@ -4103,6 +4174,7 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
                                     get_wedge_params_bits(context_ptr->blk_geom->bsize) == 0)
                                 continue;
 #endif
+#if !REMOVE_SIMILARITY_FEATS
                             // If two predictors are very similar, skip wedge compound mode search
 #if INTER_COMP_REDESIGN
                             if (cur_type == MD_COMP_WEDGE && context_ptr->inter_comp_ctrls.similar_predictions)
@@ -4111,6 +4183,7 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
 #endif
                                 if (context_ptr->prediction_mse < 8)
                                     continue;
+#endif
                             cand_array[cand_total_cnt].type = INTER_MODE;
 
                             cand_array[cand_total_cnt].distortion_ready = 0;
@@ -4174,12 +4247,13 @@ void inject_new_candidates(const SequenceControlSet *  scs_ptr,
 
                                 calc_pred_masked_compound(
                                     pcs_ptr, context_ptr, &cand_array[cand_total_cnt]);
-
+#if !REMOVE_SIMILARITY_FEATS
                             if (context_ptr->inter_comp_ctrls.similar_predictions)
                                 if (cur_type > MD_COMP_AVG &&
                                     context_ptr->prediction_mse <=
                                     context_ptr->inter_comp_ctrls.similar_predictions_th )
                                     continue;
+#endif
 #endif
                             determine_compound_mode(
                                 pcs_ptr, context_ptr, &cand_array[cand_total_cnt], cur_type);
@@ -4482,13 +4556,13 @@ void inject_global_candidates(const SequenceControlSet *  scs_ptr,
                     if (cur_type == MD_COMP_AVG && tot_comp_types > MD_COMP_AVG)
                         calc_pred_masked_compound(
                             pcs_ptr, context_ptr, &cand_array[cand_total_cnt]);
-
+#if !REMOVE_SIMILARITY_FEATS
                     if (context_ptr->inter_comp_ctrls.similar_predictions)
                         if (cur_type > MD_COMP_AVG &&
                             context_ptr->prediction_mse <=
                             context_ptr->inter_comp_ctrls.similar_predictions_th)
                             continue;
-
+#endif
 #endif
                     determine_compound_mode(pcs_ptr,
                         context_ptr,
@@ -4766,13 +4840,13 @@ void inject_predictive_me_candidates(
                             tot_comp_types = MD_COMP_AVG;
 
                     for (MD_COMP_TYPE cur_type = MD_COMP_AVG; cur_type <= tot_comp_types; cur_type++) {
-
+#if !REMOVE_SIMILARITY_FEATS
                         // If two predictors are very similar, skip wedge compound mode search
                         if (cur_type == MD_COMP_WEDGE &&
                             context_ptr->inter_comp_ctrls.similar_predictions)
                             if (context_ptr->prediction_mse < 8)
                                 continue;
-
+#endif
                         cand_array[cand_total_cnt].type = INTER_MODE;
                         cand_array[cand_total_cnt].distortion_ready = 0;
                         cand_array[cand_total_cnt].use_intrabc = 0;
@@ -4828,13 +4902,13 @@ void inject_predictive_me_candidates(
                         if (cur_type == MD_COMP_AVG && tot_comp_types > MD_COMP_AVG)
                             calc_pred_masked_compound(
                                 pcs_ptr, context_ptr, &cand_array[cand_total_cnt]);
-
+#if !REMOVE_SIMILARITY_FEATS
                         if (context_ptr->inter_comp_ctrls.similar_predictions)
                             if (cur_type > MD_COMP_AVG &&
                                 context_ptr->prediction_mse <=
                                 context_ptr->inter_comp_ctrls.similar_predictions_th)
                                 continue;
-
+#endif
                         determine_compound_mode(
                             pcs_ptr, context_ptr, &cand_array[cand_total_cnt], cur_type);
                         INCRMENT_CAND_TOTAL_COUNT(cand_total_cnt);
@@ -6502,6 +6576,7 @@ void  inject_intra_candidates(
         // if disable_cfl_flag == 1 then it doesn't matter what cli says otherwise change it to cli
         disable_cfl_flag = (EbBool)scs_ptr->static_config.disable_cfl_flag;
 
+#if !REMOVE_EDGE_SKIP_ANGLE_INTRA
     if (context_ptr->edge_based_skip_angle_intra && use_angle_delta)
     {
         EbPictureBufferDesc   *src_pic = pcs_ptr->parent_pcs_ptr->enhanced_picture_ptr;
@@ -6510,6 +6585,8 @@ void  inject_intra_candidates(
         const int cols = block_size_wide[context_ptr->blk_geom->bsize];
         angle_estimation(src_buf, src_pic->stride_y, rows, cols, /*context_ptr->blk_geom->bsize,*/directional_mode_skip_mask);
     }
+#endif
+
     uint8_t     angle_delta_shift = 1;
     if (context_ptr->disable_angle_z2_intra_flag) {
         disable_angle_prediction = 1;
@@ -7274,13 +7351,16 @@ uint32_t product_full_mode_decision(
     ModeDecisionCandidateBuffer **buffer_ptr_array,
     uint32_t                      candidate_total_count,
     uint32_t                     *best_candidate_index_array,
+#if !REMOVE_REF_FOR_RECT_PART
     uint8_t                       prune_ref_frame_for_rec_partitions,
+#endif
     uint32_t                     *best_intra_mode)
 {
     uint32_t                  cand_index;
     uint64_t                  lowest_cost = 0xFFFFFFFFFFFFFFFFull;
     uint64_t                  lowest_intra_cost = 0xFFFFFFFFFFFFFFFFull;
     uint32_t                  lowest_cost_index = 0;
+#if !REMOVE_REF_FOR_RECT_PART
     if (prune_ref_frame_for_rec_partitions) {
         if (context_ptr->blk_geom->shape == PART_N) {
             for (uint32_t i = 0; i < candidate_total_count; ++i) {
@@ -7311,7 +7391,7 @@ uint32_t product_full_mode_decision(
             }
         }
     }
-
+#endif
 
     ModeDecisionCandidate       *candidate_ptr;
 

--- a/Source/Lib/Encoder/Codec/EbModeDecision.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.h
@@ -265,7 +265,9 @@ uint32_t product_full_mode_decision(struct ModeDecisionContext *context_ptr, Blk
                                     ModeDecisionCandidateBuffer **buffer_ptr_array,
                                     uint32_t                      candidate_total_count,
                                     uint32_t *                    best_candidate_index_array,
+#if !REMOVE_REF_FOR_RECT_PART
                                     uint8_t   prune_ref_frame_for_rec_partitions,
+#endif
                                     uint32_t *best_intra_mode);
 #if TPL_LA_LAMBDA_SCALING
 uint32_t get_blk_tuned_full_lambda(struct ModeDecisionContext *context_ptr, PictureControlSet *pcs_ptr,

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
@@ -1003,9 +1003,15 @@ typedef struct ModeDecisionContext {
 #endif
 } ModeDecisionContext;
 
+#if USE_GF_UPDATE_FOR_LAMBDA
+typedef void (*EbAv1LambdaAssignFunc)(PictureControlSet* pcs_ptr, uint32_t *fast_lambda, uint32_t *full_lambda,
+                                      uint8_t bit_depth, uint16_t qp_index,
+                                      EbBool multiply_lambda);
+#else
 typedef void (*EbAv1LambdaAssignFunc)(uint32_t *fast_lambda, uint32_t *full_lambda,
                                       uint8_t bit_depth, uint16_t qp_index,
                                       EbBool multiply_lambda);
+#endif
 #if !TPL_LA_LAMBDA_SCALING
 typedef void (*EbLambdaAssignFunc)(uint32_t *fast_lambda, uint32_t *full_lambda,
                                    uint32_t *fast_chroma_lambda, uint32_t *full_chroma_lambda,

--- a/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionProcess.h
@@ -191,11 +191,13 @@ typedef struct  ObmcControls {
     uint8_t near_count;    //how many near to consider injecting obmc 0..3
 }ObmcControls;
 #endif
+#if !REMOVE_OLD_NSQ_CR
 #if NSQ_CYCLES_REDUCTION
 typedef struct  NsqCycleRControls {
     uint8_t enabled; // On/Off feature control
     uint16_t th;  // Threshold to bypass nsq <the higher th the higher speed>
 }NsqCycleRControls;
+#endif
 #endif
 #if SOFT_CYCLES_REDUCTION
 #if SWITCH_MODE_BASED_ON_STATISTICS
@@ -216,11 +218,13 @@ typedef struct  AMdCycleRControls {
 }AMdCycleRControls;
 #endif
 #endif
+#if !REMOVE_OLD_DEPTH_CR
 #if DEPTH_CYCLES_REDUCTION
 typedef struct  DepthCycleRControls {
     uint8_t enabled; // On/Off feature control
     uint16_t th;  // Threshold to bypass depth <the higher th the higher speed>
 }DepthCycleRControls;
+#endif
 #endif
 #if COEFF_BASED_TXT_BYPASS
 typedef struct  TxtCycleRControls {
@@ -249,16 +253,20 @@ typedef struct SbClassControls {
 
 typedef struct  InterCompoundControls {
     uint8_t enabled;
+#if !REMOVE_SIMILARITY_FEATS
     uint8_t similar_predictions;        // 0: OFF ; 1: Disable inter-compound based on prediction similarity
     uint8_t similar_predictions_th;     // TH Disable inter-compound when predictions are similar
+#endif
     uint8_t mrp_pruning_w_distortion;   // 0: OFF ; 1: Prune number of references based on ME/PME distortion
     uint8_t mrp_pruning_w_distance;     // 4: ALL ; 1: Prune number of references based on reference distance (Best 1)
     uint8_t wedge_search_mode;          // 0: Fast search: estimate Wedge sign 1: full search
 #if !OPT_4
     uint8_t wedge_variance_th;          // 0 : OFF ; 1: Disable inter-compound based on block variance
 #endif
+#if !REMOVE_SIMILARITY_FEATS
     uint8_t similar_previous_blk;       // 0 : OFF ; 1: Disable inter-compound if previous similar block is not compound
                                         //           2: 1 + consider up to the compound mode of the similar blk
+#endif
 }InterCompoundControls;
 
 #endif
@@ -419,6 +427,7 @@ typedef struct CoeffBSwMdCtrls {
     uint8_t skip_block;             // Allow skipping NSQ blocks
 }CoeffBSwMdCtrls;
 #endif
+#if !REMOVE_MD_TXT_SEARCH_LEVEL
 #if TXT_CONTROL
 typedef struct TxTSearchCtrls {
     uint64_t txt_weight[3]; // Used to classify the md candidates
@@ -427,6 +436,7 @@ typedef struct TxTSearchCtrls {
     uint8_t txt_table_idx; // Table of pre_allowed tx_type to be searched
     uint8_t txt_allow_skip; // Allow the skipping of tx_type_search
 }TxTSearchCtrls;
+#endif
 #endif
 typedef struct ModeDecisionContext {
     EbDctor  dctor;
@@ -621,8 +631,10 @@ typedef struct ModeDecisionContext {
     uint64_t             chroma_at_last_md_stage_intra_th;
     uint64_t             chroma_at_last_md_stage_cfl_th;
 #endif
+#if !REMOVE_IND_CHROMA_NICS
 #if M5_CHROMA_NICS
     uint8_t              independent_chroma_nics;
+#endif
 #endif
 #if !M8_CLEAN_UP
     uint8_t              full_loop_escape;
@@ -642,7 +654,9 @@ typedef struct ModeDecisionContext {
     uint8_t              use_sad_at_pme;
 #endif
 #endif
+#if !REMOVE_IFS_BLK_SIZE
     uint8_t              interpolation_filter_search_blk_size;
+#endif
     uint8_t              redundant_blk;
     uint8_t              nic_level;
     uint8_t              similar_blk_avail;
@@ -651,7 +665,9 @@ typedef struct ModeDecisionContext {
     uint8_t              comp_similar_mode;
 #endif
     uint8_t              inject_inter_candidates;
+#if !REMOVE_SIMILARITY_FEATS
     uint8_t              intra_similar_mode;
+#endif
 #if !CLEANUP_CYCLE_ALLOCATION
     uint8_t              skip_depth;
 #endif
@@ -736,8 +752,12 @@ typedef struct ModeDecisionContext {
         intrapred_buf[INTERINTRA_MODES][2 * 32 * 32]); //MAX block size for inter intra is 32x32
     uint64_t *   ref_best_cost_sq_table;
     uint32_t *   ref_best_ref_sq_table;
+#if !REMOVE_EDGE_SKIP_ANGLE_INTRA
     uint8_t      edge_based_skip_angle_intra;
+#endif
+#if !REMOVE_REF_FOR_RECT_PART
     uint8_t      prune_ref_frame_for_rec_partitions;
+#endif
 #if !OPT_4
     unsigned int source_variance; // input block variance
 #endif
@@ -884,17 +904,25 @@ typedef struct ModeDecisionContext {
 #if ADDED_CFL_OFF
     EbBool        md_disable_cfl;
 #endif
+#if !REMOVE_LIBAOM_SHORTCUT_THS
 #if CFL_REDUCED_ALPHA
     uint8_t       libaom_short_cuts_ths;
 #endif
+#endif
+#if !REMOVE_INTRA_CHROMA_FOLLOWS_LUMA
 #if UV_SEARCH_MODE_INJCECTION
     uint8_t       intra_chroma_search_follows_intra_luma_injection;
 #endif
+#endif
+#if !REMOVE_OLD_NSQ_CR
 #if NSQ_CYCLES_REDUCTION
     NsqCycleRControls nsq_cycles_red_ctrls;
 #endif
+#endif
+#if !REMOVE_OLD_DEPTH_CR
 #if DEPTH_CYCLES_REDUCTION
     DepthCycleRControls depth_cycles_red_ctrls;
+#endif
 #endif
 #if COEFF_BASED_TXT_BYPASS
     TxtCycleRControls txt_cycles_red_ctrls;
@@ -915,11 +943,13 @@ typedef struct ModeDecisionContext {
     uint64_t best_nsq_default_cost;
     uint64_t default_cost_per_shape[NUMBER_OF_SHAPES];
 #endif
+#if !REMOVE_MD_TXT_SEARCH_LEVEL
 #if TXT_CONTROL
     uint8_t md_txt_search_level;
     TxTSearchCtrls txt_search_ctrls;
     EbBool txt_rdoq;
     EbBool txt_ssse;
+#endif
 #endif
 #if SB_CLASSIFIER
     uint8_t enable_area_based_cycles_allocation;
@@ -934,8 +964,10 @@ typedef struct ModeDecisionContext {
 #if COEFF_BASED_BYPASS_NSQ
     uint16_t coeff_area_based_bypass_nsq_th;
 #endif
+#if !REMOVE_OLD_NSQ_CR
 #if DECOUPLE_FROM_ALLOCATION
     uint16_t nsq_cycles_reduction_th;
+#endif
 #endif
 #if SB64_MEM_OPT
     uint8_t sb_size;

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -284,10 +284,14 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
             }
 #endif
 #if NEW_M0_M1_ME_NICS
+#if AUG25_ADOPTS
+    else if (pcs_ptr->enc_mode <= ENC_M0) {
+#else
 #if PRESET_SHIFITNG
     else if (pcs_ptr->enc_mode <= ENC_M1) {
 #else
     else if (pcs_ptr->enc_mode <= ENC_M2) {
+#endif
 #endif
     me_context_ptr->search_area_width = me_context_ptr->search_area_height = 64;
 #if JUNE23_ADOPTIONS
@@ -328,7 +332,11 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
 #endif
 #if M8_HME_ME
 #if JUNE23_ADOPTIONS
+#if AUG25_ADOPTS
+    else if (pcs_ptr->enc_mode <= ENC_M1) {
+#else
     else if (pcs_ptr->enc_mode <= ENC_M2) {
+#endif
         me_context_ptr->search_area_width = me_context_ptr->search_area_height = 64;
         me_context_ptr->max_me_search_width = me_context_ptr->max_me_search_height = 192;
     }
@@ -482,7 +490,11 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
 #if MAY19_ADOPTIONS
 #if JUNE23_ADOPTIONS
 #if SHIFT_PRESETS
+#if AUG25_ADOPTS
+        if (pcs_ptr->enc_mode <= ENC_M2) {
+#else
         if (pcs_ptr->enc_mode <= ENC_M3) {
+#endif
 #else
         if (pcs_ptr->enc_mode <= ENC_M4) {
 #endif
@@ -530,7 +542,11 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
         }
 #endif
 #if SHIFT_PRESETS
+#if AUG27_ADOPTS
+        else {
+#else
         else if (pcs_ptr->enc_mode <= ENC_M5) {
+#endif
 #else
         else if (pcs_ptr->enc_mode <= ENC_M6) {
 #endif
@@ -566,6 +582,7 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
 #endif
 #endif
 #if FASTEST_HME
+#if !AUG27_ADOPTS
         else if (pcs_ptr->enc_mode <= ENC_M6) {
             me_context_ptr->hme_level0_total_search_area_width = me_context_ptr->hme_level0_total_search_area_height = 32;
             me_context_ptr->hme_level0_max_total_search_area_width = me_context_ptr->hme_level0_max_total_search_area_height = 128;
@@ -574,6 +591,7 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
             me_context_ptr->hme_level0_total_search_area_width = me_context_ptr->hme_level0_total_search_area_height = 16;
             me_context_ptr->hme_level0_max_total_search_area_width = me_context_ptr->hme_level0_max_total_search_area_height = 64;
         }
+#endif
 #else
         else {
             me_context_ptr->hme_level0_total_search_area_width = me_context_ptr->hme_level0_total_search_area_height = 32;
@@ -657,7 +675,11 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
 #endif
 #if PRESETS_SHIFT
 #if PRESET_SHIFITNG
+#if AUG25_ADOPTS
+        me_context_ptr->hme_decimation = pcs_ptr->enc_mode <= ENC_M0 ? ONE_DECIMATION_HME : TWO_DECIMATION_HME;
+#else
         me_context_ptr->hme_decimation = pcs_ptr->enc_mode <= ENC_M1 ? ONE_DECIMATION_HME : TWO_DECIMATION_HME;
+#endif
 #else
         me_context_ptr->hme_decimation = pcs_ptr->enc_mode <= ENC_M2 ? ONE_DECIMATION_HME : TWO_DECIMATION_HME;
 #endif
@@ -1361,7 +1383,11 @@ void *tf_set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet
 #if APR22_ADOPTIONS
 #if FAST_M8_V1
 #if SHIFT_PRESETS
+#if AUG27_ADOPTS
+    if (pcs_ptr->enc_mode <= ENC_M4) {
+#else
     if (pcs_ptr->enc_mode <= ENC_M5) {
+#endif
 #else
     if (pcs_ptr->enc_mode <= ENC_M7) {
 #endif

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -1581,7 +1581,7 @@ void *tf_set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet
 #endif
     return NULL;
 };
-
+#if !REMOVE_TF_REF_PRUNING_FUNCS
 #if ME_HME_PRUNING_CLEANUP
 void tf_set_me_hme_ref_prune_ctrls(MeContext* context_ptr, uint8_t prune_level) {
     MeHmeRefPruneCtrls* me_hme_prune_ctrls = &context_ptr->me_hme_prune_ctrls;
@@ -1648,6 +1648,7 @@ void tf_set_me_sr_adjustment_ctrls(MeContext* context_ptr, uint8_t sr_adjustment
         break;
     }
 }
+#endif
 #endif
 /******************************************************
 * Derive ME Settings for OQ for Altref Temporal Filtering
@@ -1809,11 +1810,19 @@ EbErrorType tf_signal_derivation_me_kernel_oq(SequenceControlSet *       scs_ptr
 
     // Set hme/me based reference pruning level (0-4)
     // Ref pruning is disallowed for TF in motion_estimate_sb()
+#if REMOVE_TF_REF_PRUNING_FUNCS
+    set_me_hme_ref_prune_ctrls(context_ptr->me_context_ptr, 0);
+#else
     tf_set_me_hme_ref_prune_ctrls(context_ptr->me_context_ptr, 0);
+#endif
 
     // Set hme-based me sr adjustment level
     // ME SR adjustment is disallowed for TF in motion_estimate_sb()
+#if REMOVE_TF_REF_PRUNING_FUNCS
+    set_me_sr_adjustment_ctrls(context_ptr->me_context_ptr, 0);
+#else
     tf_set_me_sr_adjustment_ctrls(context_ptr->me_context_ptr, 0);
+#endif
 #else
 #if ADD_ME_SIGNAL_FOR_PRUNING_TH
 #if MAR20_ADOPTIONS

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -1133,7 +1133,11 @@ EbErrorType signal_derivation_multi_processes_oq(
 #if FAST_M8_V1
 #if JULY31_PRESETS_ADOPTIONS
 #if SHIFT_PRESETS
+#if AUG27_ADOPTS
+    if (pcs_ptr->enc_mode <= ENC_M3)
+#else
     if (pcs_ptr->enc_mode <= ENC_M4)
+#endif
 #else
     if (pcs_ptr->enc_mode <= ENC_M5)
 #endif
@@ -2032,7 +2036,11 @@ EbErrorType signal_derivation_multi_processes_oq(
 #if MAY19_ADOPTIONS
 #if JUNE17_ADOPTIONS
 #if SHIFT_PRESETS
+#if AUG27_ADOPTS
+            if (pcs_ptr->enc_mode <= ENC_M6)
+#else
             if (pcs_ptr->enc_mode <= ENC_M4)
+#endif
 #else
             if (pcs_ptr->enc_mode <= ENC_M5)
 #endif
@@ -2285,7 +2293,11 @@ EbErrorType signal_derivation_multi_processes_oq(
 #else
 #if JUNE26_ADOPTIONS
 #if SHIFT_PRESETS
+#if AUG27_ADOPTS
+        if (pcs_ptr->enc_mode <= ENC_M4)
+#else
         if (pcs_ptr->enc_mode <= ENC_M3)
+#endif
 #else
         if (pcs_ptr->enc_mode <= ENC_M4)
 #endif
@@ -2626,7 +2638,11 @@ EbErrorType signal_derivation_multi_processes_oq(
         pcs_ptr->gm_level = GM_FULL;
 #if JUNE26_ADOPTIONS
 #if SHIFT_PRESETS
+#if AUG27_ADOPTS
+    else if (pcs_ptr->enc_mode <= ENC_M4)
+#else
     else if (pcs_ptr->enc_mode <= ENC_M3)
+#endif
 #else
     else if (pcs_ptr->enc_mode <= ENC_M4)
 #endif
@@ -2741,7 +2757,11 @@ EbErrorType signal_derivation_multi_processes_oq(
         }
 #if SHIFT_PRESETS
 #if BALANCE_M6_M7 // tf
+#if AUG27_ADOPTS
+        else {
+#else
         else if (pcs_ptr->enc_mode <= ENC_M6) {
+#endif
 #else
         else if (pcs_ptr->enc_mode <= ENC_M5) {
 #endif
@@ -2762,12 +2782,14 @@ EbErrorType signal_derivation_multi_processes_oq(
                 context_ptr->tf_level = 0;
         }
 #endif
+#if !AUG27_ADOPTS
         else {
             if (pcs_ptr->temporal_layer_index == 0)
                 context_ptr->tf_level = 3;
             else
                 context_ptr->tf_level = 0;
         }
+#endif
 #else
         else {
             if (pcs_ptr->temporal_layer_index == 0 || (pcs_ptr->temporal_layer_index == 1 && scs_ptr->static_config.hierarchical_levels >= 3))

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -13063,7 +13063,9 @@ static void search_best_independent_uv_mode(PictureControlSet *  pcs_ptr,
         : context_ptr->md_enable_smooth ? UV_SMOOTH_H_PRED : UV_D67_PRED;
 
     uint8_t uv_mode_start                           = UV_DC_PRED;
+#if !REMOVE_INTRA_CHROMA_FOLLOWS_LUMA
     uint8_t disable_z2_prediction                   = 0;
+#endif
     uint8_t disable_angle_prediction                = 0;
     uint8_t directional_mode_skip_mask[INTRA_MODES] = {0};
 #if !REMOVE_INTRA_CHROMA_FOLLOWS_LUMA
@@ -13126,9 +13128,11 @@ static void search_best_independent_uv_mode(PictureControlSet *  pcs_ptr,
                              : uv_angle_delta_counter - (uv_angle_delta_candidate_count >> 1)),
                     -MAX_ANGLE_DELTA,
                     MAX_ANGLE_DELTA);
+#if !REMOVE_INTRA_CHROMA_FOLLOWS_LUMA
                 int32_t p_angle = mode_to_angle_map[(PredictionMode)uv_mode] +
                     uv_angle_delta * ANGLE_STEP;
                 if (!disable_z2_prediction || (uv_angle_delta <= 1 && p_angle >= -1)) {
+#endif
                     candidate_array[uv_mode_total_count].type                       = INTRA_MODE;
                     candidate_array[uv_mode_total_count].distortion_ready           = 0;
                     candidate_array[uv_mode_total_count].use_intrabc                = 0;
@@ -13161,7 +13165,9 @@ static void search_best_independent_uv_mode(PictureControlSet *  pcs_ptr,
                         frm_hdr->reduced_tx_set);
 
                     uv_mode_total_count++;
+#if !REMOVE_INTRA_CHROMA_FOLLOWS_LUMA
                 }
+#endif
             }
         }
     }

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -4408,8 +4408,12 @@ void sort_full_cost_based_candidates(struct ModeDecisionContext *context_ptr,
 void construct_best_sorted_arrays_md_stage_1(struct ModeDecisionContext *  context_ptr,
                                              ModeDecisionCandidateBuffer **buffer_ptr_array,
                                              uint32_t *best_candidate_index_array,
+#if REMOVE_MD_TXT_SEARCH_LEVEL
+                                             uint32_t *sorted_candidate_index_array) {
+#else
                                              uint32_t *sorted_candidate_index_array,
                                              uint64_t *ref_fast_cost) {
+#endif
     //best = union from all classes
     uint32_t best_candi = 0;
     for (CandClass class_i = CAND_CLASS_0; class_i < CAND_CLASS_TOTAL; class_i++)
@@ -4437,8 +4441,10 @@ void construct_best_sorted_arrays_md_stage_1(struct ModeDecisionContext *  conte
     sort_array_index_fast_cost_ptr(
         buffer_ptr_array, sorted_candidate_index_array, full_recon_candidate_count);
 
+#if !REMOVE_MD_TXT_SEARCH_LEVEL
     // tx search
     *ref_fast_cost = *(buffer_ptr_array[sorted_candidate_index_array[0]]->fast_cost_ptr);
+#endif
 }
 
 void construct_best_sorted_arrays_md_stage_3(struct ModeDecisionContext *  context_ptr,
@@ -10982,7 +10988,11 @@ void update_tx_candidate_buffer(ModeDecisionCandidateBuffer *candidate_buffer,
 }
 void perform_tx_partitioning(ModeDecisionCandidateBuffer *candidate_buffer,
                              ModeDecisionContext *context_ptr, PictureControlSet *pcs_ptr,
+#if REMOVE_MD_TXT_SEARCH_LEVEL
+                             uint8_t start_tx_depth, uint8_t end_tx_depth,
+#else
                              uint64_t ref_fast_cost, uint8_t start_tx_depth, uint8_t end_tx_depth,
+#endif
 #if QP2QINDEX
                              uint32_t qindex, uint32_t *y_count_non_zero_coeffs, uint64_t *y_coeff_bits,
 #else
@@ -11610,8 +11620,12 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
                     ModeDecisionContext *context_ptr, ModeDecisionCandidateBuffer *candidate_buffer,
                     ModeDecisionCandidate *candidate_ptr, EbPictureBufferDesc *input_picture_ptr,
                     uint32_t input_origin_index, uint32_t input_cb_origin_in_index,
+#if REMOVE_MD_TXT_SEARCH_LEVEL
+                    uint32_t blk_origin_index, uint32_t blk_chroma_origin_index) {
+#else
                     uint32_t blk_origin_index, uint32_t blk_chroma_origin_index,
                     uint64_t ref_fast_cost) {
+#endif
     uint64_t y_full_distortion[DIST_CALC_TOTAL];
     uint32_t count_non_zero_coeffs[3][MAX_NUM_OF_TU_PER_CU];
 
@@ -11785,7 +11799,9 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
     perform_tx_partitioning(candidate_buffer,
                             context_ptr,
                             pcs_ptr,
+#if !REMOVE_MD_TXT_SEARCH_LEVEL
                             ref_fast_cost,
+#endif
                             start_tx_depth,
                             end_tx_depth,
 #if QP2QINDEX
@@ -11980,8 +11996,12 @@ void full_loop_core(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *b
 static void md_stage_1(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *blk_ptr,
                        ModeDecisionContext *context_ptr, EbPictureBufferDesc *input_picture_ptr,
                        uint32_t input_origin_index, uint32_t input_cb_origin_in_index,
+#if REMOVE_MD_TXT_SEARCH_LEVEL
+                       uint32_t blk_origin_index, uint32_t blk_chroma_origin_index) {
+#else
                        uint32_t blk_origin_index, uint32_t blk_chroma_origin_index,
                        uint64_t ref_fast_cost) {
+#endif
     ModeDecisionCandidateBuffer **candidate_buffer_ptr_array_base =
         context_ptr->candidate_buffer_ptr_array;
     ModeDecisionCandidateBuffer **candidate_buffer_ptr_array = &(
@@ -12033,16 +12053,24 @@ static void md_stage_1(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct
                        input_origin_index,
                        input_cb_origin_in_index,
                        blk_origin_index,
+#if REMOVE_MD_TXT_SEARCH_LEVEL
+                       blk_chroma_origin_index);
+#else
                        blk_chroma_origin_index,
                        ref_fast_cost);
+#endif
     }
 }
 
 static void md_stage_2(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct *blk_ptr,
                        ModeDecisionContext *context_ptr, EbPictureBufferDesc *input_picture_ptr,
                        uint32_t input_origin_index, uint32_t input_cb_origin_in_index,
+#if REMOVE_MD_TXT_SEARCH_LEVEL
+                       uint32_t blk_origin_index, uint32_t blk_chroma_origin_index) {
+#else
                        uint32_t blk_origin_index, uint32_t blk_chroma_origin_index,
                        uint64_t ref_fast_cost) {
+#endif
     ModeDecisionCandidateBuffer **candidate_buffer_ptr_array_base =
         context_ptr->candidate_buffer_ptr_array;
     ModeDecisionCandidateBuffer **candidate_buffer_ptr_array = &(
@@ -12102,8 +12130,12 @@ static void md_stage_2(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct
                        input_origin_index,
                        input_cb_origin_in_index,
                        blk_origin_index,
+#if REMOVE_MD_TXT_SEARCH_LEVEL
+                       blk_chroma_origin_index);
+#else
                        blk_chroma_origin_index,
                        ref_fast_cost);
+#endif
     }
 }
 
@@ -12224,7 +12256,11 @@ static void md_stage_3(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct
                        ModeDecisionContext *context_ptr, EbPictureBufferDesc *input_picture_ptr,
                        uint32_t input_origin_index, uint32_t input_cb_origin_in_index,
                        uint32_t blk_origin_index, uint32_t blk_chroma_origin_index,
+#if REMOVE_MD_TXT_SEARCH_LEVEL
+                       uint32_t fullCandidateTotalCount) {
+#else
                        uint32_t fullCandidateTotalCount, uint64_t ref_fast_cost) {
+#endif
     ModeDecisionCandidateBuffer **candidate_buffer_ptr_array_base =
         context_ptr->candidate_buffer_ptr_array;
     ModeDecisionCandidateBuffer **candidate_buffer_ptr_array = &(
@@ -12292,8 +12328,12 @@ static void md_stage_3(PictureControlSet *pcs_ptr, SuperBlock *sb_ptr, BlkStruct
                        input_origin_index,
                        input_cb_origin_in_index,
                        blk_origin_index,
+#if REMOVE_MD_TXT_SEARCH_LEVEL
+                       blk_chroma_origin_index);
+#else
                        blk_chroma_origin_index,
                        ref_fast_cost);
+#endif
     }
 }
 
@@ -12843,10 +12883,10 @@ ModeDecisionContext *context_ptr) {
     }
 
 #endif
+#if !REMOVE_SIMILARITY_FEATS
     BlkStruct *similar_cu = &context_ptr->md_blk_arr_nsq[context_ptr->similar_blk_mds];
     if (context_ptr->compound_types_to_try > MD_COMP_AVG && context_ptr->similar_blk_avail) {
         int32_t is_src_compound = similar_cu->pred_mode >= NEAREST_NEARESTMV;
-#if !REMOVE_SIMILARITY_FEATS
 #if INTER_COMP_REDESIGN
         if (context_ptr->inter_comp_ctrls.similar_previous_blk == 1) {
 #else
@@ -12864,23 +12904,23 @@ ModeDecisionContext *context_ptr) {
                 ? MD_COMP_AVG
                 : similar_cu->interinter_comp.type;
         }
-#endif
     }
+#endif
 #if INTER_COMP_REDESIGN
     // Do not add MD_COMP_WEDGE  beyond this point
     if (get_wedge_params_bits(context_ptr->blk_geom->bsize) == 0)
         context_ptr->compound_types_to_try = MIN(context_ptr->compound_types_to_try,MD_COMP_DIFF0);
 #endif
     context_ptr->inject_inter_candidates = 1;
+#if !REMOVE_SIMILARITY_FEATS
     if (context_ptr->pd_pass > PD_PASS_1 && context_ptr->similar_blk_avail) {
         int32_t is_src_intra = similar_cu->pred_mode <= PAETH_PRED;
-#if !REMOVE_SIMILARITY_FEATS
         if (context_ptr->intra_similar_mode)
             context_ptr->inject_inter_candidates = is_src_intra
                 ? 0
                 : context_ptr->inject_inter_candidates;
-#endif
     }
+#endif
 
     return return_error;
 }
@@ -14146,14 +14186,19 @@ void md_encode_block(PictureControlSet *pcs_ptr, ModeDecisionContext *context_pt
     interintra_class_pruning_1(context_ptr, best_md_stage_cost);
     memset(context_ptr->best_candidate_index_array, 0xFF, MAX_NFL_BUFF * sizeof(uint32_t));
     memset(context_ptr->sorted_candidate_index_array, 0xFF, MAX_NFL * sizeof(uint32_t));
-
+#if REMOVE_MD_TXT_SEARCH_LEVEL
+    construct_best_sorted_arrays_md_stage_1(context_ptr,
+                                            candidate_buffer_ptr_array,
+                                            context_ptr->best_candidate_index_array,
+                                            context_ptr->sorted_candidate_index_array);
+#else
     uint64_t ref_fast_cost = MAX_MODE_COST;
     construct_best_sorted_arrays_md_stage_1(context_ptr,
                                             candidate_buffer_ptr_array,
                                             context_ptr->best_candidate_index_array,
                                             context_ptr->sorted_candidate_index_array,
                                             &ref_fast_cost);
-
+#endif
     // 1st Full-Loop
     best_md_stage_cost    = (uint64_t)~0;
     context_ptr->md_stage = MD_STAGE_1;
@@ -14174,8 +14219,12 @@ void md_encode_block(PictureControlSet *pcs_ptr, ModeDecisionContext *context_pt
                        input_origin_index,
                        input_cb_origin_in_index,
                        blk_origin_index,
+#if REMOVE_MD_TXT_SEARCH_LEVEL
+                       blk_chroma_origin_index);
+#else
                        blk_chroma_origin_index,
                        ref_fast_cost);
+#endif
 
             // Sort the candidates of the target class based on the 1st full loop cost
 
@@ -14217,8 +14266,12 @@ void md_encode_block(PictureControlSet *pcs_ptr, ModeDecisionContext *context_pt
                        input_origin_index,
                        input_cb_origin_in_index,
                        blk_origin_index,
+#if REMOVE_MD_TXT_SEARCH_LEVEL
+                       blk_chroma_origin_index);
+#else
                        blk_chroma_origin_index,
                        ref_fast_cost);
+#endif
 
             // Sort the candidates of the target class based on the 1st full loop cost
 
@@ -14273,8 +14326,12 @@ void md_encode_block(PictureControlSet *pcs_ptr, ModeDecisionContext *context_pt
                input_cb_origin_in_index,
                blk_origin_index,
                blk_chroma_origin_index,
+#if REMOVE_MD_TXT_SEARCH_LEVEL
+               context_ptr->md_stage_3_total_count);
+#else
                context_ptr->md_stage_3_total_count,
                ref_fast_cost); // fullCandidateTotalCount to number of buffers to process
+#endif
 
     // Full Mode Decision (choose the best mode)
     candidate_index  = product_full_mode_decision(context_ptr,
@@ -15084,7 +15141,11 @@ void block_based_depth_reduction(
 #if MERGED_COEFF_BAND
 #if NSQ_CYCLES_REDUCTION
 #if !MERGED_COEFF_BAND || ADAPTIVE_NSQ_CR
+#if REMOVE_OLD_NSQ_CR
+uint8_t get_allowed_block(ModeDecisionContext *context_ptr) {
+#else
 uint8_t get_allowed_block(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr) {
+#endif
 #else
 uint8_t get_allowed_block(ModeDecisionContext *context_ptr) {
 #endif
@@ -15820,7 +15881,11 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
             skip_next_depth = context_ptr->blk_ptr->do_not_process_block;
 #if COEFF_BASED_BYPASS_NSQ
 #if !MERGED_COEFF_BAND || ADAPTIVE_NSQ_CR || !NSQ_CYCLES_REDUCTION
+#if REMOVE_OLD_NSQ_CR
+            uint8_t skip_nsq = get_allowed_block(context_ptr);
+#else
             uint8_t skip_nsq = get_allowed_block(pcs_ptr, context_ptr);
+#endif
 #else
             uint8_t skip_nsq = get_allowed_block(context_ptr);
 #endif

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -225,7 +225,11 @@ EbErrorType signal_derivation_pre_analysis_oq(SequenceControlSet *     scs_ptr,
 #if REVERT_BLUE
 #if JUNE17_ADOPTIONS
 #if SHIFT_PRESETS
+#if AUG27_ADOPTS
+            scs_ptr->seq_header.enable_restoration = (pcs_ptr->enc_mode <= ENC_M6) ? 1 : 0;
+#else
             scs_ptr->seq_header.enable_restoration = (pcs_ptr->enc_mode <= ENC_M5) ? 1 : 0;
+#endif
 #else
             scs_ptr->seq_header.enable_restoration = (pcs_ptr->enc_mode <= ENC_M6) ? 1 : 0;
 #endif

--- a/Source/Lib/Encoder/Codec/firstpass.c
+++ b/Source/Lib/Encoder/Codec/firstpass.c
@@ -962,6 +962,7 @@ extern EbErrorType first_pass_signal_derivation_block(
     BlkStruct *similar_cu = &context_ptr->md_blk_arr_nsq[context_ptr->similar_blk_mds];
     if (context_ptr->compound_types_to_try > MD_COMP_AVG && context_ptr->similar_blk_avail) {
         int32_t is_src_compound = similar_cu->pred_mode >= NEAREST_NEARESTMV;
+#if !REMOVE_SIMILARITY_FEATS
 #if INTER_COMP_REDESIGN
         if (context_ptr->inter_comp_ctrls.similar_previous_blk == 1) {
 #else
@@ -976,6 +977,7 @@ extern EbErrorType first_pass_signal_derivation_block(
 #endif
             context_ptr->compound_types_to_try = !is_src_compound ? MD_COMP_AVG : similar_cu->interinter_comp.type;
         }
+#endif
         }
 #if INTER_COMP_REDESIGN
     // Do not add MD_COMP_WEDGE  beyond this point
@@ -985,8 +987,10 @@ extern EbErrorType first_pass_signal_derivation_block(
     context_ptr->inject_inter_candidates = 1;
     if (context_ptr->pd_pass > PD_PASS_1 && context_ptr->similar_blk_avail) {
         int32_t is_src_intra = similar_cu->pred_mode <= PAETH_PRED;
+#if !REMOVE_SIMILARITY_FEATS
         if (context_ptr->intra_similar_mode)
             context_ptr->inject_inter_candidates = is_src_intra ? 0 : context_ptr->inject_inter_candidates;
+#endif
     }
 
     return return_error;
@@ -1201,7 +1205,9 @@ extern void first_pass_md_encode_block(PictureControlSet *pcs_ptr, ModeDecisionC
         (context_ptr->full_loop_escape == 2) ? context_ptr->sorted_candidate_index_array
                                              : context_ptr->best_candidate_index_array,
 #endif
+#if !REMOVE_REF_FOR_RECT_PART
         context_ptr->prune_ref_frame_for_rec_partitions,
+#endif
         &best_intra_mode);
     candidate_buffer = candidate_buffer_ptr_array[candidate_index];
 
@@ -1579,6 +1585,7 @@ EbErrorType first_pass_signal_derivation_enc_dec_kernel(
     // 3                                              Tx search at full loop
     context_ptr->tx_search_level = TX_SEARCH_OFF;
 #endif
+#if !REMOVE_MD_TXT_SEARCH_LEVEL
     // Set MD tx_level
     // md_txt_search_level                            Settings
     // 0                                              FULL
@@ -1587,7 +1594,7 @@ EbErrorType first_pass_signal_derivation_enc_dec_kernel(
     // 3                                              Tx_weight 1 + disabling rdoq and sssse
     // 4                                              Tx_weight 1 + disabling rdoq and sssse + reduced set
     context_ptr->md_txt_search_level = 1;
-
+#endif
     uint8_t txt_cycles_reduction_level = 0;
     set_txt_cycle_reduction_controls(context_ptr, txt_cycles_reduction_level);
 #if IFS_PUSH_BACK_STAGE_3
@@ -1617,11 +1624,13 @@ EbErrorType first_pass_signal_derivation_enc_dec_kernel(
     context_ptr->chroma_at_last_md_stage_intra_th = (uint64_t)~0;
     context_ptr->chroma_at_last_md_stage_cfl_th = (uint64_t)~0;
 
+#if !REMOVE_IND_CHROMA_NICS
     // Chroma independent modes nics
     // Level                Settings
     // 0                    All supported modes.
     // 1                    All supported modes in  Intra picture and 4 in inter picture
     context_ptr->independent_chroma_nics = 0;
+#endif
 
     // Cfl level
     // Level                Settings
@@ -1630,14 +1639,18 @@ EbErrorType first_pass_signal_derivation_enc_dec_kernel(
 
     context_ptr->md_disable_cfl = EB_TRUE;
 
+#if !REMOVE_LIBAOM_SHORTCUT_THS
     // libaom_short_cuts_ths
     // 1                    faster than libaom
     // 2                    libaom - default
     context_ptr->libaom_short_cuts_ths = 2;
+#endif
 
+#if !REMOVE_INTRA_CHROMA_FOLLOWS_LUMA
     // 0                    inject all supprted chroma mode
     // 1                    follow the luma injection
     context_ptr->intra_chroma_search_follows_intra_luma_injection = 1;
+#endif
 
     // Set disallow_4x4
     context_ptr->disallow_4x4 = EB_FALSE;
@@ -1762,12 +1775,14 @@ EbErrorType first_pass_signal_derivation_enc_dec_kernel(
         context_ptr->md_staging_count_level = 2;
     }
 
+#if !REMOVE_IFS_BLK_SIZE
     // Set interpolation filter search blk size
     // Level                Settings
     // 0                    ON for 8x8 and above
     // 1                    ON for 16x16 and above
     // 2                    ON for 32x32 and above
     context_ptr->interpolation_filter_search_blk_size = 0;
+#endif
 
     // Derive Spatial SSE Flag
     context_ptr->spatial_sse_full_loop_level = EB_TRUE;
@@ -1780,13 +1795,14 @@ EbErrorType first_pass_signal_derivation_enc_dec_kernel(
     // Derive redundant block
     context_ptr->redundant_blk = EB_FALSE;
 
+#if !REMOVE_EDGE_SKIP_ANGLE_INTRA
     // Set edge_skp_angle_intra
     context_ptr->edge_based_skip_angle_intra = 0;
-
+#endif
+#if !REMOVE_REF_FOR_RECT_PART
     // Set prune_ref_frame_for_rec_partitions
     context_ptr->prune_ref_frame_for_rec_partitions = 0;
-
-
+#endif
 
     // md_stage_1_cand_prune_th (for single candidate removal per class)
     // Remove candidate if deviation to the best is higher than md_stage_1_cand_prune_th
@@ -1809,6 +1825,7 @@ EbErrorType first_pass_signal_derivation_enc_dec_kernel(
 
     context_ptr->coeff_area_based_bypass_nsq_th = 0;
 
+#if !REMOVE_OLD_NSQ_CR
     // NSQ cycles reduction level: TBD
     uint8_t nsq_cycles_red_mode = 0;
     set_nsq_cycle_redcution_controls(context_ptr, nsq_cycles_red_mode);
@@ -1816,10 +1833,12 @@ EbErrorType first_pass_signal_derivation_enc_dec_kernel(
     // NsqCycleRControls*nsq_cycle_red_ctrls = &context_ptr->nsq_cycles_red_ctrls;
     // Overwrite allcation action when nsq_cycles_reduction th is higher.
     context_ptr->nsq_cycles_reduction_th = 0;
-
+#endif
+#if !REMOVE_OLD_DEPTH_CR
     // Depth cycles reduction level: TBD
     uint8_t depth_cycles_red_mode = 0;
     set_depth_cycle_redcution_controls(context_ptr, depth_cycles_red_mode);
+#endif
 
     uint8_t adaptive_md_cycles_level = 0;
     adaptive_md_cycles_redcution_controls(context_ptr, adaptive_md_cycles_level);
@@ -1894,10 +1913,12 @@ EbErrorType first_pass_signal_derivation_enc_dec_kernel(
     // Set md_palette_level @ MD
     context_ptr->md_palette_level = 0;
 
+#if !REMOVE_SIMILARITY_FEATS
     // intra_similar_mode
     // 0: OFF
     // 1: If previous similar block is intra, do not inject any inter
     context_ptr->intra_similar_mode = 0;
+#endif
 #if !REMOVE_USELESS_CODE
     // Set inter_intra_distortion_based_reference_pruning
     context_ptr->inter_intra_distortion_based_reference_pruning = 0;

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2313,14 +2313,18 @@ void copy_api_from_app(
     // prune unipred at me
     scs_ptr->static_config.prune_unipred_me             = ((EbSvtAv1EncConfiguration*)config_struct)->prune_unipred_me;
 #endif
+#if !REMOVE_EDGE_SKIP_ANGLE_INTRA
     // edge skip angle intra
     scs_ptr->static_config.edge_skp_angle_intra         = ((EbSvtAv1EncConfiguration*)config_struct)->edge_skp_angle_intra;
+#endif
     // intra angle delta
     scs_ptr->static_config.intra_angle_delta            = ((EbSvtAv1EncConfiguration*)config_struct)->intra_angle_delta;
     // inter intra compoound
     scs_ptr->static_config.inter_intra_compound         = ((EbSvtAv1EncConfiguration*)config_struct)->inter_intra_compound;
+#if !REMOVE_REF_FOR_RECT_PART
     //prune ref frame for rec partitions
     scs_ptr->static_config.prune_ref_rec_part           = ((EbSvtAv1EncConfiguration*)config_struct)->prune_ref_rec_part;
+#endif
     // NSQ table
     scs_ptr->static_config.nsq_table                    = ((EbSvtAv1EncConfiguration*)config_struct)->nsq_table;
     // frame end cdf update mode
@@ -3027,11 +3031,12 @@ static EbErrorType verify_settings(
       return_error = EB_ErrorBadParameter;
     }
 #endif
+#if !REMOVE_EDGE_SKIP_ANGLE_INTRA
     if (config->edge_skp_angle_intra != 0 && config->edge_skp_angle_intra != 1 && config->edge_skp_angle_intra != -1) {
       SVT_LOG("Error instance %u: Invalid Enable skip angle intra based on edge flag [0/1 or -1 for auto], your input: %d\n", channel_number + 1, config->edge_skp_angle_intra);
       return_error = EB_ErrorBadParameter;
     }
-
+#endif
     if (config->intra_angle_delta != 0 && config->intra_angle_delta != 1 && config->intra_angle_delta != -1) {
         SVT_LOG("Error instance %u: Invalid Enable intra angle delta flag [0/1 or -1 for auto], your input: %d\n", channel_number + 1, config->intra_angle_delta);
         return_error = EB_ErrorBadParameter;
@@ -3092,11 +3097,12 @@ static EbErrorType verify_settings(
       return_error = EB_ErrorBadParameter;
     }
 #endif
+#if !REMOVE_REF_FOR_RECT_PART
     if (config->prune_ref_rec_part != 0 && config->prune_ref_rec_part != 1 && config->prune_ref_rec_part != -1) {
       SVT_LOG("Error instance %u: Invalid prune_ref_rec_part flag [0/1 or -1 for auto], your input: %d\n", channel_number + 1, config->prune_ref_rec_part);
       return_error = EB_ErrorBadParameter;
     }
-
+#endif
     if (config->nsq_table != 0 && config->nsq_table != 1 && config->nsq_table != -1) {
       SVT_LOG("Error instance %u: Invalid nsq_table flag [0/1 or -1 for auto], your input: %d\n", channel_number + 1, config->nsq_table);
       return_error = EB_ErrorBadParameter;
@@ -3230,7 +3236,9 @@ EbErrorType eb_svt_enc_init_parameter(
     config_ptr->enable_restoration_filtering = DEFAULT;
     config_ptr->sg_filter_mode = DEFAULT;
     config_ptr->wn_filter_mode = DEFAULT;
+#if !REMOVE_EDGE_SKIP_ANGLE_INTRA
     config_ptr->edge_skp_angle_intra = DEFAULT;
+#endif
     config_ptr->intra_angle_delta = DEFAULT;
 #if !REMOVE_COMBINE_CLASS12
     config_ptr->combine_class_12 = DEFAULT;
@@ -3252,7 +3260,9 @@ EbErrorType eb_svt_enc_init_parameter(
 #if !SHUT_ME_CAND_SORTING
     config_ptr->prune_unipred_me = DEFAULT;
 #endif
+#if !REMOVE_REF_FOR_RECT_PART
     config_ptr->prune_ref_rec_part = DEFAULT;
+#endif
     config_ptr->nsq_table = DEFAULT;
     config_ptr->frame_end_cdf_update = DEFAULT;
     config_ptr->set_chroma_mode = DEFAULT;

--- a/gstreamer-plugin/gstsvtav1enc.c
+++ b/gstreamer-plugin/gstsvtav1enc.c
@@ -638,7 +638,9 @@ set_default_svt_configuration (EbSvtAv1EncConfiguration * svt_config)
   svt_config->enable_restoration_filtering = -1;
   svt_config->sg_filter_mode = -1;
   svt_config->wn_filter_mode = -1;
+  #if 0 //!REMOVE_EDGE_SKIP_ANGLE_INTRA
   svt_config->edge_skp_angle_intra = -1;
+  #endif
   svt_config->intra_angle_delta = -1;
   svt_config->inter_intra_compound = -1;
   svt_config->enable_paeth = -1;
@@ -648,7 +650,9 @@ set_default_svt_configuration (EbSvtAv1EncConfiguration * svt_config)
   svt_config->spatial_sse_full_loop_level = -1;
   svt_config->over_bndry_blk = -1;
   svt_config->new_nearest_comb_inject = -1;
+  #if 0 //!REMOVE_REF_FOR_RECT_PART
   svt_config->prune_ref_rec_part = -1;
+  #endif
   svt_config->nsq_table = -1;
   svt_config->frame_end_cdf_update = -1;
   svt_config->pred_me = -1;


### PR DESCRIPTION
# Description

- Use temporal layer information to improve lambda generation.
- Shift features to optimize preset trade-offs.
-- Cleanup: Remove unused signals

# Issue

Fixes #1449 

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)

@PhoenixWorthVCD 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [x] quality
- [ ] memory
- [x] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] Google Lowres
- [ ] N/A

| Preset(s)| BD-Rate  Deviation| Speed Deviation| 
| -- | -- | --
|M0 | -0.33% | No change|
|M1 | -0.17% | 6.5%|
|M2 | -0.45% | No change|
|M3 | -0.41% | No change|
|M4 | -0.73% | No change|
|M5 | -0.81% | -3%|
|M6 | -0.54% |  -3%|
|M7 | -1.01% | -4%|

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
