### PR TITLE
2pass: fix crash for encode 100+ frames

### DIFF
--- a/Source/Lib/Encoder/Codec/firstpass.c
+++ b/Source/Lib/Encoder/Codec/firstpass.c
@@ -50,7 +50,7 @@ static EbErrorType realloc_stats_out(FirstPassStatsOut* out, uint64_t frame_numb
     if (frame_number < out->size)
         return EB_ErrorNone;
     if (frame_number >= out->capability) {
-        size_t capability = frame_number > STATS_CAPABILITY_INIT ?
+        size_t capability = frame_number >= STATS_CAPABILITY_INIT ?
             STATS_CAPABILITY_GROW(frame_number) : STATS_CAPABILITY_INIT;
         EB_REALLOC_ARRAY(out->stat, capability);
         out->capability = capability;


### PR DESCRIPTION

# Description
reproduce:
SvtAv1EncApp -lad 0 -q 20  -n 100 -intra-period 119 -i 172x144.y4m -b two_passes.ivf --passes 2 --preset 3

root cause:
we need use >= instead of > since we want write stats_out->stat[frame_number]

# Issue

<!--
Mention if the PR fixes or address an issue in this section
https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
Example
Fixes #999
If this is a bug fix that does not have an issue created for it, please create one with enough info to reproduce the issue
--->

# Author(s)
guangxin.xu@intel.com

# Performance impact
<!--
Type an x in the box that is relevant to your PR. Make sure to mention in what way in the description
Example
- [x] memory
--->
- [ ] quality
- [ ] memory
- [ ] speed
- [ ] 8 bit
- [ ] 10 bit
- [x] N/A

# Test set
- [ ] obj-1-fast can be found [here](https://media.xiph.org/video/derf/objective-1-fast.tar.gz)
- [ ] other
- [x] N/A

# Merge method
- [ ] Allow the maintainer to squash and merge when PR is ready to create a 1-commit to the master branch. The maintainer will be able to fix typos / combine commit messages to create a more readable 1-commit message or use whatever is stated in the 'Description' section
- [x] I will clean up my commits and the maintainer shall use 'rebase and merge' to the master branch
