### PR TITLE
Fix TPL non16align error for openloop intra pred and dispenser

### DIFF
--- a/Source/Lib/Common/Codec/EbDefinitions.h
+++ b/Source/Lib/Common/Codec/EbDefinitions.h
@@ -602,7 +602,8 @@ extern "C" {
 #define FPFOPT_INTRA        1 // get neighbor pixel from source
 #define FPFOPT_RECON         1 // remove the use of recon in MD
 #define TPL_C_FIX                         1
-#define TPL_SANITIZER_FIX                 1
+#define TPL_SANITIZER_FIX                 0
+#define TPL_NON16ALIGN_FIX                1 // Fix TPL non16align error for openloop intra pred and dispenser
 // end
 #endif
 ///////// END MASTER_SYNCH

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -1159,10 +1159,13 @@ void tpl_mc_flow_dispenser(
 
     // Walk the first N entries in the sliding window
     for (uint32_t sb_index = 0; sb_index < pcs_ptr->sb_total_count; ++sb_index) {
+#if !TPL_NON16ALIGN_FIX
         uint32_t    sb_origin_x = (sb_index % picture_width_in_sb) * BLOCK_SIZE_64;
         uint32_t    sb_origin_y = (sb_index / picture_width_in_sb) * BLOCK_SIZE_64;
         if (((sb_origin_x + 16) <= input_picture_ptr->width) &&
-            ((sb_origin_y + 16) <= input_picture_ptr->height)) {
+            ((sb_origin_y + 16) <= input_picture_ptr->height))
+#endif
+        {
             SbParams *sb_params = &scs_ptr->sb_params_array[sb_index];
             uint32_t pa_blk_index = 0;
             while (pa_blk_index < CU_MAX_COUNT) {

--- a/Source/Lib/Encoder/Codec/EbMotionEstimation.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimation.c
@@ -12266,8 +12266,15 @@ EbErrorType open_loop_intra_search_mb(
             pa_blk_index++;
             continue;
         }
+#if !TPL_NON16ALIGN_FIX
         TxSize tx_size = bsize == 8 ? TX_8X8 : bsize == 16 ? TX_16X16 : bsize == 32 ? TX_32X32 : TX_64X64;
+#endif
         if (sb_params->raster_scan_blk_validity[md_scan_to_raster_scan[pa_blk_index]]) {
+#if TPL_NON16ALIGN_FIX
+            // always process as block16x16 even bsize or tx_size is 8x8
+            TxSize tx_size = TX_16X16;
+            bsize = 16;
+#endif
             cu_origin_x = sb_params->origin_x + blk_stats_ptr->origin_x;
             cu_origin_y = sb_params->origin_y + blk_stats_ptr->origin_y;
             above0_row = above0_data + 16;


### PR DESCRIPTION
Completely fix the sanitizer issue caused by TPL non16aligned error, disable old TPL_SANITIZER_FIX change.

 #define TPL_SANITIZER_FIX  0
 #define TPL_NON16ALIGN_FIX 1

Signed-off-by: Kelvin Hu <kelvin.hu@intel.com>

# Description


# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
