### PR TITLE
Bug fixes related to QP assignment in 1 and 2 pass

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -588,6 +588,9 @@ extern "C" {
 #define EXIT_PME                         1 // ME_MV-based PME optimizations for M7 only
 #define FASTEST_HME                      1 // (16,64) instead of (32,128) for M7 only
 #define FREQ_SSE_BUG_FIX                 1 // Always T-1 if TXS (lossless)
+
+#define PASS1_BUG_FIXES                  1 // Fix the one pass QP assignment using frames_to_be_encoded
+#define PASS2_BUG_FIXES                  1 // Fix 2pass encoding related to next_key_frame_forced
 // end
 
 ///////// END MASTER_SYNCH

--- a/Source/Lib/Encoder/Codec/pass2_strategy.c
+++ b/Source/Lib/Encoder/Codec/pass2_strategy.c
@@ -2082,7 +2082,11 @@ static void find_next_key_frame(PictureParentControlSet *pcs_ptr, FIRSTPASS_STAT
     else if ((twopass->stats_in == twopass->stats_buf_ctx->stats_in_end/* &&
              is_stat_consumption_stage_twopass(cpi)*/) ||
         rc->frames_to_key >= kf_cfg->key_freq_max) {
+#if PASS2_BUG_FIXES
+        rc->next_key_frame_forced = 0;
+#else
         rc->next_key_frame_forced = 1;
+#endif
     }
     else {
         rc->next_key_frame_forced = 0;


### PR DESCRIPTION
# Description
 Fix the one pass QP assignment using frames_to_be_encoded. frames_to_be_encoded is not available in one pass encoding
 Fix 2pass encoding related to next_key_frame_forced when intra refresh is used

# Issue

# Author(s)
@anaghdin 

# Performance impact
- [x] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [x ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
1 PASS encoding CRF (older version)

preset | AVG   PSNR/SSIM/3*yPSNR
-- | --
M1 | 0.19%
M2 | 0.06%
M3 | 0.15%
M4 | 0.08%
M5 | 0.11%
M6 | 0.13%

- [x] Google Lowres
1 PASS encoding CRF

preset | AVG   PSNR/SSIM/3*yPSNR
-- | --
M0 | -0.04%
M1 | -0.04%
M2 | -0.05%
M3* | 0.01%
M4* | 0.08%
M5* | 0.01%
M6* | 0.07%
** are for older version
- [x] Google Lowres FULL
2 PASS encoding CRF with intra refresh of 64

preset | AVG   PSNR/SSIM/3*yPSNR
-- | --
M4 | -0.88%
M6 | -1.07%


- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch