### PR TITLE
Implementation of kernel av1_haar_ac_sad_8x8_uint8_input_avx2

### DIFF
--- a/Source/Lib/Encoder/ASM_AVX2/dwt_avx2.c
+++ b/Source/Lib/Encoder/ASM_AVX2/dwt_avx2.c
@@ -1,0 +1,109 @@
+/*
+* Copyright(c) 2020 Intel Corporation
+*
+* This source code is subject to the terms of the BSD 2 Clause License and
+* the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+* was not distributed with this source code in the LICENSE file, you can
+* obtain it at https://www.aomedia.org/license/software-license. If the Alliance for Open
+* Media Patent License 1.0 was not distributed with this source code in the
+* PATENTS file, you can obtain it at https://www.aomedia.org/license/patent-license.
+*/
+
+#include "transpose_avx2.h"
+
+int eb_av1_haar_ac_sad_8x8_uint8_input_avx2(uint8_t *input, int stride, int hbd) {
+    int32_t output[64];
+
+    int32_t *out_ptr = output;
+    int      i;
+
+    if (hbd) {
+        uint16_t *x16 = CONVERT_TO_SHORTPTR(input);
+        for (i = 0; i < 8; i++) {
+            __m256i inp = _mm256_cvtepu16_epi32(_mm_loadu_si128((__m128i *)x16));
+            _mm256_storeu_si256((__m256i *)out_ptr, _mm256_slli_epi32(inp, 2));
+
+            x16 += stride;
+            out_ptr += 8;
+        }
+    } else {
+        for (i = 0; i < 8; i++) {
+            __m256i inp = _mm256_cvtepu8_epi32(_mm_loadl_epi64((__m128i *)input));
+            _mm256_storeu_si256((__m256i *)out_ptr, _mm256_slli_epi32(inp, 2));
+
+            input += stride;
+            out_ptr += 8;
+        }
+    }
+
+    const __m256i indices = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
+    const __m256i one     = _mm256_set1_epi32(1);
+    const __m256i two     = _mm256_set1_epi32(2);
+
+    for (i = 0; i < 4; i++) {
+        __m256i x_2n   = _mm256_i32gather_epi32(output + i * 16, indices, 8);
+        __m256i x_2np1 = _mm256_i32gather_epi32(output + i * 16 + 1, indices, 8);
+        __m256i x_2np2 = _mm256_i32gather_epi32(output + i * 16 + 2, indices, 8);
+
+        __m256i a = _mm256_slli_epi32(x_2n, 1);
+        __m256i b = _mm256_add_epi32(_mm256_add_epi32(x_2n, x_2np2), one);
+        b         = _mm256_sub_epi32(x_2np1, _mm256_srli_epi32(b, 1));
+
+        int32_t idx_3 = output[i * 16 + 7] - output[i * 16 + 6];
+        int32_t idx_7 = output[i * 16 + 15] - output[i * 16 + 14];
+        b             = _mm256_insert_epi32(b, idx_3, 3);
+        b             = _mm256_insert_epi32(b, idx_7, 7);
+
+        __m256i r = _mm256_shuffle_epi32(b, (1 << 4) + (2 << 6));
+
+        a = _mm256_add_epi32(a,
+                             _mm256_srai_epi32(_mm256_add_epi32(_mm256_add_epi32(r, b), one), 1));
+
+        _mm_storeu_si128((__m128i *)(output + i * 16), _mm256_castsi256_si128(a));
+        _mm_storeu_si128((__m128i *)(output + i * 16 + 4), _mm256_castsi256_si128(b));
+        _mm_storeu_si128((__m128i *)(output + i * 16 + 8), _mm256_extracti128_si256(a, 0x1));
+        _mm_storeu_si128((__m128i *)(output + i * 16 + 12), _mm256_extracti128_si256(b, 0x1));
+    }
+
+    transpose_32bit_8x8_avx2((const __m256i *const)output, (__m256i *const)output);
+
+    __m256i sum[8];
+    for (i = 0; i < 4; i++) {
+        __m256i x_2n   = _mm256_i32gather_epi32(output + i * 16, indices, 8);
+        __m256i x_2np1 = _mm256_i32gather_epi32(output + i * 16 + 1, indices, 8);
+        __m256i x_2np2 = _mm256_i32gather_epi32(output + i * 16 + 2, indices, 8);
+
+        __m256i a = x_2n;
+        __m256i b = _mm256_sub_epi32(_mm256_slli_epi32(x_2np1, 1), x_2n);
+        b         = _mm256_add_epi32(_mm256_sub_epi32(b, x_2np2), two);
+        b         = _mm256_srai_epi32(b, 2);
+
+        int32_t idx_3 = (output[i * 16 + 7] - output[i * 16 + 6] + 1) >> 1;
+        int32_t idx_7 = (output[i * 16 + 15] - output[i * 16 + 14] + 1) >> 1;
+        b             = _mm256_insert_epi32(b, idx_3, 3);
+        b             = _mm256_insert_epi32(b, idx_7, 7);
+
+        __m256i r = _mm256_shuffle_epi32(b, (1 << 4) + (2 << 6));
+
+        a = _mm256_add_epi32(a,
+                             _mm256_srai_epi32(_mm256_add_epi32(_mm256_add_epi32(r, b), one), 1));
+
+        sum[2 * i]     = _mm256_abs_epi32(a);
+        sum[2 * i + 1] = _mm256_abs_epi32(b);
+    }
+
+    __m256i sum13, sum45, sum67;
+
+    sum13 = _mm256_add_epi32(sum[1], sum[3]);
+    sum45 = _mm256_add_epi32(sum[4], sum[5]);
+    sum67 = _mm256_add_epi32(sum[6], sum[7]);
+    sum13 = _mm256_add_epi32(sum13, _mm256_add_epi32(sum45, sum67));
+
+    __m128i sum_128 = _mm_add_epi32(_mm256_castsi256_si128(sum13),
+                                    _mm256_extracti128_si256(sum13, 1));
+
+    sum_128 = _mm_hadd_epi32(sum_128, sum_128);
+    sum_128 = _mm_hadd_epi32(sum_128, sum_128);
+
+    return _mm_cvtsi128_si32(sum_128);
+}

--- a/Source/Lib/Encoder/Codec/EbTransforms.c
+++ b/Source/Lib/Encoder/Codec/EbTransforms.c
@@ -3448,19 +3448,6 @@ void svt_av1_highbd_fwd_txfm(int16_t *src_diff, TranLow *coeff,
   }
 }
 
-void svt_av1_lowbd_fwd_txfm_c(int16_t *src_diff, TranLow *coeff,
-                          int diff_stride, TxfmParam *txfm_param) {
-  svt_av1_highbd_fwd_txfm(src_diff, coeff, diff_stride, txfm_param);
-}
-
-void svt_av1_fwd_txfm(int16_t *src_diff, TranLow *coeff, int diff_stride,
-                  TxfmParam *txfm_param) {
-  if (txfm_param->bd == 8)
-    svt_av1_lowbd_fwd_txfm(src_diff, coeff, diff_stride, txfm_param);
-  else
-    svt_av1_highbd_fwd_txfm(src_diff, coeff, diff_stride, txfm_param);
-}
-
 void svt_av1_wht_fwd_txfm(int16_t *src_diff, int bw, int32_t *coeff, TxSize tx_size, int bit_depth,
                           int is_hbd) {
     TxfmParam txfm_param;
@@ -3471,7 +3458,7 @@ void svt_av1_wht_fwd_txfm(int16_t *src_diff, int bw, int32_t *coeff, TxSize tx_s
 
     txfm_param.bd     = bit_depth;
     txfm_param.is_hbd = is_hbd;
-    svt_av1_fwd_txfm(src_diff, coeff, bw, &txfm_param);
+    svt_av1_highbd_fwd_txfm(src_diff, coeff, bw, &txfm_param);
 }
 #endif
 

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
@@ -147,7 +147,6 @@ void setup_rtcd_internal(CPU_FLAGS flags) {
     eb_aom_sad128x64x4d = eb_aom_sad128x64x4d_c;
     eb_av1_txb_init_levels = eb_av1_txb_init_levels_c;
 #if TPL_C_FIX
-    svt_av1_lowbd_fwd_txfm = svt_av1_lowbd_fwd_txfm_c;
     svt_aom_satd = svt_aom_satd_c;
     svt_av1_block_error = svt_av1_block_error_c;
 #endif
@@ -599,10 +598,6 @@ void setup_rtcd_internal(CPU_FLAGS flags) {
                 if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_64x16 = eb_av1_fwd_txfm2d_64x16_avx2;
                 if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_32x16 = eb_av1_fwd_txfm2d_32x16_avx2;
                 if (flags & HAS_AVX2) eb_av1_fwd_txfm2d_16x32 = eb_av1_fwd_txfm2d_16x32_avx2;
-#if TPL_LA
-    svt_av1_lowbd_fwd_txfm   = svt_av1_lowbd_fwd_txfm_c;
-    //if (flags & HAS_AVX2) eb_av1_lowbd_fwd_txfm = av1_lowbd_fwd_txfm_avx2;
-#endif
 #ifndef NON_AVX512_SUPPORT
                 if (flags & HAS_AVX512F) {
                     eb_av1_fwd_txfm2d_64x64 = av1_fwd_txfm2d_64x64_avx512;

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.c
@@ -369,6 +369,7 @@ void setup_rtcd_internal(CPU_FLAGS flags) {
     pme_sad_loop_kernel = pme_sad_loop_kernel_c;
 #endif
     variance_highbd = variance_highbd_c;
+    eb_av1_haar_ac_sad_8x8_uint8_input = eb_av1_haar_ac_sad_8x8_uint8_input_c;
 
 #ifdef ARCH_X86
     flags &= get_cpu_flags_to_use();
@@ -737,6 +738,9 @@ void setup_rtcd_internal(CPU_FLAGS flags) {
                     SET_AVX2(pme_sad_loop_kernel, pme_sad_loop_kernel_c, pme_sad_loop_kernel_avx2);
 #endif
                     SET_AVX2(variance_highbd, variance_highbd_c, variance_highbd_avx2);
+                    SET_AVX2(eb_av1_haar_ac_sad_8x8_uint8_input,
+                             eb_av1_haar_ac_sad_8x8_uint8_input_c,
+                             eb_av1_haar_ac_sad_8x8_uint8_input_avx2);
 #endif
 
 }

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
@@ -621,6 +621,8 @@ extern "C" {
     RTCD_EXTERN void(*pme_sad_loop_kernel)(uint8_t* src, uint32_t src_stride, uint8_t* ref, uint32_t ref_stride, uint32_t block_height, uint32_t block_width, uint32_t* best_sad, int16_t* best_mvx, int16_t* best_mvy, int16_t search_position_start_x, int16_t search_position_start_y, int16_t search_area_width, int16_t search_area_height, int16_t search_step, int16_t mvx, int16_t mvy);
     RTCD_EXTERN uint32_t(*variance_highbd)(const uint16_t *a, int a_stride, const uint16_t *b, int b_stride, int w, int h, uint32_t *sse);
     uint32_t variance_highbd_c(const uint16_t *a, int a_stride, const uint16_t *b, int b_stride, int w, int h, uint32_t *sse);
+    RTCD_EXTERN int(*eb_av1_haar_ac_sad_8x8_uint8_input)(uint8_t *input, int stride, int hbd);
+    int eb_av1_haar_ac_sad_8x8_uint8_input_c(uint8_t *input, int stride, int hbd);
 #ifdef ARCH_X86
     uint32_t combined_averaging_ssd_avx2(uint8_t *src, ptrdiff_t src_stride, uint8_t *ref1, ptrdiff_t ref1_stride, uint8_t *ref2, ptrdiff_t ref2_stride, uint32_t height, uint32_t width);
     uint32_t combined_averaging_ssd_avx512(uint8_t *src, ptrdiff_t src_stride, uint8_t *ref1, ptrdiff_t ref1_stride, uint8_t *ref2, ptrdiff_t ref2_stride, uint32_t height, uint32_t width);
@@ -1292,6 +1294,7 @@ extern "C" {
 #endif
     uint32_t variance_highbd_avx2(const uint16_t *a, int a_stride, const uint16_t *b, int b_stride,
                               int w, int h, uint32_t *sse);
+    int eb_av1_haar_ac_sad_8x8_uint8_input_avx2(uint8_t *input, int stride, int hbd);
 
 #if RESTRUCTURE_SAD
 #endif

--- a/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Encoder/Codec/aom_dsp_rtcd.h
@@ -140,18 +140,11 @@ extern "C" {
     RTCD_EXTERN void(*eb_av1_fwd_txfm2d_4x4)(int16_t *input, int32_t *output, uint32_t input_stride, TxType transform_type, uint8_t  bit_depth);
 #if TPL_LA
 #if TPL_C_FIX
-    void svt_av1_lowbd_fwd_txfm_c(int16_t *src_diff, TranLow *coeff, int diff_stride, TxfmParam *txfm_param);
-    RTCD_EXTERN void(*svt_av1_lowbd_fwd_txfm)(int16_t *src_diff, TranLow *coeff, int diff_stride, TxfmParam *txfm_param);
     int svt_aom_satd_c(const TranLow *coeff, int length);
     RTCD_EXTERN int(*svt_aom_satd)(const TranLow *coeff, int length);
     int64_t svt_av1_block_error_c(const TranLow *coeff, const TranLow *dqcoeff, intptr_t block_size, int64_t *ssz);
     RTCD_EXTERN int64_t(*svt_av1_block_error)(const TranLow *coeff, const TranLow *dqcoeff, intptr_t block_size, int64_t *ssz);
 #else
-    void svt_av1_lowbd_fwd_txfm_c(int16_t *src_diff, TranLow *coeff, int diff_stride, TxfmParam *txfm_param);
-    //void av1_lowbd_fwd_txfm_sse2(const int16_t *src_diff, TranLow *coeff, int diff_stride, TxfmParam *txfm_param);
-    //void av1_lowbd_fwd_txfm_sse4_1(const int16_t *src_diff, TranLow *coeff, int diff_stride, TxfmParam *txfm_param);
-    //void av1_lowbd_fwd_txfm_avx2(const int16_t *src_diff, TranLow *coeff, int diff_stride, TxfmParam *txfm_param);
-    RTCD_EXTERN void(*svt_av1_lowbd_fwd_txfm)(int16_t *src_diff, TranLow *coeff, int diff_stride, TxfmParam *txfm_param);
     int svt_aom_satd_c(const TranLow *coeff, int length);
     int svt_aom_satd_avx2(const TranLow *coeff, int length);
     RTCD_EXTERN int (*svt_aom_satd)(const TranLow *coeff, int length);

--- a/Source/Lib/Encoder/Codec/dwt.c
+++ b/Source/Lib/Encoder/Codec/dwt.c
@@ -149,7 +149,7 @@ uint32_t av1_variance(uint8_t *input, int bw, int bh, int stride) {
   return sse - (uint32_t)(((int64_t)sum * sum) / (bw * bh));
 }
 
-int av1_haar_ac_sad_8x8_uint8_input(uint8_t *input, int stride, int hbd) {
+int eb_av1_haar_ac_sad_8x8_uint8_input_c(uint8_t *input, int stride, int hbd) {
   tran_low_t output[64];
 
   av1_fdwt8x8_uint8_input_c(input, output, stride, hbd);

--- a/Source/Lib/Encoder/Codec/dwt.c
+++ b/Source/Lib/Encoder/Codec/dwt.c
@@ -111,12 +111,12 @@ static void dyadic_analyze_53_uint8_input(int levels, int width, int height,
   }
 }
 
-void av1_fdwt8x8_uint8_input_c(uint8_t *input, tran_low_t *output, int stride,
+void eb_av1_fdwt8x8_uint8_input_c(uint8_t *input, tran_low_t *output, int stride,
                                int hbd) {
   dyadic_analyze_53_uint8_input(4, 8, 8, input, stride, output, 8, 2, hbd);
 }
 
-int av1_haar_ac_sad(tran_low_t *output, int bw, int bh, int stride) {
+int eb_av1_haar_ac_sad(tran_low_t *output, int bw, int bh, int stride) {
   int acsad = 0;
 
   for (int r = 0; r < bh; ++r)
@@ -126,7 +126,7 @@ int av1_haar_ac_sad(tran_low_t *output, int bw, int bh, int stride) {
   return acsad;
 }
 
-uint64_t av1_dct_ac_sad(tran_low_t *output, int bw, int bh, int stride) {
+uint64_t eb_av1_dct_ac_sad(tran_low_t *output, int bw, int bh, int stride) {
   uint64_t acsad = 0;
 
   for (int r = 0; r < bh; ++r)
@@ -137,7 +137,7 @@ uint64_t av1_dct_ac_sad(tran_low_t *output, int bw, int bh, int stride) {
   return acsad;
 }
 
-uint32_t av1_variance(uint8_t *input, int bw, int bh, int stride) {
+uint32_t eb_av1_variance(uint8_t *input, int bw, int bh, int stride) {
   int sum = 0;
   uint32_t sse = 0;
 
@@ -152,7 +152,7 @@ uint32_t av1_variance(uint8_t *input, int bw, int bh, int stride) {
 int eb_av1_haar_ac_sad_8x8_uint8_input_c(uint8_t *input, int stride, int hbd) {
   tran_low_t output[64];
 
-  av1_fdwt8x8_uint8_input_c(input, output, stride, hbd);
-  return av1_haar_ac_sad(output, 8, 8, 8);
+  eb_av1_fdwt8x8_uint8_input_c(input, output, stride, hbd);
+  return eb_av1_haar_ac_sad(output, 8, 8, 8);
 }
 #endif

--- a/Source/Lib/Encoder/Codec/dwt.h
+++ b/Source/Lib/Encoder/Codec/dwt.h
@@ -25,6 +25,5 @@ typedef int32_t tran_low_t;
 void av1_fdwt8x8(tran_low_t *input, tran_low_t *output, int stride);
 void av1_fdwt8x8_uint8_input_c(uint8_t *input, tran_low_t *output, int stride,
                                int hbd);
-int av1_haar_ac_sad_8x8_uint8_input(uint8_t *input, int stride, int hbd);
 #endif
 #endif  // AOM_AV1_ENCODER_DWT_H_

--- a/Source/Lib/Encoder/Codec/dwt.h
+++ b/Source/Lib/Encoder/Codec/dwt.h
@@ -23,7 +23,7 @@
 typedef int64_t tran_high_t;
 typedef int32_t tran_low_t;
 void av1_fdwt8x8(tran_low_t *input, tran_low_t *output, int stride);
-void av1_fdwt8x8_uint8_input_c(uint8_t *input, tran_low_t *output, int stride,
+void eb_av1_fdwt8x8_uint8_input_c(uint8_t *input, tran_low_t *output, int stride,
                                int hbd);
 #endif
 #endif  // AOM_AV1_ENCODER_DWT_H_

--- a/Source/Lib/Encoder/Codec/firstpass.c
+++ b/Source/Lib/Encoder/Codec/firstpass.c
@@ -739,7 +739,7 @@ static int firstpass_intra_prediction(PictureControlSet *pcs_ptr,
         uint16_t *buf = &((uint16_t *)input_picture_ptr->buffer_y)[input_origin_index];
         for (int r8 = 0; r8 < 2; ++r8) {
             for (int c8 = 0; c8 < 2; ++c8) {
-                stats->frame_avg_wavelet_energy += av1_haar_ac_sad_8x8_uint8_input(
+                stats->frame_avg_wavelet_energy += eb_av1_haar_ac_sad_8x8_uint8_input(
                     CONVERT_TO_BYTEPTR(buf) + c8 * 8 + r8 * 8 * stride, stride, hbd);
             }
         }
@@ -748,7 +748,7 @@ static int firstpass_intra_prediction(PictureControlSet *pcs_ptr,
         for (int r8 = 0; r8 < 2; ++r8) {
             for (int c8 = 0; c8 < 2; ++c8) {
                 stats->frame_avg_wavelet_energy +=
-                    av1_haar_ac_sad_8x8_uint8_input(buf + c8 * 8 + r8 * 8 * stride, stride, hbd);
+                    eb_av1_haar_ac_sad_8x8_uint8_input(buf + c8 * 8 + r8 * 8 * stride, stride, hbd);
             }
         }
     }

--- a/test/dwt_test.cc
+++ b/test/dwt_test.cc
@@ -1,0 +1,79 @@
+/*
+ * Copyright(c) 2020 Intel Corporation
+ *
+ * This source code is subject to the terms of the BSD 2 Clause License and
+ * the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+ * was not distributed with this source code in the LICENSE file, you can
+ * obtain it at https://www.aomedia.org/license/software-license. If the
+ * Alliance for Open Media Patent License 1.0 was not distributed with this
+ * source code in the PATENTS file, you can obtain it at
+ * https://www.aomedia.org/license/patent-license.
+ */
+
+#include <sstream>
+#include "gtest/gtest.h"
+#include "random.h"
+#include "aom_dsp_rtcd.h"
+
+namespace {
+
+using svt_av1_test_tool::SVTRandom;
+
+static const int block_size = 8 * 8;
+static const int test_times = 10000;
+
+static const uint16_t* prepare_data_8x8_10b(uint16_t* data, SVTRandom* rnd) {
+    for (size_t i = 0; i < block_size; i++) {
+        data[i] = (uint16_t)rnd->random();
+    }
+    return data;
+}
+
+static const uint8_t* prepare_data_8x8(uint8_t* data, SVTRandom* rnd) {
+    for (size_t i = 0; i < block_size; i++) {
+        data[i] = (uint8_t)rnd->random();
+    }
+    return data;
+}
+TEST(haar_ac_sad_8x8_uint8_input_test, 8bit) {
+    SVTRandom rnd = SVTRandom(8, false);
+
+    uint8_t input_data[block_size];
+
+    for (int i = 0; i < test_times; i++) {
+        prepare_data_8x8(input_data, &rnd);
+
+        int output_tst = eb_av1_haar_ac_sad_8x8_uint8_input_avx2(input_data, 8, 0);
+        int output_c_ref = eb_av1_haar_ac_sad_8x8_uint8_input_c(input_data, 8, 0);
+
+        // compare results
+        ASSERT_EQ(output_tst, output_c_ref)
+            << "test"
+            << "[" << i << "] "
+            << "compute av1_haar_ac_sad_8x8_uint8_input_avx2 failed!\n";
+    }
+}
+
+TEST(haar_ac_sad_8x8_uint8_input_test, 10bit) {
+    SVTRandom rnd = SVTRandom(10, false);
+
+    uint16_t input_data[block_size];
+
+    for (int i = 0; i < test_times; i++) {
+        prepare_data_8x8_10b(input_data, &rnd);
+
+        uint8_t* inp_8bit_ptr = CONVERT_TO_BYTEPTR(input_data);
+
+        int output_tst =
+            eb_av1_haar_ac_sad_8x8_uint8_input_avx2(inp_8bit_ptr, 8, 1);
+        int output_c_ref =
+            eb_av1_haar_ac_sad_8x8_uint8_input_c(inp_8bit_ptr, 8, 1);
+
+        // compare results
+        ASSERT_EQ(output_tst, output_c_ref)
+            << "test"
+            << "[" << i << "] "
+            << "compute av1_haar_ac_sad_8x8_uint8_input_avx2 failed!\n";
+    }
+}
+}  // namespace


### PR DESCRIPTION
# Description

1. Speedup kernel  av1_haar_ac_sad_8x8_uint8_input_c by implementation its SIMD version
    Estimated speedup ~5.2x faster than C implementation

2. Cleanup  svt_av1_lowbd_fwd_txfm_c in order to avoid confusion

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
@tszumski 

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [x] speed
- [ ] 8 bit
- [ ] 10 bit
- [ ] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [ ] N/A

# Merge method
- [x] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [ ] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
