### PR TITLE
Pass1 speed up

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -552,9 +552,9 @@ extern "C" {
 #define REMOVE_OLD_DEPTH_CR              1 // remove old depth cycles reduction feature (replaced by adaptive_md_cycles_level)
 #endif
 #define REMOVE_TF_REF_PRUNING_FUNCS      1 // remove redundant functions for setting TF ref pruning settings (which are always off)
-#endif
 
-// start
+
+
 #define LOSSLESS_OPT                    1 // Lossless opt
 #if LOSSLESS_OPT // 1st round
 #define OPT_0                         1 // bypass distortion_based_modulator() if no nsq
@@ -591,8 +591,15 @@ extern "C" {
 
 #define PASS1_BUG_FIXES                  1 // Fix the one pass QP assignment using frames_to_be_encoded
 #define PASS2_BUG_FIXES                  1 // Fix 2pass encoding related to next_key_frame_forced
+#define FPFOPT_NO_EP                    1  //bypass EncDec for 1st pass
+#define FPFOPT_ESTBITS                  1  //no coeff estimation for 1st pass
+#define PASS1_CLEANUP        1  // distortion_based_modulator  / generate_md_stage_0_cand
+#define FPFOPT_SRC_PATH      1 // use the source path
+#define FPFOPT_MD           1 // update generate_av1_mvp_table, update predMV, no av1_product_full_cost_func_table
+#define FPFOPT_INTRA        1 // get neighbor pixel from source
+#define FPFOPT_RECON         1 // remove the use of recon in MD
 // end
-
+#endif
 ///////// END MASTER_SYNCH
 
 #if DECOUPLE_ME_RES

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -12027,6 +12027,9 @@ void *mode_decision_kernel(void *input_ptr) {
                                     context_ptr);
 #else
                     // Encode Pass
+#if FPFOPT_NO_EP
+                    if(scs_ptr->use_output_stat_file==EB_FALSE)
+#endif
                     av1_encode_decode(
                         scs_ptr, pcs_ptr, sb_ptr, sb_index, sb_origin_x, sb_origin_y, context_ptr);
 #endif

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -247,8 +247,18 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
 #else
             else if (pcs_ptr->enc_mode <= ENC_M7) {
 #endif
+#if FASTER_FIRST_PASS
+                if (scs_ptr->use_output_stat_file) {
+                    me_context_ptr->search_area_width = me_context_ptr->search_area_height = 37;
+                    me_context_ptr->max_me_search_width = me_context_ptr->max_me_search_height = 175;
+                }
+                else {
+#endif
                 me_context_ptr->search_area_width = me_context_ptr->search_area_height = 75;
                 me_context_ptr->max_me_search_width = me_context_ptr->max_me_search_height = 350;
+#if FASTER_FIRST_PASS
+        }
+#endif
             }
 #else
 #if JUNE17_ADOPTIONS
@@ -409,8 +419,18 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
     }
 #endif
     else {
+#if FASTER_FIRST_PASS
+        if (scs_ptr->use_output_stat_file) {
+            me_context_ptr->search_area_width = me_context_ptr->search_area_height = 8;
+            me_context_ptr->max_me_search_width = me_context_ptr->max_me_search_height = 8;
+        }
+        else {
+#endif
         me_context_ptr->search_area_width = me_context_ptr->search_area_height = 16;
         me_context_ptr->max_me_search_width = me_context_ptr->max_me_search_height = 64;
+#if FASTER_FIRST_PASS
+        }
+#endif
     }
 #else
     else {


### PR DESCRIPTION
# Description
Speed up 2pass mode by optimizing pass1
Speed up the 2pass by 2X vs 1pass
Lossless for 1pass mode
# Issue
#1458 
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@chkngit 
@anaghdin 
@okhlif 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [x] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [x] other
- [ ] N/A



low res |   |   | PSNR BDR | SPEED
-- | -- | -- | -- | --
master_2pass_crf_M3 | vs. | master_1pass_crf_M3 | -0.09% | -3.17%


low res |   |   | PSNR BDR | SPEED
-- | -- | -- | -- | --
pr_2pass_crf_M3 | vs. | master_1pass_crf_M3 | -0.02% | -1.44%




# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
