### PR TITLE
2passes memory interface

### DIFF
--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -221,8 +221,8 @@ typedef struct EbSvtAv1EncConfiguration {
     *
     * Default is 0.*/
     EbBool use_qp_file;
-    /* Input stats file */
-    FILE *input_stat_file;
+    /* input buffer for the second pass */
+    SvtAv1FixedBuf rc_twopass_stats_in;
     /* output stats file */
     FILE *output_stat_file;
     /* Enable picture QP scaling between hierarchical levels

--- a/Source/API/EbSvtAv1Enc.h
+++ b/Source/API/EbSvtAv1Enc.h
@@ -63,6 +63,15 @@ typedef enum {
     SUPERRES_MODES
 } SUPERRES_MODE;
 
+/*!\brief Generic fixed size buffer structure
+ *
+ * This structure is able to hold a reference to any fixed size buffer.
+ */
+typedef struct SvtAv1FixedBuf {
+    void *buf;       /**< Pointer to the data. Does NOT own the data! */
+    uint64_t sz;       /**< Length of the buffer, in chars */
+} SvtAv1FixedBuf; /**< alias for struct aom_fixed_buf */
+
 // Will contain the EbEncApi which will live in the EncHandle class
 // Only modifiable during config-time.
 typedef struct EbSvtAv1EncConfiguration {

--- a/Source/App/EncApp/EbAppConfig.c
+++ b/Source/App/EncApp/EbAppConfig.c
@@ -1686,6 +1686,8 @@ void eb_config_dtor(EbConfig *config_ptr) {
         config_ptr->stat_file = (FILE *)NULL;
     }
     if (config_ptr->input_stat_file) {
+        free(config_ptr->rc_twopass_stats_in.buf);
+        config_ptr->rc_twopass_stats_in.buf = NULL;
         unlock_and_fclose(config_ptr->input_stat_file);
         config_ptr->input_stat_file = (FILE *)NULL;
     }
@@ -1887,6 +1889,32 @@ static int32_t read_config_file(EbConfig *config, char *config_path, uint32_t in
     return return_error;
 }
 
+/* get config->rc_twopass_stats_in from config->input_stat_file */
+EbBool load_twopass_stats_in(EbConfig *config)
+{
+#ifdef _WIN32
+    int fd = _fileno(config->input_stat_file);
+    struct _stat file_stat;
+    int ret = _fstat(fd, &file_stat);
+#else
+    int fd = fileno(config->input_stat_file);
+    struct stat file_stat;
+    int ret = fstat(fd, &file_stat);
+#endif
+    if (ret) {
+        return EB_FALSE;
+    }
+    config->rc_twopass_stats_in.buf = malloc(file_stat.st_size);
+    if (config->rc_twopass_stats_in.buf) {
+        config->rc_twopass_stats_in.sz = (uint64_t)file_stat.st_size;
+        if (fread(config->rc_twopass_stats_in.buf, 1, file_stat.st_size,
+            config->input_stat_file) != (size_t)file_stat.st_size) {
+            return EB_FALSE;
+        }
+    }
+    return config->rc_twopass_stats_in.buf != NULL;
+}
+
 /******************************************
 * Verify Settings
 ******************************************/
@@ -2007,6 +2035,12 @@ static EbErrorType verify_settings(EbConfig *config, uint32_t channel_number) {
         if (!fopen_and_lock(&config->input_stat_file, stats, EB_FALSE)) {
             fprintf(config->error_log_file,
                 "Error instance %u: can't read stats file %s for read\n",
+                channel_number + 1, stats);
+            return EB_ErrorBadParameter;
+        }
+        if (!load_twopass_stats_in(config)) {
+            fprintf(config->error_log_file,
+                "Error instance %u: can't load file %s\n",
                 channel_number + 1, stats);
             return EB_ErrorBadParameter;
         }

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -176,6 +176,7 @@ typedef struct EbConfig {
     const char*   stats;
     FILE *        input_stat_file;
     FILE *        output_stat_file;
+    EbBool        rc_firstpass_stats_out;
     SvtAv1FixedBuf rc_twopass_stats_in;
 
     FILE *        input_pred_struct_file;
@@ -501,6 +502,10 @@ typedef struct EbConfig {
     int                 mrp_level;
 } EbConfig;
 
+typedef struct EncApp {
+    SvtAv1FixedBuf rc_twopasses_stats;
+} EncApp;
+
 #if TWOPASS_RC
 extern void eb_2pass_config_update(EbConfig *config_ptr);
 #endif
@@ -513,5 +518,6 @@ extern EbErrorType read_command_line(int32_t argc, char *const argv[], EbConfig 
 extern uint32_t    get_help(int32_t argc, char *const argv[]);
 extern uint32_t    get_number_of_channels(int32_t argc, char *const argv[]);
 uint32_t get_passes(int32_t argc, char *const argv[], EncodePass pass[]);
-
+EbErrorType set_two_passes_stats(EbConfig *config, EncodePass pass,
+    const SvtAv1FixedBuf* rc_twopass_stats_in, uint32_t channel_number);
 #endif //EbAppConfig_h

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -180,7 +180,6 @@ typedef struct EbConfig {
 
     FILE *        input_pred_struct_file;
     char *        input_pred_struct_filename;
-    EbBool        use_output_stat_file;
     EbBool        y4m_input;
     unsigned char y4m_buf[9];
     EbBool        use_qp_file;

--- a/Source/App/EncApp/EbAppConfig.h
+++ b/Source/App/EncApp/EbAppConfig.h
@@ -176,10 +176,10 @@ typedef struct EbConfig {
     const char*   stats;
     FILE *        input_stat_file;
     FILE *        output_stat_file;
+    SvtAv1FixedBuf rc_twopass_stats_in;
 
     FILE *        input_pred_struct_file;
     char *        input_pred_struct_filename;
-    EbBool        use_input_stat_file;
     EbBool        use_output_stat_file;
     EbBool        y4m_input;
     unsigned char y4m_buf[9];

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -118,7 +118,7 @@ EbErrorType copy_configuration_parameters(EbConfig *config, EbAppContext *callba
         (EbBool)config->enable_adaptive_quantization;
     callback_data->eb_enc_parameters.qp                   = config->qp;
     callback_data->eb_enc_parameters.use_qp_file          = (EbBool)config->use_qp_file;
-    callback_data->eb_enc_parameters.input_stat_file      = config->input_stat_file;
+    callback_data->eb_enc_parameters.rc_twopass_stats_in  = config->rc_twopass_stats_in;
     callback_data->eb_enc_parameters.output_stat_file     = config->output_stat_file;
     callback_data->eb_enc_parameters.stat_report          = (EbBool)config->stat_report;
     callback_data->eb_enc_parameters.disable_dlf_flag     = (EbBool)config->disable_dlf_flag;

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -119,7 +119,7 @@ EbErrorType copy_configuration_parameters(EbConfig *config, EbAppContext *callba
     callback_data->eb_enc_parameters.qp                   = config->qp;
     callback_data->eb_enc_parameters.use_qp_file          = (EbBool)config->use_qp_file;
     callback_data->eb_enc_parameters.rc_twopass_stats_in  = config->rc_twopass_stats_in;
-    callback_data->eb_enc_parameters.output_stat_file     = config->output_stat_file;
+    callback_data->eb_enc_parameters.rc_firstpass_stats_out     = !!config->output_stat_file;
     callback_data->eb_enc_parameters.stat_report          = (EbBool)config->stat_report;
     callback_data->eb_enc_parameters.disable_dlf_flag     = (EbBool)config->disable_dlf_flag;
     callback_data->eb_enc_parameters.enable_warped_motion = config->enable_warped_motion;

--- a/Source/App/EncApp/EbAppContext.c
+++ b/Source/App/EncApp/EbAppContext.c
@@ -119,7 +119,7 @@ EbErrorType copy_configuration_parameters(EbConfig *config, EbAppContext *callba
     callback_data->eb_enc_parameters.qp                   = config->qp;
     callback_data->eb_enc_parameters.use_qp_file          = (EbBool)config->use_qp_file;
     callback_data->eb_enc_parameters.rc_twopass_stats_in  = config->rc_twopass_stats_in;
-    callback_data->eb_enc_parameters.rc_firstpass_stats_out     = !!config->output_stat_file;
+    callback_data->eb_enc_parameters.rc_firstpass_stats_out = config->rc_firstpass_stats_out;
     callback_data->eb_enc_parameters.stat_report          = (EbBool)config->stat_report;
     callback_data->eb_enc_parameters.disable_dlf_flag     = (EbBool)config->disable_dlf_flag;
     callback_data->eb_enc_parameters.enable_warped_motion = config->enable_warped_motion;

--- a/Source/App/EncApp/EbAppProcessCmd.c
+++ b/Source/App/EncApp/EbAppProcessCmd.c
@@ -1161,6 +1161,19 @@ AppExitConditionType process_output_stream_buffer(EbConfig *config, EbAppContext
             // Release the output buffer
             svt_av1_enc_release_out_buffer(&header_ptr);
 
+            if (header_ptr->flags & EB_BUFFERFLAG_EOS) {
+                if (config->output_stat_file) {
+                    SvtAv1FixedBuf first_pass_stat;
+                    EbErrorType ret = svt_av1_enc_get_stream_info(component_handle,
+                        SVT_AV1_STREAM_INFO_FIRST_PASS_STATS_OUT, &first_pass_stat);
+                    if (ret == EB_ErrorNone) {
+                        fwrite(first_pass_stat.buf,
+                            1, first_pass_stat.sz, config->output_stat_file);
+                    }
+                }
+
+            }
+
             ++*frame_count;
             const double fps = (double)*frame_count / config->performance_context.total_encode_time;
             const double frame_rate = config->frame_rate_numerator && config->frame_rate_denominator

--- a/Source/Lib/Common/Codec/EbMalloc.h
+++ b/Source/Lib/Common/Codec/EbMalloc.h
@@ -107,6 +107,17 @@ void eb_remove_mem_entry(void* ptr, EbPtrType type);
 #define EB_MALLOC_ARRAY(pa, count) \
     do { EB_MALLOC(pa, sizeof(*(pa)) * (count)); } while (0)
 
+#define EB_REALLOC_ARRAY(pa, count)             \
+    do {                                        \
+        size_t size = sizeof(*(pa)) * (count);  \
+        void* p = realloc(pa, size);            \
+        if (p) {                                \
+            EB_REMOVE_MEM_ENTRY(pa, EB_N_PTR);  \
+        }                                       \
+        EB_ADD_MEM(p, size, EB_N_PTR);          \
+        pa = p;                                 \
+    } while (0)
+
 #define EB_CALLOC_ARRAY(pa, count) \
     do { EB_CALLOC(pa, count, sizeof(*(pa))); } while (0)
 

--- a/Source/Lib/Encoder/Codec/EbCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbCodingLoop.c
@@ -3609,7 +3609,7 @@ EB_EXTERN void av1_encode_decode(SequenceControlSet *scs_ptr, PictureControlSet 
 
                                 // CBF Tu decision
 #if FIRST_PASS_SETUP
-                                if (scs_ptr->use_output_stat_file) {
+                                if (use_output_stat(scs_ptr)) {
                                     context_ptr->md_context
                                         ->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds]
                                         .y_has_coeff[context_ptr->txb_itr] =
@@ -4105,7 +4105,7 @@ EB_EXTERN void av1_encode_decode(SequenceControlSet *scs_ptr, PictureControlSet 
                         is_16bit);
 #if !TWOPASS_RC
                     // Collect the referenced area per 64x64
-                    if (scs_ptr->use_output_stat_file) {
+                    if (use_output_stat(scs_ptr)) {
                         if (context_ptr->md_context->md_local_blk_unit[context_ptr->blk_geom->blkidx_mds].ref_frame_index_l0 >= 0) {
                             eb_block_on_mutex(ref_obj_0->referenced_area_mutex);
                             if (context_ptr->mv_unit.pred_direction == UNI_PRED_LIST_0 ||

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -12032,7 +12032,7 @@ void *mode_decision_kernel(void *input_ptr) {
 #else
                     // Encode Pass
 #if FPFOPT_NO_EP
-                    if(scs_ptr->use_output_stat_file==EB_FALSE)
+                    if(!use_output_stat(scs_ptr))
 #endif
                     av1_encode_decode(
                         scs_ptr, pcs_ptr, sb_ptr, sb_index, sb_origin_x, sb_origin_y, context_ptr);

--- a/Source/Lib/Encoder/Codec/EbEncDecProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEncDecProcess.c
@@ -11282,7 +11282,7 @@ static void build_starting_cand_block_array(SequenceControlSet *scs_ptr, Picture
     while (blk_index < scs_ptr->max_block_cnt) {
         const BlockGeom *blk_geom = get_blk_geom_mds(blk_index);
 #if FIRST_PASS_SETUP
-        if (scs_ptr->use_output_stat_file && blk_geom->bheight >= FORCED_BLK_SIZE && blk_geom->bwidth >= FORCED_BLK_SIZE) {
+        if (use_output_stat(scs_ptr) && blk_geom->bheight >= FORCED_BLK_SIZE && blk_geom->bwidth >= FORCED_BLK_SIZE) {
             force_blk_size = FORCED_BLK_SIZE;
             if (blk_geom->bheight == FORCED_BLK_SIZE && blk_geom->bwidth == FORCED_BLK_SIZE &&
                 !pcs_ptr->parent_pcs_ptr->sb_geom[sb_index].block_is_inside_md_scan[blk_index]) {
@@ -11358,7 +11358,7 @@ static void build_starting_cand_block_array(SequenceControlSet *scs_ptr, Picture
                     results_ptr->leaf_data_array[results_ptr->leaf_count].tot_d1_blocks = tot_d1_blocks;
 
 #if FIRST_PASS_SETUP
-                    if (scs_ptr->use_output_stat_file) {
+                    if (use_output_stat(scs_ptr)) {
                         if (blk_geom->sq_size == force_blk_size)
                             results_ptr->leaf_data_array[results_ptr->leaf_count++].split_flag = EB_FALSE;
                     }
@@ -11594,7 +11594,7 @@ void *mode_decision_kernel(void *input_ptr) {
                     sb_index = (uint16_t)((y_sb_index + tile_group_y_sb_start) * pic_width_in_sb +
                                           x_sb_index + tile_group_x_sb_start);
 #if FIRST_PASS_SETUP
-                    if (scs_ptr->use_output_stat_file && sb_index == 0)
+                    if (use_output_stat(scs_ptr) && sb_index == 0)
                         setup_firstpass_data(pcs_ptr->parent_pcs_ptr);
 #endif
 #if M8_4x4
@@ -11970,7 +11970,7 @@ void *mode_decision_kernel(void *input_ptr) {
                     // [PD_PASS_2] Signal(s) derivation
                     context_ptr->md_context->pd_pass = PD_PASS_2;
 #if FIRST_PASS_SETUP
-                    if (scs_ptr->use_output_stat_file)
+                    if (use_output_stat(scs_ptr))
                         first_pass_signal_derivation_enc_dec_kernel(pcs_ptr, context_ptr->md_context);
                     else
 #if UNIFY_LEVELS
@@ -12119,7 +12119,7 @@ void *mode_decision_kernel(void *input_ptr) {
             pcs_ptr->parent_pcs_ptr->av1x->rdmult = context_ptr->full_lambda;
 #endif
 #if FIRST_PASS_SETUP
-            if (scs_ptr->use_output_stat_file) {
+            if (use_output_stat(scs_ptr)) {
                 first_pass_frame_end(pcs_ptr->parent_pcs_ptr, pcs_ptr->parent_pcs_ptr->ts_duration);
                 if(pcs_ptr->parent_pcs_ptr->end_of_sequence_flag)
                     svt_av1_end_first_pass(pcs_ptr->parent_pcs_ptr);

--- a/Source/Lib/Encoder/Codec/EbEncodeContext.c
+++ b/Source/Lib/Encoder/Codec/EbEncodeContext.c
@@ -80,6 +80,7 @@ static void encode_context_dctor(EbPtr p) {
     EB_DELETE_PTR_ARRAY(obj->packetization_reorder_queue, PACKETIZATION_REORDER_QUEUE_MAX_DEPTH);
     EB_FREE_ARRAY(obj->rate_control_tables_array);
 #if TWOPASS_RC
+    EB_FREE(obj->stats_out.stat);
     destroy_stats_buffer(&obj->stats_buf_context, obj->frame_stats_buffer);
 #endif
 }

--- a/Source/Lib/Encoder/Codec/EbEncodeContext.c
+++ b/Source/Lib/Encoder/Codec/EbEncodeContext.c
@@ -81,7 +81,6 @@ static void encode_context_dctor(EbPtr p) {
     EB_FREE_ARRAY(obj->rate_control_tables_array);
 #if TWOPASS_RC
     destroy_stats_buffer(&obj->stats_buf_context, obj->frame_stats_buffer);
-    free(obj->rc_twopass_stats_in.buf);
 #endif
 }
 

--- a/Source/Lib/Encoder/Codec/EbEncodeContext.h
+++ b/Source/Lib/Encoder/Codec/EbEncodeContext.h
@@ -49,16 +49,6 @@
 #define PARALLEL_GOP_MAX_NUMBER 256
 #define RC_GROUP_IN_GOP_MAX_NUMBER 512
 #define PICTURE_IN_RC_GROUP_MAX_NUMBER 64
-#if TWOPASS_RC
-/*!\brief Generic fixed size buffer structure
- *
- * This structure is able to hold a reference to any fixed size buffer.
- */
-typedef struct aom_fixed_buf {
-    void *buf;       /**< Pointer to the data. Does NOT own the data! */
-    size_t sz;       /**< Length of the buffer, in chars */
-} aom_fixed_buf_t; /**< alias for struct aom_fixed_buf */
-#endif
 
 typedef struct DpbDependentList
 {
@@ -218,7 +208,7 @@ typedef struct EncodeContext {
     // Number of stats buffers required for look ahead
     int num_lap_buffers;
     STATS_BUFFER_CTX stats_buf_context;
-    aom_fixed_buf_t rc_twopass_stats_in; // replaced oxcf->two_pass_cfg.stats_in in aom
+    SvtAv1FixedBuf rc_twopass_stats_in; // replaced oxcf->two_pass_cfg.stats_in in aom
 #endif
 } EncodeContext;
 

--- a/Source/Lib/Encoder/Codec/EbEncodeContext.h
+++ b/Source/Lib/Encoder/Codec/EbEncodeContext.h
@@ -68,6 +68,13 @@ typedef struct DPBInfo {
     DpbDependentList dep_list0;
     DpbDependentList dep_list1;
 } DPBInfo;
+
+typedef struct FirstPassStatsOut {
+    FIRSTPASS_STATS* stat;
+    size_t size;
+    size_t capability;
+} FirstPassStatsOut;
+
 typedef struct EncodeContext {
     EbDctor dctor;
     // Callback Functions
@@ -178,7 +185,9 @@ typedef struct EncodeContext {
     EbObjectWrapper *previous_picture_control_set_wrapper_ptr;
     EbHandle         shared_reference_mutex;
     uint64_t picture_number_alt; // The picture number overlay includes all the overlay frames
+
     EbHandle stat_file_mutex;
+
     //DPB list management
     DPBInfo dpb_list[REF_FRAMES];
     uint64_t display_picture_number;
@@ -209,6 +218,7 @@ typedef struct EncodeContext {
     int num_lap_buffers;
     STATS_BUFFER_CTX stats_buf_context;
     SvtAv1FixedBuf rc_twopass_stats_in; // replaced oxcf->two_pass_cfg.stats_in in aom
+    FirstPassStatsOut stats_out;
 #endif
 } EncodeContext;
 

--- a/Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c
@@ -407,7 +407,7 @@ void *entropy_coding_kernel(void *input_ptr) {
                 }
 
 #if TURN_OFF_EC_FIRST_PASS
-                if (!scs_ptr->use_output_stat_file){
+                if (!use_output_stat(scs_ptr)){
 #endif
                 for (uint32_t x_sb_index = 0; x_sb_index < tile_width_in_sb; ++x_sb_index) {
                     uint16_t    sb_index = (uint16_t)((x_sb_index + tile_sb_start_x) +
@@ -495,7 +495,7 @@ void *entropy_coding_kernel(void *input_ptr) {
 #if !TWOPASS_RC
                         //Jing, two pass doesn't work with multi-tile right now
                         // for Non Reference frames
-                        if (scs_ptr->use_output_stat_file && tile_cnt == 1 &&
+                        if (use_output_stat(scs_ptr) && tile_cnt == 1 &&
                             !pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag)
                             write_stat_to_file(scs_ptr,
                                                *pcs_ptr->parent_pcs_ptr->stat_struct_first_pass_ptr,
@@ -507,7 +507,7 @@ void *entropy_coding_kernel(void *input_ptr) {
                                  ref_idx < pcs_ptr->parent_pcs_ptr->ref_list0_count;
                                  ++ref_idx) {
 #if !TWOPASS_RC
-                                if (scs_ptr->use_output_stat_file && tile_cnt == 1 &&
+                                if (use_output_stat(scs_ptr) && tile_cnt == 1 &&
 #if PASS1_FIX
                                     pcs_ptr->ref_pic_ptr_array[0][ref_idx] != NULL)
 #else
@@ -533,7 +533,7 @@ void *entropy_coding_kernel(void *input_ptr) {
                                  ref_idx < pcs_ptr->parent_pcs_ptr->ref_list1_count;
                                  ++ref_idx) {
 #if !TWOPASS_RC
-                                if (scs_ptr->use_output_stat_file && tile_cnt == 1 &&
+                                if (use_output_stat(scs_ptr) && tile_cnt == 1 &&
 #if PASS1_FIX
                                     pcs_ptr->ref_pic_ptr_array[1][ref_idx] != NULL)
 #else

--- a/Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c
+++ b/Source/Lib/Encoder/Codec/EbEntropyCodingProcess.c
@@ -310,6 +310,8 @@ static EbBool update_entropy_coding_rows(PictureControlSet *pcs_ptr, uint32_t *r
 
     return process_next_row;
 }
+
+#if !TWOPASS_RC
 /******************************************************
  * Write Stat to File
  * write stat_struct per frame in the first pass
@@ -322,6 +324,7 @@ void write_stat_to_file(SequenceControlSet *scs_ptr, StatStruct stat_struct, uin
     fwrite(&stat_struct, sizeof(StatStruct), (size_t)1, scs_ptr->static_config.output_stat_file);
     eb_release_mutex(scs_ptr->encode_context_ptr->stat_file_mutex);
 }
+#endif
 
 /* Entropy Coding */
 

--- a/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
+++ b/Source/Lib/Encoder/Codec/EbInitialRateControlProcess.c
@@ -2170,7 +2170,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                 pcs_ptr->stat_struct_first_pass_ptr =
                     pcs_ptr->is_used_as_reference_flag ? &((EbReferenceObject *)pcs_ptr->reference_picture_wrapper_ptr->object_ptr)->stat_struct
                     : &pcs_ptr->stat_struct;
-                if (scs_ptr->use_output_stat_file)
+                if (use_output_stat(scs_ptr))
                     memset(pcs_ptr->stat_struct_first_pass_ptr, 0, sizeof(StatStruct));
 #endif
 
@@ -2198,7 +2198,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                     encode_context_ptr, pcs_ptr, in_results_ptr);
 
 #if TWOPASS_RC
-            if (scs_ptr->use_input_stat_file && scs_ptr->static_config.rate_control_mode == 1)
+            if (use_input_stat(scs_ptr) && scs_ptr->static_config.rate_control_mode == 1)
                 ; //skip 2pass VBR
             else
 #endif
@@ -2320,7 +2320,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                             pcs_ptr->end_of_sequence_region = EB_FALSE;
 
 #if TWOPASS_RC
-                        if (scs_ptr->use_input_stat_file && scs_ptr->static_config.rate_control_mode == 1)
+                        if (use_input_stat(scs_ptr) && scs_ptr->static_config.rate_control_mode == 1)
                             ; //skip 2pass VBR
                         else
 #endif
@@ -2387,7 +2387,7 @@ void *initial_rate_control_kernel(void *input_ptr) {
                                         pcs_ptr->reference_picture_wrapper_ptr->object_ptr)
                                        ->stat_struct
                                 : &pcs_ptr->stat_struct;
-                        if (scs_ptr->use_output_stat_file)
+                        if (use_output_stat(scs_ptr))
                             memset(pcs_ptr->stat_struct_first_pass_ptr, 0, sizeof(StatStruct));
 #endif
 #if TPL_LA

--- a/Source/Lib/Encoder/Codec/EbModeDecision.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecision.c
@@ -5432,7 +5432,7 @@ void inject_inter_candidates(PictureControlSet *pcs_ptr, ModeDecisionContext *co
         pcs_ptr->parent_pcs_ptr->pa_me_data->me_results[context_ptr->me_sb_addr];
 #if FIRST_PASS_SETUP
     EbBool       allow_bipred =
-        (scs_ptr->use_output_stat_file || context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4)
+        (use_output_stat(scs_ptr) || context_ptr->blk_geom->bwidth == 4 || context_ptr->blk_geom->bheight == 4)
         ? EB_FALSE : EB_TRUE;
 #else
     EbBool allow_bipred = context_ptr->blk_geom->bwidth != 4 && context_ptr->blk_geom->bheight != 4;

--- a/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbModeDecisionConfigurationProcess.c
@@ -2029,7 +2029,7 @@ void *mode_decision_configuration_kernel(void *input_ptr) {
 
         // Mode Decision Configuration Kernel Signal(s) derivation
 #if FIRST_PASS_SETUP
-        if (scs_ptr->use_output_stat_file)
+        if (use_output_stat(scs_ptr))
             first_pass_signal_derivation_mode_decision_config_kernel(pcs_ptr, context_ptr);
         else
             signal_derivation_mode_decision_config_kernel_oq(scs_ptr, pcs_ptr, context_ptr);

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -112,7 +112,7 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
     UNUSED(scs_ptr);
 #if !REFACTOR_ME_HME
     uint8_t hme_me_level =
-        scs_ptr->use_output_stat_file ? pcs_ptr->snd_pass_enc_mode : pcs_ptr->enc_mode;
+        use_output_stat(scs_ptr) ? pcs_ptr->snd_pass_enc_mode : pcs_ptr->enc_mode;
 #endif
     // HME/ME default settings
     me_context_ptr->number_hme_search_region_in_width  = 2;
@@ -638,7 +638,7 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
 #endif
 #if FASTER_FIRST_PASS
     if (!pcs_ptr->sc_content_detected)
-        if (scs_ptr->use_output_stat_file) {
+        if (use_output_stat(scs_ptr)) {
             me_context_ptr->hme_level0_total_search_area_width = me_context_ptr->hme_level0_total_search_area_height  = me_context_ptr->hme_level0_total_search_area_width/2;
             me_context_ptr->hme_level0_max_total_search_area_width = me_context_ptr->hme_level0_max_total_search_area_height =   me_context_ptr->hme_level0_max_total_search_area_width/2;
         }
@@ -668,7 +668,7 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
         me_context_ptr->hme_level2_search_area_in_height_array[1] = 16;
 #if FASTER_FIRST_PASS
     if (!pcs_ptr->sc_content_detected)
-        if (scs_ptr->use_output_stat_file) {
+        if (use_output_stat(scs_ptr)) {
             me_context_ptr->hme_level1_search_area_in_width_array[0] =
                 me_context_ptr->hme_level1_search_area_in_width_array[1] =
                 me_context_ptr->hme_level1_search_area_in_height_array[0] =
@@ -907,12 +907,12 @@ EbErrorType signal_derivation_me_kernel_oq(SequenceControlSet *       scs_ptr,
 #if TWOPASS_RC
     EbEncMode enc_mode = pcs_ptr->enc_mode;
 #else
-    EbEncMode enc_mode = scs_ptr->use_output_stat_file ?
+    EbEncMode enc_mode = use_output_stat(scs_ptr) ?
         pcs_ptr->snd_pass_enc_mode : pcs_ptr->enc_mode;
 #endif
 #else
     uint8_t enc_mode =
-        scs_ptr->use_output_stat_file ? pcs_ptr->snd_pass_enc_mode : pcs_ptr->enc_mode;
+        use_output_stat(scs_ptr) ? pcs_ptr->snd_pass_enc_mode : pcs_ptr->enc_mode;
 #endif
 #if ON_OFF_FEATURE_MRP
     context_ptr->me_context_ptr->mrp_level = pcs_ptr->mrp_level;
@@ -922,7 +922,7 @@ EbErrorType signal_derivation_me_kernel_oq(SequenceControlSet *       scs_ptr,
     uint8_t sc_content_detected = pcs_ptr->sc_content_detected;
 #endif
 #if !REFACTOR_ME_HME
-    uint8_t  hme_me_level = scs_ptr->use_output_stat_file ?
+    uint8_t  hme_me_level = use_output_stat(scs_ptr) ?
         pcs_ptr->snd_pass_enc_mode : pcs_ptr->enc_mode;
 #endif
     // Set ME/HME search regions
@@ -1390,7 +1390,7 @@ void *tf_set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet
 #endif
 #if !REFACTOR_ME_HME || !MAR12_ADOPTIONS
     uint8_t hme_me_level =
-        scs_ptr->use_output_stat_file ? pcs_ptr->snd_pass_enc_mode : pcs_ptr->enc_mode;
+        use_output_stat(scs_ptr) ? pcs_ptr->snd_pass_enc_mode : pcs_ptr->enc_mode;
 #endif
     // HME/ME default settings
     me_context_ptr->number_hme_search_region_in_width  = 2;
@@ -1681,14 +1681,14 @@ EbErrorType tf_signal_derivation_me_kernel_oq(SequenceControlSet *       scs_ptr
     EbErrorType return_error = EB_ErrorNone;
 #if !UNIFY_SC_NSC
     uint8_t     enc_mode =
-        scs_ptr->use_output_stat_file ? pcs_ptr->snd_pass_enc_mode : pcs_ptr->enc_mode;
+        use_output_stat(scs_ptr) ? pcs_ptr->snd_pass_enc_mode : pcs_ptr->enc_mode;
 #endif
     EbInputResolution input_resolution = scs_ptr->input_resolution;
 #if !UNIFY_SC_NSC
     uint8_t sc_content_detected = pcs_ptr->sc_content_detected;
 #endif
 #if !REFACTOR_ME_HME ||  !MAR12_ADOPTIONS
-    uint8_t  hme_me_level = scs_ptr->use_output_stat_file ?
+    uint8_t  hme_me_level = use_output_stat(scs_ptr) ?
         pcs_ptr->snd_pass_enc_mode : pcs_ptr->enc_mode;
 #endif
     // Set ME/HME search regions
@@ -2178,7 +2178,7 @@ void *motion_estimation_kernel(void *input_ptr) {
         if (in_results_ptr->task_type == 0) {
             // ME Kernel Signal(s) derivation
 #if FIRST_PASS_SETUP
-            if (scs_ptr->use_output_stat_file)
+            if (use_output_stat(scs_ptr))
                 first_pass_signal_derivation_me_kernel(scs_ptr, pcs_ptr, context_ptr);
             else
                 signal_derivation_me_kernel_oq(scs_ptr, pcs_ptr, context_ptr);
@@ -2359,7 +2359,7 @@ void *motion_estimation_kernel(void *input_ptr) {
 #if FIRST_PASS_SETUP
             // ZZ SSDs Computation
             // 1 lookahead frame is needed to get valid (0,0) SAD
-            if (scs_ptr->use_output_stat_file && scs_ptr->static_config.look_ahead_distance != 0) {
+            if (use_output_stat(scs_ptr) && scs_ptr->static_config.look_ahead_distance != 0) {
                 // ZZ SSDs Computation using full picture
                 if (pcs_ptr->picture_number > 0) {
                     compute_zz_ssd(
@@ -2378,7 +2378,7 @@ void *motion_estimation_kernel(void *input_ptr) {
 
             if (scs_ptr->static_config.rate_control_mode
 #if TWOPASS_RC
-                && !(scs_ptr->use_input_stat_file && scs_ptr->static_config.rate_control_mode == 1) //skip 2pass VBR
+                && !(use_input_stat(scs_ptr) && scs_ptr->static_config.rate_control_mode == 1) //skip 2pass VBR
 #endif
                 ) {
                 if (pcs_ptr->slice_type != I_SLICE) {

--- a/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbMotionEstimationProcess.c
@@ -248,7 +248,7 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
             else if (pcs_ptr->enc_mode <= ENC_M7) {
 #endif
 #if FASTER_FIRST_PASS
-                if (scs_ptr->use_output_stat_file) {
+                if (use_output_stat(scs_ptr)) {
                     me_context_ptr->search_area_width = me_context_ptr->search_area_height = 37;
                     me_context_ptr->max_me_search_width = me_context_ptr->max_me_search_height = 175;
                 }
@@ -420,7 +420,7 @@ void *set_me_hme_params_oq(MeContext *me_context_ptr, PictureParentControlSet *p
 #endif
     else {
 #if FASTER_FIRST_PASS
-        if (scs_ptr->use_output_stat_file) {
+        if (use_output_stat(scs_ptr)) {
             me_context_ptr->search_area_width = me_context_ptr->search_area_height = 8;
             me_context_ptr->max_me_search_width = me_context_ptr->max_me_search_height = 8;
         }

--- a/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPacketizationProcess.c
@@ -88,7 +88,7 @@ EbErrorType packetization_context_ctor(EbThreadContext *  thread_context_ptr,
 
 void update_rc_rate_tables(PictureControlSet *pcs_ptr, SequenceControlSet *scs_ptr) {
 #if TWOPASS_RC
-    if (scs_ptr->use_input_stat_file && scs_ptr->static_config.rate_control_mode == 1)
+    if (use_input_stat(scs_ptr) && scs_ptr->static_config.rate_control_mode == 1)
         return; //skip update for 2pass VBR
 #endif
     // SB Loop
@@ -714,7 +714,7 @@ void *packetization_kernel(void *input_ptr) {
         rate_control_tasks_ptr->task_type       = RC_PACKETIZATION_FEEDBACK_RESULT;
 
 #if FORCE_DECODE_ORDER
-        if(scs_ptr->use_input_stat_file ||
+        if(use_input_stat(scs_ptr) ||
             (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&
             pcs_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr)) {
             if (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&
@@ -824,7 +824,7 @@ void *packetization_kernel(void *input_ptr) {
         // Post Rate Control Taks
         eb_post_full_object(rate_control_tasks_wrapper_ptr);
 #if FORCE_DECODE_ORDER
-        if (scs_ptr->use_input_stat_file || (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&
+        if (use_input_stat(scs_ptr) || (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&
             pcs_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr))
 #else
         if (pcs_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE &&

--- a/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureDecisionProcess.c
@@ -908,7 +908,7 @@ EbErrorType signal_derivation_multi_processes_oq(
     uint8_t sc_content_detected = pcs_ptr->sc_content_detected;
 #endif
 #if !REFACTOR_ME_HME
-    uint8_t enc_mode_hme = scs_ptr->use_output_stat_file ? pcs_ptr->snd_pass_enc_mode : pcs_ptr->enc_mode;
+    uint8_t enc_mode_hme = use_output_stat(scs_ptr) ? pcs_ptr->snd_pass_enc_mode : pcs_ptr->enc_mode;
 #endif
 #if REFACTOR_ME_HME
     // If enabled here, the hme enable flags should also be enabled in ResourceCoordinationProcess
@@ -6692,7 +6692,7 @@ void* picture_decision_kernel(void *input_ptr)
                                 // ME Kernel Multi-Processes Signal(s) derivation
 #if TF_LEVELS
 #if FIRST_PASS_SETUP
-                                if (scs_ptr->use_output_stat_file)
+                                if (use_output_stat(scs_ptr))
                                     first_pass_signal_derivation_multi_processes(scs_ptr, pcs_ptr, context_ptr);
                                 else
                                     signal_derivation_multi_processes_oq(scs_ptr, pcs_ptr, context_ptr);

--- a/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
+++ b/Source/Lib/Encoder/Codec/EbPictureManagerProcess.c
@@ -820,7 +820,7 @@ void *picture_manager_kernel(void *input_ptr) {
 
                     availability_flag = EB_TRUE;
 #if FORCE_DECODE_ORDER
-                    if (entry_pcs_ptr->decode_order != decode_order && scs_ptr->use_input_stat_file)
+                    if (entry_pcs_ptr->decode_order != decode_order && use_input_stat(scs_ptr))
                         availability_flag = EB_FALSE;
 #endif
 
@@ -1588,7 +1588,7 @@ void *picture_manager_kernel(void *input_ptr) {
                     (reference_entry_ptr->reference_object_ptr)) {
                     // Release the nominal live_count value
 #if !PASS1_FIX
-                    if (scs_ptr->use_output_stat_file &&
+                    if (use_output_stat(scs_ptr) &&
                         reference_entry_ptr->reference_object_ptr->live_count == 1)
                         write_stat_to_file(
                             scs_ptr,

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -10567,7 +10567,7 @@ void tx_type_search(PictureControlSet *pcs_ptr, ModeDecisionContext *context_ptr
 
         //LUMA-ONLY
 #if FPFOPT_ESTBITS
-        if (scs_ptr->use_output_stat_file)
+        if (use_output_stat(scs_ptr))
             y_txb_coeff_bits_txt[tx_type] = 0;
         else
 #endif
@@ -11302,7 +11302,7 @@ void first_pass_perform_tx_partitioning(ModeDecisionCandidateBuffer *candidate_b
         }
 #if TX_EARLY_EXIT
 #if TWOPASS_RC
-        if (!scs_ptr->use_output_stat_file)
+        if (!use_output_stat(scs_ptr->use_output_stat_file))
 #endif
             // Variance/cost_depth_1-to-cost_depth_0 based early txs exit
             if (context_ptr->source_variance < TXS_EXIT_VAR_TH && context_ptr->tx_depth == 2 && best_tx_depth == 0)

--- a/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
+++ b/Source/Lib/Encoder/Codec/EbProductCodingLoop.c
@@ -11585,7 +11585,7 @@ void perform_tx_partitioning(ModeDecisionCandidateBuffer *candidate_buffer,
         }
 #if TX_EARLY_EXIT
 #if TWOPASS_RC
-        if (!scs_ptr->use_output_stat_file)
+        if (!use_output_stat(scs_ptr))
 #endif
         // Variance/cost_depth_1-to-cost_depth_0 based early txs exit
         if (context_ptr->source_variance < TXS_EXIT_VAR_TH && context_ptr->tx_depth == 2 && best_tx_depth == 0)
@@ -16221,7 +16221,7 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
         uint16_t redundant_blk_mds;
 #if SWITCH_MODE_BASED_ON_SQ_COEFF || SWITCH_MODE_BASED_ON_STATISTICS
 #if TWOPASS_RC
-        if (!scs_ptr->use_output_stat_file) {
+        if (!use_output_stat(scs_ptr)) {
 #endif
         // Reset settings, in case they were over-written by previous block
         signal_derivation_enc_dec_kernel_oq(scs_ptr, pcs_ptr, context_ptr,0);
@@ -16432,7 +16432,7 @@ EB_EXTERN EbErrorType mode_decision_sb(SequenceControlSet *scs_ptr, PictureContr
                 }
 #endif
 #if FIRST_PASS_SETUP
-                if (scs_ptr->use_output_stat_file)
+                if (use_output_stat(scs_ptr))
                     first_pass_md_encode_block(pcs_ptr,
                         context_ptr,
                         input_picture_ptr,

--- a/Source/Lib/Encoder/Codec/EbRateDistortionCost.c
+++ b/Source/Lib/Encoder/Codec/EbRateDistortionCost.c
@@ -1682,7 +1682,7 @@ uint64_t av1_inter_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidat
         total_distortion += chromasad_;
 
         rate = luma_rate + chroma_rate;
-        if (pcs_ptr->parent_pcs_ptr->scs_ptr->use_output_stat_file) {
+        if (use_output_stat(pcs_ptr->parent_pcs_ptr->scs_ptr)) {
             two_pass_cost_update(pcs_ptr, candidate_ptr, &rate, &total_distortion);
         }
         if (candidate_ptr->merge_flag) {
@@ -1697,7 +1697,7 @@ uint64_t av1_inter_fast_cost(BlkStruct *blk_ptr, ModeDecisionCandidate *candidat
         total_distortion = luma_sad + chromasad_;
         if (blk_geom->has_uv == 0 && chromasad_ != 0) SVT_LOG("av1_inter_fast_cost: Chroma error");
         rate = luma_rate + chroma_rate;
-        if (pcs_ptr->parent_pcs_ptr->scs_ptr->use_output_stat_file) {
+        if (use_output_stat(pcs_ptr->parent_pcs_ptr->scs_ptr)) {
             two_pass_cost_update(pcs_ptr, candidate_ptr, &rate, &total_distortion);
         }
         // Assign fast cost
@@ -1958,7 +1958,7 @@ EbErrorType av1_full_cost(PictureControlSet *pcs_ptr, ModeDecisionContext *conte
 
     rate = luma_rate + chroma_rate + coeff_rate;
     if (candidate_buffer_ptr->candidate_ptr->block_has_coeff) rate += tx_size_bits;
-    if (pcs_ptr->parent_pcs_ptr->scs_ptr->use_output_stat_file &&
+    if (use_output_stat(pcs_ptr->parent_pcs_ptr->scs_ptr) &&
         candidate_buffer_ptr->candidate_ptr->type != INTRA_MODE) {
         two_pass_cost_update_64bit(
             pcs_ptr, candidate_buffer_ptr->candidate_ptr, &rate, &total_distortion);
@@ -2107,7 +2107,7 @@ EbErrorType av1_merge_skip_full_cost(PictureControlSet *pcs_ptr, ModeDecisionCon
     skip_distortion = skip_luma_sse + skip_chroma_sse;
     skip_rate       = skip_mode_rate;
     skip_cost       = RDCOST(lambda, skip_rate, skip_distortion);
-    if (pcs_ptr->parent_pcs_ptr->scs_ptr->use_output_stat_file) {
+    if (use_output_stat(pcs_ptr->parent_pcs_ptr->scs_ptr)) {
         MvReferenceFrame ref_type[2];
         av1_set_ref_frame(ref_type, candidate_buffer_ptr->candidate_ptr->ref_frame_type);
         if ((candidate_buffer_ptr->candidate_ptr->is_compound &&

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -149,7 +149,7 @@ EbErrorType signal_derivation_pre_analysis_oq(SequenceControlSet *     scs_ptr,
 
     // HME Flags updated @ signal_derivation_multi_processes_oq
     uint8_t hme_me_level =
-        scs_ptr->use_output_stat_file ? pcs_ptr->snd_pass_enc_mode : pcs_ptr->enc_mode;
+        use_output_stat(scs_ptr) ? pcs_ptr->snd_pass_enc_mode : pcs_ptr->enc_mode;
 #endif
     // Derive HME Flag
     if (scs_ptr->static_config.use_default_me_hme) {
@@ -747,7 +747,7 @@ static void setup_two_pass(SequenceControlSet *scs_ptr) {
 
     scs_ptr->twopass.stats_buf_ctx = &encode_context_ptr->stats_buf_context;
     scs_ptr->twopass.stats_in = scs_ptr->twopass.stats_buf_ctx->stats_in_start;
-    if (scs_ptr->use_input_stat_file) {
+    if (use_input_stat(scs_ptr)) {
         const size_t packet_sz = sizeof(FIRSTPASS_STATS);
         const int packets = (int)(encode_context_ptr->rc_twopass_stats_in.sz / packet_sz);
 
@@ -1278,7 +1278,7 @@ void *resource_coordination_kernel(void *input_ptr) {
             //  If the mode of the second pass is not set from CLI, it is set to enc_mode
 #if !TWOPASS_RC
             pcs_ptr->snd_pass_enc_mode =
-                (scs_ptr->use_output_stat_file &&
+                (use_output_stat(scs_ptr) &&
                  scs_ptr->static_config.snd_pass_enc_mode != MAX_ENC_PRESET + 1)
                     ? (EbEncMode)scs_ptr->static_config.snd_pass_enc_mode
                     : pcs_ptr->enc_mode;
@@ -1293,7 +1293,7 @@ void *resource_coordination_kernel(void *input_ptr) {
 
             // Pre-Analysis Signal(s) derivation
 #if FIRST_PASS_SETUP
-            if(scs_ptr->use_output_stat_file)
+            if(use_output_stat(scs_ptr))
                 first_pass_signal_derivation_pre_analysis(scs_ptr, pcs_ptr);
             else
                 signal_derivation_pre_analysis_oq(scs_ptr, pcs_ptr);
@@ -1334,14 +1334,14 @@ void *resource_coordination_kernel(void *input_ptr) {
             reset_pcs_av1(pcs_ptr);
 #if TWOPASS_RC
             if (pcs_ptr->picture_number == 0) {
-                if (scs_ptr->use_input_stat_file)
+                if (use_input_stat(scs_ptr))
                     read_stat_from_file(scs_ptr);
-                if (scs_ptr->use_input_stat_file || scs_ptr->use_output_stat_file)
+                if (use_input_stat(scs_ptr) || use_output_stat(scs_ptr))
                     setup_two_pass(scs_ptr);
             }
             pcs_ptr->ts_duration = (int64_t)10000000*(1<<16) / scs_ptr->frame_rate;
 #else
-            if (scs_ptr->use_input_stat_file && !end_of_sequence_flag)
+            if (use_input_stat(scs_ptr) && !end_of_sequence_flag)
                 read_stat_from_file(pcs_ptr, scs_ptr);
             else {
                 memset(&pcs_ptr->stat_struct, 0, sizeof(StatStruct));

--- a/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
+++ b/Source/Lib/Encoder/Codec/EbResourceCoordinationProcess.c
@@ -710,30 +710,10 @@ static void copy_input_buffer(SequenceControlSet *sequenceControlSet, EbBufferHe
 /******************************************************
  * Read Stat from File
  ******************************************************/
-static void read_stat_from_file(SequenceControlSet *scs_ptr) {
-    size_t nbytes;
-
+static void read_stat(SequenceControlSet *scs_ptr) {
     EncodeContext *encode_context_ptr = scs_ptr->encode_context_ptr;
-    if (fseek(scs_ptr->static_config.input_stat_file, 0, SEEK_END))
-        SVT_LOG("First-pass stats file must be seekable!");
 
-    encode_context_ptr->rc_twopass_stats_in.sz =
-        ftell(scs_ptr->static_config.input_stat_file);
-    rewind(scs_ptr->static_config.input_stat_file);
-
-    encode_context_ptr->rc_twopass_stats_in.buf =
-        malloc(encode_context_ptr->rc_twopass_stats_in.sz);
-
-    if (!encode_context_ptr->rc_twopass_stats_in.buf)
-        SVT_LOG("Failed to allocate first-pass stats buffer (%lu bytes)",
-                (unsigned int)encode_context_ptr->rc_twopass_stats_in.sz);
-
-    nbytes = fread(encode_context_ptr->rc_twopass_stats_in.buf,
-                   1,
-                   encode_context_ptr->rc_twopass_stats_in.sz,
-                   scs_ptr->static_config.input_stat_file);
-    if (nbytes != encode_context_ptr->rc_twopass_stats_in.sz)
-        SVT_LOG("Failed to read first-pass stats buffer");
+    encode_context_ptr->rc_twopass_stats_in = scs_ptr->static_config.rc_twopass_stats_in;
 }
 
 static void setup_two_pass(SequenceControlSet *scs_ptr) {
@@ -1335,7 +1315,7 @@ void *resource_coordination_kernel(void *input_ptr) {
 #if TWOPASS_RC
             if (pcs_ptr->picture_number == 0) {
                 if (use_input_stat(scs_ptr))
-                    read_stat_from_file(scs_ptr);
+                    read_stat(scs_ptr);
                 if (use_input_stat(scs_ptr) || use_output_stat(scs_ptr))
                     setup_two_pass(scs_ptr);
             }

--- a/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
@@ -310,7 +310,6 @@ EbErrorType copy_sequence_control_set(SequenceControlSet *dst, SequenceControlSe
     dst->tf_segment_row_count           = src->tf_segment_row_count;
     dst->over_boundary_block_mode       = src->over_boundary_block_mode;
     dst->mfmv_enabled                   = src->mfmv_enabled;
-    dst->use_input_stat_file            = src->use_input_stat_file;
     dst->use_output_stat_file           = src->use_output_stat_file;
     dst->scd_delay                      = src->scd_delay;
     return EB_ErrorNone;

--- a/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
+++ b/Source/Lib/Encoder/Codec/EbSequenceControlSet.c
@@ -310,7 +310,6 @@ EbErrorType copy_sequence_control_set(SequenceControlSet *dst, SequenceControlSe
     dst->tf_segment_row_count           = src->tf_segment_row_count;
     dst->over_boundary_block_mode       = src->over_boundary_block_mode;
     dst->mfmv_enabled                   = src->mfmv_enabled;
-    dst->use_output_stat_file           = src->use_output_stat_file;
     dst->scd_delay                      = src->scd_delay;
     return EB_ErrorNone;
 }

--- a/Source/Lib/Encoder/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbSequenceControlSet.h
@@ -245,6 +245,16 @@ extern EbErrorType derive_input_resolution(EbInputResolution *input_resolution,
 
 EbErrorType sb_geom_init(SequenceControlSet *scs_ptr);
 
+inline static EbBool use_input_stat(const SequenceControlSet* scs_ptr)
+{
+    return scs_ptr->use_input_stat_file;
+}
+
+inline static EbBool use_output_stat(const SequenceControlSet* scs_ptr)
+{
+    return scs_ptr->use_output_stat_file;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/Lib/Encoder/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbSequenceControlSet.h
@@ -105,7 +105,6 @@ typedef struct SequenceControlSet {
     uint8_t compound_mode;
 
     /*!< Temporary input / output statistics files for 2-pass encoding */
-    EbBool use_input_stat_file;
     EbBool use_output_stat_file;
 
     /*!< Sequence resolution parameters */
@@ -247,7 +246,7 @@ EbErrorType sb_geom_init(SequenceControlSet *scs_ptr);
 
 inline static EbBool use_input_stat(const SequenceControlSet* scs_ptr)
 {
-    return scs_ptr->use_input_stat_file;
+    return !!scs_ptr->static_config.rc_twopass_stats_in.sz;
 }
 
 inline static EbBool use_output_stat(const SequenceControlSet* scs_ptr)

--- a/Source/Lib/Encoder/Codec/EbSequenceControlSet.h
+++ b/Source/Lib/Encoder/Codec/EbSequenceControlSet.h
@@ -104,9 +104,6 @@ typedef struct SequenceControlSet {
     (The signal changes per preset; 0: compound disabled, 1: compound enabled) Default is 1. */
     uint8_t compound_mode;
 
-    /*!< Temporary input / output statistics files for 2-pass encoding */
-    EbBool use_output_stat_file;
-
     /*!< Sequence resolution parameters */
     uint32_t          chroma_format_idc;
     uint16_t          subsampling_x; // add chroma subsampling parameters
@@ -251,7 +248,7 @@ inline static EbBool use_input_stat(const SequenceControlSet* scs_ptr)
 
 inline static EbBool use_output_stat(const SequenceControlSet* scs_ptr)
 {
-    return scs_ptr->use_output_stat_file;
+    return scs_ptr->static_config.rc_firstpass_stats_out;
 }
 
 #ifdef __cplusplus

--- a/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
+++ b/Source/Lib/Encoder/Codec/EbTemporalFiltering.c
@@ -2674,7 +2674,7 @@ static EbErrorType produce_temporally_filtered_pic(
                     ? 3
                     : 4;
 #if !TWOPASS_RC
-                if (picture_control_set_ptr_central->scs_ptr->use_input_stat_file &&
+                if (picture_control_set_ptr_central->use_input_stat(scs_ptr) &&
                     picture_control_set_ptr_central->temporal_layer_index == 0 &&
                     noise_levels[0] > 0.5 &&
                     ((picture_control_set_ptr_central->referenced_area_avg < 20 &&
@@ -2861,7 +2861,7 @@ static void adjust_filter_strength(PictureParentControlSet *picture_control_set_
         else
             noiselevel_adj = 1;
 #if !TWOPASS_RC
-        if (picture_control_set_ptr_central->scs_ptr->use_input_stat_file &&
+        if (picture_control_set_ptr_central->use_input_stat(scs_ptr) &&
 #if UNIFY_SC_NSC
             picture_control_set_ptr_central->temporal_layer_index == 0) {
 #else

--- a/Source/Lib/Encoder/Codec/firstpass.c
+++ b/Source/Lib/Encoder/Codec/firstpass.c
@@ -62,14 +62,6 @@ static EbErrorType realloc_stats_out(FirstPassStatsOut* out, uint64_t frame_numb
     return EB_ErrorNone;
 }
 
-static void flush_stats(SequenceControlSet *scs_ptr) {
-    FirstPassStatsOut* out = &scs_ptr->encode_context_ptr->stats_out;
-    eb_block_on_mutex(scs_ptr->encode_context_ptr->stat_file_mutex);
-    fwrite(out->stat, sizeof(FIRSTPASS_STATS), out->size,
-        scs_ptr->static_config.output_stat_file);
-    fflush(scs_ptr->static_config.output_stat_file);
-    eb_release_mutex(scs_ptr->encode_context_ptr->stat_file_mutex);
-}
 static AOM_INLINE void output_stats(SequenceControlSet *scs_ptr, FIRSTPASS_STATS *stats,
                                     uint64_t frame_number) {
     FirstPassStatsOut* stats_out = &scs_ptr->encode_context_ptr->stats_out;
@@ -177,7 +169,6 @@ void svt_av1_end_first_pass(PictureParentControlSet *pcs_ptr) {
     if (twopass->stats_buf_ctx->total_stats) {
         // add the total to the end of the file
         output_stats(scs_ptr, twopass->stats_buf_ctx->total_stats, pcs_ptr->picture_number + 1);
-        flush_stats(scs_ptr);
     }
 }
 static double raw_motion_error_stdev(int *raw_motion_err_list, int raw_motion_err_counts) {

--- a/Source/Lib/Encoder/Codec/firstpass.c
+++ b/Source/Lib/Encoder/Codec/firstpass.c
@@ -306,7 +306,7 @@ static void update_firstpass_stats(PictureParentControlSet *pcs_ptr,
     /*In the case of two pass, first pass uses it as a circular buffer,
    * when LAP is enabled it is used as a linear buffer*/
     twopass->stats_buf_ctx->stats_in_end++;
-    if ((scs_ptr->use_output_stat_file) &&
+    if ((use_output_stat(scs_ptr)) &&
         (twopass->stats_buf_ctx->stats_in_end >= twopass->stats_buf_ctx->stats_in_buf_end)) {
         twopass->stats_buf_ctx->stats_in_end = twopass->stats_buf_ctx->stats_in_start;
     }

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2273,9 +2273,8 @@ void copy_api_from_app(
     scs_ptr->intra_refresh_type = scs_ptr->static_config.intra_refresh_type;
     scs_ptr->max_temporal_layers = scs_ptr->static_config.hierarchical_levels;
     scs_ptr->static_config.use_qp_file = ((EbSvtAv1EncConfiguration*)config_struct)->use_qp_file;
-    scs_ptr->static_config.input_stat_file = ((EbSvtAv1EncConfiguration*)config_struct)->input_stat_file;
+    scs_ptr->static_config.rc_twopass_stats_in = ((EbSvtAv1EncConfiguration*)config_struct)->rc_twopass_stats_in;
     scs_ptr->static_config.output_stat_file = ((EbSvtAv1EncConfiguration*)config_struct)->output_stat_file;
-    scs_ptr->use_input_stat_file = scs_ptr->static_config.input_stat_file ? 1 : 0;
     scs_ptr->use_output_stat_file = scs_ptr->static_config.output_stat_file ? 1 : 0;
     // Deblock Filter
     scs_ptr->static_config.disable_dlf_flag = ((EbSvtAv1EncConfiguration*)config_struct)->disable_dlf_flag;
@@ -3172,7 +3171,7 @@ static EbErrorType verify_settings(
         return_error = EB_ErrorBadParameter;
     }
 
-    if (config->superres_mode > 0 && ((config->input_stat_file || config->output_stat_file))){
+    if (config->superres_mode > 0 && ((config->rc_twopass_stats_in.sz || config->output_stat_file))){
         SVT_LOG("Error instance %u: superres is not supported for 2-pass\n", channel_number + 1);
         return_error = EB_ErrorBadParameter;
     }

--- a/Source/Lib/Encoder/Globals/EbEncHandle.c
+++ b/Source/Lib/Encoder/Globals/EbEncHandle.c
@@ -2018,11 +2018,11 @@ void set_param_based_on_input(SequenceControlSet *scs_ptr)
 #if TPL_240P_IMP
     // In two pass encoding, the first pass uses sb size=64. Also when tpl is used
     // in 240P resolution, sb size is set to 64
-    if (scs_ptr->use_output_stat_file ||
+    if (use_output_stat(scs_ptr) ||
         (scs_ptr->static_config.enable_tpl_la && scs_ptr->input_resolution == INPUT_SIZE_240p_RANGE))
 #else
     // In two pass encoding, the first pass uses sb size=64
-    if (scs_ptr->use_output_stat_file)
+    if (use_output_stat(scs_ptr))
 #endif
         scs_ptr->static_config.super_block_size = 64;
     else
@@ -2105,7 +2105,7 @@ void set_param_based_on_input(SequenceControlSet *scs_ptr)
 #endif
    // scs_ptr->static_config.hierarchical_levels = (scs_ptr->static_config.rate_control_mode > 1) ? 3 : scs_ptr->static_config.hierarchical_levels;
 #if FIRST_PASS_SETUP
-    if (scs_ptr->use_output_stat_file)
+    if (use_output_stat(scs_ptr))
         scs_ptr->static_config.hierarchical_levels = 0;
 #endif
     // Configure the padding
@@ -2208,7 +2208,7 @@ void set_param_based_on_input(SequenceControlSet *scs_ptr)
     else
         scs_ptr->over_boundary_block_mode = scs_ptr->static_config.over_bndry_blk;
 #if FIRST_PASS_SETUP
-    if (scs_ptr->use_output_stat_file)
+    if (use_output_stat(scs_ptr))
         scs_ptr->over_boundary_block_mode = 0;
 #endif
     if (scs_ptr->static_config.enable_mfmv == DEFAULT)
@@ -2503,7 +2503,7 @@ void copy_api_from_app(
     if (scs_ptr->static_config.intra_period_length == -2)
         scs_ptr->intra_period_length = scs_ptr->static_config.intra_period_length = compute_default_intra_period(scs_ptr);
 #if TWOPASS_RC
-    else if (scs_ptr->static_config.intra_period_length == -1 && (scs_ptr->use_input_stat_file || scs_ptr->use_output_stat_file))
+    else if (scs_ptr->static_config.intra_period_length == -1 && (use_input_stat(scs_ptr) || use_output_stat(scs_ptr)))
         scs_ptr->intra_period_length = (MAX_NUM_GF_INTERVALS-1)* (1 << (scs_ptr->static_config.hierarchical_levels));
 #endif
     if (scs_ptr->static_config.look_ahead_distance == (uint32_t)~0)


### PR DESCRIPTION
# Description
Add memory interface for 2passes stats in and out.
Most of encoders like libaom will use memory as input/output for 2 passes stats.
This patch will make SvtAv1 follow the same tradition. 

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
guangxin.xu@intel.com


# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
