### PR TITLE
Deadlock fix when keyint is not a multiple of lad

### DIFF
--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -521,6 +521,11 @@ EbErrorType load_default_buffer_configuration_settings(
         uint32_t mg_size = 1 << scs_ptr->static_config.hierarchical_levels;
         uint32_t needed_lad_pictures = ((scs_ptr->static_config.look_ahead_distance + mg_size - 1) / mg_size) * mg_size;
 
+
+        if (scs_ptr->static_config.look_ahead_distance > 0)
+            if (((scs_ptr->static_config.intra_period_length + 1) % mg_size) > 0)
+                 needed_lad_pictures += mg_size;
+
         /*To accomodate FFMPEG EOS, 1 frame delay is needed in Resource coordination.
            note that we have the option to not add 1 frame delay of Resource Coordination. In this case we have wait for first I frame
            to be released back to be able to start first base(16). Anyway poc16 needs to wait for poc0 to finish.*/


### PR DESCRIPTION
# Description

fix deadlock when the intra period is not a multiple of the lookaheaddistance.
comes at a memory cost of ~18% to be addressed when restructuring tpl

# Issue
should Fix #1453
Fixes #1451 
<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@chkngit 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [x] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
